### PR TITLE
fix(dashboard): close WCAG 2.2 AA gaps on focus, contrast, headings, ARIA

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -107,7 +107,8 @@
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
          title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
     {%- else -%}
-      <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
+      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
+      <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#"></a>
     {%- endif -%}
 
     {%- if default_variant.multi_arch_platforms -%}
@@ -117,7 +118,8 @@
          rel="noopener"
          title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
     {%- else -%}
-      <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" href="#"></a>
+      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
+      <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="#"></a>
     {%- endif -%}
 
     {%- if include.dependency_monitoring.enabled -%}

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -107,8 +107,8 @@
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
          title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
     {%- else -%}
-      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
-      <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#"></a>
+      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+      <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"></a>
     {%- endif -%}
 
     {%- if default_variant.multi_arch_platforms -%}
@@ -118,8 +118,8 @@
          rel="noopener"
          title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
     {%- else -%}
-      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
-      <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="#"></a>
+      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+      <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}" rel="noopener"></a>
     {%- endif -%}
 
     {%- if include.dependency_monitoring.enabled -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -165,8 +165,8 @@
                href="#security"
                title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
           {%- else -%}
-            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
-            <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#"></a>
+            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+            <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#security"></a>
           {%- endif -%}
 
           {%- if default_variant.multi_arch_platforms -%}
@@ -176,8 +176,8 @@
                rel="noopener"
                title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
           {%- else -%}
-            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
-            <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="#"></a>
+            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+            <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="https://github.com/{{ site.github_username | default: site.github.owner_name }}/{{ site.repository | default: site.github.repository_name }}/pkgs/container/{{ page.name }}" rel="noopener"></a>
           {%- endif -%}
 
           {%- if page.dependency_monitoring.enabled -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -36,7 +36,11 @@
 
   <div class="container">
     <main id="main-content" role="main">
-      <h1 class="sr-only">{{ page.name }} — container details</h1>
+      {%- comment -%}
+        Heading hierarchy (WCAG 2.4.6): single visible h1 = container name (replaces sr-only h1 + duplicate h2).
+        Section headings use h2. The sr-only h1 is removed; this h1 is the visible page title.
+        CSS .detail-title h1 already targets this level for 2rem/700 styling.
+      {%- endcomment -%}
       <div class="container-detail-page">
 
         <!-- Back link -->
@@ -47,7 +51,7 @@
         <!-- Header -->
         <div class="detail-header">
           <div class="detail-title">
-            <h2>{{ page.name }}</h2>
+            <h1>{{ page.name }}</h1>
             <span class="detail-badge">{{ page.current_version }}</span>
           </div>
           <div class="detail-actions">
@@ -161,7 +165,8 @@
                href="#security"
                title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
           {%- else -%}
-            <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" href="#"></a>
+            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
+            <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#"></a>
           {%- endif -%}
 
           {%- if default_variant.multi_arch_platforms -%}
@@ -171,7 +176,8 @@
                rel="noopener"
                title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
           {%- else -%}
-            <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" href="#"></a>
+            <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. -->
+            <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="#"></a>
           {%- endif -%}
 
           {%- if page.dependency_monitoring.enabled -%}

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -608,7 +608,13 @@
       border-radius: 4px;
       cursor: pointer;
       transition: all 0.2s ease;
-      min-height: 28px;
+      /* 44px minimum touch target (WCAG 2.5.8). Explicit flex centering keeps
+         the label visually balanced when the box height exceeds the content
+         box, including in browsers without native button vertical-centering. */
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
     .detail-registry-btn:hover {
       color: var(--text-primary);

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -235,13 +235,23 @@
     }
 
     .search-input::placeholder {
-      color: var(--text-muted);
+      /* var(--text-muted) computed to ~4.4:1 on navy-950 — fails WCAG 1.4.3
+         (4.5:1 minimum for body text). --color-text-secondary is 9.1:1. */
+      color: var(--color-text-secondary);
     }
 
     .search-input:focus {
-      outline: none;
       border-color: var(--accent-blue);
       background: rgba(0, 0, 0, 0.3);
+    }
+
+    /* WCAG 2.4.11 Focus Appearance — keyboard-only focus ring, 2px solid,
+       4:1+ contrast against navy-950. :focus-visible activates on tab/arrow
+       navigation only; suppressed on mouse click so the ring doesn't flash
+       on every interaction. */
+    .search-input:focus-visible {
+      outline: 2px solid var(--color-action-primary);
+      outline-offset: 2px;
     }
 
     .search-icon {
@@ -264,7 +274,11 @@
       min-height: 44px;
       font-size: 0.75rem;
       font-weight: 500;
-      border: 1px solid var(--glass-border);
+      /* var(--glass-border) ~1.3:1 on navy-950 fails WCAG 1.4.11 (3:1 min for
+         non-text UI element borders). --color-neutral-400 (#8A93A0) ≈ 5.6:1 on
+         navy-950 (#0F1729) — comfortably above the 3:1 floor. (#4D556A from the
+         -600 step computes to ~2.4:1, still failing.) */
+      border: 1px solid var(--color-neutral-400);
       background: transparent;
       color: var(--text-secondary);
       border-radius: 6px;
@@ -810,11 +824,6 @@
     .filter-btn:focus-visible,
     .registry-btn:focus-visible,
     .theme-toggle:focus-visible {
-      outline: 2px solid var(--accent-blue);
-      outline-offset: 2px;
-    }
-
-    .search-input:focus-visible {
       outline: 2px solid var(--accent-blue);
       outline-offset: 2px;
     }

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -55,7 +55,9 @@
       const el = this.querySelector('[data-trust="trivy"]');
       if (!el) return;
       if (!summary || !summary.last_scan) {
+        // WCAG 4.1.2: anchor with display:none must be removed from the AT tree.
         el.style.display = 'none';
+        el.setAttribute('aria-hidden', 'true');
         return;
       }
       const counts = summary.counts || {};
@@ -67,13 +69,16 @@
       el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
       el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
       el.style.display = '';
+      el.removeAttribute('aria-hidden');
     }
 
     _updateMultiArch(platforms) {
       const el = this.querySelector('[data-trust="multi-arch"]');
       if (!el) return;
       if (!platforms || platforms.length === 0) {
+        // WCAG 4.1.2: anchor with display:none must be removed from the AT tree.
         el.style.display = 'none';
+        el.setAttribute('aria-hidden', 'true');
         return;
       }
       // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("AMD64 + ARM64").
@@ -83,6 +88,7 @@
         return arch.toUpperCase();
       }).join(' + ');
       el.style.display = '';
+      el.removeAttribute('aria-hidden');
     }
   }
 


