### PR TITLE
fix(dashboard): preserve variant entries when Trivy API fails

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -506,7 +506,7 @@ collect_variant_json() {
         + (if ($sbom_packages | keys | length) > 0 then {sbom_packages: $sbom_packages} else {} end)
         + (if ($changelog | keys | length) > 0 then {changelog: $changelog} else {} end)
         + (if ($build_history | length) > 0 then {build_history: $build_history} else {} end)
-        + (if $trivy_summary.last_scan != null then {trivy_summary: $trivy_summary} else {} end)
+        + (if ($trivy_summary | type) == "object" and $trivy_summary.last_scan != null then {trivy_summary: $trivy_summary} else {} end)
         + (if ($extensions | type) == "array" and ($extensions | length) > 0 then {extensions: $extensions} else {} end)
         + (if ($when_to_use | length) > 0 then {when_to_use: $when_to_use} else {} end)'
 }

--- a/helpers/trivy-utils.sh
+++ b/helpers/trivy-utils.sh
@@ -116,7 +116,13 @@ get_trivy_summary() {
     local result
     result=$(echo "$_TRIVY_SUMMARY_MAP" | jq --arg cat "$category" '.[$cat] // empty' 2>/dev/null)
 
-    if [[ -z "$result" ]]; then
+    # Defensive: ensure result is a JSON object before emitting. If the cache is
+    # in a partial/corrupt state (e.g. subshell raced an API outage and stored
+    # an array), returning a non-object here would crash downstream jq with
+    # "Cannot index array with string 'last_scan'", silently blanking the
+    # entire variant entry in containers.yml. Force the empty form on any
+    # type mismatch.
+    if [[ -z "$result" ]] || ! echo "$result" | jq -e 'type == "object"' >/dev/null 2>&1; then
         echo "$_TRIVY_EMPTY"
     else
         echo "$result"


### PR DESCRIPTION
Closes #337

## Summary

Fixes the P1 dashboard issue where 4-5 container cards (terraform, github-runner, web-shell, etc.) render variant tags with empty `data-tag=""`, empty name, empty sizes.

## Root cause (verified in CI logs of run 25153819624)

`gh api code-scanning/alerts` fails intermittently during dashboard generation (auth window race during workflow ramp-up, transient network). The Trivy summary cache then holds a non-object value for some SARIF categories. Downstream `jq` in `collect_variant_json` crashes on `$trivy_summary.last_scan` with `Cannot index array with string "last_scan"`, silently blanking the entire variant entry — `data-tag=""`, empty name, empty sizes — for whichever container was being processed during the outage.

Postgres processed BEFORE the API outage in the most recent run (07:50:18) → variants populated. Terraform processed DURING the outage (07:50:20 onward, ~76s window) → variants blanked. The bug was never about terraform's variants.yaml schema.

## Why two defensive layers

The cache lives in process-level shell variables; each `get_trivy_summary` call runs in a `$(...)` subshell, so the cache is rebuilt from scratch per variant. That makes intermittent API failures during a single dashboard run produce a mix of valid and corrupt cache states across variants. Both layers harden against that race:

- **`helpers/trivy-utils.sh`** — `get_trivy_summary` now validates the lookup result is a JSON object before emitting. Falls back to the empty form on any type mismatch (array, null, malformed).
- **`generate-dashboard.sh`** — the variant assembly check on `$trivy_summary` guards on `type == "object"` before reading `.last_scan`, so a bad value omits only the optional trust-strip Trivy field instead of poisoning the whole variant record.

## Test plan

- [x] Unit-tested `get_trivy_summary` with corrupt cache (array, wrong-type value at category key, valid object) — all 3 cases handled correctly
- [x] Tested `jq` defensive in `generate-dashboard.sh` with simulated `$trivy_summary` as array — variant entry emitted correctly, only `trivy_summary` field omitted
- [ ] CI: green on shellcheck + dashboard build
- [ ] Live verification: terraform card shows populated variant buttons after Pages redeploys

## Out of scope (separate work)

- The underlying subshell-cache rebuilding inefficiency (each variant pays an API call) — tracked as part of the broader trust-strip data pipeline work referenced in #339
- The `gh api code-scanning/alerts` auth window race itself — the workflow's `permissions.security-events: read` may need to be added explicitly; deferring to #339 / triage
- SBOM badge visibility (#339) — separate fix needed, requires OCI subject digest plumbing into lineage records (per codex review of broader plan)
