### PR TITLE
refactor(css): drop legacy aurora background to match Phase C flat backdrop

### DIFF
--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -12,19 +12,10 @@
       color: #374151;
     }
 
-    /* Detail-specific animated background overrides — sizes/gradients from theme.css */
-    .bg-animated::before {
-      animation: drift 25s ease-in-out infinite;
-    }
-    @keyframes drift {
-      0%, 100% { transform: translate(0, 0) rotate(0deg) scale(1); }
-      25% { transform: translate(3%, -2%) rotate(2deg) scale(1.05); }
-      50% { transform: translate(-2%, 3%) rotate(-1deg) scale(0.95); }
-      75% { transform: translate(1%, -1%) rotate(1.5deg) scale(1.02); }
-    }
-
-    /* F7: .shape-1/2/3 render statically — will-change removed (no animation, no cost) */
-    /* orbit1/orbit2/orbit3 keyframes removed: no consumers after F7 */
+    /* Detail-page background — flat navy per Phase C. Aurora gradient + drift
+       animation removed alongside the cross-layout `.bg-animated`. The empty
+       `<div class="bg-animated">` hook stays in the layout for future
+       (spec-noted) decoration without a markup change. */
 
     /* ============================================================
        4-ZONE LAYOUT (Phase C PR)

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -254,74 +254,13 @@ body {
   background-size: 200px 200px, 100% 100%;
 }
 
-/* Animated gradient background */
-.bg-animated {
-  position: fixed;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  z-index: -1;
-  overflow: hidden;
-}
-
-/* Floating shapes base */
-.shape {
-  position: fixed;
-  border-radius: 50%;
-  filter: blur(60px);
-  opacity: 0.5;
-  z-index: -1;
-}
-
-/* === Animated background chrome (cross-layout) === */
-/* Used by blog, post, and dashboard layouts. Container-detail overrides
-   .bg-animated::before and .shape-* animations with drift/orbit keyframes. */
-
-.bg-animated::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background:
-    radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.3) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(255, 119, 198, 0.2) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(59, 130, 246, 0.2) 0%, transparent 40%);
-  animation: float 20s ease-in-out infinite;
-}
-
-@keyframes float {
-  0%, 100% { transform: translate(0, 0) rotate(0deg); }
-  33% { transform: translate(2%, 2%) rotate(1deg); }
-  66% { transform: translate(-1%, 1%) rotate(-1deg); }
-}
-
-.shape-1 {
-  width: 400px;
-  height: 400px;
-  background: var(--gradient-1);
-  top: 10%;
-  right: 10%;
-  /* F7: no page-load animation — calm-static-render (design gate: no pulse) */
-}
-
-.shape-2 {
-  width: 300px;
-  height: 300px;
-  background: var(--gradient-3);
-  bottom: 20%;
-  left: 5%;
-  /* F7: no page-load animation */
-}
-
-.shape-3 {
-  width: 250px;
-  height: 250px;
-  background: var(--gradient-2);
-  top: 50%;
-  left: 50%;
-  /* F7: no page-load animation */
-}
+/* Background chrome — Phase C calls for a flat navy backdrop (with the
+   token-driven body gradient) rather than the legacy aurora. The
+   `.bg-animated` and `.shape-*` divs remain in the layouts as
+   non-rendering hooks so future decoration (e.g. the spec-noted "3%
+   noise overlay") can attach without a markup change. */
+.bg-animated,
+.shape { display: none; }
 
 /* Theme toggle — 32px keeps the navbar compact while staying above the
    WCAG 2.5.8 AA minimum touch target of 24x24 (44x44 is the AAA target,


### PR DESCRIPTION
## Summary

Visual parity follow-up. The dashboard, blog, post, and container-detail layouts each ship a `.bg-animated` div + three `.shape-*` blurred blobs that paint a purple/pink/blue aurora across every page. Phase C calls for a flat navy backdrop with a 3% noise overlay (already on the `body` rule), so the aurora is now legacy.

| Element | Before | After |
|---------|--------|-------|
| `.bg-animated::before` | 3 radial gradients + `float 20s` animation | display: none |
| `.shape-1/2/3` | 400/300/250px blurred gradient blobs | display: none |
| Container-detail `.bg-animated::before` drift | 25s rotate/scale animation | removed |
| Body bg | flat navy gradient + 3% noise (kept) | unchanged |

Empty `.bg-animated` and `.shape-*` divs remain in the layouts so future decoration (spec-noted noise overlay refresh) can hook without a markup change.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] `Update Dashboard & Deploy Jekyll Site` succeeds on master
- [ ] Dashboard hero no longer shows the violet/pink aurora glow on the right side
- [ ] Container detail page background matches the flat navy of `/tmp/dashboard-mockups/detail-B-progressive.html`
- [ ] No CLS regressions (the divs still occupy their stacking context)
- [ ] Lighthouse a11y >= 95