### PR TITLE
refactor(about): emphasize multi-arch coverage + typography polish

### DIFF
--- a/docs/site/about.md
+++ b/docs/site/about.md
@@ -6,7 +6,7 @@ nav_active: about
 description: docker-containers is maintained by Olivier Orabona — context, project goals, and how to reach the maintainer.
 ---
 
-`docker-containers` is a personal infrastructure project that publishes a fleet of 13 custom Docker container images to GitHub Container Registry (GHCR) and Docker Hub. Each image is built with automated upstream version monitoring, signed SBOM attestation via Sigstore, and an advisory Trivy CVE scan.
+`docker-containers` is a personal infrastructure project that publishes a fleet of 13 custom Docker container images to GitHub Container Registry (GHCR) and Docker Hub. Each image is built with automated upstream version monitoring, signed SBOM attestation via Sigstore, an advisory Trivy CVE scan, and — uncommon for a personal catalog — **published as a multi-architecture manifest (amd64 + arm64) wherever the upstream supports it**.
 
 ## Maintainer
 
@@ -21,7 +21,7 @@ Each image is treated as a verifiable artifact. The detail page for any containe
 - The exact build commit and manifest digest
 - A Sigstore attestation for the SPDX-format SBOM (when available)
 - An advisory Trivy CVE scan summary
-- The multi-architecture manifest list
+- A multi-architecture manifest list (amd64 + arm64) — see the variant page for per-arch digests
 
 The verification guide at [/verify-images/]({{ '/verify-images/' | relative_url }}) walks through reproducing those checks with `cosign`, `gh`, and `Trivy`.
 
@@ -32,6 +32,7 @@ The verification guide at [/verify-images/]({{ '/verify-images/' | relative_url 
 | Upstream tracking | Manual, irregular | Automated daily upstream-monitor workflow with auto-PRs |
 | SBOM attestation | Not standard | SPDX JSON, Sigstore-signed, attached to each push |
 | Trivy advisory | Not standard | Surfaced on every container detail page (advisory, not blocking) |
+| Multi-arch coverage | amd64-only on most personal forks | amd64 + arm64 on every image where the upstream and dependencies support it |
 | Multi-distro | Limited | Linux base + Alpine + Ubuntu + Rocky / Trixie variants where supported |
 | Extension matrices | Per-image upstream choice | Flavor-based (e.g. PostgreSQL: vector / analytics / timeseries / spatial / distributed / full) |
 

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -701,16 +701,18 @@ body {
   font-size: 1.45rem;
   font-weight: 700;
   letter-spacing: -0.015em;
-  margin-top: 2.25rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
   scroll-margin-top: 80px;
 }
 
 .page-content code {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9em;
+  font-size: 0.875em;
   background: var(--color-page-code-bg);
-  padding: 0.15em 0.4em;
+  padding: 0.2em 0.45em;
   border-radius: 4px;
+  font-weight: 500;
 }
 
 [data-theme="light"] .page-content code {
@@ -742,6 +744,81 @@ body {
   .page-content {
     padding: 5rem 1rem 2rem;
   }
+}
+
+/* ===== page-content article — additive polish (About + generic static pages) =====
+   Scoped to `article` to avoid cascade bleed into .verify-page which uses
+   .verify-main selectors at higher specificity for its own list/table overrides. */
+
+/* ----- Paragraph + section heading spacing ----- */
+
+.page-content article p {
+  margin: 0 0 1.25rem;
+}
+
+.page-content article h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+/* ----- List alignment + item spacing ----- */
+
+.page-content article ul,
+.page-content article ol {
+  padding-left: 1.5rem;       /* bullets sit within the column indent */
+  margin: 0.75rem 0 1.25rem;  /* breathing room above and below */
+}
+
+.page-content article li {
+  margin-bottom: 0.5rem;
+  line-height: 1.65;
+}
+
+.page-content article li::marker {
+  color: var(--color-text-muted); /* muted so bullet doesn't fight body type */
+}
+
+/* ----- Comparison table ----- */
+
+.page-content article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0 2rem;
+  font-size: 0.95rem;
+  background: var(--color-surface-raised);
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.page-content article thead {
+  background: var(--color-surface-overlay);
+}
+
+.page-content article th,
+.page-content article td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.page-content article th {
+  font-weight: 600;
+  font-size: 0.825rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.page-content article tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.page-content article tbody tr:hover {
+  background: var(--color-disclosure-hover-bg);
 }
 
 /* ===== Verify page ===== */


### PR DESCRIPTION
## Summary

Updates the public About page to make multi-arch (amd64 + arm64) a parallel-rank fact alongside SBOM and Trivy, plus visual polish on lists, the comparison table, and section spacing.

## Why multi-arch deserves more visibility

Most personal / community Docker catalogs ship amd64-only — building arm64 takes extra QEMU emulation time, more storage, and a willingness to maintain a second compile path. `docker-containers` quietly does both for every image where upstream supports it. Surfacing this in the trust strip (next to SBOM and Trivy) makes the commitment explicit instead of buried in a manifest list line item.

## Content changes (`about.md`)

- Intro paragraph: adds "published as a multi-architecture manifest (amd64 + arm64) wherever the upstream supports it" with the *uncommon for a personal catalog* framing.
- Comparison table: new `Multi-arch coverage` row.
- Verifiable-artifact bullet: refreshed to surface per-arch digests on the variant page.

## CSS polish (`theme.css`)

All scoped to `.page-content article` so it doesn't bleed into the verify page (which has its own `.verify-main` selectors at higher specificity):

- Lists: padding/margin, `li` row gap, muted `::marker`.
- Tables: rounded surface, uppercase eyebrow header, padded cells, last-row borderless, hover state.
- Section spacing: `h2` top margin 2.25→3rem, new `h3` rule, paragraph bottom rhythm.
- Inline code: tighter font + slight weight bump.

Tokens used: `--color-surface-raised`, `--color-surface-overlay`, `--color-border-subtle`, `--color-text-secondary`, `--color-disclosure-hover-bg`, `--color-page-code-bg`, `--color-text-muted` — all already have `[data-theme="light"]` overrides.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] After deploy, `https://oorabona.github.io/docker-containers/about/` renders the new multi-arch row in the comparison table
- [ ] Bullet markers align cleanly with their paragraph indent (no flush-left bullets next to indented body text)
- [ ] Comparison table has visible cell borders, header eyebrow style, and row hover
- [ ] Verify page (`/verify-images/`) is unchanged — its own scoped selectors take precedence
- [ ] Lighthouse a11y >= 95