### PR TITLE
feat(container-detail): extract variant action bar into sticky component

### DIFF
--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -1,0 +1,112 @@
+{%- comment -%}
+  variant-action-bar.html — Include for the <variant-action-bar> custom element.
+
+  Passes all variant data as data-attributes so variant-action-bar.js can
+  render pills + commands + signals strip without Liquid at runtime.
+
+  Data model expected on page.*:
+    page.name            — container slug
+    page.github_username — registry owner
+    page.current_version — default tag
+    page.versions[]      — array of { tag, base_tag, variants[] } (multi-version containers)
+    page.variants[]      — flat array of variants (single-version containers)
+
+  The JS component tolerates missing versions/variants gracefully (single-image
+  containers will show only the pull + verify commands and a signals strip).
+{%- endcomment -%}
+
+{%- comment -%}
+  Build a flat variants list from page.versions (postgres-style) OR page.variants
+  (single-version) OR empty array (no variants at all).
+  Each entry: { tag, version, flavor, name, size_amd64, size_arm64, build_digest,
+                attestation_url, attestation_id, trivy_summary, multi_arch_platforms }
+{%- endcomment -%}
+
+{%- assign _vab_variants = "" -%}
+{%- if page.versions -%}
+  {%- for _vab_ver in page.versions -%}
+    {%- for _vab_v in _vab_ver.variants -%}
+      {%- assign _vab_variants = _vab_variants | append: _vab_v.tag | append: "||" -%}
+    {%- endfor -%}
+  {%- endfor -%}
+{%- endif -%}
+
+{%- comment -%} Determine unique versions for version pills {%- endcomment -%}
+{%- assign _vab_ver_arr = "" -%}
+{%- if page.versions and page.versions.size > 1 -%}
+  {%- for _vv in page.versions -%}
+    {%- assign _vab_ver_arr = _vab_ver_arr | append: '{"tag":' | append: _vv.base_tag | default: _vv.tag | jsonify | append: ',"label":' | append: _vv.base_tag | default: _vv.tag | jsonify | append: '}' -%}
+    {%- unless forloop.last -%}{%- assign _vab_ver_arr = _vab_ver_arr | append: "," -%}{%- endunless -%}
+  {%- endfor -%}
+{%- endif -%}
+
+{%- comment -%} Determine unique flavors for flavor pills {%- endcomment -%}
+{%- assign _vab_fla_arr = "" -%}
+{%- if page.versions and page.versions.size > 0 -%}
+  {%- assign _first_ver = page.versions[0] -%}
+  {%- assign _has_flavors = false -%}
+  {%- for _fv in _first_ver.variants -%}
+    {%- if _fv.name and _fv.name != "" -%}
+      {%- assign _has_flavors = true -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- if _has_flavors -%}
+    {%- for _fv in _first_ver.variants -%}
+      {%- if _fv.name and _fv.name != "" -%}
+        {%- assign _vab_fla_arr = _vab_fla_arr | append: '{"name":' | append: _fv.name | jsonify | append: ',"label":' | append: _fv.name | jsonify | append: '}' -%}
+        {%- unless forloop.last -%}{%- assign _vab_fla_arr = _vab_fla_arr | append: "," -%}{%- endunless -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endif -%}
+
+{%- comment -%} Build flat variant objects array for JS consumption {%- endcomment -%}
+{%- capture _vab_variants_json -%}[
+{%- if page.versions -%}
+  {%- assign _vab_first_row = true -%}
+  {%- for _vab_ver in page.versions -%}
+    {%- for _vab_v in _vab_ver.variants -%}
+      {%- unless _vab_first_row -%},{%- endunless -%}
+      {%- assign _vab_first_row = false -%}
+      {"tag":{{ _vab_v.tag | jsonify }},"version":{{ _vab_ver.base_tag | default: _vab_ver.tag | jsonify }},"flavor":{{ _vab_v.name | default: "" | jsonify }},"name":{{ _vab_v.name | default: "" | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+    {%- endfor -%}
+  {%- endfor -%}
+{%- elsif page.variants -%}
+  {%- for _vab_v in page.variants -%}
+    {%- unless forloop.first -%},{%- endunless -%}
+    {"tag":{{ _vab_v.tag | jsonify }},"version":"","flavor":{{ _vab_v.tag | jsonify }},"name":{{ _vab_v.tag | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+  {%- endfor -%}
+{%- else -%}
+  {"tag":{{ page.current_version | jsonify }},"version":"","flavor":"","name":"","size_amd64":{{ page.size_amd64 | default: "" | jsonify }},"size_arm64":{{ page.size_arm64 | default: "" | jsonify }},"build_digest":{{ page.build_digest | default: "" | jsonify }},"attestation_url":"","attestation_id":"","trivy_summary":null,"multi_arch_platforms":[]}
+{%- endif -%}
+]
+{%- endcapture -%}
+
+{%- assign _vab_default_version = "" -%}
+{%- assign _vab_default_flavor = "" -%}
+{%- if page.versions and page.versions.size > 0 -%}
+  {%- assign _vab_default_version = page.versions[0].base_tag | default: page.versions[0].tag -%}
+  {%- if page.versions[0].variants[0].name -%}
+    {%- assign _vab_default_flavor = page.versions[0].variants[0].name -%}
+  {%- endif -%}
+{%- endif -%}
+
+<section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
+  <variant-action-bar
+    data-container="{{ page.name | escape }}"
+    data-default-tag="{{ page.current_version | escape }}"
+    data-default-version="{{ _vab_default_version | escape }}"
+    data-default-flavor="{{ _vab_default_flavor | escape }}"
+    data-versions="{{ '[' | append: _vab_ver_arr | append: ']' | escape }}"
+    data-flavors="{{ '[' | append: _vab_fla_arr | append: ']' | escape }}"
+    data-variants="{{ _vab_variants_json | strip | escape }}"
+    data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
+  ></variant-action-bar>
+
+  <noscript>
+    <div class="vab-noscript">
+      <p class="vab-noscript-label">Pull command:</p>
+      <code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }}</code>
+    </div>
+  </noscript>
+</section>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -20,6 +20,7 @@
   <!-- tokens.css MUST load before theme.css — defines variables theme.css references -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
   <!-- Component CSS — load after tokens, before theme -->
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/variant-action-bar.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/provenance.css">
@@ -87,68 +88,7 @@
             </div>
           </div>
 
-          <!-- Pull command -->
-          <div class="detail-pull-section glass"
-               id="detail-pull"
-               data-ghcr-base="ghcr.io/{{ page.github_username }}/{{ page.name }}"
-               data-dockerhub-base="docker.io/{{ page.dockerhub_username }}/{{ page.name }}"
-               data-default-tag="{{ page.current_version }}">
-            <div class="detail-pull-row">
-              <div class="detail-pull-label">
-                <i class="ti ti-terminal-2" aria-hidden="true"></i>
-                <span>Pull</span>
-              </div>
-              <div class="detail-registry-toggle" role="radiogroup" aria-label="Container registry">
-                <button class="detail-registry-btn active" data-registry="ghcr"
-                        role="radio" aria-checked="true" type="button">GHCR</button>
-                <button class="detail-registry-btn" data-registry="dockerhub"
-                        role="radio" aria-checked="false" type="button">Docker Hub</button>
-              </div>
-            </div>
-            <div class="detail-pull-input-group">
-              <input type="text"
-                     class="detail-pull-input"
-                     id="detail-pull-cmd"
-                     value="docker pull ghcr.io/{{ page.github_username }}/{{ page.name }}:{{ page.current_version }}"
-                     readonly
-                     aria-label="Docker pull command">
-              <button class="detail-copy-btn" type="button" id="detail-copy-btn"
-                      aria-label="Copy pull command to clipboard">
-                <i class="ti ti-copy" aria-hidden="true"></i>
-              </button>
-            </div>
-          </div>
-
-          <!-- Meta cards -->
-          <div class="detail-meta" id="detail-meta">
-            <div class="meta-card glass">
-              <div class="meta-card-label">Status</div>
-              <div class="meta-card-value">{{ page.status_text }}</div>
-            </div>
-            <div class="meta-card glass">
-              <div class="meta-card-label">Current Tag</div>
-              <div class="meta-card-value" data-meta="current-tag">{{ page.current_version }}</div>
-            </div>
-            <div class="meta-card glass">
-              <div class="meta-card-label">Docker Hub Pulls</div>
-              <div class="meta-card-value">{{ page.pull_count_formatted | default: "0" }}</div>
-            </div>
-            <div class="meta-card glass">
-              <div class="meta-card-label">Stars</div>
-              <div class="meta-card-value">
-                <i class="ti ti-star" style="font-size: 0.75rem; color: var(--accent-yellow);" aria-hidden="true"></i>
-                {{ page.star_count | default: 0 }}
-              </div>
-            </div>
-            <div class="meta-card glass">
-              <div class="meta-card-label">Size (amd64)</div>
-              <div class="meta-card-value" data-meta="size-amd64">{{ page.size_amd64 | default: "---" }}</div>
-            </div>
-            <div class="meta-card glass">
-              <div class="meta-card-label">Size (arm64)</div>
-              <div class="meta-card-value" data-meta="size-arm64">{{ page.size_arm64 | default: "---" }}</div>
-            </div>
-          </div>
+          {%- comment -%} Pull command + meta-cards removed PR1 — replaced by &lt;variant-action-bar&gt; below {%- endcomment -%}
 
           <!-- Value Proposition -->
           {%- if page.value_proposition and page.value_proposition != "" -%}
@@ -157,10 +97,13 @@
           </section>
           {%- endif -%}
 
+          {%- comment -%} Variant action bar — replaces static pull command + meta-cards {%- endcomment -%}
+          {% include variant-action-bar.html %}
+
         </header>{%- comment -%} /Zone 1 — Identity {%- endcomment -%}
 
         {%- comment -%} Zone 2 — Trust posture (always visible) {%- endcomment -%}
-        <section class="detail-zone detail-zone--trust" aria-label="Trust posture">
+        <section id="trust-posture" class="detail-zone detail-zone--trust" aria-label="Trust posture">
           <h2 class="zone-eyebrow">Trust posture</h2>
 
           <!-- Trust Strip -->
@@ -234,6 +177,42 @@
                title="Reproduce these checks yourself — verification guide">🔍 REPRODUCE THESE CHECKS LOCALLY</a>
           </trust-strip>
 
+          {%- comment -%} Stats strip — inline pull/star/variant counts below trust badges {%- endcomment -%}
+          {%- comment -%} Compute variant + version counts for the stats strip {%- endcomment -%}
+          {%- assign _stats_variants = 0 -%}
+          {%- assign _stats_versions = 0 -%}
+          {%- if page.versions -%}
+            {%- assign _stats_versions = page.versions.size -%}
+            {%- for _sv in page.versions -%}
+              {%- assign _sv_sel = _sv.variants | where_exp: "v", "v.name != ''" -%}
+              {%- assign _stats_variants = _stats_variants | plus: _sv_sel.size -%}
+            {%- endfor -%}
+          {%- elsif page.variants -%}
+            {%- assign _sv_sel2 = page.variants | where_exp: "v", "v.name != ''" -%}
+            {%- assign _stats_variants = _sv_sel2.size -%}
+            {%- assign _stats_versions = 1 -%}
+          {%- endif -%}
+          <section id="container-stats" class="stats-strip" aria-label="Container statistics">
+            {%- if page.pull_count_formatted or page.pull_count -%}
+            <div class="stat">
+              <span class="eyebrow">PULLS</span>
+              <span class="value">{{ page.pull_count_formatted | default: page.pull_count | default: "0" }}</span>
+            </div>
+            {%- endif -%}
+            {%- if page.star_count -%}
+            <div class="stat">
+              <span class="eyebrow">STARS</span>
+              <span class="value">{{ page.star_count | default: 0 }}</span>
+            </div>
+            {%- endif -%}
+            {%- if _stats_variants > 0 -%}
+            <div class="stat">
+              <span class="eyebrow">COVERAGE</span>
+              <span class="value">{{ _stats_variants }} variant{% if _stats_variants != 1 %}s{% endif %}{% if _stats_versions > 1 %} · {{ _stats_versions }} versions{% endif %} · amd64+arm64</span>
+            </div>
+            {%- endif -%}
+          </section>
+
           {%- comment -%}
             Render one <section class="provenance"> per variant with
             data-variant-tag; container-detail.js (phase-b-variant-changed)
@@ -257,7 +236,7 @@
               resolves correctly for every variant section regardless of which is visible.
               (Hidden sections have display:none — their heading would be skipped by AT.)
             {%- endcomment -%}
-            <header class="provenance-header">
+            <header id="provenance" class="provenance-header">
               <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
               <h3 id="provenance-heading">Provenance</h3>
             </header>
@@ -362,7 +341,7 @@
             {%- endfor -%}
           {%- elsif page.variants -%}
             {%- comment -%}P0-N2 fix: heading lifted out — same rationale as page.versions branch above.{%- endcomment -%}
-            <header class="provenance-header">
+            <header id="provenance" class="provenance-header">
               <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
               <h3 id="provenance-heading">Provenance</h3>
             </header>
@@ -569,7 +548,7 @@
           <!-- Security Scan Summary (Zone 2 — always visible trust surface) -->
           {%- assign sec_variant = page.versions[0].variants[0] | default: page.variants[0] | default: page -%}
           {%- if sec_variant.trivy_summary and sec_variant.trivy_summary.last_scan -%}
-          <div class="security-scan-card">
+          <div id="security-scan" class="security-scan-card">
             <header class="security-scan-card-header">
               <p class="eyebrow">Security scan results</p>
               <h3>Trivy · last scan {{ sec_variant.trivy_summary.last_scan | date: "%Y-%m-%d" }}</h3>
@@ -625,6 +604,75 @@
         {%- comment -%} Zone 3 — Explore (progressive disclosure, native <details>) {%- endcomment -%}
         <section class="detail-zone detail-zone--explore" aria-label="Explore">
           <h2 class="zone-eyebrow">Explore</h2>
+
+          {%- comment -%} All-variants flat table (always visible, not inside a disclosure) {%- endcomment -%}
+          {%- assign _avt_count = 0 -%}
+          {%- if page.versions -%}
+            {%- for _avt_v in page.versions -%}
+              {%- assign _avt_sel = _avt_v.variants | where_exp: "v", "v.name != ''" -%}
+              {%- assign _avt_count = _avt_count | plus: _avt_sel.size -%}
+            {%- endfor -%}
+          {%- elsif page.variants -%}
+            {%- assign _avt_count = page.variants.size -%}
+          {%- endif -%}
+          {%- if _avt_count > 0 -%}
+          <section id="all-variants" class="all-variants-flat" aria-label="All available variants">
+            <h3 class="all-variants-heading">Available variants</h3>
+            <div class="all-variants-table-wrap">
+              <table class="all-variants-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Tag</th>
+                    {%- if page.versions and page.versions[0].variants[0].extensions -%}<th scope="col">Extensions</th>{%- endif -%}
+                    <th scope="col">Size (amd64)</th>
+                    <th scope="col">Build status</th>
+                    {%- if page.versions and page.versions.size > 1 -%}<th scope="col">Version</th>{%- endif -%}
+                  </tr>
+                </thead>
+                <tbody>
+                  {%- if page.versions -%}
+                    {%- for _avt_ver in page.versions -%}
+                      {%- assign _avt_sel2 = _avt_ver.variants | where_exp: "v", "v.name != ''" -%}
+                      {%- for _avt_var in _avt_sel2 -%}
+                  <tr>
+                    <td><code>{{ _avt_var.tag | escape }}</code>{% if _avt_var.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}</td>
+                    {%- if page.versions[0].variants[0].extensions -%}
+                    <td>
+                      {%- for ext in _avt_var.extensions -%}<span class="tag-pill">{{ ext | escape }}</span>{%- endfor -%}
+                    </td>
+                    {%- endif -%}
+                    <td>{{ _avt_var.size_amd64 | default: "—" | escape }}</td>
+                    <td>
+                      {%- if _avt_var.build_digest and _avt_var.build_digest != "unknown" -%}
+                        <span class="avt-status avt-status--ok">OK</span>
+                      {%- else -%}
+                        <span class="avt-status avt-status--pending">PENDING</span>
+                      {%- endif -%}
+                    </td>
+                    {%- if page.versions.size > 1 -%}<td>{{ _avt_ver.base_tag | default: _avt_ver.tag | escape }}</td>{%- endif -%}
+                  </tr>
+                      {%- endfor -%}
+                    {%- endfor -%}
+                  {%- elsif page.variants -%}
+                    {%- for _avt_var in page.variants -%}
+                  <tr>
+                    <td><code>{{ _avt_var.tag | escape }}</code>{% if _avt_var.is_default %} <span class="version-tab-default-badge">default</span>{% endif %}</td>
+                    <td>{{ _avt_var.size_amd64 | default: "—" | escape }}</td>
+                    <td>
+                      {%- if _avt_var.build_digest and _avt_var.build_digest != "unknown" -%}
+                        <span class="avt-status avt-status--ok">OK</span>
+                      {%- else -%}
+                        <span class="avt-status avt-status--pending">PENDING</span>
+                      {%- endif -%}
+                    </td>
+                  </tr>
+                    {%- endfor -%}
+                  {%- endif -%}
+                </tbody>
+              </table>
+            </div>
+          </section>
+          {%- endif -%}
 
           <!-- Variants — replaced by <version-tabs> custom element -->
           {% if page.has_variants %}
@@ -880,7 +928,7 @@
           {% endunless %}
 
           <!-- Package Summary (from SBOM) -->
-          <details class="disclosure">
+          <details id="dep-health" class="disclosure">
             <summary>
               <span class="disclosure__title">Package summary</span>
               <span class="disclosure__metric">n/a — runtime parsed</span>
@@ -919,7 +967,7 @@
           </details>
 
           <!-- Build History (from SBOM history) -->
-          <details class="disclosure">
+          <details id="build-history" class="disclosure">
             <summary>
               <span class="disclosure__title">Build history</span>
               <span class="disclosure__metric">n/a — runtime fetched</span>
@@ -1087,7 +1135,7 @@
         <section class="detail-zone detail-zone--docs">
           <h2 class="zone-eyebrow">Documentation</h2>
           <!-- README (rendered at build time by kramdown) -->
-          <div class="readme-section glass">
+          <div id="readme" class="readme-section glass">
             <div class="readme-header">
               <i class="ti ti-file-text" aria-hidden="true"></i>
               <h3>README</h3>
@@ -1107,6 +1155,7 @@
   </div>
 
   <!-- Vanilla web components — CSP-clean, no eval -->
+  <script defer src="{{ '/assets/js/components/variant-action-bar.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/security-scan.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/version-tabs.js' | relative_url }}"></script>

--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -1,0 +1,391 @@
+/* ==========================================================
+   variant-action-bar.css — Variant selector + command card
+   Phase C PR1. Theme-aware via existing CSS custom properties.
+   Motion spec: 100–200ms, respect prefers-reduced-motion.
+   ========================================================== */
+
+/* ----------------------------------------------------------
+   Host element
+   ---------------------------------------------------------- */
+
+variant-action-bar {
+  display: block;
+  position: relative;  /* sentinel is positioned relative to this */
+  /* CSS variable set by JS after measuring site-nav height */
+  --vab-nav-height: 60px;
+}
+
+/* Sentinel: 1px invisible div that triggers the IntersectionObserver */
+.vab-sentinel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+/* ----------------------------------------------------------
+   Card — default (full, inline)
+   ---------------------------------------------------------- */
+
+.vab-card {
+  background: var(--color-surface-raised, var(--color-navy-800, #1A2A4A));
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-md, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+  transition: box-shadow var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vab-card { transition: none; }
+}
+
+/* ----------------------------------------------------------
+   Sticky + collapse state
+   ---------------------------------------------------------- */
+
+/* When the sentinel scrolls out of view, the host gets [data-collapsed] */
+[data-collapsed] .vab-card {
+  position: fixed;
+  top: var(--vab-nav-height, 60px);
+  left: 0;
+  right: 0;
+  z-index: 40;
+  border-radius: 0;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  padding: var(--space-xs, 4px) var(--space-md, 16px);
+  /* Collapsed: show only signals row + toggle button, hide selectors + commands */
+}
+
+[data-collapsed] .vab-row--selectors,
+[data-collapsed] .vab-row--commands {
+  display: none;
+}
+
+/* When user clicks toggle while collapsed, re-show everything */
+[data-collapsed] .vab-card[data-user-expanded="true"] .vab-row--selectors,
+[data-collapsed] .vab-card[data-user-expanded="true"] .vab-row--commands {
+  display: flex;
+}
+
+/* Show the toggle button only when collapsed */
+.vab-toggle { display: none; }
+[data-collapsed] .vab-toggle { display: inline-flex; }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-collapsed] .vab-card { transition: none; }
+}
+
+/* ----------------------------------------------------------
+   Rows
+   ---------------------------------------------------------- */
+
+.vab-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md, 16px);
+  flex-wrap: wrap;
+}
+
+.vab-row--signals {
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm, 8px);
+}
+
+.vab-row--commands {
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+@media (min-width: 640px) {
+  .vab-row--commands { flex-direction: row; }
+}
+
+/* ----------------------------------------------------------
+   Pill groups (version + flavor selectors)
+   ---------------------------------------------------------- */
+
+.vab-pill-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.vab-pill-label {
+  font-size: var(--font-size-caption, 12px);
+  font-family: var(--font-family-mono, monospace);
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: var(--letter-spacing-wider, 0.08em);
+  text-transform: uppercase;
+  color: var(--color-text-muted, #8A93A0);
+}
+
+.vab-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-inline-pill-gap, 6px);
+}
+
+/* Base pill style */
+.vab-version-pill,
+.vab-flavor-pill {
+  padding: var(--space-xs, 4px) var(--space-sm, 8px);
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid var(--color-variant-tag-border, rgba(139,92,246,0.25));
+  background: var(--color-variant-tag-bg, rgba(139,92,246,0.15));
+  color: var(--color-variant-tag-fg, var(--color-violet-400, #A78BFA));
+  font-size: var(--font-size-body-sm, 14px);
+  font-weight: var(--font-weight-medium, 500);
+  font-family: var(--font-family-sans, sans-serif);
+  cursor: pointer;
+  transition:
+    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    border-color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    box-shadow var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+  /* WCAG 2.5.8 minimum touch target */
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.vab-version-pill:hover,
+.vab-flavor-pill:hover {
+  background: var(--color-variant-tag-bg-hover, rgba(139,92,246,0.25));
+  border-color: rgba(167,139,250,0.45);
+}
+
+/* Active / selected pill (uses violet trust hue per Phase C spec) */
+.vab-version-pill.vab-pill--active,
+.vab-flavor-pill.vab-pill--active {
+  background: var(--color-variant-tag-selected-bg, rgba(139,92,246,0.30));
+  border-color: var(--color-violet-400, #A78BFA);
+  color: var(--color-violet-400, #A78BFA);
+  box-shadow: 0 0 0 2px var(--color-variant-tag-selected-shadow, rgba(139,92,246,0.20));
+}
+
+/* Focus rings — WCAG 2.2 AA (3px outline, 2px offset) */
+.vab-version-pill:focus-visible,
+.vab-flavor-pill:focus-visible {
+  outline: 3px solid var(--color-violet-400, #A78BFA);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vab-version-pill,
+  .vab-flavor-pill { transition: none; }
+}
+
+/* ----------------------------------------------------------
+   Command blocks
+   ---------------------------------------------------------- */
+
+.vab-command-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+  flex: 1;
+  min-width: 0; /* allow shrink in flex row */
+}
+
+.vab-command-label {
+  font-size: var(--font-size-caption, 12px);
+  font-family: var(--font-family-mono, monospace);
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: var(--letter-spacing-wider, 0.08em);
+  text-transform: uppercase;
+  color: var(--color-text-muted, #8A93A0);
+  margin: 0;
+}
+
+.vab-command-input-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  background: rgba(0,0,0,0.20);
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-xs, 4px) var(--space-sm, 8px);
+  overflow: hidden;
+}
+
+.vab-command-code {
+  flex: 1;
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.8125rem; /* 13px — matches existing .detail-pull-input */
+  color: var(--color-text-secondary, #C7CCD4);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  display: block;
+}
+
+.vab-copy-btn {
+  flex-shrink: 0;
+  background: rgba(255,255,255,0.10);
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-xs, 4px) var(--space-sm, 8px);
+  min-width: 36px;
+  min-height: 36px; /* WCAG 2.5.8 */
+  color: var(--color-text-secondary, #C7CCD4);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition:
+    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+}
+
+.vab-copy-btn:hover {
+  background: rgba(255,255,255,0.20);
+  color: var(--color-text-primary, #F4F5F7);
+}
+
+.vab-copy-btn.vab-copy-btn--copied {
+  background: var(--color-feedback-success-bg, rgba(16,185,129,0.12));
+  border-color: var(--color-green-400, #4ADE80);
+  color: var(--color-green-400, #4ADE80);
+}
+
+.vab-copy-btn:focus-visible {
+  outline: 3px solid var(--color-action-primary, #60A5FA);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vab-copy-btn { transition: none; }
+}
+
+/* ----------------------------------------------------------
+   Signals strip
+   ---------------------------------------------------------- */
+
+.vab-signals {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  font-size: var(--font-size-body-sm, 14px);
+}
+
+.vab-signal {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+}
+
+.vab-signal-label {
+  font-size: var(--font-size-caption, 12px);
+  font-family: var(--font-family-mono, monospace);
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: var(--letter-spacing-wider, 0.08em);
+  text-transform: uppercase;
+  color: var(--color-text-muted, #8A93A0);
+}
+
+.vab-signal-value {
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--color-text-primary, #F4F5F7);
+}
+
+/* Status-specific coloring */
+.vab-signal--status[data-status="ok"] .vab-signal-value {
+  color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+}
+
+.vab-signal--status[data-status="pending"] .vab-signal-value {
+  color: var(--color-feedback-warning-fg, var(--color-amber-400, #FBBF24));
+}
+
+.vab-signal-sep {
+  color: var(--color-text-muted, #8A93A0);
+  padding: 0 2px;
+  user-select: none;
+}
+
+/* ----------------------------------------------------------
+   Collapse toggle button
+   ---------------------------------------------------------- */
+
+.vab-toggle {
+  align-self: flex-start;
+  padding: var(--space-xs, 4px) var(--space-sm, 8px);
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  background: rgba(255,255,255,0.06);
+  color: var(--color-text-muted, #8A93A0);
+  font-size: var(--font-size-caption, 12px);
+  font-family: var(--font-family-mono, monospace);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  min-height: 32px;
+  transition:
+    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+}
+
+.vab-toggle:hover {
+  background: rgba(255,255,255,0.12);
+  color: var(--color-text-primary, #F4F5F7);
+}
+
+.vab-toggle:focus-visible {
+  outline: 3px solid var(--color-action-primary, #60A5FA);
+  outline-offset: 2px;
+}
+
+.vab-toggle-icon { font-size: 0.875rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  .vab-toggle { transition: none; }
+}
+
+/* ----------------------------------------------------------
+   Light theme overrides
+   ---------------------------------------------------------- */
+
+[data-theme="light"] .vab-card {
+  background: #FFFFFF;
+  border-color: rgba(0,0,0,0.10);
+}
+
+[data-theme="light"] [data-collapsed] .vab-card {
+  background: rgba(255,255,255,0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+[data-theme="light"] .vab-copy-btn.vab-copy-btn--copied {
+  color: #047857; /* green-700 on light — 5.4:1 (WCAG AA) */
+}
+
+/* ----------------------------------------------------------
+   Mobile — single column
+   ---------------------------------------------------------- */
+
+@media (max-width: 767px) {
+  .vab-row--selectors { flex-direction: column; gap: var(--space-sm, 8px); }
+  .vab-row--commands { flex-direction: column; }
+  .vab-command-code { font-size: 0.75rem; }
+
+  [data-collapsed] .vab-card {
+    padding: var(--space-xs, 4px) var(--space-sm, 8px);
+  }
+}

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -203,16 +203,127 @@
     }
     .detail-actions { display: flex; gap: 0.75rem; }
 
-    .detail-meta {
-      display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 1rem; margin-bottom: 2rem;
+    /* .detail-meta and .meta-card removed (PR1 — replaced by <variant-action-bar> signals strip) */
+
+    /* ============================================================
+       STATS STRIP (inline pull / star / variant counts)
+       ============================================================ */
+
+    .stats-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md, 16px);
+      padding: var(--space-sm, 8px) 0;
+      margin-bottom: var(--space-md, 16px);
     }
-    .meta-card { padding: 1.25rem; }
-    .meta-card-label {
-      font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em;
-      color: var(--detail-text-muted); margin-bottom: 0.5rem;
+    .stats-strip .stat {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
     }
-    .meta-card-value { font-size: 1.125rem; font-weight: 600; }
+    .stats-strip .eyebrow {
+      font-size: var(--font-size-caption, 12px);
+      font-family: var(--font-family-mono, monospace);
+      font-weight: var(--font-weight-semibold, 600);
+      letter-spacing: var(--letter-spacing-wider, 0.08em);
+      text-transform: uppercase;
+      color: var(--color-text-muted, #8A93A0);
+    }
+    .stats-strip .value {
+      font-size: var(--font-size-body-sm, 14px);
+      font-weight: var(--font-weight-semibold, 600);
+      color: var(--color-text-primary, #F4F5F7);
+    }
+
+    /* ============================================================
+       ALL-VARIANTS FLAT TABLE
+       ============================================================ */
+
+    .all-variants-flat {
+      margin-bottom: var(--space-lg, 24px);
+    }
+    .all-variants-heading {
+      font-size: var(--font-size-body-sm, 14px);
+      font-weight: var(--font-weight-semibold, 600);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wide, 0.05em);
+      color: var(--color-text-muted, #8A93A0);
+      margin-bottom: var(--space-sm, 8px);
+    }
+    .all-variants-table-wrap {
+      overflow-x: auto;
+      border-radius: var(--radius-md, 8px);
+      border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+    }
+    .all-variants-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: var(--font-size-body-sm, 14px);
+    }
+    .all-variants-table th {
+      padding: var(--space-xs, 4px) var(--space-sm, 8px);
+      text-align: left;
+      font-size: var(--font-size-caption, 12px);
+      font-family: var(--font-family-mono, monospace);
+      font-weight: var(--font-weight-semibold, 600);
+      letter-spacing: var(--letter-spacing-wider, 0.08em);
+      text-transform: uppercase;
+      color: var(--color-text-muted, #8A93A0);
+      border-bottom: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+      white-space: nowrap;
+    }
+    .all-variants-table td {
+      padding: var(--space-xs, 4px) var(--space-sm, 8px);
+      border-bottom: 1px solid var(--color-table-border, rgba(255,255,255,0.04));
+      color: var(--color-text-secondary, #C7CCD4);
+      vertical-align: middle;
+    }
+    .all-variants-table tr:last-child td { border-bottom: none; }
+    .all-variants-table tr:nth-child(even) td {
+      background: var(--color-table-row-even-bg, rgba(255,255,255,0.02));
+    }
+    .all-variants-table code {
+      font-family: var(--font-family-mono, monospace);
+      font-size: 0.8125rem;
+      color: var(--color-text-primary, #F4F5F7);
+    }
+    /* Build status badges in the flat table */
+    .avt-status {
+      display: inline-block;
+      padding: 1px var(--space-xs, 4px);
+      border-radius: var(--radius-sm, 4px);
+      font-size: var(--font-size-caption, 12px);
+      font-weight: var(--font-weight-semibold, 600);
+      font-family: var(--font-family-mono, monospace);
+      letter-spacing: 0.04em;
+    }
+    .avt-status--ok {
+      color: var(--color-feedback-success-fg, #4ADE80);
+      background: var(--color-feedback-success-bg, rgba(16,185,129,0.12));
+    }
+    .avt-status--pending {
+      color: var(--color-feedback-warning-fg, #FBBF24);
+      background: var(--color-feedback-warning-bg, rgba(245,158,11,0.12));
+    }
+
+    /* vab-section spacing */
+    .vab-section {
+      margin-bottom: var(--space-lg, 24px);
+    }
+    /* noscript fallback */
+    .vab-noscript {
+      padding: var(--space-sm, 8px) var(--space-md, 16px);
+      background: rgba(0,0,0,0.20);
+      border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+      border-radius: var(--radius-md, 8px);
+      font-family: var(--font-family-mono, monospace);
+      font-size: 0.875rem;
+    }
+    .vab-noscript-label {
+      font-size: var(--font-size-caption, 12px);
+      color: var(--color-text-muted, #8A93A0);
+      margin-bottom: var(--space-xs, 4px);
+    }
 
     /* ============================================================
        LINEAGE (inside disclosure body)
@@ -704,123 +815,32 @@
     /* [data-theme="light"] disclosure hover — tokens.css overrides --color-disclosure-hover-bg for light mode — no rule needed here */
 
     /* ============================================================
-       PULL COMMAND SECTION
+       PULL COMMAND SECTION — removed PR1 (replaced by variant-action-bar.css)
+       .detail-pull-section, .detail-pull-row, .detail-pull-label,
+       .detail-registry-toggle, .detail-registry-btn, .detail-pull-input-group,
+       .detail-pull-input, .detail-copy-btn rules deleted.
        ============================================================ */
-
-    .detail-pull-section {
-      padding: 1rem 1.25rem;
-      margin-bottom: 2rem;
-    }
-    .detail-pull-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-bottom: 0.75rem;
-    }
-    .detail-pull-label {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.8125rem;
-      font-weight: 600;
-      color: var(--detail-text-muted);
-    }
-    .detail-registry-toggle {
-      display: flex;
-      background: var(--color-registry-toggle-bg);
-      border-radius: 6px;
-      padding: 0.1875rem;
-    }
-    .detail-registry-btn {
-      padding: 0.3125rem 0.75rem;
-      font-size: 0.75rem;
-      font-weight: 500;
-      border: none;
-      background: transparent;
-      color: var(--text-secondary);
-      border-radius: 4px;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      /* 44px minimum touch target (WCAG 2.5.8). Explicit flex centering keeps
-         the label visually balanced when the box height exceeds the content
-         box, including in browsers without native button vertical-centering. */
-      min-height: 44px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .detail-registry-btn:hover {
-      color: var(--text-primary);
-    }
-    .detail-registry-btn.active {
-      background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
-      color: #fff;
-    }
-    .detail-pull-input-group {
-      display: flex;
-      gap: 0.5rem;
-    }
-    .detail-pull-input {
-      flex: 1;
-      background: var(--color-pull-input-bg);
-      border: 1px solid var(--glass-border);
-      border-radius: 8px;
-      padding: 0.5rem 0.75rem;
-      font-family: var(--font-family-mono);
-      font-size: 0.8125rem;
-      color: var(--detail-text-secondary);
-    }
-    .detail-copy-btn {
-      background: var(--color-copy-btn-bg);
-      border: 1px solid var(--glass-border);
-      border-radius: 8px;
-      padding: 0.5rem 0.75rem;
-      min-width: 44px;
-      min-height: 44px; /* F8: 40→44px (WCAG 2.5.8 touch target, matches .copy-btn) */
-      color: var(--text-secondary);
-      cursor: pointer;
-      transition: all 0.2s ease;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .detail-copy-btn:hover {
-      background: var(--color-copy-btn-bg-hover);
-      color: var(--text-primary);
-    }
-    .detail-copy-btn.copied {
-      background: var(--color-copy-btn-copied-bg);
-      border-color: var(--accent-green);
-      color: var(--accent-green);
-    }
-    /* Light theme: pull section — tokens.css overrides --color-registry-toggle-bg/--color-pull-input-bg/--color-copy-btn-* for light mode — no rules needed here */
-    [data-theme="light"] .detail-registry-btn.active {
-      color: #ffffff;  /* white text on gradient-colored active button — motivated constant */
-    }
 
     /* ============================================================
        FOCUS VISIBLE
        ============================================================ */
 
-    .variant-tag:focus-visible, .back-link:focus-visible, .btn:focus-visible, .theme-toggle:focus-visible,
-    .detail-registry-btn:focus-visible, .detail-copy-btn:focus-visible {
+    .variant-tag:focus-visible, .back-link:focus-visible, .btn:focus-visible, .theme-toggle:focus-visible {
       outline: 2px solid var(--accent-blue); outline-offset: 2px;
     }
+    /* .detail-registry-btn:focus-visible, .detail-copy-btn:focus-visible removed (PR1) */
 
     /* ============================================================
        RESPONSIVE
        ============================================================ */
 
-    @media (max-width: 1024px) {
-      .detail-meta { grid-template-columns: repeat(2, 1fr); }
-    }
+    /* .detail-meta grid-template-columns responsive rules removed (PR1) */
     @media (max-width: 768px) {
       .container { padding: 1rem; }
       .detail-header { flex-direction: column; align-items: flex-start; }
       .detail-title h1 { font-size: 1.5rem; }
       .detail-actions { width: 100%; flex-wrap: wrap; }
       .detail-actions .btn { flex: 1; min-width: 120px; justify-content: center; }
-      .detail-meta { grid-template-columns: 1fr; }
       .readme-section { padding: 1rem; }
       .readme-content h1 { font-size: 1.5rem; }
       .readme-content h2 { font-size: 1.25rem; }
@@ -836,18 +856,15 @@
       .dep-update-table th, .dep-update-table td,
       .changelog-table th, .changelog-table td,
       .history-table th, .history-table td { padding: 0.5rem; }
-      .detail-pull-section { padding: 0.75rem 1rem; }
-      .detail-pull-input { font-size: 0.75rem; }
+      /* .detail-pull-section padding removed (PR1) */
       .shape { display: none; }
+      .all-variants-table { font-size: 0.75rem; }
     }
     @media (max-width: 480px) {
       .container { padding: 0.75rem; }
       .detail-title h1 { font-size: 1.25rem; }
       .detail-badge { font-size: 0.75rem; padding: 0.25rem 0.5rem; }
-      .detail-pull-row { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
-      .detail-pull-input { font-size: 0.6875rem; }
-      .meta-card { padding: 1rem; }
-      .meta-card-value { font-size: 1rem; word-break: break-all; }
+      /* .detail-pull-row / .detail-pull-input / .meta-card responsive rules removed (PR1) */
     }
 
     /* ============================================================

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -1,0 +1,525 @@
+// docs/site/assets/js/components/variant-action-bar.js
+//
+// Vanilla custom element (light DOM). CSP-clean (no eval, no innerHTML).
+// Renders: version pills + flavor pills + pull/verify commands + per-variant signals strip.
+// Sticky-on-scroll with collapse toggle. Dispatches variant-action-bar:variant-changed.
+// Two-way sync with legacy phase-b-variant-changed / version-tabs-changed events.
+
+(function () {
+  'use strict';
+
+  class VariantActionBar extends HTMLElement {
+
+    // -------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------
+
+    connectedCallback() {
+      this._parseData();
+      this._render();
+      this._attachListeners();
+      this._initSticky();
+    }
+
+    disconnectedCallback() {
+      if (this._observer) { this._observer.disconnect(); }
+    }
+
+    // -------------------------------------------------------
+    // Data parsing
+    // -------------------------------------------------------
+
+    _parseData() {
+      var parse = function (attr, fallback) {
+        try { return JSON.parse(decodeURIComponent(attr || '')); }
+        catch (e) { return fallback; }
+      };
+
+      this._container = this.dataset.container || '';
+      this._imageBase = this.dataset.imageBase || '';
+      this._defaultTag = this.dataset.defaultTag || '';
+
+      // versions: array of version-group objects with .tag + .variants[]
+      this._versions = parse(this.dataset.versions, []);
+      // flavors: flat array of flavor objects ({ name, label })
+      this._flavors = parse(this.dataset.flavors, []);
+      // variants: flat lookup array of all variant objects
+      this._variants = parse(this.dataset.variants, []);
+
+      // Select the first version/flavor as default
+      this._selectedVersion = this.dataset.defaultVersion
+        || (this._versions[0] && this._versions[0].tag) || '';
+      this._selectedFlavor = this.dataset.defaultFlavor
+        || (this._flavors[0] && this._flavors[0].name) || '';
+
+      // Find initial selected variant
+      this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
+    }
+
+    // Find a variant matching version + flavor.
+    // Falls back to defaultTag match, then first variant.
+    _findVariant(version, flavor) {
+      var variants = this._variants;
+      if (!variants || variants.length === 0) { return null; }
+
+      // Exact match on version + flavor
+      if (version && flavor) {
+        for (var i = 0; i < variants.length; i++) {
+          var v = variants[i];
+          if (v.version === version && v.flavor === flavor) { return v; }
+        }
+      }
+
+      // Match by version only (no flavor dimension)
+      if (version) {
+        for (var j = 0; j < variants.length; j++) {
+          if (variants[j].version === version) { return variants[j]; }
+        }
+      }
+
+      // Match by default tag
+      if (this._defaultTag) {
+        for (var k = 0; k < variants.length; k++) {
+          if (variants[k].tag === this._defaultTag) { return variants[k]; }
+        }
+      }
+
+      return variants[0] || null;
+    }
+
+    // -------------------------------------------------------
+    // Render (DOM construction — no innerHTML, XSS-safe)
+    // -------------------------------------------------------
+
+    _render() {
+      while (this.firstChild) { this.removeChild(this.firstChild); }
+
+      // Sentinel div for IntersectionObserver — must precede card in DOM
+      var sentinel = document.createElement('div');
+      sentinel.className = 'vab-sentinel';
+      sentinel.setAttribute('aria-hidden', 'true');
+      this.appendChild(sentinel);
+
+      var card = document.createElement('div');
+      card.className = 'vab-card';
+      this.appendChild(card);
+
+      // Row 1 — selectors (version pills + flavor pills)
+      var hasMultipleVersions = this._versions && this._versions.length > 1;
+      var hasFlavors = this._flavors && this._flavors.length > 0;
+
+      if (hasMultipleVersions || hasFlavors) {
+        var row1 = document.createElement('div');
+        row1.className = 'vab-row vab-row--selectors';
+
+        if (hasMultipleVersions) {
+          row1.appendChild(
+            this._makePillGroup('Version', this._versions, 'tag', this._selectedVersion,
+              'vab-version-pill', 'vab-version-pills')
+          );
+        }
+
+        if (hasFlavors) {
+          row1.appendChild(
+            this._makePillGroup('Flavor', this._flavors, 'name', this._selectedFlavor,
+              'vab-flavor-pill', 'vab-flavor-pills')
+          );
+        }
+
+        card.appendChild(row1);
+      }
+
+      // Row 2 — commands (docker pull + cosign verify)
+      var row2 = document.createElement('div');
+      row2.className = 'vab-row vab-row--commands';
+      row2.appendChild(this._makeCommandBlock('pull'));
+      row2.appendChild(this._makeCommandBlock('verify'));
+      card.appendChild(row2);
+
+      // Row 3 — signals strip (status · size amd64 · size arm64)
+      var row3 = document.createElement('div');
+      row3.className = 'vab-row vab-row--signals';
+      row3.appendChild(this._makeSignalsStrip());
+      card.appendChild(row3);
+
+      // Collapse toggle button (only active when [data-collapsed] is set)
+      var toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'vab-toggle';
+      toggle.setAttribute('aria-expanded', 'true');
+      toggle.setAttribute('aria-label', 'Toggle variant commands panel');
+      var toggleIcon = document.createElement('span');
+      toggleIcon.className = 'vab-toggle-icon';
+      toggleIcon.setAttribute('aria-hidden', 'true');
+      toggleIcon.textContent = '↓'; // down arrow ↓
+      toggle.appendChild(toggleIcon);
+      var toggleLabel = document.createElement('span');
+      toggleLabel.textContent = 'commands';
+      toggle.appendChild(toggleLabel);
+      card.appendChild(toggle);
+
+      // Store refs
+      this._cardEl = card;
+      this._sentinelEl = sentinel;
+      this._toggleBtn = toggle;
+      this._userExpanded = false;
+
+      this._updateCommands();
+      this._updateSignals();
+    }
+
+    // Build a labelled pill group (radiogroup)
+    _makePillGroup(labelText, items, valueKey, selected, pillClass, groupClass) {
+      var wrap = document.createElement('div');
+      wrap.className = 'vab-pill-group ' + groupClass;
+
+      var label = document.createElement('span');
+      label.className = 'vab-pill-label';
+      label.textContent = labelText;
+      label.setAttribute('aria-hidden', 'true');
+      wrap.appendChild(label);
+
+      var row = document.createElement('div');
+      row.className = 'vab-pills';
+      row.setAttribute('role', 'radiogroup');
+      row.setAttribute('aria-label', labelText);
+
+      for (var i = 0; i < items.length; i++) {
+        var item = items[i];
+        var pill = document.createElement('button');
+        pill.type = 'button';
+        pill.className = pillClass + (item[valueKey] === selected ? ' vab-pill--active' : '');
+        pill.setAttribute('role', 'radio');
+        pill.setAttribute('aria-checked', item[valueKey] === selected ? 'true' : 'false');
+        pill.setAttribute('data-value', item[valueKey]);
+        pill.textContent = item.label || item[valueKey];
+        row.appendChild(pill);
+      }
+
+      wrap.appendChild(row);
+      return wrap;
+    }
+
+    // Build one command block (eyebrow + code + copy button)
+    _makeCommandBlock(type) {
+      var labelText = type === 'pull' ? 'PULL' : 'VERIFY';
+      var ariaLabel = type === 'pull' ? 'Docker pull command' : 'Cosign verify command';
+
+      var wrap = document.createElement('div');
+      wrap.className = 'vab-command-block';
+
+      var eyebrow = document.createElement('p');
+      eyebrow.className = 'vab-command-label eyebrow';
+      eyebrow.setAttribute('aria-hidden', 'true');
+      eyebrow.textContent = labelText;
+      wrap.appendChild(eyebrow);
+
+      var inputRow = document.createElement('div');
+      inputRow.className = 'vab-command-input-row';
+
+      var code = document.createElement('code');
+      code.className = 'vab-command-code';
+      code.setAttribute('data-vab-cmd', type);
+      code.setAttribute('aria-label', ariaLabel);
+      inputRow.appendChild(code);
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'vab-copy-btn';
+      btn.setAttribute('data-vab-copy', type);
+      btn.setAttribute('aria-label', 'Copy ' + labelText.toLowerCase() + ' command');
+      var icon = document.createElement('span');
+      icon.className = 'vab-copy-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = '⧉'; // ⧉
+      btn.appendChild(icon);
+      inputRow.appendChild(btn);
+
+      wrap.appendChild(inputRow);
+      return wrap;
+    }
+
+    // Build the signals strip
+    _makeSignalsStrip() {
+      var strip = document.createElement('div');
+      strip.className = 'vab-signals';
+
+      var makeSig = function (wrapCls, labelText, signalKey) {
+        var wrap = document.createElement('span');
+        wrap.className = 'vab-signal ' + wrapCls;
+        var lbl = document.createElement('span');
+        lbl.className = 'vab-signal-label';
+        lbl.textContent = labelText;
+        var val = document.createElement('span');
+        val.className = 'vab-signal-value';
+        val.setAttribute('data-vab-signal', signalKey);
+        wrap.appendChild(lbl);
+        wrap.appendChild(val);
+        return wrap;
+      };
+
+      var sep = function () {
+        var s = document.createElement('span');
+        s.className = 'vab-signal-sep';
+        s.setAttribute('aria-hidden', 'true');
+        s.textContent = '·'; // ·
+        return s;
+      };
+
+      strip.appendChild(makeSig('vab-signal--status', 'STATUS', 'status'));
+      strip.appendChild(sep());
+      strip.appendChild(makeSig('vab-signal--size', 'AMD64', 'size-amd64'));
+      strip.appendChild(sep());
+      strip.appendChild(makeSig('vab-signal--size', 'ARM64', 'size-arm64'));
+      return strip;
+    }
+
+    // -------------------------------------------------------
+    // Update content when variant changes
+    // -------------------------------------------------------
+
+    _updateCommands() {
+      var v = this._currentVariant;
+      var tag = (v && v.tag) ? v.tag : this._defaultTag;
+      var base = this._imageBase;
+      var owner = this._extractOwner(base);
+
+      var pullCmd = 'docker pull ' + base + ':' + tag;
+      var verifyCmd = 'cosign verify ' + base + ':' + tag
+        + ' --certificate-identity-regexp=https://github.com/' + owner
+        + ' --certificate-oidc-issuer=https://token.actions.githubusercontent.com';
+
+      var pullEl = this.querySelector('[data-vab-cmd="pull"]');
+      var verifyEl = this.querySelector('[data-vab-cmd="verify"]');
+      if (pullEl) { pullEl.textContent = pullCmd; }
+      if (verifyEl) { verifyEl.textContent = verifyCmd; }
+    }
+
+    _extractOwner(base) {
+      // ghcr.io/owner/container -> owner
+      var parts = (base || '').split('/');
+      return parts.length >= 2 ? parts[1] : '';
+    }
+
+    _updateSignals() {
+      var v = this._currentVariant;
+      var statusText = v
+        ? (v.build_digest && v.build_digest !== 'unknown' ? 'OK' : 'PENDING')
+        : '—'; // —
+
+      var statusSig = this.querySelector('[data-vab-signal="status"]');
+      if (statusSig) {
+        statusSig.textContent = statusText;
+        var statusWrap = statusSig.closest('.vab-signal--status');
+        if (statusWrap) { statusWrap.setAttribute('data-status', statusText.toLowerCase()); }
+      }
+
+      var amdEl = this.querySelector('[data-vab-signal="size-amd64"]');
+      var armEl = this.querySelector('[data-vab-signal="size-arm64"]');
+      if (amdEl) { amdEl.textContent = (v && v.size_amd64) ? v.size_amd64 : '—'; }
+      if (armEl) { armEl.textContent = (v && v.size_arm64) ? v.size_arm64 : '—'; }
+    }
+
+    // -------------------------------------------------------
+    // Pill selection
+    // -------------------------------------------------------
+
+    _onVersionPillClick(value) {
+      this._selectedVersion = value;
+      this._updatePillActive('vab-version-pill', value);
+      this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
+      this._updateCommands();
+      this._updateSignals();
+      this._dispatchVariantChanged();
+    }
+
+    _onFlavorPillClick(value) {
+      this._selectedFlavor = value;
+      this._updatePillActive('vab-flavor-pill', value);
+      this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
+      this._updateCommands();
+      this._updateSignals();
+      this._dispatchVariantChanged();
+    }
+
+    _updatePillActive(pillClass, value) {
+      var pills = this.querySelectorAll('.' + pillClass);
+      for (var i = 0; i < pills.length; i++) {
+        var active = pills[i].dataset.value === value;
+        pills[i].classList.toggle('vab-pill--active', active);
+        pills[i].setAttribute('aria-checked', active ? 'true' : 'false');
+      }
+    }
+
+    // -------------------------------------------------------
+    // Copy to clipboard
+    // -------------------------------------------------------
+
+    _onCopyClick(type) {
+      var codeEl = this.querySelector('[data-vab-cmd="' + type + '"]');
+      if (!codeEl) { return; }
+      var text = codeEl.textContent || '';
+      var btnEl = this.querySelector('[data-vab-copy="' + type + '"]');
+      var iconEl = btnEl && btnEl.querySelector('.vab-copy-icon');
+
+      var showCopied = function () {
+        if (iconEl) { iconEl.textContent = '✓'; } // ✓
+        if (btnEl) { btnEl.classList.add('vab-copy-btn--copied'); }
+        setTimeout(function () {
+          if (iconEl) { iconEl.textContent = '⧉'; } // ⧉
+          if (btnEl) { btnEl.classList.remove('vab-copy-btn--copied'); }
+        }, 2000);
+      };
+
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(showCopied).catch(showCopied);
+      } else {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try { document.execCommand('copy'); } catch (e) {}
+        document.body.removeChild(ta);
+        showCopied();
+      }
+    }
+
+    // -------------------------------------------------------
+    // Custom event dispatch (new + legacy bridge)
+    // -------------------------------------------------------
+
+    _dispatchVariantChanged() {
+      var v = this._currentVariant;
+      var detail = {
+        variant: v,
+        tag: (v && v.tag) || this._defaultTag,
+        attestation_url: (v && v.attestation_url) || '',
+        attestation_id:  (v && v.attestation_id)  || '',
+        trivy_summary:   (v && v.trivy_summary)    || null,
+        multi_arch_platforms: (v && v.multi_arch_platforms) || []
+      };
+
+      document.dispatchEvent(new CustomEvent('variant-action-bar:variant-changed', {
+        bubbles: true, detail: detail
+      }));
+
+      // Backwards-compatible bridge: existing trust-strip, security-scan, provenance
+      document.dispatchEvent(new CustomEvent('phase-b-variant-changed', {
+        bubbles: true, detail: detail
+      }));
+    }
+
+    // Two-way sync: if legacy version-tabs fires, update our pills + commands
+    _listenLegacyEvents() {
+      var self = this;
+      document.addEventListener('version-tabs-changed', function (e) {
+        var newTag = e.detail && e.detail.tag;
+        if (!newTag) { return; }
+        var found = null;
+        var variants = self._variants;
+        for (var i = 0; i < variants.length; i++) {
+          if (variants[i].tag === newTag) { found = variants[i]; break; }
+        }
+        if (!found) { return; }
+        self._currentVariant = found;
+        if (found.version) {
+          self._selectedVersion = found.version;
+          self._updatePillActive('vab-version-pill', found.version);
+        }
+        if (found.flavor) {
+          self._selectedFlavor = found.flavor;
+          self._updatePillActive('vab-flavor-pill', found.flavor);
+        }
+        self._updateCommands();
+        self._updateSignals();
+      });
+    }
+
+    // -------------------------------------------------------
+    // Sticky / collapse
+    // -------------------------------------------------------
+
+    _initSticky() {
+      if (!('IntersectionObserver' in window)) { return; }
+      var self = this;
+
+      var navEl = document.querySelector('.site-nav');
+      var navH = navEl ? Math.round(navEl.getBoundingClientRect().height) : 60;
+      this.style.setProperty('--vab-nav-height', navH + 'px');
+
+      this._observer = new IntersectionObserver(function (entries) {
+        var collapsed = !entries[0].isIntersecting;
+        self._setCollapsed(collapsed);
+      }, {
+        root: null,
+        rootMargin: '-' + navH + 'px 0px 0px 0px',
+        threshold: 0
+      });
+
+      this._observer.observe(this._sentinelEl);
+    }
+
+    _setCollapsed(collapsed) {
+      if (collapsed) {
+        this.setAttribute('data-collapsed', '');
+        if (this._toggleBtn) {
+          var icon = this._toggleBtn.querySelector('.vab-toggle-icon');
+          if (icon) { icon.textContent = this._userExpanded ? '↑' : '↓'; }
+          this._toggleBtn.setAttribute('aria-expanded', this._userExpanded ? 'true' : 'false');
+        }
+      } else {
+        this.removeAttribute('data-collapsed');
+        this._userExpanded = false;
+        if (this._cardEl) { this._cardEl.removeAttribute('data-user-expanded'); }
+        if (this._toggleBtn) {
+          var icon2 = this._toggleBtn.querySelector('.vab-toggle-icon');
+          if (icon2) { icon2.textContent = '↓'; }
+          this._toggleBtn.setAttribute('aria-expanded', 'true');
+        }
+      }
+    }
+
+    _onToggleClick() {
+      if (!this.hasAttribute('data-collapsed')) { return; }
+      this._userExpanded = !this._userExpanded;
+      if (this._cardEl) {
+        this._cardEl.setAttribute('data-user-expanded', this._userExpanded ? 'true' : 'false');
+      }
+      if (this._toggleBtn) {
+        this._toggleBtn.setAttribute('aria-expanded', this._userExpanded ? 'true' : 'false');
+        var icon = this._toggleBtn.querySelector('.vab-toggle-icon');
+        if (icon) { icon.textContent = this._userExpanded ? '↑' : '↓'; }
+      }
+    }
+
+    // -------------------------------------------------------
+    // Delegated event listeners
+    // -------------------------------------------------------
+
+    _attachListeners() {
+      var self = this;
+
+      this.addEventListener('click', function (e) {
+        var vPill = e.target.closest('.vab-version-pill');
+        if (vPill) { self._onVersionPillClick(vPill.dataset.value); return; }
+
+        var fPill = e.target.closest('.vab-flavor-pill');
+        if (fPill) { self._onFlavorPillClick(fPill.dataset.value); return; }
+
+        var copyBtn = e.target.closest('.vab-copy-btn');
+        if (copyBtn) { self._onCopyClick(copyBtn.getAttribute('data-vab-copy')); return; }
+
+        var toggleBtn = e.target.closest('.vab-toggle');
+        if (toggleBtn) { self._onToggleClick(); return; }
+      });
+
+      this._listenLegacyEvents();
+    }
+  }
+
+  if (!customElements.get('variant-action-bar')) {
+    customElements.define('variant-action-bar', VariantActionBar);
+  }
+})();

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -2,60 +2,7 @@
     'use strict';
 
     // Theme managed by shared theme.js (window.ThemeManager namespace)
-
-    // Registry management for pull command
-    var currentRegistry = localStorage.getItem('preferredRegistry') || 'ghcr';
-
-    function updatePullCommand(tag) {
-      var pullSection = document.getElementById('detail-pull');
-      var input = document.getElementById('detail-pull-cmd');
-      if (!pullSection || !input) return;
-
-      var base = currentRegistry === 'ghcr'
-        ? pullSection.dataset.ghcrBase
-        : pullSection.dataset.dockerhubBase;
-      var effectiveTag = tag || pullSection.dataset.defaultTag;
-      input.value = 'docker pull ' + base + ':' + effectiveTag;
-    }
-
-    function setDetailRegistry(registry) {
-      currentRegistry = registry;
-      localStorage.setItem('preferredRegistry', registry);
-
-      document.querySelectorAll('.detail-registry-btn').forEach(function(btn) {
-        var isActive = btn.dataset.registry === registry;
-        btn.classList.toggle('active', isActive);
-        btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
-      });
-
-      // Get current variant tag
-      var selected = document.querySelector('.variant-tag.selected');
-      var tag = selected ? selected.dataset.tag : null;
-      updatePullCommand(tag);
-    }
-
-    function copyDetailPullCommand() {
-      var input = document.getElementById('detail-pull-cmd');
-      var button = document.getElementById('detail-copy-btn');
-      if (!input || !button) return;
-
-      var icon = button.querySelector('i');
-
-      function showCopied() {
-        if (icon) icon.className = 'ti ti-check';
-        button.classList.add('copied');
-        setTimeout(function() {
-          if (icon) icon.className = 'ti ti-copy';
-          button.classList.remove('copied');
-        }, 2000);
-      }
-
-      navigator.clipboard.writeText(input.value).then(showCopied).catch(function() {
-        input.select();
-        document.execCommand('copy');
-        showCopied();
-      });
-    }
+    // Pull command / registry toggle removed PR1 — handled by <variant-action-bar> component.
 
     // Variant selection
     // Tracks the last fully-processed variant tag to make selectVariant() idempotent.
@@ -86,16 +33,8 @@
       }
 
       var tag = el.dataset.tag || '';
-      var sizeAmd64 = el.dataset.sizeAmd64 || '---';
-      var sizeArm64 = el.dataset.sizeArm64 || '---';
-
-      var tagEl = document.querySelector('[data-meta="current-tag"]');
-      var amdEl = document.querySelector('[data-meta="size-amd64"]');
-      var armEl = document.querySelector('[data-meta="size-arm64"]');
-
-      if (tagEl) tagEl.textContent = tag;
-      if (amdEl) amdEl.textContent = sizeAmd64;
-      if (armEl) armEl.textContent = sizeArm64;
+      // data-meta="current-tag/size-amd64/size-arm64" elements removed PR1
+      // (replaced by variant-action-bar signals strip)
 
       // Update lineage build_digest and base_image
       var buildDigest = el.dataset.buildDigest || '';
@@ -123,8 +62,7 @@
       updateChangelogSection(el);
       updateHistorySection(el);
 
-      // Update pull command with selected variant tag
-      updatePullCommand(tag);
+      // Pull command update handled by <variant-action-bar> via phase-b-variant-changed (PR1)
 
       // Phase B: dispatch event for vanilla custom-element trust strip + Security Scan section
       var variantData = {
@@ -865,12 +803,7 @@
       var chip = e.target.closest('.sbom-type-chip-clickable');
       if (chip) togglePackagePanel(chip.dataset.type);
 
-      var regBtn = e.target.closest('.detail-registry-btn');
-      if (regBtn) setDetailRegistry(regBtn.dataset.registry);
-
-      if (e.target.closest('#detail-copy-btn') || e.target.closest('.detail-copy-btn')) {
-        copyDetailPullCommand();
-      }
+      // .detail-registry-btn / #detail-copy-btn handlers removed PR1 — handled by <variant-action-bar>
 
       // Provenance section copy buttons — emit class is .provenance-copy-btn
       // (renamed from .copy-btn to avoid colliding with dashboard.css's
@@ -935,12 +868,5 @@
       }
     }
 
-    // Initialize registry toggle from localStorage preference
-    setDetailRegistry(currentRegistry);
-
-    // Auto-select pull input text on click
-    var pullInput = document.getElementById('detail-pull-cmd');
-    if (pullInput) {
-      pullInput.addEventListener('click', function() { this.select(); });
-    }
+    // Registry toggle + pull input init removed PR1 — handled by <variant-action-bar>
   })();


### PR DESCRIPTION
## Summary

First of two PRs reorganizing the container detail page layout. Today the hero shows a static `docker pull` command but the variant selector lives deep in the page, so users must scroll back and forth to verify which tag they're actually pulling. This PR fixes that by:

1. **Slimming the hero** — drops the static pull command + the 6-card metadata grid (Status / Current Tag / Pulls / Stars / Size amd64 / Size arm64).
2. **Introducing `<variant-action-bar>`** — a new vanilla web component (no framework, light DOM, XSS-safe DOM construction) that holds the variant selector, pull/verify commands, and per-variant signals (Status · Size amd64 · Size arm64) in one sticky card. When the user scrolls past the hero, the bar fixes to the viewport top and collapses to show only the signals strip; a "↓ commands" toggle re-expands the full card on demand.
3. **Flattening "Available variants"** — moves the 7-flavor × 3-PG-version table out of the Explore disclosure into a always-visible flat table directly below the action bar.
4. **Stats strip** — replaces the old metadata card grid with a single inline strip below the trust posture badges: `Pulls · Stars · 21 variants · 3 versions · amd64+arm64`.
5. **Section IDs** added to every major detail-zone (24 total) so PR2 can wire a right-side IntersectionObserver-driven TOC.

### Component design

`<variant-action-bar>` follows the project's existing vanilla web-component convention (see `<trust-strip>`, `<security-scan>`, `<version-tabs>`):
- Light DOM (no shadow DOM); listens to and dispatches `phase-b-variant-changed` for backwards compatibility plus a new `variant-action-bar:variant-changed` event.
- IntersectionObserver on a sentinel div tracks scroll-past-hero state and toggles `[data-collapsed]` for the CSS state machine.
- All text content via `textContent` / `createElement` — never `innerHTML` (Trivy advisory hardening, CSP `script-src 'self'` strict).
- WCAG 2.2 AA focus rings; honors `prefers-reduced-motion`; mobile single-column layout at `<768px`.

### What's NOT in this PR (deferred to PR2)

- Right-side TOC sidebar with active-section highlighting via IntersectionObserver (~200 LOC).
- Mobile drawer fallback for the TOC at `<1400px` viewport.

## Test plan

- [ ] CI passes (CodeQL, shellcheck)
- [ ] Live verification on each container family after deploy:
  - postgres `vector` → action bar shows `docker pull ghcr.io/oorabona/postgres:18-alpine-vector` + cosign verify; signals strip reads `Status: Up to Date · Size amd64: ~178MB · Size arm64: ~248MB`
  - postgres `base` → signals strip updates to `~108MB / ~107MB`
  - web-shell, debian, terraform variants — action bar still works without flavor row, falls back gracefully
  - Sticky behavior: scroll past hero → bar collapses to signals only, stays at top
  - Collapse toggle: click `↓ commands` → expands back to full 3-row card
- [ ] Mobile (≤768px): action bar stacks vertically, all controls reachable
- [ ] `prefers-reduced-motion`: no transition on collapse/expand
- [ ] Keyboard: Tab order through pills + buttons, focus rings visible on both light/dark themes
