### PR TITLE
fix(security-scan): drop .glass class — backdrop-filter blurs the headline above

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -570,7 +570,7 @@
               <p class="eyebrow">Security scan results</p>
               <h3>Trivy · last scan {{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</h3>
             </header>
-            <security-scan id="security" class="security-section glass" data-current-variant="{{ sec_variant.tag | default: page.current_version }}">
+            <security-scan id="security" class="security-section" data-current-variant="{{ sec_variant.tag | default: page.current_version }}">
               <p class="scan-meta">
                 Last scan: <time data-scan="last-scan">{{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</time>
                 (advisory mode — Trivy runs <code>continue-on-error</code> in CI; we surface findings, we do not block builds on them).


### PR DESCRIPTION
## Summary

The previous fix (PR #396) attacked the wrong layer. The visible double-stroke / blur on the `Trivy · last scan ...` headline in the security scan card on every container detail page is **NOT** caused by font-feature-settings or optical-sizing — it's caused by the sibling `<security-scan>` element having `class="security-section glass"`.

`.glass` applies `backdrop-filter: blur(12px)` to its own border-box. CDP-measured layout:

- `.security-scan-card-header` (display: flex) bottom edge: y ≈ 527.67
- `<security-scan>` (next sibling) top edge: y ≈ 518.67 — **9 px overlap** despite both elements declaring vertical margins (margin-bottom: 16, margin-top: 32 — flex container's margin behaviour produces the overlap)
- `backdrop-filter: blur(12px)` on the security-scan box → the bottom 9 px of the `<h3>` text descenders renders through that filter → visible doubled / ghost stroke

## Fix

Drop `.glass` from the `<security-scan>` element. The parent `.security-scan-card` already provides:
- `background: var(--color-surface-raised)` (card surface)
- `border: 1px solid var(--color-border-subtle)`
- `border-radius: var(--radius-lg)`
- `padding: var(--space-inset-section)`

A second translucent + blurred surface inside the card was redundant and was the sole source of the artefact.

## Diff

| File | Change |
|------|--------|
| `docs/site/_layouts/container-detail.html` (1 line) | `class="security-section glass"` → `class="security-section"` |

## Test plan

- [ ] CI passes
- [ ] After deploy, hard-reload `https://oorabona.github.io/docker-containers/container/postgres/` and confirm the `Trivy · last scan ...` headline renders crisply (no doubled stroke) in both dark and light themes
- [ ] Same on every other container detail page that has Trivy data (the entire fleet)
- [ ] No visual regression on the security-scan content (severity grid, full-report link, advisories list still readable)

## Note on PR #396

The font-feature-settings / font-optical-sizing removal in #396 was correct hygiene (those features didn't fix anything but also didn't hurt) — keeping that change. This PR addresses the actual root cause.