### PR TITLE
fix(page-toc): auto-open ancestor details on anchor click

### DIFF
--- a/docs/site/assets/js/components/page-toc.js
+++ b/docs/site/assets/js/components/page-toc.js
@@ -292,6 +292,13 @@
       var target = document.getElementById(id);
       if (!target) { return; }
 
+      // Auto-open any <details> at-or-ancestor of target so content is visible before scroll.
+      var node = target;
+      while (node) {
+        if (node.tagName === 'DETAILS') node.open = true;
+        node = node.parentElement;
+      }
+
       var offset = this._computeOffset();
       var top = target.getBoundingClientRect().top + window.scrollY - offset;
 

--- a/docs/site/assets/js/components/page-toc.js
+++ b/docs/site/assets/js/components/page-toc.js
@@ -295,7 +295,9 @@
       // Auto-open any <details> at-or-ancestor of target so content is visible before scroll.
       var node = target;
       while (node) {
-        if (node.tagName === 'DETAILS') node.open = true;
+        if (node.tagName === 'DETAILS') {
+          node.open = true;
+        }
         node = node.parentElement;
       }
 


### PR DESCRIPTION
## Summary

Two TOC sidebar links (`Build history`, `Dep health`) had their target `id` placed directly on a closed `<details>` accordion element. Clicking them in the TOC scrolled to the summary bar but left the content hidden below — confusing UX.

## Fix

In `page-toc.js::_handleLinkClick`, after resolving the target element and before computing the scroll offset, walk from `target` upward through ancestors and set `node.open = true` on every `<details>` encountered. Handles both cases:
- target IS a `<details>` (current case for the 2 broken anchors)
- target is INSIDE a `<details>` (future-proof if any heading-with-id ends up nested)

7 LOC including comment. Loop is a no-op for the 8 top-level anchors that already worked.

## Test plan

- [ ] CI passes (CodeQL, JS analyze)
- [ ] Live deploy: TOC click on `Build history` opens the disclosure + scrolls
- [ ] Live deploy: TOC click on `Dep health` opens the disclosure + scrolls
- [ ] Other 8 TOC anchors continue to work unchanged
- [ ] Bats: 193/193 green (verified locally)
- [ ] No JS console errors