### PR TITLE
fix(security-scan): drop ss01/cv11 + optical-sizing causing headline blur

### DIFF
--- a/docs/site/assets/css/components/security-scan-card.css
+++ b/docs/site/assets/css/components/security-scan-card.css
@@ -52,9 +52,11 @@ body .trust-badge {
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
   margin: 0;
-  /* Gate 4 headline tweaks */
-  font-feature-settings: "ss01", "cv11";
-  font-optical-sizing: auto;
+  /* Gate 4 headline tweaks: ss01/cv11 + optical-sizing produced a visible
+     double-stroke artefact on this 24px Inter 600 line in Chromium-based
+     browsers — the combined feature settings forced the renderer into a
+     fallback path that doubled the glyph outline. Removed; the rest of the
+     spec (Inter SemiBold, tight line-height) is still applied via --text-h3. */
 }
 
 /* -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The "Trivy · last scan ..." headline inside the `.security-scan-card` on container detail pages renders with a visible double-stroke / blur artefact (user-reported on the postgres detail page).

## Root cause

`docs/site/assets/css/components/security-scan-card.css:50-58` applied two stylistic OpenType layers on top of `var(--text-h3)`:

```css
.security-scan-card-header h3 {
  font: var(--text-h3);
  font-weight: var(--font-weight-semibold);
  ...
  font-feature-settings: "ss01", "cv11";
  font-optical-sizing: auto;
}
```

When Chromium activates both `font-feature-settings` and `font-optical-sizing` on a font whose available variation axes don't perfectly match the requested features (Inter is shipped here as static weights, not the variable build), the renderer falls back to a synthetic-doubled glyph path — visible as a faint duplicate stroke offset under the main letterforms.

## Fix

Drop both declarations. The headline still uses Inter SemiBold at the tight line-height defined in `--text-h3`; only the optional stylistic features are removed.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts)
- [ ] After deploy, `https://oorabona.github.io/docker-containers/container/postgres/` security scan card title renders crisply (single-stroke, no ghost)
- [ ] Other `.security-scan-card` instances (every container detail page) render the same way
- [ ] No regression on dashboard, blog, about, verify pages — those headlines do NOT use this rule