### PR TITLE
feat(verify): tabbed reference + walkthrough with code copy and sticky TOC

### DIFF
--- a/docs/site/_includes/components/verify-walkthrough.html
+++ b/docs/site/_includes/components/verify-walkthrough.html
@@ -22,7 +22,7 @@
           <div class="code-block__header">
             <span class="code-block__lang">bash</span>
             <button class="code-block__copy" type="button" data-copy-button
-                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+                    aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
           </div>
           <pre><code><span class="prompt">$</span> gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona</code></pre>
         </div>
@@ -39,7 +39,7 @@
           <div class="code-block__header">
             <span class="code-block__lang">bash</span>
             <button class="code-block__copy" type="button" data-copy-button
-                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+                    aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
           </div>
           <pre><code><span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts \
   --paginate \
@@ -58,7 +58,7 @@
           <div class="code-block__header">
             <span class="code-block__lang">bash</span>
             <button class="code-block__copy" type="button" data-copy-button
-                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+                    aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
           </div>
           <pre><code><span class="prompt">$</span> docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;</code></pre>
         </div>
@@ -75,7 +75,7 @@
           <div class="code-block__header">
             <span class="code-block__lang">bash</span>
             <button class="code-block__copy" type="button" data-copy-button
-                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+                    aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
           </div>
           <pre><code><span class="prompt">$</span> git clone https://github.com/oorabona/docker-containers.git
 <span class="prompt">$</span> cd docker-containers

--- a/docs/site/_includes/components/verify-walkthrough.html
+++ b/docs/site/_includes/components/verify-walkthrough.html
@@ -1,0 +1,120 @@
+{%- comment -%}
+  verify-walkthrough.html — four-step guided walkthrough for the verify page.
+  Rendered in the Walkthrough tabpanel. Uses the same .code-block convention
+  as the Reference view so copy buttons work with the same JS handler.
+{%- endcomment -%}
+
+<div class="verify-walkthrough">
+
+  <header class="verify-walkthrough__hero">
+    <span class="verify-walkthrough__eyebrow">Verification walkthrough</span>
+    <p class="verify-walkthrough__lead">Four steps that take you from a published image digest to a verified SBOM, scanned CVE inventory, and locally-rebuilt container.</p>
+  </header>
+
+  <ol class="verify-step-list" aria-label="Verification steps">
+
+    <li class="verify-step">
+      <div class="verify-step__num" aria-hidden="true">1</div>
+      <div class="verify-step__body">
+        <h2 class="verify-step__title">Verify the SBOM attestation</h2>
+        <p class="verify-step__summary">Each SBOM is signed via Sigstore (<code>actions/attest-sbom</code>) and anchored to the image digest. The attestation lives in GitHub's public attestations API — no auth needed.</p>
+        <div class="code-block" data-copy="gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona">
+          <div class="code-block__header">
+            <span class="code-block__lang">bash</span>
+            <button class="code-block__copy" type="button" data-copy-button
+                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+          </div>
+          <pre><code><span class="prompt">$</span> gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona</code></pre>
+        </div>
+        <p>The SBOM badge on each container card opens the public attestation viewer in your browser — SBOM payload, Sigstore bundle, and signing certificate chain visible without login.</p>
+      </div>
+    </li>
+
+    <li class="verify-step">
+      <div class="verify-step__num" aria-hidden="true">2</div>
+      <div class="verify-step__body">
+        <h2 class="verify-step__title">Read the Trivy scan results</h2>
+        <p class="verify-step__summary">Trivy scans run on every build in advisory mode. Results land in GitHub's Code Scanning API and are queryable with any authenticated <code>gh</code> session — no special scope required.</p>
+        <div class="code-block" data-copy="gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'">
+          <div class="code-block__header">
+            <span class="code-block__lang">bash</span>
+            <button class="code-block__copy" type="button" data-copy-button
+                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+          </div>
+          <pre><code><span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts \
+  --paginate \
+  -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'</code></pre>
+        </div>
+        <p>To filter to a single variant, match on the <code>category</code> field — it encodes the container name and platform (e.g. <code>container-postgres-18-alpine-linux/amd64</code>). The dashboard surfaces only CRITICAL counts; everything else is accessible through the API call above.</p>
+      </div>
+    </li>
+
+    <li class="verify-step">
+      <div class="verify-step__num" aria-hidden="true">3</div>
+      <div class="verify-step__body">
+        <h2 class="verify-step__title">Inspect the multi-arch manifest</h2>
+        <p class="verify-step__summary">Multi-arch images publish a manifest list referencing per-platform image manifests. To see the published architectures of any tag:</p>
+        <div class="code-block" data-copy="docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;">
+          <div class="code-block__header">
+            <span class="code-block__lang">bash</span>
+            <button class="code-block__copy" type="button" data-copy-button
+                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+          </div>
+          <pre><code><span class="prompt">$</span> docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;</code></pre>
+        </div>
+        <p>Look at the <code>manifests</code> array — each entry's <code>platform.architecture</code> reveals the published architectures. The architecture badge on each container card reflects this inspection at build time.</p>
+      </div>
+    </li>
+
+    <li class="verify-step">
+      <div class="verify-step__num" aria-hidden="true">4</div>
+      <div class="verify-step__body">
+        <h2 class="verify-step__title">Reproduce the build locally</h2>
+        <p class="verify-step__summary">Every container is built by shell scripts with no opaque CI steps. Clone the repo and run the same entry point the pipeline uses:</p>
+        <div class="code-block" data-copy="git clone https://github.com/oorabona/docker-containers.git&#10;cd docker-containers&#10;./make build &lt;container&gt; [version]">
+          <div class="code-block__header">
+            <span class="code-block__lang">bash</span>
+            <button class="code-block__copy" type="button" data-copy-button
+                    aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+          </div>
+          <pre><code><span class="prompt">$</span> git clone https://github.com/oorabona/docker-containers.git
+<span class="prompt">$</span> cd docker-containers
+<span class="prompt">$</span> ./make build &lt;container&gt; [version]</code></pre>
+        </div>
+        <p>BuildKit must be enabled (<code>DOCKER_BUILDKIT=1</code> or Docker 23+). Compare the resulting digest against the dashboard's published digest to confirm reproducibility.</p>
+      </div>
+    </li>
+
+  </ol>
+
+  <section class="verify-faq" aria-labelledby="faq-heading">
+    <h2 id="faq-heading" class="verify-faq__heading">Frequently asked questions</h2>
+
+    <details class="verify-faq__item">
+      <summary>Why does the dashboard show "Trivy scan results are advisory"?</summary>
+      <p>Trivy runs as <code>continue-on-error</code> in CI. The build does not fail when CVEs are detected; it surfaces the count for the operator to triage. Use the count as input to your image-acceptance policy, not as a blocking gate.</p>
+    </details>
+
+    <details class="verify-faq__item">
+      <summary>What does the SBOM badge state mean?</summary>
+      <p><strong>ATTESTED</strong> means both <code>attestation_url</code> and <code>attestation_id</code> are present in the published lineage record — the SBOM has been signed via Sigstore and is verifiable. <strong>PENDING</strong> covers all other cases and indicates the image will be re-attested on the next successful build.</p>
+    </details>
+
+    <details class="verify-faq__item">
+      <summary>How is the SBOM signed?</summary>
+      <p>Each successful build runs <code>anchore/sbom-action</code> to generate an SPDX JSON SBOM, then <code>actions/attest-sbom</code> signs it via Sigstore (keyless, OIDC-based) and uploads the attestation to GHCR. Verify with <code>gh attestation verify oci://ghcr.io/oorabona/&lt;image&gt;:&lt;tag&gt; --owner oorabona</code>.</p>
+    </details>
+
+    <details class="verify-faq__item">
+      <summary>Can I trust a container that shows "SBOM PENDING"?</summary>
+      <p>It is not a security flag. PENDING means the build pipeline has not yet re-run since the image was published, or the attestation pipeline hit a transient failure that will be retried. Pull by digest from a previous attested build if you need verifiable SBOM provenance immediately.</p>
+    </details>
+
+    <details class="verify-faq__item">
+      <summary>How fresh are the Trivy scan dates shown on the dashboard?</summary>
+      <p>The "SCANNED YYYY-MM-DD" timestamp on each Trivy badge reflects the most recent successful Trivy run for the corresponding image variant. Scans run on every build; if a container has not been rebuilt for an extended period, the date will reflect that staleness.</p>
+    </details>
+
+  </section>
+
+</div>

