### PR TITLE
refactor(dashboard): add truthful state to trust-strip and Provenance

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -85,24 +85,16 @@
   {%- endcomment -%}
   {%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
   <trust-strip class="trust-strip" data-current-variant="{{ default_variant.tag | default: include.current_version }}">
-    {%- comment -%} SBOM badge — Liquid renders initial state, web component updates on variant change {%- endcomment -%}
-    {%- comment -%} SBOM badge — 3-state: attested (both url+id), partial/pending (one only), missing (none, hidden) {%- endcomment -%}
-    <a class="trust-badge trust-badge--sbom"
+      <a class="trust-badge trust-badge--sbom{% unless default_variant.attestation_url and default_variant.attestation_id %} is-pending{% endunless %}"
        data-trust="sbom"
        {% if default_variant.attestation_url and default_variant.attestation_id %}
          href="{{ default_variant.attestation_url }}"
-         data-sbom-state="attested"
          title="View Sigstore attestation for this image's SBOM"
-       {% elsif default_variant.attestation_url or default_variant.attestation_id %}
-         {% if default_variant.attestation_url %}href="{{ default_variant.attestation_url }}"{% endif %}
-         data-sbom-state="partial"
-         title="SBOM attestation incomplete — awaiting next build"
        {% else %}
-         data-sbom-state="missing"
-         style="display: none"
+         title="SBOM attestation not yet generated. Will populate on next successful build with cosign attestation."
        {% endif %}
        rel="noopener"
-       >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% elsif default_variant.attestation_url or default_variant.attestation_id %}📋 SBOM PENDING{% endif %}</a>
+       >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% else %}📋 SBOM PENDING{% endif %}</a>
 
     {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
       {%- assign sev = "info" -%}
@@ -113,7 +105,7 @@
          data-trust="trivy"
          data-severity="{{ sev }}"
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
-         title="Click to see scan details on this container's detail page">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+         title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
     {%- else -%}
       <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
     {%- endif -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -139,23 +139,16 @@
         <!-- Trust Strip -->
         {%- assign default_variant = page.versions[0].variants[0] | default: page.variants[0] | default: page -%}
         <trust-strip class="trust-strip" data-current-variant="{{ default_variant.tag | default: page.current_version }}">
-          {%- comment -%} SBOM badge — 3-state: attested (both url+id), partial/pending (one only), missing (none, hidden) {%- endcomment -%}
-          <a class="trust-badge trust-badge--sbom"
+          <a class="trust-badge trust-badge--sbom{% unless default_variant.attestation_url and default_variant.attestation_id %} is-pending{% endunless %}"
              data-trust="sbom"
              {% if default_variant.attestation_url and default_variant.attestation_id %}
                href="{{ default_variant.attestation_url }}"
-               data-sbom-state="attested"
                title="View Sigstore attestation for this image's SBOM"
-             {% elsif default_variant.attestation_url or default_variant.attestation_id %}
-               {% if default_variant.attestation_url %}href="{{ default_variant.attestation_url }}"{% endif %}
-               data-sbom-state="partial"
-               title="SBOM attestation incomplete — awaiting next build"
              {% else %}
-               data-sbom-state="missing"
-               style="display: none"
+               title="SBOM attestation not yet generated. Will populate on next successful build with cosign attestation."
              {% endif %}
              rel="noopener"
-             >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% elsif default_variant.attestation_url or default_variant.attestation_id %}📋 SBOM PENDING{% endif %}</a>
+             >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% else %}📋 SBOM PENDING{% endif %}</a>
 
           {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
             {%- assign sev = "info" -%}
@@ -166,7 +159,7 @@
                data-trust="trivy"
                data-severity="{{ sev }}"
                href="#security"
-               title="Click to see scan details on this page">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+               title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
           {%- else -%}
             <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
           {%- endif -%}
@@ -196,6 +189,9 @@
 
         <!-- Provenance section — Camille's primary screenshot target (Phase C PR2) -->
         {%- comment -%}
+          Provenance fixes (PR-A 2026-05-05):
+          • F1: guard `_prov_var.base_image contains "${"` before rendering — pipeline may emit unexpanded shell vars.
+          • F4: only append "— last attempted YYYY-MM-DD" when `last_build_iso` is present; never assert "Never built" (factually wrong: many variants have build_digest but no last_build_iso field exposed in containers.yml yet).
           Fix #2: render one <section class="provenance"> per variant with data-variant-tag.
           JS (container-detail.js phase-b-variant-changed listener) shows/hides by matching tag.
           First variant is visible; others start hidden.
@@ -258,7 +254,8 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>SBOM attestation</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if _prov_var.last_build_iso %} — last attempted {{ _prov_var.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if _prov_var.trivy_summary.last_scan -%}
@@ -269,14 +266,22 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>Trivy last scan</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if _prov_var.last_build_iso %} — last attempted {{ _prov_var.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if _prov_var.base_image and _prov_var.base_image != "unknown" -%}
+              {%- if _prov_var.base_image contains "${" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd class="evidence-empty">not available</dd>
+            </div>
+              {%- else -%}
             <div class="evidence-row">
               <dt>Base image</dt>
               <dd><code class="hash">{{ _prov_var.base_image }}</code></dd>
             </div>
+              {%- endif -%}
             {%- endif -%}
             <div class="evidence-row">
               <dt>Verify</dt>
@@ -351,7 +356,8 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>SBOM attestation</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if _prov_var.last_build_iso %} — last attempted {{ _prov_var.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if _prov_var.trivy_summary.last_scan -%}
@@ -362,14 +368,22 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>Trivy last scan</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if _prov_var.last_build_iso %} — last attempted {{ _prov_var.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if _prov_var.base_image and _prov_var.base_image != "unknown" -%}
+              {%- if _prov_var.base_image contains "${" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd class="evidence-empty">not available</dd>
+            </div>
+              {%- else -%}
             <div class="evidence-row">
               <dt>Base image</dt>
               <dd><code class="hash">{{ _prov_var.base_image }}</code></dd>
             </div>
+              {%- endif -%}
             {%- endif -%}
             <div class="evidence-row">
               <dt>Verify</dt>
@@ -442,7 +456,8 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>SBOM attestation</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if prov_variant.last_build_iso %} — last attempted {{ prov_variant.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if prov_variant.trivy_summary.last_scan -%}
@@ -453,14 +468,22 @@
             {%- else -%}
             <div class="evidence-row">
               <dt>Trivy last scan</dt>
-              <dd class="evidence-empty">awaiting next build</dd>
+
+              <dd class="evidence-empty">awaiting next build{%- if prov_variant.last_build_iso %} — last attempted {{ prov_variant.last_build_iso | date: "%Y-%m-%d" }}{%- endif -%}</dd>
             </div>
             {%- endif -%}
             {%- if prov_variant.base_image and prov_variant.base_image != "unknown" -%}
+              {%- if prov_variant.base_image contains "${" -%}
+            <div class="evidence-row">
+              <dt>Base image</dt>
+              <dd class="evidence-empty">not available</dd>
+            </div>
+              {%- else -%}
             <div class="evidence-row">
               <dt>Base image</dt>
               <dd><code class="hash">{{ prov_variant.base_image }}</code></dd>
             </div>
+              {%- endif -%}
             {%- endif -%}
             <div class="evidence-row">
               <dt>Verify</dt>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -187,15 +187,21 @@
              title="Reproduce these checks yourself — verification guide">🔍 REPRODUCE THESE CHECKS LOCALLY</a>
         </trust-strip>
 
-        <!-- Provenance section — Camille's primary screenshot target (Phase C PR2) -->
         {%- comment -%}
-          Provenance fixes (PR-A 2026-05-05):
-          • F1: guard `_prov_var.base_image contains "${"` before rendering — pipeline may emit unexpanded shell vars.
-          • F4: only append "— last attempted YYYY-MM-DD" when `last_build_iso` is present; never assert "Never built" (factually wrong: many variants have build_digest but no last_build_iso field exposed in containers.yml yet).
-          Fix #2: render one <section class="provenance"> per variant with data-variant-tag.
-          JS (container-detail.js phase-b-variant-changed listener) shows/hides by matching tag.
-          First variant is visible; others start hidden.
-          For no-variant containers, fall through to the single-variant render below.
+          Render one <section class="provenance"> per variant with
+          data-variant-tag; container-detail.js (phase-b-variant-changed)
+          shows/hides by matching tag. First variant visible, others
+          hidden. No-variant containers fall through to the single-render
+          branch below.
+
+          Two truthfulness guards live inside each branch:
+          - "Base image" row: skip raw output when value still contains
+            "${...}" — the build pipeline can emit unexpanded shell
+            placeholders into the lineage record. Render "not available".
+          - "awaiting next build" rows: only append a date suffix when
+            last_build_iso is present. Never assert "Never built" — many
+            variants carry a real build_digest while last_build_iso is
+            still absent from containers.yml.
         {%- endcomment -%}
         {%- if page.versions -%}
           {%- comment -%}

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -138,6 +138,22 @@
   border-color: rgba(16, 185, 129, 0.45);
 }
 
+/* S-3/S-4/M-2 fix: pending badge — token-bound, no raw rgba, no opacity (WCAG 1.4.3 fix).
+   Selector broadened from .trust-badge--sbom.is-pending → .trust-badge.is-pending so
+   multi-arch / Trivy can reuse the modifier in PR-F without duplication.
+   --color-text-muted: #8A93A0 — 4.6:1 on navy-950 (WCAG AA body text).
+   Applied by Liquid (is-pending class) and trust-strip.js (classList.add). */
+.trust-badge.is-pending {
+  background: var(--color-surface-raised);
+  border-color: var(--color-border-subtle);
+  color: var(--color-text-muted);
+  cursor: default;
+}
+.trust-badge.is-pending:hover {
+  background: var(--color-surface-overlay);
+  border-color: var(--color-border-strong);
+}
+
 /* Multi-arch — blue/info tint */
 .trust-badge--multi-arch {
   background: rgba(59, 130, 246, 0.12);

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -138,11 +138,10 @@
   border-color: rgba(16, 185, 129, 0.45);
 }
 
-/* S-3/S-4/M-2 fix: pending badge — token-bound, no raw rgba, no opacity (WCAG 1.4.3 fix).
-   Selector broadened from .trust-badge--sbom.is-pending → .trust-badge.is-pending so
-   multi-arch / Trivy can reuse the modifier in PR-F without duplication.
-   --color-text-muted: #8A93A0 — 4.6:1 on navy-950 (WCAG AA body text).
-   Applied by Liquid (is-pending class) and trust-strip.js (classList.add). */
+/* Generic pending modifier — opacity-free so muted text keeps WCAG AA
+   contrast (--color-text-muted = #8A93A0 = 4.6:1 on navy-950). Reusable
+   across all .trust-badge variants; specific badge identity is layered
+   on top via the trust-domain hue rule. */
 .trust-badge.is-pending {
   background: var(--color-surface-raised);
   border-color: var(--color-border-subtle);

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -33,34 +33,28 @@
       this._updateMultiArch(variant.multi_arch_platforms);
     }
 
-    // 3-state SBOM badge: attested (url+id), partial/pending (one only), missing (neither).
+    // M-1 fix: 2-state SBOM badge (drop N/A / partial middle state — both resolve to PENDING).
+    // attested (url AND id) → styled chip with link, text "📋 SBOM ATTESTED".
+    // else → muted is-pending chip, text "📋 SBOM PENDING", no href.
     _updateSbom(url, id) {
       const el = this.querySelector('[data-trust="sbom"]');
       if (!el) return;
       if (url && id) {
-        // Fully attested
+        // Attested — both url and id present
         el.setAttribute('href', url);
         el.textContent = '📋 SBOM ATTESTED';
         el.dataset.sbomState = 'attested';
         el.title = "View Sigstore attestation for this image's SBOM";
         el.style.display = '';
-      } else if (url || id) {
-        // Partial — attestation data incomplete, awaiting next build
-        if (url) {
-          el.setAttribute('href', url);
-        } else {
-          el.removeAttribute('href');
-        }
-        el.textContent = '📋 SBOM PENDING';
-        el.dataset.sbomState = 'partial';
-        el.title = 'SBOM attestation incomplete — awaiting next build';
-        el.style.display = '';
+        el.classList.remove('is-pending');
       } else {
-        // Missing — hide badge, blank text for parity with Liquid (no misleading label if display override)
-        el.style.display = 'none';
+        // Pending — attestation not yet generated or incomplete
+        el.style.display = '';
         el.removeAttribute('href');
-        el.textContent = '';
-        el.dataset.sbomState = 'missing';
+        el.textContent = '📋 SBOM PENDING';
+        el.dataset.sbomState = 'pending';
+        el.classList.add('is-pending');
+        el.title = 'SBOM attestation not yet generated. Will populate on next successful build with cosign attestation.';
       }
     }
 
@@ -77,8 +71,9 @@
       const sev = critical > 0 ? 'critical' : (high > 0 ? 'high' : 'info');
       el.setAttribute('data-severity', sev);
       const date = (summary.last_scan || '').slice(0, 10);
-      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("TRIVY: N CRITICAL · SCANNED")
-      el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL · SCANNED ' + date;
+      // S-1 fix: "(advisory)" qualifier and tooltip match Liquid initial state in container-card.html.
+      el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
+      el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
       el.style.display = '';
     }
 

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -33,26 +33,19 @@
       this._updateMultiArch(variant.multi_arch_platforms);
     }
 
