### PR TITLE
fix(dashboard): trim hero detail and shrink Trivy badge on cards

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -97,21 +97,40 @@
        >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% else %}📋 SBOM PENDING{% endif %}</a>
 
     {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
-      {%- assign sev = "info" -%}
-      {%- if default_variant.trivy_summary.counts.critical > 0 -%}{%- assign sev = "critical" -%}
-      {%- elsif default_variant.trivy_summary.counts.high > 0 -%}{%- assign sev = "high" -%}
-      {%- endif -%}
       {%- comment -%}
-        Card surface: compact label (icon + count). Full context — severity, scan date,
-        advisory mode caveat — lives in the title tooltip and on the detail page badge,
-        avoiding overflow at narrow card widths. trust-strip.js mirrors this compact
-        format on variant-change events when the parent is a container card.
+        Compact card label tracks the active severity bucket: emit the count
+        of the most severe non-zero level so the number on the badge always
+        matches the badge colour. Full context (label + scan date + advisory
+        caveat) is duplicated into both `title` (hover) and `aria-label`
+        (screen reader / touch focus); the badge link itself targets the
+        detail-page security section so touch users land on the full surface.
       {%- endcomment -%}
+      {%- assign trivy_critical = default_variant.trivy_summary.counts.critical | plus: 0 -%}
+      {%- assign trivy_high     = default_variant.trivy_summary.counts.high     | plus: 0 -%}
+      {%- if trivy_critical > 0 -%}
+        {%- assign trivy_sev = "critical" -%}
+        {%- assign trivy_count = trivy_critical -%}
+        {%- assign trivy_label = "CRIT" -%}
+        {%- assign trivy_aria_label = "CRITICAL" -%}
+      {%- elsif trivy_high > 0 -%}
+        {%- assign trivy_sev = "high" -%}
+        {%- assign trivy_count = trivy_high -%}
+        {%- assign trivy_label = "HIGH" -%}
+        {%- assign trivy_aria_label = "HIGH" -%}
+      {%- else -%}
+        {%- assign trivy_sev = "info" -%}
+        {%- assign trivy_count = 0 -%}
+        {%- assign trivy_label = "" -%}
+        {%- assign trivy_aria_label = "critical / high" -%}
+      {%- endif -%}
+      {%- assign trivy_scan_date = default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" -%}
+      {%- capture trivy_full_label -%}{{ trivy_count }} {{ trivy_aria_label }} CVE(s) · scanned {{ trivy_scan_date }} · advisory mode (does not block builds){%- endcapture -%}
       <a class="trust-badge trust-badge--trivy"
          data-trust="trivy"
-         data-severity="{{ sev }}"
+         data-severity="{{ trivy_sev }}"
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
-         title="{{ default_variant.trivy_summary.counts.critical }} CRITICAL CVE(s) · scanned {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }} · advisory mode (does not block builds)">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }}</a>
+         aria-label="{{ trivy_full_label | escape }}"
+         title="{{ trivy_full_label | escape }}">🛡 TRIVY: {{ trivy_count }}{% if trivy_label %} {{ trivy_label }}{% endif %}</a>
     {%- else -%}
       <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
       <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"></a>

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -101,11 +101,17 @@
       {%- if default_variant.trivy_summary.counts.critical > 0 -%}{%- assign sev = "critical" -%}
       {%- elsif default_variant.trivy_summary.counts.high > 0 -%}{%- assign sev = "high" -%}
       {%- endif -%}
+      {%- comment -%}
+        Card surface: compact label (icon + count). Full context — severity, scan date,
+        advisory mode caveat — lives in the title tooltip and on the detail page badge,
+        avoiding overflow at narrow card widths. trust-strip.js mirrors this compact
+        format on variant-change events when the parent is a container card.
+      {%- endcomment -%}
       <a class="trust-badge trust-badge--trivy"
          data-trust="trivy"
          data-severity="{{ sev }}"
          href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
