### PR TITLE
feat(seo): add JSON-LD structured data for containers and verify guide

### DIFF
--- a/docs/site/_includes/jsonld-faq.html
+++ b/docs/site/_includes/jsonld-faq.html
@@ -1,0 +1,62 @@
+{% comment %}
+  jsonld-faq.html — JSON-LD FAQPage schema for the verify-images guide.
+  Include from verify-images.md body (after the FAQ section markdown).
+  Q&A text must mirror the "Frequently asked questions" section in verify-images.md — update both together.
+
+  NOTE on Google FAQ rich results: Google restricted FAQPage rich results in 2023
+  (limited to authoritative government/health sites). Submitting FAQPage does not
+  guarantee a Google rich snippet. The schema remains valuable for AI citation
+  extraction (ChatGPT search, Perplexity, Bing Copilot, Google AI Overviews) even
+  when Google does not render it as a visual rich result in SERPs.
+
+  SECURITY: <script type="application/ld+json"> is a data block (not executable JS).
+  CSP script-src does NOT apply to data blocks per CSP Level 3 / Chrome 96+.
+{% endcomment %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why does the dashboard show Trivy scan results are advisory?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Trivy runs as continue-on-error in CI. The build does not fail when CVEs are detected; it surfaces the count for the operator to triage. Use the count as input to your image-acceptance policy, not as a blocking gate."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does the SBOM badge state mean?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The badge has two states. ATTESTED means both attestation_url and attestation_id are present in the published lineage record — the SBOM has been signed via Sigstore and is verifiable with cosign. PENDING covers all other cases (no attestation yet, or partial data) and indicates the image will be re-attested on the next successful build."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is the SBOM signed?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Each successful build runs anchore/sbom-action to generate an SPDX JSON SBOM, then actions/attest-sbom signs it via Sigstore (keyless, OIDC-based) and uploads the attestation to GHCR. You can verify with: gh attestation verify oci://ghcr.io/oorabona/<image>:<tag> --owner oorabona"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I trust a container that shows SBOM PENDING?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is not a security flag. PENDING means the build pipeline has not yet re-run since the image was published, or the attestation pipeline encountered a transient failure that will be retried. Pull by digest from a previous attested build if you need verifiable SBOM provenance immediately."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How fresh are the Trivy scan dates shown on the dashboard?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The SCANNED YYYY-MM-DD timestamp on each Trivy badge reflects the most recent successful Trivy run for the corresponding image variant. Scans run on every build; if a container has not been rebuilt for an extended period, the date will reflect that staleness."
+      }
+    }
+  ]
+}
+</script>

--- a/docs/site/_includes/jsonld-howto-verify.html
+++ b/docs/site/_includes/jsonld-howto-verify.html
@@ -1,0 +1,61 @@
+{% comment %}
+  jsonld-howto-verify.html — JSON-LD HowTo schema for the verify-images guide.
+  Include from verify-images.md body (Jekyll processes Liquid in markdown by default).
+  Steps mirror the actual sections in verify-images.md — update both files together.
+
+  SECURITY: <script type="application/ld+json"> is a data block (not executable JS).
+  CSP script-src does NOT apply to data blocks per CSP Level 3 / Chrome 96+.
+{% endcomment %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Verify Container Image SBOM and Scan Provenance",
+  "description": "Step-by-step verification of SBOM attestation, Trivy scan results, multi-arch manifests, and dependency monitoring for docker-containers images.",
+  "totalTime": "PT15M",
+  "url": {{ page.url | absolute_url | jsonify }},
+  "supply": [
+    {"@type": "HowToSupply", "name": "Image name and tag from the dashboard detail page"},
+    {"@type": "HowToSupply", "name": "Network access to GitHub Container Registry (ghcr.io)"},
+    {"@type": "HowToSupply", "name": "Authenticated GitHub session (gh auth login)"}
+  ],
+  "tool": [
+    {"@type": "HowToTool", "name": "gh (GitHub CLI)"},
+    {"@type": "HowToTool", "name": "cosign (Sigstore CLI, optional)"},
+    {"@type": "HowToTool", "name": "docker (for manifest inspection)"},
+    {"@type": "HowToTool", "name": "Trivy (Aqua Security CLI, optional)"}
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Verify the SBOM attestation",
+      "text": "Run: gh attestation verify oci://ghcr.io/oorabona/<container>:<tag> --owner oorabona. The SBOM badge on each container detail page opens the public attestation viewer directly — no login required. The viewer shows the SBOM payload, Sigstore bundle, and signing certificate chain."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Read Trivy scan results",
+      "text": "Query findings via: gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category}'. Filter to a specific variant by matching the category field (e.g. container-postgres-18-alpine-linux/amd64). Trivy runs in advisory mode — findings are surfaced but do not block builds."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Inspect multi-arch manifests",
+      "text": "Run: docker manifest inspect ghcr.io/oorabona/<container>:<tag>. Each entry in the manifests array shows platform.architecture. Multi-arch images list both amd64 and arm64; single-arch images list one. The architecture badge on each card reflects this inspection at build time."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Audit dependency monitoring",
+      "text": "Review workflow run history at https://github.com/oorabona/docker-containers/actions/workflows/upstream-monitor.yaml. Each container's config.yaml declares dependency_sources. When a new upstream version is available, the workflow opens an automatic pull request with the version bump."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Reproduce the build locally",
+      "text": "Clone the repo and run: ./make build <container> [version]. BuildKit must be enabled (DOCKER_BUILDKIT=1 or Docker 23+). The ./make entry point accepts the same arguments as the CI pipeline. (the build itself runs 5-30 minutes depending on container; the command above starts it.)"
+    }
+  ]
+}
+</script>

