### PR TITLE
feat(docs-site): add About page and maintainer identity

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -30,6 +30,11 @@ show_excerpts: true
 header_pages:
   - index.md
 
+# Author / maintainer identity
+author:
+  name: Olivier Orabona
+  url: https://github.com/oorabona
+
 # Footer
 github_username: oorabona
 

--- a/docs/site/_includes/jsonld-software-application.html
+++ b/docs/site/_includes/jsonld-software-application.html
@@ -22,6 +22,11 @@
   "url": {{ page.url | absolute_url | jsonify }},
   "downloadUrl": "https://github.com/{{ page.github_username | default: 'oorabona' }}/docker-containers/pkgs/container/{{ page.name }}",
   "license": {{ page.github_username | default: site.github_username | prepend: "https://github.com/" | append: "/docker-containers/blob/master/LICENSE" | jsonify }},
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author.name | default: "Olivier Orabona" | jsonify }},
+    "url": {{ site.author.url | default: "https://github.com/oorabona" | jsonify }}
+  },
   "publisher": {
     "@type": "Organization",
     "name": {{ site.title | jsonify }},

--- a/docs/site/_includes/site-footer.html
+++ b/docs/site/_includes/site-footer.html
@@ -10,4 +10,9 @@
      target="_blank"
      rel="noopener noreferrer"
      aria-label="generate-dashboard.sh source on GitHub (opens in new tab)">generate-dashboard.sh</a> using Jekyll templating</p>
+  <p class="footer-maintainer">
+    Maintained by <a href="{{ '/about/' | relative_url }}">{{ site.author.name | default: "Olivier Orabona" | escape }}</a>
+    &middot; <a href="{{ site.author.url | default: 'https://github.com/oorabona' }}" target="_blank" rel="noopener noreferrer" aria-label="Maintainer GitHub profile (opens in new tab)">@{{ site.author.url | default: 'https://github.com/oorabona' | replace: 'https://github.com/', '' }}</a>
+    &middot; Released under the <a href="{{ _repo_url }}/blob/{{ _branch }}/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
+  </p>
 </footer>

--- a/docs/site/_includes/site-footer.html
+++ b/docs/site/_includes/site-footer.html
@@ -12,7 +12,9 @@
      aria-label="generate-dashboard.sh source on GitHub (opens in new tab)">generate-dashboard.sh</a> using Jekyll templating</p>
   <p class="footer-maintainer">
     Maintained by <a href="{{ '/about/' | relative_url }}">{{ site.author.name | default: "Olivier Orabona" | escape }}</a>
-    &middot; <a href="{{ site.author.url | default: 'https://github.com/oorabona' }}" target="_blank" rel="noopener noreferrer" aria-label="Maintainer GitHub profile (opens in new tab)">@{{ site.author.url | default: 'https://github.com/oorabona' | replace: 'https://github.com/', '' }}</a>
+    {%- assign _author_url = site.author.url | default: 'https://github.com/oorabona' -%}
+    {%- assign _author_handle = _author_url | replace: 'https://github.com/', '' -%}
+    &middot; <a href="{{ _author_url | escape }}" target="_blank" rel="noopener noreferrer" aria-label="Maintainer GitHub profile (opens in new tab)">@{{ _author_handle | escape }}</a>
     &middot; Released under the <a href="{{ _repo_url }}/blob/{{ _branch }}/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
   </p>
 </footer>

--- a/docs/site/_includes/site-nav.html
+++ b/docs/site/_includes/site-nav.html
@@ -5,8 +5,9 @@
       <span>Docker Containers</span>
     </a>
     <nav class="site-nav-links">
-      <a href="{{ site.baseurl }}/" class="site-nav-link{% if include.active == 'dashboard' %} active{% endif %}">Dashboard</a>
-      <a href="{{ site.baseurl }}/blog/" class="site-nav-link{% if include.active == 'blog' %} active{% endif %}">Blog</a>
+      <a href="{{ '/' | relative_url }}" class="site-nav-link{% if include.active == 'dashboard' %} active{% endif %}">Dashboard</a>
+      <a href="{{ '/verify-images/' | relative_url }}" class="site-nav-link{% if include.active == 'verify' %} active{% endif %}">Verify</a>
+      <a href="{{ '/blog/' | relative_url }}" class="site-nav-link{% if include.active == 'blog' %} active{% endif %}">Blog</a>
       <a href="{{ '/about/' | relative_url }}" class="site-nav-link{% if include.active == 'about' %} active{% endif %}">About</a>
     </nav>
     <div class="site-nav-actions">

--- a/docs/site/_includes/site-nav.html
+++ b/docs/site/_includes/site-nav.html
@@ -7,6 +7,7 @@
     <nav class="site-nav-links">
       <a href="{{ site.baseurl }}/" class="site-nav-link{% if include.active == 'dashboard' %} active{% endif %}">Dashboard</a>
       <a href="{{ site.baseurl }}/blog/" class="site-nav-link{% if include.active == 'blog' %} active{% endif %}">Blog</a>
+      <a href="{{ '/about/' | relative_url }}" class="site-nav-link{% if include.active == 'about' %} active{% endif %}">About</a>
     </nav>
     <div class="site-nav-actions">
       <button type="button" class="theme-toggle" aria-label="Toggle light/dark theme">

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -71,7 +71,10 @@
         <span class="dashboard-hero-accent">built and signed every day.</span>
       </h1>
       <p class="dashboard-hero-subtitle">
-        Every image ships with an SBOM and a cosign signature you can verify yourself, with continuous Trivy scanning across the catalog.
+        A curated fleet of Docker container images published to GHCR and Docker Hub, each built with automated upstream version monitoring, signed SBOM attestation via Sigstore, and an advisory Trivy CVE scan. Every detail page surfaces the build commit, manifest digest, and verifiable attestation so operators can audit provenance without leaving the dashboard.
+      </p>
+      <p class="dashboard-hero-detail">
+        This is not a replacement for Docker Official Images. It is a focused set of images where the maintenance load and the verification surface justify the engineering — PostgreSQL with 10 extensions in 7 flavors, hardened OpenVPN, multi-distro web-shell, self-hosted GitHub Actions runners, and a small supporting set. Maintained by <a href="{{ '/about/' | relative_url }}" class="dashboard-hero-link">Olivier Orabona</a>.
       </p>
     </section>
 

--- a/docs/site/_layouts/page.html
+++ b/docs/site/_layouts/page.html
@@ -20,7 +20,7 @@
 <body class="page-layout">
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
-  {% include site-nav.html active="none" %}
+  {% include site-nav.html active=page.nav_active %}
 
   <div class="container">
     <main id="main-content" class="page-content" role="main">

--- a/docs/site/about.md
+++ b/docs/site/about.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: About
+permalink: /about/
+nav_active: about
+description: docker-containers is maintained by Olivier Orabona — context, project goals, and how to reach the maintainer.
+---
+
+`docker-containers` is a personal infrastructure project that publishes a fleet of 13 custom Docker container images to GitHub Container Registry (GHCR) and Docker Hub. Each image is built with automated upstream version monitoring, signed SBOM attestation via Sigstore, and an advisory Trivy CVE scan.
+
+## Maintainer
+
+The project is maintained by [Olivier Orabona](https://github.com/oorabona), an independent infrastructure engineer based in France. Public profile: [github.com/oorabona](https://github.com/oorabona).
+
+## Why this project exists
+
+Docker Official Images cover the upstream-published software, but they do not always combine the extensions, hardening, or multi-distro variants that production deployments need. `docker-containers` fills that gap for a specific set of workloads: PostgreSQL with 10 extensions in 7 flavors, hardened OpenVPN, multi-distro web-shell, GitHub Actions self-hosted runners (Linux + Windows), and a small set of supporting images (Vector, Jekyll, PHP-FPM, WordPress, Terraform, Ansible, Debian, sslh, OpenResty).
+
+Each image is treated as a verifiable artifact. The detail page for any container surfaces:
+
+- The exact build commit and manifest digest
+- A Sigstore attestation for the SPDX-format SBOM (when available)
+- An advisory Trivy CVE scan summary
+- The multi-architecture manifest list
+
+The verification guide at [/verify-images/]({{ '/verify-images/' | relative_url }}) walks through reproducing those checks with `cosign`, `gh`, and `Trivy`.
+
+## How this differs from Docker Official Images
+
+| Concern | Docker Official Images | docker-containers |
+|---|---|---|
+| Upstream tracking | Manual, irregular | Automated daily upstream-monitor workflow with auto-PRs |
+| SBOM attestation | Not standard | SPDX JSON, Sigstore-signed, attached to each push |
+| Trivy advisory | Not standard | Surfaced on every container detail page (advisory, not blocking) |
+| Multi-distro | Limited | Linux base + Alpine + Ubuntu + Rocky / Trixie variants where supported |
+| Extension matrices | Per-image upstream choice | Flavor-based (e.g. PostgreSQL: vector / analytics / timeseries / spatial / distributed / full) |
+
+This project does not aim to replace Docker Official Images for general use — it ships a curated set where the maintenance load and the verification surface justify the additional engineering.
+
+## License
+
+All container images and the build system are released under the [MIT License](https://github.com/oorabona/docker-containers/blob/master/LICENSE). SBOM attestations and the published Sigstore signatures are not licensed material — they are evidence of the build provenance.
+
+## Contact
+
+- Issue tracker: [github.com/oorabona/docker-containers/issues](https://github.com/oorabona/docker-containers/issues)
+- For non-public matters, profile contact details are on the maintainer's GitHub page.
+- This site does not collect telemetry or store visitor data.

--- a/docs/site/about.md
+++ b/docs/site/about.md
@@ -39,7 +39,7 @@ This project does not aim to replace Docker Official Images for general use — 
 
 ## License
 
-All container images and the build system are released under the [MIT License](https://github.com/oorabona/docker-containers/blob/master/LICENSE). SBOM attestations and the published Sigstore signatures are not licensed material — they are evidence of the build provenance.
+All container images and the build system are released under the [MIT License](https://github.com/oorabona/docker-containers/blob/{{ site.github.default_branch | default: 'master' }}/LICENSE). SBOM attestations and the published Sigstore signatures are not licensed material — they are evidence of the build provenance.
 
 ## Contact
 

--- a/sslh/README.md
+++ b/sslh/README.md
@@ -9,14 +9,12 @@
 
 ## Why this image
 
-- 🎯 **~2 MB** — `FROM scratch`, no OS, no shell, no package manager
-- 🔒 **Static binaries** — zero shared library CVEs to track
-- 🏗️ **Multi-arch** — amd64 / arm64 / arm/v7
-- ⚡ **3 flavors** — `sslh-ev` (default, libev), `sslh-select`, `sslh-fork`
-- 🤖 **Auto-updated** — CI tracks [yrutschle/sslh](https://github.com/yrutschle/sslh) releases
-- 📦 **SBOM + attestation** — every image ships with a Sigstore-signed SPDX
-
-> 💡 **Used it? Drop a ⭐ on [github.com/oorabona/docker-containers](https://github.com/oorabona/docker-containers)** — it's the only feedback signal Docker Hub doesn't give us.
+- **~2 MB** — `FROM scratch`, no OS, no shell, no package manager
+- **Static binaries** — zero shared library CVEs to track
+- **Multi-arch** — amd64 / arm64 / arm/v7
+- **3 flavors** — `sslh-ev` (default, libev), `sslh-select`, `sslh-fork`
+- **Auto-updated** — CI tracks [yrutschle/sslh](https://github.com/yrutschle/sslh) releases
+- **SBOM + attestation** — every image ships with a Sigstore-signed SPDX
 
 ## Platforms
 - **amd64** - x86_64 systems


### PR DESCRIPTION
## Summary

Adds visible maintainer identity to the site so the publisher of each container image is no longer anonymous. Closes the E-E-A-T identity gap the prior content audit had flagged as the biggest authority signal missing from the dashboard.

### What landed

- **New `/about/` page** — first-person project context: maintainer (Olivier Orabona, profile link), why the project exists, how it differs from Docker Official Images (comparison table on tracking, SBOM, Trivy, multi-distro, extension matrices), license, contact paths.
- **`_config.yml`** — adds structured `author: { name, url }` mapping so any layout can reference `site.author.name` / `site.author.url`.
- **Footer** — keeps the existing `generated by generate-dashboard.sh` note for build transparency and adds a separate `Maintained by [name] · @handle · MIT License` attribution line.
- **Nav** — new `About` link sits alongside Dashboard / Verify / Blog. The page layout (`_layouts/page.html`) was switched from `active="none"` to `active=page.nav_active` so any future page can opt into a particular nav active-state via front matter; `about.md` sets `nav_active: about`.
- **Dashboard hero** — replaces the single subtitle line with a two-paragraph factual differentiator: what the fleet is, what each detail page surfaces, and explicit positioning against Docker Official Images. Brand voice preserved (past-tense facts, no exclamatory copy, no decorative emoji).
- **`SoftwareApplication` JSON-LD** — re-adds the `Person` author block (it had been removed in the prior PR while no real maintainer surface existed). References the new `site.author.name` / `site.author.url` mapping with `jsonify` for safe JSON encoding.
- **`sslh/README.md`** — strips decorative emoji (🎯 🔒 ⚡ 🤖 📦 💡 ⭐) from the "Why this image" bullet list plus the "Drop a star" call-to-action that violated the brand-voice rule (only 📋 🛡 🏗 🔍 are allowed, and only inside trust-strip badges). The fix is at the `sslh/` source, not the gitignored `docs/site/_containers/sslh.md` artifact, so it survives the next dashboard regeneration.

Net diff: 8 files, +75/-10 (net +65 LOC).

## Test plan

- [ ] CI passes (CodeQL, Jekyll build via `update-dashboard.yaml`)
- [ ] Live deploy: `https://oorabona.github.io/docker-containers/about/` returns 200 with the maintainer bio rendered
- [ ] Live deploy: `<head>` of /about/ has `<meta name="description">` from front matter (PR-B `seo-meta.html` integration)
- [ ] Live deploy: nav highlights "About" when on `/about/`; falls back cleanly on other pages (no nav link gets a stale active class)
- [ ] Live deploy: dashboard hero shows the new two-paragraph differentiator
- [ ] Live deploy: footer shows `Maintained by Olivier Orabona · @oorabona · MIT License` AND keeps the generator note
- [ ] Live deploy: any container detail page contains `"author":{"@type":"Person","name":"Olivier Orabona","url":"https://github.com/oorabona"}` in the JSON-LD block
- [ ] Live deploy: `[/verify-images/]` link inside the About page resolves to `/docker-containers/verify-images/` (not the bare `/verify-images/` which would 404 under the project sub-path)
- [ ] Live deploy: `_containers/sslh.md` (regenerated from `sslh/README.md`) no longer contains decorative emoji on the "Why this image" bullets
- [ ] No regressions on PR-C JSON-LD (FAQPage / HowTo / interactionStatistic still render)
- [ ] No regressions on PR-D heading hierarchy (`/about/` has exactly one visible `<h1>` from `_layouts/page.html`)
