### PR TITLE
feat(variant-action-bar): pull command + registry toggle in sticky bandeau

### DIFF
--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -69,6 +69,23 @@ variant-action-bar {
   display: none;
 }
 
+/* Collapsed signals row: spread signals left, actions right — no wrapping */
+[data-collapsed] .vab-row--signals {
+  justify-content: space-between;
+  flex-wrap: nowrap;
+}
+
+/* Prevent AMD64/ARM64 from wrapping to a second clipped line */
+[data-collapsed] .vab-signals {
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+[data-collapsed] .vab-signal-value,
+[data-collapsed] .vab-signal-label {
+  white-space: nowrap;
+}
+
 /* (toggle removed — scrolling back up re-expands via IntersectionObserver) */
 
 @media (prefers-reduced-motion: reduce) {
@@ -327,6 +344,100 @@ variant-action-bar {
 }
 
 /* ----------------------------------------------------------
+   Collapsed-mode actions group (registry mini-toggle + mini copy button)
+   Hidden in expanded mode via display:none; revealed only when [data-collapsed].
+   ---------------------------------------------------------- */
+
+.vab-collapsed-actions {
+  display: none;
+}
+
+[data-collapsed] .vab-collapsed-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  flex-shrink: 0;
+}
+
+/* Mini registry toggle pills */
+.vab-collapsed-actions .vab-registry-mini {
+  font-size: var(--font-size-caption, 12px);
+  padding: 2px 8px;
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid var(--color-variant-tag-border, rgba(139,92,246,0.25));
+  background: transparent;
+  color: var(--color-text-muted, #8A93A0);
+  cursor: pointer;
+  font-family: var(--font-family-mono, monospace);
+  letter-spacing: var(--letter-spacing-wider, 0.04em);
+  text-transform: uppercase;
+  font-weight: var(--font-weight-medium, 500);
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  transition:
+    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    border-color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+}
+
+.vab-collapsed-actions .vab-registry-mini[aria-pressed="true"] {
+  background: var(--color-variant-tag-bg, rgba(139,92,246,0.15));
+  color: var(--color-variant-tag-fg, var(--color-violet-400, #A78BFA));
+  border-color: var(--color-variant-tag-fg, var(--color-violet-400, #A78BFA));
+}
+
+.vab-collapsed-actions .vab-registry-mini:hover {
+  border-color: var(--color-variant-tag-fg, var(--color-violet-400, #A78BFA));
+  color: var(--color-variant-tag-fg, var(--color-violet-400, #A78BFA));
+}
+
+.vab-collapsed-actions .vab-registry-mini:focus-visible {
+  outline: 3px solid var(--color-violet-400, #A78BFA);
+  outline-offset: 2px;
+}
+
+/* Compact copy button */
+.vab-collapsed-actions .vab-copy-mini {
+  background: transparent;
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
+  color: var(--color-text-primary, #F4F5F7);
+  border-radius: var(--radius-sm, 4px);
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: var(--font-size-caption, 12px);
+  font-family: var(--font-family-mono, monospace);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+  transition:
+    background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    border-color var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+    color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+}
+
+.vab-collapsed-actions .vab-copy-mini:hover {
+  background: var(--color-surface-elevated, rgba(255,255,255,0.05));
+  border-color: var(--color-text-muted, #8A93A0);
+}
+
+.vab-collapsed-actions .vab-copy-mini.vab-copy-mini--copied {
+  color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+  border-color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+}
+
+.vab-collapsed-actions .vab-copy-mini:focus-visible {
+  outline: 3px solid var(--color-action-primary, #60A5FA);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vab-collapsed-actions .vab-registry-mini,
+  .vab-collapsed-actions .vab-copy-mini { transition: none; }
+}
+
+/* ----------------------------------------------------------
    Light theme overrides
    ---------------------------------------------------------- */
 
@@ -357,4 +468,9 @@ variant-action-bar {
   [data-collapsed] .vab-card {
     padding: var(--space-xs, 4px) var(--space-sm, 8px);
   }
+
+  [data-collapsed] .vab-row--signals { gap: var(--space-sm, 8px); }
+  [data-collapsed] .vab-collapsed-actions { gap: 3px; }
+  [data-collapsed] .vab-collapsed-actions .vab-registry-mini { padding: 2px 6px; font-size: 11px; }
+  [data-collapsed] .vab-collapsed-actions .vab-copy-mini { padding: 4px 6px; }
 }

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -28,6 +28,12 @@
       if (this._resizeHandler) { window.removeEventListener('resize', this._resizeHandler); }
       // F7: remove version-tabs-changed listener to prevent leak on DOM re-attach
       if (this._versionTabsHandler) { document.removeEventListener('version-tabs-changed', this._versionTabsHandler); }
+      // M-B: remove delegated listeners; reset guard so _attachListeners works on next connectedCallback
+      if (this._listenersAttached) {
+        this.removeEventListener('click', this._onClick);
+        this.removeEventListener('keydown', this._onKeydown);
+        this._listenersAttached = false;
+      }
     }
 
     // -------------------------------------------------------
@@ -199,6 +205,7 @@
       var row3 = document.createElement('div');
       row3.className = 'vab-row vab-row--signals';
       row3.appendChild(this._makeSignalsStrip());
+      row3.appendChild(this._makeCollapsedActions());
       card.appendChild(row3);
 
       // Store refs
@@ -319,6 +326,66 @@
       return strip;
     }
 
+
+    // Build the collapsed-state actions group (registry mini-toggle + mini copy button).
+    // Hidden via CSS in expanded mode; shown only when [data-collapsed] is set on the host.
+    _makeCollapsedActions() {
+      var wrap = document.createElement('div');
+      wrap.className = 'vab-collapsed-actions';
+
+      // Only render registry toggle when there are multiple registries
+      if (this._registries && this._registries.length > 1) {
+        for (var i = 0; i < this._registries.length; i++) {
+          var reg = this._registries[i];
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'vab-registry-mini';
+          btn.setAttribute('data-vab-mini-registry', reg.id);
+          btn.setAttribute('aria-pressed', reg.id === this._selectedRegistry ? 'true' : 'false');
+          // Short labels: GHCR stays as-is; Docker Hub → DH
+          btn.textContent = reg.id === 'dockerhub' ? 'DH' : reg.label;
+          wrap.appendChild(btn);
+        }
+      }
+
+      // Compact pull-command copy button
+      var copyBtn = document.createElement('button');
+      copyBtn.type = 'button';
+      copyBtn.className = 'vab-copy-mini';
+      copyBtn.setAttribute('data-vab-mini-copy', 'pull');
+      // S-4: dynamic label set here; _updateCollapsedActionsState keeps it in sync
+      copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+      // S-2: explicit classes so _onMiniCopyClick can use stable selectors
+      var icon = document.createElement('span');
+      icon.className = 'vab-copy-mini__icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = '⧉'; // ⧉
+      copyBtn.appendChild(icon);
+      var label = document.createElement('span');
+      // S-3: no leading space — gap is handled by CSS gap:4px on the parent
+      label.className = 'vab-copy-mini__label';
+      label.textContent = 'pull';
+      copyBtn.appendChild(label);
+      wrap.appendChild(copyBtn);
+
+      return wrap;
+    }
+
+    // Sync collapsed-actions buttons (aria-pressed) to current _selectedRegistry.
+    // Called after any registry change and on initial render (via _updateCommands).
+    _updateCollapsedActionsState() {
+      var miniBtns = this.querySelectorAll('[data-vab-mini-registry]');
+      for (var i = 0; i < miniBtns.length; i++) {
+        var active = miniBtns[i].getAttribute('data-vab-mini-registry') === this._selectedRegistry;
+        miniBtns[i].setAttribute('aria-pressed', active ? 'true' : 'false');
+      }
+      // S-4: update mini copy button aria-label to reflect current registry
+      var copyBtn = this.querySelector('[data-vab-mini-copy]');
+      if (copyBtn) { copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry)); }
+    }
+
+
+
     // -------------------------------------------------------
     // Update content when variant changes
     // -------------------------------------------------------
@@ -360,6 +427,9 @@
           if (existingNote) { verifyBlock.removeChild(existingNote); }
         }
       }
+
+      // Keep collapsed-actions mini toggle in sync
+      this._updateCollapsedActionsState();
     }
 
     _extractOwner(base) {
@@ -433,6 +503,33 @@
     // Copy to clipboard
     // -------------------------------------------------------
 
+    // S-4: builds the dynamic aria-label for the mini copy button.
+    _buildCopyAriaLabel(reg) {
+      var name = reg === 'dockerhub' ? 'Docker Hub' : 'GHCR';
+      return 'Copy ' + name + ' pull command';
+    }
+
+    // M-A: single clipboard helper — resolves only on success, rejects on failure.
+    // Callers must NOT call showCopied in .catch().
+    _writeToClipboard(text) {
+      if (window.isSecureContext && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        return navigator.clipboard.writeText(text);
+      }
+      return new Promise(function (resolve, reject) {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        var ok = false;
+        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+        document.body.removeChild(ta);
+        if (ok) { resolve(); } else { reject(new Error('execCommand(copy) failed')); }
+      });
+    }
+
     _onCopyClick(type) {
       var codeEl = this.querySelector('[data-vab-cmd="' + type + '"]');
       if (!codeEl) { return; }
@@ -440,6 +537,7 @@
       var btnEl = this.querySelector('[data-vab-copy="' + type + '"]');
       var iconEl = btnEl && btnEl.querySelector('.vab-copy-icon');
 
+      // M-A: confirmation only on success — .catch swallows silently
       var showCopied = function () {
         if (iconEl) { iconEl.textContent = '✓'; } // ✓
         if (btnEl) { btnEl.classList.add('vab-copy-btn--copied'); }
@@ -449,20 +547,40 @@
         }, 2000);
       };
 
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(text).then(showCopied).catch(showCopied);
-      } else {
-        var ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        try { document.execCommand('copy'); } catch (e) {}
-        document.body.removeChild(ta);
-        showCopied();
-      }
+      this._writeToClipboard(text).then(showCopied).catch(function () { /* copy failed — do not confirm */ });
     }
+
+
+    // Copy handler for the collapsed mini copy button.
+    // Reads the current pull command text (already set by _updateCommands)
+    // and writes it to clipboard, mirroring the expanded _onCopyClick pattern.
+    _onMiniCopyClick() {
+      var codeEl = this.querySelector('[data-vab-cmd="pull"]');
+      if (!codeEl) { return; }
+      var text = codeEl.textContent || '';
+
+      // S-2: stable class selectors (not fragile attribute-presence selectors)
+      var miniBtn = this.querySelector('[data-vab-mini-copy]');
+      var iconEl = miniBtn && miniBtn.querySelector('.vab-copy-mini__icon');
+      var labelEl = miniBtn && miniBtn.querySelector('.vab-copy-mini__label');
+
+      // M-A: confirmation only on success — .catch swallows silently
+      var showCopied = function () {
+        if (iconEl) { iconEl.textContent = '✓'; }
+        // S-3: no leading space — gap handled by CSS gap:4px on parent
+        if (labelEl) { labelEl.textContent = 'copied'; }
+        if (miniBtn) { miniBtn.classList.add('vab-copy-mini--copied'); }
+        setTimeout(function () {
+          if (iconEl) { iconEl.textContent = '⧉'; }
+          if (labelEl) { labelEl.textContent = 'pull'; }
+          if (miniBtn) { miniBtn.classList.remove('vab-copy-mini--copied'); }
+        }, 2000);
+      };
+
+      this._writeToClipboard(text).then(showCopied).catch(function () { /* copy failed — do not confirm */ });
+    }
+
+
 
     // -------------------------------------------------------
     // Custom event dispatch (new + legacy bridge)
@@ -594,47 +712,66 @@
     // Delegated event listeners
     // -------------------------------------------------------
 
+    // M-B: delegated click handler — stored as bound ref so it can be removed on disconnect
+    _onClick(e) {
+      var rPill = e.target.closest('.vab-registry-pill');
+      if (rPill) { this._onRegistryPillClick(rPill.dataset.value); return; }
+
+      var vPill = e.target.closest('.vab-version-pill');
+      if (vPill) { this._onVersionPillClick(vPill.dataset.value); return; }
+
+      var fPill = e.target.closest('.vab-flavor-pill');
+      if (fPill) { this._onFlavorPillClick(fPill.dataset.value); return; }
+
+      var copyBtn = e.target.closest('.vab-copy-btn');
+      if (copyBtn) { this._onCopyClick(copyBtn.getAttribute('data-vab-copy')); return; }
+
+      // Collapsed-mode mini registry toggle
+      var miniReg = e.target.closest('[data-vab-mini-registry]');
+      if (miniReg) { this._onRegistryPillClick(miniReg.getAttribute('data-vab-mini-registry')); return; }
+
+      // Collapsed-mode mini copy button
+      var miniCopy = e.target.closest('[data-vab-mini-copy]');
+      if (miniCopy) { this._onMiniCopyClick(); return; }
+    }
+
+    // M-B: delegated keydown handler — stored as bound ref so it can be removed on disconnect
+    // F4: keyboard navigation for radiogroup pills (WAI-ARIA APG roving tabindex).
+    // ArrowLeft/Right move focus+selection; Home/End jump to first/last.
+    _onKeydown(e) {
+      var pill = e.target.closest('.vab-registry-pill, .vab-version-pill, .vab-flavor-pill');
+      if (!pill) { return; }
+      var keys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
+      if (keys.indexOf(e.key) === -1) { return; }
+      e.preventDefault();
+      var group = pill.parentElement;
+      var pills = Array.prototype.slice.call(group.querySelectorAll('button'));
+      var idx = pills.indexOf(pill);
+      var next;
+      if (e.key === 'ArrowLeft')       { next = (idx - 1 + pills.length) % pills.length; }
+      else if (e.key === 'ArrowRight') { next = (idx + 1) % pills.length; }
+      else if (e.key === 'Home')       { next = 0; }
+      else                             { next = pills.length - 1; }
+      pills[next].focus();
+      pills[next].click();
+    }
+
     _attachListeners() {
-      var self = this;
+      // M-B: idempotent guard — prevents listener accumulation on DOM re-attach
+      if (this._listenersAttached) { return; }
 
-      this.addEventListener('click', function (e) {
-        var rPill = e.target.closest('.vab-registry-pill');
-        if (rPill) { self._onRegistryPillClick(rPill.dataset.value); return; }
-
-        var vPill = e.target.closest('.vab-version-pill');
-        if (vPill) { self._onVersionPillClick(vPill.dataset.value); return; }
-
-        var fPill = e.target.closest('.vab-flavor-pill');
-        if (fPill) { self._onFlavorPillClick(fPill.dataset.value); return; }
-
-        var copyBtn = e.target.closest('.vab-copy-btn');
-        if (copyBtn) { self._onCopyClick(copyBtn.getAttribute('data-vab-copy')); return; }
-      });
-
-      // F4: keyboard navigation for radiogroup pills (WAI-ARIA APG roving tabindex).
-      // ArrowLeft/Right move focus+selection; Home/End jump to first/last.
-      this.addEventListener('keydown', function (e) {
-        var pill = e.target.closest('.vab-registry-pill, .vab-version-pill, .vab-flavor-pill');
-        if (!pill) { return; }
-        var keys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
-        if (keys.indexOf(e.key) === -1) { return; }
-        e.preventDefault();
-        var group = pill.parentElement;
-        var pills = Array.prototype.slice.call(group.querySelectorAll('button'));
-        var idx = pills.indexOf(pill);
-        var next;
-        if (e.key === 'ArrowLeft')       { next = (idx - 1 + pills.length) % pills.length; }
-        else if (e.key === 'ArrowRight') { next = (idx + 1) % pills.length; }
-        else if (e.key === 'Home')       { next = 0; }
-        else                             { next = pills.length - 1; }
-        pills[next].focus();
-        pills[next].click();
-      });
+      // Bind once so removeEventListener in disconnectedCallback matches the same ref
+      this._onClick = this._onClick.bind(this);
+      this._onKeydown = this._onKeydown.bind(this);
+      this.addEventListener('click', this._onClick);
+      this.addEventListener('keydown', this._onKeydown);
 
       // F7: store bound handler reference so disconnectedCallback can remove it cleanly.
       // F1: _onVersionTabsChanged has the re-entry guard (source === 'variant-action-bar').
       this._versionTabsHandler = this._onVersionTabsChanged.bind(this);
       document.addEventListener('version-tabs-changed', this._versionTabsHandler);
+
+      this._listenersAttached = true;
     }
   }
 

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -342,7 +342,9 @@
           btn.className = 'vab-registry-mini';
           btn.setAttribute('data-vab-mini-registry', reg.id);
           btn.setAttribute('aria-pressed', reg.id === this._selectedRegistry ? 'true' : 'false');
-          // Short labels: GHCR stays as-is; Docker Hub → DH
+          // Visible text is shortened to fit the sticky bar; aria-label keeps
+          // the full registry name accessible to screen readers.
+          btn.setAttribute('aria-label', 'Pull from ' + reg.label);
           btn.textContent = reg.id === 'dockerhub' ? 'DH' : reg.label;
           wrap.appendChild(btn);
         }


### PR DESCRIPTION
## Summary

The sticky/collapsed `<variant-action-bar>` now carries the same primary action as the expanded form — pulling the image — without forcing a scroll back to the top.

- **Registry toggle (GHCR ↔ DH)** in the sticky bar, wired to `_selectedRegistry`. Switching from the sticky strip updates the expanded pills and the pull command in lockstep.
- **Pull-copy button** that copies the currently-selected pull command. Confirms only on real clipboard write success (Promise-based `_writeToClipboard` helper, replacing the duplicated try/catch on both copy paths).
- **AMD64 size always visible**: `flex-wrap: nowrap` on collapsed signals — the row no longer falls to a clipped second line on narrow viewports.
- **Lifecycle hardening**: bound handler refs on the instance, idempotent `_attachListeners`, real `disconnectedCallback` cleanup. Listeners no longer stack up on DOM-move / SPA reconnects.
- Dynamic `aria-label` ("Copy GHCR pull command" / "Copy Docker Hub pull command") so screen-reader users hear which registry the button targets.

## Test plan

- [x] State-sync traced across 4 entry paths (initial render / expanded pill click / mini toggle click / `version-tabs-changed` event) — `aria-pressed`, mini `aria-label`, and pull command stay consistent
- [x] Single-registry pages: toggle skipped via `_registries.length > 1` guard; copy button still rendered
- [x] Clipboard fallback (textarea + `execCommand('copy')`) preserved for non-secure-context / older browsers
- [ ] Visual smoke on a narrow viewport (≤ 800px wide) — confirm AMD64 stays on one line
- [ ] Keyboard nav through sticky bar reaches both mini toggle and copy button; Enter/Space activate
