### PR TITLE
feat: multi-version retention with real tags for all containers

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -130,6 +130,34 @@ jobs:
           echo "Change: $current_version -> $new_version ($change_type)"
           echo "Reason: $reason"
 
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Rotate version in variants.yaml
+        id: rotate
+        env:
+          CONTAINER: ${{ matrix.container }}
+          NEW_VERSION: ${{ steps.classify.outputs.new_version }}
+        run: |
+          if [[ -f "$CONTAINER/variants.yaml" ]]; then
+            retention=$(yq -r '.build.version_retention // 0' "$CONTAINER/variants.yaml")
+            if [[ "$retention" -gt 0 ]]; then
+              echo "🔄 Rotating version for $CONTAINER (retention: $retention)"
+              ./scripts/rotate-versions.sh "$CONTAINER" "$NEW_VERSION"
+              echo "rotated=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "ℹ️ No version_retention for $CONTAINER — skipping rotation"
+              echo "rotated=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "ℹ️ No variants.yaml for $CONTAINER — skipping rotation"
+            echo "rotated=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Close duplicate PRs
         id: close_duplicates
         uses: ./.github/actions/close-duplicate-prs
@@ -273,16 +301,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONTAINER: ${{ matrix.container }}
           NEW_VERSION: ${{ steps.classify.outputs.new_version }}
+          ROTATED: ${{ steps.rotate.outputs.rotated }}
         run: |
           echo "🔨 Triggering build for $CONTAINER after successful merge"
 
-          # Extract major version for scoped builds (e.g., "18.2-alpine" → "18")
-          affected_major=$(echo "$NEW_VERSION" | grep -oE '^[0-9]+')
-
           scope_args=""
-          if [[ -n "$affected_major" ]]; then
-            scope_args="-f scope_versions=$affected_major"
-            echo "🎯 Scoped to version: $affected_major"
+          # Only scope by major version for multi-major containers (e.g., postgres)
+          # Containers with version_retention use full version tags — no major scoping needed
+          if [[ "$ROTATED" != "true" ]]; then
+            affected_major=$(echo "$NEW_VERSION" | grep -oE '^[0-9]+')
+            if [[ -n "$affected_major" ]]; then
+              scope_args="-f scope_versions=$affected_major"
+              echo "🎯 Scoped to version: $affected_major"
+            fi
           fi
 
           gh workflow run auto-build.yaml -f container="$CONTAINER" -f force_rebuild=true $scope_args

--- a/ansible/variants.yaml
+++ b/ansible/variants.yaml
@@ -1,0 +1,6 @@
+# Ansible Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "13.4.0-ubuntu"

--- a/debian/variants.yaml
+++ b/debian/variants.yaml
@@ -1,0 +1,6 @@
+# Debian Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "trixie"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -415,13 +415,7 @@ collect_variant_json() {
     [[ -z "$build_args_json" ]] && build_args_json="[]"
 
     # SBOM data (package summary, packages detail, changelog, build history)
-    # CI generates SBOMs using resolved version tags (e.g., "1.14.5-alpine-base")
-    # but variants.yaml may use "latest" as placeholder (e.g., terraform).
-    # Resolve the SBOM tag using current_version to match CI naming.
     local sbom_tag="$variant_tag"