-         title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+         title="{{ default_variant.trivy_summary.counts.critical }} CRITICAL CVE(s) · scanned {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }} · advisory mode (does not block builds)">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }}</a>
     {%- else -%}
       <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
       <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"></a>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -157,15 +157,29 @@
              >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% else %}📋 SBOM PENDING{% endif %}</a>
 
           {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
-            {%- assign sev = "info" -%}
-            {%- if default_variant.trivy_summary.counts.critical > 0 -%}{%- assign sev = "critical" -%}
-            {%- elsif default_variant.trivy_summary.counts.high > 0 -%}{%- assign sev = "high" -%}
+            {%- assign trivy_critical = default_variant.trivy_summary.counts.critical | plus: 0 -%}
+            {%- assign trivy_high     = default_variant.trivy_summary.counts.high     | plus: 0 -%}
+            {%- if trivy_critical > 0 -%}
+              {%- assign trivy_sev = "critical" -%}
+              {%- assign trivy_count = trivy_critical -%}
+              {%- assign trivy_aria_label = "CRITICAL" -%}
+            {%- elsif trivy_high > 0 -%}
+              {%- assign trivy_sev = "high" -%}
+              {%- assign trivy_count = trivy_high -%}
+              {%- assign trivy_aria_label = "HIGH" -%}
+            {%- else -%}
+              {%- assign trivy_sev = "info" -%}
+              {%- assign trivy_count = 0 -%}
+              {%- assign trivy_aria_label = "critical / high" -%}
             {%- endif -%}
+            {%- assign trivy_scan_date = default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" -%}
+            {%- capture trivy_full_label -%}{{ trivy_count }} {{ trivy_aria_label }} CVE(s) · scanned {{ trivy_scan_date }} · advisory mode (does not block builds){%- endcapture -%}
             <a class="trust-badge trust-badge--trivy"
                data-trust="trivy"
-               data-severity="{{ sev }}"
+               data-severity="{{ trivy_sev }}"
                href="#security"
-               title="Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.">🛡 TRIVY: {{ default_variant.trivy_summary.counts.critical }} CRITICAL (advisory) · SCANNED {{ default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</a>
+               aria-label="{{ trivy_full_label | escape }}"
+               title="{{ trivy_full_label | escape }}">🛡 TRIVY: {{ trivy_count }} {{ trivy_aria_label }} (advisory) · SCANNED {{ trivy_scan_date }}</a>
           {%- else -%}
             <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
             <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="#security"></a>

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -73,8 +73,8 @@
       <p class="dashboard-hero-subtitle">
         A curated fleet of Docker container images published to GHCR and Docker Hub, each built with automated upstream version monitoring, signed SBOM attestation via Sigstore, and an advisory Trivy CVE scan. Every detail page surfaces the build commit, manifest digest, and verifiable attestation so operators can audit provenance without leaving the dashboard.
       </p>
-      <p class="dashboard-hero-detail">
-        This is not a replacement for Docker Official Images. It is a focused set of images where the maintenance load and the verification surface justify the engineering — PostgreSQL with 10 extensions in 7 flavors, hardened OpenVPN, multi-distro web-shell, self-hosted GitHub Actions runners, and a small supporting set. Maintained by <a href="{{ '/about/' | relative_url }}" class="dashboard-hero-link">Olivier Orabona</a>.
+      <p class="dashboard-hero-cta">
+        <a href="{{ '/about/' | relative_url }}" class="dashboard-hero-cta-link">Want to learn more? → About</a>
       </p>
     </section>
 

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -1055,3 +1055,27 @@
       max-width: 620px;
       margin: 0 auto;
     }
+
+    /* Hero CTA — small inline link below the subtitle, low visual weight. */
+    .dashboard-hero-cta {
+      margin: 0.75rem auto 0;
+      font-size: 0.875rem;
+    }
+    .dashboard-hero-cta-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.4rem 0.85rem;
+      border-radius: 999px;
+      border: 1px solid var(--color-neutral-400);
+      color: var(--color-text-secondary);
+      text-decoration: none;
+      letter-spacing: 0.01em;
+      transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+    }
+    .dashboard-hero-cta-link:hover,
+    .dashboard-hero-cta-link:focus-visible {
+      background: var(--color-surface-raised);
+      border-color: var(--color-text-secondary);
+      color: var(--color-text-primary);
+    }

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -63,20 +63,32 @@
       const counts = summary.counts || {};
       const critical = counts.critical || 0;
       const high = counts.high || 0;
-      const sev = critical > 0 ? 'critical' : (high > 0 ? 'high' : 'info');
+      // Pick the count + label of the active severity so the number on the
+      // badge always matches the badge colour. info-level (no CRIT, no HIGH)
+      // surfaces "0" so the chip stays a positive signal rather than blank.
+      let sev, displayCount, compactLabel, ariaSeverity;
+      if (critical > 0) {
+        sev = 'critical'; displayCount = critical; compactLabel = 'CRIT'; ariaSeverity = 'CRITICAL';
+      } else if (high > 0) {
+        sev = 'high';     displayCount = high;     compactLabel = 'HIGH'; ariaSeverity = 'HIGH';
+      } else {
+        sev = 'info';     displayCount = 0;        compactLabel = '';     ariaSeverity = 'critical / high';
+      }
       el.setAttribute('data-severity', sev);
       const date = (summary.last_scan || '').slice(0, 10);
+      const fullLabel = displayCount + ' ' + ariaSeverity + ' CVE(s) · scanned ' + date + ' · advisory mode (does not block builds)';
       // Compact label on dashboard cards (narrow width); full label on the
-      // detail-page badge. Mirrors the Liquid initial render so a variant
-      // change does not visually swap to a longer string mid-flight.
+      // detail-page badge. Both surfaces duplicate the full label into
+      // aria-label so screen-reader / touch users get the same context as
+      // hover-tooltip users.
       const isCardSurface = !!this.closest('.container-card');
       if (isCardSurface) {
-        el.textContent = '🛡 TRIVY: ' + critical;
-        el.title = critical + ' CRITICAL CVE(s) · scanned ' + date + ' · advisory mode (does not block builds)';
+        el.textContent = '🛡 TRIVY: ' + displayCount + (compactLabel ? ' ' + compactLabel : '');
       } else {
-        el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
-        el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
+        el.textContent = '🛡 TRIVY: ' + displayCount + ' ' + ariaSeverity + ' (advisory) · SCANNED ' + date;
       }
+      el.title = fullLabel;
+      el.setAttribute('aria-label', fullLabel);
       el.style.display = '';
       el.removeAttribute('aria-hidden');
     }

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -66,8 +66,17 @@
       const sev = critical > 0 ? 'critical' : (high > 0 ? 'high' : 'info');
       el.setAttribute('data-severity', sev);
       const date = (summary.last_scan || '').slice(0, 10);
-      el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
-      el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
+      // Compact label on dashboard cards (narrow width); full label on the
+      // detail-page badge. Mirrors the Liquid initial render so a variant
+      // change does not visually swap to a longer string mid-flight.
+      const isCardSurface = !!this.closest('.container-card');
+      if (isCardSurface) {
+        el.textContent = '🛡 TRIVY: ' + critical;
+        el.title = critical + ' CRITICAL CVE(s) · scanned ' + date + ' · advisory mode (does not block builds)';
+      } else {
+        el.textContent = '🛡 TRIVY: ' + critical + ' CRITICAL (advisory) · SCANNED ' + date;
+        el.title = 'Trivy scan results are advisory; severity counts indicate detected CVEs but do not block builds.';
+      }
       el.style.display = '';
       el.removeAttribute('aria-hidden');
     }