--- a/docs/site/_layouts/verify.html
+++ b/docs/site/_layouts/verify.html
@@ -14,7 +14,7 @@ layout: page
     <button id="tab-reference" role="tab" aria-selected="true" aria-controls="view-reference"
             data-view="reference" tabindex="0">Reference</button>
     <button id="tab-walkthrough" role="tab" aria-selected="false" aria-controls="view-walkthrough"
-            data-view="walkthrough" tabindex="-1">Walkthrough</button>
+            data-view="walkthrough" tabindex="0">Walkthrough</button>
   </nav>
 
   <div class="verify-layout">

--- a/docs/site/_layouts/verify.html
+++ b/docs/site/_layouts/verify.html
@@ -1,0 +1,56 @@
+---
+layout: page
+---
+{%- comment -%}
+  verify.html — chains layout: page, wraps content in tab + sticky-TOC structure.
+  Reference view is the default (no-JS fallback = Reference, tabs visible but inert).
+  Walkthrough view is toggled by code-copy.js reading ?view=walkthrough.
+{%- endcomment -%}
+
+<div class="verify-page">
+
+  {%- comment -%} Tab switcher — sticky under site-nav {%- endcomment -%}
+  <nav class="verify-tabs" role="tablist" aria-label="Verification documentation views">
+    <button id="tab-reference" role="tab" aria-selected="true" aria-controls="view-reference"
+            data-view="reference" tabindex="0">Reference</button>
+    <button id="tab-walkthrough" role="tab" aria-selected="false" aria-controls="view-walkthrough"
+            data-view="walkthrough" tabindex="-1">Walkthrough</button>
+  </nav>
+
+  <div class="verify-layout">
+
+    <main class="verify-main">
+
+      {%- comment -%} Reference panel — receives the page body via {{ content }} {%- endcomment -%}
+      <section id="view-reference" role="tabpanel" data-view="reference"
+               aria-labelledby="tab-reference">
+        {{ content }}
+      </section>
+
+      {%- comment -%} Walkthrough panel — 4 numbered steps + FAQ {%- endcomment -%}
+      <section id="view-walkthrough" role="tabpanel" data-view="walkthrough"
+               aria-labelledby="tab-walkthrough" hidden>
+        {% include components/verify-walkthrough.html %}
+      </section>
+
+    </main>
+
+    {%- comment -%} Sticky right-side TOC (Reference view only; collapses < 1024px) {%- endcomment -%}
+    <aside class="verify-toc-sticky" aria-label="Reference sections">
+      <h4 class="verify-toc-sticky__heading">On this page</h4>
+      <ul class="verify-toc-sticky__list">
+        <li><a href="#why-this-page-exists">Why this page</a></li>
+        <li><a href="#verifying-the-sbom-attestation">SBOM attestation</a></li>
+        <li><a href="#reading-trivy-scan-results">Trivy scan results</a></li>
+        <li><a href="#inspecting-multi-arch-manifests">Multi-arch manifests</a></li>
+        <li><a href="#auditing-dependency-monitoring">Dependency monitoring</a></li>
+        <li><a href="#reproducing-builds-locally">Reproduce builds locally</a></li>
+        <li><a href="#frequently-asked-questions">FAQ</a></li>
+      </ul>
+    </aside>
+
+  </div>
+
+</div>
+
+<script src="{{ '/assets/js/code-copy.js' | relative_url }}" defer></script>

--- a/docs/site/_layouts/verify.html
+++ b/docs/site/_layouts/verify.html
@@ -10,30 +10,28 @@ layout: page
 <div class="verify-page">
 
   {%- comment -%} Tab switcher — sticky under site-nav {%- endcomment -%}
