### PR TITLE
feat(variant-action-bar): registry selector + drop unused commands toggle

### DIFF
--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -101,6 +101,8 @@
   {%- endif -%}
 {%- endif -%}
 
+{%- capture _vab_registries -%}[{"id":"ghcr","label":"GHCR","host":"ghcr.io/"},{"id":"dockerhub","label":"Docker Hub","host":""}]{%- endcapture -%}
+
 <section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
   <variant-action-bar
     data-container="{{ page.name | escape }}"
@@ -111,6 +113,8 @@
     data-flavors="{{ _vab_fla_arr | strip | escape }}"
     data-variants="{{ _vab_variants_json | strip | escape }}"
     data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
+    data-image-base-dockerhub="{{ page.github_username | escape }}/{{ page.name | escape }}"
+    data-registries='{{ _vab_registries | escape }}'
   ></variant-action-bar>
 
   <noscript>

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -113,7 +113,7 @@
     data-flavors="{{ _vab_fla_arr | strip | escape }}"
     data-variants="{{ _vab_variants_json | strip | escape }}"
     data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
-    data-image-base-dockerhub="{{ page.github_username | escape }}/{{ page.name | escape }}"
+    data-image-base-dockerhub="{{ page.dockerhub_username | default: page.github_username | escape }}/{{ page.name | escape }}"
     data-registries='{{ _vab_registries | escape }}'
   ></variant-action-bar>
 

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -101,7 +101,7 @@
   {%- endif -%}
 {%- endif -%}
 
-{%- capture _vab_registries -%}[{"id":"ghcr","label":"GHCR","host":"ghcr.io/"},{"id":"dockerhub","label":"Docker Hub","host":""}]{%- endcapture -%}
+{%- capture _vab_registries -%}[{"id":"ghcr","label":"GHCR"},{"id":"dockerhub","label":"Docker Hub"}]{%- endcapture -%}
 
 <section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
   <variant-action-bar