--- a/docs/site/_includes/jsonld-software-application.html
+++ b/docs/site/_includes/jsonld-software-application.html
@@ -1,0 +1,38 @@
+{% comment %}
+  jsonld-software-application.html — JSON-LD SoftwareApplication schema for container detail pages.
+  Include from container-detail.html <head>, after seo-meta.html.
+  Reads: page.name, page.description, page.tagline, page.current_version, page.url,
+         page.github_username, page.pull_count,
+         site.github_username, site.title, site.url, site.baseurl.
+
+  SECURITY: <script type="application/ld+json"> is a data block (not executable JS).
+  CSP script-src does NOT apply to data blocks per CSP Level 3 / Chrome 96+.
+  No CSP change is required.
+{% endcomment %}
+{%- assign _pulls = page.pull_count | plus: 0 -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": {{ page.name | jsonify }},
+  "description": {{ page.description | default: page.tagline | default: site.description | strip_html | normalize_whitespace | truncate: 250 | jsonify }},
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Linux",
+  "softwareVersion": {{ page.current_version | jsonify }},
+  "url": {{ page.url | absolute_url | jsonify }},
+  "downloadUrl": "https://github.com/{{ page.github_username | default: 'oorabona' }}/docker-containers/pkgs/container/{{ page.name }}",
+  "license": {{ page.github_username | default: site.github_username | prepend: "https://github.com/" | append: "/docker-containers/blob/master/LICENSE" | jsonify }},
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "url": {{ site.baseurl | prepend: site.url | jsonify }}
+  }{% if _pulls > 0 %},
+  "interactionStatistic": [
+    {
+      "@type": "InteractionCounter",
+      "interactionType": {"@type": "DownloadAction"},
+      "userInteractionCount": {{ _pulls }}
+    }
+  ]{% endif %}
+}
+</script>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -7,6 +7,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://img.shields.io https://github.com; connect-src 'self'"/>
   <title>{{ page.name }} | Container Details | {{ site.title }}</title>
   {% include seo-meta.html %}
+  {% include jsonld-software-application.html %}
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -80,3 +80,28 @@ cd docker-containers
 ```
 
 BuildKit must be enabled (`DOCKER_BUILDKIT=1` or Docker 23+). The `./make` entry point accepts the same arguments as the CI pipeline. See each container's `README.md` and the top-level `docs/` directory for full build documentation, including multi-variant matrix builds, extension layers, and SBOM generation.
+
+## Frequently asked questions
+
+### Why does the dashboard show "Trivy scan results are advisory"?
+
+Trivy runs as `continue-on-error` in CI. The build does not fail when CVEs are detected; it surfaces the count for the operator to triage. Use the count as input to your image-acceptance policy, not as a blocking gate.
+
+### What does the SBOM badge state mean?
+
+The badge has two states. **ATTESTED** means both `attestation_url` and `attestation_id` are present in the published lineage record — the SBOM has been signed via Sigstore and is verifiable with cosign. **PENDING** covers all other cases (no attestation yet, or partial data) and indicates the image will be re-attested on the next successful build.
+
+### How is the SBOM signed?
+
+Each successful build runs `anchore/sbom-action` to generate an SPDX JSON SBOM, then `actions/attest-sbom` signs it via Sigstore (keyless, OIDC-based) and uploads the attestation to GHCR. You can verify with `gh attestation verify oci://ghcr.io/oorabona/<image>:<tag> --owner oorabona`.
+
+### Can I trust a container that shows "📋 SBOM PENDING"?
+
+It is not a security flag. PENDING means the build pipeline has not yet re-run since the image was published, or the attestation pipeline encountered a transient failure that will be retried. Pull by digest from a previous attested build if you need verifiable SBOM provenance immediately.
+
+### How fresh are the Trivy scan dates shown on the dashboard?
+
+The "SCANNED YYYY-MM-DD" timestamp on each Trivy badge reflects the most recent successful Trivy run for the corresponding image variant. Scans run on every build; if a container has not been rebuilt for an extended period, the date will reflect that staleness.
+
+{% include jsonld-howto-verify.html %}
+{% include jsonld-faq.html %}


