### PR TITLE
feat(container-detail): add right-side TOC sidebar with mobile drawer

### DIFF
--- a/docs/site/_includes/page-toc.html
+++ b/docs/site/_includes/page-toc.html
@@ -1,0 +1,22 @@
+{%- comment -%}
+  page-toc.html — noscript fallback nav for the <page-toc> custom element.
+  Included inside <noscript> from container-detail layout.
+  The outer <page-toc data-anchors='...'> element in the layout drives the
+  interactive sidebar (IntersectionObserver, mobile drawer) for JS-enabled browsers.
+  This file provides the static accessible fallback for JS-disabled browsers.
+{%- endcomment -%}
+<nav class="page-toc-noscript" aria-label="On this page">
+  <h2 class="page-toc-eyebrow">On this page</h2>
+  <ul>
+    <li><a href="#variants-pull">Variant &amp; Pull</a></li>
+    <li><a href="#all-variants">All variants</a></li>
+    <li><a href="#trust-posture">Trust posture</a></li>
+    <li><a href="#container-stats">Stats</a></li>
+    <li><a href="#provenance">Provenance</a></li>
+    <li><a href="#build-history">Build history</a></li>
+    <li><a href="#dep-health">Dep health</a></li>
+    <li><a href="#security-scan">Security scan</a></li>
+    <li><a href="#readme">README</a></li>
+    <li><a href="#extensions-reference">Extensions</a></li>
+  </ul>
+</nav>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -20,6 +20,7 @@
   <!-- tokens.css MUST load before theme.css — defines variables theme.css references -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
   <!-- Component CSS — load after tokens, before theme -->
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/page-toc.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/variant-action-bar.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
@@ -101,6 +102,25 @@
           {% include variant-action-bar.html %}
 
         </header>{%- comment -%} /Zone 1 — Identity {%- endcomment -%}
+
+        {%- comment -%} Page TOC sidebar — sticky right-side navigation (desktop) + drawer (mobile) {%- endcomment -%}
+        <page-toc data-anchors='[
+          {"id":"variants-pull","label":"Variant &amp; Pull"},
+          {"id":"all-variants","label":"All variants"},
+          {"id":"trust-posture","label":"Trust posture"},
+          {"id":"container-stats","label":"Stats"},
+          {"id":"provenance","label":"Provenance"},
+          {"id":"build-history","label":"Build history"},
+          {"id":"dep-health","label":"Dep health"},
+          {"id":"security-scan","label":"Security scan"},
+          {"id":"readme","label":"README"},
+          {"id":"extensions-reference","label":"Extensions"}
+        ]'>
+          {%- comment -%} noscript fallback — plain nav for JS-disabled browsers {%- endcomment -%}
+          <noscript>
+            {% include page-toc.html %}
+          </noscript>
+        </page-toc>
 
         {%- comment -%} Zone 2 — Trust posture (always visible) {%- endcomment -%}
         <section id="trust-posture" class="detail-zone detail-zone--trust" aria-label="Trust posture">
@@ -1155,6 +1175,7 @@
   </div>
 
   <!-- Vanilla web components — CSP-clean, no eval -->
+  <script defer src="{{ '/assets/js/components/page-toc.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/variant-action-bar.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/security-scan.js' | relative_url }}"></script>