### PR DESCRIPTION
## Summary

Direct response to two visual issues spotted on the live deploy:

1. **Hero detail paragraph** was too long ("This is not a replacement for Docker Official Images. It is a focused set of images...") — competed with the actual value prop above it. Replaced with a small `Want to learn more? → About` pill link. Full context kept on the About page where it belongs.

2. **Trivy badge on dashboard cards** rendered the full `🛡 TRIVY: N CRITICAL (advisory) · SCANNED YYYY-MM-DD` string and overflowed the card width on dense data. Cards now show `🛡 TRIVY: N` only; severity label, scan date, and `advisory` mode caveat live in the `title=` tooltip plus the detail-page badge (where the chip has room).

`trust-strip.js` was rewriting the long string back into the chip on every variant-tag click. Now it detects whether its host is inside a `.container-card` and emits the compact format on cards, keeping the full format on the detail page.

Net diff: 4 files, +44/-5 (net +39 LOC).

## Test plan

- [ ] CI passes (CodeQL, Jekyll build)
- [ ] Live deploy: dashboard hero shows the value-prop subtitle followed by a small `Want to learn more? → About` pill (no long paragraph)
- [ ] Live deploy: dashboard cards show `🛡 TRIVY: N` only (no `(advisory)`, no scan date), tooltip on hover reveals full info
- [ ] Live deploy: /container/<name>/ detail page Trivy badge keeps the full `🛡 TRIVY: N CRITICAL (advisory) · SCANNED YYYY-MM-DD` format
- [ ] Live deploy: clicking a variant tag on a dashboard card preserves the compact format (does not flash to the long version)
- [ ] Live deploy: clicking a variant tag on the detail page preserves the full format
- [ ] Hero CTA pill is keyboard-focusable and has a visible `:focus-visible` state