### PR TITLE
fix(provenance): drop dead manifest_digest_amd64 branches, label as Build digest

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -266,12 +266,13 @@
                 <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
               </div>
               {%- endif -%}
-              {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
+              {%- if _prov_var.build_digest != blank and _prov_var.build_digest != "unknown" -%}
+              {%- assign _prov_bd = _prov_var.build_digest | strip -%}
               <div class="evidence-row">
                 <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{{ _prov_var.build_digest }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_var.build_digest }}">⧉</button>
+                  <code class="hash hash-long">{{ _prov_bd }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_bd }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -359,12 +360,13 @@
                 <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
               </div>
               {%- endif -%}
-              {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
+              {%- if _prov_var.build_digest != blank and _prov_var.build_digest != "unknown" -%}
+              {%- assign _prov_bd = _prov_var.build_digest | strip -%}
               <div class="evidence-row">
                 <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{{ _prov_var.build_digest }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_var.build_digest }}">⧉</button>
+                  <code class="hash hash-long">{{ _prov_bd }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_bd }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -450,12 +452,13 @@
                 <dd><code class="hash">{{ page.last_commit_short | default: site.github.build_revision | slice: 0, 7 }}</code></dd>
               </div>
               {%- endif -%}
-              {%- if prov_variant.build_digest and prov_variant.build_digest != "unknown" -%}
+              {%- if prov_variant.build_digest != blank and prov_variant.build_digest != "unknown" -%}
+              {%- assign _pv_bd = prov_variant.build_digest | strip -%}
               <div class="evidence-row">
                 <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{{ prov_variant.build_digest }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ prov_variant.build_digest }}">⧉</button>
+                  <code class="hash hash-long">{{ _pv_bd }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _pv_bd }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -267,22 +267,11 @@
               </div>
               {%- endif -%}
               {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
-              {%- assign _show_manifest_amd64 = false -%}
-              {%- if _prov_var.manifest_digest_amd64 != blank -%}{%- assign _show_manifest_amd64 = true -%}{%- endif -%}
               <div class="evidence-row">
-                <dt>{% if _show_manifest_amd64 %}Manifest digest (amd64){% else %}Build digest{% endif %}</dt>
+                <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{% if _show_manifest_amd64 %}{{ _prov_var.manifest_digest_amd64 }}{% else %}{{ _prov_var.build_digest }}{% endif %}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy {% if _show_manifest_amd64 %}manifest{% else %}build{% endif %} digest" aria-label="Copy {% if _show_manifest_amd64 %}manifest{% else %}build{% endif %} digest" data-copy="{% if _show_manifest_amd64 %}{{ _prov_var.manifest_digest_amd64 }}{% else %}{{ _prov_var.build_digest }}{% endif %}">⧉</button>
-                </dd>
-              </div>
-              {%- endif -%}
-              {%- if _prov_var.manifest_digest_arm64 -%}
-              <div class="evidence-row">
-                <dt>Manifest digest (arm64)</dt>
-                <dd>
-                  <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                  <code class="hash hash-long">{{ _prov_var.build_digest }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_var.build_digest }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -371,22 +360,11 @@
               </div>
               {%- endif -%}
               {%- if _prov_var.build_digest and _prov_var.build_digest != "unknown" -%}
-              {%- assign _show_manifest_amd64 = false -%}
-              {%- if _prov_var.manifest_digest_amd64 != blank -%}{%- assign _show_manifest_amd64 = true -%}{%- endif -%}
               <div class="evidence-row">
-                <dt>{% if _show_manifest_amd64 %}Manifest digest (amd64){% else %}Build digest{% endif %}</dt>
+                <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{% if _show_manifest_amd64 %}{{ _prov_var.manifest_digest_amd64 }}{% else %}{{ _prov_var.build_digest }}{% endif %}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy {% if _show_manifest_amd64 %}manifest{% else %}build{% endif %} digest" aria-label="Copy {% if _show_manifest_amd64 %}manifest{% else %}build{% endif %} digest" data-copy="{% if _show_manifest_amd64 %}{{ _prov_var.manifest_digest_amd64 }}{% else %}{{ _prov_var.build_digest }}{% endif %}">⧉</button>
-                </dd>
-              </div>
-              {%- endif -%}
-              {%- if _prov_var.manifest_digest_arm64 -%}
-              <div class="evidence-row">
-                <dt>Manifest digest (arm64)</dt>
-                <dd>
-                  <code class="hash hash-long">{{ _prov_var.manifest_digest_arm64 }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_var.manifest_digest_arm64 }}">⧉</button>
+                  <code class="hash hash-long">{{ _prov_var.build_digest }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_var.build_digest }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -473,22 +451,11 @@
               </div>
               {%- endif -%}
               {%- if prov_variant.build_digest and prov_variant.build_digest != "unknown" -%}
