### PR TITLE
feat(dashboard): wire trust strip to OCI digest + Trivy scan-history

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -448,6 +448,7 @@ runs:
       continue-on-error: true  # Vulnerability scan is advisory — don't block builds on findings
 
     - name: Generate SARIF report
+      id: trivy-sarif
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' }}
       uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
@@ -460,6 +461,36 @@ runs:
         cache-dir: ~/.cache/trivy
         timeout: '15m0s'
       continue-on-error: true  # SARIF generation failure should not block build
+
+    - name: Write Trivy scan history
+      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.trivy-sarif.outcome == 'success' }}
+      shell: bash
+      run: |
+        container="${{ inputs.container }}"
+        current_tag="${{ steps.check-build.outputs.current_tag }}"
+        platform="${{ inputs.platform }}"
+
+        # Replace '/' with '-' for filename safety (e.g. linux/amd64 → linux-amd64)
+        platform_safe="${platform//\//-}"
+
+        mkdir -p .trivy-scan-history
+
+        last_scan="$(date -Iseconds)"
+        alert_count=0
+        status="clean"
+
+        # Parse SARIF if it exists to count actual findings
+        if [[ -f trivy-results.sarif ]]; then
+          alert_count=$(jq '[.runs[].results // [] | .[]] | length' trivy-results.sarif 2>/dev/null || echo 0)
+          if [[ "$alert_count" -gt 0 ]]; then
+            status="dirty"
+          fi
+        fi
+
+        scan_file=".trivy-scan-history/${container}-${current_tag}-${platform_safe}.json"
+        printf '{"last_scan":"%s","alert_count":%s,"status":"%s","scanned_severity":"CRITICAL"}\n' \
+          "$last_scan" "$alert_count" "$status" > "$scan_file"
+        echo "::notice::Wrote Trivy scan history to $scan_file (alert_count=$alert_count, status=$status)"
 
     - name: Upload SARIF to GitHub Security
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' }}
@@ -582,6 +613,44 @@ runs:
           echo "::notice::Layers flattened for $image_ref" || \
           echo "::warning::Layer flattening failed — image still usable with original layers"
         echo "::endgroup::"
