### PR TITLE
fix(ci): install pinned buildx on Windows runner via setup-buildx-action

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -93,7 +93,7 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
         # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
         # Windows: docker driver (native daemon's BuildKit) — required because Linux containers

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -93,11 +93,23 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      if: runner.os != 'Windows'
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      # Uses docker-container driver (default) which supports --push
-      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal
-      # Retry logic handles intermittent Docker Hub issues
+      with:
+        # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
+        # Windows: docker driver (native daemon's BuildKit) — required because Linux containers
+        # for BuildKit aren't available on Windows runners. We don't need a builder for the
+        # imagetools create calls anyway — they operate on registry manifests, not on a builder.
+        # Per #357: this step is now also run on Windows so `docker buildx imagetools create`
+        # uses the action-installed buildx (recent), not the runner's outdated stock buildx
+        # which rejects `--tag` and `-t` for imagetools create.
+        driver: ${{ runner.os == 'Windows' && 'docker' || 'docker-container' }}
+        # Pin buildx version: setup-buildx-action does NOT replace an already-installed
+        # buildx unless `version` is set explicitly (it only configures the builder otherwise).
+        # Without this, the Windows runner's outdated stock buildx would keep running and
+        # reject `--tag` / `-t` for imagetools create. Pinned on both OS for reproducibility.
+        version: 'v0.33.0'
+      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal.
+      # Retry logic handles intermittent Docker Hub issues.
 
     - name: Log in to GitHub Container Registry
       if: runner.os != 'Windows'


### PR DESCRIPTION
Closes #357

## Summary

The GitHub-hosted Windows runner ships an outdated Docker Buildx that rejects both `--tag` AND `-t` for `docker buildx imagetools create`. Per Docker's [official CLI doc](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/), both flag forms are valid in current buildx — so the bug is NOT the flag form, it's the runner's stale buildx.

This PR replaces the runner's stock buildx with a pinned recent version installed via `docker/setup-buildx-action`. After this, the four `imagetools create --tag` calls added in #350 work unchanged.

## Diagnosis (documented in #357)

| Fact | Source |
|---|---|
| Windows runner image (windows-2022 / windows-2025): Docker 29.1.5 | [actions/runner-images](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) |
| Docker Buildx CLI plugin **NOT listed** in runner inventory | idem |
| `docker buildx` invocation parsed (returns "unknown flag", not "unknown command") -> some buildx is present, but stale | run #25206651579 log |
| Local Docker Desktop ships Buildx v0.33.0-desktop.1, supports both `-t` and `--tag` | maintainer's local install |
| `setup-buildx-action` was gated `if: runner.os != 'Windows'` (line 96) | code |
| `setup-buildx-action` **does NOT replace already-installed buildx unless `version:` is set** — verified via the action's TypeScript source | external review pass |

## Change (in `.github/actions/build-container/action.yaml`)

Drop the `runner.os != 'Windows'` gate. Add two `with:` inputs:

| Input | Value | Why |
|---|---|---|
| `driver` | `${{ runner.os == 'Windows' && 'docker' || 'docker-container' }}` | Linux: docker-container (BuildKit container, multi-platform). Windows: docker (native daemon's BuildKit) — docker-container driver requires Linux containers, which Windows runners can't run. We don't need a builder for `imagetools create` anyway (it operates on registry manifests). |
| `version` | `'v0.33.0'` | Forces a clean install of v0.33.0 (current latest stable, 2026-03-31) on EVERY run. Without this, setup-buildx-action only configures the builder; it doesn't replace stale plugins. Pinned on both OS for reproducibility, matching the project's strict-pinning convention. |

The four `imagetools create --tag` lines from #350 (now at lines 691, 702, 718, 722) stay untouched — they will now succeed on Windows.

## Why not Path B (bypass with docker tag + push)

Considered: replace `imagetools create` on Windows with `docker tag SRC DST && docker push DST` (image is loaded locally per `scripts/build-container.sh:342`, Windows = single-arch so no manifest list needed). Rejected because:

- Branches Linux/Windows in the action code, increasing maintenance
- Doesn't help if any future buildx command is needed on Windows
- Less aligned with "same toolchain across runners" mental model

Path A unifies. Trade-off: ~30-60s extra on Windows builds for buildx download. Acceptable.

## Convergence (review loop)

| Iteration | Findings |
|---|---|
| 1 | [P2] setup-buildx-action without `version:` only configures the builder, doesn't replace plugin. Add `version: 'v0.33.0'`. |
| 2 | clean — 0 findings |

## Test plan

- [ ] `gh workflow run auto-build.yaml -f container=github-runner -f rebuild=all` returns 6/6 success (3 OS x 2 flavors: ubuntu-2404, debian-trixie, windows-ltsc2022 x base, dev)
- [ ] Windows logs show `docker buildx version v0.33.0` (or post-install equivalent)
- [ ] Windows logs show `docker buildx imagetools create --tag …` succeeding for all 4 call sites
- [ ] No regression on Linux builds (docker-container driver behavior unchanged, just pinned)
- [ ] Existing PRs #351 (Trivy P3) and #353 (#352 hydration) still pass CI smoke checks

## Related

- #347, #348 (closed, original `-t` shorthand)
- #349 (closed by @alceops, duplicate of #350)
- #350 (merged, `-t` -> `--tag` — incomplete, exposed the deeper buildx-version issue)
- #357 (this fix)
