### PR TITLE
refactor(nav): align navbar size and translucency with mockup

### DIFF
--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -323,13 +323,15 @@ body {
   /* F7: no page-load animation */
 }
 
-/* Theme toggle — min 44px for WCAG 2.5.8 touch target */
+/* Theme toggle — 32px keeps the navbar compact while staying above the
+   WCAG 2.5.8 AA minimum touch target of 24x24 (44x44 is the AAA target,
+   reserved for primary action surfaces). */
 .theme-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 32px;
+  height: 32px;
   border-radius: var(--radius-md);
   background: var(--glass-bg);
   color: var(--color-text-primary);
@@ -447,8 +449,8 @@ body {
   position: sticky;
   top: 0;
   z-index: 50;
-  backdrop-filter: blur(16px) saturate(140%);
-  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   background: var(--color-nav-bg);
   border-bottom: 1px solid var(--color-nav-border);
 }
@@ -462,7 +464,7 @@ body {
 .site-nav-inner {
   max-width: 1280px; /* F9: 1100→1280px matches .container (no --layout-max-width token yet; TODO PR4 extract) */
   margin: 0 auto;
-  padding: 0.85rem 1.25rem;
+  padding: 0.85rem 1.5rem;
   display: flex;
   align-items: center;
   gap: 1.5rem;

--- a/docs/site/assets/css/tokens.css
+++ b/docs/site/assets/css/tokens.css
@@ -344,7 +344,7 @@
   --color-severity-grid-border: rgba(255, 255, 255, 0.06);
 
   /* --- Nav chrome --- */
-  --color-nav-bg:               rgba(15, 23, 42, 0.55);     /* navy-950 alpha */
+  --color-nav-bg:               rgba(15, 23, 42, 0.85);     /* navy-950 alpha */
   --color-nav-border:           rgba(255, 255, 255, 0.08);
   --color-nav-link-hover-bg:    rgba(255, 255, 255, 0.04);
   --color-nav-link-active-bg:   rgba(139, 92, 246, 0.12);   /* violet tint */


### PR DESCRIPTION
## Summary

Visual alignment between production and the locked Phase C mockups (`/tmp/dashboard-mockups/final-dashboard.html`). The navbar was 12px taller and ~30% more translucent than the mockup; this PR closes the gap.

| Property | Before | After | Mockup |
|----------|--------|-------|--------|
| `.theme-toggle` size | 44×44 | 32×32 | ~30×30 |
| `--color-nav-bg` opacity | rgba(15,23,42,**0.55**) | **0.85** | 0.85 |
| `.site-nav` backdrop-filter | blur(16px) saturate(140%) | blur(12px) | blur(12px) |
| `.site-nav-inner` padding-X | 1.25rem | 1.5rem | 1.5rem |
| Net navbar height | ~72px | ~60px | ~60px |

## Accessibility

`.theme-toggle` 32×32 stays above the WCAG 2.5.8 AA minimum target size of 24×24. The 44×44 target is the AAA enhanced threshold (WCAG 2.5.5) and is reserved for primary action surfaces — a secondary nav toggle does not need it. Existing `.code-block__copy` and `.disclosure summary` keep their 24/44px targets unchanged.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)  
- [ ] `Update Dashboard & Deploy Jekyll Site` succeeds on master after merge
- [ ] Production navbar height matches mockup (~60px, not ~72px)
- [ ] Background-blur intensity matches mockup (less saturated, less translucent)
- [ ] Theme toggle still keyboard-reachable + clickable on mobile (touch target ≥ 24px)
- [ ] Lighthouse a11y >= 95