### PR TITLE
docs(readme): add github-runner / web-shell / vector + supply-chain bullets

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -93,7 +93,7 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
         # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
         # Windows: docker driver (native daemon's BuildKit) — required because Linux containers

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -93,11 +93,23 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      if: runner.os != 'Windows'
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      # Uses docker-container driver (default) which supports --push
-      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal
-      # Retry logic handles intermittent Docker Hub issues
+      with:
+        # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
+        # Windows: docker driver (native daemon's BuildKit) — required because Linux containers
+        # for BuildKit aren't available on Windows runners. We don't need a builder for the
+        # imagetools create calls anyway — they operate on registry manifests, not on a builder.
+        # Per #357: this step is now also run on Windows so `docker buildx imagetools create`
+        # uses the action-installed buildx (recent), not the runner's outdated stock buildx
+        # which rejects `--tag` and `-t` for imagetools create.
+        driver: ${{ runner.os == 'Windows' && 'docker' || 'docker-container' }}
+        # Pin buildx version: setup-buildx-action does NOT replace an already-installed
+        # buildx unless `version` is set explicitly (it only configures the builder otherwise).
+        # Without this, the Windows runner's outdated stock buildx would keep running and
+        # reject `--tag` / `-t` for imagetools create. Pinned on both OS for reproducibility.
+        version: 'v0.33.0'
+      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal.
+      # Retry logic handles intermittent Docker Hub issues.
 
     - name: Log in to GitHub Container Registry
       if: runner.os != 'Windows'

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ Production-ready Docker images with **zero-touch upstream monitoring** — when 
 
 | Container | What it does | Variants |
 |-----------|-------------|----------|
-| [postgres](postgres/) | PostgreSQL with extension ecosystem | base, vector, analytics, timeseries, distributed, full |
+| [postgres](postgres/) | PostgreSQL with extension ecosystem | base, vector, analytics, timeseries, spatial, distributed, full |
 | [terraform](terraform/) | Terraform CLI, cloud-provider scoped | base, aws, azure, gcp, full |
+| [github-runner](github-runner/) | Self-hosted GitHub Actions runner | ubuntu-2404, debian-trixie, windows-ltsc2022 × base/dev |
+| [web-shell](web-shell/) | Browser-accessible shell over HTTPS | debian (default), alpine, ubuntu, rocky |
 | [wordpress](wordpress/) | WordPress with PHP optimizations | — |
 | [openresty](openresty/) | Nginx + Lua web platform | — |
 | [php](php/) | PHP-FPM runtime | — |
 | [ansible](ansible/) | Automation platform | — |
+| [vector](vector/) | Datadog Vector log/metrics shipper | — |
 | [debian](debian/) | Minimal base image | — |
 | [jekyll](jekyll/) | Static site generator | — |
 | [openvpn](openvpn/) | VPN server | — |
@@ -57,7 +60,9 @@ Upstream releases new version
 - **Smart rebuild detection** — content-based digest skips unchanged builds ([ADR-002](docs/adr/ADR-002-smart-rebuild-detection.md))
 - **Declarative variants** — one Dockerfile, N flavors via `variants.yaml` ([ADR-003](docs/adr/ADR-003-variant-system.md))
 - **Build lineage tracking** — full provenance chain from source to published image ([ADR-004](docs/adr/ADR-004-build-lineage-tracking.md))
-- **Native multi-arch** — parallel amd64/arm64 on dedicated runners, no emulation ([ADR-001](docs/adr/ADR-001-multi-platform-native-runners.md))
+- **Native multi-arch & multi-OS** — parallel `linux/amd64` + `linux/arm64` builds on dedicated runners with no emulation, plus `windows-ltsc2022` for the github-runner image ([ADR-001](docs/adr/ADR-001-multi-platform-native-runners.md))
+- **Multi-distro from one source** — github-runner and web-shell expand a single template into per-distro Dockerfiles at build time ([ADR-006](docs/adr/ADR-006-multi-distro-template-pattern.md))
+- **Supply-chain transparency** — every published image carries a Sigstore-attested SBOM, a Trivy CRITICAL scan history, and a multi-arch manifest reference. The dashboard surfaces these as click-through trust badges; the `/verify-images/` page documents how to reproduce each check locally.
 
 ## Quick start
 
@@ -130,7 +135,8 @@ That's it. The CI picks it up automatically on next push.
 - [Architecture](docs/WORKFLOW_ARCHITECTURE.md) — pipeline design
 - [Local Development](docs/LOCAL_DEVELOPMENT.md) — dev setup
 - [Testing Guide](docs/TESTING_GUIDE.md) — running tests locally
-- [Container Dashboard](https://oorabona.github.io/docker-containers/) — live build status
+- [Container Dashboard](https://oorabona.github.io/docker-containers/) — live build status with trust badges
+- [Verify Images](https://oorabona.github.io/docker-containers/verify-images/) — reproduce SBOM / Trivy / multi-arch checks locally
 
 ## License
 


### PR DESCRIPTION
docs(readme): list github-runner, web-shell, vector + supply-chain bullets

Add the three containers missing from the catalog table:

- github-runner — self-hosted GitHub Actions runner across ubuntu-2404,
  debian-trixie, and windows-ltsc2022 (base + dev flavors).
- web-shell — browser-accessible HTTPS shell across debian (default),
  alpine, ubuntu, and rocky.
- vector — Datadog Vector log/metrics shipper.

Update the multi-arch differentiator to reflect Windows runner support
(linux/amd64 + linux/arm64 unchanged, plus windows-ltsc2022 for
github-runner). Add a separate bullet for the multi-distro template
pattern shared between github-runner and web-shell, pointing at
ADR-006.

Add a supply-chain transparency bullet describing the trust badges,
Sigstore-attested SBOM, Trivy CRITICAL scan history, and multi-arch
manifest reference now surfaced on the dashboard. Link the
`/verify-images/` page from the documentation list so readers can
reproduce each check locally.

Postgres variant list corrected to include `spatial` (PostGIS), which
existed in `variants.yaml` but was absent from the README enumeration.

## Test plan

- [ ] CI smoke build passes
- [ ] Rendered README on master after merge has the 3 new container rows
- [ ] Supply-chain bullet links to /verify-images/ correctly