### PR TITLE
fix(dashboard): hydrate Trivy scan history from recent build artifacts

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -150,6 +150,7 @@ on:
 # prevented (e.g. two postgres merges serialize, cancelling stale runs).
 
 permissions:
+  actions: read          # Required for #352 hydration step in update-dashboard reusable workflow
   contents: read         # Checkout only — no git push or PR creation
   packages: write        # Push container images to GHCR
   pages: write           # Required by update-dashboard reusable workflow (deploy to Pages)

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -23,6 +23,7 @@ on:
         type: boolean
 
 permissions:
+  actions: read     # Required for #352 hydration step in update-dashboard reusable workflow
   contents: read
   packages: write
   pages: write      # Required when generate_sboms triggers dashboard update

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -105,7 +105,7 @@ jobs:
             2>/dev/null || true)
 
           if [[ -z "$runs" ]]; then
-            echo "::notice::No recent successful auto-build runs in the last 24h; relying on cache only."
+            echo "::notice::No recent completed auto-build runs (success or failure) in the last 24h; relying on cache only."
             exit 0
           fi
 

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -36,6 +36,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
+  actions: read  # Required for gh run list/download (#352 hydration step)
   contents: read
   pages: write
   id-token: write
@@ -70,6 +71,94 @@ jobs:
           path: .trivy-scan-history
           key: trivy-scan-history-never-exact-match
           restore-keys: trivy-scan-history-
