### PR TITLE
refactor(dashboard): wire trust-strip and feedback tokens

### DIFF
--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -22,28 +22,8 @@
       75% { transform: translate(1%, -1%) rotate(1.5deg) scale(1.02); }
     }
 
-    .shape { will-change: transform, opacity; }
-    .shape-1 { animation: orbit1 14s ease-in-out infinite; }
-    .shape-2 { animation: orbit2 18s ease-in-out infinite; }
-    .shape-3 { animation: orbit3 22s ease-in-out infinite; }
-
-    @keyframes orbit1 {
-      0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.45; }
-      25% { transform: translate(-40px, 30px) scale(1.15); opacity: 0.55; }
-      50% { transform: translate(20px, -20px) scale(0.9); opacity: 0.35; }
-      75% { transform: translate(-15px, -25px) scale(1.08); opacity: 0.5; }
-    }
-    @keyframes orbit2 {
-      0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.4; }
-      30% { transform: translate(35px, -25px) scale(1.2); opacity: 0.55; }
-      60% { transform: translate(-30px, 15px) scale(0.85); opacity: 0.3; }
-    }
-    @keyframes orbit3 {
-      0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.45; }
-      20% { transform: translate(25px, 20px) scale(1.1); opacity: 0.5; }
-      50% { transform: translate(-20px, -30px) scale(0.92); opacity: 0.35; }
-      80% { transform: translate(10px, -15px) scale(1.18); opacity: 0.55; }
-    }
+    /* F7: .shape-1/2/3 render statically — will-change removed (no animation, no cost) */
+    /* orbit1/orbit2/orbit3 keyframes removed: no consumers after F7 */
 
     /* Detail page styles */
     .container-detail-page { min-height: 400px; }
@@ -62,7 +42,7 @@
     .detail-title { display: flex; align-items: center; gap: 1rem; }
     .detail-title h1 { font-size: 2rem; font-weight: 700; margin: 0; }
     .detail-badge {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.875rem;
+      font-family: var(--font-family-mono); font-size: 0.875rem;
       padding: 0.375rem 0.875rem; border-radius: 8px;
       background: rgba(16, 185, 129, 0.2); color: #34d399;
       border: 1px solid rgba(16, 185, 129, 0.3);
@@ -104,7 +84,7 @@
     }
     .lineage-label { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--detail-text-muted); }
     .lineage-value {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.8125rem;
+      font-family: var(--font-family-mono); font-size: 0.8125rem;
       color: var(--detail-text-secondary); word-break: break-all;
     }
     .lineage-builtin { opacity: 0.55; }
