### PR TITLE
fix(container-detail): drop unsupported `and` in where_exp filter

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -630,11 +630,11 @@
           {%- if page.versions -%}
             {%- assign _versions_count = page.versions.size -%}
             {%- for _v in page.versions -%}
-              {%- assign _selectable = _v.variants | where_exp: "v", "v.name and v.name != ''" -%}
+              {%- assign _selectable = _v.variants | where_exp: "v", "v.name != ''" -%}
               {%- assign _variants_count = _variants_count | plus: _selectable.size -%}
             {%- endfor -%}
           {%- elsif page.variants -%}
-            {%- assign _selectable = page.variants | where_exp: "v", "v.name and v.name != ''" -%}
+            {%- assign _selectable = page.variants | where_exp: "v", "v.name != ''" -%}
             {%- assign _variants_count = _selectable.size -%}
             {%- assign _versions_count = 1 -%}
           {%- endif -%}
@@ -701,7 +701,7 @@
                   {% if page.versions %}
                     <version-tabs class="version-tabs" data-active-tag="{{ default_variant.tag }}">
                       {% for version in page.versions %}
-                      {%- assign _selectable_v = version.variants | where_exp: "v", "v.name and v.name != ''" -%}
+                      {%- assign _selectable_v = version.variants | where_exp: "v", "v.name != ''" -%}
                       {%- if _selectable_v.size > 0 -%}
                       <div class="version-tabs-group" role="tablist" aria-label="Variants for version {{ version.base_tag | default: version.tag }}">
                         <p class="eyebrow version-tabs-group-label">{{ version.base_tag | default: version.tag }}</p>


### PR DESCRIPTION
## Summary

Hotfix — production deploy has been failing since PR #385 merge. Liquid `where_exp` does not support `and`/`or` boolean operators; the parser raises `Liquid syntax error: Expected end_of_string but found id` at build time.

Three sites in `_layouts/container-detail.html` (lines 633, 637, 704) used `"v.name and v.name != ''"`. The YAML schema guarantees every variant carries a `name` string, so the boolean is unnecessary — `"v.name != ''"` correctly filters synthetic empty-name carriers.

## Impact

- **Pages deploy was failing on master** since 2026-05-05 20:56 UTC (PR #385 merge). Production was stale at PR #384 state until this fix.
- After merge, the next `update-dashboard.yaml` run should succeed.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)  
- [ ] `Update Dashboard & Deploy Jekyll Site` workflow succeeds on master
- [ ] `https://oorabona.github.io/docker-containers/container/postgres/` renders the 4-zone disclosure layout (PR #385) and uses the light/dark token system (PR #386)