### PR TITLE
refactor(dashboard): row-expand layout with native details disclosure

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -1,280 +1,232 @@
-<!-- Enhanced Container Status Card - Glassmorphism Style -->
-<article class="container-card glass status-{{ include.status_color | default: 'secondary' }}"
-     data-container="{{ include.name }}"
-     data-github-username="{{ include.github_username }}"
-     data-dockerhub-username="{{ include.dockerhub_username }}"
-     aria-label="{{ include.name }} container - {{ include.status_text | default: 'Unknown status' }}">
-  <div class="card-header-row">
-    <div class="card-name">{{ include.name }}</div>
-    <span class="card-badge{% if include.status_color == 'warning' %} warning{% endif %}">
-      {{ include.current_version | default: 'unknown' }}
-    </span>
-  </div>
+<!-- Container row card — details/summary expand pattern (D1 refactor) -->
+{%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
+<details class="container-card glass status-{{ include.status_color | default: 'secondary' }}"
+         data-container="{{ include.name }}"
+         data-github-username="{{ include.github_username }}"
+         data-dockerhub-username="{{ include.dockerhub_username }}"
+         aria-label="{{ include.name }} container - {{ include.status_text | default: 'Unknown status' }}">
 
-  <div class="card-status">
-    {% if include.build_status == 'success' %}
-      <i class="ti ti-circle-check" style="color: var(--accent-green);" aria-hidden="true"></i>
-    {% elsif include.build_status == 'warning' %}
-      <i class="ti ti-alert-triangle" style="color: var(--accent-yellow);" aria-hidden="true"></i>
-    {% elsif include.build_status == 'failed' %}
-      <i class="ti ti-circle-x" style="color: var(--accent-pink);" aria-hidden="true"></i>
-    {% else %}
-      <i class="ti ti-loader" style="color: var(--accent-yellow);" aria-hidden="true"></i>
-    {% endif %}
-    {{ include.status_text | default: 'Unknown' }}
-  </div>
+  <summary class="row-summary">
+    <!-- Icon -->
+    <div class="row-icon" aria-hidden="true">
+      <i class="ti ti-package"></i>
+    </div>
 
-  {% if include.latest_version %}
-  <div class="card-meta">
-    <div class="card-meta-item">
-      <span class="card-meta-label">Latest</span>
-      <span class="card-meta-value">{{ include.latest_version }}</span>
+    <!-- Name + version -->
+    <div class="row-id">
+      <div class="row-id-name">{{ include.name }}</div>
+      <div class="row-id-version{% if include.status_color == 'warning' %} warn{% endif %}">{{ include.current_version | default: default_variant.tag | default: 'unknown' }}</div>
     </div>
-    <div class="card-meta-item">
-      <span class="card-meta-label">Pulls</span>
-      <span class="card-meta-value">
-        <i class="ti ti-download" style="font-size: 0.75rem;" aria-hidden="true"></i>
-        {{ include.pull_count_formatted | default: "0" }}
-      </span>
-    </div>
-    <div class="card-meta-item">
-      <span class="card-meta-label">Stars</span>
-      <span class="card-meta-value">
-        <i class="ti ti-star" style="font-size: 0.75rem; color: var(--accent-yellow);" aria-hidden="true"></i>
-        {{ include.star_count | default: 0 }}
-      </span>
-    </div>
-    {% if include.size_amd64 or include.size_arm64 %}
-    <div class="card-meta-item">
-      <span class="card-meta-label">Size (amd64)</span>
-      <span class="card-meta-value" data-meta="size-amd64">{{ include.size_amd64 | default: "—" }}</span>
-    </div>
-    <div class="card-meta-item">
-      <span class="card-meta-label">Size (arm64)</span>
-      <span class="card-meta-value" data-meta="size-arm64">{{ include.size_arm64 | default: "—" }}</span>
-    </div>
-    {% endif %}
-    {% if include.build_digest and include.build_digest != "unknown" and include.build_digest != "per-variant" %}
-    <div class="card-meta-item">
-      <span class="card-meta-label">Build</span>
-      <span class="card-meta-value card-lineage-digest" title="Build digest: {{ include.build_digest }}">
-        <i class="ti ti-fingerprint" style="font-size: 0.75rem;" aria-hidden="true"></i>
-        {{ include.build_digest | truncate: 12, "" }}
-      </span>
-    </div>
-    {% elsif include.build_digest == "per-variant" %}
-    <div class="card-meta-item">
-      <span class="card-meta-label">Build</span>
-      <span class="card-meta-value card-lineage-digest" title="Per-variant build digests available">
-        <i class="ti ti-fingerprint" style="font-size: 0.75rem;" aria-hidden="true"></i>
-        per-variant
-      </span>
-    </div>
-    {% endif %}
-  </div>
-  {% endif %}
 
-  {% if include.description %}
-  <div class="card-description">{{ include.description | truncate: 120 }}</div>
-  {% endif %}
-
-  {%- comment -%}
-    Trust strip: surfaces SBOM attestation, Trivy scan summary, multi-arch, deps tracking, verify guide.
-    <trust-strip> custom element — CSP-clean, no Alpine. Liquid renders initial state; web component
-    updates child [data-trust] badges on `phase-b-variant-changed` events (never innerHTML).
-  {%- endcomment -%}
-  {%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
-  <trust-strip class="trust-strip" data-current-variant="{{ default_variant.tag | default: include.current_version }}">
+    <!-- Trust-strip badges -->
+    {%- comment -%}
+      Trust strip: surfaces SBOM attestation, Trivy scan summary, multi-arch.
+      <trust-strip> custom element — CSP-clean, no Alpine. Liquid renders initial state;
+      web component updates child [data-trust] badges on `phase-b-variant-changed` events.
+    {%- endcomment -%}
+    <trust-strip class="trust-strip row-trust" data-current-variant="{{ default_variant.tag | default: include.current_version }}">
       <a class="trust-badge trust-badge--sbom{% unless default_variant.attestation_url and default_variant.attestation_id %} is-pending{% endunless %}"
-       data-trust="sbom"
-       {% if default_variant.attestation_url and default_variant.attestation_id %}
-         href="{{ default_variant.attestation_url }}"
-         title="View Sigstore attestation for this image's SBOM"
-       {% else %}
-         title="SBOM attestation not yet generated. Will populate on next successful build with cosign attestation."
-       {% endif %}
-       rel="noopener"
-       >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM ATTESTED{% else %}📋 SBOM PENDING{% endif %}</a>
+         data-trust="sbom"
+         {% if default_variant.attestation_url and default_variant.attestation_id %}
+           href="{{ default_variant.attestation_url }}"
+           title="View Sigstore attestation for this image's SBOM"
+         {% else %}
+           title="SBOM attestation not yet generated. Will populate on next successful build with cosign attestation."
+         {% endif %}
+         rel="noopener"
+         >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM{% else %}📋 SBOM{% endif %}</a>
 
-    {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
-      {%- comment -%}
-        Compact card label tracks the active severity bucket: emit the count
-        of the most severe non-zero level so the number on the badge always
-        matches the badge colour. Full context (label + scan date + advisory
-        caveat) is duplicated into both `title` (hover) and `aria-label`
-        (screen reader / touch focus); the badge link itself targets the
-        detail-page security section so touch users land on the full surface.
-      {%- endcomment -%}
-      {%- assign trivy_critical = default_variant.trivy_summary.counts.critical | plus: 0 -%}
-      {%- assign trivy_high     = default_variant.trivy_summary.counts.high     | plus: 0 -%}
-      {%- if trivy_critical > 0 -%}
-        {%- assign trivy_sev = "critical" -%}
-        {%- assign trivy_count = trivy_critical -%}
-        {%- assign trivy_label = "CRIT" -%}
-        {%- assign trivy_aria_label = "CRITICAL" -%}
-      {%- elsif trivy_high > 0 -%}
-        {%- assign trivy_sev = "high" -%}
-        {%- assign trivy_count = trivy_high -%}
-        {%- assign trivy_label = "HIGH" -%}
-        {%- assign trivy_aria_label = "HIGH" -%}
+      {%- if default_variant.trivy_summary and default_variant.trivy_summary.last_scan -%}
+        {%- comment -%}
+          Compact card label tracks the active severity bucket: emit the count
+          of the most severe non-zero level so the number on the badge always
+          matches the badge colour. Full context (label + scan date + advisory
+          caveat) is duplicated into both `title` (hover) and `aria-label`
+          (screen reader / touch focus); the badge link itself targets the
+          detail-page security section so touch users land on the full surface.
+        {%- endcomment -%}
+        {%- assign trivy_critical = default_variant.trivy_summary.counts.critical | plus: 0 -%}
+        {%- assign trivy_high     = default_variant.trivy_summary.counts.high     | plus: 0 -%}
+        {%- if trivy_critical > 0 -%}
+          {%- assign trivy_sev = "critical" -%}
+          {%- assign trivy_count = trivy_critical -%}
+          {%- assign trivy_label = "CRIT" -%}
+          {%- assign trivy_aria_label = "CRITICAL" -%}
+        {%- elsif trivy_high > 0 -%}
+          {%- assign trivy_sev = "high" -%}
+          {%- assign trivy_count = trivy_high -%}
+          {%- assign trivy_label = "HIGH" -%}
+          {%- assign trivy_aria_label = "HIGH" -%}
+        {%- else -%}
+          {%- assign trivy_sev = "info" -%}
+          {%- assign trivy_count = 0 -%}
+          {%- assign trivy_label = "" -%}
+          {%- assign trivy_aria_label = "critical / high" -%}
+        {%- endif -%}
+        {%- assign trivy_scan_date = default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" -%}
+        {%- capture trivy_full_label -%}{{ trivy_count }} {{ trivy_aria_label }} CVE(s) · scanned {{ trivy_scan_date }} · advisory mode (does not block builds){%- endcapture -%}
+        <a class="trust-badge trust-badge--trivy"
+           data-trust="trivy"
+           data-severity="{{ trivy_sev }}"
+           href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
+           aria-label="{{ trivy_full_label | escape }}"
+           title="{{ trivy_full_label | escape }}">🛡 {{ trivy_count }}{% if trivy_label %} {{ trivy_label }}{% endif %}</a>
       {%- else -%}
-        {%- assign trivy_sev = "info" -%}
-        {%- assign trivy_count = 0 -%}
-        {%- assign trivy_label = "" -%}
-        {%- assign trivy_aria_label = "critical / high" -%}
+        <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+        <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"></a>
       {%- endif -%}
-      {%- assign trivy_scan_date = default_variant.trivy_summary.last_scan | date: "%Y-%m-%d" -%}
-      {%- capture trivy_full_label -%}{{ trivy_count }} {{ trivy_aria_label }} CVE(s) · scanned {{ trivy_scan_date }} · advisory mode (does not block builds){%- endcapture -%}
-      <a class="trust-badge trust-badge--trivy"
-         data-trust="trivy"
-         data-severity="{{ trivy_sev }}"
-         href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"
-         aria-label="{{ trivy_full_label | escape }}"
-         title="{{ trivy_full_label | escape }}">🛡 TRIVY: {{ trivy_count }}{% if trivy_label %} {{ trivy_label }}{% endif %}</a>
-    {%- else -%}
-      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
-      <a class="trust-badge trust-badge--trivy" data-trust="trivy" style="display: none" aria-hidden="true" href="{{ '/container/' | append: include.name | append: '/' | relative_url }}#security"></a>
-    {%- endif -%}
 
-    {%- if default_variant.multi_arch_platforms -%}
-      <a class="trust-badge trust-badge--multi-arch"
-         data-trust="multi-arch"
-         href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}"
-         rel="noopener"
-         title="View this image's multi-arch manifest on GHCR">🏗 {{ default_variant.multi_arch_platforms | join: " + " | upcase }}</a>
-    {%- else -%}
-      <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
-      <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}" rel="noopener"></a>
-    {%- endif -%}
+      {%- if default_variant.multi_arch_platforms -%}
+        <a class="trust-badge trust-badge--multi-arch"
+           data-trust="multi-arch"
+           href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}"
+           rel="noopener"
+           title="View this image's multi-arch manifest on GHCR">🏗 ×{{ default_variant.multi_arch_platforms | size }}</a>
+      {%- else -%}
+        <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
+        <a class="trust-badge trust-badge--multi-arch" data-trust="multi-arch" style="display: none" aria-hidden="true" href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}" rel="noopener"></a>
+      {%- endif -%}
+    </trust-strip>
 
