### PR TITLE
refactor(dashboard): cross-subshell cache for Trivy summary map

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -20,6 +20,13 @@ source "$SCRIPT_DIR/helpers/attestation-utils.sh"
 source "$SCRIPT_DIR/helpers/trivy-utils.sh"
 source "$SCRIPT_DIR/helpers/extension-utils.sh"
 
+# Cross-subshell cache for Trivy summary — collect_variant_json runs in $(…)
+# subshells, so the in-memory _TRIVY_SUMMARY_MAP is lost after each call.
+# Materialize the cache to a file so sibling subshells share one API fetch.
+TRIVY_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/trivy-summary-cache.XXXXXX.json")
+export TRIVY_CACHE_FILE
+trap 'rm -f -- "$TRIVY_CACHE_FILE"' EXIT
+
 DATA_FILE="$SCRIPT_DIR/docs/site/_data/containers.yml"
 STATS_FILE="$SCRIPT_DIR/docs/site/_data/stats.yml"
 CONTAINERS_DIR="$SCRIPT_DIR/docs/site/_containers"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -23,7 +23,7 @@ source "$SCRIPT_DIR/helpers/extension-utils.sh"
 # Cross-subshell cache for Trivy summary — collect_variant_json runs in $(…)
 # subshells, so the in-memory _TRIVY_SUMMARY_MAP is lost after each call.
 # Materialize the cache to a file so sibling subshells share one API fetch.
-TRIVY_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/trivy-summary-cache.XXXXXX.json")
+TRIVY_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/trivy-summary-cache.XXXXXX")
 export TRIVY_CACHE_FILE
 trap 'rm -f -- "$TRIVY_CACHE_FILE"' EXIT
 

--- a/helpers/trivy-utils.sh
+++ b/helpers/trivy-utils.sh
@@ -32,10 +32,35 @@ _TRIVY_ALERTS_CACHE=""
 _TRIVY_SUMMARY_MAP=""
 
 # _fetch_trivy_alerts_once
-# Populates _TRIVY_ALERTS_CACHE on first call; subsequent calls are no-ops.
-# On auth/network failure, sets cache to "[]" and logs a warning once.
+# Populates _TRIVY_ALERTS_CACHE and _TRIVY_SUMMARY_MAP on first call; subsequent
+# calls are no-ops. On auth/network failure, sets caches to empty sentinels and
+# logs a warning once.
+#
+# Cross-subshell cache: generate-dashboard.sh runs collect_variant_json in $()
+# subshells; the in-memory variables are lost when each subshell exits. When
+# TRIVY_CACHE_FILE is set, the computed map is persisted to disk so sibling
+# subshells can read it without re-hitting the API.
+# NOTE: No locking is needed here — dashboard generation is single-threaded
+# (subshells are sequential, not concurrent).
 _fetch_trivy_alerts_once() {
-    [[ -n "$_TRIVY_ALERTS_CACHE" ]] && return 0
+    # Already populated in this shell? Done.
+    [[ -n "${_TRIVY_ALERTS_CACHE:-}" ]] && return 0
+
+    # Cross-subshell cache — populated by an earlier subshell of this run.
+    if [[ -n "${TRIVY_CACHE_FILE:-}" && -s "${TRIVY_CACHE_FILE}" ]]; then
+        local _cached_map
+        _cached_map=$(cat -- "${TRIVY_CACHE_FILE}" 2>/dev/null || true)
+        # Validate: must be a non-empty JSON object.
+        if [[ -n "${_cached_map}" ]] \
+            && echo "${_cached_map}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            _TRIVY_SUMMARY_MAP="${_cached_map}"
+            # Synthesise a non-empty sentinel so the in-shell guard fires next call.
+            _TRIVY_ALERTS_CACHE="[cached]"
+            return 0
+        fi
+        # Fall through: file present but empty or non-JSON object — fetch fresh.
+    fi
+
     local raw
     raw=$(gh api --paginate \
         "repos/${TRIVY_UTILS_OWNER_REPO}/code-scanning/alerts?tool_name=Trivy&state=open&per_page=100" \
@@ -83,6 +108,12 @@ _fetch_trivy_alerts_once() {
           })
         | from_entries
     ' 2>/dev/null) || _TRIVY_SUMMARY_MAP="{}"
+
+    # Persist to file cache for sibling subshells. Write failure is non-fatal.
+    # Reaching here always means the API call succeeded (failure path returns early above).
+    if [[ -n "${TRIVY_CACHE_FILE:-}" && -n "${_TRIVY_SUMMARY_MAP}" ]]; then
+        printf '%s' "${_TRIVY_SUMMARY_MAP}" > "${TRIVY_CACHE_FILE}" 2>/dev/null || true
+    fi
 }
 
 # get_trivy_summary <category>

