### PR TITLE
fix(ci): hash raw manifest for OCI subject digest

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -633,13 +633,20 @@ runs:
         # then rewritten in-place by `crane flatten`, so its current digest is the
         # final published artifact — unambiguously this build's.
         platform_tag="ghcr.io/$image_name:$current_tag-$platform_suffix"
-        # Use buildx's top-level `.Digest` template field — this is the tag's
-        # subject digest (sha256:…), the value `actions/attest-sbom` signs and
-        # the GitHub attestations API is keyed on. NOT `.Manifest.digest`,
-        # which is the inner manifest's identity and may not be set on indexes.
-        oci_digest=$(docker buildx imagetools inspect \
-          "$platform_tag" \
-          --format '{{.Digest}}' 2>/dev/null | tr -d '[:space:]' || true)
+        # Compute the OCI subject digest by hashing the raw manifest content —
+        # this is what `actions/attest-sbom` signs (it does the same hash
+        # internally) and what the GitHub attestations API is keyed on. The
+        # `--format '{{.Digest}}'` and `--format '{{json .Manifest}}'` paths
+        # both proved unreliable in CI (empty output for some image types,
+        # version-dependent template fields). `--raw | sha256sum` is the
+        # documented fallback also used by the workflow's SBOM step (see
+        # auto-build.yaml's `Generate SBOM` step), so digest sources match.
+        raw_manifest=$(docker buildx imagetools inspect "$platform_tag" --raw 2>/dev/null || true)
+        if [[ -n "$raw_manifest" ]]; then
+          oci_digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+        else
+          oci_digest=""
+        fi
 
         if [[ -z "$oci_digest" ]]; then
           echo "::warning::Could not resolve OCI subject digest for $platform_tag — skipping"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -681,17 +681,19 @@ jobs:
           generate_sbom "$image_ref" "$sbom_file"
           echo "sbom_file=$sbom_file" >> "$GITHUB_OUTPUT"
 
-          # Capture digest for attestation. Use the registry's POST-flatten digest
-          # (via `docker buildx imagetools inspect --format '{{.Digest}}'`) so the
-          # attestation subject matches the published artifact and matches what
+          # Capture digest for attestation. Hash the raw manifest content from
+          # the registry — this is what `actions/attest-sbom` signs internally
+          # and what the GitHub attestations API is keyed on. Same approach as
           # `.github/actions/build-container/action.yaml`'s "Capture OCI subject
-          # digest" step writes into the lineage file. `docker inspect ...
-          # RepoDigests` returns the LOCAL pre-flatten digest, which would create
-          # a mismatch — attestation signed for digest A, dashboard looking up B.
-          digest=$(docker buildx imagetools inspect "$image_ref" \
-            --format '{{.Digest}}' 2>/dev/null | tr -d '[:space:]' || echo "")
-          if [[ -z "$digest" ]]; then
-            # Fallback: legacy local-inspect path (pre-flatten, but better than nothing)
+          # digest" step, so attestation subject and dashboard lookup match.
+          # `--format '{{.Digest}}'` proved unreliable in CI (empty output);
+          # `docker inspect ... RepoDigests` returns the LOCAL pre-flatten
+          # digest, which would mismatch the post-flatten registry artifact.
+          raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+          if [[ -n "$raw_manifest" ]]; then
+            digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+          else
+            # Fallback: local-inspect (pre-flatten) — last-resort, may mismatch
             digest=$(docker inspect --format='{{range .RepoDigests}}{{.}}{{end}}' "$image_ref" 2>/dev/null | head -1 | sed 's/.*@//' || echo "")
           fi
           echo "digest=$digest" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the OCI subject digest extraction that was silently no-op'ing on every build after #343 merged.

The first manual workflow execution (sslh, manual trigger) showed both arm64 and amd64 jobs logging `Could not resolve OCI subject digest for ghcr.io/.../sslh:v2.3.1-alpine-{arch} — skipping`. Codex's earlier review claimed `--format '{{.Digest}}'` would expose the top-level digest as a buildx template field, but in practice that field returned empty for the GHCR-hosted manifests we publish (likely a version-dependency in the buildx CLI).

## What changed

Switched both digest extraction sites to hash the raw manifest content via `docker buildx imagetools inspect <ref> --raw | sha256sum`. This is what the registry itself uses as the subject digest, what `actions/attest-sbom` signs internally, and what the GitHub attestations API is keyed on.

| Site | Before | After |
|---|---|---|
| `build-container` action — "Capture OCI subject digest" | `--format '{{.Digest}}'` (returned empty) | `--raw` + `sha256sum` |
| `auto-build.yaml` — SBOM step's `digest` output | Same template (returned empty); fallback to local `docker inspect` (pre-flatten, mismatch risk) | Same `--raw` + `sha256sum`; same legacy local-inspect kept as last-resort fallback |

Both sites now use the same canonical extraction so attestation subject and dashboard lookup digest agree.

## Test plan

- [ ] CI green
- [ ] On merge, trigger an `auto-build.yaml` manual run on a small container with variants (postgres or github-runner — sslh skipped because it has no variant schema, hits a separate pre-existing issue)
- [ ] Workflow log for the `Capture OCI subject digest` step shows `OCI subject digest captured (post-flatten): sha256:...` (NOT `Could not resolve`)
- [ ] After dashboard regen, `_data/containers.yml` for that container has `oci_subject_digest` populated, and the SBOM badge resolves to the GitHub attestation viewer when clicked

## Known follow-up (separate)

Versions-only containers (sslh, jekyll, openvpn, etc. — no `variants:` per version) currently have empty trust strip data because `default_variant` falls back to the container object, which doesn't carry per-variant fields like `trivy_summary` or `oci_subject_digest`. This is **unrelated to #339**, surfaced during validation. Worth a separate issue + PR — either synthesize a "single-variant-per-version" structure in `generate-dashboard.sh` or add a top-level fallback path in `_includes/container-card.html`.