-  <nav class="verify-tabs" role="tablist" aria-label="Verification documentation views">
-    <button id="tab-reference" role="tab" aria-selected="true" aria-controls="view-reference"
-            data-view="reference" tabindex="0">Reference</button>
-    <button id="tab-walkthrough" role="tab" aria-selected="false" aria-controls="view-walkthrough"
-            data-view="walkthrough" tabindex="0">Walkthrough</button>
+  <nav class="verify-tabs" aria-label="Verification documentation views">
+    <button id="tab-reference" type="button" data-view="reference">Reference</button>
+    <button id="tab-walkthrough" type="button" data-view="walkthrough">Walkthrough</button>
   </nav>
 
   <div class="verify-layout">
 
-    <main class="verify-main">
+    <div class="verify-main">
 
       {%- comment -%} Reference panel — receives the page body via {{ content }} {%- endcomment -%}
-      <section id="view-reference" role="tabpanel" data-view="reference"
-               aria-labelledby="tab-reference">
+      <section id="view-reference" data-view="reference">
         {{ content }}
       </section>
 
       {%- comment -%} Walkthrough panel — 4 numbered steps + FAQ {%- endcomment -%}
-      <section id="view-walkthrough" role="tabpanel" data-view="walkthrough"
-               aria-labelledby="tab-walkthrough" hidden>
+      {%- comment -%} No hidden attr server-side: progressive enhancement — JS adds role="tabpanel",
+          aria-labelledby, and [hidden] on init. With JS off, both panels are visible. {%- endcomment -%}
+      <section id="view-walkthrough" data-view="walkthrough">
         {% include components/verify-walkthrough.html %}
       </section>
 
-    </main>
+    </div>
 
     {%- comment -%} Sticky right-side TOC (Reference view only; collapses < 1024px) {%- endcomment -%}
     <aside class="verify-toc-sticky" aria-label="Reference sections">

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -846,7 +846,8 @@ body {
   background: var(--color-surface-raised);
 }
 
