### PR TITLE
feat(dashboard): Phase C PR2a — attestation & SBOM hydration pipeline

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -672,6 +672,20 @@ runs:
         fi
       continue-on-error: true
 
+    # Re-upload the updated lineage file (now containing oci_subject_digest) so the
+    # cache-lineage job's download-artifact step gets the post-flatten digest.
+    # Without this, the artifact uploaded by "Upload build lineage" (pre-flatten) is
+    # used by cache-lineage, and oci_subject_digest is never persisted to cache.
+    # overwrite: true required — the artifact already exists from "Upload build lineage".
+    - name: Re-upload lineage with OCI subject digest
+      if: ${{ steps.push-ghcr.outputs.success == 'true' && runner.os != 'Windows' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      with:
+        name: build-lineage-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}
+        path: .build-lineage/${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}.json
+        retention-days: 1
+        overwrite: true
+
     # Push bare tag immediately so images are pullable without waiting for manifest job.
     # For multi-arch: this is a single-platform placeholder — the manifest job will
     # replace it with a proper multi-arch manifest list once all arches complete.

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -672,20 +672,6 @@ runs:
         fi
       continue-on-error: true
 
-    # Re-upload the updated lineage file (now containing oci_subject_digest) so the
-    # cache-lineage job's download-artifact step gets the post-flatten digest.
-    # Without this, the artifact uploaded by "Upload build lineage" (pre-flatten) is
-    # used by cache-lineage, and oci_subject_digest is never persisted to cache.
-    # overwrite: true required — the artifact already exists from "Upload build lineage".
-    - name: Re-upload lineage with OCI subject digest
-      if: ${{ steps.push-ghcr.outputs.success == 'true' && runner.os != 'Windows' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-      with:
-        name: build-lineage-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}
-        path: .build-lineage/${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}.json
-        retention-days: 1
-        overwrite: true
-
     # Push bare tag immediately so images are pullable without waiting for manifest job.
     # For multi-arch: this is a single-platform placeholder — the manifest job will
     # replace it with a proper multi-arch manifest list once all arches complete.

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1118,20 +1118,26 @@ jobs:
 
             # Compare with previously cached SBOM (if exists)
             cached_sbom=".build-lineage/${basename_file}"
+            compare_ok=true
             if [[ -f "$cached_sbom" ]]; then
-              compare_sboms "$sbom_file" "$cached_sbom" \
-                ".build-lineage/${container_tag}.changelog.json" \
-                || { echo "::warning::SBOM comparison failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
+              if ! compare_sboms "$sbom_file" "$cached_sbom" \
+                    ".build-lineage/${container_tag}.changelog.json"; then
+                echo "::warning::SBOM comparison failed for $container_tag — skipping build history append to avoid recording stale changelog"
+                sbom_failed=$((sbom_failed + 1))
+                compare_ok=false
+              fi
             else
               echo "No previous SBOM for $container_tag — first build"
             fi
 
-            # Extract summary and append to build history
-            summary=$(extract_sbom_summary "$sbom_file")
-            lineage_file=".build-lineage/${container_tag}.json"
-            append_build_history "$lineage_file" "$summary" \
-              ".build-lineage/${container_tag}.history.json" \
-              || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
+            # Extract summary and append to build history (only if compare succeeded or no prior SBOM)
+            if [[ "$compare_ok" == "true" ]]; then
+              summary=$(extract_sbom_summary "$sbom_file")
+              lineage_file=".build-lineage/${container_tag}.json"
+              append_build_history "$lineage_file" "$summary" \
+                ".build-lineage/${container_tag}.history.json" \
+                || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
+            fi
 
             # Replace cached SBOM with new one
             cp "$sbom_file" "$cached_sbom"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1122,8 +1122,8 @@ jobs:
             #   2. Cache is malformed   → source is valid, replace cache to self-heal.
             cached_sbom=".build-lineage/${basename_file}"
             compare_ok=true
-            if ! jq -e empty < "$sbom_file" 2>/dev/null; then
-              echo "::warning::Source SBOM for $container_tag is malformed JSON — preserving cached SBOM and skipping changelog/history"
+            if ! jq -e '(.packages // empty | type) == "array"' < "$sbom_file" >/dev/null 2>&1; then
+              echo "::warning::Source SBOM for $container_tag is not valid SPDX (missing or non-array .packages) — preserving cached SBOM"
               sbom_failed=$((sbom_failed + 1))
               compare_ok=false
             elif [[ ! -f "$cached_sbom" ]]; then
@@ -1167,6 +1167,18 @@ jobs:
 
           echo "sbom_count=$sbom_count" >> "$GITHUB_OUTPUT"
           echo "::notice::Processed $sbom_count SBOM(s); $sbom_failed processing error(s)"
+
+      - name: Upload derived lineage files (changelog + history)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: lineage-derived-${{ github.run_id }}
+          path: |
+            .build-lineage/*.changelog.json
+            .build-lineage/*.history.json
+          if-no-files-found: ignore
+          retention-days: 1
+          overwrite: true
 
       - name: Log lineage cache diagnostic summary
         run: |

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1139,8 +1139,13 @@ jobs:
                 || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
             fi
 
-            # Replace cached SBOM with new one
-            cp "$sbom_file" "$cached_sbom"
+            # Replace cached SBOM with new one (only if compare succeeded —
+            # failed compare may indicate corrupted source; preserve last known-good).
+            if [[ "$compare_ok" == "true" ]]; then
+              cp "$sbom_file" "$cached_sbom"
+            else
+              echo "::warning::Preserving previous cached SBOM for $container_tag (current compare failed — source may be corrupted)"
+            fi
 
             echo "::endgroup::"
           done < <(find .build-lineage-sbom-artifacts -name '*.sbom.json' -print0)

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1116,18 +1116,31 @@ jobs:
 
             echo "::group::Processing SBOM for $container_tag"
 
-            # Compare with previously cached SBOM (if exists)
+            # Validate source SBOM is well-formed JSON before any comparison.
+            # This disambiguates two failure modes that compare_sboms cannot distinguish:
+            #   1. Source is malformed  → preserve cache (last-known-good), skip compare.
+            #   2. Cache is malformed   → source is valid, replace cache to self-heal.
             cached_sbom=".build-lineage/${basename_file}"
             compare_ok=true
-            if [[ -f "$cached_sbom" ]]; then
-              if ! compare_sboms "$sbom_file" "$cached_sbom" \
-                    ".build-lineage/${container_tag}.changelog.json"; then
-                echo "::warning::SBOM comparison failed for $container_tag — skipping build history append to avoid recording stale changelog"
-                sbom_failed=$((sbom_failed + 1))
-                compare_ok=false
-              fi
-            else
+            if ! jq -e empty < "$sbom_file" 2>/dev/null; then
+              echo "::warning::Source SBOM for $container_tag is malformed JSON — preserving cached SBOM and skipping changelog/history"
+              sbom_failed=$((sbom_failed + 1))
+              compare_ok=false
+            elif [[ ! -f "$cached_sbom" ]]; then
               echo "No previous SBOM for $container_tag — first build"
+              # compare_ok stays true; no compare to run; cp at end will create cache
+            else
+              if compare_sboms "$sbom_file" "$cached_sbom" \
+                    ".build-lineage/${container_tag}.changelog.json"; then
+                : # success path; compare_ok stays true
+              else
+                # Source is valid JSON but compare failed — most likely cause is a
+                # malformed cached SBOM. Self-heal by replacing the cache; this lets
+                # the next build's compare have a clean baseline.
+                echo "::warning::compare_sboms failed with valid source for $container_tag — replacing cached SBOM to allow self-healing on next build"
+                sbom_failed=$((sbom_failed + 1))
+                compare_ok=true  # allow cp at end to overwrite the bad cache
+              fi
             fi
 
             # Extract summary and append to build history (only if compare succeeded or no prior SBOM)
@@ -1139,12 +1152,10 @@ jobs:
                 || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
             fi
 
-            # Replace cached SBOM with new one (only if compare succeeded —
-            # failed compare may indicate corrupted source; preserve last known-good).
+            # Replace cached SBOM with new one when compare_ok (source valid).
+            # When source is malformed, compare_ok=false preserves last-known-good.
             if [[ "$compare_ok" == "true" ]]; then
               cp "$sbom_file" "$cached_sbom"
-            else
-              echo "::warning::Preserving previous cached SBOM for $container_tag (current compare failed — source may be corrupted)"
             fi
 
             echo "::endgroup::"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1139,6 +1139,10 @@ jobs:
                 # the next build's compare have a clean baseline.
                 echo "::warning::compare_sboms failed with valid source for $container_tag — replacing cached SBOM to allow self-healing on next build"
                 sbom_failed=$((sbom_failed + 1))
+                # Stale changelog from previous build is invalid for this build — remove
+                # so append_build_history records a blank changes_summary instead of
+                # inheriting the previous build's diff.
+                rm -f ".build-lineage/${container_tag}.changelog.json"
                 compare_ok=true  # allow cp at end to overwrite the bad cache
               fi
             fi

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1096,16 +1096,19 @@ jobs:
         continue-on-error: true
 
       - name: Process SBOMs (compare + history)
+        id: process-sboms
         run: |
           source helpers/sbom-utils.sh
 
           if [[ ! -d ".build-lineage-sbom-artifacts" ]]; then
             echo "No SBOM artifacts found — skipping processing"
+            echo "sbom_count=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Find SBOM files (may be flat or in subdirectories depending on artifact count)
           sbom_count=0
+          sbom_failed=0
           while IFS= read -r -d '' sbom_file; do
             sbom_count=$((sbom_count + 1))
             basename_file=$(basename "$sbom_file")
@@ -1117,7 +1120,8 @@ jobs:
             cached_sbom=".build-lineage/${basename_file}"
             if [[ -f "$cached_sbom" ]]; then
               compare_sboms "$sbom_file" "$cached_sbom" \
-                ".build-lineage/${container_tag}.changelog.json" || true
+                ".build-lineage/${container_tag}.changelog.json" \
+                || { echo "::warning::SBOM comparison failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
             else
               echo "No previous SBOM for $container_tag — first build"
             fi
@@ -1126,7 +1130,8 @@ jobs:
             summary=$(extract_sbom_summary "$sbom_file")
             lineage_file=".build-lineage/${container_tag}.json"
             append_build_history "$lineage_file" "$summary" \
-              ".build-lineage/${container_tag}.history.json" || true
+              ".build-lineage/${container_tag}.history.json" \
+              || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
 
             # Replace cached SBOM with new one
             cp "$sbom_file" "$cached_sbom"
@@ -1134,7 +1139,16 @@ jobs:
             echo "::endgroup::"
           done < <(find .build-lineage-sbom-artifacts -name '*.sbom.json' -print0)
 
-          echo "Processed $sbom_count SBOM(s)"
+          echo "sbom_count=$sbom_count" >> "$GITHUB_OUTPUT"
+          echo "::notice::Processed $sbom_count SBOM(s); $sbom_failed processing error(s)"
+
+      - name: Log lineage cache diagnostic summary
+        run: |
+          lineage_count=$(find .build-lineage -name '*.json' -not -name '*.sbom.json' -not -name '*.history.json' -not -name '*.changelog.json' 2>/dev/null | wc -l)
+          sbom_count=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
+          changelog_count=$(find .build-lineage -name '*.changelog.json' 2>/dev/null | wc -l)
+          history_count=$(find .build-lineage -name '*.history.json' 2>/dev/null | wc -l)
+          echo "::notice::Lineage cache contents — lineage: $lineage_count, SBOMs: $sbom_count, changelogs: $changelog_count, histories: $history_count"
 
       - name: Save consolidated lineage cache
         if: steps.merge.outputs.has_files == 'true'

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -230,8 +230,8 @@ jobs:
             #   2. Cache is malformed   → source is valid, replace cache to self-heal.
             cached_sbom=".build-lineage/${basename_file}"
             compare_ok=true
-            if ! jq -e empty < "$sbom_file" 2>/dev/null; then
-              echo "::warning::Source SBOM for $container_tag is malformed JSON — preserving cached SBOM and skipping changelog/history"
+            if ! jq -e '(.packages // empty | type) == "array"' < "$sbom_file" >/dev/null 2>&1; then
+              echo "::warning::Source SBOM for $container_tag is not valid SPDX (missing or non-array .packages) — preserving cached SBOM"
               sbom_failed=$((sbom_failed + 1))
               compare_ok=false
             elif [[ ! -f "$cached_sbom" ]]; then
@@ -274,6 +274,18 @@ jobs:
           done < <(find .build-lineage-sbom-artifacts -name '*.sbom.json' -print0)
 
           echo "::notice::Processed $sbom_count SBOM(s); $sbom_failed processing error(s)"
+
+      - name: Upload derived lineage files (changelog + history)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: lineage-derived-${{ github.run_id }}
+          path: |
+            .build-lineage/*.changelog.json
+            .build-lineage/*.history.json
+          if-no-files-found: ignore
+          retention-days: 1
+          overwrite: true
 
       - name: Save updated lineage cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -216,6 +216,7 @@ jobs:
           fi
 
           sbom_count=0
+          sbom_failed=0
           while IFS= read -r -d '' sbom_file; do
             sbom_count=$((sbom_count + 1))
             basename_file=$(basename "$sbom_file")
@@ -225,26 +226,39 @@ jobs:
 
             # Compare with previously cached SBOM (if exists)
             cached_sbom=".build-lineage/${basename_file}"
+            compare_ok=true
             if [[ -f "$cached_sbom" ]]; then
-              compare_sboms "$sbom_file" "$cached_sbom" \
-                ".build-lineage/${container_tag}.changelog.json" || true
+              if ! compare_sboms "$sbom_file" "$cached_sbom" \
+                    ".build-lineage/${container_tag}.changelog.json"; then
+                echo "::warning::SBOM comparison failed for $container_tag — skipping build history append to avoid recording stale changelog"
+                sbom_failed=$((sbom_failed + 1))
+                compare_ok=false
+              fi
             else
               echo "No previous SBOM for $container_tag — first build"
             fi
 
-            # Extract summary and append to build history
-            summary=$(extract_sbom_summary "$sbom_file")
-            lineage_file=".build-lineage/${container_tag}.json"
-            append_build_history "$lineage_file" "$summary" \
-              ".build-lineage/${container_tag}.history.json" || true
+            # Extract summary and append to build history (only if compare succeeded or no prior SBOM)
+            if [[ "$compare_ok" == "true" ]]; then
+              summary=$(extract_sbom_summary "$sbom_file")
+              lineage_file=".build-lineage/${container_tag}.json"
+              append_build_history "$lineage_file" "$summary" \
+                ".build-lineage/${container_tag}.history.json" \
+                || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
+            fi
 
-            # Replace cached SBOM with new one
-            cp "$sbom_file" "$cached_sbom"
+            # Replace cached SBOM with new one (only if compare succeeded —
+            # failed compare may indicate corrupted source; preserve last known-good).
+            if [[ "$compare_ok" == "true" ]]; then
+              cp "$sbom_file" "$cached_sbom"
+            else
+              echo "::warning::Preserving previous cached SBOM for $container_tag (current compare failed — source may be corrupted)"
+            fi
 
             echo "::endgroup::"
           done < <(find .build-lineage-sbom-artifacts -name '*.sbom.json' -print0)
 
-          echo "Processed $sbom_count SBOM(s)"
+          echo "::notice::Processed $sbom_count SBOM(s); $sbom_failed processing error(s)"
 
       - name: Save updated lineage cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -247,6 +247,10 @@ jobs:
                 # the next build's compare have a clean baseline.
                 echo "::warning::compare_sboms failed with valid source for $container_tag — replacing cached SBOM to allow self-healing on next build"
                 sbom_failed=$((sbom_failed + 1))
+                # Stale changelog from previous build is invalid for this build — remove
+                # so append_build_history records a blank changes_summary instead of
+                # inheriting the previous build's diff.
+                rm -f ".build-lineage/${container_tag}.changelog.json"
                 compare_ok=true  # allow cp at end to overwrite the bad cache
               fi
             fi

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -224,18 +224,31 @@ jobs:
 
             echo "::group::Processing SBOM for $container_tag"
 
-            # Compare with previously cached SBOM (if exists)
+            # Validate source SBOM is well-formed JSON before any comparison.
+            # This disambiguates two failure modes that compare_sboms cannot distinguish:
+            #   1. Source is malformed  → preserve cache (last-known-good), skip compare.
+            #   2. Cache is malformed   → source is valid, replace cache to self-heal.
             cached_sbom=".build-lineage/${basename_file}"
             compare_ok=true
-            if [[ -f "$cached_sbom" ]]; then
-              if ! compare_sboms "$sbom_file" "$cached_sbom" \
-                    ".build-lineage/${container_tag}.changelog.json"; then
-                echo "::warning::SBOM comparison failed for $container_tag — skipping build history append to avoid recording stale changelog"
-                sbom_failed=$((sbom_failed + 1))
-                compare_ok=false
-              fi
-            else
+            if ! jq -e empty < "$sbom_file" 2>/dev/null; then
+              echo "::warning::Source SBOM for $container_tag is malformed JSON — preserving cached SBOM and skipping changelog/history"
+              sbom_failed=$((sbom_failed + 1))
+              compare_ok=false
+            elif [[ ! -f "$cached_sbom" ]]; then
               echo "No previous SBOM for $container_tag — first build"
+              # compare_ok stays true; no compare to run; cp at end will create cache
+            else
+              if compare_sboms "$sbom_file" "$cached_sbom" \
+                    ".build-lineage/${container_tag}.changelog.json"; then
+                : # success path; compare_ok stays true
+              else
+                # Source is valid JSON but compare failed — most likely cause is a
+                # malformed cached SBOM. Self-heal by replacing the cache; this lets
+                # the next build's compare have a clean baseline.
+                echo "::warning::compare_sboms failed with valid source for $container_tag — replacing cached SBOM to allow self-healing on next build"
+                sbom_failed=$((sbom_failed + 1))
+                compare_ok=true  # allow cp at end to overwrite the bad cache
+              fi
             fi
 
             # Extract summary and append to build history (only if compare succeeded or no prior SBOM)
@@ -247,12 +260,10 @@ jobs:
                 || { echo "::warning::Build history append failed for $container_tag"; sbom_failed=$((sbom_failed + 1)); }
             fi
 
-            # Replace cached SBOM with new one (only if compare succeeded —
-            # failed compare may indicate corrupted source; preserve last known-good).
+            # Replace cached SBOM with new one when compare_ok (source valid).
+            # When source is malformed, compare_ok=false preserves last-known-good.
             if [[ "$compare_ok" == "true" ]]; then
               cp "$sbom_file" "$cached_sbom"
-            else
-              echo "::warning::Preserving previous cached SBOM for $container_tag (current compare failed — source may be corrupted)"
             fi
 
             echo "::endgroup::"

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -331,14 +331,32 @@ jobs:
           # {container}-{tag}.json lineage files (which carry oci_subject_digest).
           declare -A lineage_seen=()
           merged_lineage=0
+          skipped_no_digest=0
           for run_id in $run_ids; do
             staging_run_dir="$staging/$run_id-lineage"
             [[ -d "$staging_run_dir" ]] || continue
             while IFS= read -r -d '' src; do
               fname=$(basename "$src")
-              # Skip if a newer run already provided this lineage file this session
-              [[ -n "${lineage_seen[$fname]:-}" ]] && continue
-              cp -- "$src" ".build-lineage/$fname"
+              # First-seen wins among hits with same digest-presence; a later run
+              # only gets a turn if the earlier one lacked oci_subject_digest.
+              if [[ -n "${lineage_seen[$fname]:-}" ]]; then
+                continue
+              fi
+              target=".build-lineage/$fname"
+              src_has_digest=$(jq -e '(.oci_subject_digest // "") != ""' "$src" >/dev/null 2>&1 && echo true || echo false)
+              if [[ -f "$target" ]]; then
+                tgt_has_digest=$(jq -e '(.oci_subject_digest // "") != ""' "$target" >/dev/null 2>&1 && echo true || echo false)
+                if [[ "$tgt_has_digest" == "true" && "$src_has_digest" == "false" ]]; then
+                  # Cache has digest, source doesn't — preserve cache to avoid
+                  # regressing attestation lookup (Capture OCI subject digest is
+                  # continue-on-error; a newer run may have failed that step).
+                  echo "::notice::Preserving cached lineage for $fname (source from run $run_id lacks oci_subject_digest)"
+                  skipped_no_digest=$((skipped_no_digest + 1))
+                  lineage_seen[$fname]=1
+                  continue
+                fi
+              fi
+              cp -- "$src" "$target"
               lineage_seen[$fname]=1
               merged_lineage=$((merged_lineage + 1))
             done < <(find "$staging_run_dir" -name '*.json' \
@@ -347,6 +365,10 @@ jobs:
               -not -name '*.history.json' \
               -print0)
           done
+
+          if [[ "$skipped_no_digest" -gt 0 ]]; then
+            echo "::notice::Preserved $skipped_no_digest cached lineage file(s) where source lacked oci_subject_digest (digest-capture continue-on-error fallback)"
+          fi
 
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
           echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s); total SBOM entries: $total"

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -275,8 +275,10 @@ jobs:
           fi
 
           if [[ "$downloaded" -eq 0 ]]; then
-            echo "::notice::No sbom-* artifacts available across $run_count recent run(s); relying on cache only."
-            exit 0
+            echo "::notice::No sbom-* artifacts available across $run_count recent run(s) for SBOM merge; lineage hydration may still proceed if build-lineage-* artifacts were downloaded for these runs."
+            # Do NOT exit: the lineage merge block below uses find over $staging and can
+            # still hydrate oci_subject_digest from build-lineage-* artifacts even when
+            # every sbom-* download returned "no artifact".
           fi
 
           # Merge: newer .creationInfo.created (ISO 8601, lexicographically comparable) wins.

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -96,13 +96,19 @@ jobs:
           # with PARTIAL failures (some matrix legs failed, others succeeded) still
           # produce valid scan-history artifacts via the cache-lineage job which runs
           # on success-OR-failure. Include both conclusions; exclude cancelled / in-progress.
-          runs=$(gh run list \
-            --workflow=auto-build.yaml \
-            --branch=master \
-            --limit 30 \
-            --json databaseId,createdAt,conclusion \
-            --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
-            2>/dev/null || true)
+          if ! runs=$(gh run list \
+              --workflow=auto-build.yaml \
+              --branch=master \
+              --limit 30 \
+              --json databaseId,createdAt,conclusion \
+              --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
+              2>/tmp/gh-stderr-trivy.txt); then
+            echo "::warning::gh run list failed — Trivy scan history hydration skipped, may indicate transient GitHub API issue. stderr:" >&2
+            cat /tmp/gh-stderr-trivy.txt >&2 || true
+            rm -f /tmp/gh-stderr-trivy.txt
+            exit 0
+          fi
+          rm -f /tmp/gh-stderr-trivy.txt
 
           if [[ -z "$runs" ]]; then
             echo "::notice::No recent completed auto-build runs (success or failure) in the last 24h; relying on cache only."
@@ -182,13 +188,19 @@ jobs:
           # with PARTIAL failures (some matrix legs failed, others succeeded) still
           # produce valid sbom-* artifacts via the build job that succeeded for that leg.
           # Include both conclusions; exclude cancelled / in-progress.
-          run_ids=$(gh run list \
-            --workflow=auto-build.yaml \
-            --branch=master \
-            --limit 30 \
-            --json databaseId,createdAt,conclusion \
-            --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
-            2>/dev/null || true)
+          if ! run_ids=$(gh run list \
+              --workflow=auto-build.yaml \
+              --branch=master \
+              --limit 30 \
+              --json databaseId,createdAt,conclusion \
+              --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
+              2>/tmp/gh-stderr-sbom.txt); then
+            echo "::warning::gh run list failed — SBOM hydration skipped, may indicate transient GitHub API issue. stderr:" >&2
+            cat /tmp/gh-stderr-sbom.txt >&2 || true
+            rm -f /tmp/gh-stderr-sbom.txt
+            exit 0
+          fi
+          rm -f /tmp/gh-stderr-sbom.txt
 
           if [[ -z "$run_ids" ]]; then
             echo "::notice::No recent completed auto-build runs (success or failure) in the last 24h; relying on cache only for SBOM data."

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -201,7 +201,7 @@ jobs:
 
           mkdir -p .build-lineage
 
-          # Window: last 24h, last 30 runs on master.
+          # Window: last 24h, last 100 runs on master.
           cutoff=$(date -u -d '24 hours ago' --iso-8601=seconds)
           # Note: do NOT filter on --status=success at the API level — auto-build runs
           # with PARTIAL failures (some matrix legs failed, others succeeded) still

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -322,22 +322,31 @@ jobs:
             merged=$((merged + 1))
           done < <(find "$staging" -name '*.sbom.json' -print0)
 
-          # Merge lineage files (mtime-based since they have no content timestamp).
+          # Merge lineage files: iterate run_ids in the order gh run list returned
+          # them (newest first). First seen per filename wins — this is correct
+          # because a newer run's lineage always supersedes an older run's, and
+          # we want the freshest oci_subject_digest regardless of when artifacts
+          # were extracted (extraction mtime is meaningless as a build-order proxy).
           # Exclude .sbom.json, .changelog.json, .history.json — only bare
           # {container}-{tag}.json lineage files (which carry oci_subject_digest).
+          declare -A lineage_seen=()
           merged_lineage=0
-          while IFS= read -r -d '' src; do
-            fname=$(basename "$src")
-            target=".build-lineage/$fname"
-            if [[ ! -f "$target" ]] || [[ "$src" -nt "$target" ]]; then
-              cp -- "$src" "$target"
+          for run_id in $run_ids; do
+            staging_run_dir="$staging/$run_id-lineage"
+            [[ -d "$staging_run_dir" ]] || continue
+            while IFS= read -r -d '' src; do
+              fname=$(basename "$src")
+              # Skip if a newer run already provided this lineage file this session
+              [[ -n "${lineage_seen[$fname]:-}" ]] && continue
+              cp -- "$src" ".build-lineage/$fname"
+              lineage_seen[$fname]=1
               merged_lineage=$((merged_lineage + 1))
-            fi
-          done < <(find "$staging" -name '*.json' \
-            -not -name '*.sbom.json' \
-            -not -name '*.changelog.json' \
-            -not -name '*.history.json' \
-            -print0)
+            done < <(find "$staging_run_dir" -name '*.json' \
+              -not -name '*.sbom.json' \
+              -not -name '*.changelog.json' \
+              -not -name '*.history.json' \
+              -print0)
+          done
 
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
           echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s); total SBOM entries: $total"

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -160,6 +160,72 @@ jobs:
           total=$(find .trivy-scan-history -name '*.json' 2>/dev/null | wc -l)
           echo "::notice::Hydrated from $downloaded/$run_count recent run(s); merged $merged file(s); total scan-history entries: $total"
 
+      - name: Re-download SBOM artifacts from recent auto-build runs (self-heal cache race)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Bug context: cache-lineage saves .build-lineage/*.sbom.json to the cache, but
+          # concurrent auto-build dispatches race on cache restore -- each dashboard run
+          # sees only what was cached at restore time. In-flight or recently-completed runs
+          # may have produced SBOMs that never made it into the cache this dashboard
+          # invocation restored. Self-heal: explicitly re-download sbom-* artifacts from
+          # recent successful auto-build runs and overlay into .build-lineage/. Idempotent:
+          # only overwrites if the downloaded file is newer (by mtime).
+
+          mkdir -p .build-lineage
+
+          # Window: last 30 successful runs on master (mirrors Trivy hydration pattern above).
+          run_ids=$(gh run list \
+            --workflow=auto-build.yaml \
+            --branch=master \
+            --status=success \
+            --limit 30 \
+            --json databaseId \
+            --jq '.[].databaseId' \
+            2>/dev/null || true)
+
+          if [[ -z "$run_ids" ]]; then
+            echo "::notice::No recent successful auto-build runs found; relying on cache only for SBOM data."
+            exit 0
+          fi
+
+          run_count=$(echo "$run_ids" | wc -l)
+          staging=$(mktemp -d)
+          trap 'rm -rf "$staging"' EXIT
+
+          downloaded=0
+          for run_id in $run_ids; do
+            if gh run download "$run_id" \
+                --pattern 'sbom-*' \
+                --dir "$staging/$run_id" 2>/dev/null; then
+              downloaded=$((downloaded + 1))
+            fi
+          done
+
+          if [[ "$downloaded" -eq 0 ]]; then
+            echo "::notice::No sbom-* artifacts available across $run_count recent run(s); relying on cache only."
+            exit 0
+          fi
+
+          # Merge: newer mtime wins (mtime reflects original build time via artifact extraction).
+          # For SBOM JSON there is no embedded timestamp we can use for comparison, so mtime
+          # is the best available signal. Missing target = always copy.
+          merged=0
+          while IFS= read -r -d '' src; do
+            fname=$(basename "$src")
+            target=".build-lineage/$fname"
+            if [[ ! -f "$target" ]] || [[ "$src" -nt "$target" ]]; then
+              cp -- "$src" "$target"
+              merged=$((merged + 1))
+            fi
+          done < <(find "$staging" -name '*.sbom.json' -print0)
+
+          total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
+          echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged file(s); total SBOM entries: $total"
+
       - name: Snapshot pull/star counts (idempotent per day)
         run: |
           chmod +x scripts/snapshot-stats.sh
@@ -206,6 +272,11 @@ jobs:
           echo ""
           echo "📈 Stats data:"
           cat docs/site/_data/stats.yml
+
+      - name: Verify data completeness (advisory smoke gate)
+        run: |
+          chmod +x scripts/verify-dashboard-data.sh
+          scripts/verify-dashboard-data.sh docs/site/_data/containers.yml
 
       - name: Check dependency versions
         env:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -172,23 +172,26 @@ jobs:
           # sees only what was cached at restore time. In-flight or recently-completed runs
           # may have produced SBOMs that never made it into the cache this dashboard
           # invocation restored. Self-heal: explicitly re-download sbom-* artifacts from
-          # recent successful auto-build runs and overlay into .build-lineage/. Idempotent:
-          # only overwrites if the downloaded file is newer (by mtime).
+          # recent auto-build runs and overlay into .build-lineage/. Idempotent.
 
           mkdir -p .build-lineage
 
-          # Window: last 30 successful runs on master (mirrors Trivy hydration pattern above).
+          # Window: last 24h, last 30 runs on master.
+          cutoff=$(date -u -d '24 hours ago' --iso-8601=seconds)
+          # Note: do NOT filter on --status=success at the API level — auto-build runs
+          # with PARTIAL failures (some matrix legs failed, others succeeded) still
+          # produce valid sbom-* artifacts via the build job that succeeded for that leg.
+          # Include both conclusions; exclude cancelled / in-progress.
           run_ids=$(gh run list \
             --workflow=auto-build.yaml \
             --branch=master \
-            --status=success \
             --limit 30 \
-            --json databaseId \
-            --jq '.[].databaseId' \
+            --json databaseId,createdAt,conclusion \
+            --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
             2>/dev/null || true)
 
           if [[ -z "$run_ids" ]]; then
-            echo "::notice::No recent successful auto-build runs found; relying on cache only for SBOM data."
+            echo "::notice::No recent completed auto-build runs (success or failure) in the last 24h; relying on cache only for SBOM data."
             exit 0
           fi
 
@@ -210,17 +213,34 @@ jobs:
             exit 0
           fi
 
-          # Merge: newer mtime wins (mtime reflects original build time via artifact extraction).
-          # For SBOM JSON there is no embedded timestamp we can use for comparison, so mtime
-          # is the best available signal. Missing target = always copy.
+          # Merge: newer .creationInfo.created (ISO 8601, lexicographically comparable) wins.
+          # mtime would reflect download/extraction time — not the original syft scan —
+          # so a freshly-downloaded stale SBOM could mask a cached fresh one. Reading the
+          # actual SPDX creation timestamp makes the decision deterministic regardless of
+          # when the artifact was retrieved.
           merged=0
           while IFS= read -r -d '' src; do
             fname=$(basename "$src")
             target=".build-lineage/$fname"
-            if [[ ! -f "$target" ]] || [[ "$src" -nt "$target" ]]; then
-              cp -- "$src" "$target"
-              merged=$((merged + 1))
+
+            src_created=$(jq -r '.creationInfo.created // empty' "$src" 2>/dev/null || true)
+            if [[ -z "$src_created" ]]; then
+              # Source has no creationInfo.created — skip (don't overwrite cache with malformed SBOM).
+              continue
             fi
+
+            if [[ -f "$target" ]]; then
+              tgt_created=$(jq -r '.creationInfo.created // empty' "$target" 2>/dev/null || true)
+              # ISO 8601 strings (e.g. 2026-02-22T00:46:38Z) compare correctly via bash
+              # string `>` because the format is zero-padded fixed-width.
+              # Tie (equal creation time) → keep cache, skip copy (no benefit + saves I/O).
+              if [[ -n "$tgt_created" ]] && [[ ! "$src_created" > "$tgt_created" ]]; then
+                continue
+              fi
+            fi
+
+            cp -- "$src" "$target"
+            merged=$((merged + 1))
           done < <(find "$staging" -name '*.sbom.json' -print0)
 
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -337,8 +337,9 @@ jobs:
             [[ -d "$staging_run_dir" ]] || continue
             while IFS= read -r -d '' src; do
               fname=$(basename "$src")
-              # First-seen wins among hits with same digest-presence; a later run
-              # only gets a turn if the earlier one lacked oci_subject_digest.
+              # Only skip if a previous iteration already secured a digest-bearing
+              # version. A digest-less provisional copy leaves the slot open so a
+              # later run that carries oci_subject_digest can override it.
               if [[ -n "${lineage_seen[$fname]:-}" ]]; then
                 continue
               fi
@@ -350,6 +351,7 @@ jobs:
                   # Cache has digest, source doesn't — preserve cache to avoid
                   # regressing attestation lookup (Capture OCI subject digest is
                   # continue-on-error; a newer run may have failed that step).
+                  # Mark seen: the cached version already satisfies the goal.
                   echo "::notice::Preserving cached lineage for $fname (source from run $run_id lacks oci_subject_digest)"
                   skipped_no_digest=$((skipped_no_digest + 1))
                   lineage_seen[$fname]=1
@@ -357,8 +359,14 @@ jobs:
                 fi
               fi
               cp -- "$src" "$target"
-              lineage_seen[$fname]=1
               merged_lineage=$((merged_lineage + 1))
+              if [[ "$src_has_digest" == "true" ]]; then
+                # Got a digest-bearing version — lock the slot so no later
+                # (older) run can overwrite it with a stale copy.
+                lineage_seen[$fname]=1
+              fi
+              # src lacks digest AND cache also lacks digest: leave slot open
+              # so a later iteration with a digest-bearing artifact can override.
             done < <(find "$staging_run_dir" -name '*.json' \
               -not -name '*.sbom.json' \
               -not -name '*.changelog.json' \

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -90,7 +90,9 @@ jobs:
 
           mkdir -p .trivy-scan-history
 
-          # Window: last 24h, last 30 runs on master.
+          # Window: last 24h, last 100 runs on master.
+          # --limit is applied API-side BEFORE the jq date filter; use 100 to avoid
+          # truncating runs still inside the 24h window on busy days with retries.
           cutoff=$(date -u -d '24 hours ago' --iso-8601=seconds)
           # Note: do NOT filter on --status=success at the API level — auto-build runs
           # with PARTIAL failures (some matrix legs failed, others succeeded) still
@@ -99,7 +101,7 @@ jobs:
           if ! runs=$(gh run list \
               --workflow=auto-build.yaml \
               --branch=master \
-              --limit 30 \
+              --limit 100 \
               --json databaseId,createdAt,conclusion \
               --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
               2>/tmp/gh-stderr-trivy.txt); then
@@ -208,7 +210,7 @@ jobs:
           if ! run_ids=$(gh run list \
               --workflow=auto-build.yaml \
               --branch=master \
-              --limit 30 \
+              --limit 100 \
               --json databaseId,createdAt,conclusion \
               --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
               2>/tmp/gh-stderr-sbom.txt); then

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -252,6 +252,13 @@ jobs:
             fi
 
             cp -- "$src" "$target"
+            # Derived files (.changelog.json, .history.json) are computed against the
+            # PREVIOUS .sbom.json baseline. Replacing the SBOM invalidates them — the
+            # next cache-lineage run will regenerate them from the new baseline.
+            # In the interim, show no "Recent Changes" rather than stale wrong data.
+            container_tag="${fname%.sbom.json}"
+            rm -f ".build-lineage/${container_tag}.changelog.json" \
+                  ".build-lineage/${container_tag}.history.json"
             merged=$((merged + 1))
           done < <(find "$staging" -name '*.sbom.json' -print0)
 

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -270,6 +270,26 @@ jobs:
               fi
             fi
             rm -f "$stderr_file"
+
+            # Also download lineage-derived-* artifacts (.changelog.json, .history.json)
+            # which are written ONLY by cache-lineage and never re-uploaded as part of
+            # build-lineage-*. Without this, fresh SBOMs render alongside missing/stale
+            # derived data and the dashboard hides the entire Provenance section.
+            stderr_file=$(mktemp)
+            if gh run download "$run_id" \
+                --pattern 'lineage-derived-*' \
+                --dir "$staging/$run_id-derived" 2>"$stderr_file"; then
+              :
+            else
+              if grep -qi "no artifact" "$stderr_file" 2>/dev/null; then
+                : # Expected: this run had no lineage-derived-* artifact
+              else
+                echo "::warning::gh run download (lineage-derived) failed for run $run_id. stderr:" >&2
+                cat "$stderr_file" >&2
+                download_failures=$((download_failures + 1))
+              fi
+            fi
+            rm -f "$stderr_file"
           done
 
           if [[ "$download_failures" -gt 0 ]]; then
@@ -331,7 +351,8 @@ jobs:
           # were extracted (extraction mtime is meaningless as a build-order proxy).
           # Exclude .sbom.json, .changelog.json, .history.json — only bare
           # {container}-{tag}.json lineage files (which carry oci_subject_digest).
-          declare -A lineage_seen=()
+          declare -A lineage_locked=()       # has digest, definitive — never overridden
+          declare -A lineage_provisional=()  # digest-less from newest run — can be replaced by later digest-bearing
           merged_lineage=0
           skipped_no_digest=0
           for run_id in $run_ids; do
@@ -339,10 +360,8 @@ jobs:
             [[ -d "$staging_run_dir" ]] || continue
             while IFS= read -r -d '' src; do
               fname=$(basename "$src")
-              # Only skip if a previous iteration already secured a digest-bearing
-              # version. A digest-less provisional copy leaves the slot open so a
-              # later run that carries oci_subject_digest can override it.
-              if [[ -n "${lineage_seen[$fname]:-}" ]]; then
+              # Already have a definitive digest-bearing version: skip unconditionally.
+              if [[ -n "${lineage_locked[$fname]:-}" ]]; then
                 continue
               fi
               target=".build-lineage/$fname"
@@ -350,25 +369,27 @@ jobs:
               if [[ -f "$target" ]]; then
                 tgt_has_digest=$(jq -e '(.oci_subject_digest // "") != ""' "$target" >/dev/null 2>&1 && echo true || echo false)
                 if [[ "$tgt_has_digest" == "true" && "$src_has_digest" == "false" ]]; then
-                  # Cache has digest, source doesn't — preserve cache to avoid
-                  # regressing attestation lookup (Capture OCI subject digest is
-                  # continue-on-error; a newer run may have failed that step).
-                  # Mark seen: the cached version already satisfies the goal.
+                  # Cache has digest, source doesn't — preserve cache, lock the slot.
                   echo "::notice::Preserving cached lineage for $fname (source from run $run_id lacks oci_subject_digest)"
                   skipped_no_digest=$((skipped_no_digest + 1))
-                  lineage_seen[$fname]=1
+                  lineage_locked[$fname]=1
                   continue
                 fi
               fi
-              cp -- "$src" "$target"
-              merged_lineage=$((merged_lineage + 1))
               if [[ "$src_has_digest" == "true" ]]; then
-                # Got a digest-bearing version — lock the slot so no later
-                # (older) run can overwrite it with a stale copy.
-                lineage_seen[$fname]=1
+                # Definitive answer: cp and lock — no older run can override.
+                cp -- "$src" "$target"
+                lineage_locked[$fname]=1
+                merged_lineage=$((merged_lineage + 1))
+              elif [[ -z "${lineage_provisional[$fname]:-}" ]]; then
+                # No provisional yet and no digest version found — take this newest
+                # digest-less write. Only a later digest-bearing iteration can override;
+                # older digest-less iterations cannot (first-seen-from-newest wins).
+                cp -- "$src" "$target"
+                lineage_provisional[$fname]=1
+                merged_lineage=$((merged_lineage + 1))
               fi
-              # src lacks digest AND cache also lacks digest: leave slot open
-              # so a later iteration with a digest-bearing artifact can override.
+              # else: already have provisional from a newer run — older digest-less is discarded.
             done < <(find "$staging_run_dir" -name '*.json' \
               -not -name '*.sbom.json' \
               -not -name '*.changelog.json' \
@@ -380,8 +401,25 @@ jobs:
             echo "::notice::Preserved $skipped_no_digest cached lineage file(s) where source lacked oci_subject_digest (digest-capture continue-on-error fallback)"
           fi
 
+          # Merge derived files (.changelog.json, .history.json) — chronological
+          # first-seen wins (newest run first). These don't have digest semantics:
+          # the newest run's derived file is always the authoritative version.
+          declare -A derived_seen=()
+          merged_derived=0
+          for run_id in $run_ids; do
+            derived_dir="$staging/$run_id-derived"
+            [[ -d "$derived_dir" ]] || continue
+            while IFS= read -r -d '' src; do
+              fname=$(basename "$src")
+              [[ -n "${derived_seen[$fname]:-}" ]] && continue
+              cp -- "$src" ".build-lineage/$fname"
+              derived_seen[$fname]=1
+              merged_derived=$((merged_derived + 1))
+            done < <(find "$derived_dir" -name '*.json' -print0)
+          done
+
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
-          echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s); total SBOM entries: $total"
+          echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s), $merged_derived derived file(s) (changelog/history); total SBOM entries: $total"
 
       - name: Snapshot pull/star counts (idempotent per day)
         run: |

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -248,6 +248,26 @@ jobs:
               fi
             fi
             rm -f "$stderr_file"
+
+            # Also download build-lineage-* artifacts for this run (separate from sbom-*).
+            # Lineage files contain oci_subject_digest needed for attestation lookup.
+            # They are subject to the same cache race as SBOMs: a fresh SBOM with a
+            # stale lineage causes attestation_url to point at the wrong digest.
+            stderr_file=$(mktemp)
+            if gh run download "$run_id" \
+                --pattern 'build-lineage-*' \
+                --dir "$staging/$run_id-lineage" 2>"$stderr_file"; then
+              :
+            else
+              if grep -qi "no artifact" "$stderr_file" 2>/dev/null; then
+                : # No lineage artifact for this run, normal cache miss.
+              else
+                echo "::warning::gh run download (lineage) failed for run $run_id. stderr:" >&2
+                cat "$stderr_file" >&2
+                download_failures=$((download_failures + 1))
+              fi
+            fi
+            rm -f "$stderr_file"
           done
 
           if [[ "$download_failures" -gt 0 ]]; then
@@ -286,19 +306,39 @@ jobs:
             fi
 
             cp -- "$src" "$target"
-            # Derived files (.changelog.json, .history.json) are computed against the
-            # PREVIOUS .sbom.json baseline. Replacing the SBOM invalidates them — the
-            # next BUILD of this container (which runs auto-build's cache-lineage job)
-            # will regenerate them from the new baseline. Containers that never rebuild
-            # will keep showing empty "Recent Changes" — preferred over stale wrong data.
+            # .changelog.json is computed against the PREVIOUS .sbom.json baseline.
+            # Replacing the SBOM invalidates it. Next BUILD's cache-lineage will
+            # regenerate it. In the interim, show no "Recent Changes" rather than
+            # stale wrong data.
+            #
+            # .history.json is a MONOTONIC log — each row was correct at write time.
+            # Do NOT delete it: container-detail.js hides the entire Provenance
+            # section when missing, which would hurt containers that don't rebuild
+            # often more than the (small) inaccuracy of the latest history row.
             container_tag="${fname%.sbom.json}"
-            rm -f ".build-lineage/${container_tag}.changelog.json" \
-                  ".build-lineage/${container_tag}.history.json"
+            rm -f ".build-lineage/${container_tag}.changelog.json"
             merged=$((merged + 1))
           done < <(find "$staging" -name '*.sbom.json' -print0)
 
+          # Merge lineage files (mtime-based since they have no content timestamp).
+          # Exclude .sbom.json, .changelog.json, .history.json — only bare
+          # {container}-{tag}.json lineage files (which carry oci_subject_digest).
+          merged_lineage=0
+          while IFS= read -r -d '' src; do
+            fname=$(basename "$src")
+            target=".build-lineage/$fname"
+            if [[ ! -f "$target" ]] || [[ "$src" -nt "$target" ]]; then
+              cp -- "$src" "$target"
+              merged_lineage=$((merged_lineage + 1))
+            fi
+          done < <(find "$staging" -name '*.json' \
+            -not -name '*.sbom.json' \
+            -not -name '*.changelog.json' \
+            -not -name '*.history.json' \
+            -print0)
+
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
-          echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged file(s); total SBOM entries: $total"
+          echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s); total SBOM entries: $total"
 
       - name: Snapshot pull/star counts (idempotent per day)
         run: |

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -120,13 +120,30 @@ jobs:
           trap 'rm -rf "$staging"' EXIT
 
           downloaded=0
+          download_failures=0
           for run_id in $runs; do
+            stderr_file=$(mktemp)
             if gh run download "$run_id" \
                 --pattern 'trivy-scan-history-*' \
-                --dir "$staging/$run_id" 2>/dev/null; then
+                --dir "$staging/$run_id" 2>"$stderr_file"; then
               downloaded=$((downloaded + 1))
+            else
+              # gh run download exits non-zero on either real API error OR no matching artifact.
+              # Differentiate by inspecting stderr — "no artifacts match" is informational; anything else is a real failure worth surfacing.
+              if grep -qi "no artifact" "$stderr_file" 2>/dev/null; then
+                : # Expected: this run had no trivy-scan-history-* artifact, normal cache miss.
+              else
+                echo "::warning::gh run download failed for run $run_id — may indicate transient API issue. stderr:" >&2
+                cat "$stderr_file" >&2
+                download_failures=$((download_failures + 1))
+              fi
             fi
+            rm -f "$stderr_file"
           done
+
+          if [[ "$download_failures" -gt 0 ]]; then
+            echo "::warning::$download_failures gh run download call(s) failed; Trivy scan history hydration may be incomplete"
+          fi
 
           if [[ "$downloaded" -eq 0 ]]; then
             echo "::notice::No trivy-scan-history artifacts available across $run_count recent run(s); relying on cache only."
@@ -212,13 +229,30 @@ jobs:
           trap 'rm -rf "$staging"' EXIT
 
           downloaded=0
+          download_failures=0
           for run_id in $run_ids; do
+            stderr_file=$(mktemp)
             if gh run download "$run_id" \
                 --pattern 'sbom-*' \
-                --dir "$staging/$run_id" 2>/dev/null; then
+                --dir "$staging/$run_id" 2>"$stderr_file"; then
               downloaded=$((downloaded + 1))
+            else
+              # gh run download exits non-zero on either real API error OR no matching artifact.
+              # Differentiate by inspecting stderr — "no artifacts match" is informational; anything else is a real failure worth surfacing.
+              if grep -qi "no artifact" "$stderr_file" 2>/dev/null; then
+                : # Expected: this run had no sbom-* artifact, normal cache miss.
+              else
+                echo "::warning::gh run download failed for run $run_id — may indicate transient API issue. stderr:" >&2
+                cat "$stderr_file" >&2
+                download_failures=$((download_failures + 1))
+              fi
             fi
+            rm -f "$stderr_file"
           done
+
+          if [[ "$download_failures" -gt 0 ]]; then
+            echo "::warning::$download_failures gh run download call(s) failed; SBOM hydration may be incomplete"
+          fi
 
           if [[ "$downloaded" -eq 0 ]]; then
             echo "::notice::No sbom-* artifacts available across $run_count recent run(s); relying on cache only."
@@ -254,8 +288,9 @@ jobs:
             cp -- "$src" "$target"
             # Derived files (.changelog.json, .history.json) are computed against the
             # PREVIOUS .sbom.json baseline. Replacing the SBOM invalidates them — the
-            # next cache-lineage run will regenerate them from the new baseline.
-            # In the interim, show no "Recent Changes" rather than stale wrong data.
+            # next BUILD of this container (which runs auto-build's cache-lineage job)
+            # will regenerate them from the new baseline. Containers that never rebuild
+            # will keep showing empty "Recent Changes" — preferred over stale wrong data.
             container_tag="${fname%.sbom.json}"
             rm -f ".build-lineage/${container_tag}.changelog.json" \
                   ".build-lineage/${container_tag}.history.json"

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,8 @@
 ## Backlog
 
 - [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M (from /review F-005)
+- [ ] 🔧 [Dashboard] Batch yq calls in `verify-dashboard-data.sh` once container count > 25 — Priority: L (from PR #365 senior-review F-002)
+- [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L (pre-existing, surfaced in PR #365 senior-review)
 
 ## Completed (recent)
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,9 @@
 
 ## Backlog
 
-- [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M (from /review F-005)
-- [ ] 🔧 [Dashboard] Batch yq calls in `verify-dashboard-data.sh` once container count > 25 — Priority: L (from PR #365 senior-review F-002)
-- [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L (pre-existing, surfaced in PR #365 senior-review)
+- [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M
+- [ ] 🔧 [Dashboard] Batch yq calls in `verify-dashboard-data.sh` once container count > 25 — Priority: L
+- [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L
 
 ## Completed (recent)
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 ## Backlog
 
 - [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M
-- [ ] 🔧 [Dashboard] Batch yq calls in `verify-dashboard-data.sh` once container count > 25 — Priority: L
 - [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L
 
 ## Completed (recent)

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 - [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M
 - [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L
 - [ ] 🔧 [Dashboard] Extract the SBOM processing block (compare + history + cache replace) from `auto-build.yaml` and `recreate-manifests.yaml` into a `process_sbom_artifacts` function in `helpers/sbom-utils.sh`. Both workflows currently maintain ~45-LOC duplicates that drift over time (every PR2a fix had to be applied twice). Single point of change for SBOM logic — Priority: M
+- [ ] 🔧 [Dashboard] Wire `attestation_url` and `trivy_summary` from `containers.yml` into `docs/site/_includes/container-card.html` for `has_variants: false` containers. The data pipeline now emits these fields at container level, but `docs/site/index.html` only forwards a fixed subset to the include. Without this wiring, vector/web-shell/wordpress cards continue to render empty trust-strip badges even though the data exists. Belongs in the trust-strip components PR (PR2b) — Priority: M
 
 ## Completed (recent)
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 
 - [ ] 🔧 [terraform] Make cloud CLI version validation conditional on FLAVOR — Priority: M
 - [ ] 🐛 [Dashboard] `Capture OCI subject digest` step has `continue-on-error: true` → silently publishes digest-less lineage on flatten/inspect failure. Fail-closed OR gate `auto-build.yaml:645` upload on capture success — Priority: L
+- [ ] 🔧 [Dashboard] Extract the SBOM processing block (compare + history + cache replace) from `auto-build.yaml` and `recreate-manifests.yaml` into a `process_sbom_artifacts` function in `helpers/sbom-utils.sh`. Both workflows currently maintain ~45-LOC duplicates that drift over time (every PR2a fix had to be applied twice). Single point of change for SBOM logic — Priority: M
 
 ## Completed (recent)
 

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1141,20 +1141,52 @@ generate_data() {
             changelog=$(get_changelog "$container" "$current_version")
             build_history=$(get_build_history "$container" "$current_version")
 
-            # Pipe large SBOM data via stdin to avoid ARG_MAX limits
-            container_json=$(printf '%s\n%s\n%s\n%s\n%s' \
-                "$container_json" "$sbom_summary" "$sbom_packages" "$changelog" "$build_history" | \
-                jq -s '
+            # Trust-strip data for non-variant containers (mirror variant emission).
+            # Without these fields, the dashboard renders no SBOM badge / Trivy state /
+            # attestation link for vector, web-shell, wordpress, and any future
+            # non-variant container. The variant code path (collect_variant_json)
+            # already emits these via get_attestation_id / get_trivy_summary — mirror
+            # that logic here using current_version as the tag.
+            local subject_digest="" attestation_id="" attestation_url=""
+            local trivy_category trivy_summary
+            local lineage_file="$SCRIPT_DIR/.build-lineage/${container}-${current_version}.json"
+            if [[ -f "$lineage_file" ]]; then
+                subject_digest=$(jq -r '.oci_subject_digest // empty' "$lineage_file" 2>/dev/null || true)
+                if [[ -z "$subject_digest" ]]; then
+                    subject_digest=$(jq -r '.build_digest // ""' "$lineage_file" 2>/dev/null || true)
+                    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+                        echo "[debug] non-variant: using fallback build_digest=$subject_digest for $container-$current_version" >&2
+                fi
+            fi
+            if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
+                && attestation_id=$(get_attestation_id "$subject_digest"); then
+                attestation_url=$(get_attestation_url "$attestation_id")
+            fi
+            trivy_category=$(build_trivy_category "$container" "$current_version" "linux/amd64")
+            trivy_summary=$(get_trivy_summary "$trivy_category" 2>/dev/null || echo "{}")
+            [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+                echo "[debug] non-variant: trivy_summary for $container-$current_version = ${trivy_summary:0:60}…" >&2
+
+            # Pipe large SBOM + trust-strip data via stdin to avoid ARG_MAX limits
+            container_json=$(printf '%s\n%s\n%s\n%s\n%s\n%s' \
+                "$container_json" "$sbom_summary" "$sbom_packages" "$changelog" "$build_history" \
+                "$trivy_summary" | \
+                jq -s --arg attestation_id "$attestation_id" \
+                       --arg attestation_url "$attestation_url" '
                 .[0] as $base |
                 .[1] as $sbom_summary |
                 .[2] as $sbom_packages |
                 .[3] as $changelog |
                 .[4] as $build_history |
+                .[5] as $trivy_summary |
                 $base
                 + (if ($sbom_summary | keys | length) > 0 then {sbom_summary: $sbom_summary} else {} end)
                 + (if ($sbom_packages | keys | length) > 0 then {sbom_packages: $sbom_packages} else {} end)
                 + (if ($changelog | keys | length) > 0 then {changelog: $changelog} else {} end)
-                + (if ($build_history | length) > 0 then {build_history: $build_history} else {} end)')
+                + (if ($build_history | length) > 0 then {build_history: $build_history} else {} end)
+                + (if ($attestation_id | length) > 0 then {attestation_id: $attestation_id, attestation_url: $attestation_url} else {} end)
+                + (if ($trivy_summary | type) == "object" and $trivy_summary.last_scan != null then {trivy_summary: $trivy_summary} else {} end)
+                ')
         fi
 
         # Container-level multi_arch_platforms: derived from GHCR manifest for the

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -441,6 +441,12 @@ collect_variant_json() {
     sbom_packages=$(get_sbom_packages "$container" "$sbom_tag")
     changelog=$(get_changelog "$container" "$sbom_tag")
     build_history=$(get_build_history "$container" "$sbom_tag")
+    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+        echo "[debug] sbom_summary for $container-$sbom_tag = ${sbom_summary:0:60}…" >&2
+    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+        echo "[debug] changelog for $container-$sbom_tag = ${changelog:0:60}…" >&2
+    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+        echo "[debug] build_history for $container-$sbom_tag = ${build_history:0:60}…" >&2
 
     # Attestation: look up SBOM attestation ID from GitHub Attestations API.
     # The attestations API is keyed on the OCI subject digest (sha256:…) that
@@ -454,7 +460,11 @@ collect_variant_json() {
     subject_digest=$(echo "$lineage_json" | jq -r '.oci_subject_digest // empty')
     if [[ -z "$subject_digest" ]]; then
         subject_digest=$(echo "$lineage_json" | jq -r '.build_digest // "unknown"')
+        [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+            echo "[debug] using fallback build_digest=$subject_digest (oci_subject_digest empty) for $container-$sbom_tag" >&2
     fi
+    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+        echo "[debug] subject_digest for $container-$sbom_tag = ${subject_digest:0:60}…" >&2
     if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
         && attestation_id=$(get_attestation_id "$subject_digest"); then
         attestation_url=$(get_attestation_url "$attestation_id")
@@ -464,6 +474,8 @@ collect_variant_json() {
     local trivy_category trivy_summary
     trivy_category=$(build_trivy_category "$container" "$variant_tag" "linux/amd64")
     trivy_summary=$(get_trivy_summary "$trivy_category")
+    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+        echo "[debug] trivy_summary for $container-$variant_tag = ${trivy_summary:0:60}…" >&2
 
     # Multi-arch platform list: derive from GHCR manifest (reuse ghcr_get_manifest_sizes)
     local multi_arch_platforms_json="[]"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1163,7 +1163,7 @@ generate_data() {
                 attestation_url=$(get_attestation_url "$attestation_id")
             fi
             trivy_category=$(build_trivy_category "$container" "$current_version" "linux/amd64")
-            trivy_summary=$(get_trivy_summary "$trivy_category" 2>/dev/null || echo "{}")
+            trivy_summary=$(get_trivy_summary "$trivy_category" || echo "{}")
             [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
                 echo "[debug] non-variant: trivy_summary for $container-$current_version = ${trivy_summary:0:60}…" >&2
 

--- a/helpers/attestation-utils.sh
+++ b/helpers/attestation-utils.sh
@@ -47,6 +47,8 @@ get_attestation_id() {
         "repos/${ATTESTATION_UTILS_OWNER_REPO}/attestations?subject_digest=${digest}" \
         2>/dev/null) || {
         log_warning "gh api attestations failed for digest ${digest} (auth or network)"
+        [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+            echo "[debug] attestation API call failed for digest=$digest (auth or network error)" >&2
         _ATTESTATION_CACHE["$digest"]="__MISS__"
         return 1
     }
@@ -58,6 +60,8 @@ get_attestation_id() {
 
     if [[ -z "$id" ]]; then
         # No attestation found for this digest — expected for builds with SBOM step skipped
+        [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+            echo "[debug] attestation 404 for digest=$digest (no attestation record in GitHub API)" >&2
         _ATTESTATION_CACHE["$digest"]="__MISS__"
         return 1
     fi

--- a/helpers/attestation-utils.sh
+++ b/helpers/attestation-utils.sh
@@ -61,7 +61,7 @@ get_attestation_id() {
     if [[ -z "$id" ]]; then
         # No attestation found for this digest — expected for builds with SBOM step skipped
         [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
-            echo "[debug] attestation 404 for digest=$digest (no attestation record in GitHub API)" >&2
+            echo "[debug] attestation API returned no records for digest=$digest (response had empty attestations array)" >&2
         _ATTESTATION_CACHE["$digest"]="__MISS__"
         return 1
     fi

--- a/helpers/trivy-utils.sh
+++ b/helpers/trivy-utils.sh
@@ -190,6 +190,8 @@ get_trivy_summary() {
 
     # No side-channel data — fall back to API result (or empty form on failure).
     if [[ -z "$result" ]] || ! echo "$result" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+            echo "[debug] trivy summary empty for category=$category (no side-channel file, no API result)" >&2
         echo "$_TRIVY_EMPTY"
         return 0
     fi

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -188,5 +188,10 @@ while IFS=$'\t' read -r c v i tag field; do
   gaps=$((gaps + 1))
 done <<< "$gaps_tsv"
 
-echo "::warning::$gaps data gap(s) found in $YAML (advisory mode — run update-dashboard.yaml in CI to hydrate)."
-[[ "$STRICT" == "1" ]] && exit 1 || exit 0
+if [[ "$STRICT" == "1" ]]; then
+  echo "::error file=$YAML::$gaps data gap(s) found in $YAML (STRICT mode — failing the smoke gate)" >&2
+  exit 1
+else
+  echo "::warning file=$YAML::$gaps data gap(s) found in $YAML (advisory mode — run update-dashboard.yaml in CI to hydrate)"
+  exit 0
+fi

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -75,16 +75,34 @@ fi
 # - Containers with zero versions AND zero top-level variants emit field="<no-versions>".
 # - Multi-version path (has .versions[]): v_idx is the numeric version index.
 # - Single-version path (top-level .variants[], no .versions): v_idx is "single".
+# - has_variants:false path: v_idx is "no-variants"; fields are at container level.
 # - Each (container, version, variant, missing-field) tuple emits one row.
 # - Empty/null/{}/[] all count as missing.
 gaps_tsv=$(jq -r '
   .[] | .name as $c |
-  if (.versions // []) | length > 0 then
+  if (.has_variants != null and .has_variants == false) then
+    # Container-level fields (generate-dashboard.sh non-variant path)
+    {
+      attestation_url: (.attestation_url // null),
+      trivy_summary: (.trivy_summary // null),
+      sbom_summary: (.sbom_summary // null),
+      multi_arch_platforms: (.multi_arch_platforms // null)
+    } | to_entries[] |
+    select(
+      .value == null or
+      .value == "" or
+      (.value | type == "object" and length == 0) or
+      (.value | type == "array" and length == 0)
+    ) |
+    "\($c)\tno-variants\t-\t-\t\(.key)"
+  elif (.versions // []) | length > 0 then
     # Multi-version path (current standard schema)
     (.versions // []) | to_entries[] |
-    .key as $v | (.value.variants // []) as $variants |
+    .key as $v | .value as $version_obj |
+    ($version_obj.tag // $version_obj.base_tag // "v\($v)") as $vtag |
+    ($version_obj.variants // []) as $variants |
     if ($variants | length) == 0 then
-      "\($c)\t\($v)\t-\t-\t<no-variants>"
+      "\($c)\t\($v)\t-\t\($vtag)\t<no-variants>"
     else
       $variants | to_entries[] |
       .key as $i | .value as $variant |
@@ -147,15 +165,24 @@ while IFS=$'\t' read -r c v i tag field; do
       if [[ "$v" == "single" ]]; then
         echo "::warning file=$YAML::Container $c (single-version) has no variants — trust-strip data cannot render"
       else
-        echo "::warning file=$YAML::Version $v of $c has no variants — trust-strip data cannot render"
+        # $tag holds the version tag extracted by jq (e.g. "1.0-alpine", "v0" fallback).
+        # Using the tag rather than the numeric index makes the message actionable
+        # without cross-referencing containers.yml.
+        echo "::warning file=$YAML::Version $tag of $c has no variants — trust-strip data cannot render (versions[$v])"
       fi
       ;;
     *)
-      if [[ "$v" == "single" ]]; then
-        echo "::warning file=$YAML::Missing $field for $c variant $tag (single-version, variants[$i])"
-      else
-        echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
-      fi
+      case "$v" in
+        "no-variants")
+          echo "::warning file=$YAML::Missing $field for $c (top-level fields, no variants)"
+          ;;
+        "single")
+          echo "::warning file=$YAML::Missing $field for $c variant $tag (single-version, variants[$i])"
+          ;;
+        *)
+          echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
+          ;;
+      esac
       ;;
   esac
   gaps=$((gaps + 1))

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -7,6 +7,10 @@
 # Dashboard detail pages render trust-strip data for whichever version+variant
 # the user selects, so non-default variants must be checked too.
 #
+# Implementation: one yq call (YAML→JSON) + one jq call (gap detection).
+# Total process count is constant in container/variant count, so wall-time
+# stays under a second even at hundreds of variants.
+#
 # Local dev note: when running without a prior update-dashboard.yaml execution,
 # containers.yml is regenerated without SBOM artifact hydration — almost all
 # trust-strip fields will be missing. That is expected pre-CI; this script
@@ -19,10 +23,14 @@ set -euo pipefail
 
 YAML="${1:-docs/site/_data/containers.yml}"
 STRICT="${STRICT:-0}"
-gaps=0
 
 if ! command -v yq >/dev/null 2>&1; then
   echo "::error::yq required (install: https://github.com/mikefarah/yq)" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq required" >&2
   exit 2
 fi
 
@@ -31,53 +39,65 @@ if [[ ! -f "$YAML" ]]; then
   exit 2
 fi
 
-# Collect container names
-mapfile -t containers < <(yq '.[].name' "$YAML" 2>/dev/null)
+# Convert the entire YAML to JSON once. yq's -o=json flag is fast and avoids
+# bash word-splitting hazards on nested structures.
+yaml_json=$(yq -o=json '.' "$YAML" 2>/dev/null || true)
 
-if [[ "${#containers[@]}" -eq 0 ]]; then
+if [[ -z "$yaml_json" || "$yaml_json" == "null" ]]; then
+  echo "::warning::$YAML contains no parseable container data — nothing to verify"
+  exit 0
+fi
+
+container_count=$(jq 'length' <<<"$yaml_json")
+if [[ "$container_count" -eq 0 ]]; then
   echo "::warning::$YAML contains no containers — nothing to verify"
   exit 0
 fi
 
-for container in "${containers[@]}"; do
-  [[ -z "$container" ]] && continue
+# One jq pipeline emits TSV: container<TAB>v_idx<TAB>i_idx<TAB>tag<TAB>field
+# - Containers with zero versions emit a single row with field="<no-versions>".
+# - Each (container, version, variant, missing-field) tuple emits one row.
+# - Empty/null/{}/[] all count as missing.
+gaps_tsv=$(jq -r '
+  .[] | .name as $c |
+  if (.versions // []) | length == 0 then
+    "\($c)\t-\t-\t-\t<no-versions>"
+  else
+    (.versions // []) | to_entries[] |
+    .key as $v | (.value.variants // []) | to_entries[] |
+    .key as $i | .value as $variant |
+    ($variant.tag // "unknown") as $tag |
+    {
+      attestation_url: ($variant.attestation_url // null),
+      trivy_summary: ($variant.trivy_summary // null),
+      sbom_summary: ($variant.sbom_summary // null),
+      multi_arch_platforms: ($variant.multi_arch_platforms // null)
+    } | to_entries[] |
+    select(
+      .value == null or
+      .value == "" or
+      (.value | type == "object" and length == 0) or
+      (.value | type == "array" and length == 0)
+    ) |
+    "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
+  end
+' <<<"$yaml_json")
 
-  # Collect all (version_index, variant_index) pairs for this container.
-  # Use a count-based iteration rather than yq tag iteration to keep variant
-  # ordering stable.
-  version_count=$(yq ".[] | select(.name == \"$container\") | .versions | length // 0" "$YAML" 2>/dev/null)
-  if [[ -z "$version_count" || "$version_count" == "0" ]]; then
-    echo "::warning file=$YAML::No versions found for $container"
-    gaps=$((gaps + 1))
-    continue
-  fi
-
-  for ((v=0; v<version_count; v++)); do
-    variant_count=$(yq ".[] | select(.name == \"$container\") | .versions[$v].variants | length // 0" "$YAML" 2>/dev/null)
-    if [[ -z "$variant_count" || "$variant_count" == "0" ]]; then
-      continue
-    fi
-
-    for ((i=0; i<variant_count; i++)); do
-      variant=$(yq ".[] | select(.name == \"$container\") | .versions[$v].variants[$i]" "$YAML" 2>/dev/null || true)
-      [[ -z "$variant" ]] && continue
-      variant_tag=$(printf '%s' "$variant" | yq '.tag // "unknown"' - 2>/dev/null)
-
-      for field in attestation_url trivy_summary sbom_summary multi_arch_platforms; do
-        value=$(printf '%s' "$variant" | yq ".$field // \"\"" - 2>/dev/null || true)
-        if [[ -z "$value" ]] || [[ "$value" == "null" ]] || [[ "$value" == "{}" ]] || [[ "$value" == "[]" ]]; then
-          echo "::warning file=$YAML::Missing $field for $container variant $variant_tag (versions[$v].variants[$i])"
-          gaps=$((gaps + 1))
-        fi
-      done
-    done
-  done
-done
-
-if (( gaps == 0 )); then
+if [[ -z "$gaps_tsv" ]]; then
   echo "::notice::All containers have complete trust-strip data."
   exit 0
 fi
+
+gaps=0
+while IFS=$'\t' read -r c v i tag field; do
+  [[ -z "$c" ]] && continue
+  if [[ "$field" == "<no-versions>" ]]; then
+    echo "::warning file=$YAML::No versions found for $c"
+  else
+    echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
+  fi
+  gaps=$((gaps + 1))
+done <<< "$gaps_tsv"
 
 echo "::warning::$gaps data gap(s) found in $YAML (advisory mode — run update-dashboard.yaml in CI to hydrate)."
 [[ "$STRICT" == "1" ]] && exit 1 || exit 0

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -51,10 +51,10 @@ if ! yaml_json=$(yq -o=json '.' "$YAML" 2>"$yq_stderr"); then
   exit 2
 fi
 
-# Valid parse but empty document
+# Valid parse but empty document — treat as hard error: generation likely failed.
 if [[ -z "$yaml_json" || "$yaml_json" == "null" ]]; then
-  echo "::notice::$YAML parsed successfully but contains no documents — nothing to verify"
-  exit 0
+  echo "::error file=$YAML::$YAML parsed but contains no documents — generation likely failed; refusing to deploy blank dashboard" >&2
+  exit 2
 fi
 
 # Root MUST be a sequence (list of containers). Reject scalars / mappings early
@@ -67,8 +67,8 @@ fi
 
 container_count=$(jq 'length' <<<"$yaml_json")
 if [[ "$container_count" -eq 0 ]]; then
-  echo "::warning::$YAML contains no containers — nothing to verify"
-  exit 0
+  echo "::error file=$YAML::$YAML is an empty array — generation likely failed; refusing to deploy blank dashboard" >&2
+  exit 2
 fi
 
 # One jq pipeline emits TSV: container<TAB>v_idx<TAB>i_idx<TAB>tag<TAB>field

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -72,14 +72,15 @@ if [[ "$container_count" -eq 0 ]]; then
 fi
 
 # One jq pipeline emits TSV: container<TAB>v_idx<TAB>i_idx<TAB>tag<TAB>field
-# - Containers with zero versions emit a single row with field="<no-versions>".
+# - Containers with zero versions AND zero top-level variants emit field="<no-versions>".
+# - Multi-version path (has .versions[]): v_idx is the numeric version index.
+# - Single-version path (top-level .variants[], no .versions): v_idx is "single".
 # - Each (container, version, variant, missing-field) tuple emits one row.
 # - Empty/null/{}/[] all count as missing.
 gaps_tsv=$(jq -r '
   .[] | .name as $c |
-  if (.versions // []) | length == 0 then
-    "\($c)\t-\t-\t-\t<no-versions>"
-  else
+  if (.versions // []) | length > 0 then
+    # Multi-version path (current standard schema)
     (.versions // []) | to_entries[] |
     .key as $v | (.value.variants // []) as $variants |
     if ($variants | length) == 0 then
@@ -102,6 +103,27 @@ gaps_tsv=$(jq -r '
       ) |
       "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
     end
+  elif (.variants // []) | length > 0 then
+    # Single-version path: top-level .variants[] with no .versions wrapper.
+    # generate-dashboard.sh emits this schema for containers without a version matrix.
+    (.variants // []) | to_entries[] |
+    .key as $i | .value as $variant |
+    ($variant.tag // "unknown") as $tag |
+    {
+      attestation_url: ($variant.attestation_url // null),
+      trivy_summary: ($variant.trivy_summary // null),
+      sbom_summary: ($variant.sbom_summary // null),
+      multi_arch_platforms: ($variant.multi_arch_platforms // null)
+    } | to_entries[] |
+    select(
+      .value == null or
+      .value == "" or
+      (.value | type == "object" and length == 0) or
+      (.value | type == "array" and length == 0)
+    ) |
+    "\($c)\tsingle\t\($i)\t\($tag)\t\(.key)"
+  else
+    "\($c)\t-\t-\t-\t<no-versions>"
   end
 ' <<<"$yaml_json")
 
@@ -121,7 +143,11 @@ while IFS=$'\t' read -r c v i tag field; do
       echo "::warning file=$YAML::Version $v of $c has no variants — trust-strip data cannot render"
       ;;
     *)
-      echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
+      if [[ "$v" == "single" ]]; then
+        echo "::warning file=$YAML::Missing $field for $c variant $tag (single-version, variants[$i])"
+      else
+        echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
+      fi
       ;;
   esac
   gaps=$((gaps + 1))

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -92,7 +92,8 @@ gaps_tsv=$(jq -r '
       .value == null or
       .value == "" or
       (.value | type == "object" and length == 0) or
-      (.value | type == "array" and length == 0)
+      (.value | type == "array" and length == 0) or
+      (.key == "trivy_summary" and (.value | type == "object") and (.value.last_scan // null) == null)
     ) |
     "\($c)\tno-variants\t-\t-\t\(.key)"
   elif (.versions // []) | length > 0 then
@@ -117,7 +118,8 @@ gaps_tsv=$(jq -r '
         .value == null or
         .value == "" or
         (.value | type == "object" and length == 0) or
-        (.value | type == "array" and length == 0)
+        (.value | type == "array" and length == 0) or
+        (.key == "trivy_summary" and (.value | type == "object") and (.value.last_scan // null) == null)
       ) |
       "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
     end
@@ -140,7 +142,8 @@ gaps_tsv=$(jq -r '
         .value == null or
         .value == "" or
         (.value | type == "object" and length == 0) or
-        (.value | type == "array" and length == 0)
+        (.value | type == "array" and length == 0) or
+        (.key == "trivy_summary" and (.value | type == "object") and (.value.last_scan // null) == null)
       ) |
       "\($c)\tsingle\t\($i)\t\($tag)\t\(.key)"
     end

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify generated containers.yml has the trust-strip data fields populated.
+# Advisory mode (default): emits ::warning:: lines + exits 0.
+# Strict mode (STRICT=1): exits 1 on any gap.
+#
+# Local dev note: when running without a prior update-dashboard.yaml execution,
+# containers.yml is regenerated without SBOM artifact hydration — almost all
+# trust-strip fields will be missing. That is expected pre-CI; this script
+# surfaces those gaps so you know what the CI pipeline will fill in.
+#
+# Usage:
+#   scripts/verify-dashboard-data.sh [containers_yml]
+#   STRICT=1 scripts/verify-dashboard-data.sh [containers_yml]
+set -euo pipefail
+
+YAML="${1:-docs/site/_data/containers.yml}"
+STRICT="${STRICT:-0}"
+gaps=0
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "::error::yq required (install: https://github.com/mikefarah/yq)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$YAML" ]]; then
+  echo "::error::$YAML not found — run generate-dashboard.sh first" >&2
+  exit 2
+fi
+
+# Collect container names
+mapfile -t containers < <(yq '.[].name' "$YAML" 2>/dev/null)
+
+if [[ "${#containers[@]}" -eq 0 ]]; then
+  echo "::warning::$YAML contains no containers — nothing to verify"
+  exit 0
+fi
+
+for container in "${containers[@]}"; do
+  [[ -z "$container" ]] && continue
+
+  # Read the default variant (versions[0].variants[0]) as a YAML fragment
+  default_variant=$(yq ".[] | select(.name == \"$container\") | .versions[0].variants[0]" "$YAML" 2>/dev/null || true)
+
+  if [[ -z "$default_variant" ]]; then
+    echo "::warning file=$YAML::No default variant found for $container"
+    gaps=$((gaps + 1))
+    continue
+  fi
+
+  for field in attestation_url trivy_summary sbom_summary multi_arch_platforms; do
+    value=$(printf '%s' "$default_variant" | yq ".$field // \"\"" - 2>/dev/null || true)
+
+    # Treat empty, "null", "{}", "[]" as missing
+    if [[ -z "$value" ]] \
+        || [[ "$value" == "null" ]] \
+        || [[ "$value" == "{}" ]] \
+        || [[ "$value" == "[]" ]]; then
+      echo "::warning file=$YAML::Missing $field for $container default_variant"
+      gaps=$((gaps + 1))
+    fi
+  done
+done
+
+if (( gaps == 0 )); then
+  echo "::notice::All containers have complete trust-strip data."
+  exit 0
+fi
+
+echo "::warning::$gaps data gap(s) found in $YAML (advisory mode — run update-dashboard.yaml in CI to hydrate)."
+[[ "$STRICT" == "1" ]] && exit 1 || exit 0

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -103,25 +103,29 @@ gaps_tsv=$(jq -r '
       ) |
       "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
     end
-  elif (.variants // []) | length > 0 then
-    # Single-version path: top-level .variants[] with no .versions wrapper.
+  elif (.variants != null and (.variants | type == "array")) then
+    # Single-version path: top-level .variants key exists (even if empty) with no .versions wrapper.
     # generate-dashboard.sh emits this schema for containers without a version matrix.
-    (.variants // []) | to_entries[] |
-    .key as $i | .value as $variant |
-    ($variant.tag // "unknown") as $tag |
-    {
-      attestation_url: ($variant.attestation_url // null),
-      trivy_summary: ($variant.trivy_summary // null),
-      sbom_summary: ($variant.sbom_summary // null),
-      multi_arch_platforms: ($variant.multi_arch_platforms // null)
-    } | to_entries[] |
-    select(
-      .value == null or
-      .value == "" or
-      (.value | type == "object" and length == 0) or
-      (.value | type == "array" and length == 0)
-    ) |
-    "\($c)\tsingle\t\($i)\t\($tag)\t\(.key)"
+    if (.variants | length) == 0 then
+      "\($c)\tsingle\t-\t-\t<no-variants>"
+    else
+      (.variants // []) | to_entries[] |
+      .key as $i | .value as $variant |
+      ($variant.tag // "unknown") as $tag |
+      {
+        attestation_url: ($variant.attestation_url // null),
+        trivy_summary: ($variant.trivy_summary // null),
+        sbom_summary: ($variant.sbom_summary // null),
+        multi_arch_platforms: ($variant.multi_arch_platforms // null)
+      } | to_entries[] |
+      select(
+        .value == null or
+        .value == "" or
+        (.value | type == "object" and length == 0) or
+        (.value | type == "array" and length == 0)
+      ) |
+      "\($c)\tsingle\t\($i)\t\($tag)\t\(.key)"
+    end
   else
     "\($c)\t-\t-\t-\t<no-versions>"
   end
@@ -140,7 +144,11 @@ while IFS=$'\t' read -r c v i tag field; do
       echo "::warning file=$YAML::No versions found for $c"
       ;;
     "<no-variants>")
-      echo "::warning file=$YAML::Version $v of $c has no variants — trust-strip data cannot render"
+      if [[ "$v" == "single" ]]; then
+        echo "::warning file=$YAML::Container $c (single-version) has no variants — trust-strip data cannot render"
+      else
+        echo "::warning file=$YAML::Version $v of $c has no variants — trust-strip data cannot render"
+      fi
       ;;
     *)
       if [[ "$v" == "single" ]]; then

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -41,11 +41,28 @@ fi
 
 # Convert the entire YAML to JSON once. yq's -o=json flag is fast and avoids
 # bash word-splitting hazards on nested structures.
-yaml_json=$(yq -o=json '.' "$YAML" 2>/dev/null || true)
+# Capture stderr separately so yq parse errors are surfaced (not silently swallowed).
+yq_stderr=$(mktemp)
+trap 'rm -f "$yq_stderr"' EXIT
 
+if ! yaml_json=$(yq -o=json '.' "$YAML" 2>"$yq_stderr"); then
+  echo "::error file=$YAML::yq failed to parse YAML:" >&2
+  cat "$yq_stderr" >&2
+  exit 2
+fi
+
+# Valid parse but empty document
 if [[ -z "$yaml_json" || "$yaml_json" == "null" ]]; then
-  echo "::warning::$YAML contains no parseable container data — nothing to verify"
+  echo "::notice::$YAML parsed successfully but contains no documents — nothing to verify"
   exit 0
+fi
+
+# Root MUST be a sequence (list of containers). Reject scalars / mappings early
+# with a clear error rather than letting jq's iteration error leak out later.
+if ! jq -e 'type == "array"' <<<"$yaml_json" >/dev/null 2>&1; then
+  root_type=$(jq -r 'type' <<<"$yaml_json" 2>/dev/null || echo "unknown")
+  echo "::error file=$YAML::expected top-level YAML sequence (list of containers), got $root_type" >&2
+  exit 2
 fi
 
 container_count=$(jq 'length' <<<"$yaml_json")
@@ -64,22 +81,27 @@ gaps_tsv=$(jq -r '
     "\($c)\t-\t-\t-\t<no-versions>"
   else
     (.versions // []) | to_entries[] |
-    .key as $v | (.value.variants // []) | to_entries[] |
-    .key as $i | .value as $variant |
-    ($variant.tag // "unknown") as $tag |
-    {
-      attestation_url: ($variant.attestation_url // null),
-      trivy_summary: ($variant.trivy_summary // null),
-      sbom_summary: ($variant.sbom_summary // null),
-      multi_arch_platforms: ($variant.multi_arch_platforms // null)
-    } | to_entries[] |
-    select(
-      .value == null or
-      .value == "" or
-      (.value | type == "object" and length == 0) or
-      (.value | type == "array" and length == 0)
-    ) |
-    "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
+    .key as $v | (.value.variants // []) as $variants |
+    if ($variants | length) == 0 then
+      "\($c)\t\($v)\t-\t-\t<no-variants>"
+    else
+      $variants | to_entries[] |
+      .key as $i | .value as $variant |
+      ($variant.tag // "unknown") as $tag |
+      {
+        attestation_url: ($variant.attestation_url // null),
+        trivy_summary: ($variant.trivy_summary // null),
+        sbom_summary: ($variant.sbom_summary // null),
+        multi_arch_platforms: ($variant.multi_arch_platforms // null)
+      } | to_entries[] |
+      select(
+        .value == null or
+        .value == "" or
+        (.value | type == "object" and length == 0) or
+        (.value | type == "array" and length == 0)
+      ) |
+      "\($c)\t\($v)\t\($i)\t\($tag)\t\(.key)"
+    end
   end
 ' <<<"$yaml_json")
 
@@ -91,11 +113,17 @@ fi
 gaps=0
 while IFS=$'\t' read -r c v i tag field; do
   [[ -z "$c" ]] && continue
-  if [[ "$field" == "<no-versions>" ]]; then
-    echo "::warning file=$YAML::No versions found for $c"
-  else
-    echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
-  fi
+  case "$field" in
+    "<no-versions>")
+      echo "::warning file=$YAML::No versions found for $c"
+      ;;
+    "<no-variants>")
+      echo "::warning file=$YAML::Version $v of $c has no variants — trust-strip data cannot render"
+      ;;
+    *)
+      echo "::warning file=$YAML::Missing $field for $c variant $tag (versions[$v].variants[$i])"
+      ;;
+  esac
   gaps=$((gaps + 1))
 done <<< "$gaps_tsv"
 

--- a/scripts/verify-dashboard-data.sh
+++ b/scripts/verify-dashboard-data.sh
@@ -3,6 +3,10 @@
 # Advisory mode (default): emits ::warning:: lines + exits 0.
 # Strict mode (STRICT=1): exits 1 on any gap.
 #
+# Coverage: ALL versions × ALL variants per container (not just the default).
+# Dashboard detail pages render trust-strip data for whichever version+variant
+# the user selects, so non-default variants must be checked too.
+#
 # Local dev note: when running without a prior update-dashboard.yaml execution,
 # containers.yml is regenerated without SBOM artifact hydration — almost all
 # trust-strip fields will be missing. That is expected pre-CI; this script
@@ -38,26 +42,35 @@ fi
 for container in "${containers[@]}"; do
   [[ -z "$container" ]] && continue
 
-  # Read the default variant (versions[0].variants[0]) as a YAML fragment
-  default_variant=$(yq ".[] | select(.name == \"$container\") | .versions[0].variants[0]" "$YAML" 2>/dev/null || true)
-
-  if [[ -z "$default_variant" ]]; then
-    echo "::warning file=$YAML::No default variant found for $container"
+  # Collect all (version_index, variant_index) pairs for this container.
+  # Use a count-based iteration rather than yq tag iteration to keep variant
+  # ordering stable.
+  version_count=$(yq ".[] | select(.name == \"$container\") | .versions | length // 0" "$YAML" 2>/dev/null)
+  if [[ -z "$version_count" || "$version_count" == "0" ]]; then
+    echo "::warning file=$YAML::No versions found for $container"
     gaps=$((gaps + 1))
     continue
   fi
 
-  for field in attestation_url trivy_summary sbom_summary multi_arch_platforms; do
-    value=$(printf '%s' "$default_variant" | yq ".$field // \"\"" - 2>/dev/null || true)
-
-    # Treat empty, "null", "{}", "[]" as missing
-    if [[ -z "$value" ]] \
-        || [[ "$value" == "null" ]] \
-        || [[ "$value" == "{}" ]] \
-        || [[ "$value" == "[]" ]]; then
-      echo "::warning file=$YAML::Missing $field for $container default_variant"
-      gaps=$((gaps + 1))
+  for ((v=0; v<version_count; v++)); do
+    variant_count=$(yq ".[] | select(.name == \"$container\") | .versions[$v].variants | length // 0" "$YAML" 2>/dev/null)
+    if [[ -z "$variant_count" || "$variant_count" == "0" ]]; then
+      continue
     fi
+
+    for ((i=0; i<variant_count; i++)); do
+      variant=$(yq ".[] | select(.name == \"$container\") | .versions[$v].variants[$i]" "$YAML" 2>/dev/null || true)
+      [[ -z "$variant" ]] && continue
+      variant_tag=$(printf '%s' "$variant" | yq '.tag // "unknown"' - 2>/dev/null)
+
+      for field in attestation_url trivy_summary sbom_summary multi_arch_platforms; do
+        value=$(printf '%s' "$variant" | yq ".$field // \"\"" - 2>/dev/null || true)
+        if [[ -z "$value" ]] || [[ "$value" == "null" ]] || [[ "$value" == "{}" ]] || [[ "$value" == "[]" ]]; then
+          echo "::warning file=$YAML::Missing $field for $container variant $variant_tag (versions[$v].variants[$i])"
+          gaps=$((gaps + 1))
+        fi
+      done
+    done
   done
 done
 

--- a/tests/fixtures/containers-complete.yml
+++ b/tests/fixtures/containers-complete.yml
@@ -1,0 +1,31 @@
+- name: postgres
+  versions:
+    - version: "18"
+      variants:
+        - name: full
+          tag: 18-alpine-full
+          description: "All extensions"
+          is_default: true
+          size_amd64: "450MB"
+          size_arm64: "430MB"
+          build_digest: "sha256:aabbccddeeff00112233445566778899"
+          base_image: "alpine:3.19"
+          attestation_id: "12345"
+          attestation_url: "https://github.com/oorabona/docker-containers/attestations/12345"
+          multi_arch_platforms:
+            - linux/amd64
+            - linux/arm64
+          sbom_summary:
+            total_packages: 120
+            ecosystem_breakdown:
+              alpine: 80
+              go: 40
+          trivy_summary:
+            last_scan: "2026-05-01T10:00:00Z"
+            counts:
+              critical: 0
+              high: 0
+              medium: 2
+              low: 5
+              info: 0
+            top_advisories: []

--- a/tests/fixtures/containers-empty-versions.yml
+++ b/tests/fixtures/containers-empty-versions.yml
@@ -1,0 +1,44 @@
+# Fixture: sentinel coverage — exercises <no-versions> and <no-variants> paths.
+# Used by tests/unit/data-completeness.bats.
+#
+# lonely  — has versions: []         → triggers <no-versions> sentinel
+# phantom — version with variants: [] → triggers <no-variants> sentinel
+# healthy — fully-populated variant   → must NOT trigger any warning
+
+- name: lonely
+  versions: []
+
+- name: phantom
+  versions:
+    - version: "1.0"
+      variants: []
+
+- name: healthy
+  versions:
+    - version: "2.0"
+      variants:
+        - name: full
+          tag: 2.0-full
+          description: "Full build"
+          is_default: true
+          size_amd64: "100MB"
+          size_arm64: "95MB"
+          build_digest: "sha256:aabbccddeeff00112233445566778899"
+          base_image: "alpine:3.19"
+          attestation_id: "99999"
+          attestation_url: "https://github.com/oorabona/docker-containers/attestations/99999"
+          multi_arch_platforms:
+            - linux/amd64
+          sbom_summary:
+            total_packages: 5
+            ecosystem_breakdown:
+              alpine: 5
+          trivy_summary:
+            last_scan: "2026-05-01T00:00:00Z"
+            counts:
+              critical: 0
+              high: 0
+              medium: 0
+              low: 0
+              info: 0
+            top_advisories: []

--- a/tests/fixtures/containers-empty-versions.yml
+++ b/tests/fixtures/containers-empty-versions.yml
@@ -10,12 +10,14 @@
 
 - name: phantom
   versions:
-    - version: "1.0"
+    - tag: "1.0"
+      base_tag: "1.0"
       variants: []
 
 - name: healthy
   versions:
-    - version: "2.0"
+    - tag: "2.0"
+      base_tag: "2.0"
       variants:
         - name: full
           tag: 2.0-full

--- a/tests/fixtures/containers-missing.yml
+++ b/tests/fixtures/containers-missing.yml
@@ -1,0 +1,14 @@
+- name: ansible
+  versions:
+    - version: "10.7.0"
+      variants:
+        - name: default
+          tag: 10.7.0
+          description: "Ansible automation platform"
+          is_default: true
+          size_amd64: "210MB"
+          size_arm64: ""
+          build_digest: "sha256:001122334455667788990011223344"
+          base_image: "python:3.12-slim"
+          multi_arch_platforms:
+            - linux/amd64

--- a/tests/fixtures/containers-multi-variant.yml
+++ b/tests/fixtures/containers-multi-variant.yml
@@ -1,0 +1,99 @@
+- name: postgres
+  versions:
+    - version: "18"
+      variants:
+        # versions[0].variants[0] — default, all fields present.
+        - name: full
+          tag: 18-alpine-full
+          description: "All extensions"
+          is_default: true
+          size_amd64: "450MB"
+          size_arm64: "430MB"
+          build_digest: "sha256:aabbccddeeff00112233445566778899"
+          base_image: "alpine:3.19"
+          attestation_id: "12345"
+          attestation_url: "https://github.com/oorabona/docker-containers/attestations/12345"
+          multi_arch_platforms:
+            - linux/amd64
+            - linux/arm64
+          sbom_summary:
+            total_packages: 120
+            ecosystem_breakdown:
+              alpine: 80
+              go: 40
+          trivy_summary:
+            last_scan: "2026-05-01T10:00:00Z"
+            counts:
+              critical: 0
+              high: 0
+              medium: 2
+              low: 5
+              info: 0
+            top_advisories: []
+        # versions[0].variants[1] — non-default, MISSING attestation_url + trivy_summary.
+        - name: vector
+          tag: 18-alpine-vector
+          description: "pgvector only"
+          is_default: false
+          size_amd64: "200MB"
+          size_arm64: "195MB"
+          build_digest: "sha256:1122334455667788"
+          base_image: "alpine:3.19"
+          multi_arch_platforms:
+            - linux/amd64
+            - linux/arm64
+          sbom_summary:
+            total_packages: 80
+            ecosystem_breakdown:
+              alpine: 60
+              go: 20
+    - version: "17"
+      variants:
+        # versions[1].variants[0] — non-default version, empty sbom_summary.
+        - name: full
+          tag: 17-alpine-full
+          description: "All extensions v17"
+          is_default: false
+          size_amd64: "440MB"
+          size_arm64: "420MB"
+          build_digest: "sha256:aabbccddeeff99887766"
+          base_image: "alpine:3.19"
+          attestation_id: "67890"
+          attestation_url: "https://github.com/oorabona/docker-containers/attestations/67890"
+          multi_arch_platforms:
+            - linux/amd64
+            - linux/arm64
+          sbom_summary: {}
+          trivy_summary:
+            last_scan: "2026-04-30T10:00:00Z"
+            counts:
+              critical: 0
+              high: 1
+              medium: 3
+              low: 8
+              info: 0
+            top_advisories: []
+        # versions[1].variants[1] — non-default version + variant, MISSING multi_arch_platforms.
+        - name: base
+          tag: 17-alpine-base
+          description: "Base only v17"
+          is_default: false
+          size_amd64: "150MB"
+          size_arm64: "145MB"
+          build_digest: "sha256:bbccddee11223344"
+          base_image: "alpine:3.19"
+          attestation_id: "11111"
+          attestation_url: "https://github.com/oorabona/docker-containers/attestations/11111"
+          sbom_summary:
+            total_packages: 50
+            ecosystem_breakdown:
+              alpine: 50
+          trivy_summary:
+            last_scan: "2026-04-29T10:00:00Z"
+            counts:
+              critical: 0
+              high: 0
+              medium: 1
+              low: 2
+              info: 0
+            top_advisories: []

--- a/tests/fixtures/containers-no-variants.yml
+++ b/tests/fixtures/containers-no-variants.yml
@@ -1,0 +1,23 @@
+# Fixture: has_variants:false containers (generate-dashboard.sh non-variant path).
+# Trust-strip fields live at container level (not inside variants[]).
+# Used by tests/unit/data-completeness.bats.
+#
+# standalone — fully populated has_variants:false container → no warnings
+# incomplete  — missing attestation_url, trivy_summary, sbom_summary → 3 warnings
+
+- name: standalone
+  has_variants: false
+  attestation_url: "https://example.com/att/standalone"
+  multi_arch_platforms:
+    - linux/amd64
+  sbom_summary:
+    total_packages: 25
+  trivy_summary:
+    last_scan: "2026-05-01T00:00:00Z"
+    counts:
+      critical: 0
+
+- name: incomplete
+  has_variants: false
+  multi_arch_platforms:
+    - linux/amd64

--- a/tests/fixtures/containers-single-version-empty.yml
+++ b/tests/fixtures/containers-single-version-empty.yml
@@ -1,0 +1,25 @@
+# Fixture: single-version containers where top-level variants[] is present but empty.
+# Used by tests/unit/data-completeness.bats.
+#
+# ghost — has_variants:true + variants:[] → triggers <no-variants> (single-version path)
+# real  — fully populated single-version container → must NOT trigger any warning
+
+- name: ghost
+  has_variants: true
+  variants: []
+
+- name: real
+  has_variants: true
+  variants:
+    - name: full
+      tag: 1.0
+      is_default: true
+      attestation_url: "https://example.com/att/1"
+      multi_arch_platforms:
+        - linux/amd64
+      sbom_summary:
+        total_packages: 5
+      trivy_summary:
+        last_scan: "2026-05-01T00:00:00Z"
+        counts:
+          critical: 0

--- a/tests/fixtures/containers-single-version.yml
+++ b/tests/fixtures/containers-single-version.yml
@@ -1,0 +1,28 @@
+# Fixture: containers with the single-version schema emitted by generate-dashboard.sh:606+.
+# These containers have top-level .variants[] with NO .versions[] wrapper.
+# verify-dashboard-data.sh must handle both schemas without false positives.
+
+- name: simple
+  has_variants: true
+  variants:
+    - name: full
+      tag: 1.0
+      is_default: true
+      attestation_url: "https://example.com/att/x"
+      multi_arch_platforms: [linux/amd64]
+      sbom_summary:
+        total_packages: 10
+      trivy_summary:
+        last_scan: "2026-05-01T00:00:00Z"
+        counts:
+          critical: 0
+
+- name: partial
+  has_variants: true
+  variants:
+    - name: full
+      tag: 2.0
+      is_default: true
+      multi_arch_platforms: [linux/amd64]
+      sbom_summary:
+        total_packages: 5

--- a/tests/unit/dashboard-helpers.bats
+++ b/tests/unit/dashboard-helpers.bats
@@ -248,7 +248,7 @@ EOF
     build_trivy_category()           { echo "myapp:1.2.3"; }
     get_attestation_id()             { echo "att-id-xyz"; }
     get_attestation_url()            { echo "https://example.com/att/att-id-xyz"; }
-    get_trivy_summary()              { echo '{"last_scan":"2026-05-04","critical":0,"high":1}'; }
+    get_trivy_summary()              { echo '{"last_scan":"2026-05-04T12:00:00Z","counts":{"critical":0,"high":0,"medium":2,"low":5,"info":0},"top_advisories":[]}'; }
     generate_container_page()        { :; }
     fetch_recent_activity()          { echo "[]"; }
     calculate_build_success_rate()   { echo "5:5:100"; }
@@ -271,6 +271,9 @@ EOF
     [[ "$yml_content" == *"trivy_summary"* ]]
     [[ "$yml_content" == *"att-id-xyz"* ]]
     [[ "$yml_content" == *"last_scan"* ]]
+    # Validate production schema: counts sub-object must be present (not flat critical/high at top level).
+    # yq -P serialises {"counts":{"critical":0,...}} as "counts:\n  critical: 0" in YAML.
+    [[ "$yml_content" == *"counts:"* ]]
 
     rm -f "$TRIVY_CACHE_FILE"
 }

--- a/tests/unit/dashboard-helpers.bats
+++ b/tests/unit/dashboard-helpers.bats
@@ -194,3 +194,83 @@ EOF
     run resolve_variant_lineage_file "postgres" "18-alpine-analytics" "analytics"
     [[ "$output" == *"postgres-18-alpine-analytics.json" ]]
 }
+
+# ===================================================================
+# Non-variant trust-strip emission
+# Regression test for round-14 non-variant attestation + trivy emission.
+# Integration-style: calls generate_data() with mocked helpers so the
+# non-variant (has_variants:false) code path is exercised end-to-end.
+# ===================================================================
+
+@test "generate_data: non-variant container emits attestation_url and trivy_summary" {
+    # ---- fixture: minimal container directory (no variants.yaml) ----
+    mkdir -p "$TEST_DIR/myapp"
+    printf '#!/bin/bash\necho "1.2.3"\n' > "$TEST_DIR/myapp/version.sh"
+    chmod +x "$TEST_DIR/myapp/version.sh"
+    printf 'FROM alpine:3.19\n' > "$TEST_DIR/myapp/Dockerfile"
+
+    # Lineage file with oci_subject_digest so trust-strip code path is taken
+    mkdir -p "$TEST_DIR/.build-lineage"
+    cat > "$TEST_DIR/.build-lineage/myapp-1.2.3.json" <<'EOF'
+{
+  "container": "myapp",
+  "version": "1.2.3",
+  "build_digest": "sha256:aaabbbccc",
+  "oci_subject_digest": "sha256:deadbeef1234",
+  "base_image_ref": "alpine:3.19",
+  "built_at": "2026-05-04T00:00:00+00:00"
+}
+EOF
+
+    # Output dirs expected by generate_data
+    mkdir -p "$TEST_DIR/docs/site/_data"
+    mkdir -p "$TEST_DIR/docs/site/_containers"
+
+    # Point generate-dashboard.sh globals at TEST_DIR
+    export SCRIPT_DIR="$TEST_DIR"
+    DATA_FILE="$TEST_DIR/docs/site/_data/containers.yml"
+    CONTAINERS_DIR="$TEST_DIR/docs/site/_containers"
+    STATS_FILE="$TEST_DIR/docs/site/_data/stats.yml"
+    TRIVY_CACHE_FILE=$(mktemp)
+    export TRIVY_CACHE_FILE DATA_FILE CONTAINERS_DIR STATS_FILE
+
+    # ---- mock all external helpers ----
+    get_current_published_version() { echo "1.2.3"; }
+    get_container_build_status()     { echo "success"; }
+    populate_container_build_status_cache() { :; }
+    get_dockerhub_stats()            { echo "pulls:0 stars:0"; }
+    get_ghcr_sizes()                 { echo ""; }
+    ghcr_get_manifest_sizes()        { echo ""; }
+    get_sbom_summary()               { echo "{}"; }
+    get_sbom_packages()              { echo "{}"; }
+    get_changelog()                  { echo "{}"; }
+    get_build_history()              { echo "[]"; }
+    build_trivy_category()           { echo "myapp:1.2.3"; }
+    get_attestation_id()             { echo "att-id-xyz"; }
+    get_attestation_url()            { echo "https://example.com/att/att-id-xyz"; }
+    get_trivy_summary()              { echo '{"last_scan":"2026-05-04","critical":0,"high":1}'; }
+    generate_container_page()        { :; }
+    fetch_recent_activity()          { echo "[]"; }
+    calculate_build_success_rate()   { echo "5:5:100"; }
+    write_stats_file()               { :; }
+    export -f get_current_published_version get_container_build_status \
+              populate_container_build_status_cache get_dockerhub_stats \
+              get_ghcr_sizes ghcr_get_manifest_sizes get_sbom_summary \
+              get_sbom_packages get_changelog get_build_history \
+              build_trivy_category get_attestation_id get_attestation_url \
+              get_trivy_summary generate_container_page fetch_recent_activity \
+              calculate_build_success_rate write_stats_file
+
+    # ---- run generate_data (not via `run` — we need side-effects on disk) ----
+    generate_data
+
+    # ---- assert: containers.yml contains attestation_url + trivy_summary ----
+    [ -f "$DATA_FILE" ]
+    yml_content=$(cat "$DATA_FILE")
+    [[ "$yml_content" == *"attestation_url"* ]]
+    [[ "$yml_content" == *"trivy_summary"* ]]
+    [[ "$yml_content" == *"att-id-xyz"* ]]
+    [[ "$yml_content" == *"last_scan"* ]]
+
+    rm -f "$TRIVY_CACHE_FILE"
+}

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -8,6 +8,7 @@ setup() {
     VERIFY_SCRIPT="$PROJECT_ROOT/scripts/verify-dashboard-data.sh"
     FIXTURE_COMPLETE="$PROJECT_ROOT/tests/fixtures/containers-complete.yml"
     FIXTURE_MISSING="$PROJECT_ROOT/tests/fixtures/containers-missing.yml"
+    FIXTURE_MULTI_VARIANT="$PROJECT_ROOT/tests/fixtures/containers-multi-variant.yml"
 }
 
 @test "verify-dashboard-data: complete fixture exits 0 with notice" {
@@ -25,5 +26,20 @@ setup() {
 
 @test "verify-dashboard-data STRICT=1: missing-fields fixture exits 1" {
     STRICT=1 run "$VERIFY_SCRIPT" "$FIXTURE_MISSING"
+    [ "$status" -eq 1 ]
+}
+
+@test "verify-dashboard-data: multi-variant fixture flags non-default variant gaps" {
+    run "$VERIFY_SCRIPT" "$FIXTURE_MULTI_VARIANT"
+    [ "$status" -eq 0 ]
+    # Should warn for at least 3 distinct field gaps across non-default variants
+    warning_count=$(echo "$output" | grep -c "::warning file=")
+    [ "$warning_count" -ge 3 ]
+    # Should explicitly mention non-default variant paths
+    [[ "$output" == *"variants[1]"* || "$output" == *"variants[0])"* ]] || [[ "$output" == *"versions[1]"* ]]
+}
+
+@test "verify-dashboard-data STRICT=1: multi-variant fixture exits 1 on non-default gaps" {
+    STRICT=1 run "$VERIFY_SCRIPT" "$FIXTURE_MULTI_VARIANT"
     [ "$status" -eq 1 ]
 }

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -50,7 +50,7 @@ setup() {
     [ "$status" -eq 0 ]
     # Both sentinels should fire
     [[ "$output" == *"No versions found for lonely"* ]]
-    [[ "$output" == *"Version 0 of phantom has no variants"* ]]
+    [[ "$output" == *"Version v0 of phantom has no variants"* ]]
     # Healthy container should NOT trigger any warning
     ! [[ "$output" == *"Missing"*"healthy"* ]]
     ! [[ "$output" == *"No versions"*"healthy"* ]]
@@ -87,4 +87,23 @@ setup() {
     [ "$status" -eq 2 ]
     [[ "$output" == *"::error"* ]]
     [[ "$output" == *"expected top-level YAML sequence"* ]]
+}
+
+@test "verify-dashboard-data: single-version container with empty variants[] flags <no-variants>" {
+    FIXTURE_SINGLE_EMPTY="$PROJECT_ROOT/tests/fixtures/containers-single-version-empty.yml"
+    run "$VERIFY_SCRIPT" "$FIXTURE_SINGLE_EMPTY"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Container ghost (single-version) has no variants"* ]]
+    ! [[ "$output" == *"Missing"*"real"* ]]
+}
+
+@test "verify-dashboard-data: has_variants:false fixture handles top-level fields" {
+    FIXTURE_NO_VARIANTS="$PROJECT_ROOT/tests/fixtures/containers-no-variants.yml"
+    run "$VERIFY_SCRIPT" "$FIXTURE_NO_VARIANTS"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" == *"Missing"*"standalone"* ]]
+    [[ "$output" == *"Missing attestation_url for incomplete"* ]]
+    [[ "$output" == *"Missing trivy_summary for incomplete"* ]]
+    [[ "$output" == *"Missing sbom_summary for incomplete"* ]]
+    [[ "$output" == *"top-level fields"* ]]
 }

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -43,3 +43,15 @@ setup() {
     STRICT=1 run "$VERIFY_SCRIPT" "$FIXTURE_MULTI_VARIANT"
     [ "$status" -eq 1 ]
 }
+
+@test "verify-dashboard-data: empty-versions fixture flags <no-versions> and <no-variants> sentinels" {
+    FIXTURE_EMPTY_VERSIONS="$PROJECT_ROOT/tests/fixtures/containers-empty-versions.yml"
+    run "$VERIFY_SCRIPT" "$FIXTURE_EMPTY_VERSIONS"
+    [ "$status" -eq 0 ]
+    # Both sentinels should fire
+    [[ "$output" == *"No versions found for lonely"* ]]
+    [[ "$output" == *"Version 0 of phantom has no variants"* ]]
+    # Healthy container should NOT trigger any warning
+    ! [[ "$output" == *"Missing"*"healthy"* ]]
+    ! [[ "$output" == *"No versions"*"healthy"* ]]
+}

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -50,7 +50,7 @@ setup() {
     [ "$status" -eq 0 ]
     # Both sentinels should fire
     [[ "$output" == *"No versions found for lonely"* ]]
-    [[ "$output" == *"Version v0 of phantom has no variants"* ]]
+    [[ "$output" == *"Version 1.0 of phantom has no variants"* ]]
     # Healthy container should NOT trigger any warning
     ! [[ "$output" == *"Missing"*"healthy"* ]]
     ! [[ "$output" == *"No versions"*"healthy"* ]]

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -55,3 +55,16 @@ setup() {
     ! [[ "$output" == *"Missing"*"healthy"* ]]
     ! [[ "$output" == *"No versions"*"healthy"* ]]
 }
+
+@test "verify-dashboard-data: single-version fixture detects top-level variants" {
+    FIXTURE_SINGLE="$PROJECT_ROOT/tests/fixtures/containers-single-version.yml"
+    run "$VERIFY_SCRIPT" "$FIXTURE_SINGLE"
+    [ "$status" -eq 0 ]
+    # 'simple' is fully populated → no warning for it
+    ! [[ "$output" == *"Missing"*"simple"* ]]
+    # 'partial' is missing attestation_url and trivy_summary → warnings expected
+    [[ "$output" == *"Missing attestation_url for partial"* ]]
+    [[ "$output" == *"Missing trivy_summary for partial"* ]]
+    # Warnings must indicate the single-version path (not versions[N].variants[N])
+    [[ "$output" == *"single-version"* ]]
+}

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Tests for scripts/verify-dashboard-data.sh — smoke gate for containers.yml
+# trust-strip data completeness.
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    VERIFY_SCRIPT="$PROJECT_ROOT/scripts/verify-dashboard-data.sh"
+    FIXTURE_COMPLETE="$PROJECT_ROOT/tests/fixtures/containers-complete.yml"
+    FIXTURE_MISSING="$PROJECT_ROOT/tests/fixtures/containers-missing.yml"
+}
+
+@test "verify-dashboard-data: complete fixture exits 0 with notice" {
+    run "$VERIFY_SCRIPT" "$FIXTURE_COMPLETE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"All containers have complete"* ]]
+}
+
+@test "verify-dashboard-data: missing-fields fixture warns + exits 0 (advisory mode)" {
+    run "$VERIFY_SCRIPT" "$FIXTURE_MISSING"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning"* ]]
+    [[ "$output" == *"gap"* ]]
+}
+
+@test "verify-dashboard-data STRICT=1: missing-fields fixture exits 1" {
+    STRICT=1 run "$VERIFY_SCRIPT" "$FIXTURE_MISSING"
+    [ "$status" -eq 1 ]
+}

--- a/tests/unit/data-completeness.bats
+++ b/tests/unit/data-completeness.bats
@@ -68,3 +68,23 @@ setup() {
     # Warnings must indicate the single-version path (not versions[N].variants[N])
     [[ "$output" == *"single-version"* ]]
 }
+
+@test "verify-dashboard-data: malformed YAML exits 2 with ::error::" {
+    tmpfile=$(mktemp --suffix=.yml)
+    printf 'foo: [unclosed array\nbar: {malformed\n' > "$tmpfile"
+    run "$VERIFY_SCRIPT" "$tmpfile"
+    rm -f "$tmpfile"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"::error"* ]]
+    [[ "$output" == *"yq failed to parse"* ]]
+}
+
+@test "verify-dashboard-data: non-array root YAML exits 2 with ::error::" {
+    tmpfile=$(mktemp --suffix=.yml)
+    printf '42\n' > "$tmpfile"
+    run "$VERIFY_SCRIPT" "$tmpfile"
+    rm -f "$tmpfile"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"::error"* ]]
+    [[ "$output" == *"expected top-level YAML sequence"* ]]
+}


### PR DESCRIPTION
## Summary

Wires missing trust-strip data fields into `containers.yml` so dashboard components can render SBOM badges, Trivy scan results, and the Provenance section. Prerequisite for the next dashboard PR (trust-strip components).

### Three stacked root causes addressed

1. **SBOM artifact hydration race** — `update-dashboard.yaml` had no SBOM artifact re-download loop. The Trivy hydration pattern from #352 was never paralleled for SBOM, so `.build-lineage/*.sbom.json` files arrived sporadically. Now: self-healing step walks the last 24h of completed (success OR failure) auto-build runs and downloads `sbom-*` artifacts when newer than what cache restored, using the SPDX `creationInfo.created` timestamp for content-based merge ordering.

2. **OCI subject digest never reached cached lineage** — the post-flatten digest captured in `build-container/action.yaml` mutates the lineage JSON file in place on the runner filesystem. The existing `auto-build.yaml` "Upload build lineage" step runs after the action returns and now picks up the mutated file with the digest already present, so attestation lookups query the correct OCI subject digest instead of falling back to the pre-flatten internal digest. **Caveat:** `Capture OCI subject digest` is still `continue-on-error: true`, so a flatten/imagetools failure still emits a warning and lineage publishes without `oci_subject_digest`. Hardening that step to fail-closed is tracked separately (see `TODO.md`).

3. **Silent helper failures everywhere** — helpers swallowed errors with `|| true`, making diagnosis painful. Now: opt-in `DASHBOARD_DEBUG=1` log lines in three helpers (no behavior change), and SBOM processing in `auto-build.yaml` + `recreate-manifests.yaml` replaces `|| true` swallows with `::warning::` lines + a failure counter. Failed SBOM compares no longer overwrite the cached known-good SBOM (preserves diff baseline) and skip recording stale changelog as the current build's `changes_summary`.

### Smoke gate

Ships `scripts/verify-dashboard-data.sh` — scans `containers.yml` after generation and emits `::warning::` per missing trust-strip field across **all** versions × variants per container (not just defaults). Validates the YAML root type and yq parse success up front; both bad input modes now exit 2 with `::error::` instead of silently passing. Detects empty-versions and empty-variants conditions via sentinel rows. Default mode is advisory (exits 0). `STRICT=1` mode reserved for future hardening once steady-state warning count drops to zero.

### Cross-workflow consistency

`recreate-manifests.yaml` (manual SBOM repair workflow) brought up to parity with `auto-build.yaml` so manual repair runs cannot hide failures the main pipeline now surfaces.

### Observability

Transient `gh` API failures during artifact hydration now emit `::warning::` with captured stderr, distinguishing real failures from "no recent runs" (which still emit `::notice::`).

## Test plan

- [x] CI passes (shellcheck, YAML lint, CodeQL)
- [x] `bats tests/unit/data-completeness.bats` — 7/7 pass locally (advisory + strict modes, missing-fields fixture, multi-variant non-default gaps, empty-versions/empty-variants sentinels, single-version top-level variants schema)
- [x] Manual smoke: malformed YAML → exit 2 + `::error::`; scalar root → exit 2 + `::error::expected sequence`
- [ ] After merge: trigger one `update-dashboard.yaml` run on master and verify `yq -o=json '.[] | select(.name == "postgres") | .versions[0].variants[0]' docs/site/_data/containers.yml | jq 'has("attestation_url"), has("trivy_summary"), has("sbom_summary")'` → all true
- [ ] If trust-strip data still empty post-merge: investigate workflow health (artifacts expired? digest-capture warning? SBOM step failing silently?) BEFORE dispatching the components PR
