### PR TITLE
fix(ci): allow GHCR base image cache on own-repo pull requests

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -288,9 +288,14 @@ jobs:
   cache-base-images:
     name: Cache base images
     needs: [detect-containers]
+    # Run on push, workflow_dispatch, and own-repo PRs. Fork PRs are skipped
+    # because they lack GHCR write permission — they fall through to Docker Hub
+    # (and may 429, but that is GitHub's per-fork-PR limitation, not ours).
+    # Note: head.repo.full_name is read in an `if:` evaluation context only,
+    # never piped to shell — no injection surface.
     if: |
       needs.detect-containers.outputs.count > 0 &&
-      github.event_name != 'pull_request'
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -473,7 +478,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          use_base_cache: ${{ github.event_name != 'pull_request' }}
+          use_base_cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
 
       - name: Retry build on failure
@@ -494,7 +499,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          use_base_cache: ${{ github.event_name != 'pull_request' }}
+          use_base_cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
 
       - name: Handle build failure


### PR DESCRIPTION
Closes #331
Closes #330

## Summary

Fixes the CI matrix builds that were 429-failing on every PR by allowing own-repo PRs to use the GHCR base-image cache.

## Root cause (verified in CI logs of run 25134588164)

The build action input `use_base_cache` was passed as `${{ github.event_name != 'pull_request' }}`, hardcoding `false` on every PR. With `use_base_cache=false`, the GHCR-cache verification loop in `build-container/action.yaml:367-381` was never reached and the build went directly against Docker Hub. The maintainer's anonymous Docker Hub quota was exhausted → HTTP 429 → matrix builds failed → CI auto-filed #330 (and #331 captured the pattern).

The `cache-base-images` job was disabled on PRs by the same guard. So even if GHCR had stale cache from a previous master push, no fresh cache was being built for the PR's version. (The action's verification loop already handles "tag missing in GHCR" — it iterates entries and accepts any reachable one — so this part was actually OK; it was the hard-coded `use_base_cache=false` that prevented even attempting GHCR.)

The original guard was meant to protect against fork PRs that lack GHCR write permission. The fix replaces the blanket `event_name != 'pull_request'` with a fork-aware check.

## What changed

| Location | Before | After |
|---|---|---|
| `cache-base-images` job condition | `event_name != 'pull_request'` | `event_name != 'pull_request' \|\| pr.head.repo.full_name == github.repository` |
| `build-container` initial step `use_base_cache` | same blanket | same fork-aware check |
| `build-container` retry step `use_base_cache` | same blanket | same fork-aware check |

Fork PRs continue to skip the cache path (they cannot push to GHCR) and still use Docker Hub fallback. They may still 429 on a busy maintainer quota — that's a GitHub-Actions-from-fork limitation, not addressable here.

`head.repo.full_name` is only read inside an `if:` expression context — never piped to a shell — so no command-injection surface.

## Test plan

- [ ] CI green on this PR (lint, typecheck, etc.)
- [ ] On merge, run `auto-build.yaml` against a synthetic version-bump PR (or wait for the next upstream-monitor PR) and observe:
  - `cache-base-images` job now runs
  - `Build container with retry logic` step shows `use_base_cache: true`
  - Verification loop logs `✅ GHCR cache verified via …`
  - No `HTTP 429` / `toomanyrequests` from Docker Hub in the matrix logs
- [ ] After confirmation, mark #330 and #331 closed automatically via the merge commit.

## Out of scope (different work)

- #332 (Trivy SARIF CRITICAL-only severity filter) — separate policy decision, deferred to Group B in the triage plan.
- #339 (SBOM / Trivy badge data pipeline) — needs OCI subject-digest plumbing into lineage, separate PR.
- The `cache-base-images` job time on every own-repo PR (~1-2 min for the changed container set) — acceptable trade-off vs. 429 outages on fresh version bumps.
