### PR TITLE
refactor(css): semantic tokens for light/dark theme coverage

### DIFF
--- a/docs/site/assets/css/blog.css
+++ b/docs/site/assets/css/blog.css
@@ -19,7 +19,7 @@
   display: inline-block;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  background: rgba(139, 92, 246, 0.12);
+  background: var(--color-nav-link-active-bg);
   color: var(--accent-purple);
   font-size: 0.78rem;
   font-weight: 600;
@@ -27,9 +27,7 @@
   margin-bottom: 1.25rem;
 }
 
-[data-theme="light"] .blog-hero-eyebrow {
-  background: rgba(109, 40, 217, 0.08);
-}
+/* [data-theme="light"] .blog-hero-eyebrow: tokens.css overrides --color-nav-link-active-bg (same violet-alpha, correct for light mode) */
 
 .blog-hero-title {
   font-size: clamp(2rem, 5vw, 3rem);

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -105,7 +105,7 @@
     .detail-zone--explore .disclosure > summary::-webkit-details-marker { display: none; }
     .detail-zone--explore .disclosure > summary::marker { display: none; }
     .detail-zone--explore .disclosure > summary:hover {
-      background: rgba(255, 255, 255, 0.04);
+      background: var(--color-disclosure-hover-bg);
     }
     .detail-zone--explore .disclosure > summary:focus-visible {
       outline: 2px solid var(--accent-blue);
@@ -206,8 +206,9 @@
     .detail-badge {
       font-family: var(--font-family-mono); font-size: 0.875rem;
       padding: 0.375rem 0.875rem; border-radius: 8px;
-      background: rgba(16, 185, 129, 0.2); color: #34d399;
-      border: 1px solid rgba(16, 185, 129, 0.3);
+      background: var(--color-detail-badge-bg);
+      color: var(--color-detail-badge-fg);
+      border: 1px solid var(--color-detail-badge-border);
     }
     .detail-actions { display: flex; gap: 0.75rem; }
 
@@ -234,7 +235,7 @@
     .lineage-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.75rem; }
     .lineage-item {
       display: flex; flex-direction: column; gap: 0.25rem;
-      padding: 0.75rem; border-radius: 6px; background: rgba(255, 255, 255, 0.05);
+      padding: 0.75rem; border-radius: 6px; background: var(--color-lineage-item-bg);
       animation: lineageItemIn 0.4s ease both;
       transition: opacity 0.25s ease, transform 0.25s ease;
     }
@@ -272,20 +273,20 @@
     .variant-tag {
       font-family: var(--font-family-mono); font-size: 0.75rem;
       padding: 0.375rem 0.75rem; border-radius: 6px;
-      background: rgba(139, 92, 246, 0.15); color: var(--accent-purple);
-      border: 1px solid rgba(139, 92, 246, 0.25); cursor: pointer;
+      background: var(--color-variant-tag-bg); color: var(--color-variant-tag-fg);
+      border: 1px solid var(--color-variant-tag-border); cursor: pointer;
       transition:
         background var(--motion-duration-short) var(--easing-standard),
         transform  var(--motion-duration-short) var(--easing-standard);
     }
-    .variant-tag:hover { background: rgba(139, 92, 246, 0.25); transform: translateY(-1px); }
+    .variant-tag:hover { background: var(--color-variant-tag-bg-hover); transform: translateY(-1px); }
     .variant-tag.selected {
-      background: rgba(139, 92, 246, 0.3); border-color: var(--accent-purple);
-      box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+      background: var(--color-variant-tag-selected-bg); border-color: var(--color-variant-tag-fg);
+      box-shadow: 0 0 0 2px var(--color-variant-tag-selected-shadow);
     }
     .variant-tag .badge-default {
       font-size: 0.625rem; padding: 0.125rem 0.375rem; border-radius: 3px;
-      background: rgba(16, 185, 129, 0.3); color: var(--accent-green);
+      background: var(--color-variant-badge-default-bg); color: var(--color-variant-badge-default-fg);
       margin-left: 0.25rem;
     }
 
@@ -336,7 +337,7 @@
       min-width: 16px; height: 16px; padding: 0 4px;
       border-radius: 999px; font-size: 0.5625rem; font-weight: 700;
       line-height: 16px; text-align: center;
-      background: rgba(245, 158, 11, 0.9); color: #fff;
+      background: var(--color-variant-dep-badge-bg); color: #fff;  /* white text on opaque amber — motivated constant */
       border: 2px solid var(--glass-bg, rgba(30, 30, 60, 0.6));
       font-family: 'Inter', system-ui, sans-serif;
       pointer-events: none; z-index: 1;
@@ -349,14 +350,17 @@
     }
 
     [data-theme="light"] .variant-dep-badge {
-      background: rgba(245, 158, 11, 0.95); color: #fff;
-      border-color: rgba(255, 255, 255, 0.9);
+      background: var(--color-variant-dep-badge-bg); color: #fff;  /* tokens.css light override: amber-700 */
+      border-color: rgba(255, 255, 255, 0.9);  /* white separator ring — motivated constant */
     }
 
