### PR TITLE
chore(container-detail): disable page-toc pending fix (#405)

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -106,9 +106,10 @@
         {%- comment -%}
           page-toc disabled pending fix — see issue #405.
           Click offset and scroll-active-highlight bugs make navigation worse than no TOC.
-          Component files preserved in repo (assets/js/components/page-toc.{js,css},
-          _includes/page-toc.html) ready to re-enable once the IntersectionObserver +
-          smooth-scroll offset are corrected.
+          Component files preserved in repo (assets/js/components/page-toc.js,
+          assets/css/components/page-toc.css, _includes/page-toc.html) ready to
+          re-enable once the IntersectionObserver + smooth-scroll offset are
+          corrected.
         {%- endcomment -%}
 
         {%- comment -%} Zone 2 — Trust posture (always visible) {%- endcomment -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -20,7 +20,7 @@
   <!-- tokens.css MUST load before theme.css — defines variables theme.css references -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
   <!-- Component CSS — load after tokens, before theme -->
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/page-toc.css">
+  <!-- page-toc.css disabled pending issue #405 -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/variant-action-bar.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
@@ -103,24 +103,13 @@
 
         </header>{%- comment -%} /Zone 1 — Identity {%- endcomment -%}
 
-        {%- comment -%} Page TOC sidebar — sticky right-side navigation (desktop) + drawer (mobile) {%- endcomment -%}
-        <page-toc data-anchors='[
-          {"id":"variants-pull","label":"Variant &amp; Pull"},
-          {"id":"all-variants","label":"All variants"},
-          {"id":"trust-posture","label":"Trust posture"},
-          {"id":"container-stats","label":"Stats"},
-          {"id":"provenance","label":"Provenance"},
-          {"id":"build-history","label":"Build history"},
-          {"id":"dep-health","label":"Dep health"},
-          {"id":"security-scan","label":"Security scan"},
-          {"id":"readme","label":"README"},
-          {"id":"extensions-reference","label":"Extensions"}
-        ]'>
-          {%- comment -%} noscript fallback — plain nav for JS-disabled browsers {%- endcomment -%}
-          <noscript>
-            {% include page-toc.html %}
-          </noscript>
-        </page-toc>
+        {%- comment -%}
+          page-toc disabled pending fix — see issue #405.
+          Click offset and scroll-active-highlight bugs make navigation worse than no TOC.
+          Component files preserved in repo (assets/js/components/page-toc.{js,css},
+          _includes/page-toc.html) ready to re-enable once the IntersectionObserver +
+          smooth-scroll offset are corrected.
+        {%- endcomment -%}
 
         {%- comment -%} Zone 2 — Trust posture (always visible) {%- endcomment -%}
         <section id="trust-posture" class="detail-zone detail-zone--trust" aria-label="Trust posture">
@@ -1184,7 +1173,7 @@
   </div>
 
   <!-- Vanilla web components — CSP-clean, no eval -->
-  <script defer src="{{ '/assets/js/components/page-toc.js' | relative_url }}"></script>
+  <!-- page-toc.js disabled pending issue #405 -->
   <script defer src="{{ '/assets/js/components/variant-action-bar.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/security-scan.js' | relative_url }}"></script>


### PR DESCRIPTION
Closes #405 once the click-offset and scroll-highlight bugs are fixed and the component is re-enabled.

## Summary

The right-side `<page-toc>` sidebar (introduced in #401, polished in #404) ships with two interaction bugs that make navigation worse than no TOC:

1. Click → scroll lands off-target due to incomplete offset accounting (only one of the two sticky bands counted)
2. Scroll → active highlight doesn't track the section the user perceives as current

Detail in #405 with reproduction steps and acceptance criteria.

## What changes

- Comment out the `<page-toc>` element from `_layouts/container-detail.html`
- Disable the `<link rel="stylesheet">` for `page-toc.css`
- Disable the `<script>` for `page-toc.js`

What stays:
- `docs/site/assets/js/components/page-toc.js` — preserved as-is for the eventual fix
- `docs/site/assets/css/components/page-toc.css` — preserved
- `docs/site/_includes/page-toc.html` — preserved
- The 24 section `id` attributes added by #400 — still useful for direct anchor links from elsewhere

## Test plan

- [ ] CI passes
- [ ] Live deploy: TOC sidebar no longer renders on container detail pages
- [ ] No JS errors (page-toc.js no longer loaded)
- [ ] Page load slightly lighter (one fewer CSS + one fewer JS file)