-.verify-tabs button[aria-selected="true"] {
+.verify-tabs button[aria-selected="true"],
+.verify-tabs button.is-active {
   color: var(--color-trust-verify-fg);
   background: var(--color-surface-raised);
   border: 1px solid var(--color-border-subtle);
@@ -889,18 +890,6 @@ body {
   scroll-margin-top: 80px;
 }
 
-/* Explicit reset: walkthrough step titles must NOT inherit the mono-eyebrow style */
-.verify-step__title {
-  font-family: inherit;
-  font-size: 1.2rem;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--color-text-primary);
-  border-bottom: none;
-  margin: 0 0 0.5rem;
-  padding-bottom: 0;
-}
 
 /* Trust-domain hue overrides: SBOM = teal, multi-arch section = violet */
 #view-reference h2#verifying-the-sbom-attestation,
@@ -1158,11 +1147,16 @@ body {
 }
 
 .verify-step__title {
+  font-family: inherit;
   font-size: 1.2rem;
   font-weight: var(--font-weight-semibold);
-  margin: 0 0 0.5rem;
-  line-height: 1.3;
+  letter-spacing: normal;
+  text-transform: none;
   color: var(--color-text-primary);
+  border-bottom: none;
+  margin: 0 0 0.5rem;
+  padding-bottom: 0;
+  line-height: 1.3;
 }
 
 .verify-step__summary {

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -236,7 +236,7 @@ body {
   min-height: 100vh;
   /* 3% noise overlay + navy gradient (refined-authoritative-proof-forward aesthetic) */
   background:
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.9'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.03'/></svg>"),
+    url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'200'%20height%3D'200'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20baseFrequency%3D'0.9'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'100%25'%20height%3D'100%25'%20filter%3D'url(%23n)'%20opacity%3D'0.03'%2F%3E%3C%2Fsvg%3E"),
     linear-gradient(135deg, var(--color-navy-950) 0%, var(--color-navy-900) 50%, var(--color-navy-700) 100%);
   background-attachment: fixed;
   background-size: 200px 200px, 100% 100%;
@@ -248,7 +248,7 @@ body {
 
 [data-theme="light"] body {
   background:
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.9'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.03'/></svg>"),
+    url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'200'%20height%3D'200'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20baseFrequency%3D'0.9'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'100%25'%20height%3D'100%25'%20filter%3D'url(%23n)'%20opacity%3D'0.03'%2F%3E%3C%2Fsvg%3E"),
     linear-gradient(135deg, var(--bg-gradient-1) 0%, var(--bg-gradient-2) 50%, var(--bg-gradient-3) 100%);
   background-attachment: fixed;
   background-size: 200px 200px, 100% 100%;
@@ -1230,8 +1230,8 @@ body {
   height: 16px;
   flex-shrink: 0;
   background: var(--color-text-muted);
-  -webkit-mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>') no-repeat center / contain;
-  mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>') no-repeat center / contain;
+  -webkit-mask: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%2F%3E%3C%2Fsvg%3E') no-repeat center / contain;
+  mask: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%2F%3E%3C%2Fsvg%3E') no-repeat center / contain;
   transition: transform var(--motion-duration-normal) var(--easing-standard);
 }
 

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -743,6 +743,11 @@ body {
   font-size: 1rem;
 }
 
+/* Verify page needs wider content area to accommodate 2-column grid (main + 220px TOC + 3rem gap) */
+.page-content:has(.verify-page) {
+  max-width: 1100px;
+}
+
 .page-content article h1 {
   font-size: clamp(1.85rem, 4.5vw, 2.5rem);
   line-height: 1.15;
@@ -797,3 +802,488 @@ body {
     padding: 5rem 1rem 2rem;
   }
 }
+
+/* ===== Verify page ===== */
+/* All selectors scoped under .verify-page to prevent cascade bleed.
+   Tokens referenced are from tokens.css (loaded first). */
+
+/* ----- Page container ----- */
+
+.verify-page {
+  width: 100%;
+}
+
+/* ----- Tab switcher ----- */
+
+.verify-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0.75rem 0 0;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.verify-tabs button {
+  font-family: var(--font-family-mono);
+  font-size: 0.8rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+  padding: 0.45rem 1rem;
+  border: none;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color var(--motion-duration-short) var(--easing-standard),
+              background var(--motion-duration-short) var(--easing-standard);
+  position: relative;
+  bottom: -1px;
+}
+
+.verify-tabs button:hover {
+  color: var(--color-text-secondary);
+  background: var(--color-surface-raised);
+}
+
+.verify-tabs button[aria-selected="true"] {
+  color: var(--color-trust-verify-fg);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-bottom-color: var(--color-surface-raised);
+}
+
+.verify-tabs button:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+}
+
+/* ----- Grid layout: main + sticky TOC ----- */
+
+.verify-layout {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+  gap: 3rem;
+  align-items: start;
+}
+
+/* ----- Reference main content ----- */
+
+.verify-main {
+  min-width: 0; /* prevent grid overflow */
+}
+
+/* Section headings: mono eyebrow style (design spec Phase C) */
+/* Scoped to Reference panel only (id specificity 0,2,1 beats .page-content article h2 at 0,1,2).
+   :not(.verify-step__title) prevents bleed into Walkthrough step card headings. */
+#view-reference h2:not(.verify-step__title) {
+  font-family: var(--font-family-mono);
+  font-size: 0.78rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 2.75rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  scroll-margin-top: 80px;
+}
+
+/* Explicit reset: walkthrough step titles must NOT inherit the mono-eyebrow style */
+.verify-step__title {
+  font-family: inherit;
+  font-size: 1.2rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--color-text-primary);
+  border-bottom: none;
+  margin: 0 0 0.5rem;
+  padding-bottom: 0;
+}
+
+/* Trust-domain hue overrides: SBOM = teal, multi-arch section = violet */
+#view-reference h2#verifying-the-sbom-attestation,
+#view-reference h2[id*="sbom"] {
+  color: var(--color-trust-sbom-fg);
+}
+
+#view-reference h2#inspecting-multi-arch-manifests,
+#view-reference h2[id*="multi-arch"] {
+  color: var(--color-trust-multiarch-fg);
+}
+
+.verify-main h3 {
+  font-size: 1.05rem;
+  font-weight: var(--font-weight-semibold);
+  margin: 1.75rem 0 0.5rem;
+  scroll-margin-top: 80px;
+  color: var(--color-text-primary);
+}
+
+.verify-main p {
+  line-height: 1.65;
+  color: var(--color-text-secondary);
+  margin: 0 0 1rem;
+  max-width: 65ch;
+}
+
+.verify-main p strong,
+.verify-main p code {
+  color: var(--color-text-primary);
+}
+
+.verify-main ul,
+.verify-main ol {
+  line-height: 1.65;
+  color: var(--color-text-secondary);
+  padding-left: 1.4rem;
+  margin: 0 0 1rem;
+  max-width: 65ch;
+}
+
+.verify-main p code,
+.verify-main ul code,
+.verify-main li code {
+  font-family: var(--font-family-mono);
+  font-size: 0.85em;
+  background: var(--color-surface-raised);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+}
+
+/* ----- Terminal chrome (.code-block) ----- */
+
+.code-block {
+  margin: 1rem 0 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-raised);
+  overflow: hidden;
+}
+
+.code-block__header {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.85rem;
+  background: var(--color-surface-overlay);
+  border-bottom: 1px solid var(--color-border-subtle);
+  font-family: var(--font-family-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.code-block__lang {
+  flex: 1;
+}
+
+.code-block__copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem 0.65rem;
+  min-height: 24px;
+  min-width: 24px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  transition: color var(--motion-duration-instant) var(--easing-standard),
+              border-color var(--motion-duration-instant) var(--easing-standard);
+}
+
+.code-block__copy:hover {
+  color: var(--color-action-primary);
+  border-color: var(--color-action-primary);
+}
+
+.code-block__copy.is-copied {
+  color: var(--color-feedback-success-fg);
+  border-color: var(--color-feedback-success-fg);
+}
+
+.code-block__copy i {
+  font-size: 0.85rem;
+}
+
+.code-block pre {
+  margin: 0;
+  padding: 1rem 0.85rem;
+  font-family: var(--font-family-mono);
+  font-size: 0.825rem;
+  line-height: 1.55;
+  color: var(--color-text-primary);
+  overflow-x: auto;
+  background: transparent;
+}
+
+.code-block pre code {
+  display: block;
+}
+
+/* Shell prompt — green, excluded from copy via JS */
+.code-block .prompt {
+  color: var(--color-feedback-success-fg);
+  user-select: none;
+}
+
+/* Inline comment spans within code blocks — replaces style="color: var(--color-text-muted)" */
+.code-block .comment {
+  color: var(--color-text-muted);
+}
+
+/* ----- Sticky TOC (right sidebar) ----- */
+
+.verify-toc-sticky {
+  position: sticky;
+  top: 80px;
+  align-self: start;
+  padding-top: 0.25rem;
+}
+
+/* Walkthrough view: TOC anchors are Reference-only — hide the sidebar and collapse to 1-col */
+.verify-layout[data-view="walkthrough"] .verify-toc-sticky {
+  display: none;
+}
+
+.verify-layout[data-view="walkthrough"] {
+  grid-template-columns: 1fr;
+}
+
+.verify-toc-sticky__heading {
+  font-family: var(--font-family-mono);
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0 0 0.85rem;
+}
+
+.verify-toc-sticky__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.verify-toc-sticky__list a {
+  display: block;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  transition: color var(--motion-duration-instant) var(--easing-standard),
+              border-color var(--motion-duration-instant) var(--easing-standard);
+}
+
+.verify-toc-sticky__list a:hover {
+  color: var(--color-text-primary);
+  border-left-color: var(--color-text-muted);
+}
+
+/* ----- Walkthrough view ----- */
+
+.verify-walkthrough {
+  padding-bottom: 3rem;
+}
+
+.verify-walkthrough__hero {
+  padding: 1.5rem 0 1rem;
+}
+
+.verify-walkthrough__eyebrow {
+  display: inline-block;
+  font-family: var(--font-family-mono);
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-trust-verify-fg);
+  margin-bottom: 0.75rem;
+}
+
+.verify-walkthrough__lead {
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* Step list */
+.verify-step-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.verify-step {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-raised);
+}
+
+.verify-step__num {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-overlay);
+  color: var(--color-trust-verify-fg);
+  font-family: var(--font-family-mono);
+  font-weight: var(--font-weight-semibold);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.verify-step__title {
+  font-size: 1.2rem;
+  font-weight: var(--font-weight-semibold);
+  margin: 0 0 0.5rem;
+  line-height: 1.3;
+  color: var(--color-text-primary);
+}
+
+.verify-step__summary {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0 0 1rem;
+  max-width: 65ch;
+}
+
+.verify-step__body p:not(.verify-step__summary) {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.55;
+  margin: 0.85rem 0 0;
+  max-width: 65ch;
+}
+
+.verify-step__body p code,
+.verify-step__body li code {
+  font-family: var(--font-family-mono);
+  font-size: 0.85em;
+  background: var(--color-surface-overlay);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+}
+
+/* FAQ accordion */
+.verify-faq {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.verify-faq__heading {
+  font-family: var(--font-family-mono);
+  font-size: 0.78rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0 0 1rem;
+}
+
+.verify-faq__item {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.verify-faq__item summary {
+  padding: 0.95rem 0;
+  cursor: pointer;
+  list-style: none;
+  font-weight: var(--font-weight-medium);
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.verify-faq__item summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Chevron via CSS mask — no inline SVG needed */
+.verify-faq__item summary::after {
+  content: '';
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  background: var(--color-text-muted);
+  -webkit-mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>') no-repeat center / contain;
+  mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>') no-repeat center / contain;
+  transition: transform var(--motion-duration-normal) var(--easing-standard);
+}
+
+.verify-faq__item[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.verify-faq__item p {
+  padding: 0 0 1rem;
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  font-size: 0.9rem;
+  max-width: 65ch;
+}
+
+.verify-faq__item p code {
+  font-family: var(--font-family-mono);
+  font-size: 0.85em;
+  background: var(--color-surface-raised);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+}
+
+/* ----- Responsive: collapse TOC below 1024px ----- */
+
+@media (max-width: 1024px) {
+  .verify-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .verify-toc-sticky {
+    display: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .verify-step {
+    grid-template-columns: 1fr;
+    padding: 1.25rem;
+  }
+
+  .verify-step__num {
+    margin-bottom: 0.25rem;
+  }
+}
+
+/* ===== End verify page ===== */

--- a/docs/site/assets/js/code-copy.js
+++ b/docs/site/assets/js/code-copy.js
@@ -21,7 +21,7 @@
       var code = wrap.querySelector('pre code');
       if (code) {
         var clone = code.cloneNode(true);
-        clone.querySelectorAll('.prompt').forEach(function (p) { p.remove(); });
+        clone.querySelectorAll('.prompt, .comment').forEach(function (p) { p.remove(); });
         text = clone.textContent.trim();
       }
     }
@@ -106,6 +106,9 @@
 
   function applyView(view, push) {
     var v = (view === 'walkthrough') ? 'walkthrough' : 'reference';
+    // Capture BEFORE mutating dataset.view so the guard below reflects the
+    // previous state, not the one we are about to set.
+    var alreadyActive = layout && layout.dataset.view === v;
 
     // Expose active view on the grid so CSS can hide the Reference-only TOC
     if (layout) layout.setAttribute('data-view', v);
@@ -126,7 +129,10 @@
       }
     });
 
-    if (push) {
+    // Short-circuit pushState when the requested view is already active.
+    // Repeated clicks on the active tab must not add identical entries to the
+    // back stack. Visual state updates above are idempotent so they still run.
+    if (push && !alreadyActive) {
       var url = new URL(window.location.href);
       if (v === 'reference') {
         url.searchParams.delete('view');

--- a/docs/site/assets/js/code-copy.js
+++ b/docs/site/assets/js/code-copy.js
@@ -78,12 +78,31 @@
   }
 
   // ----- Tab toggle (Reference / Walkthrough) --------------------------------
+  // Progressive enhancement: server HTML renders plain buttons + both panels visible.
+  // JS upgrades to a full WAI-ARIA 1.2 tablist on load so AT users get proper
+  // semantics only when the interaction is actually functional.
 
-  var tabs = document.querySelectorAll('.verify-tabs button[role="tab"]');
-  var panels = document.querySelectorAll('.verify-page [role="tabpanel"]');
+  var tabNav = document.querySelector('.verify-tabs');
+  var tabs = document.querySelectorAll('.verify-tabs button[data-view]');
+  var panels = document.querySelectorAll('.verify-page section[data-view]');
   var layout = document.querySelector('.verify-layout');
 
   if (!tabs.length) return; // not on the verify page — stop here
+
+  // --- ARIA upgrade: inject tablist/tab/tabpanel roles now that JS is active ---
+  if (tabNav) tabNav.setAttribute('role', 'tablist');
+
+  tabs.forEach(function (tab) {
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('aria-controls', 'view-' + tab.dataset.view);
+    // aria-selected and tabindex are set by applyView() below
+  });
+
+  panels.forEach(function (panel) {
+    panel.setAttribute('role', 'tabpanel');
+    panel.setAttribute('aria-labelledby', 'tab-' + panel.dataset.view);
+  });
+  // --- end ARIA upgrade ---
 
   function applyView(view, push) {
     var v = (view === 'walkthrough') ? 'walkthrough' : 'reference';
@@ -95,6 +114,8 @@
       var active = tab.dataset.view === v;
       tab.setAttribute('aria-selected', active ? 'true' : 'false');
       tab.tabIndex = active ? 0 : -1;
+      // Class-based hook for CSS active styling (complements aria-selected)
+      tab.classList.toggle('is-active', active);
     });
 
     panels.forEach(function (panel) {
@@ -156,8 +177,8 @@
   });
 
   // Apply correct initial view (and roving tabindex) on page load.
-  // applyView() always sets tabindex=0 on the active tab and -1 on others,
-  // correcting the no-JS fallback where both buttons have tabindex="0".
+  // applyView() sets tabindex=0 on active tab, -1 on others, hides the inactive
+  // panel, and sets aria-selected — all semantics that require JS to be functional.
   var init = new URLSearchParams(window.location.search).get('view');
   applyView(init === 'walkthrough' ? 'walkthrough' : 'reference', false);
 })();

--- a/docs/site/assets/js/code-copy.js
+++ b/docs/site/assets/js/code-copy.js
@@ -1,0 +1,147 @@
+// code-copy.js — verify page: clipboard copy + Reference/Walkthrough tab toggle.
+// Handles copy buttons (.code-block[data-copy]) and the view-switching tablist.
+// Loaded as an external file; satisfies CSP script-src 'self'. No eval needed.
+(function () {
+  'use strict';
+
+  // ----- Copy buttons -------------------------------------------------------
+
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-copy-button]');
+    if (!btn) return;
+
+    var wrap = btn.closest('.code-block');
+    if (!wrap) return;
+
+    // Primary: data-copy on the wrapper holds the pre-computed text.
+    var text = wrap.getAttribute('data-copy');
+
+    if (!text) {
+      // Fallback: read <pre><code> text, stripping .prompt spans.
+      var code = wrap.querySelector('pre code');
+      if (code) {
+        var clone = code.cloneNode(true);
+        clone.querySelectorAll('.prompt').forEach(function (p) { p.remove(); });
+        text = clone.textContent.trim();
+      }
+    }
+
+    if (!text) return;
+
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text).then(
+        function () { markCopied(btn); },
+        function () { execCommandCopy(text, btn); }
+      );
+    } else {
+      execCommandCopy(text, btn);
+    }
+  });
+
+  function markCopied(btn) {
+    // Guard re-entry: a click during the 1500ms timeout would capture
+    // prevIcon='ti ti-check' and reset would leave button stuck in copied state.
+    if (btn.classList.contains('is-copied')) return;
+
+    var icon = btn.querySelector('i');
+    var label = btn.querySelector('.copy-label');
+    var prevIcon = icon ? icon.className : null;
+    var prevLabel = label ? label.textContent : null;
+
+    btn.classList.add('is-copied');
+    btn.setAttribute('aria-label', 'Copied');
+    if (icon) icon.className = 'ti ti-check';
+    if (label) label.textContent = 'Copied';
+
+    setTimeout(function () {
+      btn.classList.remove('is-copied');
+      btn.setAttribute('aria-label', 'Copy command');
+      if (icon && prevIcon) icon.className = prevIcon;
+      if (label && prevLabel) label.textContent = prevLabel;
+    }, 1500);
+  }
+
+  function execCommandCopy(text, btn) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try {
+      document.execCommand('copy');
+      markCopied(btn);
+    } catch (err) {
+      // silent — user can select text manually
+    }
+    document.body.removeChild(ta);
+  }
+
+  // ----- Tab toggle (Reference / Walkthrough) --------------------------------
+
+  var tabs = document.querySelectorAll('.verify-tabs button[role="tab"]');
+  var panels = document.querySelectorAll('.verify-page [role="tabpanel"]');
+  var layout = document.querySelector('.verify-layout');
+
+  if (!tabs.length) return; // not on the verify page — stop here
+
+  function applyView(view, push) {
+    var v = (view === 'walkthrough') ? 'walkthrough' : 'reference';
+
+    // Expose active view on the grid so CSS can hide the Reference-only TOC
+    if (layout) layout.setAttribute('data-view', v);
+
+    tabs.forEach(function (tab) {
+      var active = tab.dataset.view === v;
+      tab.setAttribute('aria-selected', active ? 'true' : 'false');
+      tab.tabIndex = active ? 0 : -1;
+    });
+
+    panels.forEach(function (panel) {
+      if (panel.dataset.view === v) {
+        panel.removeAttribute('hidden');
+      } else {
+        panel.setAttribute('hidden', '');
+      }
+    });
+
+    if (push) {
+      var url = new URL(window.location.href);
+      if (v === 'reference') {
+        url.searchParams.delete('view');
+      } else {
+        url.searchParams.set('view', v);
+      }
+      history.pushState({ view: v }, '', url.toString());
+    }
+  }
+
+  tabs.forEach(function (tab) {
+    tab.addEventListener('click', function () { applyView(tab.dataset.view, true); });
+  });
+
+  // Left/Right arrow keys navigate the tablist (ARIA 1.2 composite widget pattern)
+  tabs.forEach(function (tab, i) {
+    tab.addEventListener('keydown', function (e) {
+      var n = tabs.length;
+      var next = -1;
+      if (e.key === 'ArrowRight') next = (i + 1) % n;
+      else if (e.key === 'ArrowLeft') next = (i - 1 + n) % n;
+      if (next !== -1) {
+        tabs[next].focus();
+        applyView(tabs[next].dataset.view, true);
+        e.preventDefault();
+      }
+    });
+  });
+
+  window.addEventListener('popstate', function (e) {
+    var v = (e.state && e.state.view)
+      ? e.state.view
+      : new URLSearchParams(window.location.search).get('view') || 'reference';
+    applyView(v, false);
+  });
+
+  var init = new URLSearchParams(window.location.search).get('view');
+  if (init === 'walkthrough') applyView('walkthrough', false);
+})();

