### PR TITLE
docs(github): add bug + enhancement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Something visible is broken or behaving unexpectedly
+title: "fix(<scope>): "
+labels: bug
+---
+
+<!--
+Title format: fix(<scope>): <short summary>
+Scope examples: dashboard, ci, postgres, terraform, web-shell, github-runner, blog
+Add a scope label too (postgres, terraform, ci-related, etc.) so /next can rank it.
+-->
+
+## Symptom
+
+What's visible / broken from a user-facing perspective. Include the URL, the container, or the workflow that surfaces the bug.
+
+## Reproduction
+
+Steps to observe the bug. Mention the exact commit SHA, branch, image tag, or live URL.
+
+```
+1.
+2.
+3.
+```
+
+## Expected vs actual
+
+- Expected: …
+- Actual: …
+
+## Root cause (if known)
+
+1–3 lines linking to the offending file/line. If unknown, leave blank — the maintainer (or an automated triage agent) will fill this during investigation.
+
+## Acceptance
+
+A concrete, observable check that proves the bug is fixed. e.g. *"the X badge shows `🏗 amd64 + arm64` after clicking a variant tag on the postgres card"*.
+
+## Related
+
+PRs, commits, sibling issues, ADRs, or memory snapshots that contextualize this bug. Use `#N` for sibling issues, full URL for external refs.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -17,7 +17,17 @@ What's visible / broken from a user-facing perspective. Include the URL, the con
 
 ## Reproduction
 
-Steps to observe the bug. Mention the exact commit SHA, branch, image tag, or live URL.
+<!--
+For container-runtime bugs, fill these inline (delete what doesn't apply):
+  **Image tag:**    e.g. `ghcr.io/oorabona/postgres:18-alpine-vector`
+  **Host:**         e.g. Docker 27.5 on Ubuntu 24.04 / WSL2
+For CI bugs:
+  **Workflow run:** e.g. https://github.com/oorabona/docker-containers/actions/runs/...
+For dashboard / docs bugs:
+  **URL + browser:** e.g. https://oorabona.github.io/docker-containers/ on Firefox 132
+-->
+
+Steps to observe the bug. Reference exact commit SHA, branch, image tag, or live URL.
 
 ```
 1.
@@ -41,3 +51,14 @@ A concrete, observable check that proves the bug is fixed. e.g. *"the X badge sh
 ## Related
 
 PRs, commits, sibling issues, ADRs, or memory snapshots that contextualize this bug. Use `#N` for sibling issues, full URL for external refs.
+
+## Logs / output (optional)
+
+<details>
+<summary>Click to expand</summary>
+
+```
+<!-- paste error logs, stack traces, container output here -->
+```
+
+</details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,31 @@
+---
+name: Enhancement / feature request
+about: Propose new behavior, an improvement, or a cleanup
+title: "feat(<scope>): "
+labels: enhancement
+---
+
+<!--
+Title format: feat(<scope>): <short summary> (use refactor/, docs/, chore/ etc. when fitting)
+Add a scope label too so /next can rank it.
+-->
+
+## Motivation
+
+Who benefits and why now. If this is driven by a specific user signal, link it. If it's solo-maintainer scratch-your-own-itch, say so — that's a valid signal too, just be explicit.
+
+## Proposal
+
+Concrete change, scoped tightly. Files/components touched, expected new behavior.
+
+## Alternatives
+
+Other options considered and why they were rejected. If "none considered", say so — keeps the decision audit-trail honest.
+
+## Acceptance
+
+A concrete, observable check or success criterion. Done = …
+
+## Related
+
+ADRs, prior issues, design memory snapshots, similar work in other containers.


### PR DESCRIPTION
## Summary

Adds GitHub issue templates so future bug reports and enhancements arrive with consistent, decision-supporting structure.

- `bug.md` — symptom / reproduction / expected vs actual / root cause / acceptance / related
- `enhancement.md` — motivation / proposal / alternatives / acceptance / related
- `config.yml` — keeps blank issues enabled (solo-maintainer fallback), no external contact links

Title prefilled with conventional commit format (`fix(<scope>):` / `feat(<scope>):`) so issues, commits, and PRs share the same scope/type vocabulary the repo already uses.

## Why now

Phase B follow-up. The "Issues vs TODO.md" rule (CLAUDE.md global) routes contributable / cross-PR / public-narrative work to issues. With `/next` now scanning open issues alongside TODO.md, having a structured body up-front makes prioritization cheaper. First test case: #337 (terraform empty `data-tag`).

## Test plan

- [ ] Open a new issue from the GitHub UI; verify both templates appear in the picker
- [ ] "Bug report" pre-fills `fix(<scope>): ` title and `bug` label
- [ ] "Enhancement" pre-fills `feat(<scope>): ` title and `enhancement` label
- [ ] Blank issue option still available for edge cases
