### PR TITLE
fix(container-detail): wire variant pills and hide duplicate disclosure

### DIFF
--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -33,9 +33,10 @@
 
 {%- comment -%} Determine unique versions for version pills {%- endcomment -%}
 {%- comment -%}
-  F2 fix: the old append|jsonify chain was malformed — jsonify applied to the
-  whole accumulator string, not to individual values. Use capture so each field
-  gets its own | jsonify call, producing literal JSON the browser can parse.
+  Use {% capture %} so each field gets its own | jsonify call, producing
+  literal JSON the browser can parse. A chained `| append: ... | jsonify`
+  encodes the whole accumulator string each iteration, yielding deeply-
+  nested-escaped output that fails JSON.parse.
 {%- endcomment -%}
 {%- capture _vab_ver_arr -%}
 {%- if page.versions and page.versions.size > 1 -%}[

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -32,33 +32,42 @@
 {%- endif -%}
 
 {%- comment -%} Determine unique versions for version pills {%- endcomment -%}
-{%- assign _vab_ver_arr = "" -%}
-{%- if page.versions and page.versions.size > 1 -%}
+{%- comment -%}
+  F2 fix: the old append|jsonify chain was malformed — jsonify applied to the
+  whole accumulator string, not to individual values. Use capture so each field
+  gets its own | jsonify call, producing literal JSON the browser can parse.
+{%- endcomment -%}
+{%- capture _vab_ver_arr -%}
+{%- if page.versions and page.versions.size > 1 -%}[
   {%- for _vv in page.versions -%}
-    {%- assign _vab_ver_arr = _vab_ver_arr | append: '{"tag":' | append: _vv.base_tag | default: _vv.tag | jsonify | append: ',"label":' | append: _vv.base_tag | default: _vv.tag | jsonify | append: '}' -%}
-    {%- unless forloop.last -%}{%- assign _vab_ver_arr = _vab_ver_arr | append: "," -%}{%- endunless -%}
+    {%- unless forloop.first -%},{%- endunless -%}
+    {"tag":{{ _vv.base_tag | default: _vv.tag | jsonify }},"label":{{ _vv.base_tag | default: _vv.tag | jsonify }}}
   {%- endfor -%}
-{%- endif -%}
+]{%- else -%}[]{%- endif -%}
+{%- endcapture -%}
 
 {%- comment -%} Determine unique flavors for flavor pills {%- endcomment -%}
-{%- assign _vab_fla_arr = "" -%}
+{%- assign _has_flavors = false -%}
 {%- if page.versions and page.versions.size > 0 -%}
   {%- assign _first_ver = page.versions[0] -%}
-  {%- assign _has_flavors = false -%}
   {%- for _fv in _first_ver.variants -%}
     {%- if _fv.name and _fv.name != "" -%}
       {%- assign _has_flavors = true -%}
     {%- endif -%}
   {%- endfor -%}
-  {%- if _has_flavors -%}
-    {%- for _fv in _first_ver.variants -%}
-      {%- if _fv.name and _fv.name != "" -%}
-        {%- assign _vab_fla_arr = _vab_fla_arr | append: '{"name":' | append: _fv.name | jsonify | append: ',"label":' | append: _fv.name | jsonify | append: '}' -%}
-        {%- unless forloop.last -%}{%- assign _vab_fla_arr = _vab_fla_arr | append: "," -%}{%- endunless -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endif -%}
 {%- endif -%}
+{%- capture _vab_fla_arr -%}
+{%- if _has_flavors -%}[
+  {%- assign _fla_first = true -%}
+  {%- for _fv in _first_ver.variants -%}
+    {%- if _fv.name and _fv.name != "" -%}
+      {%- unless _fla_first -%},{%- endunless -%}
+      {%- assign _fla_first = false -%}
+      {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
+    {%- endif -%}
+  {%- endfor -%}
+]{%- else -%}[]{%- endif -%}
+{%- endcapture -%}
 
 {%- comment -%} Build flat variant objects array for JS consumption {%- endcomment -%}
 {%- capture _vab_variants_json -%}[
@@ -97,16 +106,40 @@
     data-default-tag="{{ page.current_version | escape }}"
     data-default-version="{{ _vab_default_version | escape }}"
     data-default-flavor="{{ _vab_default_flavor | escape }}"
-    data-versions="{{ '[' | append: _vab_ver_arr | append: ']' | escape }}"
-    data-flavors="{{ '[' | append: _vab_fla_arr | append: ']' | escape }}"
+    data-versions="{{ _vab_ver_arr | strip | escape }}"
+    data-flavors="{{ _vab_fla_arr | strip | escape }}"
     data-variants="{{ _vab_variants_json | strip | escape }}"
     data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
   ></variant-action-bar>
 
   <noscript>
     <div class="vab-noscript">
-      <p class="vab-noscript-label">Pull command:</p>
-      <code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }}</code>
+      <p class="vab-noscript-label">JavaScript is disabled — showing default variant.</p>
+      <pre><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }}</code></pre>
+      <pre><code>cosign verify ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }} \
+  --certificate-identity-regexp=https://github.com/{{ page.github_username | escape }} \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com</code></pre>
+      {%- if page.versions or page.variants -%}
+      <details>
+        <summary>All variants</summary>
+        <table>
+          <thead><tr><th>Tag</th><th>Pull command</th></tr></thead>
+          <tbody>
+            {%- if page.versions -%}
+              {%- for _ns_ver in page.versions -%}
+                {%- for _ns_v in _ns_ver.variants -%}
+                  <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
+                {%- endfor -%}
+              {%- endfor -%}
+            {%- elsif page.variants -%}
+              {%- for _ns_v in page.variants -%}
+                <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
+              {%- endfor -%}
+            {%- endif -%}
+          </tbody>
+        </table>
+      </details>
+      {%- endif -%}
     </div>
   </noscript>
 </section>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -740,9 +740,18 @@
             {%- endif -%}
           {%- endif -%}
 