--- a/docs/site/assets/js/code-copy.js
+++ b/docs/site/assets/js/code-copy.js
@@ -120,18 +120,31 @@
     tab.addEventListener('click', function () { applyView(tab.dataset.view, true); });
   });
 
-  // Left/Right arrow keys navigate the tablist (ARIA 1.2 composite widget pattern)
+  // Keyboard nav: manual activation pattern (WAI-ARIA 1.2 §3.5 tablist, manual variant).
+  // Arrow/Home/End ONLY move focus + update roving tabindex. They do NOT activate the
+  // tab (no applyView, no pushState). Activation fires only via click or Enter/Space
+  // (which natively trigger the click handler on the focused button element).
+  function moveFocusToTab(target) {
+    Array.from(tabs).forEach(function (t) {
+      t.setAttribute('tabindex', t === target ? '0' : '-1');
+    });
+    target.focus();
+  }
+
   tabs.forEach(function (tab, i) {
     tab.addEventListener('keydown', function (e) {
-      var n = tabs.length;
-      var next = -1;
-      if (e.key === 'ArrowRight') next = (i + 1) % n;
-      else if (e.key === 'ArrowLeft') next = (i - 1 + n) % n;
-      if (next !== -1) {
-        tabs[next].focus();
-        applyView(tabs[next].dataset.view, true);
-        e.preventDefault();
+      var tabArr = Array.from(tabs);
+      var n = tabArr.length;
+      var next = null;
+      switch (e.key) {
+        case 'ArrowRight': next = tabArr[(i + 1) % n]; break;
+        case 'ArrowLeft':  next = tabArr[(i - 1 + n) % n]; break;
+        case 'Home':       next = tabArr[0]; break;
+        case 'End':        next = tabArr[n - 1]; break;
+        default: return; // let Enter/Space fall through to native click handler
       }
+      e.preventDefault();
+      moveFocusToTab(next);
     });
   });
 
@@ -142,6 +155,9 @@
     applyView(v, false);
   });
 