@@ -126,7 +106,7 @@
     .version-title { font-size: 1rem; font-weight: 600; margin: 0; color: var(--detail-text-secondary); }
     .variant-tags-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
     .variant-tag {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem;
+      font-family: var(--font-family-mono); font-size: 0.75rem;
       padding: 0.375rem 0.75rem; border-radius: 6px;
       background: rgba(139, 92, 246, 0.15); color: var(--accent-purple);
       border: 1px solid rgba(139, 92, 246, 0.25); cursor: pointer;
@@ -231,7 +211,7 @@
     .readme-content h4 { font-size: 1.125rem; }
     .readme-content p { margin-bottom: 1em; }
     .readme-content code {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.875em;
+      font-family: var(--font-family-mono); font-size: 0.875em;
       padding: 0.2em 0.4em; background: rgba(0, 0, 0, 0.3); border-radius: 4px; color: #f472b6;
     }
     .readme-content pre {
@@ -274,7 +254,7 @@
       font-size: 0.75rem; padding: 0.375rem 0.75rem; border-radius: 6px;
       background: rgba(139, 92, 246, 0.12); color: var(--accent-purple);
       border: 1px solid rgba(139, 92, 246, 0.2);
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       transition: all 0.2s ease;
     }
     .sbom-type-chip-clickable {
@@ -328,7 +308,7 @@
       display: flex; justify-content: space-between; align-items: baseline;
       padding: 0.25rem 0.5rem; border-radius: 4px;
       font-size: 0.75rem;
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
     }
     .sbom-package-item:nth-child(odd) { background: rgba(255, 255, 255, 0.03); }
     .sbom-pkg-name {
@@ -372,10 +352,10 @@
     .changelog-type-removed { background: rgba(239, 68, 68, 0.2); color: #f87171; border: 1px solid rgba(239, 68, 68, 0.3); }
     .changelog-type-updated { background: rgba(59, 130, 246, 0.2); color: #60a5fa; border: 1px solid rgba(59, 130, 246, 0.3); }
     .changelog-pkg-name {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.8125rem;
+      font-family: var(--font-family-mono); font-size: 0.8125rem;
     }
     .changelog-version {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem;
+      font-family: var(--font-family-mono); font-size: 0.75rem;
       color: var(--detail-text-muted);
     }
     .changelog-version-new { color: #34d399; }
@@ -400,14 +380,14 @@
     .history-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
     .history-date { font-size: 0.75rem; color: var(--detail-text-muted); }
     .history-version {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem;
+      font-family: var(--font-family-mono); font-size: 0.75rem;
     }
     .history-changes {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.6875rem;
+      font-family: var(--font-family-mono); font-size: 0.6875rem;
       color: var(--detail-text-muted);
     }
     .history-duration {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem;
+      font-family: var(--font-family-mono); font-size: 0.75rem;
       color: var(--detail-text-muted);
     }
 
@@ -476,7 +456,7 @@
     .dep-update-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
     .dep-name a { color: var(--accent-blue); text-decoration: none; }
     .dep-name a:hover { text-decoration: underline; }
-    .dep-version { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem; }
+    .dep-version { font-family: var(--font-family-mono); font-size: 0.75rem; }
     .dep-version-current { color: var(--detail-text-muted); }
     .dep-version-latest { color: #34d399; font-weight: 500; }
 
@@ -508,7 +488,7 @@
       border: 1px solid rgba(16, 185, 129, 0.15);
     }
     .dep-uptodate-version {
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.6875rem;
+      font-family: var(--font-family-mono); font-size: 0.6875rem;
       color: var(--detail-text-muted); margin-left: 0.25rem;
     }
 
@@ -633,7 +613,7 @@
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       padding: 0.5rem 0.75rem;
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       font-size: 0.8125rem;
       color: var(--detail-text-secondary);
     }
@@ -642,8 +622,8 @@
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       padding: 0.5rem 0.75rem;
-      min-width: 40px;
-      min-height: 40px;
+      min-width: 44px;
+      min-height: 44px; /* F8: 40→44px (WCAG 2.5.8 touch target, matches .copy-btn) */
       color: var(--text-secondary);
       cursor: pointer;
       transition: all 0.2s ease;

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -467,7 +467,7 @@
     }
 
     .card-badge {
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       font-size: 0.75rem;
       padding: 0.25rem 0.625rem;
       border-radius: 6px;
@@ -530,7 +530,7 @@
 
     /* Build lineage digest in card */
     .card-lineage-digest {
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       font-size: 0.6875rem;
       opacity: 0.8;
     }
@@ -560,7 +560,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       font-size: 0.6875rem;
       padding: 0.5rem 0.625rem;
       min-height: 44px;
@@ -658,7 +658,7 @@
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       padding: 0.5rem 0.75rem;
-      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-family: var(--font-family-mono);
       font-size: 0.75rem;
       color: var(--text-secondary);
     }
@@ -985,21 +985,22 @@
     }
 
     .status-pill-info {
-      background: rgba(59, 130, 246, 0.14);
+      background: var(--color-feedback-info-bg);
       border-color: rgba(59, 130, 246, 0.32);
-      color: var(--accent-blue);
+      color: var(--color-feedback-info-fg);
     }
 
     .status-pill-warn {
-      background: rgba(245, 158, 11, 0.16);
+      background: var(--color-feedback-warning-bg);
       border-color: rgba(245, 158, 11, 0.34);
-      color: var(--accent-yellow);
+      color: var(--color-feedback-warning-fg);
     }
 
     .status-pill-err {
-      background: rgba(236, 72, 153, 0.14);
-      border-color: rgba(236, 72, 153, 0.32);
-      color: var(--accent-pink);
+      /* fully migrated to error tokens; no border token yet — darker alpha of error-bg */
+      background:   var(--color-feedback-error-bg);
+      border-color: rgba(239, 68, 68, 0.32);
+      color:        var(--color-feedback-error-fg);
     }
 
 /* ============================================================
@@ -1025,7 +1026,8 @@
     }
 
     .dashboard-hero-accent {
-      background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+      /* info-fg (blue-400) → verify-fg (violet-400): Phase C trust-domain palette */
+      background: linear-gradient(135deg, var(--color-feedback-info-fg), var(--color-trust-verify-fg));
       -webkit-background-clip: text;
       background-clip: text;
       color: transparent;

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -127,15 +127,15 @@
 
 .trust-badge i { font-size: 0.9em; }
 
-/* SBOM — green tint (matches status-pill-ok family) */
+/* SBOM — teal trust-domain identity (Sigstore-brand-adjacent, Phase C) */
 .trust-badge--sbom {
-  background: rgba(16, 185, 129, 0.12);
-  border-color: rgba(16, 185, 129, 0.28);
-  color: var(--accent-green);
+  background: var(--color-trust-sbom-bg);
+  border-color: var(--color-trust-sbom-border);
+  color: var(--color-trust-sbom-fg);
 }
 .trust-badge--sbom:hover {
-  background: rgba(16, 185, 129, 0.2);
-  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(20, 184, 166, 0.25);
+  border-color: rgba(45, 212, 191, 0.55);
 }
 
 /* Generic pending modifier — opacity-free so muted text keeps WCAG AA
@@ -153,15 +153,15 @@
   border-color: var(--color-border-strong);
 }
 
-/* Multi-arch — blue/info tint */
+/* Multi-arch — violet trust-domain identity (architectural, Phase C) */
 .trust-badge--multi-arch {
-  background: rgba(59, 130, 246, 0.12);
-  border-color: rgba(59, 130, 246, 0.28);
-  color: var(--accent-blue);
+  background: var(--color-trust-multiarch-bg);
+  border-color: var(--color-trust-multiarch-border);
+  color: var(--color-trust-multiarch-fg);
 }
 .trust-badge--multi-arch:hover {
-  background: rgba(59, 130, 246, 0.2);
-  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(139, 92, 246, 0.22);
+  border-color: rgba(167, 139, 250, 0.50);
 }
 
 /* Deps — neutral/info tint */
@@ -191,11 +191,11 @@
   outline-offset: 2px;
 }
 
-/* Trivy scan — default green (0 CRITICAL) */
+/* Trivy scan — clean state (0 CRITICAL) uses trust-domain token */
 .trust-badge--trivy {
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--color-trust-trivy-clean-bg);
   border-color: rgba(16, 185, 129, 0.28);
-  color: var(--accent-green);
+  color: var(--color-trust-trivy-clean-fg);
 }
 .trust-badge--trivy:hover {
   background: rgba(16, 185, 129, 0.2);
@@ -302,7 +302,7 @@ body {
   background: var(--gradient-1);
   top: 10%;
   right: 10%;
-  animation: pulse 8s ease-in-out infinite;
+  /* F7: no page-load animation — calm-static-render (design gate: no pulse) */
 }
 
 .shape-2 {
@@ -311,7 +311,7 @@ body {
   background: var(--gradient-3);
   bottom: 20%;
   left: 5%;
-  animation: pulse 10s ease-in-out infinite reverse;
+  /* F7: no page-load animation */
 }
 
 .shape-3 {
@@ -320,12 +320,7 @@ body {
   background: var(--gradient-2);
   top: 50%;
   left: 50%;
-  animation: pulse 12s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { transform: scale(1); opacity: 0.5; }
-  50% { transform: scale(1.1); opacity: 0.3; }
+  /* F7: no page-load animation */
 }
 
 /* Theme toggle — min 44px for WCAG 2.5.8 touch target */
@@ -465,7 +460,7 @@ body {
 }
 
 .site-nav-inner {
-  max-width: 1100px;
+  max-width: 1280px; /* F9: 1100→1280px matches .container (no --layout-max-width token yet; TODO PR4 extract) */
   margin: 0 auto;
   padding: 0.85rem 1.25rem;
   display: flex;


### PR DESCRIPTION
## Summary

Aligns CSS rules with the existing 3-tier design-token taxonomy. Behavior-preserving for layout / structure; visible identity-hue changes for trust-strip badges (intentional per the locked design direction).

### Token discipline migrations

- **Trust-strip badges** (`theme.css`):
  - `.trust-badge--sbom` — `rgba(16, 185, 129, ...)` → `--color-trust-sbom-{bg,fg,border}` (teal identity)
  - `.trust-badge--multi-arch` — `rgba(59, 130, 246, ...)` → `--color-trust-multiarch-{bg,fg,border}` (cyan identity)
  - `.trust-badge--trivy` clean state — `var(--accent-green)` → `--color-trust-trivy-clean-{bg,fg}`
- **Status pills** (`dashboard.css`): `--accent-blue/yellow/pink` → `--color-feedback-{info,warning,error}-{fg,bg}`. The `.status-pill-err` migration is now complete (background was previously legacy pink alongside red foreground — half-migrated).
- **Dashboard hero gradient** (`dashboard.css`): `--accent-blue → --accent-purple` → `--color-feedback-info-fg → --color-trust-verify-fg`.
- **Monospace cascade**: 18 hardcoded `'SF Mono', 'Fira Code', monospace` instances replaced with `var(--font-family-mono)` so JetBrains Mono leads the cascade in Provenance / hash / code / digest / pull-input contexts.

### Motion + layout adjustments

- **`.shape-1/2/3`**: removed continuous `pulse` / `orbit*` page-load animations + their `@keyframes` definitions and `will-change` hints. Decorative shapes render statically — calm-static-render aesthetic.
- **`.detail-copy-btn`**: min-height 40px → 44px (matches `.copy-btn`, completes the touch-target standardization started in #376).
- **`.site-nav-inner`**: max-width 1100px → 1280px (matches `.container`, fixes nav truncation in 1100–1280px viewport range).

### Visual changes (intentional, not pure refactor)

- SBOM badge: green → teal hue.
- Multi-arch badge: blue → cyan hue.
- Status-error pill: pink-on-red half-state → red-on-red coherent state.
- Hero gradient: blue→purple → blue→cyan endpoint.
- Decorative bg shapes: animated → static.

These are intentional Phase C identity locks reaching the wire — they were always meant to land but the prior rules retained legacy raw rgba.

### Deferred to follow-up

- Trust-badge hover states (`.trust-badge--sbom:hover`, `.trust-badge--multi-arch:hover`) still use raw rgba alpha overlays. Migrating them requires new `--color-trust-{sbom,multiarch}-{bg,border}-hover` semantic tokens — expands scope. Pulled into a follow-up PR alongside extracting `--layout-max-width` (currently 1280px is duplicated literally in `.site-nav-inner` and `.container`).

Net diff: 3 files, +51/-74 (net -23 LOC).

## Test plan

- [ ] CI passes (CodeQL, Jekyll build via update-dashboard.yaml)
- [ ] Live deploy: dashboard + container-detail render without visual regressions on layout/structure
- [ ] Live deploy: SBOM trust-badge renders teal (was green) and remains AA-contrast on navy-950
- [ ] Live deploy: multi-arch trust-badge renders cyan (was blue) and remains AA-contrast
- [ ] Live deploy: `.status-pill-err` chip shows red text on red-tinted background (no longer pink-on-red half-migrated)
- [ ] Live deploy: hero gradient is blue → cyan (was blue → purple)
- [ ] Live deploy: bg shapes render static (no continuous pulse/orbit motion)
- [ ] Live deploy: Provenance/hash text uses JetBrains Mono (verify via DevTools computed font-family)
- [ ] Live deploy: detail page Pull section copy button has 44px hit area (matches `.copy-btn`)
- [ ] Live deploy: nav menu does not truncate at 1100–1280px viewport widths
- [ ] No regressions on PR-A SBOM 2-state badge (`.trust-badge.is-pending` still works)
- [ ] No regressions on PR-D focus rings or heading hierarchy
