### PR TITLE
fix(postgres): preload pg_search for ParadeDB 0.23.x bg worker

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -275,6 +275,13 @@ RUN PRELOAD=""; \
     if [ -f /usr/local/lib/postgresql/pg_cron.so ]; then \
         PRELOAD="${PRELOAD:+$PRELOAD,}pg_cron"; \
     fi; \
+    # pg_search if present — ParadeDB 0.23.x added a background worker
+    # requirement, so the extension must be in shared_preload_libraries BEFORE
+    # Postgres starts; without it `CREATE EXTENSION pg_search` raises
+    # "pg_search must be loaded via shared_preload_libraries" during initdb.
+    if [ -f /usr/local/lib/postgresql/pg_search.so ]; then \
+        PRELOAD="${PRELOAD:+$PRELOAD,}pg_search"; \
+    fi; \
     # Save for reference
     echo "$PRELOAD" > /etc/postgresql-preload.conf; \
     # Modify postgresql.conf.sample so initdb creates config with preload libraries

--- a/postgres/flavors/full.yaml
+++ b/postgres/flavors/full.yaml
@@ -31,11 +31,13 @@ builtin_extensions:
   - adminpack
 
 # shared_preload_libraries
+# pg_search (ParadeDB) added since 0.23.x — bg worker requirement.
 shared_preload_libraries:
   - pg_qualstats
   - citus
   - timescaledb
   - pg_cron
+  - pg_search
 
 # Image tags to publish
 tags:

--- a/postgres/flavors/vector.yaml
+++ b/postgres/flavors/vector.yaml
@@ -17,9 +17,13 @@ extensions:
 builtin_extensions: []
 
 # shared_preload_libraries (inherited from base)
-# pg_cron requires shared_preload; paradedb does NOT (PG17+)
+# pg_cron is a scheduled-job background worker.
+# pg_search (ParadeDB) requires shared_preload_libraries since 0.23.x: the
+# extension uses a background worker for the BM25 search engine and the
+# CREATE EXTENSION call fails at initdb time without it.
 shared_preload_libraries:
   - pg_cron
+  - pg_search
 
 # License notice: paradedb (pg_search) is AGPL-3.0 licensed.
 # Ensure compliance with AGPL terms when distributing this flavor.


### PR DESCRIPTION
## Summary

Closes #390.

The `postgres:18-alpine-full` and `postgres:18-alpine-vector` containers (and their 17-/16- siblings) crash on startup because ParadeDB 0.23.x added a bg worker requirement to pg_search. The Dockerfile preload-detection block probes for installed extension `.so` files (citus, timescaledb, pg_qualstats, pg_cron) but never had a branch for `pg_search.so`, so the worker is never preloaded and `CREATE EXTENSION pg_search` fails at initdb time.

## Changes

| File | Change |
|------|--------|
| `postgres/Dockerfile` | Add a detection branch for `/usr/local/lib/postgresql/pg_search.so` to extend `$PRELOAD` |
| `postgres/flavors/full.yaml` | Add `pg_search` to the documented `shared_preload_libraries` list |
| `postgres/flavors/vector.yaml` | Same; refresh stale comment that predated the 0.23.x worker change |

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] After merge, the upstream-monitor or auto-build rebuilds the postgres images and republishes the `-full`/`-vector` tags
- [ ] `docker run --rm ghcr.io/oorabona/postgres:18-alpine-full` initializes without the `pg_search must be loaded via shared_preload_libraries` error
- [ ] `psql -c 'SHOW shared_preload_libraries'` includes `pg_search` for both flavors
- [ ] `CREATE EXTENSION pg_search;` succeeds; a sample BM25 query runs to completion
- [ ] Other flavors (`base`, `analytics`, `distributed`, `spatial`, `timeseries`) still start cleanly — the new detection branch is additive