--- a/tests/unit/trivy-cache.bats
+++ b/tests/unit/trivy-cache.bats
@@ -1,0 +1,275 @@
+#!/usr/bin/env bats
+
+# Tests for the cross-subshell file cache in _fetch_trivy_alerts_once
+# (helpers/trivy-utils.sh).
+#
+# All tests run offline: the `gh` CLI is overridden with a function that emits
+# canned JSON (or fails loudly as a "poison" sentinel).
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+
+    # Canned single-alert JSON — mimics `gh api --paginate` raw output which is
+    # one JSON array per page, NOT an array-of-arrays.  The jq pipeline in
+    # _fetch_trivy_alerts_once uses `jq -s '[.[][] | ...]'`, so the input must
+    # be a flat array that jq -s wraps into a one-element outer array.
+    CANNED_ALERTS='[{"rule":{"id":"CVE-2024-1234","severity":"critical","description":"Test CVE"},"most_recent_instance":{"category":"container-postgres-18-alpine-linux/amd64","created_at":"2026-04-30T10:00:00Z","location":{"path":"usr/lib/libfoo.so"}}}]'
+    export CANNED_ALERTS
+
+    # Reset in-process cache vars between tests (re-sourcing resets them too).
+    unset _TRIVY_ALERTS_CACHE _TRIVY_SUMMARY_MAP TRIVY_CACHE_FILE
+}
+
+# ---------------------------------------------------------------------------
+# Helper: install a gh mock that writes to a counter file on each invocation.
+# Caller must set GH_COUNTER_FILE to an existing (possibly empty) file.
+# ---------------------------------------------------------------------------
+_install_gh_counter_mock() {
+    gh() {
+        local _n
+        _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+        echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+        echo "${CANNED_ALERTS}"
+    }
+    export -f gh
+}
+
+# Helper: install a "poison" gh mock — any call appends to GH_COUNTER_FILE
+# and exits non-zero so the test assertion catches it.
+_install_gh_poison() {
+    gh() {
+        local _n
+        _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+        echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+        echo "POISON: gh was called unexpectedly" >&2
+        return 1
+    }
+    export -f gh
+}
+
+# ---------------------------------------------------------------------------
+
+@test "1: TRIVY_CACHE_FILE unset — uses API path, no file I/O" {
+    unset TRIVY_CACHE_FILE
+
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    _install_gh_counter_mock
+    source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+
+    _fetch_trivy_alerts_once
+
+    # API must have been called exactly once.
+    local call_count
+    call_count=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+    [[ "$call_count" -eq 1 ]]
+
+    # In-memory map is populated.
+    [[ -n "${_TRIVY_SUMMARY_MAP:-}" && "${_TRIVY_SUMMARY_MAP}" != "{}" ]]
+
+    # No TRIVY_CACHE_FILE was set — nothing to write to.
+    [[ -z "${TRIVY_CACHE_FILE:-}" ]]
+
+    rm -f "${GH_COUNTER_FILE}"
+}
+
+@test "2: empty cache file falls through to API; file is written with JSON" {
+    local cache_file
+    cache_file=$(mktemp)
+    # Truncate to zero bytes (empty = cache miss).
+    : > "$cache_file"
+    export TRIVY_CACHE_FILE="$cache_file"
+
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    _install_gh_counter_mock
+    source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+
+    _fetch_trivy_alerts_once
+
+    # API called (empty file is a cache miss).
+    local call_count
+    call_count=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+    [[ "$call_count" -eq 1 ]]
+
+    # File was written with a non-empty JSON object.
+    [[ -s "$cache_file" ]]
+    local written
+    written=$(cat -- "$cache_file")
+    [[ -n "$written" ]]
+    echo "$written" | jq -e 'type == "object"' >/dev/null 2>&1
+
+    rm -f "$cache_file" "${GH_COUNTER_FILE}"
+}
+
+@test "3: populated cache file is read; poison gh is NEVER called" {
+    local cache_file
+    cache_file=$(mktemp)
+
+    # Pre-populate with a compact valid summary map.
+    local valid_map
+    valid_map=$(jq -cn '{"container-postgres-18-alpine-linux/amd64":{"last_scan":"2026-04-30T10:00:00Z","counts":{"critical":1,"high":0,"medium":0,"low":0,"info":0},"top_advisories":[]}}')
+    echo "$valid_map" | tee "$cache_file" >/dev/null
+    export TRIVY_CACHE_FILE="$cache_file"
+
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    _install_gh_poison
+    source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+
+    # Direct call (not `run`) so _TRIVY_SUMMARY_MAP is visible in this scope.
+    _fetch_trivy_alerts_once
+
+    # Poison gh must NOT have been called (counter stays 0).
+    local call_count
+    call_count=$(cat "${GH_COUNTER_FILE}")
+    [[ "$call_count" -eq 0 ]]
+
+    # _TRIVY_SUMMARY_MAP must be a valid JSON object matching the file content.
+    [[ -n "${_TRIVY_SUMMARY_MAP:-}" && "${_TRIVY_SUMMARY_MAP}" != "{}" ]]
+    echo "${_TRIVY_SUMMARY_MAP}" | jq -e 'type == "object"' >/dev/null 2>&1
+
+    # Structural check: the cached key must be present.
+    local got_key
+    got_key=$(echo "${_TRIVY_SUMMARY_MAP}" | jq -r 'keys[0]')
+    [[ "$got_key" == "container-postgres-18-alpine-linux/amd64" ]]
+
+    rm -f "$cache_file" "${GH_COUNTER_FILE}"
+}
+
+@test "4: corrupt cache (non-JSON) does NOT leave garbage in _TRIVY_SUMMARY_MAP" {
+    local cache_file
+    cache_file=$(mktemp)
+    echo "not json" | tee "$cache_file" >/dev/null
+    export TRIVY_CACHE_FILE="$cache_file"
+
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    _install_gh_counter_mock
+    source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+
+    _fetch_trivy_alerts_once
+
+    # After the call, _TRIVY_SUMMARY_MAP must be either empty, "{}", or valid JSON —
+    # NEVER the raw "not json" string that would crash downstream jq.
+    local map="${_TRIVY_SUMMARY_MAP:-}"
+    if [[ -n "$map" && "$map" != "{}" ]]; then
+        # If non-empty and non-sentinel, it must parse as a JSON object.
+        echo "$map" | jq -e 'type == "object"' >/dev/null 2>&1
+    fi
+
+    rm -f "$cache_file" "${GH_COUNTER_FILE}"
+}
+
+@test "6: empty API result ({}) is cached cross-subshell — no second API call" {
+    local cache_file
+    cache_file=$(mktemp)
+    : > "$cache_file"
+    export TRIVY_CACHE_FILE="$cache_file"
+
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    # Override CANNED_ALERTS with an empty array — API returns zero findings.
+    export CANNED_ALERTS='[]'
+
+    # First subshell: cache miss — must call gh, compute {} map, write to file.
+    (
+        gh() {
+            local _n
+            _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+            echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+            echo "${CANNED_ALERTS}"
+        }
+        export -f gh
+        source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+        _fetch_trivy_alerts_once
+        # Cache file must have been written (even though map is {}).
+        [[ -s "$TRIVY_CACHE_FILE" ]]
+        # Map inside this subshell must be a valid JSON object.
+        echo "${_TRIVY_SUMMARY_MAP:-}" | jq -e 'type == "object"' >/dev/null 2>&1
+    )
+
+    # Second subshell: file is populated with {}; poison gh confirms API not called again.
+    local map_in_second
+    map_in_second=$(
+        gh() {
+            local _n
+            _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+            echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+            echo "POISON: second subshell must not call gh" >&2
+            return 1
+        }
+        export -f gh
+        source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+        _fetch_trivy_alerts_once
+        echo "${_TRIVY_SUMMARY_MAP:-}"
+    )
+
+    # API must have been called exactly once (first subshell only).
+    local total_calls
+    total_calls=$(cat "${GH_COUNTER_FILE}")
+    [[ "$total_calls" -eq 1 ]]
+
+    # Second subshell's map must be a valid JSON object (the cached {}).
+    echo "${map_in_second}" | jq -e 'type == "object"' >/dev/null 2>&1
+
+    rm -f "$cache_file" "${GH_COUNTER_FILE}"
+}
+
+@test "5: sibling subshells share one API fetch via TRIVY_CACHE_FILE" {
+    local cache_file
+    cache_file=$(mktemp)
+    # Ensure cache file exists but is empty (mktemp creates a non-empty tmp sometimes on some OS).
+    : > "$cache_file"
+    export TRIVY_CACHE_FILE="$cache_file"
+
+    # File-based counter survives subshell boundaries.
+    # Starts empty; mocks use `|| echo 0` fallback so no explicit init needed.
+    GH_COUNTER_FILE=$(mktemp)
+    export GH_COUNTER_FILE
+
+    # First subshell: cache file is empty — must call gh and write to cache file.
+    (
+        gh() {
+            local _n
+            _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+            echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+            echo "${CANNED_ALERTS}"
+        }
+        export -f gh
+        source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+        _fetch_trivy_alerts_once
+        # Verify the cache file was written by this subshell.
+        [[ -s "$TRIVY_CACHE_FILE" ]]
+    )
+
+    # Second subshell: cache file should now be populated; poison gh confirms
+    # the API is NOT called again.
+    (
+        gh() {
+            local _n
+            _n=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+            echo $(( _n + 1 )) | tee "${GH_COUNTER_FILE}" >/dev/null
+            echo "POISON: second subshell must not call gh" >&2
+            return 1
+        }
+        export -f gh
+        source "$PROJECT_ROOT/helpers/trivy-utils.sh"
+        _fetch_trivy_alerts_once
+        # _TRIVY_SUMMARY_MAP must be non-empty (read from file).
+        [[ -n "${_TRIVY_SUMMARY_MAP:-}" && "${_TRIVY_SUMMARY_MAP}" != "{}" ]]
+    )
+
+    # API was called exactly once (first subshell only).
+    local total_calls
+    total_calls=$(cat "${GH_COUNTER_FILE}")
+    [[ "$total_calls" -eq 1 ]]
+
+    rm -f "$cache_file" "${GH_COUNTER_FILE}"
+}