-    if [[ "$version" == "latest" && "$current_version" != "no-published-version" ]]; then
-        sbom_tag=$(variant_image_tag "$current_version" "$variant_name" "$container_dir")
-    fi
     local sbom_summary sbom_packages changelog build_history
     sbom_summary=$(get_sbom_summary "$container" "$sbom_tag")
     sbom_packages=$(get_sbom_packages "$container" "$sbom_tag")

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -89,17 +89,9 @@ list_variants() {
     fi
 
     if [[ -n "$version" ]]; then
-        # New structure: get variants for specific version
+        # Get variants for specific version
         local result
         result=$(yq -r ".versions[] | select(.tag == \"$version\") | .variants[].name" "$variants_file" 2>/dev/null)
-
-        # If no variants found for this version, try "latest" as fallback.
-        # This is intentional for containers with dynamic versions (e.g., terraform)
-        # where variants.yaml uses tag: "latest" as a placeholder that gets resolved
-        # to the actual upstream version at build time by list_build_matrix.
-        if [[ -z "$result" ]]; then
-            result=$(yq -r '.versions[] | select(.tag == "latest") | .variants[].name' "$variants_file" 2>/dev/null)
-        fi
 
         echo "$result"
     else
@@ -160,11 +152,6 @@ variant_property() {
         local result
         result=$(yq -r ".versions[] | select(.tag == \"$version\") | .variants[] | select(.name == \"$variant_name\") | .$property // \"\"" "$variants_file" 2>/dev/null)
 
-        # If not found for this version, try "latest" as fallback
-        if [[ -z "$result" ]]; then
-            result=$(yq -r '.versions[] | select(.tag == "latest") | .variants[] | select(.name == "'"$variant_name"'") | .'"$property"' // ""' "$variants_file" 2>/dev/null)
-        fi
-
         echo "$result"
     else
         # Fallback: try old structure
@@ -202,6 +189,20 @@ default_variant() {
             echo "$result"
         fi
     fi
+}
+
+# Get version_retention setting from build config
+# Returns: retention count (0 = no automatic rotation)
+version_retention() {
+    local container_dir="$1"
+    local variants_file="$container_dir/variants.yaml"
+
+    if [[ ! -f "$variants_file" ]]; then
+        echo "0"
+        return
+    fi
+
+    yq -r '.build.version_retention // 0' "$variants_file" 2>/dev/null || echo "0"
 }
 
 # Get base suffix from build config (e.g., "-alpine")
@@ -304,7 +305,10 @@ list_build_matrix() {
         # e.g., major "18" with real_version "18.2-alpine" → full_version "18.2-alpine"
         local full_version=""
         if [[ "$pg_version" != "latest" && -n "$real_version" && "$real_version" != "latest" ]]; then
-            if [[ "$real_version" == "${pg_version}."* || "$real_version" == "${pg_version}-"* ]]; then
+            if [[ "$real_version" == "$pg_version" ]]; then
+                # Exact match (e.g., real_version "1.14.6-alpine" == tag "1.14.6-alpine")
+                full_version="$real_version"
+            elif [[ "$real_version" == "${pg_version}."* || "$real_version" == "${pg_version}-"* ]]; then
                 # real_version belongs to this major version — use it directly
                 full_version="$real_version"
             elif [[ -x "$container_dir/version.sh" ]]; then
@@ -317,34 +321,52 @@ list_build_matrix() {
         local is_latest_version="$is_first_version"
         is_first_version=false
 
-        while IFS= read -r variant_name; do
-            [[ -z "$variant_name" ]] && continue
+        local variants_list
+        variants_list=$(list_variants "$container_dir" "$pg_version")
 
-            local tag
-            tag=$(variant_image_tag "$effective_version" "$variant_name" "$container_dir")
-            local flavor
-            flavor=$(variant_property "$container_dir" "$variant_name" "flavor" "$pg_version")
-            local is_default
-            is_default=$(variant_property "$container_dir" "$variant_name" "default" "$pg_version")
-
-            # Priority: base/"" → 0, full → 2, else → 1
-            local priority=1
-            if [[ "$flavor" == "base" || -z "$flavor" ]]; then
-                priority=0
-            elif [[ "$flavor" == "full" ]]; then
-                priority=2
-            fi
-
+        if [[ -z "$variants_list" ]]; then
+            # Versions-only entry (no variants) — produce a single build entry
             if [[ "$first" != "true" ]]; then
                 result+=","
             fi
             first=false
 
+            local base_sfx
+            base_sfx=$(base_suffix "$container_dir")
             local dockerfile
             dockerfile=$(version_dockerfile "$container_dir" "$pg_version")
 
-            result+="{\"version\":\"$effective_version\",\"variant\":\"$variant_name\",\"tag\":\"$tag\",\"flavor\":\"$flavor\",\"is_default\":$([[ "$is_default" == "true" ]] && echo "true" || echo "false"),\"is_latest_version\":$is_latest_version,\"dockerfile\":\"$dockerfile\",\"priority\":$priority,\"full_version\":\"$full_version\"}"
-        done < <(list_variants "$container_dir" "$pg_version")
+            result+="{\"version\":\"$effective_version\",\"variant\":\"\",\"tag\":\"${effective_version}${base_sfx}\",\"flavor\":\"\",\"is_default\":true,\"is_latest_version\":$is_latest_version,\"dockerfile\":\"$dockerfile\",\"priority\":0,\"full_version\":\"$full_version\"}"
+        else
+            while IFS= read -r variant_name; do
+                [[ -z "$variant_name" ]] && continue
+
+                local tag
+                tag=$(variant_image_tag "$effective_version" "$variant_name" "$container_dir")
+                local flavor
+                flavor=$(variant_property "$container_dir" "$variant_name" "flavor" "$pg_version")
+                local is_default
+                is_default=$(variant_property "$container_dir" "$variant_name" "default" "$pg_version")
+
+                # Priority: base/"" → 0, full → 2, else → 1
+                local priority=1
+                if [[ "$flavor" == "base" || -z "$flavor" ]]; then
+                    priority=0
+                elif [[ "$flavor" == "full" ]]; then
+                    priority=2
+                fi
+
+                if [[ "$first" != "true" ]]; then
+                    result+=","
+                fi
+                first=false
+
+                local dockerfile
+                dockerfile=$(version_dockerfile "$container_dir" "$pg_version")
+
+                result+="{\"version\":\"$effective_version\",\"variant\":\"$variant_name\",\"tag\":\"$tag\",\"flavor\":\"$flavor\",\"is_default\":$([[ "$is_default" == "true" ]] && echo "true" || echo "false"),\"is_latest_version\":$is_latest_version,\"dockerfile\":\"$dockerfile\",\"priority\":$priority,\"full_version\":\"$full_version\"}"
+            done <<< "$variants_list"
+        fi
     done < <(list_versions "$container_dir")
 
     result+="]"
@@ -452,5 +474,5 @@ list_variant_tags() {
 
 # Export functions for use in other scripts
 export -f resolve_major_version has_variants list_versions version_count list_variants variant_count
-export -f variant_property default_variant base_suffix
+export -f variant_property default_variant base_suffix version_retention
 export -f version_dockerfile requires_extensions variant_image_tag list_build_matrix list_container_builds list_variant_tags

--- a/jekyll/variants.yaml
+++ b/jekyll/variants.yaml
@@ -1,0 +1,6 @@
+# Jekyll Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "4.4.1-alpine"

--- a/openresty/variants.yaml
+++ b/openresty/variants.yaml
@@ -1,0 +1,6 @@
+# OpenResty Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.29.2.1-alpine"

--- a/openvpn/variants.yaml
+++ b/openvpn/variants.yaml
@@ -1,0 +1,6 @@
+# OpenVPN Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "v2.7.0-alpine"

--- a/php/variants.yaml
+++ b/php/variants.yaml
@@ -1,0 +1,6 @@
+# PHP Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "8.5.3-fpm-alpine"

--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Rotate versions in variants.yaml for automated version updates
+#
+# Usage: rotate-versions.sh <container_dir> <new_version>
+#
+# Algorithm:
+#   1. Read build.version_retention (exit 2 if absent/zero — not a managed container)
+#   2. Check if new_version already exists (idempotent — exit 0)
+#   3. If container has variants: copy variants from first versions[] entry
+#   4. If no variants: create simple version entry {tag: "new_version"}
+#   5. Prepend new entry to versions[]
+#   6. Trim to version_retention entries
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$ROOT_DIR/helpers/variant-utils.sh"
+
+usage() {
+    echo "Usage: $(basename "$0") <container_dir> <new_version>" >&2
+    echo "Exit codes: 0=success, 1=error, 2=not a version_retention container" >&2
+    exit 1
+}
+
+[[ $# -lt 2 ]] && usage
+
+container_dir="$1"
+new_version="$2"
+variants_file="$container_dir/variants.yaml"
+
+if [[ ! -f "$variants_file" ]]; then
+    echo "Error: $variants_file not found" >&2
+    exit 1
+fi
+
+# Step 1: Check version_retention
+retention=$(version_retention "$container_dir")
+if [[ "$retention" -eq 0 ]]; then
+    echo "No version_retention configured for $container_dir — skipping" >&2
+    exit 2
+fi
+
+# Step 2: Check idempotence — does new_version already exist?
+existing_tags=$(yq -r '.versions[].tag' "$variants_file" 2>/dev/null)
+while IFS= read -r tag; do
+    if [[ "$tag" == "$new_version" ]]; then
+        echo "Version $new_version already exists in $variants_file — no changes needed" >&2
+        exit 0
+    fi
+done <<< "$existing_tags"
+
+# Step 3/4: Build the new version entry
+first_has_variants=$(yq -r '.versions[0].variants | length // 0' "$variants_file" 2>/dev/null || echo "0")
+
+if [[ -n "$first_has_variants" && "$first_has_variants" -gt 0 ]]; then
+    # Container has variants — copy from first entry, update tag
+    yq -i "
+        .versions |= [{\"tag\": \"$new_version\", \"variants\": .[0].variants}] + .
+    " "$variants_file"
+else
+    # Versions-only — simple entry
+    yq -i "
+        .versions |= [{\"tag\": \"$new_version\"}] + .
+    " "$variants_file"
+fi
+
+# Step 6: Trim to retention count
+current_count=$(yq -r '.versions | length' "$variants_file")
+if [[ "$current_count" -gt "$retention" ]]; then
+    yq -i ".versions |= .[:$retention]" "$variants_file"
+fi
+
+echo "Rotated $variants_file: added $new_version (retention: $retention)" >&2

--- a/sslh/variants.yaml
+++ b/sslh/variants.yaml
@@ -1,0 +1,6 @@
+# SSLH Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "v2.3.0-alpine"

--- a/terraform/variants.yaml
+++ b/terraform/variants.yaml
@@ -2,21 +2,18 @@
 # Defines multiple image variants to reduce attack surface and image sizes
 #
 # Each variant produces a separate image tag:
-#   ghcr.io/oorabona/terraform:latest          (full - default for backwards compatibility)
-#   ghcr.io/oorabona/terraform:1.10.5-base     (base variant)
-#   ghcr.io/oorabona/terraform:1.10.5-aws      (AWS variant)
+#   ghcr.io/oorabona/terraform:1.14.6-alpine-base  (base variant)
+#   ghcr.io/oorabona/terraform:1.14.6-alpine-aws   (AWS variant)
+#   ghcr.io/oorabona/terraform:1.14.6-alpine        (full - default)
 #   etc.
 
 # Build configuration
 build:
-  # No extension dependencies (unlike postgres)
   requires_extensions: false
+  version_retention: 3
 
-# Single version entry with multiple variants
-# NOTE: Terraform uses dynamic versioning - actual version comes from version.sh
-# The "latest" tag is a fallback key for variant lookups when version is dynamic
 versions:
-  - tag: "latest"
+  - tag: "1.14.6-alpine"
     variants:
       - name: base
         suffix: "-base"

--- a/tests/unit/rotate-versions.bats
+++ b/tests/unit/rotate-versions.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/rotate-versions.sh
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    # Ensure yq and helpers are accessible
+    export PATH="${ORIG_DIR}/bin:$PATH"
+
+    # Create helpers directory structure so rotate-versions.sh can source variant-utils.sh
+    mkdir -p helpers scripts
+    cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+    cp "$ORIG_DIR/scripts/rotate-versions.sh" scripts/
+    chmod +x scripts/rotate-versions.sh
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+# --- Helper to create test fixtures ---
+
+create_versioned_container() {
+    local dir="${1:-.}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "2.0.0"
+  - tag: "1.9.0"
+EOF
+}
+
+create_versioned_with_variants() {
+    local dir="${1:-.}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.14.6-alpine"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+      - name: aws
+        suffix: "-aws"
+        flavor: aws
+EOF
+}
+
+create_no_retention() {
+    local dir="${1:-.}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  requires_extensions: true
+
+versions:
+  - tag: "18"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+EOF
+}
+
+# --- Tests ---
+
+@test "rotate: basic prepend + trim" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_versioned_container "myapp"
+    run scripts/rotate-versions.sh "myapp" "2.1.0"
+    [ "$status" -eq 0 ]
+
+    # New version should be first
+    local first_tag
+    first_tag=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    [ "$first_tag" = "2.1.0" ]
+
+    # Should have 3 entries (retention=3)
+    local count
+    count=$(yq -r '.versions | length' myapp/variants.yaml)
+    [ "$count" -eq 3 ]
+
+    # Third entry is 1.9.0 (original second)
+    local third_tag
+    third_tag=$(yq -r '.versions[2].tag' myapp/variants.yaml)
+    [ "$third_tag" = "1.9.0" ]
+}
+
+@test "rotate: trim removes oldest when exceeding retention" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_versioned_container "myapp"
+
+    # Add two more to go from 2 → 4, but retention=3 so it should stay at 3
+    scripts/rotate-versions.sh "myapp" "2.1.0"
+    scripts/rotate-versions.sh "myapp" "2.2.0"
+
+    local count
+    count=$(yq -r '.versions | length' myapp/variants.yaml)
+    [ "$count" -eq 3 ]
+
+    # Newest first
+    local first_tag
+    first_tag=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    [ "$first_tag" = "2.2.0" ]
+
+    # Oldest (1.9.0) should have been trimmed
+    local has_old
+    has_old=$(yq -r '.versions[].tag' myapp/variants.yaml | grep -c "1.9.0" || true)
+    [ "$has_old" -eq 0 ]
+}
+
+@test "rotate: idempotence — existing version exits 0 without changes" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_versioned_container "myapp"
+    run scripts/rotate-versions.sh "myapp" "2.0.0"
+    [ "$status" -eq 0 ]
+
+    # Should still have exactly 2 entries
+    local count
+    count=$(yq -r '.versions | length' myapp/variants.yaml)
+    [ "$count" -eq 2 ]
+}
+
+@test "rotate: container with variants copies variants from first entry" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_versioned_with_variants "tf"
+    run scripts/rotate-versions.sh "tf" "1.15.0-alpine"
+    [ "$status" -eq 0 ]
+
+    # New entry should have variants copied from first
+    local first_tag
+    first_tag=$(yq -r '.versions[0].tag' tf/variants.yaml)
+    [ "$first_tag" = "1.15.0-alpine" ]
+
+    local variant_count
+    variant_count=$(yq -r '.versions[0].variants | length' tf/variants.yaml)
+    [ "$variant_count" -eq 2 ]
+
+    local base_name
+    base_name=$(yq -r '.versions[0].variants[0].name' tf/variants.yaml)
+    [ "$base_name" = "base" ]
+}
+
+@test "rotate: exit code 2 when no version_retention" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_no_retention "pg"
+    run scripts/rotate-versions.sh "pg" "19"
+    [ "$status" -eq 2 ]
+}
+
+@test "rotate: exit code 1 when no variants.yaml" {
+    mkdir -p "nonexistent"
+    run scripts/rotate-versions.sh "nonexistent" "1.0.0"
+    [ "$status" -eq 1 ]
+}

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -70,10 +70,10 @@ create_terraform_variants() {
     cat > "$dir/variants.yaml" <<'EOF'
 build:
   base_suffix: ""
-
+  version_retention: 3
 
 versions:
-  - tag: "latest"
+  - tag: "1.14.6-alpine"
     variants:
       - name: base
         suffix: ""
@@ -202,26 +202,26 @@ EOF
     [ "$output" = "18-alpine-analytics" ]
 }
 
-@test "variant_image_tag: terraform base → latest (no base_suffix)" {
+@test "variant_image_tag: terraform base → 1.14.6-alpine (no base_suffix)" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
     hash -r
 
     create_terraform_variants "tf"
-    run variant_image_tag "latest" "base" "tf"
+    run variant_image_tag "1.14.6-alpine" "base" "tf"
     [ "$status" -eq 0 ]
-    [ "$output" = "latest" ]
+    [ "$output" = "1.14.6-alpine" ]
 }
 
-@test "variant_image_tag: terraform aws → latest-aws" {
+@test "variant_image_tag: terraform aws → 1.14.6-alpine-aws" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
     hash -r
 
     create_terraform_variants "tf"
-    run variant_image_tag "latest" "aws" "tf"
+    run variant_image_tag "1.14.6-alpine" "aws" "tf"
     [ "$status" -eq 0 ]
-    [ "$output" = "latest-aws" ]
+    [ "$output" = "1.14.6-alpine-aws" ]
 }
 
 # --- default_variant (requires real yq) ---
@@ -309,24 +309,21 @@ EOF
 
 # --- list_build_matrix with real_version ---
 
-@test "list_build_matrix: with real_version substitutes latest" {
+@test "list_build_matrix: terraform uses version tag directly" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
     hash -r
 
     create_terraform_variants "tf"
-    run list_build_matrix "tf" "1.14.5"
+    run list_build_matrix "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
-    # All entries should have version=1.14.5, not "latest"
+    # All entries should have version=1.14.6-alpine (the tag from variants.yaml)
     local count
-    count=$(echo "$output" | jq '[.[] | select(.version == "1.14.5")] | length')
+    count=$(echo "$output" | jq '[.[] | select(.version == "1.14.6-alpine")] | length')
     [ "$count" -gt 0 ]
-    local latest_count
-    latest_count=$(echo "$output" | jq '[.[] | select(.version == "latest")] | length')
-    [ "$latest_count" -eq 0 ]
 }
 
-@test "list_build_matrix: without real_version keeps latest" {
+@test "list_build_matrix: without real_version keeps yaml tag" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
     hash -r
@@ -334,9 +331,9 @@ EOF
     create_terraform_variants "tf"
     run list_build_matrix "tf"
     [ "$status" -eq 0 ]
-    local latest_count
-    latest_count=$(echo "$output" | jq '[.[] | select(.version == "latest")] | length')
-    [ "$latest_count" -gt 0 ]
+    local tag_count
+    tag_count=$(echo "$output" | jq '[.[] | select(.version == "1.14.6-alpine")] | length')
+    [ "$tag_count" -gt 0 ]
 }
 
 @test "list_build_matrix: postgres ignores real_version (tags are not latest)" {
@@ -362,7 +359,7 @@ EOF
     hash -r
 
     create_terraform_variants "tf"
-    run list_build_matrix "tf" "1.14.5"
+    run list_build_matrix "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
     # base variant: is_default=true, priority=0
     local base_default
@@ -381,26 +378,26 @@ EOF
     [ "$aws_priority" = "1" ]
 }
 
-@test "list_build_matrix: terraform real_version produces correct tags" {
+@test "list_build_matrix: terraform produces correct tags from version" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
     hash -r
 
     create_terraform_variants "tf"
-    run list_build_matrix "tf" "1.14.5"
+    run list_build_matrix "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
-    # base has suffix "" and base_suffix="" → tag = "1.14.5"
+    # base has suffix "" and base_suffix="" → tag = "1.14.6-alpine"
     local base_tag
     base_tag=$(echo "$output" | jq -r '[.[] | select(.variant == "base")] | .[0].tag')
-    [ "$base_tag" = "1.14.5" ]
-    # aws has suffix "-aws" → tag = "1.14.5-aws"
+    [ "$base_tag" = "1.14.6-alpine" ]
+    # aws has suffix "-aws" → tag = "1.14.6-alpine-aws"
     local aws_tag
     aws_tag=$(echo "$output" | jq -r '[.[] | select(.variant == "aws")] | .[0].tag')
-    [ "$aws_tag" = "1.14.5-aws" ]
-    # full has suffix "-full" → tag = "1.14.5-full"
+    [ "$aws_tag" = "1.14.6-alpine-aws" ]
+    # full has suffix "-full" → tag = "1.14.6-alpine-full"
     local full_tag
     full_tag=$(echo "$output" | jq -r '[.[] | select(.variant == "full")] | .[0].tag')
-    [ "$full_tag" = "1.14.5-full" ]
+    [ "$full_tag" = "1.14.6-alpine-full" ]
 }
 
 # --- list_container_builds ---
@@ -411,7 +408,7 @@ EOF
     hash -r
 
     create_terraform_variants "tf"
-    run list_container_builds "tf" "1.14.5"
+    run list_container_builds "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
     local all_have_container
     all_have_container=$(echo "$output" | jq 'all(.container == "tf")')
@@ -445,7 +442,7 @@ EOF
     hash -r
 
     create_terraform_variants "tf"
-    run list_container_builds "tf" "1.14.5"
+    run list_container_builds "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
     # First entry should have priority 0 (base)
     local first_priority
@@ -483,7 +480,7 @@ EOF
     hash -r
 
     create_terraform_variants "tf"
-    run list_build_matrix "tf" "1.14.5"
+    run list_build_matrix "tf" "1.14.6-alpine"
     [ "$status" -eq 0 ]
     local all_latest
     all_latest=$(echo "$output" | jq 'all(.is_latest_version == true)')
@@ -501,4 +498,110 @@ EOF
     local is_latest
     is_latest=$(echo "$output" | jq '.[0].is_latest_version')
     [ "$is_latest" = "true" ]
+}
+
+# --- version_retention ---
+
+@test "version_retention: terraform returns 3" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_terraform_variants "tf"
+    run version_retention "tf"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3" ]
+}
+
+@test "version_retention: postgres returns 0 (no version_retention)" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_postgres_variants "pg"
+    run version_retention "pg"
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "version_retention: no variants.yaml returns 0" {
+    mkdir -p "novar"
+    run version_retention "novar"
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+# --- versions-only build path (no variants) ---
+
+create_simple_container_variants() {
+    local dir="${1:-.}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "2.0.0"
+  - tag: "1.9.0"
+EOF
+}
+
+@test "list_build_matrix: versions-only produces entries without variants" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_simple_container_variants "simple"
+    run list_build_matrix "simple" "2.0.0"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 2 ]
+    # First entry (version 2.0.0) should be is_latest_version=true
+    local first_version
+    first_version=$(echo "$output" | jq -r '.[0].version')
+    [ "$first_version" = "2.0.0" ]
+    local first_latest
+    first_latest=$(echo "$output" | jq '.[0].is_latest_version')
+    [ "$first_latest" = "true" ]
+    # Variant should be empty
+    local first_variant
+    first_variant=$(echo "$output" | jq -r '.[0].variant')
+    [ "$first_variant" = "" ]
+    # Second entry should be is_latest_version=false
+    local second_latest
+    second_latest=$(echo "$output" | jq '.[1].is_latest_version')
+    [ "$second_latest" = "false" ]
+}
+
+@test "list_container_builds: versions-only produces sorted entries" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_simple_container_variants "simple"
+    run list_container_builds "simple" "2.0.0"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 2 ]
+    local all_have_container
+    all_have_container=$(echo "$output" | jq 'all(.container == "simple")')
+    [ "$all_have_container" = "true" ]
+}
+
+# --- full_version direct match ---
+
+@test "list_build_matrix: full_version exact match for real version tags" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_terraform_variants "tf"
+    run list_build_matrix "tf" "1.14.6-alpine"
+    [ "$status" -eq 0 ]
+    # full_version should match the real_version since tag == real_version
+    local full_version
+    full_version=$(echo "$output" | jq -r '.[0].full_version')
+    [ "$full_version" = "1.14.6-alpine" ]
 }