+  // Apply correct initial view (and roving tabindex) on page load.
+  // applyView() always sets tabindex=0 on the active tab and -1 on others,
+  // correcting the no-JS fallback where both buttons have tabindex="0".
   var init = new URLSearchParams(window.location.search).get('view');
-  if (init === 'walkthrough') applyView('walkthrough', false);
+  applyView(init === 'walkthrough' ? 'walkthrough' : 'reference', false);
 })();

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -1,8 +1,9 @@
 ---
-layout: page
+layout: verify
 title: How we verify images
 description: Reproduce every trust signal yourself — SBOM, Trivy, multi-arch, dependency monitoring.
 permalink: /verify-images/
+nav_active: verify
 ---
 
 ## Why this page exists
@@ -13,9 +14,13 @@ The trust badges on each container card link here so anyone can replicate every 
 
 Each container's SBOM is signed via Sigstore using `actions/attest-sbom`. The attestation is anchored to the image digest and recorded in the GitHub attestations API, which is publicly accessible without authentication. To verify locally using the GitHub CLI:
 
-```bash
-gh attestation verify oci://ghcr.io/oorabona/<container>:<tag> --owner oorabona
-```
+<div class="code-block" data-copy="gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona">
+  <div class="code-block__header">
+    <span class="code-block__lang">bash</span>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+  </div>
+  <pre><code><span class="prompt">$</span> gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona</code></pre>
+</div>
 
 The SBOM badge in each container card opens the public attestation viewer directly in your browser — no login required. For example, a direct URL looks like `https://github.com/oorabona/docker-containers/attestations/<id>`. The viewer shows the SBOM payload, the Sigstore bundle, and the signing certificate chain.
 
