### PR TITLE
fix(container-detail): rewrite Liquid comment to unblock Jekyll build

### DIFF
--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -33,10 +33,10 @@
 
 {%- comment -%} Determine unique versions for version pills {%- endcomment -%}
 {%- comment -%}
-  Use {% capture %} so each field gets its own | jsonify call, producing
-  literal JSON the browser can parse. A chained `| append: ... | jsonify`
-  encodes the whole accumulator string each iteration, yielding deeply-
-  nested-escaped output that fails JSON.parse.
+  Build a literal JSON array via capture, with per-field jsonify on each
+  value. A chained append-then-jsonify pipeline encodes the whole
+  accumulator string each loop iteration, yielding deeply-nested-escaped
+  output that fails JSON.parse.
 {%- endcomment -%}
 {%- capture _vab_ver_arr -%}
 {%- if page.versions and page.versions.size > 1 -%}[


### PR DESCRIPTION
## Summary

GitHub Pages Jekyll build is broken on master after PR #402 merge. The Liquid 4.0.4 parser bundled with the `jekyll-build-pages` action does not properly skip literal Liquid tag text inside `{%- comment -%}` blocks: it parses the inner `{% capture %}` literal as a real tag missing its variable name, producing:

```
Liquid Exception: Liquid syntax error (variant-action-bar.html line 36): Syntax Error in 'capture' - Valid syntax: capture [var]
```

**Fix:** rewrite the offending comment to describe the construct in prose, without the literal `{% capture %}` tag syntax. No behavioral change to the rendered HTML — only comment text changes.

## Test plan

- [ ] CI passes (Jekyll build succeeds — this is the regression fix gate)
- [ ] Live deploy after merge serves `/container/postgres/` with version + flavor pills rendering (the F2 fix from PR #402 finally lands)
- [ ] No JS console errors

## Note

This is a one-line cosmetic fix to a comment to work around Liquid 4.0.4 parsing quirks. The deeper fix (the F2 jsonify rebuild via capture) shipped in PR #402 and is unaffected by this PR.