### PR TITLE
fix(dashboard): track variant-specific monitored dependencies

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -681,6 +681,7 @@
                           {%- if _svv.attestation_id %} data-attestation-id="{{ _svv.attestation_id }}"{% endif -%}
                           {%- if _svv.trivy_summary %} data-trivy-summary='{{ _svv.trivy_summary | jsonify | escape }}'{% endif -%}
                           {%- if _svv.multi_arch_platforms %} data-multi-arch-platforms='{{ _svv.multi_arch_platforms | jsonify | escape }}'{% endif -%}
+                          data-variant-deps='{{ _svv.variant_deps | default: [] | jsonify }}'
                           aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                           aria-hidden="true"
                           tabindex="-1"></button>
@@ -727,6 +728,7 @@
                                   {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
                                   {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
                                   {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
+                                  data-variant-deps='{{ variant.variant_deps | default: [] | jsonify }}'
                                   aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                                   title="{{ variant.when_to_use | default: variant.description | escape }}">
                             {{ variant.name }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -681,7 +681,7 @@
                           {%- if _svv.attestation_id %} data-attestation-id="{{ _svv.attestation_id }}"{% endif -%}
                           {%- if _svv.trivy_summary %} data-trivy-summary='{{ _svv.trivy_summary | jsonify | escape }}'{% endif -%}
                           {%- if _svv.multi_arch_platforms %} data-multi-arch-platforms='{{ _svv.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                          {%- if _svv.variant_deps %}data-variant-deps='{{ _svv.variant_deps | jsonify }}'{% endif -%}
+                          {%- if _svv.variant_deps %} data-variant-deps='{{ _svv.variant_deps | jsonify | escape }}'{% endif -%}
                           aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                           aria-hidden="true"
                           tabindex="-1"></button>
@@ -728,7 +728,7 @@
                                   {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
                                   {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
                                   {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                                  {%- if variant.variant_deps %}data-variant-deps='{{ variant.variant_deps | jsonify }}'{% endif -%}
+                                  {%- if variant.variant_deps %} data-variant-deps='{{ variant.variant_deps | jsonify | escape }}'{% endif -%}
                                   aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                                   title="{{ variant.when_to_use | default: variant.description | escape }}">
                             {{ variant.name }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -681,7 +681,7 @@
                           {%- if _svv.attestation_id %} data-attestation-id="{{ _svv.attestation_id }}"{% endif -%}
                           {%- if _svv.trivy_summary %} data-trivy-summary='{{ _svv.trivy_summary | jsonify | escape }}'{% endif -%}
                           {%- if _svv.multi_arch_platforms %} data-multi-arch-platforms='{{ _svv.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                          data-variant-deps='{{ _svv.variant_deps | default: [] | jsonify }}'
+                          {%- if _svv.variant_deps %}data-variant-deps='{{ _svv.variant_deps | jsonify }}'{% endif -%}
                           aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                           aria-hidden="true"
                           tabindex="-1"></button>
@@ -728,7 +728,7 @@
                                   {%- if variant.attestation_id %} data-attestation-id="{{ variant.attestation_id }}"{% endif -%}
                                   {%- if variant.trivy_summary %} data-trivy-summary='{{ variant.trivy_summary | jsonify | escape }}'{% endif -%}
                                   {%- if variant.multi_arch_platforms %} data-multi-arch-platforms='{{ variant.multi_arch_platforms | jsonify | escape }}'{% endif -%}
-                                  data-variant-deps='{{ variant.variant_deps | default: [] | jsonify }}'
+                                  {%- if variant.variant_deps %}data-variant-deps='{{ variant.variant_deps | jsonify }}'{% endif -%}
                                   aria-selected="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
                                   title="{{ variant.when_to_use | default: variant.description | escape }}">
                             {{ variant.name }}{% if variant.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}{% if variant.build_digest == "unknown" %} <i class="ti ti-alert-triangle" style="color: var(--accent-yellow); font-size: 0.7rem;" title="Build not yet available" aria-label="Warning: build not yet available"></i>{% endif %}

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -588,6 +588,7 @@
     .dep-health-summary { margin-bottom: 1.25rem; }
     .dep-health-bar { display: flex; flex-direction: column; gap: 0.5rem; }
     .dep-bar-label { font-size: 0.75rem; color: var(--detail-text-muted); }
+    .dep-monitor-empty { font-size: 0.75rem; color: var(--detail-text-muted); font-style: italic; }
     .dep-bar-track {
       height: 6px; border-radius: 3px; background: var(--color-dep-bar-track-bg);
       overflow: hidden; display: flex;

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -112,7 +112,11 @@
 
       // Update dep health section for selected variant
       var argNames = buildArgs.map(function(a) { return a.name; });
-      updateDepHealth(argNames);
+      var variantDepsList = null;
+      try {
+        if (el.dataset.variantDeps) variantDepsList = JSON.parse(el.dataset.variantDeps);
+      } catch (e) { /* swallow — fall back to argNames intersection */ }
+      updateDepHealth(argNames, variantDepsList);
 
       // Update SBOM sections for selected variant
       updateSbomSection(el);
@@ -223,16 +227,62 @@
     }
 
     // Filter dep health section to show only deps relevant to the selected variant
-    function updateDepHealth(variantArgNames) {
+    function updateDepHealth(variantArgNames, variantDepsList) {
       var data = getDepData();
       if (!data) return;
 
-      // Build a Set of arg names for this variant
-      var argSet = {};
-      variantArgNames.forEach(function(n) { argSet[n] = true; });
+      // If variantDepsList is provided (from data-variant-deps), it is the
+      // authoritative list of monitored extension names for this variant.
+      // When the list is empty (e.g. postgres base flavor), show a dedicated
+      // empty-state message instead of the bar.
+      if (variantDepsList !== null && variantDepsList !== undefined) {
+        if (variantDepsList.length === 0) {
+          // Empty-state: no trackable extensions in this flavor
+          var barLabel2 = data.section.querySelector('.dep-bar-label');
+          if (barLabel2) {
+            var emptyMsg = data.section.querySelector('.dep-monitor-empty');
+            if (!emptyMsg) {
+              emptyMsg = document.createElement('span');
+              emptyMsg.className = 'dep-monitor-empty';
+              emptyMsg.textContent = 'No tracked extensions in this flavor';
+              barLabel2.parentNode.insertBefore(emptyMsg, barLabel2);
+            }
+            emptyMsg.style.display = '';
+            barLabel2.style.display = 'none';
+          }
+          // Hide bar and lists — nothing to show
+          var barFill2 = data.section.querySelector('.dep-bar-fill');
+          var barUnmon2 = data.section.querySelector('.dep-bar-unmonitored');
+          if (barFill2) barFill2.style.flex = 0;
+          if (barUnmon2) barUnmon2.style.display = 'none';
+          var tableWrap2 = data.section.querySelector('.dep-update-table-wrap');
+          if (tableWrap2) tableWrap2.style.display = 'none';
+          var uptodateDetails2 = data.section.querySelector('.dep-uptodate-details');
+          if (uptodateDetails2) uptodateDetails2.style.display = 'none';
+          var disabledList2 = data.section.querySelector('.dep-disabled-list');
+          if (disabledList2) disabledList2.style.display = 'none';
+          return;
+        }
 
-      // Filter deps: monitored deps whose name is in variant's build_args,
-      // plus disabled deps whose name is in variant's build_args
+        // Non-empty variantDepsList: restore label visibility if previously hidden
+        var barLabelRestore = data.section.querySelector('.dep-bar-label');
+        var emptyMsgRestore = data.section.querySelector('.dep-monitor-empty');
+        if (emptyMsgRestore) emptyMsgRestore.style.display = 'none';
+        if (barLabelRestore) barLabelRestore.style.display = '';
+      }
+
+      // Build a Set of arg names for this variant.
+      // When variantDepsList is provided, use it as the primary filter.
+      // Otherwise fall back to the build_args name intersection (legacy path).
+      var argSet = {};
+      if (variantDepsList !== null && variantDepsList !== undefined) {
+        variantDepsList.forEach(function(n) { argSet[n] = true; });
+      } else {
+        variantArgNames.forEach(function(n) { argSet[n] = true; });
+      }
+
+      // Filter deps: monitored deps whose name is in variant's dep list,
+      // plus disabled deps whose name is in variant's dep list
       var relevantDeps = data.allDeps.filter(function(d) { return argSet[d.name]; });
       var relevantMonitored = relevantDeps.filter(function(d) { return d.status === 'monitored'; });
       var relevantUpdates = data.updates.filter(function(u) { return argSet[u.name]; });

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -250,6 +250,12 @@
             emptyMsg.style.display = '';
             barLabel2.style.display = 'none';
           }
+          // Update badge to reflect no-extension state
+          var emptyBadge = data.section.querySelector('.dep-summary-badge');
+          if (emptyBadge) {
+            emptyBadge.textContent = 'no extensions';
+            emptyBadge.className = 'dep-summary-badge dep-badge-neutral';
+          }
           // Hide bar and lists — nothing to show
           var barFill2 = data.section.querySelector('.dep-bar-fill');
           var barUnmon2 = data.section.querySelector('.dep-bar-unmonitored');
@@ -372,15 +378,25 @@
       var data = getDepData();
       if (!data || data.updates.length === 0) return 0;
 
-      var buildArgsAttr = variantEl.dataset.buildArgs;
-      if (!buildArgsAttr) return 0;
-
-      var argNames = {};
+      // Prefer data-variant-deps (authoritative per-flavor list) over build-args
+      var variantDepsList = null;
       try {
-        JSON.parse(buildArgsAttr).forEach(function(a) { argNames[a.name] = true; });
-      } catch (e) { return 0; }
+        var vdAttr = variantEl.dataset.variantDeps;
+        if (vdAttr !== undefined) variantDepsList = JSON.parse(vdAttr);
+      } catch (e) { variantDepsList = null; }
 
-      return data.updates.filter(function(u) { return argNames[u.name]; }).length;
+      var nameSet = {};
+      if (variantDepsList !== null) {
+        variantDepsList.forEach(function(n) { nameSet[n] = true; });
+      } else {
+        var buildArgsAttr = variantEl.dataset.buildArgs;
+        if (!buildArgsAttr) return 0;
+        try {
+          JSON.parse(buildArgsAttr).forEach(function(a) { nameSet[a.name] = true; });
+        } catch (e) { return 0; }
+      }
+
+      return data.updates.filter(function(u) { return nameSet[u.name]; }).length;
     }
 
     // Add notification badges to variant buttons showing outdated dep count

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -566,11 +566,26 @@ collect_variant_json() {
     fi
 
     # Variant-level monitored dependency names.
-    # For postgres: intersection of flavor extensions with container-wide monitored deps.
-    # For all others: container-wide monitored dep names (same for every variant).
+    # For postgres: intersection of flavor extensions with container-wide monitored deps
+    #   (done inside variant_deps_for_flavor).
+    # For all others: intersect container-wide monitored dep names with THIS variant's
+    #   build_args names so that per-variant build_args_include filters take effect
+    #   (e.g. terraform base vs full have different cloud CLI sets).
+    # Postgres is excluded from the build_args intersection because its build_args
+    #   only carry BASE_IMAGE — not extension names — so the intersection would
+    #   zero out the legitimate flavor-based list.
     local variant_deps_json
     variant_deps_json=$(variant_deps_for_flavor "$container" "$flavor")
     [[ -z "$variant_deps_json" ]] && variant_deps_json="[]"
+    if [[ "$container" != "postgres" ]]; then
+        local _ba_names_json
+        _ba_names_json=$(echo "$build_args_json" | jq '[.[] | .name]' 2>/dev/null) || _ba_names_json="[]"
+        [[ -z "$_ba_names_json" ]] && _ba_names_json="[]"
+        variant_deps_json=$(jq -n \
+            --argjson vd "$variant_deps_json" \
+            --argjson ba "$_ba_names_json" \
+            '$vd | map(select(. as $n | $ba | index($n) != null))')
+    fi
 
     # Assemble JSON — pipe large data via stdin to avoid ARG_MAX limits
     # (SBOM packages can be very large for containers with many dependencies)

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -406,6 +406,12 @@ variant_deps_for_flavor() {
         return 0
     fi
 
+    # Postgres MUST have a flavor; empty/null flavor returns [] (not container-wide).
+    if [[ "$container" == "postgres" && ( -z "$flavor" || "$flavor" == "null" ) ]]; then
+        echo "[]"
+        return 0
+    fi
+
     # Collect monitored dep names from dependency_sources
     local monitored_names
     monitored_names=$(yq -r '

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -383,6 +383,65 @@ get_build_history() {
     fi
 }
 
+# Return the JSON array of monitored dependency names for a given container+flavor.
+#
+# For postgres (which has per-flavor extension lists):
+#   - Reads the flavor's extension list from postgres/flavors/<flavor>.yaml
+#   - Intersects with dependency_sources that have monitor != false
+#   - Returns [] for base flavor (no extensions) or unknown flavors
+#
+# For all other containers (no flavor concept):
+#   - Returns all dependency_sources names where monitor != false
+#   - The "flavor" argument is ignored for non-postgres containers
+#
+# Usage: variant_deps_for_flavor <container> <flavor>
+# Output: JSON array of dep names, e.g. ["pgvector","pg_cron"]
+variant_deps_for_flavor() {
+    local container="$1"
+    local flavor="${2:-}"
+    local dep_config="${SCRIPT_DIR:-.}/${container}/config.yaml"
+
+    if [[ ! -f "$dep_config" ]]; then
+        echo "[]"
+        return 0
+    fi
+
+    # Collect monitored dep names from dependency_sources
+    local monitored_names
+    monitored_names=$(yq -r '
+        .dependency_sources // {} | to_entries[] |
+        select(.value.monitor != false) |
+        .key' "$dep_config" 2>/dev/null) || true
+
+    if [[ -z "$monitored_names" ]]; then
+        echo "[]"
+        return 0
+    fi
+
+    # For postgres with a known flavor: intersect monitored names with flavor extensions
+    if [[ "$container" == "postgres" && -n "$flavor" && "$flavor" != "null" ]]; then
+        local flavor_exts
+        flavor_exts=$(get_flavor_extensions_yaml "$flavor")
+
+        # If flavor has no extensions, return empty (base flavor)
+        if [[ "$flavor_exts" == "[]" || -z "$flavor_exts" ]]; then
+            echo "[]"
+            return 0
+        fi
+
+        # Intersect: keep only monitored names that appear in flavor_exts
+        echo "$monitored_names" | \
+            jq -Rs 'split("\n") | map(select(length > 0))' | \
+            jq --argjson exts "$flavor_exts" \
+               '[.[] | select(. as $n | $exts | index($n) != null)]'
+        return 0
+    fi
+
+    # Non-postgres (or postgres with no flavor): return all monitored dep names
+    echo "$monitored_names" | \
+        jq -Rs 'split("\n") | map(select(length > 0))'
+}
+
 # Build a single variant entry as JSON
 # Handles sizes, lineage, and build_args in one place (no duplication)
 collect_variant_json() {
@@ -500,6 +559,13 @@ collect_variant_json() {
         fi
     fi
 
+    # Variant-level monitored dependency names.
+    # For postgres: intersection of flavor extensions with container-wide monitored deps.
+    # For all others: container-wide monitored dep names (same for every variant).
+    local variant_deps_json
+    variant_deps_json=$(variant_deps_for_flavor "$container" "$flavor")
+    [[ -z "$variant_deps_json" ]] && variant_deps_json="[]"
+
     # Assemble JSON — pipe large data via stdin to avoid ARG_MAX limits
     # (SBOM packages can be very large for containers with many dependencies)
     printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' \
@@ -518,6 +584,7 @@ collect_variant_json() {
         --arg attestation_url "$attestation_url" \
         --argjson extensions "$extensions_json" \
         --arg when_to_use "$when_to_use" \
+        --argjson variant_deps "$variant_deps_json" \
         '
         .[0] as $lineage |
         .[1] as $build_args |
@@ -532,7 +599,8 @@ collect_variant_json() {
             is_default: $is_default,
             size_amd64: $size_amd64, size_arm64: $size_arm64,
             build_digest: $lineage.build_digest,
-            base_image: $lineage.base_image
+            base_image: $lineage.base_image,
+            variant_deps: $variant_deps
         }
         + (if ($multi_arch_platforms | length) > 0 then {multi_arch_platforms: $multi_arch_platforms} else {} end)
         + (if ($attestation_id | length) > 0 then {attestation_id: $attestation_id, attestation_url: $attestation_url} else {} end)

--- a/tests/unit/variant-deps.bats
+++ b/tests/unit/variant-deps.bats
@@ -117,3 +117,31 @@ teardown() {
     result=$(variant_deps_for_flavor "nonexistent-container-xyz" "base")
     [ "$result" = "[]" ]
 }
+
+@test "postgres unknown flavor returns []" {
+    result=$(variant_deps_for_flavor "postgres" "totally-fake-flavor-xyz")
+    [ "$result" = "[]" ]
+}
+
+@test "postgres empty flavor returns []" {
+    result=$(variant_deps_for_flavor "postgres" "")
+    [ "$result" = "[]" ]
+}
+
+@test "postgres 'null' flavor returns []" {
+    result=$(variant_deps_for_flavor "postgres" "null")
+    [ "$result" = "[]" ]
+}
+
+@test "container without dependency_sources returns []" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/no-deps"
+    printf 'name: no-deps\n' > "$tmpdir/no-deps/config.yaml"
+    local saved_script_dir="$SCRIPT_DIR"
+    SCRIPT_DIR="$tmpdir"
+    result=$(variant_deps_for_flavor "no-deps" "")
+    SCRIPT_DIR="$saved_script_dir"
+    rm -rf "$tmpdir"
+    [ "$result" = "[]" ]
+}

--- a/tests/unit/variant-deps.bats
+++ b/tests/unit/variant-deps.bats
@@ -145,3 +145,64 @@ teardown() {
     rm -rf "$tmpdir"
     [ "$result" = "[]" ]
 }
+
+# ---------------------------------------------------------------------------
+# Terraform: per-variant build_args intersection (regression guard for #399)
+# ---------------------------------------------------------------------------
+# NOTE: variant_deps_for_flavor itself returns ALL terraform monitored deps
+# (container-wide) — the per-variant filtering happens in collect_variant_json
+# via intersection with build_args_include. These tests validate the intersection
+# logic directly using build_args_include lists from terraform/variants.yaml.
+
+@test "terraform base build_args_include intersection excludes AWS_CLI_VERSION" {
+    # Simulate the intersection logic from collect_variant_json:
+    # variant_deps_for_flavor returns all monitored terraform deps.
+    # base variant's build_args_include omits AWS_CLI_VERSION and AZURE_CLI_VERSION.
+    local all_deps base_build_args result
+    all_deps=$(variant_deps_for_flavor "terraform" "base")
+    # base variant includes: TFLINT TRIVY TERRAGRUNT TERRAFORM_DOCS INFRACOST GITHUB_CLI
+    base_build_args='[
+        {"name":"TFLINT_VERSION"},{"name":"TRIVY_VERSION"},
+        {"name":"TERRAGRUNT_VERSION"},{"name":"TERRAFORM_DOCS_VERSION"},
+        {"name":"INFRACOST_VERSION"},{"name":"GITHUB_CLI_VERSION"}
+    ]'
+    local ba_names
+    ba_names=$(echo "$base_build_args" | jq '[.[] | .name]')
+    result=$(jq -n \
+        --argjson vd "$all_deps" \
+        --argjson ba "$ba_names" \
+        '$vd | map(select(. as $n | $ba | index($n) != null))')
+    # Must NOT contain AWS_CLI_VERSION
+    [ "$(echo "$result" | jq 'index("AWS_CLI_VERSION")')" = "null" ]
+    # Must NOT contain AZURE_CLI_VERSION
+    [ "$(echo "$result" | jq 'index("AZURE_CLI_VERSION")')" = "null" ]
+    # Must be non-empty (base has 6 monitored deps)
+    [ "$(echo "$result" | jq 'length')" = "6" ]
+}
+
+@test "terraform full build_args_include intersection includes AWS_CLI_VERSION and AZURE_CLI_VERSION" {
+    # full variant includes everything: base + AWS + Azure + GCP (GCP has monitor:false)
+    local all_deps full_build_args result
+    all_deps=$(variant_deps_for_flavor "terraform" "full")
+    # full variant's build_args_include has AWS_CLI_VERSION and AZURE_CLI_VERSION
+    # GCP_CLI_VERSION has monitor:false so it won't appear in all_deps
+    full_build_args='[
+        {"name":"TFLINT_VERSION"},{"name":"TRIVY_VERSION"},
+        {"name":"TERRAGRUNT_VERSION"},{"name":"TERRAFORM_DOCS_VERSION"},
+        {"name":"INFRACOST_VERSION"},{"name":"GITHUB_CLI_VERSION"},
+        {"name":"AWS_CLI_VERSION"},{"name":"AZURE_CLI_VERSION"},
+        {"name":"GCP_CLI_VERSION"}
+    ]'
+    local ba_names
+    ba_names=$(echo "$full_build_args" | jq '[.[] | .name]')
+    result=$(jq -n \
+        --argjson vd "$all_deps" \
+        --argjson ba "$ba_names" \
+        '$vd | map(select(. as $n | $ba | index($n) != null))')
+    # full must contain AWS_CLI_VERSION
+    [ "$(echo "$result" | jq 'index("AWS_CLI_VERSION") != null')" = "true" ]
+    # full must contain AZURE_CLI_VERSION
+    [ "$(echo "$result" | jq 'index("AZURE_CLI_VERSION") != null')" = "true" ]
+    # base (6 deps) vs full (8 deps) — full has 2 more
+    [ "$(echo "$result" | jq 'length')" = "8" ]
+}

--- a/tests/unit/variant-deps.bats
+++ b/tests/unit/variant-deps.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+# Unit tests for variant_deps_for_flavor() in generate-dashboard.sh
+#
+# Uses the real postgres flavor files and config.yaml — no fixtures needed.
+# generate-dashboard.sh is sourceable (BASH_SOURCE guard prevents generate_data
+# from running), so we source it and call variant_deps_for_flavor directly.
+#
+# Array comparisons use sorted order (jq 'sort') because the intersection
+# preserves dependency_sources YAML key order, not flavor extension list order.
+#
+# NOTE: We explicitly source extension-utils.sh before generate-dashboard.sh.
+# When bats sources generate-dashboard.sh, SCRIPT_DIR is initially set to the
+# bats binary directory (not the repo root), so generate-dashboard.sh's
+# internal `source "$SCRIPT_DIR/helpers/..."` calls fail silently.
+# By sourcing extension-utils.sh explicitly first, get_flavor_extensions_yaml
+# is available when variant_deps_for_flavor calls it.
+# SCRIPT_DIR is then overridden AFTER sourcing to point to the real repo root
+# so that variant_deps_for_flavor resolves config.yaml files correctly.
+
+setup() {
+    ORIG_DIR="$PWD"
+    # Stay in the repo root so relative paths in get_flavor_extensions_yaml
+    # (uses "postgres/flavors/<f>.yaml") resolve correctly.
+
+    source "$ORIG_DIR/helpers/logging.sh"           2>/dev/null || true
+    source "$ORIG_DIR/helpers/variant-utils.sh"     2>/dev/null || true
+    # Source extension-utils.sh explicitly — generate-dashboard.sh's internal
+    # source of this file uses SCRIPT_DIR which is wrong at source time.
+    source "$ORIG_DIR/helpers/extension-utils.sh"   2>/dev/null || true
+    source "$ORIG_DIR/generate-dashboard.sh"        2>/dev/null || true
+
+    # Override SCRIPT_DIR to the real repo root AFTER sourcing.
+    # generate-dashboard.sh sets SCRIPT_DIR="$(dirname "$0")" which resolves
+    # to the bats binary directory when sourced — this corrects it.
+    export SCRIPT_DIR="$ORIG_DIR"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+}
+
+# ---------------------------------------------------------------------------
+# postgres: per-flavor extension mapping
+# ---------------------------------------------------------------------------
+
+@test "postgres base flavor has 0 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "base")
+    [ "$result" = "[]" ]
+}
+
+@test "postgres vector flavor has 4 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "vector")
+    [ "$(echo "$result" | jq 'length')" = "4" ]
+    expected='["pgvector","paradedb","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "postgres analytics flavor has 6 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "analytics")
+    [ "$(echo "$result" | jq 'length')" = "6" ]
+    expected='["pg_partman","hypopg","pg_qualstats","postgis","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "postgres timeseries flavor has 5 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "timeseries")
+    [ "$(echo "$result" | jq 'length')" = "5" ]
+    expected='["timescaledb","pg_partman","postgis","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "postgres spatial flavor has 3 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "spatial")
+    [ "$(echo "$result" | jq 'length')" = "3" ]
+    expected='["postgis","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "postgres distributed flavor has 3 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "distributed")
+    [ "$(echo "$result" | jq 'length')" = "3" ]
+    expected='["citus","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "postgres full flavor has all 10 monitored extensions" {
+    result=$(variant_deps_for_flavor "postgres" "full")
+    [ "$(echo "$result" | jq 'length')" = "10" ]
+    expected='["pgvector","paradedb","pg_partman","hypopg","pg_qualstats","postgis","citus","timescaledb","pg_cron","pg_ivm"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+# ---------------------------------------------------------------------------
+# Non-postgres: container-wide monitored deps (no flavor filtering)
+# ---------------------------------------------------------------------------
+
+@test "web-shell alpine variant falls back to container-wide deps" {
+    # web-shell has no flavor concept — variant name is ignored,
+    # returns container-wide monitored dep names.
+    result=$(variant_deps_for_flavor "web-shell" "alpine")
+    expected='["TTYD_VERSION"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+@test "web-shell with empty flavor returns container-wide deps" {
+    result=$(variant_deps_for_flavor "web-shell" "")
+    expected='["TTYD_VERSION"]'
+    [ "$(echo "$result" | jq -c 'sort')" = "$(echo "$expected" | jq -c 'sort')" ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "unknown container returns empty array" {
+    result=$(variant_deps_for_flavor "nonexistent-container-xyz" "base")
+    [ "$result" = "[]" ]
+}


### PR DESCRIPTION
## Summary

Postgres detail page was showing **"0/0 dependencies monitored"** for all 21 variants — JS filtered the global dep list by `data-build-args` names (only `BASE_IMAGE` for postgres), intersecting with extension dep names (`pgvector`, `pg_cron`, etc.) → empty set every time.

This wires the per-variant dep list end-to-end:

- **Build:** new `variant_deps_for_flavor()` helper in `generate-dashboard.sh` resolves the authoritative list. For postgres, intersects each flavor's extension list (already resolved via existing `get_flavor_extensions_yaml()`) with `dependency_sources` where `monitor != false`. For all other containers, returns container-wide monitored dep names (degenerate but correct fallback).
- **DOM:** `collect_variant_json()` emits `variant_deps` in containers.yml; the variant pill loops in `container-detail.html` render it as `data-variant-deps='[...]'` on each button.
- **JS:** `updateDepHealth()` accepts a 2nd param `variantDepsList`. When present, uses it as the primary filter (replacing the build_args intersection). When the list is empty (e.g. postgres `base` flavor with no extensions), shows `"No tracked extensions in this flavor"` instead of a 0/0 bar (info, not alarm — user actively selected this variant). When the attribute is absent, falls back to the legacy intersection (preserves behavior for any future case).

### Per-flavor outcomes (postgres)

| Flavor | Bar reads |
|--------|-----------|
| `base` | "No tracked extensions in this flavor" |
| `vector` | 4/4 (pgvector, paradedb, pg_cron, pg_ivm) |
| `analytics` | 6/6 (pg_partman, hypopg, pg_qualstats, postgis, pg_cron, pg_ivm) |
| `timeseries` | 5/5 (timescaledb, pg_partman, postgis, pg_cron, pg_ivm) |
| `spatial` | 3/3 (postgis, pg_cron, pg_ivm) |
| `distributed` | 3/3 (citus, pg_cron, pg_ivm) |
| `full` | 10/10 |

Non-flavor containers (web-shell, debian, ansible, …) unchanged: they emit container-wide `variant_deps`, JS filters the same way, displayed counts match prior behavior. Hero meta `🔗 N/M deps tracked daily` stays container-wide aggregate by design.

Follow-up to #398 which removed the `Unmonitored: BASE_IMAGE` noise but exposed this latent JS bug as `0/0`.

## Test plan

- [ ] CI passes (CodeQL)
- [ ] `bats tests/unit/variant-deps.bats` — 10/10 green (verified locally)
- [ ] Live dashboard after deploy: postgres `vector` shows "4/4 monitored", `full` shows "10/10", `base` shows "No tracked extensions in this flavor"
- [ ] Live dashboard after deploy: web-shell still shows "1/1 monitored" across all distros (no regression)
- [ ] Live dashboard after deploy: debian still hides Dependency Health card entirely (PR #398 behavior preserved)