-    [data-theme="light"] .variant-tag { background: rgba(139, 92, 246, 0.12); color: #5b21b6; border-color: rgba(139, 92, 246, 0.3); }
-    [data-theme="light"] .variant-tag:hover { background: rgba(139, 92, 246, 0.2); border-color: rgba(139, 92, 246, 0.5); color: #4c1d95; }
-    [data-theme="light"] .variant-tag.selected { background: rgba(59, 130, 246, 0.15); border-color: #3b82f6; color: #1e40af; }
-    [data-theme="light"] .detail-badge { background: rgba(16, 185, 129, 0.15); color: #047857; border-color: rgba(16, 185, 129, 0.3); }
+    /* [data-theme="light"] .variant-tag: tokens.css overrides --color-variant-tag-* for light mode — no rule needed here */
+    [data-theme="light"] .variant-tag.selected { border-color: var(--color-action-primary); }
+    [data-theme="light"] .detail-badge {
+      background: var(--color-detail-badge-bg);
+      color: var(--color-detail-badge-fg);
+      border-color: var(--color-detail-badge-border);
+    }
 
     /* ============================================================
        README (Zone 4 — Documentation)
@@ -379,10 +383,10 @@
     .readme-content p { margin-bottom: 1em; }
     .readme-content code {
       font-family: var(--font-family-mono); font-size: 0.875em;
-      padding: 0.2em 0.4em; background: rgba(0, 0, 0, 0.3); border-radius: 4px; color: #f472b6;
+      padding: 0.2em 0.4em; background: var(--color-readme-code-bg); border-radius: 4px; color: var(--color-readme-code-fg);
     }
     .readme-content pre {
-      background: rgba(0, 0, 0, 0.3); border-radius: 8px;
+      background: var(--color-readme-pre-bg); border-radius: 8px;
       padding: 1rem; overflow-x: auto; margin: 1em 0;
     }
     .readme-content pre code { background: none; padding: 0; color: var(--text-secondary); }
@@ -396,7 +400,7 @@
     }
     .readme-content table { width: 100%; border-collapse: collapse; margin: 1em 0; }
     .readme-content th, .readme-content td { padding: 0.75rem; border: 1px solid var(--glass-border); text-align: left; }
-    .readme-content th { background: rgba(255, 255, 255, 0.05); font-weight: 600; }
+    .readme-content th { background: var(--color-table-row-odd-bg); font-weight: 600; }
     .readme-content img { max-width: 100%; border-radius: 8px; }
     .table-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; margin: 1em 0; }
     .table-wrapper table { margin: 0; }
@@ -414,16 +418,17 @@
     .sbom-total-badge {
       font-size: 0.75rem; font-weight: 600; padding: 0.25rem 0.625rem;
       border-radius: 999px; margin-left: auto;
-      background: rgba(59, 130, 246, 0.2); color: #60a5fa;
-      border: 1px solid rgba(59, 130, 246, 0.3);
+      background: var(--color-sbom-total-badge-bg);
+      color: var(--color-sbom-total-badge-fg);
+      border: 1px solid var(--color-sbom-total-badge-border);
     }
     .sbom-breakdown {
       display: flex; flex-wrap: wrap; gap: 0.5rem;
     }
     .sbom-type-chip {
       font-size: 0.75rem; padding: 0.375rem 0.75rem; border-radius: 6px;
-      background: rgba(139, 92, 246, 0.12); color: var(--accent-purple);
-      border: 1px solid rgba(139, 92, 246, 0.2);
+      background: var(--color-sbom-chip-bg); color: var(--color-sbom-chip-fg);
+      border: 1px solid var(--color-sbom-chip-border);
       font-family: var(--font-family-mono);
       transition: all 0.2s ease;
     }
@@ -431,14 +436,14 @@
       cursor: pointer; user-select: none;
     }
     .sbom-type-chip-clickable:hover {
-      background: rgba(139, 92, 246, 0.25);
-      border-color: rgba(139, 92, 246, 0.4);
+      background: var(--color-sbom-chip-bg-hover);
+      border-color: var(--color-sbom-chip-border-hover);
       transform: translateY(-1px);
     }
     .sbom-type-chip-active {
-      background: rgba(139, 92, 246, 0.3);
-      border-color: rgba(139, 92, 246, 0.5);
-      box-shadow: 0 0 8px rgba(139, 92, 246, 0.2);
+      background: var(--color-sbom-chip-active-bg);
+      border-color: var(--color-sbom-chip-active-border);
+      box-shadow: 0 0 8px var(--color-sbom-chip-active-shadow);
     }
     .sbom-type-count {
       font-weight: 600; margin-left: 0.25rem;
@@ -447,7 +452,7 @@
     /* Package drill-down panel */
     .sbom-package-panel {
       margin-top: 1rem; padding: 1rem;
-      background: rgba(0, 0, 0, 0.15);
+      background: var(--color-sbom-panel-bg);
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       animation: sbomPanelIn 0.25s ease;
@@ -480,7 +485,7 @@
       font-size: 0.75rem;
       font-family: var(--font-family-mono);
     }
-    .sbom-package-item:nth-child(odd) { background: rgba(255, 255, 255, 0.03); }
+    .sbom-package-item:nth-child(odd) { background: var(--color-sbom-item-stripe-bg); }
     .sbom-pkg-name {
       color: var(--detail-text-primary);
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -504,8 +509,9 @@
     .changelog-summary-badge {
       font-size: 0.6875rem; font-weight: 600; padding: 0.25rem 0.625rem;
       border-radius: 999px; margin-left: auto;
-      background: rgba(245, 158, 11, 0.2); color: #fbbf24;
-      border: 1px solid rgba(245, 158, 11, 0.3);
+      background: var(--color-changelog-badge-bg);
+      color: var(--color-changelog-badge-fg);
+      border: 1px solid var(--color-changelog-badge-border);
     }
     .changelog-table-wrap { overflow-x: auto; }
     .changelog-table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
@@ -514,16 +520,16 @@
       letter-spacing: 0.05em; color: var(--detail-text-muted); padding: 0.5rem 0.75rem;
       border-bottom: 1px solid var(--glass-border);
     }
-    .changelog-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .changelog-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid var(--color-table-border); }
     .changelog-table tbody tr { animation: lineageItemIn 0.4s ease both; }
-    .changelog-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
+    .changelog-table tbody tr:nth-child(even) { background: var(--color-table-row-even-bg); }
     .changelog-type-badge {
       font-size: 0.625rem; font-weight: 600; text-transform: uppercase;
       padding: 0.125rem 0.5rem; border-radius: 999px;
     }
-    .changelog-type-added { background: rgba(16, 185, 129, 0.2); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.3); }
-    .changelog-type-removed { background: rgba(239, 68, 68, 0.2); color: #f87171; border: 1px solid rgba(239, 68, 68, 0.3); }
-    .changelog-type-updated { background: rgba(59, 130, 246, 0.2); color: #60a5fa; border: 1px solid rgba(59, 130, 246, 0.3); }
+    .changelog-type-added   { background: var(--color-badge-added-bg);   color: var(--color-badge-added-fg);   border: 1px solid var(--color-badge-added-border); }
+    .changelog-type-removed { background: var(--color-badge-removed-bg); color: var(--color-badge-removed-fg); border: 1px solid var(--color-badge-removed-border); }
+    .changelog-type-updated { background: var(--color-badge-updated-bg); color: var(--color-badge-updated-fg); border: 1px solid var(--color-badge-updated-border); }
     .changelog-pkg-name {
       font-family: var(--font-family-mono); font-size: 0.8125rem;
     }
@@ -531,7 +537,7 @@
       font-family: var(--font-family-mono); font-size: 0.75rem;
       color: var(--detail-text-muted);
     }
-    .changelog-version-new { color: #34d399; }
+    .changelog-version-new { color: var(--color-badge-added-fg); }
 
     /* ============================================================
        BUILD HISTORY (inside disclosure body)
@@ -551,9 +557,9 @@
       letter-spacing: 0.05em; color: var(--detail-text-muted); padding: 0.5rem 0.75rem;
       border-bottom: 1px solid var(--glass-border);
     }
-    .history-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .history-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid var(--color-table-border); }
     .history-table tbody tr { animation: lineageItemIn 0.4s ease both; }
-    .history-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
+    .history-table tbody tr:nth-child(even) { background: var(--color-table-row-even-bg); }
     .history-date { font-size: 0.75rem; color: var(--detail-text-muted); }
     .history-version {
       font-family: var(--font-family-mono); font-size: 0.75rem;
@@ -567,22 +573,8 @@
       color: var(--detail-text-muted);
     }
 
-    /* Light theme: SBOM section overrides */
-    [data-theme="light"] .sbom-total-badge { background: rgba(59, 130, 246, 0.12); color: #1d4ed8; border-color: rgba(59, 130, 246, 0.3); }
-    [data-theme="light"] .sbom-type-chip { background: rgba(139, 92, 246, 0.08); color: #5b21b6; border-color: rgba(139, 92, 246, 0.2); }
-    [data-theme="light"] .sbom-type-chip-clickable:hover { background: rgba(139, 92, 246, 0.15); }
-    [data-theme="light"] .sbom-type-chip-active { background: rgba(139, 92, 246, 0.2); box-shadow: 0 0 8px rgba(139, 92, 246, 0.1); }
-    [data-theme="light"] .sbom-package-panel { background: rgba(0, 0, 0, 0.03); }
-    [data-theme="light"] .sbom-package-item:nth-child(odd) { background: rgba(0, 0, 0, 0.03); }
-    [data-theme="light"] .changelog-summary-badge { background: rgba(245, 158, 11, 0.12); color: #92400e; border-color: rgba(245, 158, 11, 0.3); }
-    [data-theme="light"] .changelog-type-added { background: rgba(16, 185, 129, 0.1); color: #047857; border-color: rgba(16, 185, 129, 0.3); }
-    [data-theme="light"] .changelog-type-removed { background: rgba(239, 68, 68, 0.1); color: #b91c1c; border-color: rgba(239, 68, 68, 0.3); }
-    [data-theme="light"] .changelog-type-updated { background: rgba(59, 130, 246, 0.1); color: #1d4ed8; border-color: rgba(59, 130, 246, 0.3); }
-    [data-theme="light"] .changelog-version-new { color: #047857; }
-    [data-theme="light"] .changelog-table td,
-    [data-theme="light"] .history-table td { border-bottom-color: rgba(0, 0, 0, 0.06); }
-    [data-theme="light"] .changelog-table tbody tr:nth-child(even),
-    [data-theme="light"] .history-table tbody tr:nth-child(even) { background: rgba(0, 0, 0, 0.02); }
+    /* Light theme: SBOM section — tokens.css overrides all --color-sbom-* for light mode — no rules needed here */
+    /* Light theme: changelog/history — tokens.css overrides --color-badge-added, --color-badge-removed, --color-badge-updated, --color-changelog-X, --color-table-X for light mode — no rules needed here */
 
     /* ============================================================
        DEPENDENCY HEALTH (inside disclosure body)
@@ -598,27 +590,27 @@
       font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
       padding: 0.25rem 0.625rem; border-radius: 999px; margin-left: auto;
     }
-    .dep-badge-ok { background: rgba(16, 185, 129, 0.2); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.3); }
-    .dep-badge-warning { background: rgba(245, 158, 11, 0.2); color: #fbbf24; border: 1px solid rgba(245, 158, 11, 0.3); }
-    .dep-badge-neutral { background: rgba(107, 114, 128, 0.2); color: rgba(255,255,255,0.6); border: 1px solid rgba(107, 114, 128, 0.3); }
+    .dep-badge-ok      { background: var(--color-dep-badge-ok-bg);      color: var(--color-dep-badge-ok-fg);      border: 1px solid var(--color-dep-badge-ok-border); }
+    .dep-badge-warning { background: var(--color-dep-badge-warning-bg); color: var(--color-dep-badge-warning-fg); border: 1px solid var(--color-dep-badge-warning-border); }
+    .dep-badge-neutral { background: var(--color-dep-badge-neutral-bg); color: var(--color-dep-badge-neutral-fg); border: 1px solid var(--color-dep-badge-neutral-border); }
 
     .dep-health-summary { margin-bottom: 1.25rem; }
     .dep-health-bar { display: flex; flex-direction: column; gap: 0.5rem; }
     .dep-bar-label { font-size: 0.75rem; color: var(--detail-text-muted); }
     .dep-bar-track {
-      height: 6px; border-radius: 3px; background: rgba(255, 255, 255, 0.08);
+      height: 6px; border-radius: 3px; background: var(--color-dep-bar-track-bg);
       overflow: hidden; display: flex;
     }
     .dep-bar-fill {
       height: 100%;
-      background: linear-gradient(90deg, #34d399, #10b981);
+      background: linear-gradient(90deg, var(--color-dep-bar-fill-start), var(--color-dep-bar-fill-end));
       border-radius: 3px 0 0 3px;
       transition: flex 0.4s ease;
     }
     .dep-bar-fill:only-child { border-radius: 3px; }
     .dep-bar-unmonitored {
       height: 100%;
-      background: linear-gradient(90deg, #f59e0b, #d97706);
+      background: linear-gradient(90deg, var(--color-dep-bar-warn-start), var(--color-dep-bar-warn-end));
       border-radius: 0 3px 3px 0;
       transition: flex 0.4s ease;
     }
@@ -630,22 +622,22 @@
       letter-spacing: 0.05em; color: var(--detail-text-muted); padding: 0.5rem 0.75rem;
       border-bottom: 1px solid var(--glass-border);
     }
-    .dep-update-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .dep-update-table td { padding: 0.625rem 0.75rem; border-bottom: 1px solid var(--color-table-border); }
     .dep-update-row { animation: lineageItemIn 0.4s ease both; }
-    .dep-update-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
+    .dep-update-table tbody tr:nth-child(even) { background: var(--color-table-row-even-bg); }
     .dep-name a { color: var(--accent-blue); text-decoration: none; }
     .dep-name a:hover { text-decoration: underline; }
     .dep-version { font-family: var(--font-family-mono); font-size: 0.75rem; }
     .dep-version-current { color: var(--detail-text-muted); }
-    .dep-version-latest { color: #34d399; font-weight: 500; }
+    .dep-version-latest { color: var(--color-dep-version-latest-fg); font-weight: 500; }
 
     .dep-change-badge {
       font-size: 0.625rem; font-weight: 600; text-transform: uppercase;
       padding: 0.125rem 0.5rem; border-radius: 999px;
     }
-    .dep-change-major { background: rgba(239, 68, 68, 0.2); color: #f87171; border: 1px solid rgba(239, 68, 68, 0.3); }
-    .dep-change-minor { background: rgba(245, 158, 11, 0.2); color: #fbbf24; border: 1px solid rgba(245, 158, 11, 0.3); }
-    .dep-change-patch { background: rgba(16, 185, 129, 0.2); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.3); }
+    .dep-change-major { background: var(--color-badge-major-bg); color: var(--color-badge-major-fg); border: 1px solid var(--color-badge-major-border); }
+    .dep-change-minor { background: var(--color-badge-minor-bg); color: var(--color-badge-minor-fg); border: 1px solid var(--color-badge-minor-border); }
+    .dep-change-patch { background: var(--color-badge-patch-bg); color: var(--color-badge-patch-fg); border: 1px solid var(--color-badge-patch-border); }
 
     .dep-uptodate-details { margin-bottom: 1rem; }
     .dep-uptodate-summary {
@@ -663,8 +655,8 @@
     .dep-uptodate-list { display: flex; flex-wrap: wrap; gap: 0.5rem; padding: 0.75rem 0 0.25rem 0; }
     .dep-uptodate-item {
       font-size: 0.75rem; padding: 0.25rem 0.625rem; border-radius: 6px;
-      background: rgba(16, 185, 129, 0.08); color: var(--detail-text-secondary);
-      border: 1px solid rgba(16, 185, 129, 0.15);
+      background: var(--color-dep-uptodate-item-bg); color: var(--detail-text-secondary);
+      border: 1px solid var(--color-dep-uptodate-item-border);
     }
     .dep-uptodate-version {
       font-family: var(--font-family-mono); font-size: 0.6875rem;
@@ -678,7 +670,7 @@
     .dep-disabled-label { color: var(--detail-text-muted); font-style: italic; }
     .dep-disabled-item {
       padding: 0.125rem 0.5rem; border-radius: 4px;
-      background: rgba(107, 114, 128, 0.1); color: var(--detail-text-muted);
+      background: var(--color-dep-badge-neutral-bg); color: var(--detail-text-muted);
       font-style: italic; font-size: 0.6875rem; cursor: help;
     }
 
@@ -692,35 +684,16 @@
     }
     .dep-workflow-link:hover { color: var(--accent-blue); }
 
-    /* Light theme: dependency health overrides */
-    [data-theme="light"] .dep-badge-ok { background: rgba(16, 185, 129, 0.12); color: #047857; border-color: rgba(16, 185, 129, 0.3); }
-    [data-theme="light"] .dep-badge-warning { background: rgba(245, 158, 11, 0.12); color: #92400e; border-color: rgba(245, 158, 11, 0.3); }
-    [data-theme="light"] .dep-badge-neutral { background: rgba(107, 114, 128, 0.1); color: #4b5563; border-color: rgba(107, 114, 128, 0.2); }
-    [data-theme="light"] .dep-bar-track { background: rgba(0, 0, 0, 0.06); }
-    [data-theme="light"] .dep-update-table td { border-bottom-color: rgba(0, 0, 0, 0.06); }
-    [data-theme="light"] .dep-update-table tbody tr:nth-child(even) { background: rgba(0, 0, 0, 0.02); }
-    [data-theme="light"] .dep-version-latest { color: #047857; }
-    [data-theme="light"] .dep-change-major { background: rgba(239, 68, 68, 0.1); color: #b91c1c; border-color: rgba(239, 68, 68, 0.3); }
-    [data-theme="light"] .dep-change-minor { background: rgba(245, 158, 11, 0.1); color: #92400e; border-color: rgba(245, 158, 11, 0.3); }
-    [data-theme="light"] .dep-change-patch { background: rgba(16, 185, 129, 0.1); color: #047857; border-color: rgba(16, 185, 129, 0.3); }
-    [data-theme="light"] .dep-uptodate-item { background: rgba(16, 185, 129, 0.06); border-color: rgba(16, 185, 129, 0.15); }
+    /* Light theme: dependency health — tokens.css overrides all --color-dep-X and --color-badge-X tokens for light mode — no rules needed here */
 
-    /* Light theme: lineage & readme overrides for WCAG 2.2 AA contrast */
-    [data-theme="light"] .lineage-item {
-      background: rgba(0, 0, 0, 0.04);
-    }
-    [data-theme="light"] .readme-content code {
-      background: rgba(0, 0, 0, 0.06);
-      color: #9333ea;
-    }
-    [data-theme="light"] .readme-content pre {
-      background: #1e293b;
-    }
+    /* Light theme: lineage item — tokens.css overrides --color-lineage-item-bg for light mode — no rule needed here */
+    /* Light theme: readme overrides for WCAG 2.2 AA contrast */
+    /* [data-theme="light"] readme code/pre: tokens.css overrides --color-readme-code-bg/fg and --color-readme-pre-bg — no rules needed here */
     [data-theme="light"] .readme-content pre code {
-      color: #e2e8f0;
+      color: #e2e8f0;  /* fixed: light code on dark pre bg — intentional contrast reversal */
     }
     [data-theme="light"] .readme-content th {
-      background: rgba(0, 0, 0, 0.04);
+      background: var(--color-lineage-item-bg);  /* reuses same subtle raised surface */
     }
     [data-theme="light"] .readme-content blockquote {
       color: var(--detail-text-muted);
@@ -732,13 +705,11 @@
       color: var(--text-primary);
     }
 
-    /* Light theme: disclosure overrides */
+    /* Light theme: disclosure surface — semi-transparent white panel (glassmorphism on light bg) */
     [data-theme="light"] .detail-zone--explore .disclosure {
-      background: rgba(255, 255, 255, 0.6);
+      background: var(--glass-bg);
     }
-    [data-theme="light"] .detail-zone--explore .disclosure > summary:hover {
-      background: rgba(0, 0, 0, 0.03);
-    }
+    /* [data-theme="light"] disclosure hover — tokens.css overrides --color-disclosure-hover-bg for light mode — no rule needed here */
 
     /* ============================================================
        PULL COMMAND SECTION
@@ -764,7 +735,7 @@
     }
     .detail-registry-toggle {
       display: flex;
-      background: rgba(0, 0, 0, 0.2);
+      background: var(--color-registry-toggle-bg);
       border-radius: 6px;
       padding: 0.1875rem;
     }
@@ -799,7 +770,7 @@
     }
     .detail-pull-input {
       flex: 1;
-      background: rgba(0, 0, 0, 0.2);
+      background: var(--color-pull-input-bg);
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       padding: 0.5rem 0.75rem;
@@ -808,7 +779,7 @@
       color: var(--detail-text-secondary);
     }
     .detail-copy-btn {
-      background: rgba(255, 255, 255, 0.1);
+      background: var(--color-copy-btn-bg);
       border: 1px solid var(--glass-border);
       border-radius: 8px;
       padding: 0.5rem 0.75rem;
@@ -822,29 +793,17 @@
       justify-content: center;
     }
     .detail-copy-btn:hover {
-      background: rgba(255, 255, 255, 0.2);
+      background: var(--color-copy-btn-bg-hover);
       color: var(--text-primary);
     }
     .detail-copy-btn.copied {
-      background: rgba(16, 185, 129, 0.2);
+      background: var(--color-copy-btn-copied-bg);
       border-color: var(--accent-green);
       color: var(--accent-green);
     }
-    /* Light theme overrides for pull section */
-    [data-theme="light"] .detail-registry-toggle {
-      background: rgba(0, 0, 0, 0.06);
-    }
+    /* Light theme: pull section — tokens.css overrides --color-registry-toggle-bg/--color-pull-input-bg/--color-copy-btn-* for light mode — no rules needed here */
     [data-theme="light"] .detail-registry-btn.active {
-      color: #ffffff;
-    }
-    [data-theme="light"] .detail-pull-input {
-      background: rgba(0, 0, 0, 0.04);
-    }
-    [data-theme="light"] .detail-copy-btn {
-      background: rgba(0, 0, 0, 0.04);
-    }
-    [data-theme="light"] .detail-copy-btn:hover {
-      background: rgba(0, 0, 0, 0.08);
+      color: #ffffff;  /* white text on gradient-colored active button — motivated constant */
     }
 
     /* ============================================================

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -50,46 +50,32 @@
       color: #ffffff;
     }
 
-    /* Light theme: Variant tags - WCAG 2.1 AA compliant */
-    [data-theme="light"] .variant-tag {
-      background: rgba(139, 92, 246, 0.12);
-      color: #5b21b6;
-      border-color: rgba(139, 92, 246, 0.3);
-    }
-
-    [data-theme="light"] .variant-tag:hover {
-      background: rgba(139, 92, 246, 0.2);
-      border-color: rgba(139, 92, 246, 0.5);
-      color: #4c1d95;
-    }
-
+    /* Light theme: Variant tags — tokens.css overrides --color-variant-tag-* for light mode; sibling selectors use token refs */
     [data-theme="light"] .variant-tag.selected {
-      background: rgba(59, 130, 246, 0.15);
-      border-color: #3b82f6;
-      color: #1e40af;
+      border-color: var(--color-action-primary);
     }
 
     [data-theme="light"] .variant-tag .badge {
-      background: rgba(59, 130, 246, 0.2);
-      color: #1d4ed8;
+      background: var(--color-feedback-info-bg);
+      color: var(--color-feedback-info-fg);
     }
 
     [data-theme="light"] .variant-tag .badge-primary {
-      background: rgba(16, 185, 129, 0.2);
-      color: #047857;
+      background: var(--color-variant-badge-default-bg);
+      color: var(--color-variant-badge-default-fg);
     }
 
     /* Light theme: Card badges - WCAG 2.1 AA compliant */
     [data-theme="light"] .card-badge {
-      background: rgba(16, 185, 129, 0.15);
-      color: #047857;
-      border-color: rgba(16, 185, 129, 0.3);
+      background: var(--color-detail-badge-bg);
+      color: var(--color-detail-badge-fg);
+      border-color: var(--color-detail-badge-border);
     }
 
     [data-theme="light"] .card-badge.warning {
-      background: rgba(180, 83, 9, 0.15);
-      color: #92400e;
-      border-color: rgba(180, 83, 9, 0.3);
+      background: var(--color-dep-badge-warning-bg);
+      color: var(--color-dep-badge-warning-fg);
+      border-color: var(--color-dep-badge-warning-border);
     }
 
     /* Light theme: Card links */
@@ -116,16 +102,16 @@
       background: rgba(0, 0, 0, 0.06);
     }
     [data-theme="light"] .activity-icon.success {
-      background: rgba(4, 120, 87, 0.12);
-      color: #047857;
+      background: var(--color-dep-badge-ok-bg);
+      color: var(--color-dep-badge-ok-fg);
     }
     [data-theme="light"] .activity-icon.failure {
-      background: rgba(190, 24, 93, 0.12);
-      color: #be185d;
+      background: rgba(190, 24, 93, 0.12);  /* pink-700 alpha — no semantic token yet; kept as motivated literal */
+      color: var(--color-pink-700);
     }
     [data-theme="light"] .activity-icon.pending {
-      background: rgba(180, 83, 9, 0.12);
-      color: #b45309;
+      background: var(--color-dep-badge-warning-bg);
+      color: var(--color-dep-badge-warning-fg);
     }
     [data-theme="light"] .activity-link:hover {
       background: rgba(0, 0, 0, 0.04);
@@ -143,10 +129,10 @@
       background: rgba(59, 130, 246, 0.15);
     }
     [data-theme="light"] .registry-toggle {
-      background: rgba(0, 0, 0, 0.06);
+      background: var(--color-registry-toggle-bg);
     }
     [data-theme="light"] .pull-input {
-      background: rgba(0, 0, 0, 0.04);
+      background: var(--color-pull-input-bg);
     }
     [data-theme="light"] .pull-select {
       background: rgba(255, 255, 255, 0.8);
@@ -156,10 +142,10 @@
       color: #111827;
     }
     [data-theme="light"] .copy-btn {
-      background: rgba(0, 0, 0, 0.04);
+      background: var(--color-copy-btn-bg);
     }
     [data-theme="light"] .copy-btn:hover {
-      background: rgba(0, 0, 0, 0.08);
+      background: var(--color-copy-btn-bg-hover);
     }
 
     /* Controls bar */

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -52,7 +52,9 @@
 
     /* Light theme: Variant tags — tokens.css overrides --color-variant-tag-* for light mode; sibling selectors use token refs */
     [data-theme="light"] .variant-tag.selected {
-      border-color: var(--color-action-primary);
+      background: rgba(109, 40, 217, 0.10);       /* violet-700 alpha — matches variant-tag-bg family */
+      color: var(--color-violet-700);             /* violet-700 fg — 7.10:1 on white (AAA) */
+      border-color: rgba(109, 40, 217, 0.45);     /* violet-700 alpha — consistent with sbom-chip-border-hover level */
     }
 
     [data-theme="light"] .variant-tag .badge {

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -134,8 +134,8 @@
   color: var(--color-trust-sbom-fg);
 }
 .trust-badge--sbom:hover {
-  background: rgba(20, 184, 166, 0.25);
-  border-color: rgba(45, 212, 191, 0.55);
+  background: var(--color-trust-sbom-bg-hover);
+  border-color: var(--color-trust-sbom-border-hover);
 }
 
 /* Generic pending modifier — opacity-free so muted text keeps WCAG AA
@@ -160,19 +160,19 @@
   color: var(--color-trust-multiarch-fg);
 }
 .trust-badge--multi-arch:hover {
-  background: rgba(139, 92, 246, 0.22);
-  border-color: rgba(167, 139, 250, 0.50);
+  background: var(--color-trust-multiarch-bg-hover);
+  border-color: var(--color-trust-multiarch-border-hover);
 }
 
 /* Deps — neutral/info tint */
 .trust-badge--deps {
-  background: rgba(59, 130, 246, 0.08);
-  border-color: rgba(59, 130, 246, 0.2);
-  color: var(--accent-blue);
+  background: var(--color-trust-deps-bg);
+  border-color: var(--color-trust-deps-border);
+  color: var(--color-trust-deps-fg);
 }
 .trust-badge--deps:hover {
-  background: rgba(59, 130, 246, 0.15);
-  border-color: rgba(59, 130, 246, 0.35);
+  background: var(--color-trust-deps-bg-hover);
+  border-color: var(--color-trust-deps-border-hover);
 }
 
 /* Verify CTA — M2 fix: --color-trust-verify-fg (#22D3EE → 7.4:1 on navy-950)
@@ -194,30 +194,30 @@
 /* Trivy scan — clean state (0 CRITICAL) uses trust-domain token */
 .trust-badge--trivy {
   background: var(--color-trust-trivy-clean-bg);
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--color-trust-trivy-clean-border);
   color: var(--color-trust-trivy-clean-fg);
 }
 .trust-badge--trivy:hover {
-  background: rgba(16, 185, 129, 0.2);
-  border-color: rgba(16, 185, 129, 0.45);
+  background: var(--color-trust-trivy-clean-bg-hover);
+  border-color: var(--color-trust-trivy-clean-border-hover);
 }
 .trust-badge--trivy[data-severity="critical"] {
-  background: rgba(239, 68, 68, 0.14);
-  border-color: rgba(239, 68, 68, 0.35);
-  color: #f87171;
+  background: var(--color-trust-trivy-critical-bg);
+  border-color: var(--color-trust-trivy-critical-border);
+  color: var(--color-trust-trivy-critical-fg);
 }
 .trust-badge--trivy[data-severity="critical"]:hover {
-  background: rgba(239, 68, 68, 0.22);
-  border-color: rgba(239, 68, 68, 0.5);
+  background: var(--color-trust-trivy-critical-bg-hover);
+  border-color: var(--color-trust-trivy-critical-border-hover);
 }
 .trust-badge--trivy[data-severity="high"] {
-  background: rgba(245, 158, 11, 0.14);
-  border-color: rgba(245, 158, 11, 0.32);
-  color: var(--accent-yellow);
+  background: var(--color-trust-trivy-warn-bg);
+  border-color: var(--color-trust-trivy-warn-border);
+  color: var(--color-trust-trivy-warn-fg);
 }
 .trust-badge--trivy[data-severity="high"]:hover {
-  background: rgba(245, 158, 11, 0.22);
-  border-color: rgba(245, 158, 11, 0.48);
+  background: var(--color-trust-trivy-warn-bg-hover);
+  border-color: var(--color-trust-trivy-warn-border-hover);
 }
 /* medium / low / info: inherit .trust-badge--trivy (green) */
 
@@ -339,14 +339,14 @@ body {
   border: 1px solid var(--glass-border);
 }
 
-.theme-toggle:hover { background: rgba(255, 255, 255, 0.2); transform: scale(1.05); }
+.theme-toggle:hover { background: var(--color-btn-hover-bg); transform: scale(1.05); }
 .theme-toggle i { font-size: 1.25rem; }
-[data-theme="light"] .theme-toggle { background: rgba(0, 0, 0, 0.05); }
-[data-theme="light"] .theme-toggle:hover { background: rgba(0, 0, 0, 0.1); }
+[data-theme="light"] .theme-toggle { background: var(--color-copy-btn-bg); }
+[data-theme="light"] .theme-toggle:hover { background: var(--color-copy-btn-bg-hover); }
 
 [data-theme="light"] .glass {
-  background: rgba(255, 255, 255, 0.75);
-  border-color: rgba(0, 0, 0, 0.1);
+  background: var(--glass-bg);
+  border-color: var(--glass-border);
 }
 
 /* Glassmorphism */
@@ -381,9 +381,9 @@ body {
 }
 
 .btn:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--color-btn-hover-bg);
   transform: translateY(-2px);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 20px var(--color-btn-hover-shadow);
 }
 
 .btn-primary {
@@ -449,14 +449,14 @@ body {
   z-index: 50;
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
-  background: rgba(15, 23, 42, 0.55);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--color-nav-bg);
+  border-bottom: 1px solid var(--color-nav-border);
 }
 
 [data-theme="light"] .site-nav,
 :root[data-theme="light"] .site-nav {
-  background: rgba(255, 255, 255, 0.7);
-  border-bottom-color: rgba(0, 0, 0, 0.06);
+  background: var(--color-nav-bg);
+  border-bottom-color: var(--color-nav-border);
 }
 
 .site-nav-inner {
@@ -499,16 +499,16 @@ body {
 
 .site-nav-link:hover {
   color: var(--text, inherit);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--color-nav-link-hover-bg);
 }
 
 .site-nav-link.active {
   color: var(--text, inherit);
-  background: rgba(139, 92, 246, 0.12);
+  background: var(--color-nav-link-active-bg);
 }
 
 [data-theme="light"] .site-nav-link.active {
-  background: rgba(109, 40, 217, 0.1);
+  background: var(--color-nav-link-active-bg);
 }
 
 .site-nav-actions {
@@ -525,12 +525,12 @@ body {
 .security-section {
   margin-top: 2rem;
   padding: 1.5rem 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--color-border-subtle);
   scroll-margin-top: 80px;
 }
 
 [data-theme="light"] .security-section {
-  border-top-color: rgba(0, 0, 0, 0.08);
+  border-top-color: var(--color-border-subtle);
 }
 
 .security-section h2 {
@@ -573,13 +573,13 @@ body {
   gap: 0.25rem;
   padding: 0.75rem 0.5rem;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--color-severity-grid-bg);
+  border: 1px solid var(--color-severity-grid-border);
 }
 
 [data-theme="light"] .severity-grid > * {
-  background: rgba(15, 23, 42, 0.03);
-  border-color: rgba(15, 23, 42, 0.06);
+  background: var(--color-severity-grid-bg);
+  border-color: var(--color-severity-grid-border);
 }
 
 .severity-grid .count {
@@ -600,7 +600,7 @@ body {
 /* Color coding: critical (col 1) and high (col 2) only when > 0 */
 .severity-grid > *:nth-child(1) .count[data-nonzero],
 .severity-grid > *:nth-child(1).nonzero .count {
-  color: #f87171;
+  color: var(--color-feedback-error-fg);
 }
 
 .severity-grid > *:nth-child(2) .count[data-nonzero],
@@ -660,24 +660,24 @@ body {
 .variants-table th,
 .variants-table td {
   padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--color-border-subtle);
   text-align: left;
   vertical-align: top;
 }
 
 [data-theme="light"] .variants-table th,
 [data-theme="light"] .variants-table td {
-  border-bottom-color: rgba(0, 0, 0, 0.06);
+  border-bottom-color: var(--color-border-subtle);
 }
 
 .variants-table thead th {
   font-weight: 600;
   color: var(--accent-purple);
-  background: rgba(139, 92, 246, 0.06);
+  background: var(--color-sbom-chip-bg);  /* violet-alpha — same tint family as chips */
 }
 
 [data-theme="light"] .variants-table thead th {
-  background: rgba(109, 40, 217, 0.04);
+  background: var(--color-sbom-chip-bg);
 }
 
 .variants-table td:first-child code {
@@ -767,13 +767,13 @@ body {
 .page-content code {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.9em;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-page-code-bg);
   padding: 0.15em 0.4em;
   border-radius: 4px;
 }
 
 [data-theme="light"] .page-content code {
-  background: rgba(15, 23, 42, 0.06);
+  background: var(--color-page-code-bg);
 }
 
 .page-content pre code {
@@ -787,13 +787,13 @@ body {
   overflow-x: auto;
   padding: 1rem;
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--color-page-pre-bg);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.875rem;
 }
 
 [data-theme="light"] .page-content pre {
-  background: rgba(15, 23, 42, 0.05);
+  background: var(--color-page-pre-bg);
 }
 
 /* Mobile adjustments */

--- a/docs/site/assets/css/tokens.css
+++ b/docs/site/assets/css/tokens.css
@@ -201,6 +201,164 @@
   --color-trust-verify-bg:       transparent;
   --color-trust-verify-border:   rgba(34, 211, 238, 0.50);
   --color-trust-verify-hover-bg: rgba(34, 211, 238, 0.10);
+
+  /* Trust-badge hover states (bg + border intensify on hover) */
+  --color-trust-sbom-bg-hover:        rgba(20, 184, 166, 0.25);   /* teal-500 alpha ×1.67 */
+  --color-trust-sbom-border-hover:    rgba(45, 212, 191, 0.55);
+  --color-trust-multiarch-bg-hover:   rgba(139, 92, 246, 0.22);   /* violet-500 alpha ×1.83 */
+  --color-trust-multiarch-border-hover: rgba(167, 139, 250, 0.50);
+
+  /* Deps badge (info/neutral — blue hue) */
+  --color-trust-deps-fg:          var(--color-blue-400);
+  --color-trust-deps-bg:          rgba(59, 130, 246, 0.08);   /* blue-500 alpha low */
+  --color-trust-deps-border:      rgba(59, 130, 246, 0.20);
+  --color-trust-deps-bg-hover:    rgba(59, 130, 246, 0.15);
+  --color-trust-deps-border-hover: rgba(59, 130, 246, 0.35);
+
+  /* Trivy badge border + hover (clean / warn / critical states) */
+  --color-trust-trivy-clean-border:        rgba(16, 185, 129, 0.28);   /* green-500 alpha */
+  --color-trust-trivy-clean-bg-hover:      rgba(16, 185, 129, 0.20);
+  --color-trust-trivy-clean-border-hover:  rgba(16, 185, 129, 0.45);
+  --color-trust-trivy-critical-bg:         rgba(239, 68, 68, 0.14);    /* red-500 alpha */
+  --color-trust-trivy-critical-border:     rgba(239, 68, 68, 0.35);
+  --color-trust-trivy-critical-bg-hover:   rgba(239, 68, 68, 0.22);
+  --color-trust-trivy-critical-border-hover: rgba(239, 68, 68, 0.50);
+  --color-trust-trivy-warn-border:         rgba(245, 158, 11, 0.32);   /* amber-500 alpha */
+  --color-trust-trivy-warn-bg-hover:       rgba(245, 158, 11, 0.22);
+  --color-trust-trivy-warn-border-hover:   rgba(245, 158, 11, 0.48);
+}
+
+/* Component-level semantic tokens (Tier 2 — consumed by theme.css + container-detail.css)
+   Groups: variant-tag / sbom / changelog / dep-health / detail-badge / readme / nav / layout */
+:root,
+[data-theme="dark"] {
+  /* --- Variant tag chips (violet-toned, identity: current variants of a container) --- */
+  --color-variant-tag-bg:          rgba(139, 92, 246, 0.15);   /* violet-500 alpha  */
+  --color-variant-tag-border:      rgba(139, 92, 246, 0.25);
+  --color-variant-tag-fg:          var(--color-violet-400);    /* #A78BFA */
+  --color-variant-tag-bg-hover:    rgba(139, 92, 246, 0.25);
+  --color-variant-tag-selected-bg: rgba(139, 92, 246, 0.30);
+  --color-variant-tag-selected-shadow: rgba(139, 92, 246, 0.20);
+  /* default badge within variant-tag (green = "this is the default") */
+  --color-variant-badge-default-bg:  rgba(16, 185, 129, 0.30); /* green-500 alpha */
+  --color-variant-badge-default-fg:  var(--color-green-400);
+
+  /* --- SBOM total count badge (blue/info) --- */
+  --color-sbom-total-badge-fg:     var(--color-blue-400);      /* #60A5FA */
+  --color-sbom-total-badge-bg:     rgba(59, 130, 246, 0.20);
+  --color-sbom-total-badge-border: rgba(59, 130, 246, 0.30);
+
+  /* --- SBOM type chips (violet — same hue as variant-tag, different semantic role) --- */
+  --color-sbom-chip-fg:            var(--color-violet-400);
+  --color-sbom-chip-bg:            rgba(139, 92, 246, 0.12);
+  --color-sbom-chip-border:        rgba(139, 92, 246, 0.20);
+  --color-sbom-chip-bg-hover:      rgba(139, 92, 246, 0.25);
+  --color-sbom-chip-border-hover:  rgba(139, 92, 246, 0.40);
+  --color-sbom-chip-active-bg:     rgba(139, 92, 246, 0.30);
+  --color-sbom-chip-active-border: rgba(139, 92, 246, 0.50);
+  --color-sbom-chip-active-shadow: rgba(139, 92, 246, 0.20);
+
+  /* --- SBOM package panel + row stripe --- */
+  --color-sbom-panel-bg:           rgba(0, 0, 0, 0.15);
+  --color-sbom-item-stripe-bg:     rgba(255, 255, 255, 0.03);
+
+  /* --- Changelog summary badge (amber — "N changes in this version") --- */
+  --color-changelog-badge-fg:      var(--color-amber-400);     /* #FBBF24 */
+  --color-changelog-badge-bg:      rgba(245, 158, 11, 0.20);
+  --color-changelog-badge-border:  rgba(245, 158, 11, 0.30);
+
+  /* --- Changelog / dep-change type badges (state: added/updated/removed/major/minor/patch) --- */
+  --color-badge-added-fg:          var(--color-green-400);     /* #4ADE80 — dark fg */
+  --color-badge-added-bg:          rgba(16, 185, 129, 0.20);
+  --color-badge-added-border:      rgba(16, 185, 129, 0.30);
+  --color-badge-removed-fg:        var(--color-red-400);       /* #F87171 */
+  --color-badge-removed-bg:        rgba(239, 68, 68, 0.20);
+  --color-badge-removed-border:    rgba(239, 68, 68, 0.30);
+  --color-badge-updated-fg:        var(--color-blue-400);      /* #60A5FA */
+  --color-badge-updated-bg:        rgba(59, 130, 246, 0.20);
+  --color-badge-updated-border:    rgba(59, 130, 246, 0.30);
+  /* major = danger, minor = warn, patch = success */
+  --color-badge-major-fg:          var(--color-red-400);
+  --color-badge-major-bg:          rgba(239, 68, 68, 0.20);
+  --color-badge-major-border:      rgba(239, 68, 68, 0.30);
+  --color-badge-minor-fg:          var(--color-amber-400);
+  --color-badge-minor-bg:          rgba(245, 158, 11, 0.20);
+  --color-badge-minor-border:      rgba(245, 158, 11, 0.30);
+  --color-badge-patch-fg:          var(--color-green-400);
+  --color-badge-patch-bg:          rgba(16, 185, 129, 0.20);
+  --color-badge-patch-border:      rgba(16, 185, 129, 0.30);
+
+  /* --- Dep health summary badges (reuse feedback tints but named for the role) --- */
+  --color-dep-badge-ok-fg:          var(--color-green-400);
+  --color-dep-badge-ok-bg:          rgba(16, 185, 129, 0.20);
+  --color-dep-badge-ok-border:      rgba(16, 185, 129, 0.30);
+  --color-dep-badge-warning-fg:     var(--color-amber-400);
+  --color-dep-badge-warning-bg:     rgba(245, 158, 11, 0.20);
+  --color-dep-badge-warning-border: rgba(245, 158, 11, 0.30);
+  --color-dep-badge-neutral-fg:     rgba(255, 255, 255, 0.60); /* no primitive — structural muted */
+  --color-dep-badge-neutral-bg:     rgba(107, 114, 128, 0.20);
+  --color-dep-badge-neutral-border: rgba(107, 114, 128, 0.30);
+
+  /* --- Dep health bar (progress bar track + fill gradients) --- */
+  --color-dep-bar-track-bg:         rgba(255, 255, 255, 0.08);
+  --color-dep-bar-fill-start:        var(--color-green-400);  /* #4ADE80 */
+  --color-dep-bar-fill-end:          var(--color-green-500);  /* #10B981 */
+  --color-dep-bar-warn-start:        var(--color-amber-500);  /* #F59E0B */
+  --color-dep-bar-warn-end:          var(--color-amber-600);  /* #D97706 */
+
+  /* --- Dep version latest / up-to-date items --- */
+  --color-dep-version-latest-fg:    var(--color-green-400);   /* #4ADE80 */
+  --color-dep-uptodate-item-bg:     rgba(16, 185, 129, 0.08);
+  --color-dep-uptodate-item-border: rgba(16, 185, 129, 0.15);
+
+  /* --- Detail badge (zone-1 identity, green = "available") --- */
+  --color-detail-badge-fg:      var(--color-green-400);
+  --color-detail-badge-bg:      rgba(16, 185, 129, 0.20);
+  --color-detail-badge-border:  rgba(16, 185, 129, 0.30);
+
+  /* --- Readme inline code (pink accent on dark, distinguishes code from prose) --- */
+  --color-readme-code-bg:   rgba(0, 0, 0, 0.30);
+  --color-readme-code-fg:   #f472b6;               /* pink-400 — decorative only, no a11y claim */
+  --color-readme-pre-bg:    rgba(0, 0, 0, 0.30);
+
+  /* --- Lineage items (faint raised bg) --- */
+  --color-lineage-item-bg:   rgba(255, 255, 255, 0.05);
+
+  /* --- Table row stripe (subtle alternating row bg) --- */
+  --color-table-row-even-bg:  rgba(255, 255, 255, 0.02);
+  --color-table-row-odd-bg:   rgba(255, 255, 255, 0.03);   /* sbom-package-item */
+  --color-table-border:       rgba(255, 255, 255, 0.04);
+
+  /* --- Variant dep notification badge (amber, high-visibility — not for text) --- */
+  --color-variant-dep-badge-bg: rgba(245, 158, 11, 0.90);  /* opaque amber for floating notification dot */
+
+  /* --- Pull section toggle + input --- */
+  --color-registry-toggle-bg:  rgba(0, 0, 0, 0.20);
+  --color-pull-input-bg:       rgba(0, 0, 0, 0.20);
+  --color-copy-btn-bg:         rgba(255, 255, 255, 0.10);
+  --color-copy-btn-bg-hover:   rgba(255, 255, 255, 0.20);
+  --color-copy-btn-copied-bg:  rgba(16, 185, 129, 0.20);
+
+  /* --- Severity grid (security scan, 5-column) --- */
+  --color-severity-grid-bg:     rgba(255, 255, 255, 0.03);
+  --color-severity-grid-border: rgba(255, 255, 255, 0.06);
+
+  /* --- Nav chrome --- */
+  --color-nav-bg:               rgba(15, 23, 42, 0.55);     /* navy-950 alpha */
+  --color-nav-border:           rgba(255, 255, 255, 0.08);
+  --color-nav-link-hover-bg:    rgba(255, 255, 255, 0.04);
+  --color-nav-link-active-bg:   rgba(139, 92, 246, 0.12);   /* violet tint */
+
+  /* --- .btn:hover / generic glass-surface hover --- */
+  --color-btn-hover-bg:         rgba(255, 255, 255, 0.20);
+  --color-btn-hover-shadow:     rgba(0, 0, 0, 0.20);
+
+  /* --- Disclosure summary hover (explore zone) --- */
+  --color-disclosure-hover-bg:  rgba(255, 255, 255, 0.04);
+
+  /* --- page-content inline code (standalone pages, not readme) --- */
+  --color-page-code-bg:   rgba(255, 255, 255, 0.08);
+  --color-page-pre-bg:    rgba(0, 0, 0, 0.30);
 }
 
 /* Spacing semantic aliases */
@@ -269,6 +427,140 @@
   --color-feedback-error-fg:   var(--color-red-700);     /* #B91C1C — 6.47:1 on white (was red-400 2.77:1 FAIL) */
   --color-feedback-info-fg:    var(--color-blue-700);    /* #1D4ED8 — 6.70:1 on white (was blue-400 2.54:1 FAIL) */
   --color-feedback-success-bg: rgba(4, 120, 87, 0.10);  /* green-700 alpha — tinted on white surfaces */
+
+  /* Trust badge hover — same mechanism, slightly lower alpha for bright surfaces */
+  --color-trust-sbom-bg-hover:          rgba(15, 118, 110, 0.18);  /* teal-700 alpha */
+  --color-trust-sbom-border-hover:      rgba(15, 118, 110, 0.40);
+  --color-trust-multiarch-bg-hover:     rgba(109, 40, 217, 0.16);  /* violet-700 alpha */
+  --color-trust-multiarch-border-hover: rgba(109, 40, 217, 0.40);
+  --color-trust-deps-fg:                var(--color-blue-700);     /* #1D4ED8 — 6.70:1 on white */
+  --color-trust-deps-bg:                rgba(29, 78, 216, 0.08);
+  --color-trust-deps-border:            rgba(29, 78, 216, 0.20);
+  --color-trust-deps-bg-hover:          rgba(29, 78, 216, 0.14);
+  --color-trust-deps-border-hover:      rgba(29, 78, 216, 0.35);
+  --color-trust-trivy-clean-bg-hover:   rgba(4, 120, 87, 0.14);   /* green-700 alpha */
+  --color-trust-trivy-clean-border:     rgba(4, 120, 87, 0.28);
+  --color-trust-trivy-clean-border-hover: rgba(4, 120, 87, 0.45);
+  --color-trust-trivy-critical-bg:      rgba(185, 28, 28, 0.12);  /* red-700 alpha */
+  --color-trust-trivy-critical-border:  rgba(185, 28, 28, 0.35);
+  --color-trust-trivy-critical-bg-hover:  rgba(185, 28, 28, 0.20);
+  --color-trust-trivy-critical-border-hover: rgba(185, 28, 28, 0.50);
+  --color-trust-trivy-warn-border:      rgba(180, 83, 9, 0.32);   /* amber-700 alpha */
+  --color-trust-trivy-warn-bg-hover:    rgba(180, 83, 9, 0.18);
+  --color-trust-trivy-warn-border-hover: rgba(180, 83, 9, 0.48);
+
+  /* Component tokens — light overrides (WCAG AA verified on #FFFFFF) */
+
+  /* Variant tags: violet-700 on white — 7.10:1 (AAA) */
+  --color-variant-tag-fg:           var(--color-violet-700);   /* #6D28D9 — 7.10:1 on white */
+  --color-variant-tag-bg:           rgba(109, 40, 217, 0.10);
+  --color-variant-tag-border:       rgba(109, 40, 217, 0.25);
+  --color-variant-tag-bg-hover:     rgba(109, 40, 217, 0.18);
+  --color-variant-tag-selected-bg:  rgba(59, 130, 246, 0.14);  /* blue on light-selected */
+  --color-variant-tag-selected-shadow: rgba(59, 130, 246, 0.18);
+  --color-variant-badge-default-bg:  rgba(4, 120, 87, 0.14);   /* green-700 alpha on white */
+  --color-variant-badge-default-fg:  var(--color-green-700);
+
+  /* SBOM badges: violet-700 + blue-700 on white */
+  --color-sbom-total-badge-fg:       var(--color-blue-700);    /* #1D4ED8 — 6.70:1 on white */
+  --color-sbom-total-badge-bg:       rgba(29, 78, 216, 0.12);
+  --color-sbom-total-badge-border:   rgba(29, 78, 216, 0.30);
+  --color-sbom-chip-fg:              var(--color-violet-700);  /* #6D28D9 — 7.10:1 on white */
+  --color-sbom-chip-bg:              rgba(109, 40, 217, 0.08);
+  --color-sbom-chip-border:          rgba(109, 40, 217, 0.20);
+  --color-sbom-chip-bg-hover:        rgba(109, 40, 217, 0.15);
+  --color-sbom-chip-active-bg:       rgba(109, 40, 217, 0.18);
+  --color-sbom-chip-active-shadow:   rgba(109, 40, 217, 0.10);
+  --color-sbom-panel-bg:             rgba(0, 0, 0, 0.03);
+  --color-sbom-item-stripe-bg:       rgba(0, 0, 0, 0.03);
+
+  /* Changelog / dep-change badges on white */
+  --color-changelog-badge-fg:        var(--color-amber-700);  /* #B45309 — 5.02:1 on white */
+  --color-changelog-badge-bg:        rgba(180, 83, 9, 0.12);
+  --color-changelog-badge-border:    rgba(180, 83, 9, 0.30);
+  --color-badge-added-fg:            var(--color-green-700);  /* #047857 — 5.48:1 on white */
+  --color-badge-added-bg:            rgba(4, 120, 87, 0.10);
+  --color-badge-removed-fg:          var(--color-red-700);    /* #B91C1C — 6.47:1 on white */
+  --color-badge-removed-bg:          rgba(185, 28, 28, 0.10);
+  --color-badge-updated-fg:          var(--color-blue-700);   /* #1D4ED8 — 6.70:1 on white */
+  --color-badge-updated-bg:          rgba(29, 78, 216, 0.10);
+  --color-badge-major-fg:            var(--color-red-700);
+  --color-badge-major-bg:            rgba(185, 28, 28, 0.10);
+  --color-badge-minor-fg:            var(--color-amber-700);
+  --color-badge-minor-bg:            rgba(180, 83, 9, 0.10);
+  --color-badge-patch-fg:            var(--color-green-700);
+  --color-badge-patch-bg:            rgba(4, 120, 87, 0.10);
+
+  /* Dep health */
+  --color-dep-badge-ok-fg:           var(--color-green-700);
+  --color-dep-badge-ok-bg:           rgba(4, 120, 87, 0.12);
+  --color-dep-badge-warning-fg:      var(--color-amber-700);  /* #B45309 — 5.02:1; was #92400e (same value) */
+  --color-dep-badge-warning-bg:      rgba(180, 83, 9, 0.12);
+  --color-dep-badge-warning-border:  rgba(180, 83, 9, 0.30);
+  --color-dep-badge-neutral-fg:      #4b5563;                 /* neutral-700-level — 7.37:1 on white */
+  --color-dep-badge-neutral-bg:      rgba(107, 114, 128, 0.10);
+  --color-dep-badge-neutral-border:  rgba(107, 114, 128, 0.20);
+  --color-dep-bar-track-bg:          rgba(0, 0, 0, 0.06);
+  --color-dep-version-latest-fg:     var(--color-green-700);  /* was #047857 (same value, now token ref) */
+  --color-dep-uptodate-item-bg:      rgba(4, 120, 87, 0.06);
+  --color-variant-dep-badge-bg:      rgba(180, 83, 9, 0.90);  /* amber-700 alpha — opaque notification dot on light */
+
+  /* Detail badge */
+  --color-detail-badge-fg:           var(--color-green-700);  /* #047857 — 5.48:1 on white */
+  --color-detail-badge-bg:           rgba(4, 120, 87, 0.14);
+  --color-detail-badge-border:       rgba(4, 120, 87, 0.30);
+
+  /* Readme inline code (purple on light — 5.04:1 on white) */
+  --color-readme-code-bg:            rgba(0, 0, 0, 0.06);
+  --color-readme-code-fg:            #9333ea;                 /* violet-600 — 5.04:1 on white */
+  --color-readme-pre-bg:             #1e293b;                 /* fixed dark for readability of code */
+
+  /* Lineage items */
+  --color-lineage-item-bg:           rgba(0, 0, 0, 0.04);
+
+  /* Table */
+  --color-table-row-even-bg:         rgba(0, 0, 0, 0.02);
+  --color-table-row-odd-bg:          rgba(0, 0, 0, 0.03);
+  --color-table-border:              rgba(0, 0, 0, 0.06);
+
+  /* Pull section */
+  --color-registry-toggle-bg:        rgba(0, 0, 0, 0.06);
+  --color-pull-input-bg:             rgba(0, 0, 0, 0.04);
+  --color-copy-btn-bg:               rgba(0, 0, 0, 0.04);
+  --color-copy-btn-bg-hover:         rgba(0, 0, 0, 0.08);
+
+  /* Severity grid */
+  --color-severity-grid-bg:          rgba(15, 23, 42, 0.03);
+  --color-severity-grid-border:      rgba(15, 23, 42, 0.06);
+
+  /* Nav */
+  --color-nav-bg:                    rgba(255, 255, 255, 0.70);
+  --color-nav-border:                rgba(0, 0, 0, 0.06);
+  --color-nav-link-active-bg:        rgba(109, 40, 217, 0.10);  /* violet-700 alpha */
+
+  /* Disclosure */
+  --color-disclosure-hover-bg:       rgba(0, 0, 0, 0.03);
+
+  /* Page code */
+  --color-page-code-bg:              rgba(15, 23, 42, 0.06);
+  --color-page-pre-bg:               rgba(15, 23, 42, 0.05);
+
+  /* Nav link hover — dark-on-light (was white-on-white at rgba(255,255,255,0.04)) */
+  --color-nav-link-hover-bg:         rgba(0, 0, 0, 0.04);
+
+  /* .btn:hover — dark-on-light (was white-on-white at rgba(255,255,255,0.20)) */
+  --color-btn-hover-bg:              rgba(0, 0, 0, 0.10);
+
+  /* Trust badge resting bg/border — 700-level hue to match hover ladder (SENIOR-M1) */
+  --color-trust-sbom-bg:             rgba(15, 118, 110, 0.10);   /* teal-700 alpha */
+  --color-trust-sbom-border:         rgba(15, 118, 110, 0.28);
+  --color-trust-multiarch-bg:        rgba(109, 40, 217, 0.08);   /* violet-700 alpha */
+  --color-trust-multiarch-border:    rgba(109, 40, 217, 0.25);
+
+  /* Feedback bg siblings — symmetric coverage (SENIOR-M2) */
+  --color-feedback-warning-bg:       rgba(180, 83, 9, 0.10);     /* amber-700 alpha */
+  --color-feedback-error-bg:         rgba(185, 28, 28, 0.10);    /* red-700 alpha */
+  --color-feedback-info-bg:          rgba(29, 78, 216, 0.10);    /* blue-700 alpha */
 }
 
 /* ----------------------------------------------------------

--- a/docs/site/assets/css/tokens.css
+++ b/docs/site/assets/css/tokens.css
@@ -469,7 +469,9 @@
   --color-sbom-chip-bg:              rgba(109, 40, 217, 0.08);
   --color-sbom-chip-border:          rgba(109, 40, 217, 0.20);
   --color-sbom-chip-bg-hover:        rgba(109, 40, 217, 0.15);
+  --color-sbom-chip-border-hover:    rgba(109, 40, 217, 0.45);  /* violet-700 alpha — visible on white, matches 700-level fg */
   --color-sbom-chip-active-bg:       rgba(109, 40, 217, 0.18);
+  --color-sbom-chip-active-border:   rgba(109, 40, 217, 0.55);  /* violet-700 alpha — slightly stronger than border-hover */
   --color-sbom-chip-active-shadow:   rgba(109, 40, 217, 0.10);
   --color-sbom-panel-bg:             rgba(0, 0, 0, 0.03);
   --color-sbom-item-stripe-bg:       rgba(0, 0, 0, 0.03);
@@ -480,20 +482,27 @@
   --color-changelog-badge-border:    rgba(180, 83, 9, 0.30);
   --color-badge-added-fg:            var(--color-green-700);  /* #047857 — 5.48:1 on white */
   --color-badge-added-bg:            rgba(4, 120, 87, 0.10);
+  --color-badge-added-border:        rgba(4, 120, 87, 0.30);   /* green-700 alpha */
   --color-badge-removed-fg:          var(--color-red-700);    /* #B91C1C — 6.47:1 on white */
   --color-badge-removed-bg:          rgba(185, 28, 28, 0.10);
+  --color-badge-removed-border:      rgba(185, 28, 28, 0.30);  /* red-700 alpha */
   --color-badge-updated-fg:          var(--color-blue-700);   /* #1D4ED8 — 6.70:1 on white */
   --color-badge-updated-bg:          rgba(29, 78, 216, 0.10);
+  --color-badge-updated-border:      rgba(29, 78, 216, 0.30);  /* blue-700 alpha */
   --color-badge-major-fg:            var(--color-red-700);
   --color-badge-major-bg:            rgba(185, 28, 28, 0.10);
+  --color-badge-major-border:        rgba(185, 28, 28, 0.30);  /* red-700 alpha */
   --color-badge-minor-fg:            var(--color-amber-700);
   --color-badge-minor-bg:            rgba(180, 83, 9, 0.10);
+  --color-badge-minor-border:        rgba(180, 83, 9, 0.30);   /* amber-700 alpha */
   --color-badge-patch-fg:            var(--color-green-700);
   --color-badge-patch-bg:            rgba(4, 120, 87, 0.10);
+  --color-badge-patch-border:        rgba(4, 120, 87, 0.30);   /* green-700 alpha */
 
   /* Dep health */
   --color-dep-badge-ok-fg:           var(--color-green-700);
   --color-dep-badge-ok-bg:           rgba(4, 120, 87, 0.12);
+  --color-dep-badge-ok-border:       rgba(4, 120, 87, 0.30);   /* green-700 alpha */
   --color-dep-badge-warning-fg:      var(--color-amber-700);  /* #B45309 — 5.02:1; was #92400e (same value) */
   --color-dep-badge-warning-bg:      rgba(180, 83, 9, 0.12);
   --color-dep-badge-warning-border:  rgba(180, 83, 9, 0.30);


### PR DESCRIPTION
## Summary

Aligns production CSS to the locked Phase C mockups via token-only references. The light/dark `ThemeManager` toggle already shipped — this PR fills the token-coverage gap so both themes resolve to the mockup-equivalent colors.

- **~30 new semantic tokens** in `tokens.css` (variant-tag, sbom-chip, trust-badge hover variants, dep-bar gradients, table-row, registry-toggle, code-block, severity-grid, badge-added/removed/updated, dep-version-latest, etc.) — each paired with `[data-theme="light"]` overrides using 700-level primitive hues.
- **WCAG AA verified** on white: `#0F766E` teal-700 (5.47:1), `#0E7490` cyan-700 (5.36:1), `#6D28D9` violet-700 (7.10:1), `#1D4ED8` blue-700 (6.70:1), `#047857` green-700 (5.48:1), `#B45309` amber-700 (5.02:1), `#B91C1C` red-700 (6.47:1).
- **Ad-hoc rgba/hex elimination**: `theme.css` 58 → 11, `container-detail.css` 90 → 3. Remaining literals are gradient stops or motivated reversals (e.g. light-on-dark-pre code blocks).
- **Hue-ladder consistency**: trust-badge sbom/multi-arch resting and hover both use 700-level alpha in light so the hover state intensifies rather than shifting hue.
- **Feedback bg coverage**: warning/error/info tokens gain light variants matching the existing success-bg override.
- **Hover visibility**: `.btn:hover` and `.site-nav-link:hover` now have explicit light values so feedback states stay visible on white.

## Files

- `assets/css/tokens.css` (+292 LOC: new semantic tokens + light overrides)
- `assets/css/theme.css` (-55 net: ad-hoc rgba → var refs)
- `assets/css/container-detail.css` (-98 net: same)
- `assets/css/dashboard.css` (-2 net)
- `assets/css/blog.css` (-2 net)

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] `https://oorabona.github.io/docker-containers/` renders identically to current dark theme (no visual regression vs master)
- [ ] Click theme toggle → light theme renders with mockup-aligned colors (no white-on-white invisible hovers)
- [ ] `.dep-health-section` retains its padding (CSS comment bug fix)
- [ ] `[data-theme="light"] .readme-content pre code` keeps `#e2e8f0` text on dark pre bg (CSS comment bug fix)
- [ ] Trust badges sbom/multi-arch: hover stays in same hue family as resting state on light
- [ ] Lighthouse a11y >= 95 in both themes
