### PR TITLE
feat(seo): add sitemap, meta tags, robots.txt, and llms.txt

### DIFF
--- a/docs/site/Gemfile
+++ b/docs/site/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+
+group :jekyll_plugins do
+  gem "jekyll-feed"
+  gem "jekyll-sitemap"
+end

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -16,6 +16,7 @@ markdown: kramdown
 # theme: minima  # Disabled - using custom glassmorphism layouts
 plugins:
   - jekyll-feed
+  - jekyll-sitemap
 
 # Jekyll skips future-dated posts — used intentionally to stagger blog
 # publication: drop several posts at once, each with a future date; the
@@ -47,7 +48,6 @@ tabler:
   
 # SEO and metadata
 title_separator: " | "
-description_extra: "Docker container monitoring dashboard"
 
 # Jekyll source = docs/site/ (set in .github/workflows/update-dashboard.yaml).
 # Only content inside docs/site/ is built; no excludes needed for repo-root files

--- a/docs/site/_includes/seo-meta.html
+++ b/docs/site/_includes/seo-meta.html
@@ -1,0 +1,33 @@
+{% comment %}
+  seo-meta.html — Consolidated SEO head block (description, canonical, OG, Twitter Card).
+  Include this from every layout's <head> AFTER <title>.
+  Reads: page.seo_title, page.title, page.name, page.description, page.tagline, page.excerpt,
+         page.og_image, page.image, include.og_image_fallback, page.layout, page.url,
+         site.title, site.description, site.url, site.baseurl.
+  Parameters:
+    og_image_fallback — caller-supplied last-resort OG image path (e.g. slug-based PNG for posts).
+                        Only emitted when page.og_image and page.image are both absent.
+{% endcomment %}
+
+{% assign _seo_title = page.seo_title | default: page.title | default: page.name | default: site.title %}
+{% assign _seo_desc = page.description | default: page.tagline | default: page.excerpt %}
+{% if _seo_desc == nil or _seo_desc == "" %}
+  {% assign _seo_desc = site.description %}
+{% endif %}
+{% assign _seo_url = page.url | absolute_url %}
+{% assign _seo_image = page.og_image | default: page.image | default: include.og_image_fallback %}
+
+<meta name="description" content="{{ _seo_desc | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+<link rel="canonical" href="{{ _seo_url }}">
+
+<meta property="og:title" content="{{ _seo_title | escape }}">
+<meta property="og:description" content="{{ _seo_desc | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+<meta property="og:url" content="{{ _seo_url }}">
+<meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
+{% if _seo_image %}<meta property="og:image" content="{{ _seo_image | absolute_url }}">{% endif %}
+<meta property="og:site_name" content="{{ site.title | escape }}">
+
+<meta name="twitter:card" content="{% if _seo_image %}summary_large_image{% else %}summary{% endif %}">
+<meta name="twitter:title" content="{{ _seo_title | escape }}">
+<meta name="twitter:description" content="{{ _seo_desc | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+{% if _seo_image %}<meta name="twitter:image" content="{{ _seo_image | absolute_url }}">{% endif %}

--- a/docs/site/_layouts/blog.html
+++ b/docs/site/_layouts/blog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.title }} | {{ site.title }}</title>
-  <meta name="description" content="Insights, postmortems, and release notes on the open-source Docker images of this project."/>
+  {% include seo-meta.html %}
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.name }} | Container Details | {{ site.title }}</title>
+  {% include seo-meta.html %}
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.title }} | {{ site.title }}</title>
+  {% include seo-meta.html %}
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/site/_layouts/default.html
+++ b/docs/site/_layouts/default.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.title }} | {{ site.title }}</title>
+  {% include seo-meta.html %}
 
   <!-- Google Fonts: Inter (sans) + JetBrains Mono (mono) — Phase C typography spec -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/site/_layouts/page.html
+++ b/docs/site/_layouts/page.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.title }} | {{ site.title }}</title>
-  <meta name="description" content="{{ page.description | default: site.description }}"/>
+  {% include seo-meta.html %}
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/site/_layouts/post.html
+++ b/docs/site/_layouts/post.html
@@ -6,18 +6,11 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.title }} | {{ site.title }}</title>
-  <meta name="description" content="{{ page.description | default: page.excerpt | strip_html | truncate: 160 }}">
-
-  <!-- Open Graph / Twitter -->
-  <meta property="og:title" content="{{ page.title }}"/>
-  <meta property="og:description" content="{{ page.description | default: page.excerpt | strip_html | truncate: 200 }}"/>
-  <meta property="og:type" content="article"/>
-  <meta property="og:url" content="{{ site.url }}{{ site.baseurl }}{{ page.url }}"/>
-  <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/og/{{ page.slug }}.png"/>
-  <meta property="og:image:width" content="1200"/>
-  <meta property="og:image:height" content="630"/>
-  <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}/assets/og/{{ page.slug }}.png"/>
+  {% comment %}Post OG image: prefer per-post og_image front-matter, fall back to slug-based PNG.{% endcomment %}
+  {% capture _post_og_fallback %}/assets/og/{{ page.slug }}.png{% endcapture %}
+  {% include seo-meta.html og_image_fallback=_post_og_fallback %}
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/site/blog.md
+++ b/docs/site/blog.md
@@ -2,4 +2,5 @@
 layout: blog
 title: Blog
 permalink: /blog/
