### PR TITLE
feat(trivy): scan and surface all severities

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -54,9 +54,9 @@ inputs:
     required: false
     default: 'true'
   vulnerability_severity:
-    description: Minimum severity to report (advisory only, does not block builds)
+    description: 'Severities surfaced in SARIF + dashboard (advisory). Build is never blocked — Trivy runs continue-on-error.'
     required: false
-    default: 'CRITICAL'
+    default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
   use_base_cache:
     description: 'Use GHCR base image cache (skip on PRs where cache-base-images is not run)'
     required: false
@@ -452,7 +452,7 @@ runs:
         image-ref: 'ghcr.io/${{ steps.check-build.outputs.image_name }}:${{ steps.check-build.outputs.current_tag }}'
         format: 'table'
         exit-code: '0'
-        severity: '${{ inputs.vulnerability_severity }},CRITICAL'
+        severity: '${{ inputs.vulnerability_severity }}'
         ignore-unfixed: true
         vuln-type: 'os,library'
         cache-dir: ~/.cache/trivy
@@ -467,7 +467,7 @@ runs:
         image-ref: 'ghcr.io/${{ steps.check-build.outputs.image_name }}:${{ steps.check-build.outputs.current_tag }}'
         format: 'sarif'
         output: 'trivy-results.sarif'
-        severity: 'CRITICAL'
+        severity: '${{ inputs.vulnerability_severity }}'
         ignore-unfixed: true
         vuln-type: 'os,library'
         cache-dir: ~/.cache/trivy
@@ -477,6 +477,8 @@ runs:
     - name: Write Trivy scan history
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.trivy-sarif.outcome == 'success' }}
       shell: bash
+      env:
+        VULNERABILITY_SEVERITY: ${{ inputs.vulnerability_severity }}
       run: |
         container="${{ inputs.container }}"
         current_tag="${{ steps.check-build.outputs.current_tag }}"
@@ -490,18 +492,48 @@ runs:
         last_scan="$(date -Iseconds)"
         alert_count=0
         status="clean"
+        counts_json='{"critical":0,"high":0,"medium":0,"low":0,"info":0}'
 
-        # Parse SARIF if it exists to count actual findings
+        # Parse SARIF to count findings per severity (Option C: full breakdown)
         if [[ -f trivy-results.sarif ]]; then