--- a/tests/unit/trivy-cache.bats
+++ b/tests/unit/trivy-cache.bats
@@ -126,8 +126,8 @@ _install_gh_poison() {
 
     # Poison gh must NOT have been called (counter stays 0).
     local call_count
-    call_count=$(cat "${GH_COUNTER_FILE}")
-    [[ "$call_count" -eq 0 ]]
+    call_count=$(cat "${GH_COUNTER_FILE}" 2>/dev/null || echo 0)
+    [[ "${call_count:-0}" -eq 0 ]]
 
     # _TRIVY_SUMMARY_MAP must be a valid JSON object matching the file content.
     [[ -n "${_TRIVY_SUMMARY_MAP:-}" && "${_TRIVY_SUMMARY_MAP}" != "{}" ]]


### PR DESCRIPTION
## Summary

`generate-dashboard.sh` invokes `collect_variant_json` inside `$(…)` subshells (~21 calls per run on postgres alone). The in-shell `_TRIVY_SUMMARY_MAP` cache populated by `_fetch_trivy_alerts_once` is lost on every subshell exit, so the GitHub Code Scanning API is hit ~21× per dashboard run instead of 1×.

This PR materializes the cache to a file (`TRIVY_CACHE_FILE`, an exported env var pointing at a per-run `mktemp`) so sibling subshells share a single fetch.

## Design

| Site | Change |
|---|---|
| `generate-dashboard.sh:23-27` | After sourcing helpers, `mktemp` a unique cache file, `export TRIVY_CACHE_FILE`, register `trap rm -f EXIT`. 7 lines added. |
| `helpers/trivy-utils.sh:_fetch_trivy_alerts_once` | New read guard before API: if `$TRIVY_CACHE_FILE` is set, non-empty, and contains a valid JSON object (`jq -e 'type == "object"'`), reuse it. New write guard after API: persist `_TRIVY_SUMMARY_MAP` to disk, including legitimate empty-result `{}`. Fall through gracefully on any read/write error. |

The pre-existing failure path (`_TRIVY_ALERTS_CACHE="[]"` + early `return 0`) returns BEFORE the write guard, so transient API failures cannot poison the on-disk cache.

No behavior change for the in-shell cache hit, the failure path, or any caller of `get_trivy_summary`. Single-threaded — no locking needed.

## Adversarial test coverage

`tests/unit/trivy-cache.bats` — 6 tests, 6/6 pass:

- `TRIVY_CACHE_FILE` unset → legacy behavior, no file I/O
- empty cache file falls through to API, then gets written with valid JSON
- populated cache file is read; poison-`gh` stub is NEVER invoked (assertion-by-poison)
- corrupt JSON does not leave garbage in `_TRIVY_SUMMARY_MAP` (downstream `jq` cannot crash)
- two sibling subshells share one API fetch via the cache file
- empty API result (`{}`) is cached — only one fetch for repos with zero Trivy CRITICAL findings (the steady state)

The last case was an early gap caught by external review: an initial draft treated `{}` as a cache miss, undoing the optimization for the most common case (zero findings). Now `{}` is a cacheable result.

## Trigger patterns matched (rationale for adversarial test surface)

This refactor matches multiple patterns from `feedback_iterative_codex_review_complex_diffs.md`:

- **Cross-boundary state propagation** — file produced by one subshell, consumed by sibling subshells in the same run
- **Two code paths must agree on a value** — read path & write path must share the same JSON schema and "valid object" semantics
- **Sentinel values** — `{}` (legitimate zero-findings) vs `"[]"` (failure path) vs missing file vs corrupt content

Hence the 6-case adversarial suite + an external review pass on the diff.

## Test plan

- [ ] `./tests/run-tests.sh trivy-cache` returns 6/6 pass
- [ ] First post-merge `update-dashboard.yaml` run shows a single `_fetch_trivy_alerts_once` API call in logs (was N, one per variant)
- [ ] Live dashboard at https://oorabona.github.io/docker-containers/ remains unchanged for trust-strip badges (read-side semantics preserved)
- [ ] No regression on the in-shell cache hit (already covered by test 1)