-    {%- if include.dependency_monitoring.enabled -%}
-      <a class="trust-badge trust-badge--deps"
-         href="{{ include.upstream_monitor_url }}"
-         rel="noopener"
-         title="View the daily upstream-monitor workflow runs">
-        🔗 {{ include.dependency_monitoring.monitored }}/{{ include.dependency_monitoring.total }} deps tracked daily
-      </a>
-    {%- endif -%}
-    <a class="trust-badge trust-badge--verify"
-       href="{{ '/verify-images/' | relative_url }}"
-       title="Reproduce these checks yourself — verification guide">🔍 REPRODUCE THESE CHECKS LOCALLY</a>
-  </trust-strip>
-
-  <!-- Variants Section (for multi-image containers) -->
-  {% if include.versions or include.variants %}
-  <div class="variants-section">
-    <div class="variants-header">
-      <i class="ti ti-versions" aria-hidden="true"></i>
-      <span>Available variants</span>
+    <!-- Pull count + size stats -->
+    <div class="row-stats">
+      <span><i class="ti ti-download" aria-hidden="true"></i>{{ include.pull_count_formatted | default: "—" }}</span>
+      <span><i class="ti ti-cube" aria-hidden="true"></i><span data-meta="size-amd64">{{ include.size_amd64 | default: "—" }}</span></span>
     </div>