-          {%- comment -%} Visible disclosure — only rendered when there are SELECTABLE (non-synthetic) variants {%- endcomment -%}
+          {%- comment -%}
+            Hidden DOM container holding the canonical <version-tabs> elements.
+            User-facing variant selection lives in <variant-action-bar> + the
+            "Available variants" flat table above. The buttons here remain in
+            the DOM as the source-of-truth for selectVariant() in
+            container-detail.js — `version-tabs-changed` dispatches from the
+            action bar target these `.variant-tag[data-tag=...]` elements.
+            `hidden` prevents user-visible duplication while keeping DOM
+            accessible to JS.
+          {%- endcomment -%}
           {%- if _variants_count > 0 -%}
-          <details class="disclosure">
+          <details class="disclosure" hidden>
             <summary>
               <span class="disclosure__title">Available variants</span>
               <span class="disclosure__metric">{{ _variants_count }} variant{% if _variants_count != 1 %}s{% endif %}{% if _versions_count > 1 %} · {{ _versions_count }} versions{% endif %}</span>

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -23,6 +23,11 @@
 
     disconnectedCallback() {
       if (this._observer) { this._observer.disconnect(); }
+      // F5: clean up nav resize tracking
+      if (this._navResizeObserver) { this._navResizeObserver.disconnect(); }
+      if (this._resizeHandler) { window.removeEventListener('resize', this._resizeHandler); }
+      // F7: remove version-tabs-changed listener to prevent leak on DOM re-attach
+      if (this._versionTabsHandler) { document.removeEventListener('version-tabs-changed', this._versionTabsHandler); }
     }
 
     // -------------------------------------------------------
@@ -30,8 +35,11 @@
     // -------------------------------------------------------
 
     _parseData() {
+      // F3: Liquid uses | escape (HTML-entity encoding). Browsers auto-decode attribute
+      // values, so attr arrives as raw JSON. decodeURIComponent is wrong here — it throws
+      // URIError on any bare % in tag names or URLs. Drop it entirely.
       var parse = function (attr, fallback) {
-        try { return JSON.parse(decodeURIComponent(attr || '')); }
+        try { return JSON.parse(attr || ''); }
         catch (e) { return fallback; }
       };
 
@@ -169,6 +177,7 @@
     }
 
     // Build a labelled pill group (radiogroup)
