### PR TITLE
fix(dashboard): trust strip for versions-only containers

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -143,7 +143,20 @@
         <div class="version-label">{{ version.base_tag | default: version.tag }}</div>
         <div class="variant-tags">
           {% for variant in version.variants %}
+            {%- comment -%}
+              Versions-only containers synthesize a single variant with empty
+              `name` (the version itself IS the canonical build). Render the
+              tag with `display:none` so it stays invisible (the version-label
+              identifies the build) while preserving its data-* attributes
+              and `.selected` class — the trust-strip JS and detail-page
+              container-detail.js both initialize from .variant-tag.selected
+              and would lose data for the canonical build if the element were
+              skipped entirely.
+            {%- endcomment -%}
+            {%- assign synthetic = false -%}
+            {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
             <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
+                  {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
                   title="{{ variant.description }} — Click to select"
                   data-tag="{{ variant.tag }}"
                   data-size-amd64="{{ variant.size_amd64 | default: '' }}"

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -203,7 +203,20 @@
                 <h3 class="version-title">{{ version.base_tag | default: version.tag }}</h3>
                 <div class="variant-tags-row">
                   {% for variant in version.variants %}
+                    {%- comment -%}
+                      Versions-only containers carry a synthesized empty-name
+                      variant (the version itself IS the canonical build).
+                      Render with `display:none` to hide the unlabeled pill
+                      while preserving the data-* carrier — container-detail.js
+                      reads SBOM, changelog, build-history, and lineage data
+                      from .variant-tag.selected; skipping the element would
+                      blank Build Lineage / Security / Changelog sections for
+                      the very build this page documents.
+                    {%- endcomment -%}
+                    {%- assign synthetic = false -%}
+                    {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
                     <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
+                          {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
                           data-tag="{{ variant.tag }}"
                           data-size-amd64="{{ variant.size_amd64 | default: '' }}"
                           data-size-arm64="{{ variant.size_arm64 | default: '' }}"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -552,6 +552,30 @@ collect_variants_json() {
                 variants_arr=$(printf '%s\n%s' "$variants_arr" "$var_json" | jq -s '.[0] + [.[1]]')
             done < <(list_variants "$container_dir" "$ver_tag")
 
+            # Versions-only container (no per-version variants array, e.g. sslh,
+            # jekyll, openvpn): synthesize a single canonical variant from the
+            # version itself so trust-strip plumbing in container-card.html
+            # (which dereferences default_variant.trivy_summary etc.) has data
+            # to read. Without this, default_variant falls back to `include`
+            # and the trust strip silently shows no badges. Affects ~70% of
+            # the catalog. The synthetic variant has empty `name`; the Liquid
+            # template hides the visible `:name` label when name is empty.
+            #
+            # Gate strictly on exact-tag lineage existence — `resolve_variant_lineage_file`
+            # falls back to the legacy single-file format when per-tag lineage
+            # is missing, which would surface a stale digest/attestation from
+            # a different version's build (e.g. v2.3.0 fallback bleeding into
+            # v2.3.1's trust strip). We'd rather show no badge than the wrong
+            # one. Older retained versions without a recent build will have
+            # empty trust strips until rebuilt — acceptable degradation.
+            if [[ "$variants_arr" == "[]" ]] \
+                && [[ -f "$SCRIPT_DIR/.build-lineage/${container}-${ver_tag}.json" ]]; then
+                local var_json
+                var_json=$(collect_variant_json "$container" "$container_dir" "" \
+                    "$ver_tag" "$current_version" "$base_image" "true")
+                variants_arr=$(printf '%s\n%s' "[]" "$var_json" | jq -s '.[0] + [.[1]]')
+            fi
+
             local ver_json
             ver_json=$(printf '%s' "$variants_arr" | jq \
                 --arg tag "$ver_tag" --arg base_tag "$base_tag" \


### PR DESCRIPTION
Closes #345

## Summary

Fixes the trust strip for the 9 versions-only containers (sslh, jekyll, openvpn, debian, wordpress, vector, ansible, openresty, php) where the badges have been silently empty since Phase B / PR #329. Surfaced today during validation of #339 / #344 by triggering `auto-build` on sslh — even with the V2 scan-history pipeline writing the side-channel correctly, the trust strip stayed empty because `default_variant` in the Liquid template had nowhere to point.

## What changed

- **`generate-dashboard.sh:collect_variants_json`** synthesizes a single canonical variant when `list_variants` returns nothing for a version (versions-only schema). The synthetic variant has empty `name` and inherits the version tag. **Gated strictly on exact-tag lineage existence** (`.build-lineage/<container>-<ver_tag>.json`) so older retained versions whose lineage isn't cached don't surface a stale digest from the fallback `<container>.json` (codex P2 caught this; 13.4 vs 13.6 retention is one example where major-version comparison would silently bleed old digests forward).

- **`_includes/container-card.html`** and **`_layouts/container-detail.html`** mark the synthetic variant with `style="display: none" aria-hidden="true"` rather than skipping the element. The trust-strip event bridge (`<trust-strip>` web component) and `container-detail.js` both initialize state from `.variant-tag.selected` data-* attributes; removing the element entirely would blank Build Lineage, SBOM, changelog, and history sections for the canonical build. Hidden + aria-hidden preserves the data carrier while keeping the visible UI free of an unlabeled pill (the version-label / version-title above already identifies the build).

## Review history

4 codex xhigh passes; 2 P2 issues found and fixed before this final pass returned clean (`No discrete correctness issues were identified`). Same iterative pattern as #343, applying the freshly-captured `feedback_iterative_codex_review_complex_diffs.md` rule.

| # | Pri | Issue | Fix |
|---|---|---|---|
| 1 | P2 | Detail page also rendered the synthetic variant as a blank pill | Apply the same hide-don't-skip treatment to container-detail.html |
| 2 | P2 | Synthetic variant could read stale lineage from `<container>.json` fallback when exact-tag file missing | Gate synthesis on exact lineage file existence |
| 3 | P2 | `display: none` skipping the element entirely lost the data carrier consumed by container-detail.js | Switched from `{% if %}` skip to inline `style="display: none"` so JS still reads from `.variant-tag.selected` |

## Test plan

- [ ] CI green
- [ ] After merge, trigger `auto-build.yaml` on jekyll (versions-only) AND github-runner (multi-variant) to validate both code paths
- [ ] Live dashboard:
  - Versions-only cards (sslh, jekyll, etc.) show populated trust strip — Trivy badge with `0 critical · scanned <date>`, multi-arch badge, SBOM badge clickable
  - Multi-variant cards (postgres, terraform, github-runner, web-shell) unchanged
- [ ] Detail pages for versions-only containers show populated Build Lineage / SBOM / changelog sections (consumed from the hidden `.variant-tag.selected`)

## Related

- Origin: validation of #339 / #344 surfaced this. The V2 scan-history pipeline was working correctly; the consumer side was the gap.
- Issue template adoption test case: this issue followed the new bug template (`#338`) format end-to-end.