--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -128,7 +128,8 @@ variant-action-bar {
 
 /* Base pill style */
 .vab-version-pill,
-.vab-flavor-pill {
+.vab-flavor-pill,
+.vab-registry-pill {
   padding: var(--space-xs, 4px) var(--space-sm, 8px);
   border-radius: var(--radius-full, 9999px);
   border: 1px solid var(--color-variant-tag-border, rgba(139,92,246,0.25));
@@ -149,14 +150,16 @@ variant-action-bar {
 }
 
 .vab-version-pill:hover,
-.vab-flavor-pill:hover {
+.vab-flavor-pill:hover,
+.vab-registry-pill:hover {
   background: var(--color-variant-tag-bg-hover, rgba(139,92,246,0.25));
   border-color: rgba(167,139,250,0.45);
 }
 
 /* Active / selected pill (uses violet trust hue per Phase C spec) */
 .vab-version-pill.vab-pill--active,
-.vab-flavor-pill.vab-pill--active {
+.vab-flavor-pill.vab-pill--active,
+.vab-registry-pill.vab-pill--active {
   background: var(--color-variant-tag-selected-bg, rgba(139,92,246,0.30));
   border-color: var(--color-violet-400, #A78BFA);
   color: var(--color-violet-400, #A78BFA);
@@ -165,14 +168,16 @@ variant-action-bar {
 
 /* Focus rings — WCAG 2.2 AA (3px outline, 2px offset) */
 .vab-version-pill:focus-visible,
-.vab-flavor-pill:focus-visible {
+.vab-flavor-pill:focus-visible,
+.vab-registry-pill:focus-visible {
   outline: 3px solid var(--color-violet-400, #A78BFA);
   outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .vab-version-pill,
-  .vab-flavor-pill { transition: none; }
+  .vab-flavor-pill,
+  .vab-registry-pill { transition: none; }
 }
 
 /* ----------------------------------------------------------

--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -69,15 +69,7 @@ variant-action-bar {
   display: none;
 }
 
-/* When user clicks toggle while collapsed, re-show everything */
-[data-collapsed] .vab-card[data-user-expanded="true"] .vab-row--selectors,
-[data-collapsed] .vab-card[data-user-expanded="true"] .vab-row--commands {
-  display: flex;
-}
-
-/* Show the toggle button only when collapsed */
-.vab-toggle { display: none; }
-[data-collapsed] .vab-toggle { display: inline-flex; }
+/* (toggle removed — scrolling back up re-expands via IntersectionObserver) */
 
 @media (prefers-reduced-motion: reduce) {
   [data-collapsed] .vab-card { transition: none; }
@@ -318,43 +310,15 @@ variant-action-bar {
 }
 
 /* ----------------------------------------------------------
-   Collapse toggle button
+   Verify note (shown when registry is not GHCR)
    ---------------------------------------------------------- */
 
-.vab-toggle {
-  align-self: flex-start;
-  padding: var(--space-xs, 4px) var(--space-sm, 8px);
-  border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
-  background: rgba(255,255,255,0.06);
+.vab-verify-note {
+  font-size: 0.75rem;
   color: var(--color-text-muted, #8A93A0);
-  font-size: var(--font-size-caption, 12px);
-  font-family: var(--font-family-mono, monospace);
-  font-weight: var(--font-weight-medium, 500);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs, 4px);
-  min-height: 32px;
-  transition:
-    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
-    color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
-}
-
-.vab-toggle:hover {
-  background: rgba(255,255,255,0.12);
-  color: var(--color-text-primary, #F4F5F7);
-}
-
-.vab-toggle:focus-visible {
-  outline: 3px solid var(--color-action-primary, #60A5FA);
-  outline-offset: 2px;
-}
-
-.vab-toggle-icon { font-size: 0.875rem; }
-
-@media (prefers-reduced-motion: reduce) {
-  .vab-toggle { transition: none; }
+  font-style: italic;
+  display: block;
+  margin-top: 4px;
 }
 
 /* ----------------------------------------------------------

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -55,13 +55,31 @@
       var hasDockerHubBase = !!this.dataset.imageBaseDockerhub;
       var defaultRegistries = hasDockerHubBase
         ? [
-            { id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' },
-            { id: 'dockerhub', label: 'Docker Hub', host: '' }
+            { id: 'ghcr', label: 'GHCR' },
+            { id: 'dockerhub', label: 'Docker Hub' }
           ]
-        : [{ id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' }];
+        : [{ id: 'ghcr', label: 'GHCR' }];
       this._registries = parse(this.dataset.registries, defaultRegistries);
       if (!this._registries || !this._registries.length) {
         this._registries = defaultRegistries;
+      }
+      // Cross-validate: keep only registries whose pull-base is actually
+      // implemented in _updateCommands (today: 'ghcr' + 'dockerhub'). Drop any
+      // unknown ids — rendering a "quay" pill that silently falls back to a
+      // GHCR pull command is worse than not showing it at all. Also drop
+      // 'dockerhub' when data-image-base-dockerhub is missing (same reason).
+      var SUPPORTED_REGISTRY_IDS = { ghcr: true, dockerhub: true };
+      this._registries = this._registries.filter(function (r) {
+        if (!SUPPORTED_REGISTRY_IDS[r.id]) return false;
+        if (r.id === 'dockerhub') return hasDockerHubBase;
+        return true;
+      });
+      // Guarantee GHCR is always available — every container ships there and
+      // the pull-base path is always wired. Without this, a misconfigured
+      // data-registries (e.g. only "dockerhub" with no DH base) could leave
+      // the registry list empty and orphan _selectedRegistry below.
+      if (!this._registries.some(function (r) { return r.id === 'ghcr'; })) {
+        this._registries.unshift({ id: 'ghcr', label: 'GHCR' });
       }
       // Default registry: explicit attribute → first registry → 'ghcr'.
       // Validate that the requested default exists in _registries; otherwise

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -57,7 +57,9 @@
       if (!this._registries || !this._registries.length) {
         this._registries = defaultRegistries;
       }
-      this._selectedRegistry = 'ghcr';
+      var defaultFromAttr = (this.dataset.defaultRegistry || '').trim();
+      this._selectedRegistry = defaultFromAttr
+        || (this._registries.length > 0 ? this._registries[0].id : 'ghcr');
 
       // versions: array of version-group objects with .tag + .variants[]
       this._versions = parse(this.dataset.versions, []);
@@ -320,6 +322,8 @@
           if (!existingNote) {
             var note = document.createElement('small');
             note.className = 'vab-verify-note';
+            note.setAttribute('role', 'status');
+            note.setAttribute('aria-live', 'polite');
             note.textContent = 'Verified via GHCR · attestation source';
             verifyBlock.appendChild(note);
           }

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -48,18 +48,29 @@
       this._imageBaseDockerHub = this.dataset.imageBaseDockerhub || this.dataset.imageBase || '';
       this._defaultTag = this.dataset.defaultTag || '';
 
-      // Registry options (default: GHCR + Docker Hub)
-      var defaultRegistries = [
-        { id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' },
-        { id: 'dockerhub', label: 'Docker Hub', host: '' }
-      ];
+      // Registry options. We only synthesize the GHCR + Docker Hub default pair
+      // when the page actually provides a Docker Hub image base — otherwise
+      // selecting "Docker Hub" would silently fall back to the GHCR base. Pages
+      // without `data-image-base-dockerhub` get GHCR-only (no pill group rendered).
+      var hasDockerHubBase = !!this.dataset.imageBaseDockerhub;
+      var defaultRegistries = hasDockerHubBase
+        ? [
+            { id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' },
+            { id: 'dockerhub', label: 'Docker Hub', host: '' }
+          ]
+        : [{ id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' }];
       this._registries = parse(this.dataset.registries, defaultRegistries);
       if (!this._registries || !this._registries.length) {
         this._registries = defaultRegistries;
       }
+      // Default registry: explicit attribute → first registry → 'ghcr'.
+      // Validate that the requested default exists in _registries; otherwise
+      // fall back to the first available so the radiogroup always has an active
+      // pill (avoids all-tabIndex=-1 keyboard-trap state).
       var defaultFromAttr = (this.dataset.defaultRegistry || '').trim();
-      this._selectedRegistry = defaultFromAttr
-        || (this._registries.length > 0 ? this._registries[0].id : 'ghcr');
+      var firstId = this._registries.length > 0 ? this._registries[0].id : 'ghcr';
+      var validDefault = defaultFromAttr && this._registries.some(function (r) { return r.id === defaultFromAttr; });
+      this._selectedRegistry = validDefault ? defaultFromAttr : firstId;
 
       // versions: array of version-group objects with .tag + .variants[]
       this._versions = parse(this.dataset.versions, []);

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -1,8 +1,8 @@
 // docs/site/assets/js/components/variant-action-bar.js
 //
 // Vanilla custom element (light DOM). CSP-clean (no eval, no innerHTML).
-// Renders: version pills + flavor pills + pull/verify commands + per-variant signals strip.
-// Sticky-on-scroll with collapse toggle. Dispatches variant-action-bar:variant-changed.
+// Renders: registry pills + version pills + flavor pills + pull/verify commands + per-variant signals strip.
+// Sticky-on-scroll (auto-collapses to signals strip; scroll up re-expands). Dispatches variant-action-bar:variant-changed.
 // Two-way sync with legacy phase-b-variant-changed / version-tabs-changed events.
 
 (function () {
@@ -45,7 +45,19 @@
 
       this._container = this.dataset.container || '';
       this._imageBase = this.dataset.imageBase || '';
+      this._imageBaseDockerHub = this.dataset.imageBaseDockerhub || this.dataset.imageBase || '';
       this._defaultTag = this.dataset.defaultTag || '';
+
+      // Registry options (default: GHCR + Docker Hub)
+      var defaultRegistries = [
+        { id: 'ghcr', label: 'GHCR', host: 'ghcr.io/' },
+        { id: 'dockerhub', label: 'Docker Hub', host: '' }
+      ];
+      this._registries = parse(this.dataset.registries, defaultRegistries);
+      if (!this._registries || !this._registries.length) {
+        this._registries = defaultRegistries;
+      }
+      this._selectedRegistry = 'ghcr';
 
       // versions: array of version-group objects with .tag + .variants[]
       this._versions = parse(this.dataset.versions, []);
@@ -112,13 +124,21 @@
       card.className = 'vab-card';
       this.appendChild(card);
 
-      // Row 1 — selectors (version pills + flavor pills)
+      // Row 1 — selectors: [REGISTRY pills] · [VERSION pills] · [FLAVOR pills]
       var hasMultipleVersions = this._versions && this._versions.length > 1;
       var hasFlavors = this._flavors && this._flavors.length > 0;
+      var hasRegistries = this._registries && this._registries.length > 1;
 
-      if (hasMultipleVersions || hasFlavors) {
+      if (hasRegistries || hasMultipleVersions || hasFlavors) {
         var row1 = document.createElement('div');
         row1.className = 'vab-row vab-row--selectors';
+
+        if (hasRegistries) {
+          row1.appendChild(
+            this._makePillGroup('Registry', this._registries, 'id', this._selectedRegistry,
+              'vab-registry-pill', 'vab-registry-pills vab-pill-group--registry')
+          );
+        }
 
         if (hasMultipleVersions) {
           row1.appendChild(
@@ -150,27 +170,9 @@
       row3.appendChild(this._makeSignalsStrip());
       card.appendChild(row3);
 
-      // Collapse toggle button (only active when [data-collapsed] is set)
-      var toggle = document.createElement('button');
-      toggle.type = 'button';
-      toggle.className = 'vab-toggle';
-      toggle.setAttribute('aria-expanded', 'true');
-      toggle.setAttribute('aria-label', 'Toggle variant commands panel');
-      var toggleIcon = document.createElement('span');
-      toggleIcon.className = 'vab-toggle-icon';
-      toggleIcon.setAttribute('aria-hidden', 'true');
-      toggleIcon.textContent = '↓'; // down arrow ↓
-      toggle.appendChild(toggleIcon);
-      var toggleLabel = document.createElement('span');
-      toggleLabel.textContent = 'commands';
-      toggle.appendChild(toggleLabel);
-      card.appendChild(toggle);
-
       // Store refs
       this._cardEl = card;
       this._sentinelEl = sentinel;
-      this._toggleBtn = toggle;
-      this._userExpanded = false;
 
       this._updateCommands();
       this._updateSignals();
@@ -293,11 +295,15 @@
     _updateCommands() {
       var v = this._currentVariant;
       var tag = (v && v.tag) ? v.tag : this._defaultTag;
-      var base = this._imageBase;
-      var owner = this._extractOwner(base);
+      var ghcrBase = this._imageBase;
+      var owner = this._extractOwner(ghcrBase);
 
-      var pullCmd = 'docker pull ' + base + ':' + tag;
-      var verifyCmd = 'cosign verify ' + base + ':' + tag
+      // Pull command uses selected registry; verify always uses GHCR (Sigstore lives there)
+      var pullBase = (this._selectedRegistry === 'dockerhub')
+        ? this._imageBaseDockerHub
+        : ghcrBase;
+      var pullCmd = 'docker pull ' + pullBase + ':' + tag;
+      var verifyCmd = 'cosign verify ' + ghcrBase + ':' + tag
         + ' --certificate-identity-regexp=https://github.com/' + owner
         + ' --certificate-oidc-issuer=https://token.actions.githubusercontent.com';
 
@@ -305,6 +311,22 @@
       var verifyEl = this.querySelector('[data-vab-cmd="verify"]');
       if (pullEl) { pullEl.textContent = pullCmd; }
       if (verifyEl) { verifyEl.textContent = verifyCmd; }
+
+      // Show verify note when registry is not GHCR
+      var verifyBlock = verifyEl && verifyEl.closest('.vab-command-block');
+      if (verifyBlock) {
+        var existingNote = verifyBlock.querySelector('.vab-verify-note');
+        if (this._selectedRegistry !== 'ghcr') {
+          if (!existingNote) {
+            var note = document.createElement('small');
+            note.className = 'vab-verify-note';
+            note.textContent = 'Verified via GHCR · attestation source';
+            verifyBlock.appendChild(note);
+          }
+        } else {
+          if (existingNote) { verifyBlock.removeChild(existingNote); }
+        }
+      }
     }
 
     _extractOwner(base) {
@@ -353,6 +375,14 @@
       this._updateSignals();
       this._dispatchVariantChanged();
     }
+
+
+    _onRegistryPillClick(value) {
+      this._selectedRegistry = value;
+      this._updatePillActive('vab-registry-pill', value);
+      this._updateCommands();
+    }
+
 
     // F4: also update roving tabindex when active pill changes
     _updatePillActive(pillClass, value) {
@@ -522,33 +552,8 @@
     _setCollapsed(collapsed) {
       if (collapsed) {
         this.setAttribute('data-collapsed', '');
-        if (this._toggleBtn) {
-          var icon = this._toggleBtn.querySelector('.vab-toggle-icon');
-          if (icon) { icon.textContent = this._userExpanded ? '↑' : '↓'; }
-          this._toggleBtn.setAttribute('aria-expanded', this._userExpanded ? 'true' : 'false');
-        }
       } else {
         this.removeAttribute('data-collapsed');
-        this._userExpanded = false;
-        if (this._cardEl) { this._cardEl.removeAttribute('data-user-expanded'); }
-        if (this._toggleBtn) {
-          var icon2 = this._toggleBtn.querySelector('.vab-toggle-icon');
-          if (icon2) { icon2.textContent = '↓'; }
-          this._toggleBtn.setAttribute('aria-expanded', 'true');
-        }
-      }
-    }
-
-    _onToggleClick() {
-      if (!this.hasAttribute('data-collapsed')) { return; }
-      this._userExpanded = !this._userExpanded;
-      if (this._cardEl) {
-        this._cardEl.setAttribute('data-user-expanded', this._userExpanded ? 'true' : 'false');
-      }
-      if (this._toggleBtn) {
-        this._toggleBtn.setAttribute('aria-expanded', this._userExpanded ? 'true' : 'false');
-        var icon = this._toggleBtn.querySelector('.vab-toggle-icon');
-        if (icon) { icon.textContent = this._userExpanded ? '↑' : '↓'; }
       }
     }
 
@@ -560,6 +565,9 @@
       var self = this;
 
       this.addEventListener('click', function (e) {
+        var rPill = e.target.closest('.vab-registry-pill');
+        if (rPill) { self._onRegistryPillClick(rPill.dataset.value); return; }
+
         var vPill = e.target.closest('.vab-version-pill');
         if (vPill) { self._onVersionPillClick(vPill.dataset.value); return; }
 
@@ -568,15 +576,12 @@
 
         var copyBtn = e.target.closest('.vab-copy-btn');
         if (copyBtn) { self._onCopyClick(copyBtn.getAttribute('data-vab-copy')); return; }
-
-        var toggleBtn = e.target.closest('.vab-toggle');
-        if (toggleBtn) { self._onToggleClick(); return; }
       });
 
       // F4: keyboard navigation for radiogroup pills (WAI-ARIA APG roving tabindex).
       // ArrowLeft/Right move focus+selection; Home/End jump to first/last.
       this.addEventListener('keydown', function (e) {
-        var pill = e.target.closest('.vab-version-pill, .vab-flavor-pill');
+        var pill = e.target.closest('.vab-registry-pill, .vab-version-pill, .vab-flavor-pill');
         if (!pill) { return; }
         var keys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
         if (keys.indexOf(e.key) === -1) { return; }


### PR DESCRIPTION
## Summary

Two related changes to `<variant-action-bar>` to simplify the scrolled-state UX and surface a real registry choice:

### 1. Drop the "↓ commands" toggle

The toggle button on the action bar (re-expand to full 3 rows when scrolled-collapsed) added chrome for limited unique value. When scrolled past the hero, the signals strip (Status · Size amd64 · Size arm64) is sufficient context. To see the pull command again, the user can either scroll back up (the bar auto-expands when the sentinel re-enters viewport) or read the always-visible "Available variants" flat table directly below.

Drops:
- The `<button class="vab-toggle">` DOM element
- The `[data-user-expanded]` state attribute, CSS rules, and JS handlers
- The `_onToggleClick()` method
- Simplifies `_setCollapsed()` to just toggle `[data-collapsed]`

Auto-collapse on scroll past hero is **preserved** (the IntersectionObserver pattern stays).

### 2. Add Registry selector pills (GHCR · Docker Hub)

Today the pull command is hardcoded to GHCR. Many users prefer Docker Hub or need to switch when one is rate-limited.

New pill group inserted **before** the version pills in Row 1:

```
[REGISTRY: GHCR · Docker Hub]  ·  [VERSION: PG18 · PG17 · PG16]  ·  [FLAVOR: base · vector · ...]
```

When the user selects Docker Hub:
- Pull command becomes `docker pull <owner>/<container>:<tag>` (no `ghcr.io/` prefix)
- Verify command stays as-is (Sigstore attestation lives at GHCR)
- Small caption appears under verify: *"Verified via GHCR · attestation source"* — explicit so the user understands why the verify reference doesn't match the pull registry

Default selection: GHCR (current behavior preserved).

### Data attribute additions

In `_includes/variant-action-bar.html`:
- `data-image-base-dockerhub="<owner>/<container>"` (no host prefix)
- `data-registries='[{"id":"ghcr","label":"GHCR","host":"ghcr.io/"},{"id":"dockerhub","label":"Docker Hub","host":""}]'`

### Accessibility

- Registry pills use the same APG radio pattern + roving tabindex (ArrowLeft/Right cycle within the group)
- Verify-note `<small>` is in the document flow (announced by screen readers when registry switches)

## Test plan

- [ ] CI passes (CodeQL, JS analyze)
- [ ] Live deploy: variant-action-bar Row 1 shows Registry pills (GHCR active by default)
- [ ] Click "Docker Hub" → pull command updates to `docker pull oorabona/postgres:18-alpine` (no ghcr.io/ prefix); verify command stays on GHCR; caption "Verified via GHCR · attestation source" visible
- [ ] Click "GHCR" → pull command back to `docker pull ghcr.io/oorabona/postgres:18-alpine`; caption disappears
- [ ] Scroll past hero → bar auto-collapses, signals strip visible, NO toggle button
- [ ] Scroll back up → bar auto-expands to full 3 rows
- [ ] Keyboard: ArrowLeft/Right cycles through registry pills; Tab jumps to next group
- [ ] No JS console errors

## Net diff

3 files, +72/-99 LOC (net reduction of 27 LOC despite adding the registry feature, thanks to dropping the toggle).