+    // F4: roving tabindex — only the active pill has tabindex=0, others -1.
     _makePillGroup(labelText, items, valueKey, selected, pillClass, groupClass) {
       var wrap = document.createElement('div');
       wrap.className = 'vab-pill-group ' + groupClass;
@@ -186,12 +195,15 @@
 
       for (var i = 0; i < items.length; i++) {
         var item = items[i];
+        var isActive = item[valueKey] === selected;
         var pill = document.createElement('button');
         pill.type = 'button';
-        pill.className = pillClass + (item[valueKey] === selected ? ' vab-pill--active' : '');
+        pill.className = pillClass + (isActive ? ' vab-pill--active' : '');
         pill.setAttribute('role', 'radio');
-        pill.setAttribute('aria-checked', item[valueKey] === selected ? 'true' : 'false');
+        pill.setAttribute('aria-checked', isActive ? 'true' : 'false');
         pill.setAttribute('data-value', item[valueKey]);
+        // F4: roving tabindex — only the selected pill is in the tab sequence
+        pill.tabIndex = isActive ? 0 : -1;
         pill.textContent = item.label || item[valueKey];
         row.appendChild(pill);
       }
@@ -342,12 +354,15 @@
       this._dispatchVariantChanged();
     }
 
+    // F4: also update roving tabindex when active pill changes
     _updatePillActive(pillClass, value) {
       var pills = this.querySelectorAll('.' + pillClass);
       for (var i = 0; i < pills.length; i++) {
         var active = pills[i].dataset.value === value;
         pills[i].classList.toggle('vab-pill--active', active);
         pills[i].setAttribute('aria-checked', active ? 'true' : 'false');
+        // F4: keep roving tabindex invariant
+        pills[i].tabIndex = active ? 0 : -1;
       }
     }
 
@@ -409,37 +424,70 @@
       document.dispatchEvent(new CustomEvent('phase-b-variant-changed', {
         bubbles: true, detail: detail
       }));
+
+      // F1: also drive container-detail.js which listens to version-tabs-changed
+      // to update SBOM, changelog, lineage, history, dep-health, etc.
+      // Tag detail.source so our own version-tabs-changed listener can skip it
+      // and prevent A<->B ping-pong.
+      var versionTabsEvent = new CustomEvent('version-tabs-changed', {
+        bubbles: true,
+        detail: { variant: v, tag: detail.tag, source: 'variant-action-bar' }
+      });
+      document.body.dispatchEvent(versionTabsEvent);
     }
 