-    // M-1 fix: 2-state SBOM badge (drop N/A / partial middle state — both resolve to PENDING).
-    // attested (url AND id) → styled chip with link, text "📋 SBOM ATTESTED".
-    // else → muted is-pending chip, text "📋 SBOM PENDING", no href.
     _updateSbom(url, id) {
       const el = this.querySelector('[data-trust="sbom"]');
       if (!el) return;
       if (url && id) {
-        // Attested — both url and id present
         el.setAttribute('href', url);
         el.textContent = '📋 SBOM ATTESTED';
-        el.dataset.sbomState = 'attested';
         el.title = "View Sigstore attestation for this image's SBOM";
         el.style.display = '';
         el.classList.remove('is-pending');
       } else {
-        // Pending — attestation not yet generated or incomplete
         el.style.display = '';
         el.removeAttribute('href');
         el.textContent = '📋 SBOM PENDING';
-        el.dataset.sbomState = 'pending';
         el.classList.add('is-pending');
         el.title = 'SBOM attestation not yet generated. Will populate on next successful build with cosign attestation.';
       }
@@ -71,7 +64,6 @@
       const sev = critical > 0 ? 'critical' : (high > 0 ? 'high' : 'info');
       el.setAttribute('data-severity', sev);
       const date = (summary.last_scan || '').slice(0, 10);
-      // S-1 fix: "(advisory)" qualifier and tooltip match Liquid initial state in container-card.html.
       el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
       el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
       el.style.display = '';


### PR DESCRIPTION
## Summary

Closes 4 truthfulness gaps in the dashboard's trust-strip + Provenance section that surfaced after Phase C deployment.

- **Base image** row in Provenance now guards against unexpanded shell variables (literal `${BASE_IMAGE}:18-alpine` strings can leak through `generate-dashboard.sh` when a lineage record is incomplete). Defensive Liquid check (`contains "${"`) renders "not available" instead of the raw placeholder.

- **SBOM badge** is now always visible — replaced `display:none` with a 2-state indicator: ATTESTED (link to attestation) when both `attestation_url` and `attestation_id` are present, else a muted PENDING chip with explanatory tooltip. Generic `.trust-badge.is-pending` modifier (forward-friendly when multi-arch / Trivy reuse the muted state). CSS rule binds to existing design tokens (`--color-surface-raised`, `--color-border-subtle`, `--color-text-muted`); no opacity composite, contrast stays WCAG 1.4.3 clean.

- **Trivy badge** on dashboard cards now reads `🛡 TRIVY: N CRITICAL (advisory)` so severity counts can't be mistaken for blocking thresholds. `trust-strip.js _updateTrivy()` updated so the qualifier survives variant-tag click events (Liquid + JS contract).

- **Provenance "awaiting next build"** state no longer asserts a "Never built" suffix when the data layer doesn't expose `last_build_iso` (would self-contradict against neighbouring `build_digest` rows). The date suffix renders only when real data is present; absent → silent.

- **Comment hygiene**: 3 near-duplicate Provenance branches (versions / variants / no-variant) used to repeat the same multi-line explanatory comments. Consolidated into one section-level note at the top of `<section class="provenance">`.

Net diff: 4 files, +74/-48 (net +26 LOC).

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] Jekyll build succeeds in `update-dashboard.yaml`
- [ ] Live deploy: dashboard cards render `📋 SBOM ATTESTED` (linked) for variants with attestation; muted `📋 SBOM PENDING` (no link, tooltip) for variants without
- [ ] Live deploy: dashboard cards render `🛡 TRIVY: N CRITICAL (advisory)` and the qualifier survives a variant-tag click
- [ ] Live deploy: postgres detail page Provenance "Base image" row shows resolved value (e.g. `postgres:18-alpine`) when data is good, "not available" when data carries `${...}` placeholder
- [ ] Live deploy: Provenance "awaiting next build" rows render alone (no "Never built") for variants whose `last_build_iso` is unset
- [ ] No regressions in heuristic mobile rendering (≤ 768px) of trust-strip badges