--- a/vector/variants.yaml
+++ b/vector/variants.yaml
@@ -1,0 +1,6 @@
+# Vector Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "0.53.0-alpine"

--- a/web-shell/variants.yaml
+++ b/web-shell/variants.yaml
@@ -2,21 +2,18 @@
 # Defines multi-distribution image variants
 #
 # Each variant produces a separate image tag:
-#   ghcr.io/oorabona/web-shell:latest            (debian - default)
+#   ghcr.io/oorabona/web-shell:1.7.7             (debian - default)
 #   ghcr.io/oorabona/web-shell:1.7.7-alpine      (alpine variant)
 #   ghcr.io/oorabona/web-shell:1.7.7-ubuntu      (ubuntu variant)
 #   ghcr.io/oorabona/web-shell:1.7.7-rocky       (rocky variant)
 
 # Build configuration
 build:
-  # No extension dependencies
   requires_extensions: false
+  version_retention: 3
 
-# Single version entry with multiple distro variants
-# NOTE: web-shell uses dynamic versioning from ttyd — actual version comes from version.sh
-# The "latest" tag is a fallback key for variant lookups when version is dynamic
 versions:
-  - tag: "latest"
+  - tag: "1.7.7"
     variants:
       - name: debian
         suffix: ""

--- a/wordpress/variants.yaml
+++ b/wordpress/variants.yaml
@@ -1,0 +1,6 @@
+# WordPress Container Variants
+build:
+  version_retention: 3
+
+versions:
+  - tag: "6.9.1-alpine"


