### PR TITLE
fix(build-extensions): skip extension rebuild when image already in registry

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -39,7 +39,7 @@ on:
         type: string
         default: ''
       scope_extensions:
-        description: 'Comma-separated extensions to rebuild (e.g., "citus"). Empty = all.'
+        description: 'Comma-separated extensions to consider for build (skipped when image already exists in registry; pass `force` rebuild mode to override). Empty = all.'
         required: false
         type: string
         default: ''
@@ -128,7 +128,7 @@ on:
         type: string
         default: ''
       scope_extensions:
-        description: 'Comma-separated extensions to rebuild (e.g., "citus"). Empty = all.'
+        description: 'Comma-separated extensions to consider for build (skipped when image already exists in registry; pass `force` rebuild mode to override). Empty = all.'
         required: false
         type: string
         default: ''
@@ -247,9 +247,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOPE_VERSIONS: ${{ github.event.inputs.scope_versions || inputs.scope_versions }}
           SCOPE_EXTENSIONS: ${{ github.event.inputs.scope_extensions || inputs.scope_extensions }}
+          REBUILD: ${{ env.REBUILD_MODE }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
         run: |
           chmod +x scripts/build-extensions.sh helpers/extension-utils.sh
+
+          # Wire effective rebuild modes through to build-extensions.sh, so the
+          # documented override in scope_extensions actually bypasses the
+          # registry-skip path.
+          force_arg=()
+          if [[ "$REBUILD" == "force" || "$REBUILD" == "all" ]]; then
+            force_arg=(--force)
+          fi
 
           # Parse versions map (passed via env to prevent expression injection)
           IFS='|' read -ra ENTRIES <<< "$VERSIONS_MAP"
@@ -276,11 +285,11 @@ jobs:
                 IFS=',' read -ra EXT_LIST <<< "$SCOPE_EXTENSIONS"
                 for ext in "${EXT_LIST[@]}"; do
                   [[ -z "$ext" ]] && continue
-                  ./scripts/build-extensions.sh "$container" --major-version "$major_version" --extension "$ext"
+                  ./scripts/build-extensions.sh "$container" --major-version "$major_version" --extension "$ext" "${force_arg[@]}"
                 done
               else
                 echo "🔧 Building all extensions for $container v$major_version..."
-                ./scripts/build-extensions.sh "$container" --major-version "$major_version"
+                ./scripts/build-extensions.sh "$container" --major-version "$major_version" "${force_arg[@]}"
               fi
             done
           done

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -384,6 +384,42 @@ build_tag_push_extensions() {
     fi
 }
 
+# Decide whether a given extension needs (re)building.
+# Honors LOCAL_ONLY (image inspect), FORCE, and registry presence.
+# Logs the skip reason itself so callers can stay terse.
+# Returns 0 to build, 1 to skip.
+_should_build_extension() {
+    local ext="$1" config_file="$2" major_ver="$3" container_dir="$4"
+    local dockerfile="$container_dir/extensions/build/${ext}.Dockerfile"
+
+    if [[ ! -f "$dockerfile" ]]; then
+        log_warning "$ext: no Dockerfile (skipped)"
+        return 1
+    fi
+
+    local version image
+    version=$(ext_config "$ext" "version" "$config_file")
+    image=$(ext_image_name "$ext" "$version" "$major_ver")
+
+    if [[ "$LOCAL_ONLY" == "true" ]]; then
+        if [[ "$FORCE" != "true" ]] && docker image inspect "$image" &>/dev/null; then
+            log_success "$ext $version already exists locally"
+            return 1
+        fi
+        return 0
+    fi
+
+    if [[ "$FORCE" == "true" ]]; then
+        return 0
+    fi
+
+    if image_exists_in_registry "$image" 2>/dev/null; then
+        log_success "$ext $version already exists in registry"
+        return 1
+    fi
+
+    return 0
+}
 
 main() {
     parse_args "$@"
@@ -419,38 +455,29 @@ main() {
     local extensions_to_build=()
 
     if [[ -n "$EXTENSION" ]]; then
-        extensions_to_build=("$EXTENSION")
+        # Strict typo check: explicit --extension must have a real Dockerfile
+        local _explicit_dockerfile="$container_dir/extensions/build/${EXTENSION}.Dockerfile"
+        if [[ ! -f "$_explicit_dockerfile" ]]; then
+            log_error "Extension '$EXTENSION': no Dockerfile at $_explicit_dockerfile"
+            exit 1
+        fi
+        if _should_build_extension "$EXTENSION" "$config_file" "$major_ver" "$container_dir"; then
+            extensions_to_build=("$EXTENSION")
+        fi
     else
         while IFS= read -r ext; do
-            local dockerfile="$container_dir/extensions/build/${ext}.Dockerfile"
-
-            if [[ ! -f "$dockerfile" ]]; then
-                log_warning "$ext: no Dockerfile (skipped)"
-                continue
-            fi
-
-            local version image
-            version=$(ext_config "$ext" "version" "$config_file")
-            image=$(ext_image_name "$ext" "$version" "$major_ver")
-
-            if [[ "$LOCAL_ONLY" == "true" ]]; then
-                if docker image inspect "$image" &>/dev/null && [[ "$FORCE" != "true" ]]; then
-                    log_success "$ext $version already exists locally"
-                else
-                    extensions_to_build+=("$ext")
-                fi
-            elif [[ "$FORCE" == "true" ]]; then
+            if _should_build_extension "$ext" "$config_file" "$major_ver" "$container_dir"; then
                 extensions_to_build+=("$ext")
-            elif ! image_exists_in_registry "$image" 2>/dev/null; then
-                extensions_to_build+=("$ext")
-            else
-                log_success "$ext $version already exists in registry"
             fi
         done < <(list_extensions_by_priority "$config_file" "$major_ver")
     fi
 
     if [[ ${#extensions_to_build[@]} -eq 0 ]]; then
-        log_success "All extensions are up to date"
+        if [[ -n "$EXTENSION" ]]; then
+            log_success "$EXTENSION already up to date"
+        else
+            log_success "All extensions are up to date"
+        fi
         exit 0
     fi
 
@@ -463,4 +490,7 @@ main() {
     build_tag_push_extensions "$config_file" "$major_ver" "$container_dir" "$do_push" "${extensions_to_build[@]}"
 }
 
-main "$@"
+# Only run main when executed directly, not when sourced (e.g. by unit tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+
+# Unit tests for _should_build_extension() in scripts/build-extensions.sh
+#
+# 8-case truth table covering LOCAL_ONLY, FORCE, docker-inspect result,
+# registry presence, and missing Dockerfile.
+#
+# Mocking strategy:
+#   - docker()           : bash function override (exits 0 = image found, 1 = not found)
+#   - image_exists_in_registry(): bash function override (same convention)
+#   - ext_config()       : returns a deterministic version "1.2.3"
+#   - ext_image_name()   : returns a deterministic tag "ghcr.io/test/ext-pgvector:pg17-1.2.3"
+#   - Dockerfile presence: created/absent in TEST_TEMP_DIR
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Source helper: push to scripts/ so SCRIPT_DIR/ROOT_DIR resolve correctly.
+# build-extensions.sh has a BASH_SOURCE guard so main() is NOT called when
+# the script is sourced rather than executed directly.
+# ---------------------------------------------------------------------------
+_source_build_extensions() {
+    pushd "$SCRIPTS_DIR" > /dev/null 2>&1
+    # shellcheck disable=SC1091
+    source "./build-extensions.sh"
+    popd > /dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    setup_temp_dir
+
+    # Minimal extension filesystem under TEST_TEMP_DIR
+    CONTAINER_DIR="$TEST_TEMP_DIR/postgres"
+    EXT_BUILD_DIR="$CONTAINER_DIR/extensions/build"
+    mkdir -p "$EXT_BUILD_DIR"
+
+    # Minimal config.yaml (ext_config reads from it via yq)
+    mkdir -p "$CONTAINER_DIR/extensions"
+    cat > "$CONTAINER_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  pgvector:
+    version: "1.2.3"
+    repo: "https://github.com/pgvector/pgvector"
+    priority: 1
+EOF
+
+    CONFIG_FILE="$CONTAINER_DIR/extensions/config.yaml"
+    MAJOR_VER="17"
+    EXT_DOCKERFILE="$EXT_BUILD_DIR/pgvector.Dockerfile"
+
+    # Default: Dockerfile present
+    touch "$EXT_DOCKERFILE"
+
+    # Reset globals that _should_build_extension reads
+    export FORCE=false
+    export LOCAL_ONLY=false
+    export CONTAINER="postgres"
+
+    # Override ROOT_DIR so that build-extensions.sh path resolution doesn't
+    # point at the real repo (we re-assign after sourcing below)
+    export ROOT_DIR="$TEST_TEMP_DIR"
+
+    _source_build_extensions
+
+    # Install mocks AFTER sourcing — build-extensions.sh sources
+    # helpers/extension-utils.sh which defines real `ext_config` and
+    # `ext_image_name`. Mocks declared before would be overwritten.
+    _setup_default_mocks
+
+    # After sourcing, redirect ROOT_DIR to our temp tree
+    ROOT_DIR="$TEST_TEMP_DIR"
+}
+
+teardown() {
+    teardown_temp_dir
+    unset FORCE LOCAL_ONLY CONTAINER ROOT_DIR
+}
+
+# ---------------------------------------------------------------------------
+# Default mock helpers — individual tests override as needed
+# ---------------------------------------------------------------------------
+
+# docker image inspect: default = image NOT found locally
+_mock_docker_absent() {
+    docker() { return 1; }
+    export -f docker
+}
+
+# docker image inspect: image found locally
+_mock_docker_present() {
+    docker() { return 0; }
+    export -f docker
+}
+
+# image_exists_in_registry: default = NOT in registry
+_mock_registry_absent() {
+    image_exists_in_registry() { return 1; }
+    export -f image_exists_in_registry
+}
+
+# image_exists_in_registry: image exists in registry
+_mock_registry_present() {
+    image_exists_in_registry() { return 0; }
+    export -f image_exists_in_registry
+}
+
+_setup_default_mocks() {
+    _mock_docker_absent
+    _mock_registry_absent
+
+    # ext_config always returns a deterministic version
+    ext_config() { echo "1.2.3"; }
+    export -f ext_config
+
+    # ext_image_name returns a deterministic tag
+    ext_image_name() { echo "ghcr.io/test/ext-pgvector:pg17-1.2.3"; }
+    export -f ext_image_name
+}
+
+# ---------------------------------------------------------------------------
+# 8-case truth table
+# ---------------------------------------------------------------------------
+
+# Case 1: LOCAL_ONLY=true, image found locally, FORCE=false  →  skip (return 1)
+@test "1: LOCAL_ONLY=true, image present locally, FORCE=false → skip" {
+    export LOCAL_ONLY=true
+    export FORCE=false
+    _mock_docker_present
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"already exists locally"* ]]
+}
+
+# Case 2: LOCAL_ONLY=true, image found locally, FORCE=true  →  build (return 0)
+@test "2: LOCAL_ONLY=true, image present locally, FORCE=true → build" {
+    export LOCAL_ONLY=true
+    export FORCE=true
+    _mock_docker_present
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 0 ]
+}
+
+# Case 3: LOCAL_ONLY=true, image absent locally  →  build (return 0)
+@test "3: LOCAL_ONLY=true, image absent locally → build" {
+    export LOCAL_ONLY=true
+    export FORCE=false
+    _mock_docker_absent
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 0 ]
+}
+
+# Case 4: LOCAL_ONLY=false, FORCE=true  →  build regardless (return 0)
+@test "4: LOCAL_ONLY=false, FORCE=true → build regardless" {
+    export LOCAL_ONLY=false
+    export FORCE=true
+    # registry check is irrelevant when FORCE=true
+    _mock_registry_present
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 0 ]
+}
+
+# Case 5: LOCAL_ONLY=false, FORCE=false, image in registry  →  skip (return 1)
+@test "5: LOCAL_ONLY=false, FORCE=false, image in registry → skip" {
+    export LOCAL_ONLY=false
+    export FORCE=false
+    _mock_registry_present
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"already exists in registry"* ]]
+}
+
+# Case 6: LOCAL_ONLY=false, FORCE=false, image absent  →  build (return 0)
+@test "6: LOCAL_ONLY=false, FORCE=false, image absent → build" {
+    export LOCAL_ONLY=false
+    export FORCE=false
+    _mock_registry_absent
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 0 ]
+}
+
+# Case 7: Dockerfile missing  →  skip with warning (return 1)
+@test "7: Dockerfile missing → skip with warning" {
+    export LOCAL_ONLY=false
+    export FORCE=false
+    rm -f "$EXT_DOCKERFILE"
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no Dockerfile"* ]]
+}
+
+# Case 8: LOCAL_ONLY=false, FORCE=true, image absent in registry  →  build
+# Differs from case 4 (FORCE=true with registry PRESENT): exercises the
+# FORCE-short-circuit path BEFORE the registry probe so a registry outage
+# during a force rebuild can't accidentally skip.
+@test "8: LOCAL_ONLY=false, FORCE=true, image absent in registry → build (force short-circuits before probe)" {
+    export LOCAL_ONLY=false
+    export FORCE=true
+    _mock_registry_absent
+
+    # Sentinel: registry probe must NOT be called when FORCE=true (defence
+    # against a future refactor that swaps the order).
+    image_exists_in_registry() {
+        touch "$TEST_TEMP_DIR/registry_probe_called"
+        echo "REGISTRY_PROBE_CALLED" >&2
+        return 1
+    }
+    export -f image_exists_in_registry
+
+    run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_TEMP_DIR/registry_probe_called" ]
+}


