### PR TITLE
docs(verify-images): document Trivy CRITICAL-only dashboard policy

### DIFF
--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -39,6 +39,17 @@ gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate \
   -q '.[] | select(.most_recent_instance.category == "container-postgres-18-alpine-linux/amd64")'
 ```
 
+### Why the dashboard only highlights CRITICAL counts
+
+Each container card's Trivy badge surfaces the count of **CRITICAL**-severity findings only. High, medium, low, and informational findings are still scanned, still uploaded to GitHub Code Scanning, and still queryable through the API command above — they are intentionally not promoted to the dashboard headline.
+
+Two reasons for this choice:
+
+- **Signal vs noise.** A solo-maintained container catalog routinely carries dozens of low/medium advisories that originate in upstream base images and that the maintainer cannot fix directly. Showing the full count on the dashboard would normalize a constantly red badge and erode the meaning of "go look at this image's security posture." CRITICAL is the cut-off where downstream consumers should pause and verify before pulling.
+- **Defense in depth, not single source of truth.** GitHub's Security tab (and the `gh api` query above) remains the authoritative full-detail view for anyone running their own risk assessment. The dashboard is a glanceable surface, not a replacement for the Code Scanning UI.
+
+If you operate this catalog yourself and prefer a different threshold, the SARIF severity filter lives in `.github/actions/build-container/action.yaml` (search for the `trivy-action` step) and the dashboard summary aggregation in `helpers/trivy-utils.sh`. Both are plain code; widening the threshold is a one-line change in each file plus a fresh dashboard regeneration.
+
 ## Inspecting multi-arch manifests
 
 Multi-arch images publish a manifest list that references per-platform image manifests. To see which CPU architectures are present for any tag:


### PR DESCRIPTION
Closes #332

## Summary

Documents the Trivy severity policy on `/verify-images/` instead of widening the SARIF severity filter.

The dashboard's Trivy badge has been surfacing only CRITICAL counts since the trust strip shipped (PR #329). #332 flagged that the high/medium/low/info buckets always show 0, leaving readers wondering whether the dashboard is broken or the policy is intentional.

This change is option **B1** from the triage discussion: take the cheap-and-honest path of explaining the policy, rather than option B2 which would have widened the SARIF upload to include lower-severity findings. The B2 path was rejected because:

- Lower-severity findings are dominated by upstream base-image advisories the maintainer cannot fix directly. A constantly red badge would erode meaning.
- A solo maintainer cannot triage hundreds of low/info findings, so promoting them is performative rather than informative.
- The full Security tab + `gh api code-scanning/alerts` remains available for anyone running their own risk assessment.

## What the new section says

- Trivy badge = CRITICAL count only, by design.
- High/medium/low/info findings are still scanned, still uploaded to GitHub Code Scanning, still queryable via the existing `gh api` example earlier in the page.
- Two reasons: signal-vs-noise (upstream-driven advisories) and defense-in-depth (Security tab is the authoritative view).
- Pointer to the two code locations that govern the threshold (build-container action SARIF filter + `helpers/trivy-utils.sh`) for anyone who wants to widen it in their own fork.

## Test plan

- [ ] CI green (Jekyll build, shellcheck if any)
- [ ] After merge + Pages redeploy, the new section renders correctly in the "Reading Trivy scan results" portion of `/verify-images/`
- [ ] Heading hierarchy stays consistent (no orphan `###` under a closed `##`)

## Out of scope

- The underlying severity-filter code in `build-container/action.yaml` is unchanged. Future maintainers (or a fork) can flip the policy via the two pointers documented in the new section.
- `<security-scan>` web component on container detail pages is unaffected — it already shows the full per-severity breakdown when alerts exist; this PR is only about the dashboard headline policy.