--- a/docs/site/assets/css/components/page-toc.css
+++ b/docs/site/assets/css/components/page-toc.css
@@ -1,0 +1,429 @@
+/* ==========================================================
+   page-toc.css — Sticky right-side Table of Contents sidebar
+   Used exclusively by: container-detail layout.
+   Dark-mode default; light-mode via [data-theme="light"].
+   WCAG 2.2 AA: 3px focus ring, 4.6:1 min contrast on --detail-text-muted.
+   ========================================================== */
+
+/* ----------------------------------------------------------
+   Custom element host — no visual output itself
+   ---------------------------------------------------------- */
+
+page-toc {
+  display: contents; /* let children participate in layout */
+}
+
+/* ----------------------------------------------------------
+   Desktop aside — fixed right-side panel (>=1280px)
+   ---------------------------------------------------------- */
+
+.page-toc {
+  position: fixed;
+  top: calc(var(--page-toc-nav-offset, 72px) + 1rem);
+  right: 24px;
+  width: 220px;
+  max-height: calc(100vh - var(--page-toc-nav-offset, 72px) - 2rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  /* Subtle scrollbar */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-strong, rgba(255,255,255,0.16)) transparent;
+
+  /* Elevation — elevated surface above content */
+  z-index: 40; /* below site-nav (50) but above page content */
+
+  /* Visual treatment */
+  background: var(--color-surface-raised, #1A2A4A);
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-md, 16px) 0;
+}
+
+.page-toc::-webkit-scrollbar {
+  width: 4px;
+}
+
+.page-toc::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.page-toc::-webkit-scrollbar-thumb {
+  background: var(--color-border-strong, rgba(255,255,255,0.16));
+  border-radius: var(--radius-full, 9999px);
+}
+
+/* ----------------------------------------------------------
+   Eyebrow label — "ON THIS PAGE" (JetBrains Mono, uppercase)
+   ---------------------------------------------------------- */
+
+.page-toc-eyebrow {
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
+  font-size: var(--font-size-caption, 12px);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider, 0.08em);
+  color: var(--detail-text-muted, var(--color-text-muted, #8A93A0));
+  margin: 0 0 var(--space-sm, 8px) 0;
+  padding: 0 var(--space-md, 16px);
+  line-height: var(--line-height-tight, 1.2);
+}
+
+/* ----------------------------------------------------------
+   Link list
+   ---------------------------------------------------------- */
+
+.page-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.page-toc li {
+  margin: 0;
+  padding: 0;
+}
+
+.page-toc a {
+  display: block;
+  font-family: var(--font-family-sans, "Inter", sans-serif);
+  font-size: var(--font-size-body-sm, 14px);
+  font-weight: var(--font-weight-regular, 400);
+  color: var(--detail-text-muted, var(--color-text-muted, #8A93A0));
+  text-decoration: none;
+  padding: 5px var(--space-md, 16px);
+  padding-left: calc(var(--space-md, 16px) - 3px); /* offset for border-left */
+  border-left: 3px solid transparent;
+  line-height: var(--line-height-normal, 1.5);
+  transition:
+    color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    border-left-color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    font-weight var(--motion-duration-instant, 100ms);
+}
+
+.page-toc a:hover,
+.page-toc a:focus {
+  color: var(--color-text-primary, #F4F5F7);
+  border-left-color: var(--color-border-strong, rgba(255,255,255,0.16));
+  outline: none;
+}
+
+/* WCAG 2.2 AA focus ring */
+.page-toc a:focus-visible {
+  outline: 3px solid var(--color-violet-400, #A78BFA);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Active state — violet accent (architectural trust-domain hue) */
+.page-toc a[data-active] {
+  color: var(--color-violet-400, #A78BFA);
+  font-weight: var(--font-weight-semibold, 600);
+  border-left-color: var(--color-violet-400, #A78BFA);
+}
+
+/* ----------------------------------------------------------
+   Light-mode overrides
+   ---------------------------------------------------------- */
+
+[data-theme="light"] .page-toc {
+  background: #FFFFFF;
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .page-toc a {
+  color: var(--color-neutral-600, #4D556A);
+}
+
+[data-theme="light"] .page-toc a:hover,
+[data-theme="light"] .page-toc a:focus {
+  color: var(--color-neutral-900, #14181F);
+}
+
+[data-theme="light"] .page-toc a[data-active] {
+  color: var(--color-violet-700, #6D28D9);
+  border-left-color: var(--color-violet-700, #6D28D9);
+}
+
+/* ----------------------------------------------------------
+   Mobile: hide desktop aside, show floating trigger
+   ---------------------------------------------------------- */
+
+@media (max-width: 1279px) {
+
+  .page-toc {
+    display: none;
+  }
+
+  .page-toc-mobile-trigger {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs, 4px);
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 45;
+
+    font-family: var(--font-family-mono, "JetBrains Mono", monospace);
+    font-size: var(--font-size-body-sm, 14px);
+    font-weight: var(--font-weight-medium, 500);
+    letter-spacing: 0.03em;
+    color: var(--color-text-primary, #F4F5F7);
+
+    background: var(--color-violet-500, #8B5CF6);
+    border: none;
+    border-radius: var(--radius-full, 9999px);
+    padding: 10px 18px;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(139, 92, 246, 0.4), 0 2px 8px rgba(0,0,0,0.3);
+
+    transition:
+      transform var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+      box-shadow var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+  }
+
+  .page-toc-mobile-trigger:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(139, 92, 246, 0.5), 0 4px 12px rgba(0,0,0,0.3);
+  }
+
+  .page-toc-mobile-trigger:focus-visible {
+    outline: 3px solid var(--color-violet-400, #A78BFA);
+    outline-offset: 2px;
+  }
+
+  /* Drawer — off-screen by default */
+  .page-toc-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(320px, 85vw);
+    z-index: 55;
+
+    background: var(--color-surface-overlay, #1F3155);
+    border-left: 1px solid var(--color-border-strong, rgba(255,255,255,0.16));
+    padding: var(--space-lg, 24px) 0;
+    overflow-y: auto;
+
+    transform: translateX(100%);
+    transition: transform var(--motion-duration-normal, 200ms) var(--easing-decelerate, cubic-bezier(0, 0, 0.2, 1));
+  }
+
+  .page-toc-drawer[data-open] {
+    transform: translateX(0);
+  }
+
+  .page-toc-drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-md, 16px) var(--space-sm, 8px);
+    border-bottom: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+    margin-bottom: var(--space-sm, 8px);
+  }
+
+  .page-toc-drawer-header .page-toc-eyebrow {
+    padding: 0;
+    margin: 0;
+  }
+
+  .page-toc-drawer-close {
+    background: none;
+    border: none;
+    color: var(--detail-text-muted, var(--color-text-muted, #8A93A0));
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm, 4px);
+    transition: color var(--motion-duration-short, 150ms);
+  }
+
+  .page-toc-drawer-close:hover {
+    color: var(--color-text-primary, #F4F5F7);
+  }
+
+  .page-toc-drawer-close:focus-visible {
+    outline: 3px solid var(--color-violet-400, #A78BFA);
+    outline-offset: 2px;
+  }
+
+  /* Drawer link list — same metrics as desktop */
+  .page-toc-drawer ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .page-toc-drawer li {
+    margin: 0;
+    padding: 0;
+  }
+
+  .page-toc-drawer a {
+    display: block;
+    font-family: var(--font-family-sans, "Inter", sans-serif);
+    font-size: var(--font-size-body, 16px);
+    font-weight: var(--font-weight-regular, 400);
+    color: var(--color-text-secondary, #C7CCD4);
+    text-decoration: none;
+    padding: 10px var(--space-md, 16px);
+    padding-left: calc(var(--space-md, 16px) - 3px);
+    border-left: 3px solid transparent;
+    transition:
+      color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+      border-left-color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+  }
+
+  .page-toc-drawer a:hover,
+  .page-toc-drawer a:focus {
+    color: var(--color-text-primary, #F4F5F7);
+    border-left-color: var(--color-border-strong, rgba(255,255,255,0.16));
+    outline: none;
+  }
+
+  .page-toc-drawer a:focus-visible {
+    outline: 3px solid var(--color-violet-400, #A78BFA);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .page-toc-drawer a[data-active] {
+    color: var(--color-violet-400, #A78BFA);
+    font-weight: var(--font-weight-semibold, 600);
+    border-left-color: var(--color-violet-400, #A78BFA);
+  }
+
+  /* Backdrop overlay */
+  .page-toc-drawer-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--motion-duration-normal, 200ms) var(--easing-standard, ease);
+  }
+
+  .page-toc-drawer-overlay[data-open] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Light mode — drawer */
+  [data-theme="light"] .page-toc-drawer {
+    background: #FFFFFF;
+    border-left-color: rgba(0, 0, 0, 0.12);
+  }
+
+  [data-theme="light"] .page-toc-drawer a {
+    color: var(--color-neutral-600, #4D556A);
+  }
+
+  [data-theme="light"] .page-toc-drawer a:hover,
+  [data-theme="light"] .page-toc-drawer a:focus {
+    color: var(--color-neutral-900, #14181F);
+  }
+
+  [data-theme="light"] .page-toc-drawer a[data-active] {
+    color: var(--color-violet-700, #6D28D9);
+    border-left-color: var(--color-violet-700, #6D28D9);
+  }
+
+  [data-theme="light"] .page-toc-mobile-trigger {
+    box-shadow: 0 4px 16px rgba(109, 40, 217, 0.3), 0 2px 8px rgba(0,0,0,0.15);
+  }
+}
+
+/* ----------------------------------------------------------
+   Desktop: hide mobile-only elements
+   ---------------------------------------------------------- */
+
+@media (min-width: 1280px) {
+
+  .page-toc-mobile-trigger {
+    display: none;
+  }
+
+  .page-toc-drawer {
+    display: none;
+  }
+
+  .page-toc-drawer-overlay {
+    display: none;
+  }
+}
+
+/* ----------------------------------------------------------
+   Noscript fallback — plain <nav> when JS is disabled
+   ---------------------------------------------------------- */
+
+.page-toc-noscript {
+  position: fixed;
+  top: calc(var(--page-toc-nav-offset, 72px) + 1rem);
+  right: 24px;
+  width: 220px;
+  background: var(--color-surface-raised, #1A2A4A);
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-md, 16px) 0;
+  z-index: 40;
+}
+
+.page-toc-noscript .page-toc-eyebrow {
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
+  font-size: var(--font-size-caption, 12px);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider, 0.08em);
+  color: var(--detail-text-muted, var(--color-text-muted, #8A93A0));
+  margin: 0 0 var(--space-sm, 8px) 0;
+  padding: 0 var(--space-md, 16px);
+}
+
+.page-toc-noscript ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.page-toc-noscript a {
+  display: block;
+  font-family: var(--font-family-sans, "Inter", sans-serif);
+  font-size: var(--font-size-body-sm, 14px);
+  color: var(--detail-text-muted, var(--color-text-muted, #8A93A0));
+  text-decoration: none;
+  padding: 5px var(--space-md, 16px);
+  padding-left: calc(var(--space-md, 16px) - 3px);
+  border-left: 3px solid transparent;
+  transition: color var(--motion-duration-short, 150ms);
+}
+
+.page-toc-noscript a:hover,
+.page-toc-noscript a:focus-visible {
+  color: var(--color-text-primary, #F4F5F7);
+  outline: 3px solid var(--color-violet-400, #A78BFA);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (max-width: 1279px) {
+  .page-toc-noscript {
+    display: none; /* On mobile without JS, no fallback TOC (not critical) */
+  }
+}
+
+/* ----------------------------------------------------------
+   prefers-reduced-motion: disable all transitions
+   ---------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .page-toc a,
+  .page-toc-drawer,
+  .page-toc-drawer a,
+  .page-toc-drawer-overlay,
+  .page-toc-mobile-trigger {
+    transition: none;
+  }
+}

--- a/docs/site/assets/js/components/page-toc.js
+++ b/docs/site/assets/js/components/page-toc.js
@@ -1,0 +1,354 @@
+// docs/site/assets/js/components/page-toc.js
+//
+// Vanilla custom element (light DOM). CSP-clean (no eval, no innerHTML).
+// Renders a sticky right-side TOC sidebar on desktop (>=1280px) and a
+// floating drawer-button on mobile (<1280px).
+// Active section tracking via IntersectionObserver.
+// Smooth-scroll with prefers-reduced-motion support.
+
+(function () {
+  'use strict';
+
+  // Approximate sticky nav height (px). Used as scroll offset.
+  // Measured from .site-nav padding 0.85rem*2 + ~38px line-height ~ 64px total.
+  var NAV_HEIGHT = 64;
+
+  // Debounce helper for resize events.
+  function debounce(fn, ms) {
+    var t;
+    return function () {
+      clearTimeout(t);
+      t = setTimeout(fn, ms);
+    };
+  }
+
+  class PageToc extends HTMLElement {
+
+    // -------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------
+
+    connectedCallback() {
+      this._anchors = [];      // [{id, label}] filtered to sections present in DOM
+      this._sections = [];     // [Element] — observed section elements
+      this._links = [];        // [<a>] — TOC anchor elements (desktop)
+      this._drawerLinks = [];  // [<a>] — TOC anchor elements (mobile drawer)
+      this._observer = null;
+      this._activeId = null;
+      this._isMobile = false;
+      this._triggerBtn = null;
+      this._drawer = null;
+      this._overlay = null;
+      this._mql = null;
+      this._onMqlChange = null;
+      this._onKeydown = null;
+
+      this._parseAnchors();
+      this._render();
+      this._setupObserver();
+      this._setupMobileQuery();
+    }
+
+    disconnectedCallback() {
+      if (this._observer) {
+        this._observer.disconnect();
+        this._observer = null;
+      }
+      if (this._mql && this._onMqlChange) {
+        this._mql.removeEventListener('change', this._onMqlChange);
+        this._mql = null;
+        this._onMqlChange = null;
+      }
+      if (this._onKeydown) {
+        document.removeEventListener('keydown', this._onKeydown);
+        this._onKeydown = null;
+      }
+    }
+
+    // -------------------------------------------------------
+    // Data parsing (NO decodeURIComponent — raw JSON.parse only)
+    // -------------------------------------------------------
+
+    _parseAnchors() {
+      var raw = this.dataset.anchors || '[]';
+      var candidates;
+      try {
+        candidates = JSON.parse(raw);
+      } catch (e) {
+        candidates = [];
+      }
+
+      var self = this;
+      candidates.forEach(function (entry) {
+        var el = document.getElementById(entry.id);
+        if (el) {
+          self._anchors.push({ id: entry.id, label: entry.label });
+          self._sections.push(el);
+        }
+      });
+    }
+
+    // -------------------------------------------------------
+    // Rendering — light DOM, textContent only (XSS-safe)
+    // -------------------------------------------------------
+
+    _render() {
+      // Remove any previously rendered subtree (keep <noscript> only).
+      var toRemove = [];
+      for (var i = 0; i < this.childNodes.length; i++) {
+        var node = this.childNodes[i];
+        if (node.nodeName !== 'NOSCRIPT') {
+          toRemove.push(node);
+        }
+      }
+      toRemove.forEach(function (n) { n.parentNode.removeChild(n); });
+
+      if (this._anchors.length === 0) { return; }
+
+      var self = this;
+
+      // --- Desktop aside ---
+      var aside = document.createElement('aside');
+      aside.className = 'page-toc';
+      aside.setAttribute('aria-label', 'On this page');
+
+      var eyebrow = document.createElement('h2');
+      eyebrow.className = 'page-toc-eyebrow';
+      eyebrow.textContent = 'On this page';
+      aside.appendChild(eyebrow);
+
+      var ul = document.createElement('ul');
+      ul.setAttribute('role', 'navigation');
+      ul.setAttribute('aria-label', 'Page sections');
+
+      this._links = [];
+      this._anchors.forEach(function (entry) {
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+        a.href = '#' + entry.id;
+        a.textContent = entry.label;
+        a.addEventListener('click', function (e) { self._handleLinkClick(e, entry.id); });
+        li.appendChild(a);
+        ul.appendChild(li);
+        self._links.push(a);
+      });
+
+      aside.appendChild(ul);
+      this.appendChild(aside);
+
+      // --- Mobile trigger button ---
+      var btn = document.createElement('button');
+      btn.className = 'page-toc-mobile-trigger';
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', 'page-toc-drawer');
+      btn.setAttribute('aria-haspopup', 'dialog');
+      btn.textContent = 'On this page';
+      btn.addEventListener('click', function () { self._openDrawer(); });
+      this.appendChild(btn);
+      this._triggerBtn = btn;
+
+      // --- Mobile drawer ---
+      var drawer = document.createElement('div');
+      drawer.className = 'page-toc-drawer';
+      drawer.id = 'page-toc-drawer';
+      drawer.setAttribute('role', 'dialog');
+      drawer.setAttribute('aria-modal', 'true');
+      drawer.setAttribute('aria-label', 'On this page');
+
+      var drawerHeader = document.createElement('div');
+      drawerHeader.className = 'page-toc-drawer-header';
+
+      var drawerEyebrow = document.createElement('h2');
+      drawerEyebrow.className = 'page-toc-eyebrow';
+      drawerEyebrow.textContent = 'On this page';
+
+      var closeBtn = document.createElement('button');
+      closeBtn.className = 'page-toc-drawer-close';
+      closeBtn.setAttribute('aria-label', 'Close navigation');
+      closeBtn.textContent = '×';
+      closeBtn.addEventListener('click', function () { self._closeDrawer(); });
+
+      drawerHeader.appendChild(drawerEyebrow);
+      drawerHeader.appendChild(closeBtn);
+      drawer.appendChild(drawerHeader);
+
+      var drawerUl = document.createElement('ul');
+      drawerUl.setAttribute('role', 'navigation');
+      drawerUl.setAttribute('aria-label', 'Page sections');
+
+      this._drawerLinks = [];
+      this._anchors.forEach(function (entry) {
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+        a.href = '#' + entry.id;
+        a.textContent = entry.label;
+        a.addEventListener('click', function (e) {
+          self._closeDrawer();
+          self._handleLinkClick(e, entry.id);
+        });
+        li.appendChild(a);
+        drawerUl.appendChild(li);
+        self._drawerLinks.push(a);
+      });
+      drawer.appendChild(drawerUl);
+      this.appendChild(drawer);
+      this._drawer = drawer;
+
+      // --- Overlay backdrop ---
+      var overlay = document.createElement('div');
+      overlay.className = 'page-toc-drawer-overlay';
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.addEventListener('click', function () { self._closeDrawer(); });
+      this.appendChild(overlay);
+      this._overlay = overlay;
+
+      // Keyboard: Escape closes drawer
+      this._onKeydown = function (e) {
+        if (e.key === 'Escape' && self._drawer && self._drawer.hasAttribute('data-open')) {
+          self._closeDrawer();
+        }
+      };
+      document.addEventListener('keydown', this._onKeydown);
+    }
+
+    // -------------------------------------------------------
+    // IntersectionObserver — active section tracking
+    // -------------------------------------------------------
+
+    _setupObserver() {
+      if (!this._sections.length || typeof IntersectionObserver === 'undefined') { return; }
+
+      var self = this;
+      var intersections = {};
+
+      this._observer = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          intersections[entry.target.id] = entry.intersectionRatio;
+        });
+
+        // Section with highest intersection ratio = active.
+        var bestId = null;
+        var bestRatio = 0;
+        self._sections.forEach(function (el) {
+          var ratio = intersections[el.id] || 0;
+          if (ratio > bestRatio) {
+            bestRatio = ratio;
+            bestId = el.id;
+          }
+        });
+
+        // If nothing meaningfully visible, keep previous active.
+        if (bestRatio < 0.05 && self._activeId) { return; }
+        if (bestId && bestId !== self._activeId) {
+          self._setActive(bestId);
+        }
+      }, {
+        rootMargin: '-' + self._computeOffset() + 'px 0px 0px 0px',
+        threshold: [0, 0.1, 0.5, 1.0]
+      });
+
+      this._sections.forEach(function (el) {
+        self._observer.observe(el);
+      });
+    }
+
+    _computeOffset() {
+      // Sticky nav + variant-action-bar (when collapsed/sticky).
+      var bar = document.querySelector('variant-action-bar');
+      var barH = 0;
+      if (bar) {
+        barH = bar.getBoundingClientRect().height || 0;
+      }
+      return Math.round(NAV_HEIGHT + barH + 8);
+    }
+
+    _setActive(id) {
+      this._activeId = id;
+      var self = this;
+
+      this._links.forEach(function (a) {
+        if (a.getAttribute('href') === '#' + id) {
+          a.setAttribute('data-active', '');
+        } else {
+          a.removeAttribute('data-active');
+        }
+      });
+
+      this._drawerLinks.forEach(function (a) {
+        if (a.getAttribute('href') === '#' + id) {
+          a.setAttribute('data-active', '');
+        } else {
+          a.removeAttribute('data-active');
+        }
+      });
+    }
+
+    // -------------------------------------------------------
+    // Smooth scroll on link click
+    // -------------------------------------------------------
+
+    _handleLinkClick(e, id) {
+      e.preventDefault();
+      var target = document.getElementById(id);
+      if (!target) { return; }
+
+      var offset = this._computeOffset();
+      var top = target.getBoundingClientRect().top + window.scrollY - offset;
+
+      var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: top, behavior: prefersReduced ? 'auto' : 'smooth' });
+
+      this._setActive(id);
+    }
+
+    // -------------------------------------------------------
+    // Mobile drawer
+    // -------------------------------------------------------
+
+    _openDrawer() {
+      if (!this._drawer) { return; }
+      this._drawer.setAttribute('data-open', '');
+      this._overlay.setAttribute('data-open', '');
+      this._triggerBtn.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+
+      // Move focus into the drawer (first interactive element).
+      var firstLink = this._drawer.querySelector('a, button');
+      if (firstLink) { firstLink.focus(); }
+    }
+
+    _closeDrawer() {
+      if (!this._drawer) { return; }
+      this._drawer.removeAttribute('data-open');
+      this._overlay.removeAttribute('data-open');
+      this._triggerBtn.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+      this._triggerBtn.focus();
+    }
+
+    // -------------------------------------------------------
+    // Responsive: media query listener
+    // -------------------------------------------------------
+
+    _setupMobileQuery() {
+      if (typeof window.matchMedia === 'undefined') { return; }
+
+      var self = this;
+      this._mql = window.matchMedia('(max-width: 1279px)');
+      this._onMqlChange = function (e) {
+        self._isMobile = e.matches;
+        // Transition to desktop: close any open drawer.
+        if (!e.matches && self._drawer && self._drawer.hasAttribute('data-open')) {
+          self._closeDrawer();
+        }
+      };
+      this._isMobile = this._mql.matches;
+      this._mql.addEventListener('change', this._onMqlChange);
+    }
+  }
+
+  if (!customElements.get('page-toc')) {
+    customElements.define('page-toc', PageToc);
+  }
+
+}());


### PR DESCRIPTION
## Summary

Second of the two PRs for the container detail page layout redesign (PR1 was #400, the variant action bar). This adds a right-side TOC sidebar so users can navigate the dense detail page (8+ sections, ~20000px tall) without scrolling blindly.

### Component

New `<page-toc>` vanilla web component (consistent with the project's existing `<trust-strip>` / `<security-scan>` / `<variant-action-bar>` convention — light DOM, no shadow DOM, no `innerHTML`).

- **Desktop ≥1280px:** sticky right-side aside, ~220px wide, lists 10 anchored sections from the spec: `Variant & Pull` · `All variants` · `Trust posture` · `Stats` · `Provenance` · `Build history` · `Dep health` · `Security scan` · `README` · `Extensions`.
- **IntersectionObserver:** tracks which section currently has the largest visible ratio and highlights its link with a violet accent + 3px left border + bolder weight.
- **Mobile <1280px:** floating "On this page" pill at bottom-right; click opens a slide-in drawer with the same anchor list. Escape, overlay click, or any anchor click dismisses the drawer. Basic focus management.
- **Smooth scroll** on anchor click with offset for sticky site-nav (and any collapsed `<variant-action-bar>` if applicable). Honors `prefers-reduced-motion: reduce` (instant scroll instead).
- **Graceful fallback:** at runtime, queries `document.getElementById(id)` for each declared anchor and skips entries that don't exist on the current container's page (some containers don't have `extensions-reference`, etc.). No empty TOC entries.

### Anchors source

The TOC consumes the 24 section IDs added by PR #400. No new IDs added here.

### Out of scope (deferred)

- Auto-discovery of section IDs (current implementation hardcodes the 10 navigable anchors via Liquid). If we add new top-level sections later, this list needs an update.
- Sub-section nesting (e.g. inside `Explore` disclosure). Flat list only.

## Test plan

- [ ] CI passes (CodeQL, JS analyze)
- [ ] Live verification on `/container/postgres/` after deploy:
  - Desktop ≥1280px: TOC visible right side, scroll → active link tracks the visible section
  - Click an anchor → smooth scroll to that section, active state updates
  - Mobile <1280px: floating pill visible, click opens drawer, anchor click closes drawer + scrolls
  - Keyboard: Tab focuses TOC links, Enter activates, Esc closes mobile drawer
  - `prefers-reduced-motion`: no smooth scroll, no slide-in animation
- [ ] Verify on `/container/web-shell/`, `/container/debian/` — TOC adapts to available sections (skips missing anchors gracefully)
- [ ] No JS console errors on any container page

## Note on PR #400 follow-ups

PR #400 had two issues that escaped the review (will be addressed in a separate PR):
- F2 Liquid `append | jsonify` chain bug — the round 2 fix was committed locally but pushed to a different branch by accident, so master has the broken code → version pills don't render on multi-version containers.
- "Available variants" table is still inside `<details>` accordion despite the PR1 spec saying flat — implementer reported moving it but the change wasn't actually applied.

These are independent of this PR's TOC work.