@@ -25,19 +30,27 @@ The SBOM badge in each container card opens the public attestation viewer direct
 
 Trivy scans run on every build in advisory mode: findings do not block the build, but they are surfaced. Results are uploaded to GitHub via `github/codeql-action/upload-sarif`, which populates the Code Scanning API. Note that the Security tab UI in GitHub requires authentication even for public repos — that is why each container's detail page embeds the scan summary directly. To query findings programmatically with any authenticated GitHub session (`gh auth login` is enough; no special scope is required):
 
-```bash
-gh api repos/oorabona/docker-containers/code-scanning/alerts \
+<div class="code-block" data-copy="gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'">
+  <div class="code-block__header">
+    <span class="code-block__lang">bash</span>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+  </div>
+  <pre><code><span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts \
   --paginate \
-  -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'
-```
+  -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'</code></pre>
+</div>
 
 To filter findings to a single container variant, match on the `category` field, which encodes the container name and platform:
 
-```bash
-# Replace the category value with the variant you want to inspect
-gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate \
-  -q '.[] | select(.most_recent_instance.category == "container-postgres-18-alpine-linux/amd64")'
-```
+<div class="code-block" data-copy="gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | select(.most_recent_instance.category == &quot;container-postgres-18-alpine-linux/amd64&quot;)'">
+  <div class="code-block__header">
+    <span class="code-block__lang">bash</span>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+  </div>
+  <pre><code><span class="prompt comment">#</span> Replace the category value with the variant you want to inspect
+<span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate \
+  -q '.[] | select(.most_recent_instance.category == "container-postgres-18-alpine-linux/amd64")'</code></pre>
+</div>
 
 ### Why the dashboard only highlights CRITICAL counts
 
@@ -54,9 +67,13 @@ If you operate this catalog yourself and prefer a different threshold, the SARIF
 
 Multi-arch images publish a manifest list that references per-platform image manifests. To see which CPU architectures are present for any tag:
 
-```bash
-docker manifest inspect ghcr.io/oorabona/<container>:<tag>
-```
+<div class="code-block" data-copy="docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;">
+  <div class="code-block__header">
+    <span class="code-block__lang">bash</span>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+  </div>
+  <pre><code><span class="prompt">$</span> docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;</code></pre>
+</div>
 
 Look at the `manifests` array in the output — each entry's `platform.architecture` field reveals the published architectures. Multi-arch images list both `amd64` and `arm64`; single-arch images list one. The architecture badge on each card reflects this inspection at build time.
 
@@ -73,11 +90,15 @@ Nothing in this pipeline is opaque: the `version.sh` script in each container di
 
 Every container build is driven by shell scripts with no opaque CI steps. To reproduce a build on your own machine:
 
-```bash
-git clone https://github.com/oorabona/docker-containers.git
-cd docker-containers
-./make build <container> [version]
-```
+<div class="code-block" data-copy="git clone https://github.com/oorabona/docker-containers.git&#10;cd docker-containers&#10;./make build &lt;container&gt; [version]">
+  <div class="code-block__header">
+    <span class="code-block__lang">bash</span>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+  </div>
+  <pre><code><span class="prompt">$</span> git clone https://github.com/oorabona/docker-containers.git
+<span class="prompt">$</span> cd docker-containers
+<span class="prompt">$</span> ./make build &lt;container&gt; [version]</code></pre>
+</div>
 
 BuildKit must be enabled (`DOCKER_BUILDKIT=1` or Docker 23+). The `./make` entry point accepts the same arguments as the CI pipeline. See each container's `README.md` and the top-level `docs/` directory for full build documentation, including multi-variant matrix builds, extension layers, and SBOM generation.
 
@@ -95,7 +116,7 @@ The badge has two states. **ATTESTED** means both `attestation_url` and `attesta
 
 Each successful build runs `anchore/sbom-action` to generate an SPDX JSON SBOM, then `actions/attest-sbom` signs it via Sigstore (keyless, OIDC-based) and uploads the attestation to GHCR. You can verify with `gh attestation verify oci://ghcr.io/oorabona/<image>:<tag> --owner oorabona`.
 