-              {%- assign _show_prov_manifest_amd64 = false -%}
-              {%- if prov_variant.manifest_digest_amd64 != blank -%}{%- assign _show_prov_manifest_amd64 = true -%}{%- endif -%}
               <div class="evidence-row">
-                <dt>{% if _show_prov_manifest_amd64 %}Manifest digest (amd64){% else %}Build digest{% endif %}</dt>
+                <dt>Build digest</dt>
                 <dd>
-                  <code class="hash hash-long">{% if _show_prov_manifest_amd64 %}{{ prov_variant.manifest_digest_amd64 }}{% else %}{{ prov_variant.build_digest }}{% endif %}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy {% if _show_prov_manifest_amd64 %}manifest{% else %}build{% endif %} digest" aria-label="Copy {% if _show_prov_manifest_amd64 %}manifest{% else %}build{% endif %} digest" data-copy="{% if _show_prov_manifest_amd64 %}{{ prov_variant.manifest_digest_amd64 }}{% else %}{{ prov_variant.build_digest }}{% endif %}">⧉</button>
-                </dd>
-              </div>
-              {%- endif -%}
-              {%- if prov_variant.manifest_digest_arm64 -%}
-              <div class="evidence-row">
-                <dt>Manifest digest (arm64)</dt>
-                <dd>
-                  <code class="hash hash-long">{{ prov_variant.manifest_digest_arm64 }}</code>
-                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ prov_variant.manifest_digest_arm64 }}">⧉</button>
+                  <code class="hash hash-long">{{ prov_variant.build_digest }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ prov_variant.build_digest }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}


### PR DESCRIPTION
## Summary

The Provenance section was rendering an empty row labeled "Manifest digest (amd64)" with no value and a non-functional copy button. Root cause: the Liquid template referenced `_prov_var.manifest_digest_amd64` / `_prov_var.manifest_digest_arm64` fields that **never existed** in `containers.yml` — the build pipeline only emits a single `build_digest` field (the post-flatten OCI subject digest, equivalent to the amd64 manifest digest).

Liquid 4.0.4 evaluates `nil != blank` as true, which made the `_show_manifest_amd64` branch fire and rendered the misleading label.

## Fix

Remove the three dead conditional blocks (one per render path: synthetic-variant rendering, versions-loop, and single-variants-loop). Always render a single "Build digest" row with the actual data we have.

Net diff: -42 / +9 LOC. No data layer changes — the existing `build_digest` field is what we surface now.

## What about multi-arch?

The user asked why the digest was labeled amd64-only and what would be "pertinent" for multi-arch images. The honest answer is that today only the post-flatten amd64 digest is captured. Genuine multi-arch tracking (index digest + per-arch manifest digests) requires extending the build pipeline. Tracked in **#407** with full acceptance criteria.

## Test plan

- [ ] CI passes
- [ ] Live deploy: postgres detail page Provenance section shows a single "Build digest" row with a populated 12-char SHA value
- [ ] Copy button works (data-copy populated)
- [ ] No empty row labeled "Manifest digest (amd64)" anywhere
- [ ] Same on web-shell, debian, github-runner detail pages

Closes #407 only when the multi-arch tracking lands; this PR addresses the immediate render bug only.