### PR DESCRIPTION
## Summary

- The CI `build-extensions` job hits the 120-minute timeout on every run because the per-extension `--extension <name>` invocation in `scripts/build-extensions.sh` was the **only** code path missing the `image_exists_in_registry` skip check that the multi-extension loop already had. paradedb (~1h30 Rust compile) was rebuilt every time despite living in GHCR.
- Fix: extract `_should_build_extension()` and call it from both branches. The named-extension path now skips when the GHCR tag is present.
- `--extension <typo>` is now a hard error (missing Dockerfile → `log_error` + `exit 1`) so a manual scope mistake doesn't silently no-op.
- `auto-build.yaml` now wires `--force` from the workflow's `rebuild=force` / `rebuild=all` / `force_rebuild=true` modes, so the documented override actually bypasses the skip path.
- `scope_extensions` description updated to reflect the new build-if-missing semantics.

## Test plan

- [x] `bats tests/unit/build-extensions.bats` — 8/8 pass (full truth table + a sentinel that fails if a future refactor probes the registry under FORCE=true)
- [x] `bash -n scripts/build-extensions.sh` syntax OK
- [x] `shellcheck scripts/build-extensions.sh` clean (only the pre-existing SC1091 info)
- [x] `bats tests/unit/` — full suite still passes
- [ ] Trigger an `auto-build` run on a postgres dep update where extension images already exist — confirm `Build PostgreSQL Extensions` job exits in seconds with `"X already exists in registry"` rather than recompiling
- [ ] Trigger with `rebuild=force` to confirm the override path actually rebuilds