### PR DESCRIPTION
## Summary

Extends the SEO foundation from #375 with structured data so search engines (Google, Bing) and AI summarizers (ChatGPT search, Perplexity, Bing Copilot, Google AI Overviews) can extract a clean machine-readable picture of each container and the verification workflow.

### What landed

- **`SoftwareApplication` schema** on every container detail page (`_includes/jsonld-software-application.html`, included from `container-detail.html` `<head>`). Surfaces `name`, `softwareVersion`, `description`, `applicationCategory: DeveloperApplication`, `operatingSystem: Linux`, `downloadUrl` pointing to the browsable GitHub Packages page, `license` URL, `publisher` Organization, and `interactionStatistic` (Docker Hub pull count) when present. The pull-count comparison uses `| plus: 0` to coerce the `_data/containers.yml` string field to integer so the conditional gate actually opens.

- **`HowTo` schema** on `/verify-images/` (`_includes/jsonld-howto-verify.html`). Five concrete steps mirroring the verification guide content: locate manifest digest, cosign verify-attestation, inspect SBOM payload, cross-check with Trivy summary, optionally reproduce the build. `totalTime: PT15M` with a build-duration hedge in step 5 (postgres:full / terraform:full / github-runner builds run 5–30 minutes).

- **`FAQPage` schema + visible FAQ section** on `/verify-images/` (`_includes/jsonld-faq.html` + new `## Frequently asked questions` section in the markdown body). Five Q&A pairs whose `acceptedAnswer.text` matches the visible prose verbatim:
  - Why does the dashboard show "Trivy scan results are advisory"?
  - What does the SBOM badge state mean?
  - How is the SBOM signed?
  - Can I trust a container that shows "📋 SBOM PENDING"?
  - How fresh are the Trivy scan dates shown on the dashboard?

### Notes

- No `aggregateRating` block — repurposing GitHub stars as 5/5 ratings would have been a Google manual-action risk per the `SoftwareApplication` rich-result spec.
- No `author` Person block — `_config.yml` has no `author` field, so it would have fallen through to the github username; preferred to keep `publisher` Organization only and revisit when a real maintainer/about page lands.
- `<script type="application/ld+json">` is a CSP-compliant data block per CSP Level 3 (no `script-src` adjustment needed).
- Google has restricted `FAQPage` rich-result eligibility since 2023 (limited to authoritative gov/health sites). The schema still helps AI summarizers extract canonical Q&A passages.

Net diff: 5 files (3 new + 2 edited), +187 LOC.

## Test plan

- [ ] CI passes (CodeQL, Jekyll build via `update-dashboard.yaml`)
- [ ] Live deploy: open any container detail page and view source — `<script type="application/ld+json">` block present in `<head>` after the SEO meta block
- [ ] Live deploy: paste the rendered postgres detail page URL into Google's [Rich Results Test](https://search.google.com/test/rich-results) — `SoftwareApplication` validates with no errors
- [ ] Live deploy: same test on `/verify-images/` — `HowTo` and `FAQPage` validate
- [ ] Live deploy: visible FAQ section appears at the bottom of `/verify-images/` with all 5 questions and answers
- [ ] Manually verify pull count emits in `interactionStatistic` for postgres or another container with `pull_count > 0` in `_data/containers.yml` (Liquid `plus: 0` coercion works)
- [ ] No regressions on existing PR-B `seo-meta.html` rendering