-    // Two-way sync: if legacy version-tabs fires, update our pills + commands
-    _listenLegacyEvents() {
-      var self = this;
-      document.addEventListener('version-tabs-changed', function (e) {
-        var newTag = e.detail && e.detail.tag;
-        if (!newTag) { return; }
-        var found = null;
-        var variants = self._variants;
-        for (var i = 0; i < variants.length; i++) {
-          if (variants[i].tag === newTag) { found = variants[i]; break; }
-        }
-        if (!found) { return; }
-        self._currentVariant = found;
-        if (found.version) {
-          self._selectedVersion = found.version;
-          self._updatePillActive('vab-version-pill', found.version);
-        }
-        if (found.flavor) {
-          self._selectedFlavor = found.flavor;
-          self._updatePillActive('vab-flavor-pill', found.flavor);
-        }
-        self._updateCommands();
-        self._updateSignals();
-      });
+    // Two-way sync: if legacy version-tabs fires, update our pills + commands.
+    // F1 re-entry guard: skip events that originated from this component.
+    // F7: extracted as named method so disconnectedCallback can removeEventListener.
+    _onVersionTabsChanged(e) {
+      // F1: ignore events we dispatched ourselves — prevents A<->B ping-pong
+      if (e.detail && e.detail.source === 'variant-action-bar') { return; }
+
+      var newTag = e.detail && e.detail.tag;
+      if (!newTag) { return; }
+      var found = null;
+      var variants = this._variants;
+      for (var i = 0; i < variants.length; i++) {
+        if (variants[i].tag === newTag) { found = variants[i]; break; }
+      }
+      if (!found) { return; }
+      this._currentVariant = found;
+      if (found.version) {
+        this._selectedVersion = found.version;
+        this._updatePillActive('vab-version-pill', found.version);
+      }
+      if (found.flavor) {
+        this._selectedFlavor = found.flavor;
+        this._updatePillActive('vab-flavor-pill', found.flavor);
+      }
+      this._updateCommands();
+      this._updateSignals();
     }
 
     // -------------------------------------------------------
     // Sticky / collapse
     // -------------------------------------------------------
+
+    _refreshNavHeight() {
+      var navEl = document.querySelector('.site-nav');
+      var navH = navEl ? Math.round(navEl.getBoundingClientRect().height) : 60;
+      this.style.setProperty('--vab-nav-height', navH + 'px');
+      this._setupStickyObserver(navH);
+    }
+
+    _setupStickyObserver(navH) {
+      if (this._observer) { this._observer.disconnect(); }
+      var self = this;
+      this._observer = new IntersectionObserver(function (entries) {
+        var collapsed = !entries[0].isIntersecting;
+        self._setCollapsed(collapsed);
+      }, {
+        root: null,
+        rootMargin: '-' + navH + 'px 0px 0px 0px',
+        threshold: 0
+      });
+      if (this._sentinelEl) { this._observer.observe(this._sentinelEl); }
+    }
 
     _initSticky() {
       if (!('IntersectionObserver' in window)) { return; }
@@ -449,16 +497,26 @@
       var navH = navEl ? Math.round(navEl.getBoundingClientRect().height) : 60;
       this.style.setProperty('--vab-nav-height', navH + 'px');
 
-      this._observer = new IntersectionObserver(function (entries) {
-        var collapsed = !entries[0].isIntersecting;
-        self._setCollapsed(collapsed);
-      }, {
-        root: null,
-        rootMargin: '-' + navH + 'px 0px 0px 0px',
-        threshold: 0
-      });
+      this._setupStickyObserver(navH);
 
-      this._observer.observe(this._sentinelEl);
+      // F5: keep nav height fresh on resize/orientation change so rootMargin
+      // stays correct across breakpoints.
+      if (typeof ResizeObserver !== 'undefined' && navEl) {
+        this._navResizeObserver = new ResizeObserver(function (entries) {
+          var height = entries[0].contentRect.height;
+          self.style.setProperty('--vab-nav-height', height + 'px');
+          self._setupStickyObserver(Math.round(height));
+        });
+        this._navResizeObserver.observe(navEl);
+      } else {
+        // Fallback: debounced resize listener for browsers without ResizeObserver
+        var resizeTimer;
+        this._resizeHandler = function () {
+          clearTimeout(resizeTimer);
+          resizeTimer = setTimeout(function () { self._refreshNavHeight(); }, 100);
+        };
+        window.addEventListener('resize', this._resizeHandler);
+      }
     }
 
     _setCollapsed(collapsed) {
@@ -515,7 +573,30 @@
         if (toggleBtn) { self._onToggleClick(); return; }
       });
 