+      continue-on-error: true
+
+    # Capture the FINAL OCI subject digest for the platform-suffixed image — this
+    # must run after `crane flatten` so the digest reflects the published artifact,
+    # not the pre-flatten manifest. The dashboard's SBOM badge resolves attestations
+    # via this digest, so a stale value here means a broken attestation lookup.
+    - name: Capture OCI subject digest
+      if: ${{ steps.push-ghcr.outputs.success == 'true' && runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        image_name="${{ steps.check-build.outputs.image_name }}"
+        current_tag="${{ steps.check-build.outputs.current_tag }}"
+        platform_suffix="${{ steps.check-build.outputs.platform_suffix }}"
+        lineage_file=".build-lineage/${image_name##*/}-${current_tag}.json"
+
+        # Resolve the OCI digest of the platform-suffixed image that was just pushed
+        # AND flattened. The platform-suffixed tag was pushed in this very job and
+        # then rewritten in-place by `crane flatten`, so its current digest is the
+        # final published artifact — unambiguously this build's.
+        platform_tag="ghcr.io/$image_name:$current_tag-$platform_suffix"
+        # Use buildx's top-level `.Digest` template field — this is the tag's
+        # subject digest (sha256:…), the value `actions/attest-sbom` signs and
+        # the GitHub attestations API is keyed on. NOT `.Manifest.digest`,
+        # which is the inner manifest's identity and may not be set on indexes.
+        oci_digest=$(docker buildx imagetools inspect \
+          "$platform_tag" \
+          --format '{{.Digest}}' 2>/dev/null | tr -d '[:space:]' || true)
+
+        if [[ -z "$oci_digest" ]]; then
+          echo "::warning::Could not resolve OCI subject digest for $platform_tag — skipping"
+        elif [[ -f "$lineage_file" ]]; then
+          tmp=$(mktemp)
+          jq --arg d "$oci_digest" '.oci_subject_digest = $d' "$lineage_file" > "$tmp" \
+            && mv "$tmp" "$lineage_file"
+          echo "::notice::OCI subject digest captured (post-flatten): $oci_digest"
+        else
+          echo "::warning::Lineage file not found at $lineage_file — OCI digest not saved"
+        fi
       continue-on-error: true
 
     # Push bare tag immediately so images are pullable without waiting for manifest job.

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -651,6 +651,16 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+      - name: Upload Trivy scan history
+        if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.build.os != 'windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: trivy-scan-history-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
+          path: .trivy-scan-history/
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
       # SBOM generation (amd64 only — packages are identical across arches)
       - name: Install syft
         id: install-syft
@@ -671,11 +681,18 @@ jobs:
           generate_sbom "$image_ref" "$sbom_file"
           echo "sbom_file=$sbom_file" >> "$GITHUB_OUTPUT"
 
-          # Capture digest for attestation (from local image after push)
-          digest=$(docker inspect --format='{{range .RepoDigests}}{{.}}{{end}}' "$image_ref" 2>/dev/null | head -1 | sed 's/.*@//' || echo "")
+          # Capture digest for attestation. Use the registry's POST-flatten digest
+          # (via `docker buildx imagetools inspect --format '{{.Digest}}'`) so the
+          # attestation subject matches the published artifact and matches what
+          # `.github/actions/build-container/action.yaml`'s "Capture OCI subject
+          # digest" step writes into the lineage file. `docker inspect ...
+          # RepoDigests` returns the LOCAL pre-flatten digest, which would create
+          # a mismatch — attestation signed for digest A, dashboard looking up B.
+          digest=$(docker buildx imagetools inspect "$image_ref" \
+            --format '{{.Digest}}' 2>/dev/null | tr -d '[:space:]' || echo "")
           if [[ -z "$digest" ]]; then
-            # Fallback: query registry
-            digest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null | sha256sum | awk '{print "sha256:"$1}' || echo "")
+            # Fallback: legacy local-inspect path (pre-flatten, but better than nothing)
+            digest=$(docker inspect --format='{{range .RepoDigests}}{{.}}{{end}}' "$image_ref" 2>/dev/null | head -1 | sed 's/.*@//' || echo "")
           fi
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
         continue-on-error: true
@@ -1020,12 +1037,38 @@ jobs:
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
 
+      - name: Restore Trivy scan history cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .trivy-scan-history
+          key: trivy-scan-history-${{ github.run_id }}
+          restore-keys: trivy-scan-history-
+
       - name: Download current build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: build-lineage-*
           path: .build-lineage-artifacts/
           merge-multiple: false
+
+      - name: Download Trivy scan history artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: trivy-scan-history-*
+          path: .trivy-scan-history-artifacts/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Merge Trivy scan history files
+        run: |
+          mkdir -p .trivy-scan-history
+          if [ -d ".trivy-scan-history-artifacts" ]; then
+            find .trivy-scan-history-artifacts -name '*.json' -exec cp {} .trivy-scan-history/ \;
+            count=$(find .trivy-scan-history -name '*.json' | wc -l)
+            echo "Consolidated $count Trivy scan history file(s)"
+          else
+            echo "No Trivy scan history artifacts found"
+          fi
 
       - name: Merge lineage files
         id: merge
@@ -1096,6 +1139,12 @@ jobs:
         with:
           path: .build-lineage
           key: build-lineage-${{ github.run_id }}
+
+      - name: Save Trivy scan history cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .trivy-scan-history
+          key: trivy-scan-history-${{ github.run_id }}
 
   update-dashboard:
     needs: [detect-containers, build-and-push, create-manifest, cache-lineage]

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -64,6 +64,13 @@ jobs:
           key: build-lineage-never-exact-match
           restore-keys: build-lineage-
 
+      - name: Restore Trivy scan history cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .trivy-scan-history
+          key: trivy-scan-history-never-exact-match
+          restore-keys: trivy-scan-history-
+
       - name: Snapshot pull/star counts (idempotent per day)
         run: |
           chmod +x scripts/snapshot-stats.sh

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -279,17 +279,21 @@ yaml_escape() {
 # These functions build container data as JSON objects, eliminating the need
 # for manual YAML string construction. The JSON is converted to YAML via yq.
 
-# Resolve variant lineage data as JSON: {build_digest, base_image}
-# Includes version mismatch check and fallback base_image derivation
+# Resolve variant lineage data as JSON: {build_digest, base_image, oci_subject_digest}
+# Includes version mismatch check and fallback base_image derivation.
+# `oci_subject_digest` is propagated from the raw lineage file when present so
+# downstream attestation lookups can use the OCI digest (the value the
+# attestations API is keyed on) rather than the internal build-cache digest.
 resolve_variant_lineage_json() {
     local container="$1" tag="$2" version="$3" fallback_base_image="${4:-unknown}" flavor="${5:-}"
 
-    local lineage_file build_digest="unknown" base_image="unknown"
+    local lineage_file build_digest="unknown" base_image="unknown" oci_subject_digest=""
     lineage_file=$(resolve_variant_lineage_file "$container" "$tag" "$flavor")
 
     if [[ -n "$lineage_file" ]]; then
         build_digest=$(jq -r '.build_digest // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
         base_image=$(jq -r '.base_image_ref // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
+        oci_subject_digest=$(jq -r '.oci_subject_digest // empty' "$lineage_file" 2>/dev/null || echo "")
         # Version mismatch check: lineage file may be from a different version
         if [[ "$base_image" != "unknown" ]]; then
             local lineage_ver
@@ -302,6 +306,7 @@ resolve_variant_lineage_json() {
             if [[ -n "$lineage_major" && -n "$version_major" && "$lineage_major" != "$version_major" ]]; then
                 base_image="${base_image%%:*}:${version}"
                 build_digest="unknown"
+                oci_subject_digest=""
             fi
         fi
     else
@@ -312,8 +317,8 @@ resolve_variant_lineage_json() {
         fi
     fi
 
-    BD="$build_digest" BI="$base_image" \
-        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI)'
+    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
 }
 
 # --- SBOM data helpers ---
@@ -430,10 +435,21 @@ collect_variant_json() {
     changelog=$(get_changelog "$container" "$sbom_tag")
     build_history=$(get_build_history "$container" "$sbom_tag")
 
-    # Attestation: look up SBOM attestation ID from GitHub Attestations API
-    local build_digest attestation_id="" attestation_url=""
-    build_digest=$(echo "$lineage_json" | jq -r '.build_digest // "unknown"')
-    if attestation_id=$(get_attestation_id "$build_digest"); then
+    # Attestation: look up SBOM attestation ID from GitHub Attestations API.
+    # The attestations API is keyed on the OCI subject digest (sha256:…) that
+    # `actions/attest-sbom` signs — NOT the internal build-cache digest. Prefer
+    # `.oci_subject_digest` when the build pipeline has captured it; fall back
+    # to `.build_digest` for older lineage files predating the post-flatten
+    # capture step. NB: jq's `//` only treats null/false as missing, so an
+    # empty-string `.oci_subject_digest` would short-circuit incorrectly — the
+    # explicit shell-level check below handles that case.
+    local subject_digest attestation_id="" attestation_url=""
+    subject_digest=$(echo "$lineage_json" | jq -r '.oci_subject_digest // empty')
+    if [[ -z "$subject_digest" ]]; then
+        subject_digest=$(echo "$lineage_json" | jq -r '.build_digest // "unknown"')
+    fi
+    if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
+        && attestation_id=$(get_attestation_id "$subject_digest"); then
         attestation_url=$(get_attestation_url "$attestation_id")
     fi
 

--- a/helpers/trivy-utils.sh
+++ b/helpers/trivy-utils.sh
@@ -106,15 +106,30 @@ get_trivy_summary() {
 
     _fetch_trivy_alerts_once
 
-    # Fast lookup: the full jq processing was done once in _fetch_trivy_alerts_once.
-    # _TRIVY_SUMMARY_MAP is a JSON object keyed by SARIF category.
-    if [[ -z "${_TRIVY_SUMMARY_MAP:-}" || "$_TRIVY_SUMMARY_MAP" == "{}" ]]; then
-        echo "$_TRIVY_EMPTY"
-        return 0
+    # --- Side-channel: read scan-history file if available ---
+    # Category format: container-<name>-<tag>-<platform>  (platform contains '/')
+    # e.g. container-postgres-18-alpine-linux/amd64
+    # Strip the leading "container-" prefix, then replace '/' with '-' for the filename.
+    # Resolve under the parent script's SCRIPT_DIR (the repo root) when set —
+    # generate-dashboard.sh works from any cwd, so this lookup must too. Fall
+    # back to cwd when sourced standalone (e.g. self-test).
+    local sc_root sc_relative sc_file sc_last_scan
+    sc_root="${SCRIPT_DIR:-.}"
+    sc_relative="${category#container-}"         # postgres-18-alpine-linux/amd64
+    sc_file="$sc_root/.trivy-scan-history/${sc_relative//\//-}.json"   # postgres-18-alpine-linux-amd64.json
+    sc_last_scan=""
+    if [[ -f "$sc_file" ]]; then
+        sc_last_scan=$(jq -r '.last_scan // empty' "$sc_file" 2>/dev/null || true)
     fi
 
+    # Fast lookup: the full jq processing was done once in _fetch_trivy_alerts_once.
+    # _TRIVY_SUMMARY_MAP is a JSON object keyed by SARIF category.
     local result
-    result=$(echo "$_TRIVY_SUMMARY_MAP" | jq --arg cat "$category" '.[$cat] // empty' 2>/dev/null)
+    if [[ -z "${_TRIVY_SUMMARY_MAP:-}" || "$_TRIVY_SUMMARY_MAP" == "{}" ]]; then
+        result=""
+    else
+        result=$(echo "$_TRIVY_SUMMARY_MAP" | jq --arg cat "$category" '.[$cat] // empty' 2>/dev/null)
+    fi
 
     # Defensive: ensure result is a JSON object before emitting. If the cache is
     # in a partial/corrupt state (e.g. subshell raced an API outage and stored
@@ -122,6 +137,33 @@ get_trivy_summary() {
     # "Cannot index array with string 'last_scan'", silently blanking the
     # entire variant entry in containers.yml. Force the empty form on any
     # type mismatch.
+    # Side-channel takes precedence over API when present. The Code Scanning
+    # API indexes SARIF uploads asynchronously and can lag the in-pipeline
+    # scan by minutes; the side-channel was written by THIS very pipeline run
+    # and is therefore the authoritative source of truth for "what did this
+    # scan produce". When the side-channel exists we synthesize the entire
+    # summary from `_TRIVY_EMPTY` and overlay side-channel fields, so any stale
+    # API data (e.g. old open advisories that the latest scan no longer flags)
+    # is dropped. The SARIF upload is CRITICAL-only by policy (see
+    # `/verify-images/`), so `alert_count` IS the critical count by definition;
+    # high/medium/low/info stay zero and top_advisories stays empty.
+    if [[ -n "$sc_last_scan" ]]; then
+        local sc_alert_count
+        sc_alert_count=$(jq -r '.alert_count // 0' "$sc_file" 2>/dev/null || echo 0)
+        echo "$_TRIVY_EMPTY" | jq \
+            --arg ls "$sc_last_scan" \
+            --argjson ac "$sc_alert_count" \
+            '.last_scan = $ls | .counts.critical = $ac'
+        return 0
+    fi
+
+    # No side-channel data — fall back to API result (or empty form on failure).
+    if [[ -z "$result" ]] || ! echo "$result" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        echo "$_TRIVY_EMPTY"
+        return 0
+    fi
+
+    # Re-validate after potential mutation
     if [[ -z "$result" ]] || ! echo "$result" | jq -e 'type == "object"' >/dev/null 2>&1; then
         echo "$_TRIVY_EMPTY"
     else
@@ -138,3 +180,83 @@ build_trivy_category() {
     local container="$1" tag="$2" platform="$3"
     echo "container-${container}-${tag}-${platform}"
 }
+
+# ---------------------------------------------------------------------------
+# Self-test (runs only when script is executed directly: bash helpers/trivy-utils.sh)
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+
+    echo "Running trivy-utils self-test..."
+
+    # Create a temporary scan-history directory and fake file
+    _test_dir=$(mktemp -d)
+    trap 'rm -rf "$_test_dir"' EXIT
+
+    mkdir -p "$_test_dir/.trivy-scan-history"
+    printf '{"last_scan":"2026-04-30T10:00:00Z","alert_count":0,"status":"clean"}\n' \
+        > "$_test_dir/.trivy-scan-history/container-fake-1.0-linux-amd64.json"
+
+    # Change into the temp dir so the relative path ".trivy-scan-history/..." resolves
+    pushd "$_test_dir" > /dev/null
+
+    # Simulate empty API: override the cache map so _fetch_trivy_alerts_once is a no-op
+    _TRIVY_ALERTS_CACHE="[]"
+    _TRIVY_SUMMARY_MAP="{}"
+
+    result=$(get_trivy_summary "container-container-fake-1.0-linux/amd64")
+
+    popd > /dev/null
+
+    last_scan=$(echo "$result" | jq -r '.last_scan')
+
+    if [[ "$last_scan" == "2026-04-30T10:00:00Z" ]]; then
+        echo "PASS test-1: last_scan = $last_scan (non-null, correct value)"
+    else
+        echo "FAIL test-1: expected last_scan=2026-04-30T10:00:00Z, got: $last_scan"
+        echo "Full result: $result"
+        exit 1
+    fi
+    critical=$(echo "$result" | jq -r '.counts.critical')
+    if [[ "$critical" == "0" ]]; then
+        echo "PASS test-1: counts.critical = 0 (clean scan, correct)"
+    else
+        echo "FAIL test-1: expected counts.critical=0 for clean scan, got: $critical"
+        echo "Full result: $result"
+        exit 1
+    fi
+
+    # Test 2: side-channel has alert_count=3 (dirty CRITICAL scan), API map is empty.
+    # Expected: last_scan non-null AND counts.critical == 3.
+    printf '{"last_scan":"2026-04-30T11:00:00Z","alert_count":3,"status":"dirty","scanned_severity":"CRITICAL"}\n' \
+        > "$_test_dir/.trivy-scan-history/container-dirty-2.0-linux-amd64.json"
+
+    pushd "$_test_dir" > /dev/null
+
+    _TRIVY_ALERTS_CACHE="[]"
+    _TRIVY_SUMMARY_MAP="{}"
+
+    result2=$(get_trivy_summary "container-container-dirty-2.0-linux/amd64")
+
+    popd > /dev/null
+
+    last_scan2=$(echo "$result2" | jq -r '.last_scan')
+    critical2=$(echo "$result2" | jq -r '.counts.critical')
+
+    if [[ "$last_scan2" == "2026-04-30T11:00:00Z" ]]; then
+        echo "PASS test-2: last_scan = $last_scan2 (non-null, correct value)"
+    else
+        echo "FAIL test-2: expected last_scan=2026-04-30T11:00:00Z, got: $last_scan2"
+        echo "Full result: $result2"
+        exit 1
+    fi
+    if [[ "$critical2" == "3" ]]; then
+        echo "PASS test-2: counts.critical = $critical2 (side-channel alert_count propagated correctly)"
+    else
+        echo "FAIL test-2: expected counts.critical=3, got: $critical2"
+        echo "Full result: $result2"
+        exit 1
+    fi
+
+    echo "All self-tests passed."
+fi

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -186,6 +186,7 @@ _emit_build_lineage() {
   "runtime": "$runtime_info",
   "image_id": "${image_id:-unknown}",
   "build_digest": "${BUILD_DIGEST:-unknown}",
+  "oci_subject_digest": "${OCI_SUBJECT_DIGEST:-}",
   "base_image_ref": "${_BASE_IMAGE_REF:-unknown}",
   "base_image_digest": "${_BASE_DIGEST:-unresolved}",
   "built_at": "$build_ts",


### PR DESCRIPTION
Closes #339

## Summary

Wires the trust-strip Trivy + SBOM badges to actually populated data per the V2 plan agreed in triage. Two pillars:

1. **Trivy scan-history side-channel.** Every CI scan now writes `.trivy-scan-history/<container>-<tag>-<platform>.json` with `{last_scan, alert_count, status, scanned_severity}` — including when the scan is clean. The dashboard reads this as the authoritative source for `last_scan` + `counts.critical`, falling back to GitHub Code Scanning API only when the side-channel is absent. Resolves the "freshly clean scan still shows yesterday's advisories" lag from async SARIF indexing.
2. **OCI subject digest in lineage.** Build action captures the post-flatten OCI digest of the platform-suffixed GHCR tag and writes it to `.build-lineage/<container>-<tag>.json`. The auto-build SBOM step uses the same post-flatten digest source for `actions/attest-sbom`, so attestation subject and dashboard lookup key match. `generate-dashboard.sh` prefers `oci_subject_digest` over the internal `build_digest` when querying the GitHub attestations API (which is keyed on OCI digest, not build-cache digest — that was the old bug).

User-visible result: after this lands and a new CI cycle completes, the trust strip on each container card will display the Trivy badge consistently (with `0 critical · scanned <date>` for clean images, `N critical · scanned <date>` for dirty), and the SBOM badge will resolve to the actual Sigstore attestation viewer instead of staying hidden.

## Review history

8 successive codex xhigh review passes (`/llm --codex --review --uncommitted`). Each pass found new correctness bugs that the previous one missed because the surface is genuinely complex (CI infra timing + jq edge cases + cache propagation + async API + crane flatten manifest rewriting). All 12 catches were legitimate; full sequence:

| # | Pri | Issue | Fix location |
|---|---|---|---|
| 1 | P2 | OCI digest race — bare tag inspected pre-alias | action.yaml: switched to platform-suffixed tag |
| 2 | P2 | Scan-history not propagated across matrix → cache-lineage | auto-build.yaml: upload-artifact + download-artifact + merge |
| 3 | P2 | Failed SARIF treated as clean scan | action.yaml: gate scan-history step on `steps.trivy-sarif.outcome == 'success'` |
| 4 | P2 | Wrong counts when API absent but side-channel dirty | trivy-utils.sh: synthesize critical from `alert_count` |
| 5 | P2 | Capture digest before `crane flatten` rewrites tag | action.yaml: moved capture to post-flatten |
| 6 | P2 | `{{json .Manifest}}.digest` returns null on indexes | action.yaml: use buildx top-level `{{.Digest}}` |
| 7 | P2 | Captured `oci_subject_digest` not consumed by dashboard | generate-dashboard.sh: prefer `oci_subject_digest` over `build_digest` |
| 8 | P2 | `resolve_variant_lineage_json` didn't propagate the field | generate-dashboard.sh: read from raw lineage file, emit in synth JSON |
| 9 | P2 | SBOM step's digest source was pre-flatten `docker inspect` | auto-build.yaml: switched to post-flatten `imagetools inspect` |
| 10 | P2 | `unknown` literal short-circuits the empty-string fallback | build-container.sh: empty default instead of `unknown` |
| 11 | P2 | Side-channel only filled `last_scan`, kept stale API counts | trivy-utils.sh: side-channel always wins, synthesize from `_TRIVY_EMPTY` |
| 12 | P3 | Scan-history path not cwd-independent | trivy-utils.sh: resolve under `${SCRIPT_DIR:-.}` |

## Self-test (local)

`bash helpers/trivy-utils.sh` runs an inline test asserting:
- Clean scan (`alert_count: 0, status: clean`) → `last_scan` non-null, `counts.critical: 0`
- Dirty scan (`alert_count: 3, status: dirty`) → `last_scan` non-null, `counts.critical: 3`

Both pass on the final tree.

## Test plan

- [ ] CI green on this PR (lint, shellcheck, codeql)
- [ ] On merge, run `auto-build.yaml` against a synthetic version-bump PR (or wait for the next upstream-monitor PR) and observe:
  - `.trivy-scan-history/` artifacts uploaded from each matrix job, downloaded into cache-lineage
  - `_data/containers.yml` has `oci_subject_digest` populated for at least one container variant
  - GitHub attestations API returns a result for that digest (verify via `gh api repos/oorabona/docker-containers/attestations?subject_digest=<digest>`)
- [ ] Live dashboard after Pages redeploy: Trivy badge visible on every container card with `scanned <date>`; SBOM badge clickable, leads to Sigstore attestation viewer
- [ ] No regression on cards where lineage hasn't been refreshed (graceful empty state)

## Out of scope

- Subshell-cache inefficiency (each variant pays an API call to populate `_TRIVY_SUMMARY_MAP`) — unchanged here, mentioned in #340 PR. Worth a separate refactor if dashboard generation time becomes an issue.
- Windows build path uses pre-flatten `docker inspect` for SBOM digest — Windows skips `crane flatten` (line break risk on Windows layers per existing comment), so its pre-flatten digest IS the final digest. No fix needed.

## Acknowledgement

The review loop was deeper than estimated. Initial estimate was 1.5h, actual was ~3.5h end-to-end including 8 codex passes. Worth it: every catch was a real correctness bug that would have shipped a broken trust-strip data path.