+description: Articles on supply-chain provenance, SBOM verification, multi-arch builds, and image hardening — written from the docker-containers project's day-to-day operations.
 ---

--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -1,0 +1,48 @@
+# docker-containers
+
+> Custom Docker container images with automated upstream version monitoring, SBOM attestation via Sigstore, and trust-strip CI/CD signals.
+
+This site documents a fleet of 13 container images published to GHCR (`ghcr.io/oorabona/<image>`) and Docker Hub (`docker.io/oorabona/<image>`). Each image carries: a published version derived from upstream tracking, a Trivy advisory scan, an optional SBOM attestation in SPDX format, and multi-architecture manifests (amd64 + arm64 where supported).
+
+## Project facts
+
+- License: MIT
+- Source: https://github.com/oorabona/docker-containers
+- Maintainer: Olivier Orabona (https://github.com/oorabona)
+- First architecture decision (ADR-001): 2026-01-31
+- Build pipeline: GitHub Actions (`auto-build.yaml`, `upstream-monitor.yaml`)
+- Primary persona: AppSec engineers verifying supply-chain provenance before adopting third-party images.
+
+## Containers
+
+- [ansible](/docker-containers/container/ansible/) — Production-ready Ansible automation container built from source with Python virtual environment isolation and automatic dependency monitoring.
+- [debian](/docker-containers/container/debian/) — Debian Base Container, used as the foundation for other images in this fleet.
+- [github-runner](/docker-containers/container/github-runner/) — Self-hosted GitHub Actions runner supporting Linux (Ubuntu 24.04, Debian Trixie) and Windows (Server 2022), in base and dev flavors.
+- [jekyll](/docker-containers/container/jekyll/) — Lightweight Alpine-based container for building and serving Jekyll static sites with live reload support.
+- [openresty](/docker-containers/container/openresty/) — High-performance web platform combining Nginx with LuaJIT for dynamic, programmable request handling.
+- [openvpn](/docker-containers/container/openvpn/) — OpenVPN built from sources with advanced security features on Alpine Linux.
+- [php](/docker-containers/container/php/) — Production-ready PHP-FPM container with Composer integration, optimized for modern PHP applications.
+- [postgres](/docker-containers/container/postgres/) — PostgreSQL with 10 extensions (pgvector, paradedb, pg_cron, postgis, timescaledb, citus, and more) in 7 flavors.
+- [sslh](/docker-containers/container/sslh/) — SSLH protocol multiplexer in a 2 MB container image.
+- [terraform](/docker-containers/container/terraform/) — Enterprise-grade Terraform container with DevOps tooling for multi-cloud infrastructure as code (AWS, Azure, GCP flavors).
+- [vector](/docker-containers/container/vector/) — High-performance observability data pipeline built on Vector with a musl static binary on Alpine Linux.
+- [web-shell](/docker-containers/container/web-shell/) — Secure browser-based terminal built on the Debian base image with ttyd, DevOps tools, optional SSH server.
+- [wordpress](/docker-containers/container/wordpress/) — Production-ready WordPress container built on PHP-FPM with WP-CLI, auto-install, and security hardening.
+
+## How to verify an image
+
+- Verify SBOM attestation with cosign: see [/docker-containers/verify-images/](/docker-containers/verify-images/).
+- Check Trivy scan summary: each container detail page has a "Security scan" card with severity counts. Scans are advisory (continue-on-error in CI), not blocking.
+- Pull by digest (immutable): copy the `sha256:...` from the container detail page.
+
+## Documentation
+
+- Architecture decisions: https://github.com/oorabona/docker-containers/tree/master/docs/adr
+- Verification guide: /docker-containers/verify-images/
+- Blog: /docker-containers/blog/
+
+## Notes for AI citation
+
+- Image facts (versions, digests, scan dates) are sourced from `.build-lineage/*.json` snapshots produced at build time. Treat each fact as accurate as of the build's `built_at` timestamp.
+- Multi-version retention: each container retains its 3 most recent versions (`build.version_retention: 3`); postgres retains all versions (manual policy).
+- This site does not collect telemetry or store visitor data.

--- a/docs/site/robots.txt
+++ b/docs/site/robots.txt
@@ -1,0 +1,45 @@
+# robots.txt — docker-containers project policy statement
+#
+# NOTE ON ENFORCEMENT: GitHub Pages serves this file at
+# https://oorabona.github.io/docker-containers/robots.txt — a project
+# sub-path. The robots.txt protocol (RFC 9309) requires the file at the
+# host root (https://oorabona.github.io/robots.txt) to be honored by
+# search engines. This sub-path file is therefore policy documentation,
+# not crawler-enforced directives. Sitemap discovery is provided by
+# Search Console submission and the auto-included <sitemap> reference
+# in the served XML.
+#
+# Project policy: this is open-source documentation. All content is
+# intended for indexing and citation, including by AI crawlers.
+
+User-agent: *
+Allow: /
+
+# AI / LLM crawlers — explicitly allowed (not blocked).
+# Documented for transparency: anyone can use this site for training,
+# retrieval, or citation. Source code: https://github.com/oorabona/docker-containers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://oorabona.github.io/docker-containers/sitemap.xml

--- a/docs/site/robots.txt
+++ b/docs/site/robots.txt
@@ -5,9 +5,9 @@
 # sub-path. The robots.txt protocol (RFC 9309) requires the file at the
 # host root (https://oorabona.github.io/robots.txt) to be honored by
 # search engines. This sub-path file is therefore policy documentation,
-# not crawler-enforced directives. Sitemap discovery is provided by
-# Search Console submission and the auto-included <sitemap> reference
-# in the served XML.
+# not crawler-enforced directives. Sitemap discovery still works via
+# Search Console submission and via the explicit `Sitemap:` line below
+# (honored by the crawlers that do fetch this file even at sub-paths).
 #
 # Project policy: this is open-source documentation. All content is
 # intended for indexing and citation, including by AI crawlers.


### PR DESCRIPTION
## Summary

Adds the SEO foundation to the Jekyll dashboard site. Site previously had no sitemap, no meta description, no canonical URLs, no OG/Twitter Card, no robots.txt, no llms.txt — invisible to search engines and AI crawlers.

### What landed

- **`jekyll-sitemap` plugin** — declared in `_config.yml` (plugins:) and a new `Gemfile` for local Bundler runs. GitHub Pages CI picks it up via the allowlist. Generates `/sitemap.xml` on next deploy.

- **`_includes/seo-meta.html`** — consolidated head block: `<meta name="description">`, `<link rel="canonical">`, `og:*` (title/description/url/type/image/site_name), and `twitter:card` (auto downgrades summary_large_image → summary when no OG image is available). Description fallback chain: `page.description → page.tagline → page.excerpt → site.description`. Title chain includes `page.name` so container detail pages (collection front matter has `name:` not `title:`) emit a real OG title.

- **6 layouts include the partial** — dashboard.html, container-detail.html, page.html, post.html, blog.html, default.html. `post.html` collapses 17 LOC of bespoke OG markup into a single `og_image_fallback` parameter pointing to the slug-based generated PNG (preserves `og:image:width`/`height` 1200×630 sizing).

- **`robots.txt`** — policy comment block at the top noting the GitHub Pages sub-path serving caveat (RFC 9309 requires the file at host root for crawler enforcement; this sub-path file is therefore documentation, not enforced directives — sitemap discovery still works via Search Console submission). Explicit `Allow:` rules for 8 named AI crawlers (GPTBot, ChatGPT-User, Google-Extended, anthropic-ai, ClaudeBot, PerplexityBot, Applebot-Extended, CCBot).

- **`llms.txt`** — per https://llmstxt.org/ format. Lists all 13 containers with one-line descriptions sourced from `_data/containers.yml`. Includes how-to-verify pointers, ADR link, and AI citation notes. No fabricated facts (date references checked against actual git/ADR history).

- **Cleanup** — removed `description_extra` (dead config, never read by any template) and `default_og_image` (referenced a file that did not exist, would have 404'd in OG previews).

Net diff: 11 files, +145/-15 (4 new files, 7 modified).

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts, CodeQL)
- [ ] Jekyll build succeeds in `update-dashboard.yaml` after merge
- [ ] Live deploy: `https://oorabona.github.io/docker-containers/sitemap.xml` returns 200 with all detail pages listed
- [ ] Live deploy: dashboard `<head>` includes `<meta name="description">`, `<link rel="canonical">`, `og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`, `twitter:card`
- [ ] Live deploy: container-detail OG `og:title` shows the container name (e.g. `postgres`) — not the generic site title
- [ ] Live deploy: post layout OG includes 1200×630 generated PNG via `og_image_fallback` parameter
- [ ] Live deploy: `https://oorabona.github.io/docker-containers/robots.txt` returns 200 with policy comment + crawler rules
- [ ] Live deploy: `https://oorabona.github.io/docker-containers/llms.txt` returns 200 with the 13 containers listed
- [ ] No regressions on Slack/Confluence URL unfurls of any layout