-      this._listenLegacyEvents();
+      // F4: keyboard navigation for radiogroup pills (WAI-ARIA APG roving tabindex).
+      // ArrowLeft/Right move focus+selection; Home/End jump to first/last.
+      this.addEventListener('keydown', function (e) {
+        var pill = e.target.closest('.vab-version-pill, .vab-flavor-pill');
+        if (!pill) { return; }
+        var keys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
+        if (keys.indexOf(e.key) === -1) { return; }
+        e.preventDefault();
+        var group = pill.parentElement;
+        var pills = Array.prototype.slice.call(group.querySelectorAll('button'));
+        var idx = pills.indexOf(pill);
+        var next;
+        if (e.key === 'ArrowLeft')       { next = (idx - 1 + pills.length) % pills.length; }
+        else if (e.key === 'ArrowRight') { next = (idx + 1) % pills.length; }
+        else if (e.key === 'Home')       { next = 0; }
+        else                             { next = pills.length - 1; }
+        pills[next].focus();
+        pills[next].click();
+      });
+
+      // F7: store bound handler reference so disconnectedCallback can remove it cleanly.
+      // F1: _onVersionTabsChanged has the re-entry guard (source === 'variant-action-bar').
+      this._versionTabsHandler = this._onVersionTabsChanged.bind(this);
+      document.addEventListener('version-tabs-changed', this._versionTabsHandler);
     }
   }
 


### PR DESCRIPTION
## Summary

Two follow-up fixes for the PR #400 variant-action-bar work that surfaced during live deploy verification.

### 1. Liquid `append | jsonify` chain produced exponential JSON escaping (blocking on master)

The `<variant-action-bar data-versions=...>` and `data-flavors=...` attributes were built with a chain of `| append: '...' | append: value | jsonify` that JSON-encodes the accumulator on each iteration. Result: deeply-nested-escaped strings that fail `JSON.parse()` → fall back to `[]` → **version + flavor pills NEVER rendered on multi-version containers** (postgres, github-runner, terraform, web-shell, php, sslh, vector, wordpress).

Verified live: the rendered attribute on `/container/postgres/` was `data-versions="[&quot;\&quot;\\\&quot;\\\\\\\&quot;\\\\\\\\\\\\\\\&quot;..."` — pure escape soup.

This fix exists as a local commit (`54d9c50`) that was accidentally pushed to a separate branch instead of the PR branch, so the squash-merge into master only included the broken initial code.

**Fix:** rebuild the version + flavor JSON arrays via `{% capture %}` blocks with per-field `| jsonify`, producing literal valid JSON. Cherry-picked verbatim from `54d9c50`.

### 2. Duplicate "Available variants" disclosure visible (UX)

The container detail page rendered "Available variants" twice:
- The new always-visible `<section id="all-variants" class="all-variants-flat">` flat table (correct, from PR #400)
- An older `<details class="disclosure">` accordion containing the legacy `<version-tabs>` button selector (left in place because `selectVariant()` in `container-detail.js` still finds variants via these `.variant-tag[data-tag=...]` elements)

Users saw the heading "Available variants" twice on the page, with the disclosure version closed by default and visually heavier.

**Fix:** add the HTML `hidden` attribute to the disclosure. The `<version-tabs>` element stays in the DOM (so `selectVariant()` continues to work via the `version-tabs-changed` events the action bar dispatches), but it's no longer rendered to users. Net effect: only the flat table version is visible. Single source of truth for the user-facing list.

## Test plan

- [ ] CI passes (CodeQL, JS analyze)
- [ ] Live verification on `/container/postgres/`:
  - `data-versions` and `data-flavors` attributes contain valid JSON (no escape soup)
  - Version pills (PG 18 / PG 17 / PG 16) render in the variant action bar
  - Flavor pills (base / vector / analytics / timeseries / spatial / distributed / full) render
  - Clicking a pill updates pull command, verify command, AND signals strip
  - Only ONE "Available variants" heading visible (the flat table); the duplicate disclosure is gone
- [ ] Live verification on `/container/web-shell/`:
  - Distro variants render in the action bar
  - "Available variants" heading appears once (flat)
- [ ] No JS console errors

## Note on hook silence

The `post-push-copilot-rereview.sh` hook was silent for the missing commit's push because that push went to a branch with no associated PR → `gh pr list --head <branch>` returned empty → hook silently exited. Mitigations are tracked in TODO.local.md for follow-up: add an explicit branch-name log line in the hook for diagnostics, and investigate how the working branch silently switched.
