### PR TITLE
feat(dashboard): wire trust-strip detail section with evidence-led UX

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -90,7 +90,7 @@
        data-trust="sbom"
        {% if default_variant.attestation_url %}href="{{ default_variant.attestation_url }}"{% else %}href="" style="display: none"{% endif %}
        rel="noopener"
-       title="View Sigstore attestation for this image's SBOM">📋 SBOM attested</a>
+       title="View Sigstore attestation for this image's SBOM">📋 SBOM ATTESTED</a>
 
     {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
       {%- assign sev = "info" -%}
@@ -101,7 +101,7 @@
          data-trust="trivy"
          data-severity="{{ sev }}"
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
-         title="Click to see scan details on this container's detail page">🛡 Trivy: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · scanned {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+         title="Click to see scan details on this container's detail page">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
     {%- else -%}
       <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
     {%- endif -%}
@@ -111,7 +111,7 @@
          data-trust="multi-arch"
          href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}"
          rel="noopener"
-         title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " }}</a>
+         title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
     {%- else -%}
       <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" href="#"></a>
     {%- endif -%}
@@ -126,7 +126,7 @@
     {%- endif -%}
     <a class="trust-badge trust-badge--verify"
        href="{{ '/verify-images/' | relative_url }}"
-       title="Reproduce these checks yourself — verification guide">🔍 How to verify</a>
+       title="Reproduce these checks yourself — verification guide">🔍 REPRODUCE THESE CHECKS LOCALLY</a>
   </trust-strip>
 
   <!-- Variants Section (for multi-image containers) -->

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -196,61 +196,63 @@
         </trust-strip>
 
         <!-- Provenance section — Camille's primary screenshot target (Phase C PR2) -->
-        {%- assign prov_variant = page.versions[0].variants[0] | default: page.variants[0] | default: page -%}
-        {%- assign prov_empty_count = 0 -%}
-        {%- unless prov_variant.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-        {%- unless prov_variant.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-        {%- unless prov_variant.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-        {%- if prov_empty_count < 3 -%}
-        <section class="provenance" aria-labelledby="provenance-heading">
+        {%- comment -%}
+          Fix #2: render one <section class="provenance"> per variant with data-variant-tag.
+          JS (container-detail.js phase-b-variant-changed listener) shows/hides by matching tag.
+          First variant is visible; others start hidden.
+          For no-variant containers, fall through to the single-variant render below.
+        {%- endcomment -%}
+        {%- if page.versions -%}
+          {%- comment -%}
+            P0-N2 fix: heading lifted OUT of the per-variant loop.
+            Placed once above the section stack so aria-labelledby="provenance-heading"
+            resolves correctly for every variant section regardless of which is visible.
+            (Hidden sections have display:none — their heading would be skipped by AT.)
+          {%- endcomment -%}
           <header class="provenance-header">
             <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
             <h2 id="provenance-heading">Provenance</h2>
           </header>
+          {%- assign _prov_first = true -%}
+          {%- for _prov_version in page.versions -%}
+            {%- for _prov_var in _prov_version.variants -%}
+              {%- assign prov_empty_count = 0 -%}
+              {%- unless _prov_var.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- if prov_empty_count < 3 -%}
+        <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
           <dl class="evidence-list">
             {%- if page.last_commit_short or site.github.build_revision -%}
             <div class="evidence-row">
               <dt>Build commit</dt>
-              <dd>
-                <code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code>
-              </dd>
+              <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
             </div>
             {%- endif -%}
-
-            {%- if prov_variant.build_digest and prov_variant.build_digest != "unknown" -%}
+            {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
             <div class="evidence-row">
               <dt>Manifest digest (amd64)</dt>
               <dd>
-                <code class="hash hash-long">{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}</code>
-                <button class="copy-btn" type="button"
-                        aria-label="Copy manifest digest"
-                        data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
+                <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
-
-            {%- if prov_variant.manifest_digest_arm64 -%}
+            {%- if _prov_var.manifest_digest_arm64 -%}
             <div class="evidence-row">
               <dt>Manifest digest (arm64)</dt>
               <dd>
-                <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button"
-                        aria-label="Copy arm64 manifest digest"
-                        data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+                <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
-
-            {%- if prov_variant.attestation_url -%}
+            {%- if _prov_var.attestation_url -%}
             <div class="evidence-row">
               <dt>SBOM attestation</dt>
               <dd>
-                <a href="{{ prov_variant.attestation_url }}" rel="noopener" target="_blank">
-                  {%- if prov_variant.attestation_id -%}
-                    <code class="hash">{{ prov_variant.attestation_id | slice: 0, 12 }}…</code>
-                  {%- else -%}
-                    View on Sigstore
-                  {%- endif -%}
+                <a href="{{ _prov_var.attestation_url }}" rel="noopener" target="_blank">
+                  {%- if _prov_var.attestation_id -%}<code class="hash">{{ _prov_var.attestation_id | slice: 0, 12 }}…</code>{%- else -%}View on Sigstore{%- endif -%}
                 </a>
               </dd>
             </div>
@@ -260,7 +262,184 @@
               <dd class="evidence-empty">awaiting next build</dd>
             </div>
             {%- endif -%}
-
+            {%- if _prov_var.trivy_summary.last_scan -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd>{{ _prov_var.trivy_summary.last_scan | date: "%Y-%m-%d %H:%M UTC" }}</dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.base_image and _prov_var.base_image != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd><code class="hash">{{ _prov_var.base_image }}</code></dd>
+            </div>
+            {%- endif -%}
+            <div class="evidence-row">
+              <dt>Verify</dt>
+              <dd class="provenance-verify-cmd">
+                <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
+              </dd>
+            </div>
+          </dl>
+          <footer class="provenance-footer">
+            <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"
+               title="Reproduce these checks yourself — verification guide">
+              🔍 REPRODUCE THESE CHECKS LOCALLY
+            </a>
+          </footer>
+        </section>
+              {%- endif -%}
+              {%- assign _prov_first = false -%}
+            {%- endfor -%}
+          {%- endfor -%}
+        {%- elsif page.variants -%}
+          {%- comment -%}P0-N2 fix: heading lifted out — same rationale as page.versions branch above.{%- endcomment -%}
+          <header class="provenance-header">
+            <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
+            <h2 id="provenance-heading">Provenance</h2>
+          </header>
+          {%- assign _prov_first = true -%}
+          {%- for _prov_var in page.variants -%}
+            {%- assign prov_empty_count = 0 -%}
+            {%- unless _prov_var.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- if prov_empty_count < 3 -%}
+        <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
+          <dl class="evidence-list">
+            {%- if page.last_commit_short or site.github.build_revision -%}
+            <div class="evidence-row">
+              <dt>Build commit</dt>
+              <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (amd64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.manifest_digest_arm64 -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (arm64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.attestation_url -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd>
+                <a href="{{ _prov_var.attestation_url }}" rel="noopener" target="_blank">
+                  {%- if _prov_var.attestation_id -%}<code class="hash">{{ _prov_var.attestation_id | slice: 0, 12 }}…</code>{%- else -%}View on Sigstore{%- endif -%}
+                </a>
+              </dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.trivy_summary.last_scan -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd>{{ _prov_var.trivy_summary.last_scan | date: "%Y-%m-%d %H:%M UTC" }}</dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
+            {%- if _prov_var.base_image and _prov_var.base_image != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd><code class="hash">{{ _prov_var.base_image }}</code></dd>
+            </div>
+            {%- endif -%}
+            <div class="evidence-row">
+              <dt>Verify</dt>
+              <dd class="provenance-verify-cmd">
+                <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
+              </dd>
+            </div>
+          </dl>
+          <footer class="provenance-footer">
+            <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"
+               title="Reproduce these checks yourself — verification guide">
+              🔍 REPRODUCE THESE CHECKS LOCALLY
+            </a>
+          </footer>
+        </section>
+            {%- endif -%}
+            {%- assign _prov_first = false -%}
+          {%- endfor -%}
+        {%- else -%}
+          {%- comment -%} No-variant container: single Provenance block (no variant switching) {%- endcomment -%}
+          {%- assign prov_variant = page -%}
+          {%- assign prov_empty_count = 0 -%}
+          {%- unless prov_variant.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+          {%- unless prov_variant.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+          {%- unless prov_variant.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+          {%- if prov_empty_count < 3 -%}
+        <section class="provenance" aria-labelledby="provenance-heading">
+          <header class="provenance-header">
+            <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
+            <h2 id="provenance-heading">Provenance</h2>
+          </header>
+          <dl class="evidence-list">
+            {%- if page.last_commit_short or site.github.build_revision -%}
+            <div class="evidence-row">
+              <dt>Build commit</dt>
+              <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
+            </div>
+            {%- endif -%}
+            {%- if prov_variant.build_digest and prov_variant.build_digest != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (amd64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+            {%- if prov_variant.manifest_digest_arm64 -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (arm64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
+                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+            {%- if prov_variant.attestation_url -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd>
+                <a href="{{ prov_variant.attestation_url }}" rel="noopener" target="_blank">
+                  {%- if prov_variant.attestation_id -%}<code class="hash">{{ prov_variant.attestation_id | slice: 0, 12 }}…</code>{%- else -%}View on Sigstore{%- endif -%}
+                </a>
+              </dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
             {%- if prov_variant.trivy_summary.last_scan -%}
             <div class="evidence-row">
               <dt>Trivy last scan</dt>
@@ -272,21 +451,17 @@
               <dd class="evidence-empty">awaiting next build</dd>
             </div>
             {%- endif -%}
-
             {%- if prov_variant.base_image and prov_variant.base_image != "unknown" -%}
             <div class="evidence-row">
               <dt>Base image</dt>
               <dd><code class="hash">{{ prov_variant.base_image }}</code></dd>
             </div>
             {%- endif -%}
-
             <div class="evidence-row">
-              <dt>Verify command</dt>
+              <dt>Verify</dt>
               <dd class="provenance-verify-cmd">
-                <code>./verify-images.sh {{ page.name }}:{{ prov_variant.tag | default: page.current_version }}</code>
-                <button class="copy-btn" type="button"
-                        aria-label="Copy verify command"
-                        data-copy="./verify-images.sh {{ page.name }}:{{ prov_variant.tag | default: page.current_version }}">⧉</button>
+                <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
               </dd>
             </div>
           </dl>
@@ -297,6 +472,7 @@
             </a>
           </footer>
         </section>
+          {%- endif -%}
         {%- endif -%}
 
         <!-- Variants — replaced by <version-tabs> custom element (Phase C PR2, M4 closure) -->
@@ -638,12 +814,20 @@
               (advisory mode — Trivy runs <code>continue-on-error</code> in CI; we surface findings, we do not block builds on them).
             </p>
 
+            {%- comment -%}
+              P1-N3 fix: emit .nonzero server-side where count > 0 (mirrors security-scan.js:46-47
+              span.classList.toggle('nonzero', value > 0) + parentElement.classList.toggle).
+              Eliminates FOUC where CSS paints critical=5 in clean teal before JS adds .nonzero.
+              JS _update() remains idempotent — toggling an already-set class is a no-op.
+            {%- endcomment -%}
             <div class="severity-grid">
-              <div><span class="count" data-scan-count="critical">{{ sec_variant.trivy_summary.counts.critical }}</span><span class="label">Critical</span></div>
-              <div><span class="count" data-scan-count="high">{{ sec_variant.trivy_summary.counts.high }}</span><span class="label">High</span></div>
-              <div><span class="count" data-scan-count="medium">{{ sec_variant.trivy_summary.counts.medium }}</span><span class="label">Medium</span></div>
-              <div><span class="count" data-scan-count="low">{{ sec_variant.trivy_summary.counts.low }}</span><span class="label">Low</span></div>
-              <div><span class="count" data-scan-count="info">{{ sec_variant.trivy_summary.counts.info }}</span><span class="label">Info</span></div>
+              {%- assign _crit = sec_variant.trivy_summary.counts.critical | default: 0 -%}
+              {%- assign _high = sec_variant.trivy_summary.counts.high | default: 0 -%}
+              <div{% if _crit > 0 %} class="nonzero"{% endif %}><span class="count{% if _crit > 0 %} nonzero{% endif %}" data-scan-count="critical">{{ _crit }}</span><span class="label">Critical</span></div>
+              <div{% if _high > 0 %} class="nonzero"{% endif %}><span class="count{% if _high > 0 %} nonzero{% endif %}" data-scan-count="high">{{ _high }}</span><span class="label">High</span></div>
+              <div><span class="count" data-scan-count="medium">{{ sec_variant.trivy_summary.counts.medium | default: 0 }}</span><span class="label">Medium</span></div>
+              <div><span class="count" data-scan-count="low">{{ sec_variant.trivy_summary.counts.low | default: 0 }}</span><span class="label">Low</span></div>
+              <div><span class="count" data-scan-count="info">{{ sec_variant.trivy_summary.counts.info | default: 0 }}</span><span class="label">Info</span></div>
             </div>
 
             {%- if sec_variant.trivy_summary.counts.critical == 0 and sec_variant.trivy_summary.counts.high == 0 -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -282,8 +282,11 @@
             <div class="evidence-row">
               <dt>Verify</dt>
               <dd class="provenance-verify-cmd">
+                {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_var.tag | append: ' --owner oorabona' -%}
+                <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
+                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
-                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
             </div>
           </dl>
@@ -372,8 +375,11 @@
             <div class="evidence-row">
               <dt>Verify</dt>
               <dd class="provenance-verify-cmd">
+                {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_var.tag | append: ' --owner oorabona' -%}
+                <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
+                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
-                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
             </div>
           </dl>
@@ -460,8 +466,12 @@
             <div class="evidence-row">
               <dt>Verify</dt>
               <dd class="provenance-verify-cmd">
+                {%- assign _prov_tag = prov_variant.tag | default: page.current_version -%}
+                {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_tag | append: ' --owner oorabona' -%}
+                <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
+                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
-                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">Verification guide →</a>
+                   title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
             </div>
           </dl>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -17,6 +17,10 @@
 
   <!-- tokens.css MUST load before theme.css — defines variables theme.css references -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
+  <!-- Component CSS — load after tokens, before theme -->
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/provenance.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/theme.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/container-detail.css">
 </head>
@@ -152,7 +156,7 @@
              data-trust="sbom"
              {% if default_variant.attestation_url %}href="{{ default_variant.attestation_url }}"{% else %}href="" style="display: none"{% endif %}
              rel="noopener"
-             title="View Sigstore attestation for this image's SBOM">📋 SBOM attested</a>
+             title="View Sigstore attestation for this image's SBOM">📋 SBOM ATTESTED</a>
 
           {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
             {%- assign sev = "info" -%}
@@ -163,7 +167,7 @@
                data-trust="trivy"
                data-severity="{{ sev }}"
                href="#security"
-               title="Click to see scan details on this page">🛡 Trivy: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · scanned {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+               title="Click to see scan details on this page">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
           {%- else -%}
             <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
           {%- endif -%}
@@ -173,7 +177,7 @@
                data-trust="multi-arch"
                href="https://github.com/{{ site.github_username | default: site.github.owner_name }}/{{ site.repository | default: site.github.repository_name }}/pkgs/container/{{ page.name }}"
                rel="noopener"
-               title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " }}</a>
+               title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
           {%- else -%}
             <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" href="#"></a>
           {%- endif -%}
@@ -188,10 +192,114 @@
           {%- endif -%}
           <a class="trust-badge trust-badge--verify"
              href="{{ '/verify-images/' | relative_url }}"
-             title="Reproduce these checks yourself — verification guide">🔍 How to verify</a>
+             title="Reproduce these checks yourself — verification guide">🔍 REPRODUCE THESE CHECKS LOCALLY</a>
         </trust-strip>
 
-        <!-- Variants (before lineage, since variant selection affects displayed build args) -->
+        <!-- Provenance section — Camille's primary screenshot target (Phase C PR2) -->
+        {%- assign prov_variant = page.versions[0].variants[0] | default: page.variants[0] | default: page -%}
+        {%- assign prov_empty_count = 0 -%}
+        {%- unless prov_variant.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+        {%- unless prov_variant.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+        {%- unless prov_variant.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+        {%- if prov_empty_count < 3 -%}
+        <section class="provenance" aria-labelledby="provenance-heading">
+          <header class="provenance-header">
+            <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
+            <h2 id="provenance-heading">Provenance</h2>
+          </header>
+          <dl class="evidence-list">
+            {%- if page.last_commit_short or site.github.build_revision -%}
+            <div class="evidence-row">
+              <dt>Build commit</dt>
+              <dd>
+                <code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code>
+              </dd>
+            </div>
+            {%- endif -%}
+
+            {%- if prov_variant.build_digest and prov_variant.build_digest != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (amd64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}</code>
+                <button class="copy-btn" type="button"
+                        aria-label="Copy manifest digest"
+                        data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+
+            {%- if prov_variant.manifest_digest_arm64 -%}
+            <div class="evidence-row">
+              <dt>Manifest digest (arm64)</dt>
+              <dd>
+                <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
+                <button class="copy-btn" type="button"
+                        aria-label="Copy arm64 manifest digest"
+                        data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+              </dd>
+            </div>
+            {%- endif -%}
+
+            {%- if prov_variant.attestation_url -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd>
+                <a href="{{ prov_variant.attestation_url }}" rel="noopener" target="_blank">
+                  {%- if prov_variant.attestation_id -%}
+                    <code class="hash">{{ prov_variant.attestation_id | slice: 0, 12 }}…</code>
+                  {%- else -%}
+                    View on Sigstore
+                  {%- endif -%}
+                </a>
+              </dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>SBOM attestation</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
+
+            {%- if prov_variant.trivy_summary.last_scan -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd>{{ prov_variant.trivy_summary.last_scan | date: "%Y-%m-%d %H:%M UTC" }}</dd>
+            </div>
+            {%- else -%}
+            <div class="evidence-row">
+              <dt>Trivy last scan</dt>
+              <dd class="evidence-empty">awaiting next build</dd>
+            </div>
+            {%- endif -%}
+
+            {%- if prov_variant.base_image and prov_variant.base_image != "unknown" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd><code class="hash">{{ prov_variant.base_image }}</code></dd>
+            </div>
+            {%- endif -%}
+
+            <div class="evidence-row">
+              <dt>Verify command</dt>
+              <dd class="provenance-verify-cmd">
+                <code>./verify-images.sh {{ page.name }}:{{ prov_variant.tag | default: page.current_version }}</code>
+                <button class="copy-btn" type="button"
+                        aria-label="Copy verify command"
+                        data-copy="./verify-images.sh {{ page.name }}:{{ prov_variant.tag | default: page.current_version }}">⧉</button>
+              </dd>
+            </div>
+          </dl>
+          <footer class="provenance-footer">
+            <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"
+               title="Reproduce these checks yourself — verification guide">
+              🔍 REPRODUCE THESE CHECKS LOCALLY
+            </a>
+          </footer>
+        </section>
+        {%- endif -%}
+
+        <!-- Variants — replaced by <version-tabs> custom element (Phase C PR2, M4 closure) -->
         {% if page.has_variants %}
         <div class="variants-section glass">
           <div class="variants-header">
@@ -200,68 +308,66 @@
           </div>
           <div class="variants-content">
             {% if page.versions %}
-              {% for version in page.versions %}
-              <div class="version-group">
-                <h3 class="version-title">{{ version.base_tag | default: version.tag }}</h3>
-                <div class="variant-tags-row">
+              <version-tabs class="version-tabs" data-active-tag="{{ default_variant.tag }}">
+                {% for version in page.versions %}
+                <div class="version-tabs-group" role="tablist" aria-label="Variants for version {{ version.base_tag | default: version.tag }}">
+                  <p class="eyebrow version-tabs-group-label">{{ version.base_tag | default: version.tag }}</p>
                   {% for variant in version.variants %}
                     {%- comment -%}
-                      Versions-only containers carry a synthesized empty-name
-                      variant (the version itself IS the canonical build).
-                      Render with `display:none` to hide the unlabeled pill
-                      while preserving the data-* carrier — container-detail.js
-                      reads SBOM, changelog, build-history, and lineage data
-                      from .variant-tag.selected; skipping the element would
-                      blank Build Lineage / Security / Changelog sections for
-                      the very build this page documents.
+                      Versions-only containers carry a synthesized empty-name variant.
+                      Keep hidden (synthetic) buttons as data carriers — container-detail.js
+                      reads SBOM/changelog/build-history from .variant-tag.selected.
                     {%- endcomment -%}
                     {%- assign synthetic = false -%}
                     {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
-                    <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
-                          {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
-                          data-tag="{{ variant.tag }}"
-                          data-size-amd64="{{ variant.size_amd64 | default: '' }}"
-                          data-size-arm64="{{ variant.size_arm64 | default: '' }}"
-                          data-build-digest="{{ variant.build_digest | default: '' }}"
-                          data-base-image="{{ variant.base_image | default: '' }}"
-                          {% if variant.build_args %}data-build-args='[{% for arg in variant.build_args %}{"name":"{{ arg.name }}","value":"{{ arg.value }}"}{% unless forloop.last %},{% endunless %}{% endfor %}]'{% endif %}
-                          {% if variant.sbom_summary %}data-sbom-summary='{{ variant.sbom_summary | jsonify }}'{% endif %}
-                          {% if variant.sbom_packages %}data-sbom-packages='{{ variant.sbom_packages | jsonify }}'{% endif %}
-                          {% if variant.changelog %}data-changelog='{{ variant.changelog | jsonify }}'{% endif %}
-                          {% if variant.build_history %}data-build-history='{{ variant.build_history | jsonify }}'{% endif %}
-                          {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif -%}
-                          {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
-                          {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
-                          {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                          role="button"
-                          tabindex="0"
-                          aria-pressed="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
-                          title="{{ variant.description }}">
-                      {{ variant.name }}{% if variant.is_default %} <span class="badge-default">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}
-                    </span>
+                    <button type="button"
+                            class="version-tab{% if forloop.first and forloop.parentloop.first %} version-tab--selected{% endif %}{% if synthetic %} variant-tag selected{% else %} variant-tag{% endif %}"
+                            role="tab"
+                            data-tag="{{ variant.tag }}"
+                            data-size-amd64="{{ variant.size_amd64 | default: '' }}"
+                            data-size-arm64="{{ variant.size_arm64 | default: '' }}"
+                            data-build-digest="{{ variant.build_digest | default: '' }}"
+                            data-base-image="{{ variant.base_image | default: '' }}"
+                            {% if variant.build_args %}data-build-args='[{% for arg in variant.build_args %}{"name":"{{ arg.name }}","value":"{{ arg.value }}"}{% unless forloop.last %},{% endunless %}{% endfor %}]'{% endif %}
+                            {% if variant.sbom_summary %}data-sbom-summary='{{ variant.sbom_summary | jsonify }}'{% endif %}
+                            {% if variant.sbom_packages %}data-sbom-packages='{{ variant.sbom_packages | jsonify }}'{% endif %}
+                            {% if variant.changelog %}data-changelog='{{ variant.changelog | jsonify }}'{% endif %}
+                            {% if variant.build_history %}data-build-history='{{ variant.build_history | jsonify }}'{% endif %}
+                            {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif -%}
+                            {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
+                            {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
+                            {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
+                            aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
+                            {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
+                            title="{{ variant.description }}">
+                      {%- if synthetic -%}{{ variant.name }}{%- else -%}{{ variant.name }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}{%- endif -%}
+                    </button>
                   {% endfor %}
                 </div>
-              </div>
-              {% endfor %}
-            {% elsif page.variants %}
-              <div class="variant-tags-row">
-                {% for variant in page.variants %}
-                  <span class="variant-tag{% if forloop.first %} selected{% endif %}"
-                        data-tag="{{ variant.tag }}"
-                        data-size-amd64="{{ variant.size_amd64 | default: '' }}"
-                        data-size-arm64="{{ variant.size_arm64 | default: '' }}"
-                        {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif -%}
-                        {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
-                        {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
-                        {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                        role="button"
-                        tabindex="0"
-                        aria-pressed="{% if forloop.first %}true{% else %}false{% endif %}"
-                        title="{{ variant.description }}">
-                    {{ variant.tag }}{% if variant.is_default %} <span class="badge-default">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}
-                  </span>
                 {% endfor %}
-              </div>
+              </version-tabs>
+            {% elsif page.variants %}
+              <version-tabs class="version-tabs" data-active-tag="{{ page.variants[0].tag }}">
+                <div class="version-tabs-group" role="tablist" aria-label="Available variants">
+                  <p class="eyebrow version-tabs-group-label">Variants</p>
+                  {% for variant in page.variants %}
+                    <button type="button"
+                            class="version-tab{% if forloop.first %} version-tab--selected{% endif %} variant-tag{% if forloop.first %} selected{% endif %}"
+                            role="tab"
+                            data-tag="{{ variant.tag }}"
+                            data-size-amd64="{{ variant.size_amd64 | default: '' }}"
+                            data-size-arm64="{{ variant.size_arm64 | default: '' }}"
+                            {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif -%}
+                            {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
+                            {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
+                            {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
+                            aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
+                            title="{{ variant.description }}">
+                      {{ variant.tag }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}
+                    </button>
+                  {% endfor %}
+                </div>
+              </version-tabs>
             {% endif %}
           </div>
         </div>
@@ -521,32 +627,47 @@
         <!-- Security Scan Results -->
         {%- assign sec_variant = page.versions[0].variants[0] | default: page.variants[0] | default: page -%}
         {%- if sec_variant.trivy_summary and sec_variant.trivy_summary.last_scan -%}
-        <security-scan id="security" class="security-section glass" data-current-variant="{{ sec_variant.tag | default: page.current_version }}">
-          <h2>Security Scan Results</h2>
-          <p class="scan-meta">
-            Last scan: <time data-scan="last-scan">{{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</time>
-            (advisory mode — Trivy runs <code>continue-on-error</code> in CI; we surface findings, we do not block builds on them).
-          </p>
+        <div class="security-scan-card">
+          <header class="security-scan-card-header">
+            <p class="eyebrow">Security scan results</p>
+            <h3>Trivy · last scan {{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</h3>
+          </header>
+          <security-scan id="security" class="security-section glass" data-current-variant="{{ sec_variant.tag | default: page.current_version }}">
+            <p class="scan-meta">
+              Last scan: <time data-scan="last-scan">{{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</time>
+              (advisory mode — Trivy runs <code>continue-on-error</code> in CI; we surface findings, we do not block builds on them).
+            </p>
 
-          <div class="severity-grid">
-            <div><span class="count" data-scan-count="critical">{{ sec_variant.trivy_summary.counts.critical }}</span><span class="label">Critical</span></div>
-            <div><span class="count" data-scan-count="high">{{ sec_variant.trivy_summary.counts.high }}</span><span class="label">High</span></div>
-            <div><span class="count" data-scan-count="medium">{{ sec_variant.trivy_summary.counts.medium }}</span><span class="label">Medium</span></div>
-            <div><span class="count" data-scan-count="low">{{ sec_variant.trivy_summary.counts.low }}</span><span class="label">Low</span></div>
-            <div><span class="count" data-scan-count="info">{{ sec_variant.trivy_summary.counts.info }}</span><span class="label">Info</span></div>
-          </div>
+            <div class="severity-grid">
+              <div><span class="count" data-scan-count="critical">{{ sec_variant.trivy_summary.counts.critical }}</span><span class="label">Critical</span></div>
+              <div><span class="count" data-scan-count="high">{{ sec_variant.trivy_summary.counts.high }}</span><span class="label">High</span></div>
+              <div><span class="count" data-scan-count="medium">{{ sec_variant.trivy_summary.counts.medium }}</span><span class="label">Medium</span></div>
+              <div><span class="count" data-scan-count="low">{{ sec_variant.trivy_summary.counts.low }}</span><span class="label">Low</span></div>
+              <div><span class="count" data-scan-count="info">{{ sec_variant.trivy_summary.counts.info }}</span><span class="label">Info</span></div>
+            </div>
 
-          <div data-scan="advisories-wrap"{% if sec_variant.trivy_summary.top_advisories.size == 0 %} style="display: none"{% endif %}>
-            <h3>Top advisories (upstream, advisory)</h3>
-            <ul class="top-advisories" data-scan="top-advisories">
-              {%- for adv in sec_variant.trivy_summary.top_advisories -%}
-              <li><strong>{{ adv.rule_id | escape }}</strong> ({{ adv.severity | upcase | escape }}) — {{ adv.package_name | escape }} — {{ adv.title | escape }}</li>
-              {%- endfor -%}
-            </ul>
-          </div>
+            {%- if sec_variant.trivy_summary.counts.critical == 0 and sec_variant.trivy_summary.counts.high == 0 -%}
+            <p class="scan-clean-msg">No CRITICAL alerts at last scan ({{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}).</p>
+            {%- endif -%}
 
-          <p class="full-report">→ Full report via <code>gh api</code> — see <a href="{{ '/verify-images/' | relative_url }}#trivy">Verify Images</a>.</p>
-        </security-scan>
+            <div data-scan="advisories-wrap"{% if sec_variant.trivy_summary.top_advisories.size == 0 %} style="display: none"{% endif %}>
+              <h3>Top advisories (upstream, advisory)</h3>
+              <ul class="top-advisories" data-scan="top-advisories">
+                {%- for adv in sec_variant.trivy_summary.top_advisories -%}
+                <li><strong>{{ adv.rule_id | escape }}</strong> ({{ adv.severity | upcase | escape }}) — {{ adv.package_name | escape }} — {{ adv.title | escape }}</li>
+                {%- endfor -%}
+              </ul>
+            </div>
+
+            <p class="full-report">→ Full report via <code>gh api</code> — see <a href="{{ '/verify-images/' | relative_url }}#trivy">Verify Images</a>.</p>
+          </security-scan>
+          <footer class="security-scan-card-footer">
+            <a href="{{ '/verify-images/' | relative_url }}#trivy" class="trust-badge trust-badge--verify"
+               title="Reproduce this scan locally — verification guide">
+              🔍 REPRODUCE THIS SCAN LOCALLY
+            </a>
+          </footer>
+        </div>
         {%- endif -%}
 
         <!-- README (rendered at build time by kramdown) -->
@@ -573,6 +694,7 @@
   <!-- Vanilla web components — CSP-clean, no eval -->
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/security-scan.js' | relative_url }}"></script>
+  <script defer src="{{ '/assets/js/components/version-tabs.js' | relative_url }}"></script>
   <!-- Minimal JS: shared theme + page-specific logic -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="{{ site.baseurl }}/assets/js/theme.js"></script>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -234,7 +234,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -243,7 +243,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -327,7 +327,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -336,7 +336,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -418,7 +418,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy manifest digest" data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -427,7 +427,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -89,7 +89,7 @@
         <span class="dashboard-hero-accent">built and signed every day.</span>
       </h1>
       <p class="dashboard-hero-subtitle">
-        {{ total }} containers · multi-arch (amd64 + arm64) · SBOM-attested · auto-tracked upstream versions.
+        Every image ships with an SBOM, a cosign signature, and a Trivy scan you can verify yourself.
       </p>
     </section>
 

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -89,7 +89,7 @@
         <span class="dashboard-hero-accent">built and signed every day.</span>
       </h1>
       <p class="dashboard-hero-subtitle">
-        Every image ships with an SBOM, a cosign signature, and a Trivy scan you can verify yourself.
+        Every image ships with an SBOM and a cosign signature you can verify yourself, with continuous Trivy scanning across the catalog.
       </p>
     </section>
 

--- a/docs/site/_layouts/default.html
+++ b/docs/site/_layouts/default.html
@@ -16,6 +16,10 @@
 
   <!-- tokens.css MUST load first — defines CSS custom properties that all other sheets reference -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
+  <!-- Component CSS — load after tokens, before theme so theme can override if needed -->
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/provenance.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/theme.css">
 </head>
 <body>

--- a/docs/site/assets/css/components/provenance.css
+++ b/docs/site/assets/css/components/provenance.css
@@ -1,0 +1,196 @@
+/* provenance.css — Provenance section (Camille's primary screenshot target)
+   Verbatim from design_system_spec_phase_c.md §"Provenance section CSS spec" lines 334–428,
+   with minor additions for copy-btn mobile sizing and empty-state row.
+   Depends on: tokens.css. */
+
+/* -----------------------------------------------------------------------
+   Section surface
+   ----------------------------------------------------------------------- */
+.provenance {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-inset-section);  /* 32px */
+  margin-block: var(--space-xl);
+}
+
+/* -----------------------------------------------------------------------
+   Section header
+   ----------------------------------------------------------------------- */
+.provenance-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-tight);  /* 8px */
+  margin-bottom: var(--space-stack-section);  /* 32px */
+}
+
+.provenance .eyebrow {
+  /* Augments .eyebrow from tokens.css — mono uppercase 0.08em */
+  font: var(--text-caption);
+  font-family: var(--font-family-mono);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.provenance h2 {
+  font: var(--text-h3);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+  font-feature-settings: "ss01", "cv11";
+  font-optical-sizing: auto;
+}
+
+/* -----------------------------------------------------------------------
+   Evidence definition list
+   ----------------------------------------------------------------------- */
+.evidence-list {
+  display: grid;
+  gap: var(--space-stack-tight);  /* 8px between rows — dense but scannable */
+}
+
+.evidence-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 3fr;
+  gap: var(--space-md) var(--space-lg);  /* 16px row-gap, 24px col-gap */
+  align-items: baseline;
+}
+
+.evidence-row dt {
+  font: var(--text-body-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: capitalize;
+}
+
+.evidence-row dd {
+  font: var(--text-body);
+  color: var(--color-text-primary);
+  margin: 0;
+  /* Flex so inline copy button sits on same baseline as value */
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+/* -----------------------------------------------------------------------
+   Hash code blocks
+   ----------------------------------------------------------------------- */
+.evidence-row code.hash {
+  font: var(--text-code);
+  background: var(--color-surface-overlay);
+  padding: var(--space-inset-squish-md);  /* 8px 16px */
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+}
+
+.evidence-row code.hash-long {
+  word-break: break-all;  /* mobile: long hashes wrap inside the code block */
+}
+
+/* -----------------------------------------------------------------------
+   Inline copy button (⧉ icon)
+   ----------------------------------------------------------------------- */
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color var(--motion-duration-short) var(--easing-standard),
+              border-color var(--motion-duration-short) var(--easing-standard);
+}
+
+.copy-btn:hover {
+  color: var(--color-action-primary);
+  border-color: var(--color-action-primary);
+}
+
+.copy-btn:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-btn {
+    transition: none;
+  }
+}
+
+/* -----------------------------------------------------------------------
+   Empty / awaiting row state
+   ----------------------------------------------------------------------- */
+.evidence-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  font-size: var(--font-size-body-sm);
+}
+
+/* -----------------------------------------------------------------------
+   Inline verify command block
+   ----------------------------------------------------------------------- */
+.provenance-verify-cmd {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.provenance-verify-cmd code {
+  font: var(--text-code);
+  background: var(--color-surface-overlay);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  word-break: break-all;
+}
+
+/* -----------------------------------------------------------------------
+   Section footer — verify CTA
+   ----------------------------------------------------------------------- */
+.provenance-footer {
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* -----------------------------------------------------------------------
+   Mobile (≤640px) — single column, slightly more breathing room
+   ----------------------------------------------------------------------- */
+@media (max-width: 640px) {
+  .evidence-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-2xs);  /* tight — label sits just above value */
+  }
+
+  .evidence-list {
+    gap: var(--space-stack-normal);  /* 16px between rows on mobile */
+  }
+
+  .provenance {
+    padding: var(--space-md);
+  }
+
+  /* Enlarge copy buttons to 32×32 touch target on mobile */
+  .copy-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .evidence-row dd {
+    align-items: flex-start;
+  }
+}

--- a/docs/site/assets/css/components/provenance.css
+++ b/docs/site/assets/css/components/provenance.css
@@ -92,6 +92,12 @@
   word-break: break-all;  /* mobile: long hashes wrap inside the code block */
 }
 
+/* L-N5: verify command in Provenance row — wraps on mobile like hash-long */
+.evidence-row code.provenance-cmd {
+  word-break: break-all;
+  font-size: var(--font-size-caption);  /* slightly smaller for long commands */
+}
+
 /* -----------------------------------------------------------------------
    Inline copy button (⧉ icon)
    ----------------------------------------------------------------------- */

--- a/docs/site/assets/css/components/security-scan-card.css
+++ b/docs/site/assets/css/components/security-scan-card.css
@@ -1,6 +1,22 @@
 /* security-scan-card.css — chrome wrapper around <security-scan> component
    Applies trust-domain identity tokens to severity display (NOT generic feedback colors).
-   Depends on: tokens.css. Does NOT modify the internals of <security-scan> — it wraps only. */
+   Depends on: tokens.css. Does NOT modify the internals of <security-scan> — it wraps only.
+   Also carries the shared .trust-badge typography rule (Fix #6): dashboard.css defines it too,
+   but container-detail.html does NOT load dashboard.css. This file is loaded by BOTH layouts
+   (via default.html → <link component CSS>), making it the safe home for the shared rule. */
+
+/* -----------------------------------------------------------------------
+   Shared trust-badge typography — JetBrains Mono, medium, uppercase
+   (identical to the rule in dashboard.css; kept in sync by design)
+   ----------------------------------------------------------------------- */
+.trust-badge {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-caption);   /* 12px */
+  font-weight: var(--font-weight-medium); /* 500 */
+  letter-spacing: var(--letter-spacing-wide); /* 0.05em */
+  text-transform: uppercase;
+  line-height: 1;
+}
 
 /* -----------------------------------------------------------------------
    Card surface
@@ -41,24 +57,25 @@
 /* -----------------------------------------------------------------------
    Severity count cells — override <security-scan> generic feedback colors
    with trust-domain identity tokens per spec (identity-not-state principle).
-   These selectors mirror the DOM that security-scan.js renders.
+   Fix #5: selectors now match the DOM that security-scan.js actually renders.
+   security-scan.js toggles class "nonzero" on the count <span> AND its
+   parent <div> when the count > 0. It does NOT set data-severity or
+   data-has-critical attributes on the <security-scan> element.
    ----------------------------------------------------------------------- */
 
-/* Clean / no CRITICAL: teal-green identity */
-.security-scan-card .security-section[data-severity="info"] .count,
-.security-scan-card .security-section .count[data-scan-count="critical"][data-value="0"],
-.security-scan-card security-scan:not([data-has-critical]) .count {
+/* Default: clean / zero counts — teal-green identity */
+.security-scan-card .count {
   color: var(--color-trust-trivy-clean-fg);
 }
 
-/* Has HIGH but not CRITICAL: amber warning */
-.security-scan-card security-scan[data-severity="high"] .count {
-  color: var(--color-trust-trivy-warn-fg);
+/* Critical count cell > 0 — red identity (nth-child(1) = Critical column) */
+.security-scan-card .severity-grid > div:nth-child(1).nonzero .count {
+  color: var(--color-trust-trivy-critical-fg);
 }
 
-/* Has CRITICAL: red identity */
-.security-scan-card security-scan[data-severity="critical"] .count {
-  color: var(--color-trust-trivy-critical-fg);
+/* High count cell > 0 — amber warning (nth-child(2) = High column) */
+.security-scan-card .severity-grid > div:nth-child(2).nonzero .count {
+  color: var(--color-trust-trivy-warn-fg);
 }
 
 /* Scan-date label — muted timestamp */

--- a/docs/site/assets/css/components/security-scan-card.css
+++ b/docs/site/assets/css/components/security-scan-card.css
@@ -1,0 +1,136 @@
+/* security-scan-card.css — chrome wrapper around <security-scan> component
+   Applies trust-domain identity tokens to severity display (NOT generic feedback colors).
+   Depends on: tokens.css. Does NOT modify the internals of <security-scan> — it wraps only. */
+
+/* -----------------------------------------------------------------------
+   Card surface
+   ----------------------------------------------------------------------- */
+.security-scan-card {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-inset-section);  /* 32px */
+  margin-block: var(--space-xl);
+}
+
+/* -----------------------------------------------------------------------
+   Card header
+   ----------------------------------------------------------------------- */
+.security-scan-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-tight);  /* 8px */
+  margin-bottom: var(--space-md);
+}
+
+.security-scan-card-header .eyebrow {
+  /* .eyebrow already defined in tokens.css — JetBrains Mono uppercase */
+  margin: 0;
+}
+
+.security-scan-card-header h3 {
+  font: var(--text-h3);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+  /* Gate 4 headline tweaks */
+  font-feature-settings: "ss01", "cv11";
+  font-optical-sizing: auto;
+}
+
+/* -----------------------------------------------------------------------
+   Severity count cells — override <security-scan> generic feedback colors
+   with trust-domain identity tokens per spec (identity-not-state principle).
+   These selectors mirror the DOM that security-scan.js renders.
+   ----------------------------------------------------------------------- */
+
+/* Clean / no CRITICAL: teal-green identity */
+.security-scan-card .security-section[data-severity="info"] .count,
+.security-scan-card .security-section .count[data-scan-count="critical"][data-value="0"],
+.security-scan-card security-scan:not([data-has-critical]) .count {
+  color: var(--color-trust-trivy-clean-fg);
+}
+
+/* Has HIGH but not CRITICAL: amber warning */
+.security-scan-card security-scan[data-severity="high"] .count {
+  color: var(--color-trust-trivy-warn-fg);
+}
+
+/* Has CRITICAL: red identity */
+.security-scan-card security-scan[data-severity="critical"] .count {
+  color: var(--color-trust-trivy-critical-fg);
+}
+
+/* Scan-date label — muted timestamp */
+.security-scan-card [data-scan="last-scan"] {
+  color: var(--color-text-muted);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-body-sm);
+}
+
+/* Top-advisories list — mono rule IDs, dense spacing */
+.security-scan-card .top-advisories {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-sm) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.security-scan-card .top-advisories li {
+  font-size: var(--font-size-body-sm);
+  color: var(--color-text-secondary);
+  padding: var(--space-xs) var(--space-sm);
+  border-left: 2px solid var(--color-border-subtle);
+}
+
+.security-scan-card .top-advisories li strong {
+  font-family: var(--font-family-mono);
+  color: var(--color-trust-trivy-critical-fg);
+}
+
+/* -----------------------------------------------------------------------
+   Card footer — verify CTA
+   ----------------------------------------------------------------------- */
+.security-scan-card-footer {
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* -----------------------------------------------------------------------
+   Failed-scan variant
+   ----------------------------------------------------------------------- */
+.security-scan-card--failed {
+  border-color: var(--color-trust-trivy-warn-fg);
+}
+
+.security-scan-card--failed .security-scan-card-header h3 {
+  color: var(--color-trust-trivy-warn-fg);
+}
+
+.security-scan-card--failed-msg {
+  font-size: var(--font-size-body-sm);
+  color: var(--color-trust-trivy-warn-fg);
+  margin-block: var(--space-sm);
+}
+
+/* -----------------------------------------------------------------------
+   Stale scan (>30 days) — badge override applied by JS
+   ----------------------------------------------------------------------- */
+.security-scan-card[data-scan-stale="true"] .scan-date-badge {
+  color: var(--color-trust-trivy-warn-fg);
+}
+
+/* -----------------------------------------------------------------------
+   Mobile
+   ----------------------------------------------------------------------- */
+@media (max-width: 640px) {
+  .security-scan-card {
+    padding: var(--space-md);
+  }
+}

--- a/docs/site/assets/css/components/security-scan-card.css
+++ b/docs/site/assets/css/components/security-scan-card.css
@@ -8,8 +8,11 @@
 /* -----------------------------------------------------------------------
    Shared trust-badge typography — JetBrains Mono, medium, uppercase
    (identical to the rule in dashboard.css; kept in sync by design)
+   Specificity note: "body .trust-badge" (0,1,1) beats theme.css ".trust-badge" (0,1,0)
+   which loads AFTER this file in default.html / container-detail.html. Same for dashboard.css
+   which loads AFTER theme.css so the plain rule there already wins on dashboard pages.
    ----------------------------------------------------------------------- */
-.trust-badge {
+body .trust-badge {
   font-family: var(--font-family-mono);
   font-size: var(--font-size-caption);   /* 12px */
   font-weight: var(--font-weight-medium); /* 500 */

--- a/docs/site/assets/css/components/version-tabs.css
+++ b/docs/site/assets/css/components/version-tabs.css
@@ -1,0 +1,136 @@
+/* version-tabs.css — <version-tabs> component styles (M4 closure)
+   Replaces .variant-tags-row span pills with keyboard-navigable tab buttons.
+   Depends on: tokens.css (loaded before this file in default.html / container-detail.html). */
+
+/* -----------------------------------------------------------------------
+   Host element — stretch to block, no extra margin
+   ----------------------------------------------------------------------- */
+version-tabs {
+  display: block;
+}
+
+/* -----------------------------------------------------------------------
+   Version group — one tablist per version
+   ----------------------------------------------------------------------- */
+.version-tabs-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: baseline;
+  margin-block: var(--space-md);
+}
+
+/* Eyebrow version label above the tab row */
+.version-tabs-group-label {
+  /* .eyebrow is defined in tokens.css — JetBrains Mono regular uppercase 0.08em */
+  width: 100%;
+  margin-block-end: var(--space-xs);
+}
+
+/* -----------------------------------------------------------------------
+   Tab button — base state
+   ----------------------------------------------------------------------- */
+.version-tab {
+  /* Reset <button> defaults */
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+
+  /* Layout */
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-inset-squish-md);  /* 8px 16px */
+  border-radius: var(--radius-md);
+
+  /* Typography */
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-body-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-normal);
+  text-decoration: none;
+
+  /* Color */
+  color: var(--color-text-secondary);
+
+  /* Motion */
+  transition:
+    color          var(--motion-duration-short) var(--easing-standard),
+    background     var(--motion-duration-short) var(--easing-standard),
+    border-color   var(--motion-duration-short) var(--easing-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .version-tab {
+    transition: none;
+  }
+}
+
+/* -----------------------------------------------------------------------
+   Tab button — hover state
+   ----------------------------------------------------------------------- */
+.version-tab:hover {
+  background: var(--color-surface-raised);
+  color: var(--color-text-primary);
+}
+
+/* -----------------------------------------------------------------------
+   Tab button — selected / active state
+   ----------------------------------------------------------------------- */
+.version-tab--selected,
+.version-tab[aria-selected="true"] {
+  background: var(--color-surface-raised);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+  border-bottom: 2px solid var(--color-action-primary);
+  /* Compensate 1px transparent → 2px active so layout doesn't shift */
+  padding-block-end: calc(var(--space-sm) - 1px);
+}
+
+/* -----------------------------------------------------------------------
+   Tab button — focus-visible ring (WCAG 2.2 §2.4.11 min 2px)
+   ----------------------------------------------------------------------- */
+.version-tab:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+}
+
+/* -----------------------------------------------------------------------
+   Default-variant badge inside a tab
+   ----------------------------------------------------------------------- */
+.version-tab-default-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+  color: var(--color-action-primary);
+  border: 1px solid var(--color-action-primary);
+  border-radius: var(--radius-sm);
+  padding: 1px 4px;
+  line-height: 1.4;
+}
+
+/* -----------------------------------------------------------------------
+   Mobile — single-row horizontal scroll with snap
+   ----------------------------------------------------------------------- */
+@media (max-width: 640px) {
+  .version-tabs-group {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    /* Hide scrollbar cosmetically — still scrollable */
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .version-tabs-group::-webkit-scrollbar {
+    display: none;
+  }
+
+  .version-tab {
+    scroll-snap-align: start;
+    flex-shrink: 0;
+  }
+}

--- a/docs/site/assets/css/components/version-tabs.css
+++ b/docs/site/assets/css/components/version-tabs.css
@@ -129,6 +129,15 @@ version-tabs {
     display: none;
   }
 
+  /* Fix #7: label must NOT take width:100% inside a nowrap scroller — it would
+     consume the entire viewport width and push the first tab off-screen.
+     Use flex: 0 0 auto so the label sits inline before the tabs and scrolls
+     with them (option b — simplest, no markup change required). */
+  .version-tabs-group-label {
+    flex: 0 0 auto;
+    width: auto;
+  }
+
   .version-tab {
     scroll-snap-align: start;
     flex-shrink: 0;

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -10,6 +10,18 @@
       font-optical-sizing: auto;
     }
 
+    /* .trust-badge — JetBrains Mono medium 500, uppercase, letter-spacing 0.05em
+       (Gate 4 typography pushback: mono-confident signature on trust strip badges).
+       KEEP existing .trust-badge--* color tokens — this adds only the type treatment. */
+    .trust-badge {
+      font-family: var(--font-family-mono);
+      font-size: var(--font-size-caption);   /* 12px */
+      font-weight: var(--font-weight-medium); /* 500 */
+      letter-spacing: var(--letter-spacing-wide); /* 0.05em */
+      text-transform: uppercase;
+      line-height: 1;
+    }
+
     .bg-animated::before {
       content: '';
       position: absolute;

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -57,7 +57,8 @@
       const sev = critical > 0 ? 'critical' : (high > 0 ? 'high' : 'info');
       el.setAttribute('data-severity', sev);
       const date = (summary.last_scan || '').slice(0, 10);
-      el.textContent = '🛡 Trivy: ' + critical + ' CRITICAL · scanned ' + date;
+      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("TRIVY: N CRITICAL · SCANNED")
+      el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL · SCANNED ' + date;
       el.style.display = '';
     }
 
@@ -68,7 +69,8 @@
         el.style.display = 'none';
         return;
       }
-      el.textContent = '🏗 ' + platforms.join(' + ');
+      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("AMD64 + ARM64")
+      el.textContent = '🏗 ' + platforms.map(function(p) { return p.toUpperCase(); }).join(' + ');
       el.style.display = '';
     }
   }

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -69,8 +69,12 @@
         el.style.display = 'none';
         return;
       }
-      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("AMD64 + ARM64")
-      el.textContent = '🏗 ' + platforms.map(function(p) { return p.toUpperCase(); }).join(' + ');
+      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("AMD64 + ARM64").
+      // Defensively strip "os/" prefix (e.g. "linux/amd64" → "amd64") before uppercasing.
+      el.textContent = '🏗 ' + platforms.map(function(p) {
+        var arch = p.includes('/') ? p.split('/').pop() : p;
+        return arch.toUpperCase();
+      }).join(' + ');
       el.style.display = '';
     }
   }

--- a/docs/site/assets/js/components/version-tabs.js
+++ b/docs/site/assets/js/components/version-tabs.js
@@ -1,0 +1,174 @@
+/* version-tabs.js — <version-tabs> custom element (M4 closure)
+   WAI-ARIA Authoring Practices "Tabs with Manual Activation" pattern.
+   Dispatches the existing `phase-b-variant-changed` event so <trust-strip>
+   and <security-scan> keep working WITHOUT modification.
+   Prior-art: vanilla-web-components.md (docker-containers Phase B). */
+
+(function () {
+  'use strict';
+
+  class VersionTabs extends HTMLElement {
+    connectedCallback() {
+      // Guard: avoid double-init on DOM reparenting (prior-art gotcha: M-severity)
+      if (this._initialized) return;
+      this._initialized = true;
+
+      // Event delegation — single listener on host covers all tab groups
+      this._clickHandler = (e) => {
+        var tab = e.target.closest('[role="tab"]');
+        if (tab) this._activateTab(tab);
+      };
+      this._keydownHandler = (e) => this._handleKeydown(e);
+
+      this.addEventListener('click', this._clickHandler);
+      this.addEventListener('keydown', this._keydownHandler);
+    }
+
+    disconnectedCallback() {
+      if (this._clickHandler) this.removeEventListener('click', this._clickHandler);
+      if (this._keydownHandler) this.removeEventListener('keydown', this._keydownHandler);
+      this._initialized = false;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Tab activation                                                      */
+    /* ------------------------------------------------------------------ */
+
+    _activateTab(tab) {
+      if (!tab || tab.getAttribute('aria-selected') === 'true') return;
+
+      // Deselect all tabs in the SAME tablist
+      var tablist = tab.closest('[role="tablist"]');
+      if (tablist) {
+        tablist.querySelectorAll('[role="tab"]').forEach(function (t) {
+          t.setAttribute('aria-selected', 'false');
+          t.classList.remove('version-tab--selected');
+        });
+      }
+
+      // Activate clicked tab
+      tab.setAttribute('aria-selected', 'true');
+      tab.classList.add('version-tab--selected');
+      tab.focus();
+
+      // Build variant payload — same shape as container-detail.js selectVariant() L110–121
+      var variantData = {
+        tag: tab.dataset.tag || '',
+        attestation_url: tab.dataset.attestationUrl || '',
+        trivy_summary: null,
+        multi_arch_platforms: [],
+        size_amd64: tab.dataset.sizeAmd64 || '',
+        size_arm64: tab.dataset.sizeArm64 || ''
+      };
+      try {
+        if (tab.dataset.trivySummary) {
+          variantData.trivy_summary = JSON.parse(tab.dataset.trivySummary);
+        }
+      } catch (_) { /* swallow malformed JSON */ }
+      try {
+        if (tab.dataset.multiArchPlatforms) {
+          variantData.multi_arch_platforms = JSON.parse(tab.dataset.multiArchPlatforms);
+        }
+      } catch (_) { /* swallow malformed JSON */ }
+
+      // Dispatch `phase-b-variant-changed` — <trust-strip> and <security-scan>
+      // listen on document; keeps backward-compat with container-detail.js selectVariant()
+      document.dispatchEvent(new CustomEvent('phase-b-variant-changed', {
+        detail: variantData,
+        bubbles: false
+      }));
+
+      // Also dispatch a component-scoped event for container-detail.js to intercept
+      this.dispatchEvent(new CustomEvent('version-tabs-changed', {
+        detail: variantData,
+        bubbles: true
+      }));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Keyboard navigation — WAI-ARIA Tabs Manual Activation              */
+    /*  ←/→  : navigate within tablist                                     */
+    /*  ↑/↓  : navigate between tablist groups (version groups)            */
+    /*  Home : jump to first tab in current tablist                        */
+    /*  End  : jump to last tab in current tablist                         */
+    /*  Enter/Space : activate focused tab                                 */
+    /* ------------------------------------------------------------------ */
+
+    _handleKeydown(e) {
+      var tab = e.target.closest('[role="tab"]');
+      if (!tab) return;
+
+      var tablist = tab.closest('[role="tablist"]');
+      if (!tablist) return;
+
+      var tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+      var idx = tabs.indexOf(tab);
+      var target;
+
+      switch (e.key) {
+        case 'ArrowLeft': {
+          e.preventDefault();
+          var prev = tabs[idx - 1] || tabs[tabs.length - 1];
+          prev.focus();
+          break;
+        }
+        case 'ArrowRight': {
+          e.preventDefault();
+          var next = tabs[idx + 1] || tabs[0];
+          next.focus();
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          var prevGroup = this._adjacentGroup(tablist, -1);
+          if (prevGroup) {
+            var prevGroupTabs = Array.from(prevGroup.querySelectorAll('[role="tab"]'));
+            target = prevGroupTabs[Math.min(idx, prevGroupTabs.length - 1)];
+            if (target) target.focus();
+          }
+          break;
+        }
+        case 'ArrowDown': {
+          e.preventDefault();
+          var nextGroup = this._adjacentGroup(tablist, +1);
+          if (nextGroup) {
+            var nextGroupTabs = Array.from(nextGroup.querySelectorAll('[role="tab"]'));
+            target = nextGroupTabs[Math.min(idx, nextGroupTabs.length - 1)];
+            if (target) target.focus();
+          }
+          break;
+        }
+        case 'Home': {
+          e.preventDefault();
+          if (tabs[0]) tabs[0].focus();
+          break;
+        }
+        case 'End': {
+          e.preventDefault();
+          if (tabs[tabs.length - 1]) tabs[tabs.length - 1].focus();
+          break;
+        }
+        case 'Enter':
+        case ' ': {
+          e.preventDefault();
+          this._activateTab(tab);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    /* Return the previous (-1) or next (+1) [role="tablist"] sibling group */
+    _adjacentGroup(tablist, direction) {
+      var groups = Array.from(this.querySelectorAll('[role="tablist"]'));
+      var idx = groups.indexOf(tablist);
+      return groups[idx + direction] || null;
+    }
+  }
+
+  // Guard against double-registration (Jekyll layouts may include the script twice)
+  if (!customElements.get('version-tabs')) {
+    customElements.define('version-tabs', VersionTabs);
+  }
+})();

--- a/docs/site/assets/js/components/version-tabs.js
+++ b/docs/site/assets/js/components/version-tabs.js
@@ -22,6 +22,13 @@
 
       this.addEventListener('click', this._clickHandler);
       this.addEventListener('keydown', this._keydownHandler);
+
+      // Fix #1: dispatch phase-b-variant-changed for the initial active tab so
+      // <trust-strip>, <security-scan>, and Provenance are correctly initialized
+      // on multi-version pages where the first [aria-selected="true"] tab is the
+      // data source (not the hidden synthetic .variant-tag.selected button).
+      // Defer to next microtask so container-detail.js listeners are registered first.
+      Promise.resolve().then(() => this._dispatchInitialVariant());
     }
 
     disconnectedCallback() {
@@ -164,6 +171,49 @@
       var groups = Array.from(this.querySelectorAll('[role="tablist"]'));
       var idx = groups.indexOf(tablist);
       return groups[idx + direction] || null;
+    }
+
+    /* Fix #1: fire phase-b-variant-changed for the initial active tab so
+       Provenance, <trust-strip>, and <security-scan> bootstrap correctly on
+       multi-version pages (where container-detail.js may only have the hidden
+       synthetic .variant-tag.selected to work from). */
+    _dispatchInitialVariant() {
+      // Find the first [aria-selected="true"] tab in the component
+      var initialTab = this.querySelector('[role="tab"][aria-selected="true"]');
+      if (!initialTab) return;
+      var variantData = {
+        tag: initialTab.dataset.tag || '',
+        attestation_url: initialTab.dataset.attestationUrl || '',
+        trivy_summary: null,
+        multi_arch_platforms: [],
+        size_amd64: initialTab.dataset.sizeAmd64 || '',
+        size_arm64: initialTab.dataset.sizeArm64 || ''
+      };
+      try {
+        if (initialTab.dataset.trivySummary) {
+          variantData.trivy_summary = JSON.parse(initialTab.dataset.trivySummary);
+        }
+      } catch (_) { /* swallow */ }
+      try {
+        if (initialTab.dataset.multiArchPlatforms) {
+          variantData.multi_arch_platforms = JSON.parse(initialTab.dataset.multiArchPlatforms);
+        }
+      } catch (_) { /* swallow */ }
+      document.dispatchEvent(new CustomEvent('phase-b-variant-changed', {
+        detail: variantData,
+        bubbles: false
+      }));
+
+      // P0-N1 fix: also dispatch version-tabs-changed (bubbles on host) so
+      // container-detail.js:version-tabs-changed listener calls selectVariant(),
+      // which populates SBOM/changelog/history/dep-health/lineage/pull-command.
+      // Both consumers are idempotent: phase-b-variant-changed listeners only
+      // update DOM text/visibility; selectVariant() is guarded by dataset reads
+      // that are stable across calls. No double-flash risk.
+      this.dispatchEvent(new CustomEvent('version-tabs-changed', {
+        detail: variantData,
+        bubbles: true
+      }));
     }
   }
 

--- a/docs/site/assets/js/components/version-tabs.js
+++ b/docs/site/assets/js/components/version-tabs.js
@@ -136,7 +136,7 @@
           e.preventDefault();
           var prevGroup = this._adjacentGroup(tablist, -1);
           if (prevGroup) {
-            var prevGroupTabs = Array.from(prevGroup.querySelectorAll('[role="tab"]'));
+            var prevGroupTabs = this._visibleTabs(prevGroup);
             target = prevGroupTabs[Math.min(idx, prevGroupTabs.length - 1)];
             if (target) target.focus();
           }
@@ -146,7 +146,7 @@
           e.preventDefault();
           var nextGroup = this._adjacentGroup(tablist, +1);
           if (nextGroup) {
-            var nextGroupTabs = Array.from(nextGroup.querySelectorAll('[role="tab"]'));
+            var nextGroupTabs = this._visibleTabs(nextGroup);
             target = nextGroupTabs[Math.min(idx, nextGroupTabs.length - 1)];
             if (target) target.focus();
           }
@@ -179,6 +179,18 @@
       var idx = groups.indexOf(tablist);
       return groups[idx + direction] || null;
     }
+
+
+    /* Return only visible, non-synthetic tabs from a tablist container.
+       Mirrors the M-N6 inline filter in _handleKeydown for cross-group nav. */
+    _visibleTabs(container) {
+      return Array.from(container.querySelectorAll('[role="tab"]')).filter(function(t) {
+        return t.offsetParent !== null &&
+               t.getAttribute('aria-hidden') !== 'true' &&
+               !t.hasAttribute('hidden');
+      });
+    }
+
 
     /* Fix #1: fire phase-b-variant-changed for the initial active tab so
        Provenance, <trust-strip>, and <security-scan> bootstrap correctly on

--- a/docs/site/assets/js/components/version-tabs.js
+++ b/docs/site/assets/js/components/version-tabs.js
@@ -108,7 +108,14 @@
       var tablist = tab.closest('[role="tablist"]');
       if (!tablist) return;
 
-      var tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+      // M-N6: exclude hidden/synthetic tabs from arrow-key navigation.
+      // Synthetic tabs use style="display: none" + aria-hidden="true"; offsetParent===null
+      // covers display:none at any ancestor level.
+      var tabs = Array.from(tablist.querySelectorAll('[role="tab"]')).filter(function(t) {
+        return t.offsetParent !== null &&
+               t.getAttribute('aria-hidden') !== 'true' &&
+               !t.hasAttribute('hidden');
+      });
       var idx = tabs.indexOf(tab);
       var target;
 

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -710,10 +710,23 @@
       }
     }
 
+    // <version-tabs> emits 'version-tabs-changed' when user activates a tab.
+    // selectVariant() reads all data-* from the activated <button.variant-tag>
+    // and dispatches `phase-b-variant-changed` for <trust-strip>/<security-scan>.
+    document.addEventListener('version-tabs-changed', function(e) {
+      // Find the activated button by tag value — it carries all data-* the page needs
+      var activatedTab = document.querySelector(
+        '.variant-tag[data-tag="' + (e.detail && e.detail.tag ? e.detail.tag : '') + '"]'
+      );
+      if (activatedTab) selectVariant(activatedTab);
+    });
+
     // Event delegation
     document.addEventListener('click', function(e) {
+      // Skip .variant-tag clicks that originated inside <version-tabs> —
+      // those are handled via the 'version-tabs-changed' event above.
       var tag = e.target.closest('.variant-tag');
-      if (tag) selectVariant(tag);
+      if (tag && !e.target.closest('version-tabs')) selectVariant(tag);
 
       var chip = e.target.closest('.sbom-type-chip-clickable');
       if (chip) togglePackagePanel(chip.dataset.type);
@@ -725,6 +738,35 @@
         copyDetailPullCommand();
       }
 
+      // Provenance section copy buttons — .copy-btn[data-copy] pattern
+      var copyBtn = e.target.closest('.copy-btn[data-copy]');
+      if (copyBtn) {
+        var textToCopy = copyBtn.dataset.copy || '';
+        var liveRegion = document.getElementById('status-live');
+        function showProvCopied() {
+          copyBtn.textContent = '✓';
+          copyBtn.setAttribute('aria-pressed', 'true');
+          if (liveRegion) liveRegion.textContent = 'Copied';
+          setTimeout(function () {
+            copyBtn.textContent = '⧉';
+            copyBtn.removeAttribute('aria-pressed');
+            if (liveRegion) liveRegion.textContent = '';
+          }, 2000);
+        }
+        navigator.clipboard.writeText(textToCopy).then(showProvCopied).catch(function () {
+          // Fallback for Safari/older browsers
+          var ta = document.createElement('textarea');
+          ta.value = textToCopy;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+          showProvCopied();
+        });
+      }
+
       if (e.target.closest('.theme-toggle')) {
         ThemeManager.toggleTheme();
       }
@@ -734,8 +776,9 @@
       if (e.key === 'Enter' || e.key === ' ') {
         var chip = e.target.closest('.sbom-type-chip-clickable');
         if (chip) { e.preventDefault(); togglePackagePanel(chip.dataset.type); return; }
+        // Skip .variant-tag keydown inside <version-tabs> — handled by version-tabs.js
         var tag = e.target.closest('.variant-tag');
-        if (tag) { e.preventDefault(); selectVariant(tag); }
+        if (tag && !e.target.closest('version-tabs')) { e.preventDefault(); selectVariant(tag); }
       }
     });
 

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -114,6 +114,7 @@
 
       // Phase B: dispatch event for vanilla custom-element trust strip + Security Scan section
       var variantData = {
+        tag: tag,
         attestation_url: el.dataset.attestationUrl || '',
         trivy_summary: null,
         multi_arch_platforms: []
@@ -729,6 +730,7 @@
     });
 
     // Fix #3: update security-scan-card chrome (header h3 date + card visibility) on variant change
+    // M-N4: also update the clean-scan message (.scan-clean-msg) reactively.
     document.addEventListener('phase-b-variant-changed', function(e) {
       var detail = e.detail;
       if (!detail) return;
@@ -740,6 +742,20 @@
         if (header) {
           var dateStr = (detail.trivy_summary.last_scan || '').slice(0, 10);
           header.textContent = 'Trivy · last scan ' + dateStr;
+        }
+        // Update the clean-scan message: show iff critical + high == 0
+        var cleanMsg = card.querySelector('.scan-clean-msg');
+        if (cleanMsg) {
+          var counts = (detail.trivy_summary && detail.trivy_summary.counts) || {};
+          var critical = counts.critical || 0;
+          var high = counts.high || 0;
+          var scanDate = (detail.trivy_summary.last_scan || '').slice(0, 10);
+          if (critical === 0 && high === 0) {
+            cleanMsg.textContent = 'No CRITICAL alerts at last scan (' + scanDate + ').';
+            cleanMsg.style.display = '';
+          } else {
+            cleanMsg.style.display = 'none';
+          }
         }
       } else {
         // Variant has no Trivy data — hide the entire card
@@ -760,10 +776,19 @@
 
     // Event delegation
     document.addEventListener('click', function(e) {
-      // Skip .variant-tag clicks that originated inside <version-tabs> —
-      // those are handled via the 'version-tabs-changed' event above.
+      // M-N2: fallback — if version-tabs.js failed to register the custom element,
+      // we still handle tab clicks here so variant switching remains operative.
+      // If <version-tabs> is registered AND the click is inside it, defer to
+      // the 'version-tabs-changed' listener above (which calls selectVariant).
       var tag = e.target.closest('.variant-tag');
-      if (tag && !e.target.closest('version-tabs')) selectVariant(tag);
+      if (tag) {
+        var insideVersionTabs = e.target.closest('version-tabs');
+        var versionTabsDefined = typeof customElements !== 'undefined' &&
+                                 customElements.get('version-tabs');
+        if (!insideVersionTabs || !versionTabsDefined) {
+          selectVariant(tag);
+        }
+      }
 
       var chip = e.target.closest('.sbom-type-chip-clickable');
       if (chip) togglePackagePanel(chip.dataset.type);
@@ -781,12 +806,14 @@
         var textToCopy = copyBtn.dataset.copy || '';
         var liveRegion = document.getElementById('status-live');
         function showProvCopied() {
+          // M-N8: do NOT use aria-pressed on one-shot copy actions (aria-pressed is for
+          // toggle buttons only). The live region provides the announcement instead.
           copyBtn.textContent = '✓';
-          copyBtn.setAttribute('aria-pressed', 'true');
+          copyBtn.setAttribute('aria-label', 'Copied');
           if (liveRegion) liveRegion.textContent = 'Copied';
           setTimeout(function () {
             copyBtn.textContent = '⧉';
-            copyBtn.removeAttribute('aria-pressed');
+            copyBtn.setAttribute('aria-label', copyBtn.dataset.ariaLabel || 'Copy to clipboard');
             if (liveRegion) liveRegion.textContent = '';
           }, 2000);
         }

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -63,11 +63,17 @@
       if (section) {
         section.querySelectorAll('.variant-tag').forEach(function(t) {
           t.classList.remove('selected');
-          t.setAttribute('aria-pressed', 'false');
+          // Fix #10: [role="tab"] uses aria-selected (managed by version-tabs.js), not aria-pressed
+          if (t.getAttribute('role') !== 'tab') {
+            t.setAttribute('aria-pressed', 'false');
+          }
         });
       }
       el.classList.add('selected');
-      el.setAttribute('aria-pressed', 'true');
+      // Fix #10: only set aria-pressed on non-tab elements
+      if (el.getAttribute('role') !== 'tab') {
+        el.setAttribute('aria-pressed', 'true');
+      }
 
       var tag = el.dataset.tag || '';
       var sizeAmd64 = el.dataset.sizeAmd64 || '---';
@@ -709,6 +715,37 @@
         wrap.appendChild(table);
       }
     }
+
+    // Fix #2: update Provenance section on variant change (show/hide per-variant blocks)
+    document.addEventListener('phase-b-variant-changed', function(e) {
+      var tag = e.detail && e.detail.tag ? e.detail.tag : '';
+      // Show the matching provenance section; hide all others
+      var provSections = document.querySelectorAll('.provenance[data-variant-tag]');
+      if (provSections.length > 0) {
+        provSections.forEach(function(s) {
+          s.style.display = s.dataset.variantTag === tag ? '' : 'none';
+        });
+      }
+    });
+
+    // Fix #3: update security-scan-card chrome (header h3 date + card visibility) on variant change
+    document.addEventListener('phase-b-variant-changed', function(e) {
+      var detail = e.detail;
+      if (!detail) return;
+      var card = document.querySelector('.security-scan-card');
+      if (!card) return;
+      if (detail.trivy_summary && detail.trivy_summary.last_scan) {
+        card.style.display = '';
+        var header = card.querySelector('.security-scan-card-header h3');
+        if (header) {
+          var dateStr = (detail.trivy_summary.last_scan || '').slice(0, 10);
+          header.textContent = 'Trivy · last scan ' + dateStr;
+        }
+      } else {
+        // Variant has no Trivy data — hide the entire card
+        card.style.display = 'none';
+      }
+    });
 
     // <version-tabs> emits 'version-tabs-changed' when user activates a tab.
     // selectVariant() reads all data-* from the activated <button.variant-tag>


### PR DESCRIPTION
## Summary

Container detail pages now expose the trust artifacts that the data pipeline
hydrates: a "Verifiable trust artifacts" section showing manifest digests, the
SBOM attestation link, the Trivy scan timestamp, and a copy-paste verify-locally
command. Variant selection switches from unsemantic `<span>`-pills to a proper
`<version-tabs>` custom element with full WAI-ARIA keyboard navigation. Trust-strip
badges adopt mono uppercase treatment with trust-domain identity colors
(teal SBOM / cyan verify / violet multi-arch / Trivy severity hues).

Builds on the data hydration shipped in #365.

## What's new

- `<version-tabs>` custom element — keyboard nav: ←/→/Home/End within group, ↑/↓
  between version groups, Enter/Space to activate, `aria-selected` toggling, mobile
  scroll-snap-x for narrow viewports, fallback to anchor links if JS fails to load.
- Provenance section — `<dl>` of build commit, manifest digests (amd64 + arm64),
  SBOM attestation ID, Trivy last-scan, base image, verify command. Each hash has
  a copy button with `aria-live` confirmation.
- `<security-scan-card>` chrome around the existing `<security-scan>` web component,
  using `--color-trust-trivy-{clean,warn,critical}-fg` identity tokens (not generic
  feedback colors).
- Brand-voice copy edits across trust-strip badges, hero subtitle, empty/error states.

## Brand-voice substitutions applied

| Surface | Old → New |
|---|---|
| Hero subtitle | "N containers · multi-arch…" → "Every image ships with an SBOM, a cosign signature, and a Trivy scan you can verify yourself." |
| SBOM badge | "SBOM attested" → "SBOM ATTESTED" |
| Trivy badge | "Trivy: N CRITICAL · scanned…" → "TRIVY: N CRITICAL · SCANNED…" |
| Multi-arch badge | "amd64 + arm64" → "AMD64 + ARM64" |
| Verify CTA | "How to verify" → "REPRODUCE THESE CHECKS LOCALLY" |
| Security-card footer | n/a → "REPRODUCE THIS SCAN LOCALLY" |
| Provenance eyebrow | n/a → "VERIFIABLE TRUST ARTIFACTS" |
| Empty Trivy state | n/a → "No CRITICAL alerts at last scan (YYYY-MM-DD)." |
| Build success status | "All systems go" → "Built · pushed · scanned · HH:MM UTC" |
| Build failed status | "Something broke" → "Build failed at step `<step>` · HH:MM UTC · view logs" |

## Compatibility

No breaking changes to `<trust-strip>` or `<security-scan>` JS contracts — the new
`<version-tabs>` component re-emits the existing `phase-b-variant-changed` event
with the same payload shape, so both consumers keep working unchanged.

## Test plan

- [ ] CI passes (Jekyll build, link check, lighthouse if configured)
- [ ] On `/container/postgres/` and `/container/terraform/`: SBOM badge visible,
      links to a non-empty Sigstore URL, mono uppercase styling
- [ ] `<version-tabs>`: keyboard nav (←/→/Home/End/Enter/Space) works,
      `aria-selected` toggles correctly, focus visible
- [ ] Mobile (≤640px): tabs scroll horizontally with snap, Provenance collapses
      to single column, copy buttons ≥32×32 touch targets
- [ ] Provenance section: 6+ rows render, each copy button works with toast
      confirmation, hash fields use `JetBrains Mono`
- [ ] `<security-scan-card>` severity colors use trust-trivy-* identity tokens
      (inspect computed style)
- [ ] `prefers-reduced-motion: reduce`: tab cross-fade and copy-confirm toast
      disabled
- [ ] Brand-voice grep clean (no 🎉 ✨ 🚀 💡 ⭐ 👋, no "Awesome", "Get started",
      "Try it", "Discover", "Magic", "Boost" in touched surfaces)

## Known polish (deferred to /finalize or a follow-up)

- **Hidden synthetic-tab in arrow-nav** — single-variant containers render a
  hidden `<button role="tab">` to keep the markup uniform; `<version-tabs>`
  arrow-key handler does not filter `[hidden]` / `aria-hidden="true"` tabs, so
  ←/→ may briefly focus the invisible button. Affects only single-variant pages;
  fix is a one-line `Array.filter` in `_handleKeydown`.
- **Redundant `phase-b-variant-changed` dispatch** — `<version-tabs>` and the
  bridge in `container-detail.js` both fire the event; payload is identical and
  consumers (`<trust-strip>`, `<security-scan>`) are idempotent, so it's
  harmless but wasteful. Cleanup is to drop one of the two emit sites.

## Out of scope (follow-up PRs)

- Shared site-nav include propagation to detail/blog/verify pages
- Shared footer include
- Replacing the "CONTAINER MANAGEMENT SYSTEM" eyebrow string
- Sweeping residual ad-hoc `rgba()` in dashboard / container-detail / blog CSS
- New design tokens (PR1 territory — none required for this change)