+
+      - name: Hydrate Trivy scan history from recent auto-build runs (#352)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          # Bug context (#352): cache-lineage saves a per-run-id cache for
+          # trivy-scan-history. Concurrent auto-build dispatches race on cache
+          # restore — each run sees the most-recent cache available at THAT
+          # moment, so siblings that save afterward are invisible. The dashboard
+          # then restores "most recent" cache which can be missing data.
+          # Self-heal: explicitly re-download artifacts from recent successful
+          # auto-build runs and overlay onto .trivy-scan-history/. Newer
+          # last_scan timestamp wins (see merge block below). Idempotent.
+
+          mkdir -p .trivy-scan-history
+
+          # Window: last 24h, last 30 runs on master.
+          cutoff=$(date -u -d '24 hours ago' --iso-8601=seconds)
+          # Note: do NOT filter on --status=success at the API level — auto-build runs
+          # with PARTIAL failures (some matrix legs failed, others succeeded) still
+          # produce valid scan-history artifacts via the cache-lineage job which runs
+          # on success-OR-failure. Include both conclusions; exclude cancelled / in-progress.
+          runs=$(gh run list \
+            --workflow=auto-build.yaml \
+            --branch=master \
+            --limit 30 \
+            --json databaseId,createdAt,conclusion \
+            --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
+            2>/dev/null || true)
+
+          if [[ -z "$runs" ]]; then
+            echo "::notice::No recent successful auto-build runs in the last 24h; relying on cache only."
+            exit 0
+          fi
+
+          run_count=$(echo "$runs" | wc -l)
+          staging=$(mktemp -d)
+          trap 'rm -rf "$staging"' EXIT
+
+          downloaded=0
+          for run_id in $runs; do
+            if gh run download "$run_id" \
+                --pattern 'trivy-scan-history-*' \
+                --dir "$staging/$run_id" 2>/dev/null; then
+              downloaded=$((downloaded + 1))
+            fi
+          done
+
+          if [[ "$downloaded" -eq 0 ]]; then
+            echo "::notice::No trivy-scan-history artifacts available across $run_count recent run(s); relying on cache only."
+            exit 0
+          fi
+
+          # Merge: newer .last_scan (ISO 8601, lexicographically comparable) wins.
+          # mtime would reflect download/extraction time — not the original scan —
+          # and could regress a cached fresh entry behind a freshly-downloaded
+          # stale one. Reading the actual scan timestamp from each JSON makes the
+          # decision deterministic regardless of when the artifact was retrieved.
+          merged=0
+          while IFS= read -r -d '' src; do
+            base=$(basename "$src")
+            tgt=".trivy-scan-history/$base"
+
+            src_scan=$(jq -r '.last_scan // empty' "$src" 2>/dev/null || true)
+            if [[ -z "$src_scan" ]]; then
+              # Source has no last_scan — skip (don't overwrite cache with garbage).
+              continue
+            fi
+
+            if [[ -f "$tgt" ]]; then
+              tgt_scan=$(jq -r '.last_scan // empty' "$tgt" 2>/dev/null || true)
+              # ISO 8601 strings (e.g. 2026-04-30T22:16:07+00:00) compare correctly
+              # via bash string `>` because the format is zero-padded fixed-width.
+              # Tie (equal scan time) → keep cache, skip copy (no benefit + saves I/O).
+              if [[ -n "$tgt_scan" ]] && [[ ! "$src_scan" > "$tgt_scan" ]]; then
+                continue
+              fi
+            fi
+
+            cp -- "$src" "$tgt"
+            merged=$((merged + 1))
+          done < <(find "$staging" -name '*.json' -print0)
+
+          total=$(find .trivy-scan-history -name '*.json' 2>/dev/null | wc -l)
+          echo "::notice::Hydrated from $downloaded/$run_count recent run(s); merged $merged file(s); total scan-history entries: $total"
 
       - name: Snapshot pull/star counts (idempotent per day)
         run: |
@@ -197,6 +286,13 @@ jobs:
         with:
           path: .build-lineage
           key: build-lineage-${{ github.run_id }}
+
+      - name: Save hydrated Trivy scan history cache (#352, distinct key from cache-lineage)
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .trivy-scan-history
+          key: trivy-scan-history-dashboard-${{ github.run_id }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
Closes #352

## Summary

`auto-build.yaml`'s `cache-lineage` job saves a per-run-id cache for `.trivy-scan-history/`, restored by `update-dashboard.yaml` via prefix match. When 2+ auto-builds dispatch within seconds (concurrent upstream-monitor PRs OR a manual batch), their `cache-lineage` jobs **race**: each restores the most-recent cache available at THAT moment, merges its own artifacts, and saves under its own run-id key. Sibling runs that save afterward are invisible to the peer's cache. The dashboard then restores the "most recent" cache which can be missing data.

Observed concretely on 2026-04-30 when 7 versions-only containers dispatched in 6s — the `debian` trust-strip badge was absent on the live dashboard despite a successful build with a valid scan-history artifact (`debian-trixie-linux-amd64.json`, 105 bytes, `last_scan` populated, `alert_count: 0`).

## Design — self-heal at the dashboard regen layer

After the existing `Restore Trivy scan history cache` step, this PR adds a **hydration step** that:

1. Lists recent auto-build runs on master via `gh run list` (window: last 24h, last 30 runs).
2. Filters to runs whose `conclusion` is `success` OR `failure` — partial failures still produce valid scan-history artifacts via `cache-lineage` running on `(success || failure)`.
3. Downloads `trivy-scan-history-*` artifacts from each into a staging dir via `gh run download`.
4. Overlays files onto `.trivy-scan-history/` using `last_scan` (ISO 8601, lexicographically comparable) as the conflict-resolution key. mtime is **not** used — it reflects download/extraction time, not the original Trivy scan, and would let a freshly-downloaded stale artifact overwrite a cached fresh one.

Then a new **persist step** saves the hydrated map back to the actions cache under a distinct key `trivy-scan-history-dashboard-${{ github.run_id }}`. Reasons:

- The original `trivy-scan-history-${{ github.run_id }}` is already taken by the upstream `cache-lineage` job, and Actions cache keys are immutable — same-key save is a silent no-op.
- The shared `trivy-scan-history-` prefix on the restore step finds either format. The dashboard's save runs AFTER `cache-lineage`, so it wins the prefix-match restore for subsequent runs, propagating the repaired state.

## Permissions

Both `gh run list` and `gh run download` need `actions: read`. Reusable workflows **cannot** elevate the caller's `GITHUB_TOKEN` scope, so all three callers of `update-dashboard.yaml` must grant it:

| Workflow | Role | Permission added |
|---|---|---|
| `update-dashboard.yaml` | reusable + standalone (workflow_dispatch / schedule / push) | ✓ |
| `auto-build.yaml` | calls update-dashboard via workflow_call after every container build | ✓ |
| `recreate-manifests.yaml` | calls update-dashboard via workflow_call when `generate_sboms == true` | ✓ |

## Failure semantics

The hydration step is best-effort and never fails the workflow:
- `gh run list` failure → `runs=""` → step exits 0 with a `::notice::` (cache-only path)
- All `gh run download` calls failed → `downloaded=0` → exit 0 with notice
- Individual artifact corrupt / missing `last_scan` → file is skipped (no overwrite with garbage)
- Unable to write cache (cache miss key, etc.) → `if: always()` save still attempts, failure is silent

## Convergence (review loop)

External review surfaced the trigger-pattern signature of this fix — cross-boundary state propagation, two code paths agreeing on a key, sentinel-value handling — and caught the issues across multiple iterations:

| Iteration | P2 findings |
|---|---|
| 1 | (a) `actions: read` not propagated to caller; (b) mtime ≠ scan time |
| 2 | (a) third caller `recreate-manifests.yaml` missed; (b) hydrated state never persisted to cache |
| 3 | (a) `--status=success` excluded partial-fail runs; (b) cache-key collision with `cache-lineage` save when called from auto-build |
| 4 | clean — 0 findings |

## Test plan

- [ ] CI workflow_dispatch on `update-dashboard.yaml` standalone — verify `::notice::Hydrated from N/M recent run(s); merged X file(s); total scan-history entries: …` appears in logs
- [ ] Live dashboard at https://oorabona.github.io/docker-containers/ shows `debian` trust-strip badge after merge (already shown post-operational re-trigger; verify it persists across a scheduled regen with no fresh debian build)
- [ ] No regression on the 6 other versions-only containers' badges
- [ ] Concurrent auto-build dispatches (e.g. upstream-monitor opens 2+ PRs) — next dashboard regen has all containers' badges, not just the latest builder's
- [ ] When dispatched via `auto-build.yaml`, hydration step succeeds (not silent no-op due to perms)
- [ ] When dispatched via `recreate-manifests.yaml`, hydration step succeeds