-    {% if include.versions %}
-      <!-- Multi-version structure: group by version -->
-      {% for version in include.versions %}
-      <div class="version-group">
-        <div class="version-label">{{ version.base_tag | default: version.tag }}</div>
-        <div class="variant-tags">
-          {% for variant in version.variants %}
-            {%- comment -%}
-              Versions-only containers synthesize a single variant with empty
-              `name` (the version itself IS the canonical build). Render the
-              tag with `display:none` so it stays invisible (the version-label
-              identifies the build) while preserving its data-* attributes
-              and `.selected` class — the trust-strip JS and detail-page
-              container-detail.js both initialize from .variant-tag.selected
-              and would lose data for the canonical build if the element were
-              skipped entirely.
-            {%- endcomment -%}
-            {%- assign synthetic = false -%}
-            {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
-            <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
-                  {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
-                  title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
-                  data-tag="{{ variant.tag }}"
-                  data-size-amd64="{{ variant.size_amd64 | default: '' }}"
-                  data-size-arm64="{{ variant.size_arm64 | default: '' }}"
-                  {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
-                  {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif %}
-                  {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif %}
-                  {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif %}
-                  role="button"
-                  tabindex="0"
-                  aria-pressed="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
-                  aria-label="Select variant {{ variant.name }}{% if variant.is_default %} (default){% endif %}">
-              :{{ variant.name }}
-              {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
-            </span>
-          {% endfor %}
+
+    <!-- Spacer + toggle chevron -->
+    <span class="row-toggle-spacer" aria-hidden="true"></span>
+    <i class="ti ti-chevron-right row-toggle" aria-hidden="true"></i>
+  </summary>
+
+  <!-- Expanded body -->
+  <div class="row-body">
+
+    <!-- About -->
+    {% if include.description %}
+    <section>
+      <h3>About</h3>
+      <p class="card-description">{{ include.description }}</p>
+    </section>
+    {% endif %}
+
+    <!-- Pull command -->
+    {% if include.ghcr_image and include.dockerhub_image %}
+    <section>
+      <h3>Pull command</h3>
+      <div class="pull-section"
+           data-ghcr-base="ghcr.io/{{ include.github_username }}/{{ include.name }}"
+           data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"
+           data-default-tag="{% if include.versions[0].variants[0] %}{{ include.versions[0].variants[0].tag }}{% elsif include.variants[0] %}{{ include.variants[0].tag }}{% else %}{{ include.current_version }}{% endif %}">
+        <div class="pull-input-group">
+          <input type="text"
+                 class="pull-input"
+                 id="pull-{{ include.name }}"
+                 value="docker pull {{ include.ghcr_image }}"
+                 readonly
+                 aria-label="Docker pull command for {{ include.name }}">
+          <button class="copy-btn" type="button"
+                  aria-label="Copy pull command to clipboard">
+            <i class="ti ti-copy" aria-hidden="true"></i>
+          </button>
         </div>
       </div>
-      {% endfor %}
-    {% else %}
-      <!-- Single-version structure -->
-      <div class="variant-tags">
-        {% for variant in include.variants %}
-          <span class="variant-tag{% if forloop.first %} selected{% endif %}"
-                title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
-                data-tag="{{ variant.tag }}"
-                data-size-amd64="{{ variant.size_amd64 | default: '' }}"
-                data-size-arm64="{{ variant.size_arm64 | default: '' }}"
-                {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
-                {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif %}
-                {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif %}
-                {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif %}
-                role="button"
-                tabindex="0"
-                aria-pressed="{% if forloop.first %}true{% else %}false{% endif %}"
-                aria-label="Select variant {{ variant.tag }}{% if variant.is_default %} (default){% endif %}">
-            :{{ variant.tag }}
-            {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
-          </span>
-        {% endfor %}
-      </div>
+    </section>
     {% endif %}
-  </div>
-  {% endif %}
 
-  <!-- Docker Pull Command Section -->
-  {% if include.ghcr_image and include.dockerhub_image %}
-  <div class="pull-section"
-       data-ghcr-base="ghcr.io/{{ include.github_username }}/{{ include.name }}"
-       data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"
-       data-default-tag="{% if include.versions[0].variants[0] %}{{ include.versions[0].variants[0].tag }}{% elsif include.variants[0] %}{{ include.variants[0].tag }}{% else %}{{ include.current_version }}{% endif %}">
-    <div class="pull-header">
-      <i class="ti ti-brand-docker" aria-hidden="true"></i>
-      <span>Pull command</span>
-    </div>
-    <div class="pull-input-group">
-      <input type="text"
-             class="pull-input"
-             id="pull-{{ include.name }}"
-             value="docker pull {{ include.ghcr_image }}"
-             readonly
-             aria-label="Docker pull command for {{ include.name }}">
-      <button class="copy-btn" type="button"
-              aria-label="Copy pull command to clipboard">
-        <i class="ti ti-copy" aria-hidden="true"></i>
-      </button>
-    </div>
-  </div>
-  {% endif %}
+    <!-- Variants -->
+    {% if include.versions or include.variants %}
+    <section class="row-body-variants">
+      <div class="variants-section">
+        <div class="variants-header">
+          <i class="ti ti-versions" aria-hidden="true"></i>
+          <span>Available variants</span>
+        </div>
+        {% if include.versions %}
+          <!-- Multi-version structure: group by version -->
+          {% for version in include.versions %}
+          <div class="version-group">
+            <div class="version-label">{{ version.base_tag | default: version.tag }}</div>
+            <div class="variant-tags">
+              {% for variant in version.variants %}
+                {%- comment -%}
+                  Versions-only containers synthesize a single variant with empty
+                  `name` (the version itself IS the canonical build). Render the
+                  tag with `display:none` so it stays invisible (the version-label
+                  identifies the build) while preserving its data-* attributes
+                  and `.selected` class — the trust-strip JS and detail-page
+                  container-detail.js both initialize from .variant-tag.selected
+                  and would lose data for the canonical build if the element were
+                  skipped entirely.
+                {%- endcomment -%}
+                {%- assign synthetic = false -%}
+                {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
+                <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
+                      {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
+                      title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
+                      data-tag="{{ variant.tag }}"
+                      data-size-amd64="{{ variant.size_amd64 | default: '' }}"
+                      data-size-arm64="{{ variant.size_arm64 | default: '' }}"
+                      {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
+                      {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif %}
+                      {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif %}
+                      {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif %}
+                      role="button"
+                      tabindex="0"
+                      aria-pressed="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
+                      aria-label="Select variant {{ variant.name }}{% if variant.is_default %} (default){% endif %}">
+                  :{{ variant.name }}
+                  {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
+                </span>
+              {% endfor %}
+            </div>
+          </div>
+          {% endfor %}
+        {% else %}
+          <!-- Single-version structure -->
+          <div class="variant-tags">
+            {% for variant in include.variants %}
+              <span class="variant-tag{% if forloop.first %} selected{% endif %}"
+                    title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
+                    data-tag="{{ variant.tag }}"
+                    data-size-amd64="{{ variant.size_amd64 | default: '' }}"
+                    data-size-arm64="{{ variant.size_arm64 | default: '' }}"
+                    {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
+                    {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif %}
+                    {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif %}
+                    {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif %}
+                    role="button"
+                    tabindex="0"
+                    aria-pressed="{% if forloop.first %}true{% else %}false{% endif %}"
+                    aria-label="Select variant {{ variant.tag }}{% if variant.is_default %} (default){% endif %}">
+                :{{ variant.tag }}
+                {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
+              </span>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    </section>
+    {% endif %}
 
-  <!-- Quick Links -->
-  <nav class="card-links" aria-label="Container links">
-    <a href="{{ '/container/' | append: include.name | append: '/' | relative_url }}"
-       class="card-link" title="View Details">
-      <i class="ti ti-info-circle" aria-hidden="true"></i> Details
-    </a>
-    <a href="https://github.com/{{ include.github_username }}/docker-containers/tree/master/{{ include.name }}"
-       class="card-link" target="_blank" rel="noopener noreferrer" title="View Source (opens in new tab)">
-      <i class="ti ti-folder" aria-hidden="true"></i> Source
-    </a>
-    <a href="https://ghcr.io/{{ include.github_username }}/{{ include.name }}"
-       class="card-link" target="_blank" rel="noopener noreferrer" title="GHCR Package (opens in new tab)">
-      <i class="ti ti-package" aria-hidden="true"></i> GHCR
-    </a>
-    <a href="https://hub.docker.com/r/{{ include.dockerhub_username }}/{{ include.name }}"
-       class="card-link" target="_blank" rel="noopener noreferrer" title="Docker Hub (opens in new tab)">
-      <i class="ti ti-brand-docker" aria-hidden="true"></i> Hub
-    </a>
-  </nav>
-</article>
+    <!-- Footer links -->
+    <div class="body-footer">
+      <a href="{{ '/container/' | append: include.name | append: '/' | relative_url }}">
+        <i class="ti ti-eye" aria-hidden="true"></i> Detail page
+      </a>
+      <a href="{{ '/verify-images/' | relative_url }}">
+        <i class="ti ti-shield" aria-hidden="true"></i> Verify image
+      </a>
+      <a href="https://github.com/{{ include.github_username }}/docker-containers/tree/master/{{ include.name }}"
+         target="_blank" rel="noopener noreferrer">
+        <i class="ti ti-brand-github" aria-hidden="true"></i> Source
+      </a>
+      {%- if include.dependency_monitoring.enabled -%}
+      <a href="{{ include.upstream_monitor_url }}" rel="noopener" title="View the daily upstream-monitor workflow runs">
+        🔗 {{ include.dependency_monitoring.monitored }}/{{ include.dependency_monitoring.total }} deps tracked
+      </a>
+      {%- endif -%}
+    </div>
+
+  </div>
+</details>

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -103,8 +103,8 @@
     }
 
     /* Light theme: glass surfaces, hover states, inputs */
-    [data-theme="light"] .container-card:hover {
-      background: rgba(255, 255, 255, 0.9);
+    [data-theme="light"] .row-summary:hover {
+      background: rgba(0, 0, 0, 0.04);
     }
     [data-theme="light"] .stat-card:hover {
       background: rgba(255, 255, 255, 0.9);
@@ -313,7 +313,6 @@
 
     /* No results message */
     .no-results {
-      grid-column: 1 / -1;
       text-align: center;
       padding: 3rem;
       color: var(--text-muted);
@@ -400,145 +399,196 @@
       gap: 0.75rem;
     }
 
-    /* Section title */
+    /* Section title — mono eyebrow (D1 polish) */
     .section-title {
-      font-size: 1.25rem;
-      font-weight: 600;
-      margin-bottom: 1.5rem;
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.5rem;
+      margin: 2.25rem 0 1rem;
+      font-size: 0.78rem;
+      font-weight: 500;
+      color: var(--color-text-muted);
+      font-family: var(--font-family-mono);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
+    .section-title i { font-size: 1rem; }
 
-    /* Container cards grid */
+    /* Container rows — flex column replacing the old card grid */
     .cards-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-      gap: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
       margin-bottom: 2rem;
     }
 
-    /* Container card */
+    /* Container card — <details> wrapper */
     .container-card {
-      padding: 1.5rem;
-      transition: all 0.3s ease;
-      position: relative;
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 10px;
+      background: var(--color-surface-raised);
       overflow: hidden;
+      transition: border-color 150ms ease;
+    }
+
+    .container-card[open] {
+      border-color: var(--color-action-primary);
+    }
+
+    /* Row summary — the always-visible clickable header */
+    .row-summary {
+      display: grid;
+      grid-template-columns: 36px minmax(140px, 1fr) auto auto auto 24px;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.7rem 1rem;
+      cursor: pointer;
+      list-style: none;
+    }
+
+    /* Hide the native details marker in all browsers */
+    .row-summary::-webkit-details-marker { display: none; }
+    .row-summary::marker { display: none; }
+
+    .row-summary:hover {
+      background: var(--color-surface-overlay);
+    }
+
+    /* Container icon */
+    .row-icon {
+      width: 32px;
+      height: 32px;
       display: flex;
-      flex-direction: column;
-      height: 100%;
-    }
-
-    .container-card::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 3px;
-      background: linear-gradient(90deg, var(--accent-green), var(--accent-blue));
-      opacity: 0;
-      transition: opacity 0.3s ease;
-    }
-
-    .container-card:hover {
-      transform: translateY(-4px);
-      background: rgba(255, 255, 255, 0.15);
-    }
-
-    .container-card:hover::before {
-      opacity: 1;
-    }
-
-    .container-card.status-green::before { background: var(--accent-green); opacity: 1; }
-    .container-card.status-warning::before { background: var(--accent-yellow); opacity: 1; }
-    .container-card.status-error::before { background: var(--accent-pink); opacity: 1; }
-
-    .card-header-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 1rem;
-    }
-
-    .card-name {
-      font-size: 1.125rem;
-      font-weight: 600;
-    }
-
-    .card-badge {
-      font-family: var(--font-family-mono);
-      font-size: 0.75rem;
-      padding: 0.25rem 0.625rem;
+      align-items: center;
+      justify-content: center;
       border-radius: 6px;
-      background: rgba(16, 185, 129, 0.2);
-      color: #34d399;
-      border: 1px solid rgba(16, 185, 129, 0.3);
+      background: var(--color-surface-overlay);
+      color: var(--color-trust-verify-fg);
+      font-size: 1rem;
+      flex-shrink: 0;
     }
 
-    .card-badge.warning {
-      background: rgba(245, 158, 11, 0.2);
-      color: #fbbf24;
-      border-color: rgba(245, 158, 11, 0.3);
+    /* Name + version column */
+    .row-id { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
+    .row-id-name { font-size: 0.95rem; font-weight: 600; }
+    .row-id-version {
+      font-family: var(--font-family-mono);
+      font-size: 0.72rem;
+      color: var(--color-feedback-success-fg);
+      letter-spacing: 0.02em;
+    }
+    .row-id-version.warn { color: var(--color-feedback-warning-fg); }
+
+    /* Trust badges column — compact sizing on rows */
+    .row-trust {
+      display: flex;
+      gap: 0.35rem;
+      flex-wrap: wrap;
+    }
+    .row-trust .trust-badge {
+      padding: 0.18rem 0.5rem;
+      font-size: 0.7rem;
     }
 
-    .card-status {
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      margin-bottom: 0.75rem;
+    /* Pull count + size column */
+    .row-stats {
+      display: flex;
+      gap: 1rem;
+      font-family: var(--font-family-mono);
+      font-size: 0.72rem;
+      color: var(--color-text-muted);
+      white-space: nowrap;
     }
+    .row-stats span i { margin-right: 0.25rem; }
 
-    .card-status i {
-      margin-right: 0.25rem;
+    /* Spacer keeps chevron aligned to the rightmost column */
+    .row-toggle-spacer { display: block; }
+
+    /* Chevron toggle */
+    .row-toggle {
+      color: var(--color-text-muted);
+      transition: transform 150ms ease;
+      flex-shrink: 0;
     }
+    .container-card[open] .row-toggle { transform: rotate(90deg); }
 
-    .card-meta {
+    /* Expanded body */
+    .row-body {
+      padding: 0.75rem 1rem 1rem 4rem;
+      border-top: 1px solid var(--color-border-subtle);
+      background: var(--color-surface-base);
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: 0.75rem;
-      margin-bottom: 1rem;
-      font-size: 0.8125rem;
-    }
-
-    .card-meta-item {
-      display: flex;
-      flex-direction: column;
-    }
-
-    .card-meta-label {
-      /* M3 fix: --color-text-secondary (#C7CCD4) → 9.1:1 on navy-950 — was rgba(255,255,255,0.5) */
+      gap: 1.25rem;
+      font-size: 0.875rem;
       color: var(--color-text-secondary);
-      font-size: var(--font-size-caption);
-      text-transform: uppercase;
-      letter-spacing: var(--letter-spacing-wide);
     }
 
-    .card-meta-value {
-      color: var(--text-secondary);
-    }
+    .row-body section { min-width: 0; }
 
-    .card-description {
-      font-size: 0.8125rem;
-      color: var(--text-muted);
-      line-height: 1.5;
-      margin-bottom: 1rem;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    /* Build lineage digest in card */
-    .card-lineage-digest {
+    .row-body section h3 {
       font-family: var(--font-family-mono);
-      font-size: 0.6875rem;
-      opacity: 0.8;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+      margin: 0 0 0.5rem;
+      font-weight: 500;
     }
 
-    /* Variants section */
-    .variants-section {
-      margin-bottom: 1rem;
+    .row-body p { margin: 0; line-height: 1.55; }
+
+    /* Variants section spans full row width */
+    .row-body-variants { grid-column: 1 / -1; }
+
+    /* Pull command — adapted for row-body context */
+    .pull-section {
+      /* no margin-top: auto — pull-section is now in a grid cell */
     }
+
+    .pull-input-group {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .pull-input {
+      flex: 1;
+      background: var(--color-surface-overlay);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 6px;
+      padding: 0.5rem 0.75rem;
+      font-family: var(--font-family-mono);
+      font-size: 0.75rem;
+      color: var(--color-text-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .copy-btn {
+      background: none;
+      border: 1px solid var(--color-border-subtle);
+      border-radius: 4px;
+      color: var(--color-text-muted);
+      padding: 0.25rem 0.5rem;
+      min-width: 44px;
+      min-height: 38px;
+      cursor: pointer;
+      font-size: 0.85em;
+      transition: color 150ms ease, border-color 150ms ease;
+    }
+
+    .copy-btn:hover {
+      color: var(--color-action-primary);
+      border-color: var(--color-action-primary);
+    }
+
+    .copy-btn.copied {
+      color: var(--color-feedback-success-fg);
+      border-color: var(--color-feedback-success-fg);
+    }
+
+    /* Variants section inside row-body */
+    .variants-section { margin-bottom: 0; }
 
     .variants-header {
       display: flex;
@@ -546,7 +596,7 @@
       gap: 0.5rem;
       margin-bottom: 0.5rem;
       font-size: 0.75rem;
-      color: var(--text-muted);
+      color: var(--color-text-muted);
     }
 
     .variant-tags {
@@ -555,21 +605,21 @@
       gap: 0.375rem;
     }
 
-    /* Variant tags - WCAG 2.1 AA compliant (4.5:1 contrast) + 44px touch target */
+    /* Variant tags — WCAG 2.1 AA compliant (4.5:1 contrast) + 44px touch target */
     .variant-tag {
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
       font-family: var(--font-family-mono);
-      font-size: 0.6875rem;
-      padding: 0.5rem 0.625rem;
+      font-size: 0.7rem;
+      padding: 0.2rem 0.55rem;
       min-height: 44px;
       border-radius: 4px;
-      background: rgba(139, 92, 246, 0.25);
-      color: #e9d5ff;
-      border: 1px solid rgba(167, 139, 250, 0.4);
-      cursor: default;
-      transition: all 0.15s ease;
+      background: var(--color-surface-overlay);
+      color: var(--color-text-primary);
+      border: 1px solid var(--color-border-subtle);
+      cursor: pointer;
+      transition: border-color 150ms ease;
     }
 
     .variant-tag .badge {
@@ -588,9 +638,8 @@
     }
 
     .variant-tag.selected {
-      background: rgba(59, 130, 246, 0.4);
-      border-color: #60a5fa;
-      color: #bfdbfe;
+      border-color: var(--color-feedback-success-fg);
+      color: var(--color-feedback-success-fg);
     }
 
     /* Default pill indicated as a clickable reset target while a
@@ -609,122 +658,48 @@
     }
 
     .variant-tag:hover {
-      background: rgba(139, 92, 246, 0.35);
-      border-color: rgba(167, 139, 250, 0.6);
-      color: #f3e8ff;
+      border-color: var(--color-action-primary);
     }
 
     /* Version groups for multi-version containers */
-    .version-group {
-      margin-bottom: 0.5rem;
-    }
-
-    .version-group:last-child {
-      margin-bottom: 0;
-    }
+    .version-group { margin-bottom: 0.5rem; }
+    .version-group:last-child { margin-bottom: 0; }
 
     .version-label {
       font-size: 0.6875rem;
       font-weight: 600;
-      color: var(--text-muted);
+      color: var(--color-text-muted);
       margin-bottom: 0.25rem;
       padding-left: 0.125rem;
     }
 
-    /* Pull command */
-    .pull-section {
-      margin-top: auto;
-      margin-bottom: 1rem;
-      padding-top: 1rem;
-    }
-
-    .pull-header {
+    /* Footer action links */
+    .body-footer {
+      grid-column: 1 / -1;
       display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      margin-bottom: 0.5rem;
-      font-size: 0.75rem;
-      color: var(--text-muted);
-    }
-
-    .pull-select {
-      background: rgba(255, 255, 255, 0.1);
-      border: 1px solid var(--glass-border);
-      border-radius: 6px;
-      color: var(--text-primary);
-      font-size: 0.75rem;
-      padding: 0.25rem 0.5rem;
-      cursor: pointer;
-    }
-
-    .pull-select option {
-      background: #1a1a2e;
-      color: white;
-    }
-
-    .pull-input-group {
-      display: flex;
-      gap: 0.5rem;
-    }
-
-    .pull-input {
-      flex: 1;
-      background: rgba(0, 0, 0, 0.2);
-      border: 1px solid var(--glass-border);
-      border-radius: 8px;
-      padding: 0.5rem 0.75rem;
-      font-family: var(--font-family-mono);
-      font-size: 0.75rem;
-      color: var(--text-secondary);
-    }
-
-    .copy-btn {
-      background: rgba(255, 255, 255, 0.1);
-      border: 1px solid var(--glass-border);
-      border-radius: 8px;
-      padding: 0.5rem 0.75rem;
-      min-width: 44px;
-      min-height: 44px;
-      color: var(--text-secondary);
-      cursor: pointer;
-      transition: all 0.2s ease;
-    }
-
-    .copy-btn:hover {
-      background: rgba(255, 255, 255, 0.2);
-      color: var(--text-primary);
-    }
-
-    .copy-btn.copied {
-      background: rgba(16, 185, 129, 0.2);
-      border-color: var(--accent-green);
-      color: var(--accent-green);
-    }
-
-    /* Card links */
-    .card-links {
-      display: flex;
-      gap: 0.5rem;
+      gap: 0.6rem;
       flex-wrap: wrap;
+      padding-top: 0.75rem;
+      border-top: 1px solid var(--color-border-subtle);
+      margin-top: 0.25rem;
     }
 
-    .card-link {
+    .body-footer a {
       display: inline-flex;
       align-items: center;
-      gap: 0.375rem;
-      padding: 0.375rem 0.75rem;
-      font-size: 0.75rem;
+      gap: 0.3rem;
+      padding: 0.4rem 0.75rem;
       border-radius: 6px;
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      color: var(--text-secondary);
+      font-size: 0.8rem;
       text-decoration: none;
-      transition: all 0.2s ease;
+      border: 1px solid var(--color-border-subtle);
+      background: var(--color-surface-raised);
+      color: var(--color-text-primary);
+      transition: border-color 150ms ease;
     }
 
-    .card-link:hover {
-      background: rgba(255, 255, 255, 0.1);
-      color: var(--text-primary);
+    .body-footer a:hover {
+      border-color: var(--color-action-primary);
     }
 
     /* Activity section */
@@ -855,10 +830,6 @@
         grid-template-columns: repeat(2, 1fr);
       }
 
-      .cards-grid {
-        grid-template-columns: repeat(2, 1fr);
-      }
-
       .quick-actions-grid {
         grid-template-columns: repeat(2, 1fr);
       }
@@ -866,6 +837,39 @@
       .controls-row {
         flex-wrap: wrap;
         gap: 1rem;
+      }
+    }
+
+    /* Responsive - Tablets and small laptops (880px breakpoint matches mockup) */
+    @media (max-width: 880px) {
+      .stats-grid, .health-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      /* Row summary collapses: icon + id on first row, trust + stats on second */
+      .row-summary {
+        grid-template-columns: 32px 1fr;
+        gap: 0.6rem;
+      }
+
+      .row-summary > .row-trust,
+      .row-summary > .row-stats {
+        grid-column: 1 / -1;
+        padding-left: 44px;
+      }
+
+      .row-summary > .row-toggle-spacer { display: none; }
+
+      .row-summary > .row-toggle {
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: end;
+      }
+
+      /* Row body becomes single-column on mobile */
+      .row-body {
+        grid-template-columns: 1fr;
+        padding-left: 1rem;
       }
     }
 
@@ -877,10 +881,6 @@
 
       .stats-grid {
         grid-template-columns: repeat(2, 1fr);
-      }
-
-      .cards-grid {
-        grid-template-columns: 1fr;
       }
 
       .quick-actions-grid {
@@ -906,10 +906,6 @@
 
       .registry-toggle {
         flex-wrap: wrap;
-      }
-
-      .health-grid {
-        grid-template-columns: repeat(2, 1fr);
       }
     }
 
@@ -948,10 +944,6 @@
 
       .health-grid {
         grid-template-columns: 1fr;
-      }
-
-      .section-title {
-        font-size: 1rem;
       }
     }
 

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -36,18 +36,19 @@
     _updateSbom(url, id) {
       const el = this.querySelector('[data-trust="sbom"]');
       if (!el) return;
+      const isCardSurface = !!this.closest('.container-card');
       if (url && id) {
         el.setAttribute('href', url);
-        el.textContent = '📋 SBOM ATTESTED';
         el.title = "View Sigstore attestation for this image's SBOM";
         el.style.display = '';
         el.classList.remove('is-pending');
+        el.textContent = isCardSurface ? '📋 SBOM' : '📋 SBOM ATTESTED';
       } else {
         el.style.display = '';
         el.removeAttribute('href');
-        el.textContent = '📋 SBOM PENDING';
         el.classList.add('is-pending');
         el.title = 'SBOM attestation not yet generated. Will populate on next successful build with cosign attestation.';
+        el.textContent = isCardSurface ? '📋 SBOM' : '📋 SBOM PENDING';
       }
     }
 
@@ -83,7 +84,7 @@
       // hover-tooltip users.
       const isCardSurface = !!this.closest('.container-card');
       if (isCardSurface) {
-        el.textContent = '🛡 TRIVY: ' + displayCount + (compactLabel ? ' ' + compactLabel : '');
+        el.textContent = '🛡 ' + displayCount + (compactLabel ? ' ' + compactLabel : '');
       } else {
         el.textContent = '🛡 TRIVY: ' + displayCount + ' ' + ariaSeverity + ' (advisory) · SCANNED ' + date;
       }
@@ -102,12 +103,19 @@
         el.setAttribute('aria-hidden', 'true');
         return;
       }
-      // Fix #8/#9: brand-voice uppercase — matches Liquid initial state ("AMD64 + ARM64").
+      // Card surface: compact count format (e.g. "🏗 ×2") — matches Liquid card output.
+      // Detail surface: full format (e.g. "🏗 AMD64 + ARM64").
       // Defensively strip "os/" prefix (e.g. "linux/amd64" → "amd64") before uppercasing.
-      el.textContent = '🏗 ' + platforms.map(function(p) {
+      const isCardSurface = !!this.closest('.container-card');
+      const archNames = platforms.map(function(p) {
         var arch = p.includes('/') ? p.split('/').pop() : p;
         return arch.toUpperCase();
-      }).join(' + ');
+      });
+      el.textContent = isCardSurface
+        ? '🏗 ×' + platforms.length
+        : '🏗 ' + archNames.join(' + ');
+      el.title = 'Multi-arch manifest: ' + platforms.join(', ');
+      el.setAttribute('aria-label', 'Multi-arch: ' + archNames.join(', '));
       el.style.display = '';
       el.removeAttribute('aria-hidden');
     }


### PR DESCRIPTION
## Summary

Replaces the dashboard's card grid with a row-per-container layout built on native HTML `<details>/<summary>`. The summary keeps the trust strip + stats front-of-house so visitors scan the fleet's verification posture without expanding anything; the body reveals description, pull command, full variant list, and source links on demand.

Visual contract validated against the interactive mockup at `final-dashboard.html` (locally, mockup server retired after merge).

### What landed

- **`_includes/container-card.html` — rewritten** as `<details class="container-card">` with a `<summary class="row-summary">` that holds the icon, name + version, trust strip, stats, and a rotating chevron. The `.container-card` class stays on the wrapper so every existing JS path (search filter, variant tag click, copy button, registry toggle) keeps working — **zero JS rewrite required for hydration**.
- **`assets/css/dashboard.css` — cards section replaced**: 36 px icon, name/version stack, compact trust-strip, mono stat span, chevron rotation on `[open]`, body grid at desktop and single-column at `≤ 880 px`. The `.section-title` selector is reskinned as a mono eyebrow (uppercase, 0.06 em letter-spacing) to match the new visual register without touching `index.html`.
- **`assets/js/components/trust-strip.js` — surface-aware updates**: `_updateSbom`, `_updateTrivy`, `_updateMultiArch` now branch on `isCardSurface = !!this.closest('.container-card')` and emit the compact format on dashboard rows (`📋 SBOM` · `🛡 N CRIT` · `🏗 ×N`) versus the full format on the detail page (`📋 SBOM ATTESTED` · `🛡 TRIVY: N CRIT (advisory) · SCANNED YYYY-MM-DD` · `🏗 AMD64 + ARM64`). Both paths stay byte-identical to the matching Liquid initial render — no visual flicker on variant click.
- **Row sub-headings** use `<h3>` (About, Pull command, Variants) so page heading flow runs `<h1>` (hero) → `<h2>` (section title) → `<h3>` (row body), no skip — passes WCAG 1.3.1.
- **`.variant-tag` keeps the 44 px touch target** (WCAG 2.5.5) — the row body styling no longer shrinks pills to 32 px.
- **Size span gains `data-meta="size-amd64"`** so `selectVariantTag()` keeps updating the visible size on variant click instead of leaving stale metadata.
- **Row version label prefers `current_version`** over `default_variant.tag`. Containers whose first variant is a base variant (e.g. terraform's `1.15.0-alpine-base`) now advertise the canonical published default (`1.15.0-alpine`).
- **Hidden description carrier dropped**: the visible `<p>{{ description }}</p>` now carries `class="card-description"` directly — single source of truth for both the user and `applyFilters()` JS search.

### Net diff: 3 files, +438 / −486 (net −48 LOC)

## Test plan

- [ ] CI passes (CodeQL, Jekyll build via update-dashboard.yaml)
- [ ] Live deploy: dashboard renders 13 row-cards with the trust strip visible on each row, no expand needed
- [ ] Live deploy: clicking any row expands inline showing About + Pull command + Variants (when present) + Detail/Verify/Source action links
- [ ] Live deploy: clicking a variant pill on a multi-version card (postgres) keeps the row open, updates trust strip, pull command, size — no visual flicker
- [ ] Live deploy: search box filters rows by container name, description, and variant tag names
- [ ] Live deploy: status filter (`Up to date` / `Updates available`) filters rows correctly
- [ ] Live deploy: registry toggle (GHCR ↔ Docker Hub) updates pull commands inside the expanded body
- [ ] Live deploy: `terraform` row shows `1.15.0-alpine` (current_version) — not `1.15.0-alpine-base` (first variant)
- [ ] Live deploy: dashboard heading flow has exactly one `<h1>` (hero); axe-core / Lighthouse a11y reports no heading-order warnings
- [ ] Live deploy: keyboard tab to a row, press Enter — row expands. Press Enter again — collapses. Focus stays on the summary.
- [ ] Mobile (≤ 768 px): rows stack cleanly, trust strip wraps to second line, body collapses to single column
- [ ] No regression on PR-A SBOM 2-state, PR-D heading hierarchy / ARIA, PR-F token discipline, PR-H reset affordance, PR #381 Trivy severity tracking
- [ ] Light-mode visual check is queued separately (TODO.local.md) — not gating this merge
