### PR TITLE
fix(dashboard): expand search, variant reset, clipboard guards

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -6,6 +6,16 @@
 
 A minimal Debian container with customizable version support. This container provides a clean Debian base image with version flexibility for various use cases.
 
+## Why this image
+
+A small, opinionated Debian base built `FROM debian:trixie` (Debian 13) with the additions a downstream container usually needs anyway: configurable locales, a passwordless sudo non-root user, `aptitude`, and `ca-certificates` — all installed in a single layer with the apt cache cleaned up.
+
+- **Single tracked release.** `variants.yaml` ships only the `trixie` track, kept current via the daily upstream-monitor workflow. No fan-out across stable / oldstable; pin to `trixie` and let the rebuild pipeline carry the patch updates.
+- **Non-root user out of the box.** A `debian` user is created with passwordless sudo so containers using this base can run as a non-root identity without paving the user-creation boilerplate themselves.
+- **Configurable locales.** `LOCALES` build arg installs the requested locale set and sets `LANG`/`LANGUAGE`/`LC_ALL` from the first entry, so downstream images can land a non-default locale without re-running `localedef`.
+- **As-a-base-image role.** `web-shell`'s Debian distro variant derives from this image (see `web-shell/generate-dockerfile.sh`). Other fleet containers use upstream Debian / Ubuntu directly; the role here is the curated "fleet-internal Debian base" rather than a universal base layer.
+- **Multiple architectures.** Published for `linux/amd64` and `linux/arm64` via a multi-arch manifest. Downstream `FROM` statements pick the correct platform automatically.
+
 ## Features
 
 - **Multi-Architecture Support**: Available for amd64 and arm64 architectures

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -163,7 +163,7 @@
             {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
             <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
                   {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
-                  title="{{ variant.description }} — Click to select"
+                  title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
                   data-tag="{{ variant.tag }}"
                   data-size-amd64="{{ variant.size_amd64 | default: '' }}"
                   data-size-arm64="{{ variant.size_arm64 | default: '' }}"
@@ -187,7 +187,7 @@
       <div class="variant-tags">
         {% for variant in include.variants %}
           <span class="variant-tag{% if forloop.first %} selected{% endif %}"
-                title="{{ variant.description }} — Click to select"
+                title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
                 data-tag="{{ variant.tag }}"
                 data-size-amd64="{{ variant.size_amd64 | default: '' }}"
                 data-size-arm64="{{ variant.size_arm64 | default: '' }}"

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -243,7 +243,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -252,7 +252,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -302,7 +302,7 @@
               <dd class="provenance-verify-cmd">
                 {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_var.tag | append: ' --owner oorabona' -%}
                 <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
-                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
+                <button type="button" class="provenance-copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
                    title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
@@ -345,7 +345,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ _prov_var.manifest_digest_amd64 | default: _prov_var.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -354,7 +354,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -404,7 +404,7 @@
               <dd class="provenance-verify-cmd">
                 {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_var.tag | append: ' --owner oorabona' -%}
                 <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
-                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
+                <button type="button" class="provenance-copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
                    title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
@@ -445,7 +445,7 @@
               <dt>Manifest digest (amd64)</dt>
               <dd>
                 <code class="hash hash-long">{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy manifest digest" aria-label="Copy manifest digest" data-copy="{{ prov_variant.manifest_digest_amd64 | default: prov_variant.build_digest }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -454,7 +454,7 @@
               <dt>Manifest digest (arm64)</dt>
               <dd>
                 <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
-                <button class="copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+                <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
               </dd>
             </div>
             {%- endif -%}
@@ -505,7 +505,7 @@
                 {%- assign _prov_tag = prov_variant.tag | default: page.current_version -%}
                 {%- assign _verify_cmd = 'gh attestation verify oci://ghcr.io/oorabona/' | append: page.name | append: ':' | append: _prov_tag | append: ' --owner oorabona' -%}
                 <code class="hash provenance-cmd">{{ _verify_cmd }}</code>
-                <button type="button" class="copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
+                <button type="button" class="provenance-copy-btn" data-copy="{{ _verify_cmd }}" data-aria-label="Copy verify command" aria-label="Copy verify command">⧉</button>
                 <a href="{{ '/verify-images/' | relative_url }}" class="provenance-verify-link"
                    title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
               </dd>
@@ -561,7 +561,7 @@
                             {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
                             aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                             {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
-                            title="{{ variant.description }}">
+                            title="{{ variant.when_to_use | default: variant.description | escape }}">
                       {%- if synthetic -%}{{ variant.name }}{%- else -%}{{ variant.name }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}{%- endif -%}
                     </button>
                   {% endfor %}
@@ -584,7 +584,7 @@
                             {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
                             {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
                             aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
-                            title="{{ variant.description }}">
+                            title="{{ variant.when_to_use | default: variant.description | escape }}">
                       {{ variant.tag }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}
                     </button>
                   {% endfor %}

--- a/docs/site/assets/css/components/provenance.css
+++ b/docs/site/assets/css/components/provenance.css
@@ -101,7 +101,7 @@
 /* -----------------------------------------------------------------------
    Inline copy button (⧉ icon)
    ----------------------------------------------------------------------- */
-.copy-btn {
+.provenance-copy-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -117,21 +117,17 @@
               border-color var(--motion-duration-short) var(--easing-standard);
 }
 
-.copy-btn:hover {
+.provenance-copy-btn:hover {
   color: var(--color-action-primary);
   border-color: var(--color-action-primary);
 }
 
-.copy-btn:focus-visible {
+.provenance-copy-btn:focus-visible {
   outline: 2px solid var(--color-action-primary);
   outline-offset: 2px;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .copy-btn {
-    transition: none;
-  }
-}
+/* prefers-reduced-motion: canonical block in tokens.css — no duplicate here */
 
 /* -----------------------------------------------------------------------
    Empty / awaiting row state
@@ -191,7 +187,7 @@
   }
 
   /* Enlarge copy buttons to 32×32 touch target on mobile */
-  .copy-btn {
+  .provenance-copy-btn {
     width: 32px;
     height: 32px;
   }

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -738,10 +738,4 @@
       color: var(--color-action-primary-hover);
     }
 
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important; scroll-behavior: auto !important;
-      }
-      .bg-animated, .shape { animation: none !important; }
-    }
+    /* prefers-reduced-motion: canonical block lives in tokens.css — no duplicate here */

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -593,6 +593,21 @@
       color: #bfdbfe;
     }
 
+    /* Default pill indicated as a clickable reset target while a
+       non-default variant is the active selection. dashboard.js toggles
+       the modifier; the rule lives here because dashboard.css is the
+       only stylesheet loaded on the dashboard page. */
+    .variant-tag.is-reset-target {
+      border-style: dashed;
+      border-color: rgba(96, 165, 250, 0.7);
+      opacity: 0.85;
+    }
+    .variant-tag.is-reset-target::after {
+      content: ' ↺';
+      font-size: 0.7em;
+      opacity: 0.8;
+    }
+
     .variant-tag:hover {
       background: rgba(139, 92, 246, 0.35);
       border-color: rgba(167, 139, 250, 0.6);

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -801,8 +801,10 @@
         copyDetailPullCommand();
       }
 
-      // Provenance section copy buttons — .copy-btn[data-copy] pattern
-      var copyBtn = e.target.closest('.copy-btn[data-copy]');
+      // Provenance section copy buttons — emit class is .provenance-copy-btn
+      // (renamed from .copy-btn to avoid colliding with dashboard.css's
+      // pull-command .copy-btn rule when both stylesheets share a layout).
+      var copyBtn = e.target.closest('.provenance-copy-btn[data-copy]');
       if (copyBtn) {
         var textToCopy = copyBtn.dataset.copy || '';
         var liveRegion = document.getElementById('status-live');

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -82,7 +82,14 @@
         var statusColor = card.classList.contains('status-green') ? 'up-to-date' :
                          card.classList.contains('status-warning') ? 'update-available' :
                          'not-published';
-        var matchesSearch = currentSearch === '' || name.includes(currentSearch);
+        // F1: also match description text and variant tag names
+        var descEl = card.querySelector('.card-description');
+        var desc = descEl ? descEl.textContent.toLowerCase() : '';
+        var variantTexts = Array.from(card.querySelectorAll('.variant-tag'))
+          .map(function(t) { return t.dataset.tag ? t.dataset.tag.toLowerCase() : ''; })
+          .join(' ');
+        var searchable = name + ' ' + desc + ' ' + variantTexts;
+        var matchesSearch = currentSearch === '' || searchable.includes(currentSearch);
         var matchesStatus = currentStatus === 'all' || statusColor === currentStatus;
         var isVisible = matchesSearch && matchesStatus;
         card.style.display = isVisible ? '' : 'none';
@@ -140,12 +147,37 @@
       var card = element.closest('.container-card');
       var tag = element.dataset.tag;
 
-      card.querySelectorAll('.variant-tag').forEach(function(t) {
-        t.classList.remove('selected');
+      var variantTags = card.querySelectorAll('.variant-tag');
+      // The card's true default is the FIRST variant carrying the
+      // default badge — multi-version cards (e.g. postgres) repeat the
+      // badge on every version's base variant, so iterating every match
+      // and overwriting would point at the last version's default
+      // instead of the one the page initially selected.
+      var defaultVariantEl = null;
+      variantTags.forEach(function(t) {
+        if (!defaultVariantEl && t.querySelector('.badge-primary, .badge[aria-hidden]')) {
+          defaultVariantEl = t;
+        }
+        t.classList.remove('selected', 'is-reset-target');
         t.setAttribute('aria-pressed', 'false');
       });
       element.classList.add('selected');
       element.setAttribute('aria-pressed', 'true');
+      // When a non-default variant is selected, surface the default pill
+      // as a reset affordance (visual emphasis + tooltip swap).
+      if (defaultVariantEl && defaultVariantEl !== element) {
+        defaultVariantEl.classList.add('is-reset-target');
+        if (!defaultVariantEl.dataset.origTitle) {
+          defaultVariantEl.dataset.origTitle = defaultVariantEl.title || '';
+        }
+        defaultVariantEl.title = 'Reset to default variant';
+      } else if (defaultVariantEl) {
+        // default is now selected, restore title
+        if (defaultVariantEl.dataset.origTitle !== undefined) {
+          defaultVariantEl.title = defaultVariantEl.dataset.origTitle;
+          delete defaultVariantEl.dataset.origTitle;
+        }
+      }
 
       var pullSection = card.querySelector('.pull-section');
       var ghcrBase = pullSection ? pullSection.dataset.ghcrBase : '';
@@ -199,11 +231,37 @@
         }, 2000);
       }
 
-      navigator.clipboard.writeText(input.value).then(showCopied).catch(function() {
+      // Modern path: navigator.clipboard.writeText returns a Promise but
+      // can also throw synchronously when clipboard is undefined (insecure
+      // contexts, older browsers). Wrap to fall through to the legacy path.
+      var clipboardPromise = null;
+      try {
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+          clipboardPromise = navigator.clipboard.writeText(input.value);
+        }
+      } catch (e) {
+        clipboardPromise = null;
+      }
+
+      function legacyCopy() {
         input.select();
-        document.execCommand('copy');
-        showCopied();
-      });
+        var ok = false;
+        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+        if (ok) {
+          showCopied();
+        } else {
+          console.warn('[dashboard] clipboard copy failed (execCommand returned false)');
+        }
+      }
+
+      if (clipboardPromise && typeof clipboardPromise.then === 'function') {
+        clipboardPromise.then(showCopied).catch(function(e) {
+          console.warn('[dashboard] navigator.clipboard.writeText failed; falling back', e);
+          legacyCopy();
+        });
+      } else {
+        legacyCopy();
+      }
     }
 
     // Event delegation (F-006: no inline onclick handlers)

--- a/vector/README.md
+++ b/vector/README.md
@@ -6,6 +6,16 @@
 
 High-performance observability data pipeline for collecting, transforming, and routing logs, metrics, and events. Built on [Vector](https://vector.dev/) with a pre-built musl static binary on Alpine Linux.
 
+## Why this image
+
+This image packages [Vector](https://vector.dev/) as a minimal, production-hardened container suited for vendor-free observability pipelines.
+
+- **Minimal attack surface.** Built on Alpine Linux using the upstream musl-linked static Vector binary from GitHub Releases. The binary is self-contained — it does not depend on glibc or a shell interpreter at runtime, even though Alpine still ships `ash` for image-level operations.
+- **Multiple architectures.** Published for both `linux/amd64` and `linux/arm64`, tested on each arch in CI. Pulls the correct platform layer automatically on `docker pull`.
+- **Verifiable provenance.** Every build produces a Sigstore SBOM attestation (cosign) and a Trivy vulnerability scan. Digests are recorded in build lineage and surfaced on the dashboard.
+- **Automated upstream tracking.** The upstream-monitor workflow checks the Vector GitHub release feed daily and opens a PR when a new version is available, keeping the image current without manual intervention.
+- **Common sink/source coverage.** Supports Docker log collection, syslog, file tailing, Prometheus scrape, and OpenTelemetry out of the box. Pairs directly with the `oorabona/postgres:<version>-full-alpine` flavor (TimescaleDB + ParadeDB) for a complete vendor-free log/metrics store — see the PostgreSQL sink example below.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Bundles a small set of dashboard UX fixes plus content depth on the two thinnest container detail pages. Closes most of the residual UX items from `TODO.local.md`'s `PR-H` section.

### JavaScript

- **Search filter** (`dashboard.js`): now matches container description and variant tag names in addition to the container name. Searching `vector` or `pgvector` now surfaces postgres correctly.
- **Variant reset affordance** (`dashboard.js`): when a non-default variant is picked, the card's true default pill (the FIRST variant carrying the default badge — multi-version cards repeat the badge per version, the prior implementation pointed at the wrong one) gets a dashed outline + circular-arrow glyph + `Reset to default variant` tooltip.
- **Clipboard helper hardening** (`dashboard.js`): guards `navigator.clipboard.writeText` against absent-API throws (insecure contexts, older browsers); only signals "copied" when the legacy `execCommand` fallback returned `true`; logs `console.warn` on failure so a silent no-op is debuggable.
- **Provenance copy handler** (`container-detail.js`): event delegate now targets the renamed `.provenance-copy-btn` selector. The prior selector silently broke when the rename landed.

### CSS

- **`.is-reset-target` rule** moved from `container-detail.css` into `dashboard.css` because `dashboard.js` toggles the class only on the dashboard page, and the dashboard layout does not load `container-detail.css` — the affordance was invisible to users.
- **`.copy-btn` rename to `.provenance-copy-btn`** in `_includes/components/provenance.css` (4 selectors) plus all 9 callers in `_layouts/container-detail.html`. Avoids latent collision with the `dashboard.css` `.copy-btn` rule (44px pull-command button) if both stylesheets ever share a layout.
- **Reduced-motion dedup**: removed two duplicate `@media (prefers-reduced-motion: reduce)` rules from `provenance.css` and `container-detail.css`. The canonical rule lives in `tokens.css` and already applies globally; per-file copies were noise.

### Liquid templates

- **Variant title hover**: 4 occurrences updated (2 in `container-card.html`, 2 in `container-detail.html`) to prefer `variant.when_to_use` when present, fall back to `variant.description`. The chain runs through `escape` for HTML attribute safety.

### Content

- **`vector/README.md`** — new "Why this image" section: musl static binary on Alpine, multi-arch, SBOM + Sigstore attestation, automated upstream tracking, sink/source coverage. The pairing example references `oorabona/postgres:<version>-full-alpine` (the actual published flavor) instead of the non-existent `postgres:full` literal.
- **`debian/README.md`** — "Why this image" rewritten from the actual `Dockerfile` and `variants.yaml` state: single `trixie` track (not slim/bookworm/bullseye as the prior draft incorrectly claimed), passwordless sudo non-root user, configurable `LOCALES` build arg, used as base for `web-shell`'s Debian distro variant.

### Items investigated but no code change

- `build_success_rate` calculation — verified `generate-dashboard.sh` already excludes skipped runs from the denominator. The 48% figure is accurate live data, not a formula bug.
- Dashboard stats counters (`0/0/0/13` snapshot) — the IDs are populated at runtime by `updateFilterCounts()` from live DOM, the zeros are HTML initial values replaced on `DOMContentLoaded`. No traceable wiring bug at small edit sizes.
- Provenance section header wrapping — already correctly hoisted outside the per-variant loop in both the `page.versions` and `page.variants` branches.

Net diff: 9 files, +123/-38 (net +85 LOC).

## Test plan

- [ ] CI passes (CodeQL, Jekyll build via `update-dashboard.yaml`)
- [ ] Live deploy: dashboard search "vector" surfaces both `vector` and `postgres` cards (postgres because of the `vector` flavor variant); search "pgvector" surfaces postgres
- [ ] Live deploy: clicking a non-default variant pill on a multi-version card (e.g. postgres) marks the card's INITIAL default pill (not the latest version's default) with the dashed circular-arrow reset affordance; tooltip reads `Reset to default variant`
- [ ] Live deploy: clicking the marked default pill clears the reset affordance and selects the default variant
- [ ] Live deploy: copy button on dashboard pull-command works (success path + execCommand fallback path); on failure, the warning shows in the browser console
- [ ] Live deploy: copy buttons in container detail Provenance section work (manifest digests + verify command — were silently broken by the rename without a JS update)
- [ ] Live deploy: hovering a variant pill with a `when_to_use` field shows the richer tooltip; pills without it fall back to `description`
- [ ] Live deploy: `/container/vector/` and `/container/debian/` show the new "Why this image" sections with factual claims (no `postgres:full` placeholder, no `slim/bookworm/bullseye` for debian)
- [ ] No regression on PR-D heading hierarchy or PR-F token discipline