### PR DESCRIPTION
## Summary

Closes 6 WCAG 2.2 AA conformance gaps surfaced in `docs/audit/dashboard-2026-05-05.md` Theme 5. Each fix references the specific success criterion it addresses; tokens used (`--color-text-secondary`, `--color-neutral-400`, `--color-action-primary`) are already defined in `tokens.css`.

### What landed

- **Search input focus ring (WCAG 2.4.11)** — replaces `outline: none` with a 2px solid `:focus-visible` ring at 4:1+ contrast against navy-950. Activates on tab/arrow navigation only; suppressed on mouse click so the ring doesn't flash on every interaction.

- **Search placeholder contrast (WCAG 1.4.3)** — was `--text-muted` (~4.4:1), now `--color-text-secondary` (9.1:1, well above the 4.5:1 floor for body text).

- **Filter button border contrast (WCAG 1.4.11)** — was `--glass-border` (~1.3:1), now `--color-neutral-400` (#8A93A0, ~5.6:1 — comfortably above the 3:1 minimum for non-text UI element borders).

- **Heading hierarchy (WCAG 2.4.6)** — container detail page now has exactly one visible `<h1>` (the container name). Earlier markup had a sr-only h1 alongside a duplicate visible h2. Section headings remain at `<h2>`. Existing CSS rule `.detail-title h1` already styles this level (2rem / 700) — no visual regression.

- **Hidden trust badges (WCAG 4.1.2)** — Trivy and multi-arch anchors that hide via `display:none` now also carry `aria-hidden="true"`. `trust-strip.js _updateTrivy` and `_updateMultiArch` toggle the attribute symmetrically with the show/hide paths. The PR-A 2-state SBOM badge (visible muted PENDING state) is left alone — it's visible by design.

- **Touch target on `.detail-registry-btn` (WCAG 2.5.8)** — min-height raised from 28px to 44px to match `.copy-btn` and the project-wide touch-target standard. Explicit `inline-flex` + `align-items: center` keeps the label visually balanced when the box height exceeds the content height.

### Already compliant

- **Variant-tag keyboard handler (WCAG 2.1.1)** — `dashboard.js:269-278` already has Enter / Space `keydown` with `preventDefault` + handler invocation. `tabindex="0"` confirmed on every variant-tag span. No change needed.

Net diff: 5 files, +44/-15.

## Test plan

- [ ] CI passes (CodeQL, build)
- [ ] Live deploy: tab to the dashboard search input — visible 2px outline appears around the input; click with mouse — no outline (border highlight only)
- [ ] Live deploy: search input placeholder text reads at full contrast against the input background
- [ ] Live deploy: filter button borders render visibly distinct from the page background
- [ ] Live deploy: container detail page contains exactly one visible `<h1>` (container name); axe-core / Lighthouse a11y reports no "heading order" or "no h1" warnings
- [ ] Live deploy: tab through trust strip — Trivy / multi-arch badges absent from the AT tree when display:none, present when visible (verify with NVDA or VoiceOver)
- [ ] Live deploy: GHCR / Docker Hub registry toggle on detail page is at least 44px tall and label stays vertically centered
- [ ] No regressions on the PR-A 2-state SBOM badge (still renders ATTESTED with link, or muted PENDING with tooltip)
- [ ] Variant-tag keyboard navigation still works (Enter / Space switches the variant)