### PR DESCRIPTION
## Summary
- Migrate all containers from `tag: "latest"` placeholder to real version tags in `variants.yaml`
- Add `build.version_retention` setting for automated version rotation (all containers except postgres)
- Create `scripts/rotate-versions.sh` for upstream-monitor integration
- Support versions-only build path (containers without variants)
- Remove "latest" tag fallbacks and SBOM workarounds

## Changes
- **helpers/variant-utils.sh**: `version_retention()` helper, `full_version` direct-match fix, versions-only build path, removed "latest" fallbacks
- **9 new `variants.yaml`**: ansible, debian, jekyll, openresty, openvpn, php, sslh, vector, wordpress
- **2 updated `variants.yaml`**: web-shell (`latest` → `1.7.7`), terraform (`latest` → `1.14.6-alpine`)
- **scripts/rotate-versions.sh**: New script for automated version rotation
- **upstream-monitor.yaml**: Integrated version rotation step
- **generate-dashboard.sh**: Removed "latest" SBOM tag workaround
- **tests**: 42 unit tests for variant-utils + 6 for rotate-versions (all passing)

## Test plan
- [x] All 137 unit tests pass (`bats tests/unit/`)
- [x] Build matrix output verified for web-shell, terraform, ansible, postgres
- [ ] CI: trigger web-shell build after merge to verify dashboard warning disappears
- [ ] Verify `./scripts/rotate-versions.sh web-shell 1.7.8` produces correct YAML