### PR TITLE
fix(ci): use --tag long form on docker buildx imagetools create

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -681,7 +681,7 @@ runs:
         ghcr_dst="ghcr.io/$image_name:$current_tag"
         echo "::notice::Creating early tag alias: $ghcr_dst (will be upgraded to multi-arch by manifest job)"
         # GHCR has no rate-limit; surface real failures instead of swallowing them.
-        retry_with_backoff 3 5 docker buildx imagetools create -t "$ghcr_dst" "$ghcr_src"
+        retry_with_backoff 3 5 docker buildx imagetools create --tag "$ghcr_dst" "$ghcr_src"
 
         # Docker Hub per-arch alias is only needed on Windows.
         # Linux: the manifest job creates the authoritative multi-arch tag at docker.io,
@@ -692,7 +692,7 @@ runs:
         if [[ "${{ runner.os }}" == "Windows" && "${{ steps.push-dockerhub.outputs.success }}" == "true" ]]; then
           dh_src="docker.io/$image_name:$current_tag-$platform_suffix"
           dh_dst="docker.io/$image_name:$current_tag"
-          retry_with_backoff 5 30 docker buildx imagetools create -t "$dh_dst" "$dh_src"
+          retry_with_backoff 5 30 docker buildx imagetools create --tag "$dh_dst" "$dh_src"
         fi
 
         # Create latest-* rolling tags for Windows (single-arch — manifest job won't handle these)
@@ -708,11 +708,11 @@ runs:
 
           if [[ -n "$latest_tag" ]]; then
             echo "::notice::Creating Windows rolling tag: ghcr.io/$image_name:$latest_tag"
-            retry_with_backoff 3 5 docker buildx imagetools create -t "ghcr.io/$image_name:$latest_tag" "$ghcr_src"
+            retry_with_backoff 3 5 docker buildx imagetools create --tag "ghcr.io/$image_name:$latest_tag" "$ghcr_src"
 
             if [[ "${{ steps.push-dockerhub.outputs.success }}" == "true" ]]; then
               dh_src="docker.io/$image_name:$current_tag-$platform_suffix"
-              retry_with_backoff 5 30 docker buildx imagetools create -t "docker.io/$image_name:$latest_tag" "$dh_src"
+              retry_with_backoff 5 30 docker buildx imagetools create --tag "docker.io/$image_name:$latest_tag" "$dh_src"
             fi
           fi
         fi


### PR DESCRIPTION
Closes #348

## Summary

The Windows buildx version of `imagetools create` rejects the `-t` shorthand (`unknown shorthand flag: 't' in -t`); only the long-form `--tag` is portable across both the Linux and Windows builders.

Patches all **4** call sites in `.github/actions/build-container/action.yaml` (lines 684 / 695 / 711 / 715), not just the 2 cited in #348 — the failure cascade masked the others. The CI run halted on the first `-t` at line 684 before reaching the Windows-only sites at 695/711/715, all of which would re-fail post-merge if left unconverted (failure-cascade pattern from `feedback_iterative_codex_review_complex_diffs.md`).

| Site | Context | OS reach |
|---|---|---|
| 684 | GHCR early-tag alias (`ghcr_dst`) | all OS — first to fire |
| 695 | Docker Hub `current_tag` alias | Windows only |
| 711 | GHCR rolling `latest_tag` | Windows only |
| 715 | Docker Hub rolling `latest_tag` | Windows only |

Codex review pass: 0 findings (changes are option-equivalent for `docker buildx imagetools create`; whitespace and surrounding code untouched).

May also resolve #347 (same shorthand-flag symptom auto-filed against the Server 2025 host) — to be confirmed and closed as duplicate after the post-merge validation run.

## Test plan

- [ ] `auto-build.yaml github-runner rebuild=all` returns 6/6 success (3 OS × 2 flavors: ubuntu-2404, debian-trixie, windows-ltsc2022 × base, dev)
- [ ] Windows logs show successful `docker buildx imagetools create --tag …` for both `ghcr.io` and `docker.io` paths
- [ ] Linux variants remain green (no regression on the unconditional `ghcr_dst` site)
- [ ] #347 closed as duplicate of #348 once validation succeeds