+          # Build a rule_id → severity (lowercase) map from tool.driver.rules
+          severities_json=$(jq -c '
+            [.runs[].tool.driver.rules // [] | .[] |
+              {(.id): ([.properties.tags // [] | .[] | ascii_downcase] |
+                map(select(. == "critical" or . == "high" or . == "medium" or . == "low")) |
+                first // "info")}]
+            | add // {}
+          ' trivy-results.sarif 2>/dev/null || echo "{}")
+
+          # Count results by severity via the rule→severity map
+          counts_json=$(jq -c --argjson sev_map "$severities_json" '
+            reduce ([.runs[].results // [] | .[]][] | (.ruleId? // "")) as $rid
+              ({"critical":0,"high":0,"medium":0,"low":0,"info":0};
+                ($sev_map[$rid] // "info") as $s
+                | if .[$s] != null then .[$s] += 1 else . end)
+          ' trivy-results.sarif 2>/dev/null || echo '{"critical":0,"high":0,"medium":0,"low":0,"info":0}')
+
           alert_count=$(jq '[.runs[].results // [] | .[]] | length' trivy-results.sarif 2>/dev/null || echo 0)
           if [[ "$alert_count" -gt 0 ]]; then
             status="dirty"
           fi
         fi
 
+        # Build scanned_severities as a JSON array from the comma-separated input.
+        # Use `jq -n` with --arg (null input + bound variable) instead of `jq -R` over
+        # a piped string: an empty $VULNERABILITY_SEVERITY produces zero records on
+        # stdin so `jq -R` emits nothing, leaving --argjson with invalid JSON below.
+        scanned_severities_json=$(jq -nc --arg s "$VULNERABILITY_SEVERITY" \
+          'if $s == "" then [] else $s | split(",") | map(ascii_upcase | gsub("^\\s+|\\s+$"; "")) end')
+
         scan_file=".trivy-scan-history/${container}-${current_tag}-${platform_safe}.json"
-        printf '{"last_scan":"%s","alert_count":%s,"status":"%s","scanned_severity":"CRITICAL"}\n' \
-          "$last_scan" "$alert_count" "$status" > "$scan_file"
+        jq -nc \
+          --arg ls "$last_scan" \
+          --argjson ac "$alert_count" \
+          --arg st "$status" \
+          --argjson c "$counts_json" \
+          --argjson ss "$scanned_severities_json" \
+          '{last_scan:$ls,alert_count:$ac,status:$st,counts:$c,scanned_severities:$ss}' > "$scan_file"
         echo "::notice::Wrote Trivy scan history to $scan_file (alert_count=$alert_count, status=$status)"
 
     - name: Upload SARIF to GitHub Security

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -524,7 +524,7 @@ runs:
         # a piped string: an empty $VULNERABILITY_SEVERITY produces zero records on
         # stdin so `jq -R` emits nothing, leaving --argjson with invalid JSON below.
         scanned_severities_json=$(jq -nc --arg s "$VULNERABILITY_SEVERITY" \
-          'if $s == "" then [] else $s | split(",") | map(ascii_upcase | gsub("^\\s+|\\s+$"; "")) end')
+          'if $s == "" then [] else $s | split(",") | map(ascii_upcase | gsub("^\\s+|\\s+$"; "")) | map(select(. != "")) end')
 
         scan_file=".trivy-scan-history/${container}-${current_tag}-${platform_safe}.json"
         jq -nc \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,14 +21,17 @@ Unless related to the current implementation of these containers, please forward
 
 ### Vulnerability Scanning
 
-All container builds are automatically scanned for CVE vulnerabilities using Trivy:
+All container builds are automatically scanned for CVE vulnerabilities using Trivy.
 
-| Severity | Default Behavior |
-|----------|------------------|
-| CRITICAL | ❌ Blocks push |
-| HIGH | ⚠️ Warning (configurable) |
-| MEDIUM | ℹ️ Logged |
-| LOW | ℹ️ Logged |
+Trivy runs in advisory mode (`continue-on-error: true`) — no severity blocks builds or pushes. All findings are surfaced for transparency.
+
+| Severity | Behavior |
+|----------|----------|
+| CRITICAL | Surfaced on dashboard with red emphasis; reported in GitHub Security tab |
+| HIGH     | Surfaced on dashboard with warning emphasis; reported in GitHub Security tab |
+| MEDIUM   | Surfaced on dashboard (advisory context); reported in GitHub Security tab |
+| LOW      | Surfaced on dashboard (advisory context); reported in GitHub Security tab |
+| UNKNOWN  | Bucketed into INFO column on the 5-cell dashboard grid |
 
 **Features:**
 - Scans OS packages and application dependencies
@@ -42,8 +45,8 @@ All container builds are automatically scanned for CVE vulnerabilities using Tri
 - uses: ./.github/actions/build-container
   with:
     container: mycontainer
-    scan_vulnerabilities: 'true'  # Enable/disable scanning
-    vulnerability_severity: 'CRITICAL'  # Minimum severity to fail
+    scan_vulnerabilities: 'true'                                  # Enable/disable scanning
+    vulnerability_severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'    # Severities surfaced (advisory)
 ```
 
 ### CI/CD Security

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -337,7 +337,7 @@ Builds a specific container using the universal `make` script with enhanced erro
 - `force_rebuild`: Force rebuild even if up-to-date
 - `dockerhub_username`, `dockerhub_token`, `github_token`: Registry credentials
 - `scan_vulnerabilities`: Enable Trivy security scanning (default: `true`)
-- `vulnerability_severity`: Minimum severity to fail build - `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` (default: `CRITICAL`)
+- `vulnerability_severity`: Comma-separated severities surfaced in SARIF + dashboard. Default `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`. **Advisory only** — Trivy runs `continue-on-error: true`; build is never blocked on findings.
 
 **Key Features:**
 - Delegates to universal `make` script with `--bare` mode
@@ -348,10 +348,10 @@ Builds a specific container using the universal `make` script with enhanced erro
 - Build status reporting
 
 **Security Scanning:**
-- Scans for OS and library vulnerabilities after build
-- Blocks push on CRITICAL vulnerabilities by default
-- Generates SARIF reports for GitHub Security integration
-- PR builds show results without blocking
+- Scans for OS and library vulnerabilities after build (all severities: UNKNOWN → CRITICAL)
+- Advisory only — `continue-on-error: true` is permanent policy; no severity level blocks the build
+- Generates SARIF reports for GitHub Security integration (full severity breakdown)
+- Per-severity counts written to `.trivy-scan-history/` for dashboard display
 
 **Build Caching (Registry-based):**
 - Uses GHCR as persistent cache backend (`ghcr.io/<owner>/<container>:buildcache`)

--- a/docs/adr/ADR-008-trivy-severity-policy.md
+++ b/docs/adr/ADR-008-trivy-severity-policy.md
@@ -1,0 +1,81 @@
+# ADR-008: Trivy Severity Policy — Option C (Full Scan, All Severities, CRITICAL = Actionable)
+
+**Status:** Accepted
+**Date:** 2026-05-07
+
+## Context
+
+Phase B (PR #329, Apr 2026) shipped the trust-strip data pipeline including Trivy scan history.
+The pipeline was wired with `vulnerability_severity: CRITICAL` — scanning only CRITICAL findings,
+uploading only CRITICAL findings to SARIF, and writing a side-channel file that set only
+`counts.critical` from `alert_count`.
+
+Meanwhile, the dashboard detail page (`docs/site/_layouts/container-detail.html`) renders a
+**5-cell severity grid** (CRITICAL / HIGH / MEDIUM / LOW / INFO), a design decision established
+in ADR-007 (Phase C trust-strip identity) to serve persona Camille (AppSec engineer — primary
+persona, screenshots the trust-strip into Confluence to justify org-wide image adoption).
+
+The structural mismatch: the CRITICAL-only pipeline made the 4 non-critical cells permanently
+zero. The docs (`docs/site/verify-images.md:55-64`, `docs/GITHUB_ACTIONS.md:340`) stated the
+CRITICAL-only policy explicitly, but the UI implied full-severity coverage. Neither the docs nor
+the UI told the truth about the other.
+
+## Decision
+
+Adopt **Option C**: scan all severities, upload all severities to SARIF, surface all severities
+in the dashboard. CRITICAL remains the primary **actionable** threshold — it gets the strongest visual
+emphasis (red ring, `.nonzero` class). HIGH also receives a warning emphasis. MEDIUM,
+LOW, and INFO render as advisory context with neutral styling.
+
+Blocking semantics are **unchanged**: `continue-on-error: true` on Trivy steps is permanent
+policy; no severity level blocks the build or the push. This is not a change to build policy —
+it is a change to what evidence the trust-strip surface presents.
+
+Specific changes (PR implementing this ADR):
+
+- `vulnerability_severity` input default changed from `CRITICAL` to `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`.
+- SARIF generation step wired to the same input (no longer hardcoded to `CRITICAL`).
+- Scan-history file format extended: `counts` object (all 5 severities) + `scanned_severities`
+  array replace the old `scanned_severity: "CRITICAL"` scalar.
+- `helpers/trivy-utils.sh` side-channel merge rewritten as **overlay-not-replace**: the API
+  result is the base; side-channel overlays `last_scan` and `counts` (authoritative for
+  pipeline-fresh data). Legacy files without `counts` fall back to the `alert_count` → critical
+  back-compat path with no migration required.
+
+## Consequences
+
+**Positive:**
+- The 5-cell severity grid shows real numbers — the Phase B trust-strip investment is fully
+  utilised for persona Camille's evidence-led triage workflow.
+- Docs, CI configuration, and dashboard UI are now consistent.
+- Non-CRITICAL findings become queryable from the dashboard surface, not just via `gh api`.
+
+**Field semantics:**
+- `alert_count` in scan-history files now represents total findings across all surfaced
+  severities, not the CRITICAL count it represented in the pre-Option-C era. The
+  `helpers/trivy-utils.sh` legacy back-compat branch detects pre-Option-C files via the
+  absence of the new `counts` field and treats `alert_count` as `counts.critical` (which
+  it was, by definition, in that era).
+
+**Negative (accepted trade-offs):**
+- GitHub Code Scanning Security tab fills with HIGH/MEDIUM/LOW alerts that are not actionable
+  by the maintainer (upstream base-image advisories). Accepted: transparency-first is the
+  project's stated brand value.
+- SARIF uploads are approximately 30% larger (more rules + results). Accepted: the upload step
+  already runs `continue-on-error: true`; size increase has no operational impact on builds.
+- Code Scanning indexing lag for non-CRITICAL alerts is longer. Mitigated: the side-channel
+  file is written in-pipeline and is always the authoritative source for dashboard counts.
+
+## Alternatives Rejected
+
+| Option | Reason rejected |
+|--------|----------------|
+| **A. Docs-aligned CRITICAL-only** — keep pipeline as-is, remove the 4 non-critical cells from the UI | UI becomes deceptive UX: the 5-cell grid is Phase B's trust-strip identity per ADR-007; removing cells discards the design investment and misleads Camille about scan depth. |
+| **B. UI-aligned, hide non-zero cells** — keep CRITICAL scan, conditionally render only the CRITICAL cell | Same problem as A: wastes Phase B's pipeline investment in scan data and contradicts the evidence-led brand voice ("no marketing fluff → show what was scanned"). |
+
+## References
+
+- `docs/adr/ADR-007-phase-c-redesign.md` — trust-strip identity, persona Camille, Phase B pipeline
+- `helpers/trivy-utils.sh` — side-channel overlay merge implementation
+- `.github/actions/build-container/action.yaml` — `vulnerability_severity` input, scan-history writer
+- `docs/site/verify-images.md` — public-facing severity policy documentation

--- a/docs/adr/ADR-008-trivy-severity-policy.md
+++ b/docs/adr/ADR-008-trivy-severity-policy.md
@@ -25,7 +25,9 @@ the UI told the truth about the other.
 Adopt **Option C**: scan all severities, upload all severities to SARIF, surface all severities
 in the dashboard. CRITICAL remains the primary **actionable** threshold — it gets the strongest visual
 emphasis (red ring, `.nonzero` class). HIGH also receives a warning emphasis. MEDIUM,
-LOW, and INFO render as advisory context with neutral styling.
+LOW, and INFO render as advisory context with neutral styling. (Trivy `UNKNOWN` advisories are bucketed
+into INFO — Trivy SARIF lacks an UNKNOWN field in the 5-cell grid contract; we keep the grid stable
+rather than adding a 6th column for upstream-unclassified entries.)
 
 Blocking semantics are **unchanged**: `continue-on-error: true` on Trivy steps is permanent
 policy; no severity level blocks the build or the push. This is not a change to build policy —

--- a/docs/adr/ADR-008-trivy-severity-policy.md
+++ b/docs/adr/ADR-008-trivy-severity-policy.md
@@ -16,7 +16,7 @@ in ADR-007 (Phase C trust-strip identity) to serve persona Camille (AppSec engin
 persona, screenshots the trust-strip into Confluence to justify org-wide image adoption).
 
 The structural mismatch: the CRITICAL-only pipeline made the 4 non-critical cells permanently
-zero. The docs (`docs/site/verify-images.md:55-64`, `docs/GITHUB_ACTIONS.md:340`) stated the
+zero. The docs (`docs/site/verify-images.md` and `docs/GITHUB_ACTIONS.md`) stated the
 CRITICAL-only policy explicitly, but the UI implied full-severity coverage. Neither the docs nor
 the UI told the truth about the other.
 

--- a/docs/site/_includes/components/verify-walkthrough.html
+++ b/docs/site/_includes/components/verify-walkthrough.html
@@ -45,7 +45,7 @@
   --paginate \
   -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'</code></pre>
         </div>
-        <p>To filter to a single variant, match on the <code>category</code> field — it encodes the container name and platform (e.g. <code>container-postgres-18-alpine-linux/amd64</code>). The dashboard surfaces only CRITICAL counts; everything else is accessible through the API call above.</p>
+        <p>To filter to a single variant, match on the <code>category</code> field — it encodes the container name and platform (e.g. <code>container-postgres-18-alpine-linux/amd64</code>). The dashboard surfaces all scanned severities (CRITICAL through INFO); CRITICAL and HIGH are visually emphasised, the rest render as advisory context.</p>
       </div>
     </li>
 

--- a/docs/site/_includes/components/verify-walkthrough.html
+++ b/docs/site/_includes/components/verify-walkthrough.html
@@ -45,7 +45,7 @@
   --paginate \
   -q '.[] | {rule_id: .rule.id, severity: .rule.severity, category: .most_recent_instance.category, package: .most_recent_instance.location.path}'</code></pre>
         </div>
-        <p>To filter to a single variant, match on the <code>category</code> field — it encodes the container name and platform (e.g. <code>container-postgres-18-alpine-linux/amd64</code>). The dashboard surfaces all scanned severities (CRITICAL through INFO); CRITICAL and HIGH are visually emphasised, the rest render as advisory context.</p>
+        <p>To filter to a single variant, match on the <code>category</code> field — it encodes the container name and platform (e.g. <code>container-postgres-18-alpine-linux/amd64</code>). The dashboard surfaces all scanned severities (CRITICAL through INFO); CRITICAL and HIGH are visually emphasised, the rest render as advisory context. Trivy <code>UNKNOWN</code> findings (severity unclassified upstream) are bucketed into the INFO column.</p>
       </div>
     </li>
 

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -52,16 +52,11 @@ To filter findings to a single container variant, match on the `category` field,
   -q '.[] | select(.most_recent_instance.category == "container-postgres-18-alpine-linux/amd64")'</code></pre>
 </div>
 
-### Why the dashboard only highlights CRITICAL counts
+### Per-severity breakdown
 
-Each container card's Trivy badge surfaces the count of **CRITICAL**-severity findings only. High, medium, low, and informational findings are still scanned, still uploaded to GitHub Code Scanning, and still queryable through the API command above — they are intentionally not promoted to the dashboard headline.
+Each container's detail page surfaces all scanned severities (CRITICAL → INFO). CRITICAL gets the strongest visual emphasis (red ring); HIGH gets a warning emphasis. MEDIUM, LOW, and INFO render as advisory context with neutral styling. All findings, including non-blocking ones, are uploaded to GitHub Code Scanning under category `container-<name>-<tag>-<platform>`; query the full advisory list via the `gh api` command above.
 
-Two reasons for this choice:
-
-- **Signal vs noise.** A solo-maintained container catalog routinely carries dozens of low/medium advisories that originate in upstream base images and that the maintainer cannot fix directly. Showing the full count on the dashboard would normalize a constantly red badge and erode the meaning of "go look at this image's security posture." CRITICAL is the cut-off where downstream consumers should pause and verify before pulling.
-- **Defense in depth, not single source of truth.** GitHub's Security tab (and the `gh api` query above) remains the authoritative full-detail view for anyone running their own risk assessment. The dashboard is a glanceable surface, not a replacement for the Code Scanning UI.
-
-If you operate this catalog yourself and prefer a different threshold, the SARIF severity filter lives in `.github/actions/build-container/action.yaml` (search for the `trivy-action` step) and the dashboard summary aggregation in `helpers/trivy-utils.sh`. Both are plain code; widening the threshold is a one-line change in each file plus a fresh dashboard regeneration.
+The scan policy runs all severities (`UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) in advisory mode — full scan chosen for transparency over alert-list cleanliness. `continue-on-error: true` is permanent policy — no severity level blocks the build. The severity parameter lives in `.github/actions/build-container/action.yaml` (`vulnerability_severity` input, default `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) and can be narrowed per-call if alert volume becomes operationally noisy.
 
 ## Inspecting multi-arch manifests
 

--- a/docs/site/verify-images.md
+++ b/docs/site/verify-images.md
@@ -54,7 +54,7 @@ To filter findings to a single container variant, match on the `category` field,
 
 ### Per-severity breakdown
 
-Each container's detail page surfaces all scanned severities (CRITICAL → INFO). CRITICAL gets the strongest visual emphasis (red ring); HIGH gets a warning emphasis. MEDIUM, LOW, and INFO render as advisory context with neutral styling. All findings, including non-blocking ones, are uploaded to GitHub Code Scanning under category `container-<name>-<tag>-<platform>`; query the full advisory list via the `gh api` command above.
+Each container's detail page surfaces all scanned severities (CRITICAL → INFO). CRITICAL gets the strongest visual emphasis (red ring); HIGH gets a warning emphasis. MEDIUM, LOW, and INFO render as advisory context with neutral styling. Findings tagged `UNKNOWN` by Trivy (severity not classified upstream) are bucketed into the **INFO** column. All findings, including non-blocking ones, are uploaded to GitHub Code Scanning under category `container-<name>-<tag>-<platform>`; query the full advisory list via the `gh api` command above.
 
 The scan policy runs all severities (`UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) in advisory mode — full scan chosen for transparency over alert-list cleanliness. `continue-on-error: true` is permanent policy — no severity level blocks the build. The severity parameter lives in `.github/actions/build-container/action.yaml` (`vulnerability_severity` input, default `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) and can be narrowed per-call if alert volume becomes operationally noisy.
 

--- a/helpers/trivy-utils.sh
+++ b/helpers/trivy-utils.sh
@@ -168,23 +168,48 @@ get_trivy_summary() {
     # "Cannot index array with string 'last_scan'", silently blanking the
     # entire variant entry in containers.yml. Force the empty form on any
     # type mismatch.
-    # Side-channel takes precedence over API when present. The Code Scanning
-    # API indexes SARIF uploads asynchronously and can lag the in-pipeline
-    # scan by minutes; the side-channel was written by THIS very pipeline run
-    # and is therefore the authoritative source of truth for "what did this
-    # scan produce". When the side-channel exists we synthesize the entire
-    # summary from `_TRIVY_EMPTY` and overlay side-channel fields, so any stale
-    # API data (e.g. old open advisories that the latest scan no longer flags)
-    # is dropped. The SARIF upload is CRITICAL-only by policy (see
-    # `/verify-images/`), so `alert_count` IS the critical count by definition;
-    # high/medium/low/info stay zero and top_advisories stays empty.
+    # Option C overlay model (see ADR-008): the Code Scanning API indexes SARIF
+    # uploads asynchronously and can lag the in-pipeline scan by minutes; the
+    # side-channel was written by THIS very pipeline run and is authoritative for
+    # "what did this scan produce". When the side-channel exists we overlay its
+    # fields onto the API result (base), so the dashboard shows THIS pipeline's
+    # fresh counts while preserving top_advisories from the API. The API result
+    # is the base when it is a valid object; _TRIVY_EMPTY is the fallback.
+    # New scan-history files (Option C, post-ADR-008) carry a `counts` object
+    # covering all severities; legacy files carry only `alert_count` (= critical
+    # count by old CRITICAL-only policy). Back-compat: absence of `counts` in
+    # the side-channel triggers the legacy path which sets only counts.critical.
     if [[ -n "$sc_last_scan" ]]; then
-        local sc_alert_count
+        local base
+        if [[ -n "$result" ]] && echo "$result" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            base="$result"
+        else
+            base="$_TRIVY_EMPTY"
+        fi
+
+        local sc_counts sc_alert_count
+        sc_counts=$(jq -c '.counts // empty' "$sc_file" 2>/dev/null || true)
         sc_alert_count=$(jq -r '.alert_count // 0' "$sc_file" 2>/dev/null || echo 0)
-        echo "$_TRIVY_EMPTY" | jq \
-            --arg ls "$sc_last_scan" \
-            --argjson ac "$sc_alert_count" \
-            '.last_scan = $ls | .counts.critical = $ac'
+
+        if [[ -n "$sc_counts" ]]; then
+            # New format (Option C): partial-overlay merge onto base.
+            # (.counts + $sc) merges objects: keys present in $sc override the
+            # corresponding keys in base; keys absent from $sc are preserved from
+            # base (API). Today's writer always emits all 5 keys, so partial
+            # overlay is forward-compat for future writers that may emit subsets
+            # (e.g. only counts.critical). Side-channel is authoritative only for
+            # the keys it supplies; remaining keys fall back to the API result.
+            echo "$base" | jq \
+                --arg ls "$sc_last_scan" \
+                --argjson sc "$sc_counts" \
+                '.last_scan = $ls | .counts = (.counts + $sc)'
+        else
+            # Legacy format (pre-Option-C): only alert_count = critical count.
+            echo "$base" | jq \
+                --arg ls "$sc_last_scan" \
+                --argjson ac "$sc_alert_count" \
+                '.last_scan = $ls | .counts.critical = $ac'
+        fi
         return 0
     fi
 
@@ -288,6 +313,132 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     else
         echo "FAIL test-2: expected counts.critical=3, got: $critical2"
         echo "Full result: $result2"
+        exit 1
+    fi
+
+    # Test 3: side-channel with new Option C shape (counts object), API map empty.
+    # Expected: all five severity counts propagated from side-channel.
+    printf '{"last_scan":"2026-05-07T09:00:00Z","alert_count":11,"status":"dirty","counts":{"critical":5,"high":3,"medium":2,"low":1,"info":0},"scanned_severities":["UNKNOWN","LOW","MEDIUM","HIGH","CRITICAL"]}\n' \
+        > "$_test_dir/.trivy-scan-history/container-allsev-3.0-linux-amd64.json"
+
+    pushd "$_test_dir" > /dev/null
+
+    _TRIVY_ALERTS_CACHE="[]"
+    _TRIVY_SUMMARY_MAP="{}"
+
+    result3=$(get_trivy_summary "container-container-allsev-3.0-linux/amd64")
+
+    popd > /dev/null
+
+    critical3=$(echo "$result3" | jq -r '.counts.critical')
+    high3=$(echo "$result3" | jq -r '.counts.high')
+    medium3=$(echo "$result3" | jq -r '.counts.medium')
+    low3=$(echo "$result3" | jq -r '.counts.low')
+
+    if [[ "$critical3" == "5" && "$high3" == "3" && "$medium3" == "2" && "$low3" == "1" ]]; then
+        echo "PASS test-3: all severity counts propagated (critical=$critical3 high=$high3 medium=$medium3 low=$low3)"
+    else
+        echo "FAIL test-3: expected critical=5 high=3 medium=2 low=1, got: critical=$critical3 high=$high3 medium=$medium3 low=$low3"
+        echo "Full result: $result3"
+        exit 1
+    fi
+
+    # Test 4: API map has counts for category X; side-channel for X has new-format counts.
+    # Side-channel is authoritative for ALL severities (full-object replace of .counts).
+    # Expected: side-channel counts win entirely; last_scan from side-channel (fresh).
+    mkdir -p "$_test_dir/.trivy-scan-history"
+    printf '{"last_scan":"2026-05-07T10:00:00Z","alert_count":1,"status":"dirty","counts":{"critical":1,"high":0,"medium":0,"low":0,"info":0},"scanned_severities":["UNKNOWN","LOW","MEDIUM","HIGH","CRITICAL"]}\n' \
+        > "$_test_dir/.trivy-scan-history/container-apiovrl-4.0-linux-amd64.json"
+
+    pushd "$_test_dir" > /dev/null
+
+    _TRIVY_ALERTS_CACHE="[]"
+    # Inject API result for category X (simulates pre-existing Code Scanning data)
+    _TRIVY_SUMMARY_MAP=$(jq -nc '{
+        "container-container-apiovrl-4.0-linux/amd64": {
+            "last_scan": "2026-05-06T08:00:00Z",
+            "counts": {"critical": 0, "high": 4, "medium": 2, "low": 0, "info": 0},
+            "top_advisories": [{"rule_id":"CVE-2025-0001","severity":"high","title":"test","package_name":"libfoo"}]
+        }
+    }')
+
+    result4=$(get_trivy_summary "container-container-apiovrl-4.0-linux/amd64")
+
+    popd > /dev/null
+
+    critical4=$(echo "$result4" | jq -r '.counts.critical')
+    high4=$(echo "$result4" | jq -r '.counts.high')
+    last_scan4=$(echo "$result4" | jq -r '.last_scan')
+
+    if [[ "$critical4" == "1" && "$high4" == "0" && "$last_scan4" == "2026-05-07T10:00:00Z" ]]; then
+        echo "PASS test-4: side-channel counts override API entirely (critical=$critical4 high=$high4 last_scan=$last_scan4)"
+    else
+        echo "FAIL test-4: expected critical=1 high=0 last_scan=2026-05-07T10:00:00Z"
+        echo "  got: critical=$critical4 high=$high4 last_scan=$last_scan4"
+        echo "Full result: $result4"
+        exit 1
+    fi
+
+    # Test 5: no side-channel file for category Y, but API map has counts for Y.
+    # Expected: API counts surface unchanged.
+    pushd "$_test_dir" > /dev/null
+
+    _TRIVY_ALERTS_CACHE="[]"
+    _TRIVY_SUMMARY_MAP=$(jq -nc '{
+        "container-container-apionly-5.0-linux/amd64": {
+            "last_scan": "2026-05-07T07:00:00Z",
+            "counts": {"critical": 0, "high": 2, "medium": 3, "low": 1, "info": 0},
+            "top_advisories": []
+        }
+    }')
+
+    result5=$(get_trivy_summary "container-container-apionly-5.0-linux/amd64")
+
+    popd > /dev/null
+
+    high5=$(echo "$result5" | jq -r '.counts.high')
+    medium5=$(echo "$result5" | jq -r '.counts.medium')
+
+    if [[ "$high5" == "2" && "$medium5" == "3" ]]; then
+        echo "PASS test-5: API-only category returns API counts unchanged (high=$high5 medium=$medium5)"
+    else
+        echo "FAIL test-5: expected high=2 medium=3 from API, got: high=$high5 medium=$medium5"
+        echo "Full result: $result5"
+        exit 1
+    fi
+
+    # Test 6: partial side-channel counts (only critical) — API high/medium MUST be preserved.
+    # Locks the partial-overlay merge contract: keys absent from side-channel are kept from API.
+    mkdir -p "$_test_dir/.trivy-scan-history"
+    printf '{"last_scan":"2026-05-07T12:00:00Z","alert_count":1,"status":"dirty","counts":{"critical":1}}\n' \
+        > "$_test_dir/.trivy-scan-history/container-partial-6.0-linux-amd64.json"
+
+    pushd "$_test_dir" > /dev/null
+
+    _TRIVY_ALERTS_CACHE="[]"
+    _TRIVY_SUMMARY_MAP=$(jq -nc '{
+        "container-container-partial-6.0-linux/amd64": {
+            "last_scan": "2026-05-06T08:00:00Z",
+            "counts": {"critical": 0, "high": 4, "medium": 2, "low": 0, "info": 0},
+            "top_advisories": []
+        }
+    }')
+
+    result6=$(get_trivy_summary "container-container-partial-6.0-linux/amd64")
+
+    popd > /dev/null
+
+    critical6=$(echo "$result6" | jq -r '.counts.critical')
+    high6=$(echo "$result6" | jq -r '.counts.high')
+    medium6=$(echo "$result6" | jq -r '.counts.medium')
+    last_scan6=$(echo "$result6" | jq -r '.last_scan')
+
+    if [[ "$critical6" == "1" && "$high6" == "4" && "$medium6" == "2" && "$last_scan6" == "2026-05-07T12:00:00Z" ]]; then
+        echo "PASS test-6: partial side-channel overlay (critical=$critical6 overridden; high=$high6 medium=$medium6 preserved from API; last_scan=$last_scan6)"
+    else
+        echo "FAIL test-6: expected critical=1 high=4 medium=2 last_scan=2026-05-07T12:00:00Z"
+        echo "  got: critical=$critical6 high=$high6 medium=$medium6 last_scan=$last_scan6"
+        echo "Full result: $result6"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- Trivy now scans **all severities** (UNKNOWN→CRITICAL) and uploads the full SARIF to GitHub Code Scanning. The dashboard's 5-cell severity grid was structurally always-zero for HIGH/MEDIUM/LOW/INFO; it now reflects real per-severity counts from each scan.
- `continue-on-error: true` is preserved — Trivy stays advisory, no build blocking. CRITICAL+HIGH get visual emphasis (red ring / warning); others render as advisory context.
- `helpers/trivy-utils.sh` side-channel branch rewritten: API result is now the base, side-channel `counts` overlay onto it (partial-overlay semantics — keys absent in side-channel preserve API values). Legacy back-compat path retained for pre-PR scan-history files via the absence of the `counts` field.
- Decision recorded in [docs/adr/ADR-008-trivy-severity-policy.md](docs/adr/ADR-008-trivy-severity-policy.md). Public-page docs (`verify-images.md`, `GITHUB_ACTIONS.md`, `verify-walkthrough.html`) aligned.

## Test plan

- [x] `bash helpers/trivy-utils.sh` self-test (6 cases: clean / legacy CRITICAL-only / new per-severity / side-channel-overrides-API / API-only / partial-overlay merge contract)
- [x] `bats tests/unit/trivy-cache.bats tests/unit/dashboard-helpers.bats tests/unit/data-completeness.bats` (41/41 pass)
- [x] `shellcheck helpers/trivy-utils.sh` clean
- [x] Senior code review (opus) + 2 codex (xhigh) passes — final verdict SHIP
- [ ] Validate against a real CI run (PR builds will exercise the new SARIF severity extraction jq end-to-end on actual scan output)
- [ ] Inspect regenerated dashboard locally after merge → confirm non-zero `high/medium/low/info` counts surface for at least one container with known historical CVEs
