### PR TITLE
fix(container-detail): hide dependency card when all deps are non-trackable

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -218,12 +218,16 @@
             {%- endif -%}
 
             {%- if page.dependency_monitoring.enabled -%}
+              {%- assign _hero_dep_disabled = page.dependency_monitoring.disabled | default: 0 -%}
+              {%- assign _hero_dep_trackable = page.dependency_monitoring.total | default: 0 | minus: _hero_dep_disabled -%}
+              {%- if _hero_dep_trackable > 0 -%}
               <a class="trust-badge trust-badge--deps"
                  href="{{ page.upstream_monitor_url }}"
                  rel="noopener noreferrer"
                  title="View the daily upstream-monitor workflow runs">
-                🔗 {{ page.dependency_monitoring.monitored }}/{{ page.dependency_monitoring.total }} deps tracked daily
+                🔗 {{ page.dependency_monitoring.monitored }}/{{ _hero_dep_trackable }} deps tracked daily
               </a>
+              {%- endif -%}
             {%- endif -%}
             <a class="trust-badge trust-badge--verify"
                href="{{ '/verify-images/' | relative_url }}"
@@ -951,6 +955,9 @@
           {%- else -%}
             {%- assign _dep_metric = dm.monitored | append: " monitored" -%}
           {%- endif -%}
+          {%- assign _dep_disabled_count = dm.disabled | default: 0 -%}
+          {%- assign _dep_trackable = dm.total | default: 0 | minus: _dep_disabled_count -%}
+          {%- if _dep_trackable > 0 -%}
           <details class="disclosure">
             <summary>
               <span class="disclosure__title">Dependency health</span>
@@ -960,7 +967,7 @@
             <div class="disclosure__body">
               <section class="dep-health-section glass" aria-label="Dependency health monitoring"
                        data-dep-updates='{% if container_updates %}{{ container_updates.updates | jsonify }}{% else %}[]{% endif %}'
-                       data-dep-all='{{ dm.deps | jsonify }}'>
+                       data-dep-all='{% assign trackable_deps = dm.deps | where: "status", "monitored" %}{{ trackable_deps | jsonify }}'>
                 <div class="dep-health-header">
                   <i class="ti ti-heartbeat" aria-hidden="true"></i>
                   <h3>Dependency Health</h3>
@@ -975,9 +982,9 @@
 
                 <div class="dep-health-summary">
                   <div class="dep-health-bar">
-                    {%- if dm.total and dm.total > 0 -%}
-                    <div class="dep-bar-label">{{ dm.monitored }}/{{ dm.total }} dependencies monitored</div>
-                    {% assign pct = dm.monitored | times: 100 | divided_by: dm.total %}
+                    {%- if _dep_trackable > 0 -%}
+                    <div class="dep-bar-label">{{ dm.monitored }}/{{ _dep_trackable }} dependencies monitored</div>
+                    {% assign pct = dm.monitored | times: 100 | divided_by: _dep_trackable %}
                     {% assign pct_unmon = 100 | minus: pct %}
                     <div class="dep-bar-track">
                       <div class="dep-bar-fill" style="flex: {{ pct }}"></div>
@@ -1023,7 +1030,6 @@
                 {% endif %}
 
                 {% assign up_to_date_deps = "" %}
-                {% assign disabled_deps = "" %}
                 {% for dep in dm.deps %}
                   {% if dep.status == "monitored" %}
                     {% assign has_update = false %}
@@ -1041,12 +1047,6 @@
                         {% assign up_to_date_deps = up_to_date_deps | append: "||" | append: dep.name %}
                       {% endif %}
                     {% endunless %}
-                  {% elsif dep.status == "disabled" %}
-                    {% if disabled_deps == "" %}
-                      {% assign disabled_deps = dep.name | append: "::" | append: dep.reason %}
-                    {% else %}
-                      {% assign disabled_deps = disabled_deps | append: "||" | append: dep.name | append: "::" | append: dep.reason %}
-                    {% endif %}
                   {% endif %}
                 {% endfor %}
 
@@ -1071,17 +1071,6 @@
                 </details>
                 {% endif %}
 
-                {% if disabled_deps != "" %}
-                <div class="dep-disabled-list">
-                  <span class="dep-disabled-label">Unmonitored:</span>
-                  {% assign disabled_arr = disabled_deps | split: "||" %}
-                  {% for item in disabled_arr %}
-                    {% assign parts = item | split: "::" %}
-                    <span class="dep-disabled-item" data-dep-name="{{ parts[0] }}" title="{{ parts[1] }}">{{ parts[0] }}</span>
-                  {% endfor %}
-                </div>
-                {% endif %}
-
                 <div class="dep-health-footer">
                   <a href="{{ _repo_url }}/actions/workflows/upstream-monitor.yaml"
                      class="dep-workflow-link" target="_blank" rel="noopener noreferrer">
@@ -1091,6 +1080,7 @@
               </section>
             </div>
           </details>
+          {%- endif -%}
           {% endif %}
 
         </section>{%- comment -%} /Zone 3 — Explore {%- endcomment -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -982,7 +982,6 @@
 
                 <div class="dep-health-summary">
                   <div class="dep-health-bar">
-                    {%- if _dep_trackable > 0 -%}
                     <div class="dep-bar-label">{{ dm.monitored }}/{{ _dep_trackable }} dependencies monitored</div>
                     {% assign pct = dm.monitored | times: 100 | divided_by: _dep_trackable %}
                     {% assign pct_unmon = 100 | minus: pct %}
@@ -990,9 +989,6 @@
                       <div class="dep-bar-fill" style="flex: {{ pct }}"></div>
                       {% if pct_unmon > 0 %}<div class="dep-bar-unmonitored" style="flex: {{ pct_unmon }}"></div>{% endif %}
                     </div>
-                    {%- else -%}
-                    <span class="dep-monitor-empty">No dependencies tracked</span>
-                    {%- endif -%}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary

Hide the "Dependency Health" card entirely when `total - disabled = 0`, eliminating contradictory "ALL UP TO DATE" + "0/1 monitored" signals for containers where every dependency is marked non-trackable (e.g. `BASE_IMAGE`, `*_BASE` — architectural fallbacks tagged `monitor: false` in `config.yaml`).

Derive a trackable count in the template, filter `data-dep-all` to monitored entries only, remove the `Unmonitored: BASE_IMAGE` list UI. Data layer (`generate-dashboard.sh`) is unchanged — display-only filter.

### Before / after by container

| Container | Before | After |
|-----------|--------|-------|
| `debian` (1 dep, all disabled) | Full-width amber bar "0/1 monitored" + "Unmonitored: BASE_IMAGE" alongside green "ALL UP TO DATE" badge | Section hidden entirely |
| `web-shell` (1 monitored + 3 disabled `*_BASE`) | Amber-heavy bar "1/4 monitored" | Green bar "1/1 monitored" |
| `postgres` (10 monitored + 1 disabled `BASE_IMAGE`) | Bar showing "0/1 monitored" due to variant scoping | Bar shows "10/10 monitored" |

The amber-bar-as-warning was misleading because non-trackable deps are an architectural decision, not a monitoring gap a maintainer can act on.

## Test plan

- [ ] CI passes (shellcheck, jekyll build)
- [ ] Live dashboard after deploy: `/container/debian/` no longer shows the Dependency Health card
- [ ] Live dashboard after deploy: `/container/web-shell/` shows "1/1 dependencies monitored" with green bar
- [ ] Live dashboard after deploy: `/container/postgres/` shows accurate ratio for the monitored extensions
- [ ] No regression on the hero `🔗 N/M deps tracked daily` meta line for containers with mixed deps