-### Can I trust a container that shows "📋 SBOM PENDING"?
+### Can I trust a container that shows "SBOM PENDING"?
 
 It is not a security flag. PENDING means the build pipeline has not yet re-run since the image was published, or the attestation pipeline encountered a transient failure that will be retried. Pull by digest from a previous attested build if you need verifiable SBOM provenance immediately.
 

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -17,7 +17,7 @@ Each container's SBOM is signed via Sigstore using `actions/attest-sbom`. The at
 <div class="code-block" data-copy="gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona">
   <div class="code-block__header">
     <span class="code-block__lang">bash</span>
-    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
   <pre><code><span class="prompt">$</span> gh attestation verify oci://ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt; --owner oorabona</code></pre>
 </div>
@@ -33,7 +33,7 @@ Trivy scans run on every build in advisory mode: findings do not block the build
 <div class="code-block" data-copy="gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'">
   <div class="code-block__header">
     <span class="code-block__lang">bash</span>
-    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
   <pre><code><span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts \
   --paginate \
@@ -45,7 +45,7 @@ To filter findings to a single container variant, match on the `category` field,
 <div class="code-block" data-copy="gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate -q '.[] | select(.most_recent_instance.category == &quot;container-postgres-18-alpine-linux/amd64&quot;)'">
   <div class="code-block__header">
     <span class="code-block__lang">bash</span>
-    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
   <pre><code><span class="prompt comment">#</span> Replace the category value with the variant you want to inspect
 <span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate \
@@ -70,7 +70,7 @@ Multi-arch images publish a manifest list that references per-platform image man
 <div class="code-block" data-copy="docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;">
   <div class="code-block__header">
     <span class="code-block__lang">bash</span>
-    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
   <pre><code><span class="prompt">$</span> docker manifest inspect ghcr.io/oorabona/&lt;container&gt;:&lt;tag&gt;</code></pre>
 </div>
@@ -93,7 +93,7 @@ Every container build is driven by shell scripts with no opaque CI steps. To rep
 <div class="code-block" data-copy="git clone https://github.com/oorabona/docker-containers.git&#10;cd docker-containers&#10;./make build &lt;container&gt; [version]">
   <div class="code-block__header">
     <span class="code-block__lang">bash</span>
-    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy"></i><span class="copy-label">Copy</span></button>
+    <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
   <pre><code><span class="prompt">$</span> git clone https://github.com/oorabona/docker-containers.git
 <span class="prompt">$</span> cd docker-containers

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -47,7 +47,7 @@ To filter findings to a single container variant, match on the `category` field,
     <span class="code-block__lang">bash</span>
     <button class="code-block__copy" type="button" data-copy-button aria-label="Copy command"><i class="ti ti-copy" aria-hidden="true"></i><span class="copy-label">Copy</span></button>
   </div>
-  <pre><code><span class="prompt comment">#</span> Replace the category value with the variant you want to inspect
+  <pre><code><span class="comment"># Replace the category value with the variant you want to inspect</span>
 <span class="prompt">$</span> gh api repos/oorabona/docker-containers/code-scanning/alerts --paginate \
   -q '.[] | select(.most_recent_instance.category == "container-postgres-18-alpine-linux/amd64")'</code></pre>
 </div>


### PR DESCRIPTION
## Summary

Editorial redesign of `/verify-images/` (Phase C continuation, locked design decisions in `active.md`).

- **Reference view (default)**: mono eyebrow section headings, sticky right-side TOC (collapses < 1024px), terminal-chrome code blocks with header bar (language label + copy button) and `$` prompt + `#` comment spans excluded from clipboard text.
- **Walkthrough view**: 4 numbered guided steps (SBOM, Trivy, multi-arch, reproduce locally) with FAQ accordion (native `<details>`, fleet-consistent with dashboard rows). Bookmarkable via `?view=walkthrough`.
- **Progressive enhancement (no-JS first)**: server HTML renders both panels visible with plain `<button>` elements (no ARIA tab roles, no `[hidden]` attribute). Without JS, all content remains reachable and the buttons are honest plain controls (not falsely advertised as tabs to AT). With JS, `code-copy.js` upgrades the markup to a full WAI-ARIA 1.2 manual-activation tablist and applies initial `[hidden]` to the inactive panel.
- **ARIA (post-upgrade)**: full `tablist`/`tab`/`tabpanel` chain with matching `id`/`aria-labelledby`, roving tabindex, manual-activation pattern (ArrowLeft/ArrowRight + Home/End move focus only; click/Enter/Space activate + pushState).
- **CSP-compliant**: external `/assets/js/code-copy.js` only, no inline `<script>`. JSON-LD `HowTo` + `FAQ` schemas preserved at end of markdown body.
- **WCAG 2.2 AA strict**: copy button target >= 24x24px (Section 2.5.8), heading specificity isolated to Reference panel only, `prefers-reduced-motion` respected via existing tokens.

## Files

- `_layouts/verify.html` (new, chains `layout: page`)
- `_includes/components/verify-walkthrough.html` (new, 120 LOC)
- `assets/js/code-copy.js` (new, IIFE: clipboard + tab toggle + URL sync + ARIA upgrade)
- `assets/css/theme.css` (additive +490 LOC, scoped under `.verify-page`; `.is-active` class paired with `[aria-selected="true"]`)
- `verify-images.md` (front matter `layout: verify` + `nav_active: verify`, terminal-chrome HTML blocks)

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] `https://oorabona.github.io/docker-containers/verify-images/` renders editorial Reference view
- [ ] Click "Walkthrough" tab → URL becomes `?view=walkthrough`, content swaps, TOC sidebar collapses
- [ ] Refresh on `?view=walkthrough` → loads in Walkthrough mode
- [ ] Click already-active tab → no extra back-stack entry (browser history clean)
- [ ] Copy button → `$` prompt and `#` comment markers excluded from clipboard
- [ ] JS disabled → both panels visible (full content reachable), tabs render as plain buttons (no false tab semantics)
- [ ] Lighthouse a11y >= 95
