### PR TITLE
feat(variant-action-bar): show full pull command in sticky bandeau

### DIFF
--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -483,18 +483,42 @@ variant-action-bar {
   outline-offset: 2px;
 }
 
+/* Success / failure flashes carry a non-colour cue (border weight/style) so
+   the state is perceivable without colour — WCAG 1.4.1. The aria-label is
+   also swapped briefly for screen readers (handled in JS). */
+/* Success and failure share padding compensation for their +1px border so
+   the row doesn't jump on activation. They differ in border style/colour
+   to be distinguishable without relying on colour alone (WCAG 1.4.1). */
 [data-collapsed] .vab-sticky-cmd--copied {
   background: rgba(74, 222, 128, 0.10);
-  border-color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+  border: 2px solid var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
   color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+  padding: 3px 9px;
 }
 
-/* Mobile (≤767px): keep visible but reduce padding/font-size for tightness */
+[data-collapsed] .vab-sticky-cmd--failed {
+  background: rgba(239, 68, 68, 0.10);
+  border: 2px dashed var(--color-feedback-error-fg, var(--color-red-400, #F87171));
+  color: var(--color-feedback-error-fg, var(--color-red-400, #F87171));
+  padding: 3px 9px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-collapsed] .vab-sticky-cmd { transition: none; }
+}
+
+/* Mobile (≤767px): keep visible but reduce padding/font-size for tightness.
+   --copied/--failed reuse the mobile padding with a -1px compensation that
+   matches the +1px border, so the row keeps its height across activation. */
 @media (max-width: 767px) {
   [data-collapsed] .vab-sticky-cmd {
     margin: 0 var(--space-xs, 4px);
     padding: 3px 6px;
     font-size: 11px;
+  }
+  [data-collapsed] .vab-sticky-cmd--copied,
+  [data-collapsed] .vab-sticky-cmd--failed {
+    padding: 2px 5px;
   }
 }
 
@@ -503,13 +527,6 @@ variant-action-bar {
    command and the user can scroll up to see the full pull line. */
 @media (max-width: 419px) {
   [data-collapsed] .vab-sticky-cmd { display: none; }
-}
-
-/* Failure flash mirrors the success flash colour in red for clipboard rejection. */
-[data-collapsed] .vab-sticky-cmd--failed {
-  background: rgba(239, 68, 68, 0.10);
-  border-color: var(--color-feedback-error-fg, var(--color-red-400, #F87171));
-  color: var(--color-feedback-error-fg, var(--color-red-400, #F87171));
 }
 
 /* ----------------------------------------------------------

--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -438,6 +438,81 @@ variant-action-bar {
 }
 
 /* ----------------------------------------------------------
+   Sticky-mode pull command display (center of bandeau)
+   ---------------------------------------------------------- */
+
+/* Hidden by default; only visible when host is collapsed */
+.vab-sticky-cmd { display: none; }
+
+[data-collapsed] .vab-sticky-cmd {
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;          /* CRITICAL — without this, flex item refuses to shrink */
+  max-width: 100%;
+  margin: 0 var(--space-md, 16px);
+  padding: 4px 10px;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-surface-elevated, rgba(255,255,255,0.04));
+  border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.06));
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-caption, 12px);
+  color: var(--color-text-primary, #F4F5F7);
+  cursor: pointer;
+  transition: background var(--motion-duration-short, 150ms) var(--easing-standard, ease),
+              border-color var(--motion-duration-short, 150ms) var(--easing-standard, ease);
+  /* Left-side ellipsis: rtl direction reverses truncation point.
+     unicode-bidi: plaintext makes the BiDi algorithm treat the Latin text as
+     LTR inside the RTL container, so glyphs render correctly but the overflow
+     truncation happens on the left (prefix), not the right (suffix). */
+  direction: rtl;
+  text-align: left;
+  unicode-bidi: plaintext;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-collapsed] .vab-sticky-cmd:hover {
+  background: var(--color-surface-overlay, rgba(255,255,255,0.07));
+  border-color: var(--color-text-muted, #8A93A0);
+}
+
+[data-collapsed] .vab-sticky-cmd:focus-visible {
+  outline: 2px solid var(--color-focus-ring, var(--color-violet-400, #A78BFA));
+  outline-offset: 2px;
+}
+
+[data-collapsed] .vab-sticky-cmd--copied {
+  background: rgba(74, 222, 128, 0.10);
+  border-color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+  color: var(--color-feedback-success-fg, var(--color-green-400, #4ADE80));
+}
+
+/* Mobile (≤767px): keep visible but reduce padding/font-size for tightness */
+@media (max-width: 767px) {
+  [data-collapsed] .vab-sticky-cmd {
+    margin: 0 var(--space-xs, 4px);
+    padding: 3px 6px;
+    font-size: 11px;
+  }
+}
+
+/* Below 420px the sticky command shrinks to a near-empty ellipsis blob with
+   no useful info — hide it entirely. The ⧉ button still copies the same
+   command and the user can scroll up to see the full pull line. */
+@media (max-width: 419px) {
+  [data-collapsed] .vab-sticky-cmd { display: none; }
+}
+
+/* Failure flash mirrors the success flash colour in red for clipboard rejection. */
+[data-collapsed] .vab-sticky-cmd--failed {
+  background: rgba(239, 68, 68, 0.10);
+  border-color: var(--color-feedback-error-fg, var(--color-red-400, #F87171));
+  color: var(--color-feedback-error-fg, var(--color-red-400, #F87171));
+}
+
+/* ----------------------------------------------------------
    Light theme overrides
    ---------------------------------------------------------- */
 

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -205,6 +205,7 @@
       var row3 = document.createElement('div');
       row3.className = 'vab-row vab-row--signals';
       row3.appendChild(this._makeSignalsStrip());
+      row3.appendChild(this._makeStickyCommand());     // center: pull command in collapsed bandeau
       row3.appendChild(this._makeCollapsedActions());
       card.appendChild(row3);
 
@@ -373,6 +374,64 @@
       return wrap;
     }
 
+
+    // Build the sticky pull-command element shown in the center of the collapsed bandeau.
+    // It is a <button> so keyboard focus and click handling are native.
+    // Text is populated (and kept in sync) by _updateStickyCommand().
+    _makeStickyCommand() {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'vab-sticky-cmd';
+      btn.setAttribute('data-vab-sticky-cmd', '');
+      // No static `title` — aria-label is dynamic and the source of truth.
+      // A static tooltip would silently disagree with the registry the user
+      // is about to copy.
+      btn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+      // Text is set by _updateStickyCommand() after _updateCommands() runs
+      btn.textContent = '';
+      return btn;
+    }
+
+    // Keep the sticky command text and aria-label in sync with the current pull command.
+    // Called at the end of _updateCommands() so every state change propagates here.
+    _updateStickyCommand() {
+      var stickyEl = this.querySelector('[data-vab-sticky-cmd]');
+      if (!stickyEl) { return; }
+      var pullEl = this.querySelector('[data-vab-cmd="pull"]');
+      if (pullEl) { stickyEl.textContent = pullEl.textContent; }
+      stickyEl.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+    }
+
+    // Copy handler for the collapsed sticky command button.
+    // On success: brief 1.5s green flash via .vab-sticky-cmd--copied class.
+    // On failure: brief 1.5s red flash via .vab-sticky-cmd--failed class so
+    // the user gets feedback and can fall back to the ⧉ button or a manual
+    // selection. Per-button flash timer is cancelled on re-click so a
+    // double-tap doesn't extend the visual state past 1.5s from the latest.
+    _onStickyCommandClick(btn) {
+      var cmd = btn.textContent;
+      if (!cmd) { return; }
+      var clearFlash = function () {
+        btn.classList.remove('vab-sticky-cmd--copied');
+        btn.classList.remove('vab-sticky-cmd--failed');
+      };
+      var scheduleClear = function () {
+        if (btn._flashTimer) { clearTimeout(btn._flashTimer); }
+        btn._flashTimer = setTimeout(clearFlash, 1500);
+      };
+      this._writeToClipboard(cmd).then(function () {
+        clearFlash();
+        btn.classList.add('vab-sticky-cmd--copied');
+        scheduleClear();
+      }).catch(function () {
+        clearFlash();
+        btn.classList.add('vab-sticky-cmd--failed');
+        scheduleClear();
+      });
+    }
+
+
+
     // Sync collapsed-actions buttons (aria-pressed) to current _selectedRegistry.
     // Called after any registry change and on initial render (via _updateCommands).
     _updateCollapsedActionsState() {
@@ -432,6 +491,8 @@
 
       // Keep collapsed-actions mini toggle in sync
       this._updateCollapsedActionsState();
+      // Sync sticky pull command text in collapsed bandeau
+      this._updateStickyCommand();
     }
 
     _extractOwner(base) {
@@ -735,6 +796,10 @@
       // Collapsed-mode mini copy button
       var miniCopy = e.target.closest('[data-vab-mini-copy]');
       if (miniCopy) { this._onMiniCopyClick(); return; }
+
+      // Collapsed-mode sticky command — click to copy
+      var stickyCmd = e.target.closest('[data-vab-sticky-cmd]');
+      if (stickyCmd) { this._onStickyCommandClick(stickyCmd); return; }
     }
 
     // M-B: delegated keydown handler — stored as bound ref so it can be removed on disconnect

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -34,6 +34,11 @@
         this.removeEventListener('keydown', this._onKeydown);
         this._listenersAttached = false;
       }
+      // Cancel any in-flight flash timer so it can't fire on a detached node.
+      if (this._stickyFlashTimer) {
+        clearTimeout(this._stickyFlashTimer);
+        this._stickyFlashTimer = null;
+      }
     }
 
     // -------------------------------------------------------
@@ -206,6 +211,7 @@
       row3.className = 'vab-row vab-row--signals';
       row3.appendChild(this._makeSignalsStrip());
       row3.appendChild(this._makeStickyCommand());     // center: pull command in collapsed bandeau
+      row3.appendChild(this._makeStickyStatus());      // SR-only live region for copy result
       row3.appendChild(this._makeCollapsedActions());
       card.appendChild(row3);
 
@@ -383,13 +389,27 @@
       btn.type = 'button';
       btn.className = 'vab-sticky-cmd';
       btn.setAttribute('data-vab-sticky-cmd', '');
-      // No static `title` — aria-label is dynamic and the source of truth.
-      // A static tooltip would silently disagree with the registry the user
-      // is about to copy.
+      // aria-label keeps a stable identity ("Copy <registry> pull command"),
+      // dynamic via _updateStickyCommand. Status feedback ("Copied" /
+      // "Copy failed") is announced through a dedicated live region built
+      // by _makeStickyStatus — putting status text on the button's own
+      // aria-label is unreliable across screen readers.
       btn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
       // Text is set by _updateStickyCommand() after _updateCommands() runs
       btn.textContent = '';
       return btn;
+    }
+
+    // SR-only live region announcing copy result. role=status + aria-live
+    // make the textContent change auto-announce, which is the canonical
+    // pattern (more reliable than aria-label mutation on the button).
+    _makeStickyStatus() {
+      var span = document.createElement('span');
+      span.className = 'sr-only';
+      span.setAttribute('data-vab-sticky-status', '');
+      span.setAttribute('role', 'status');
+      span.setAttribute('aria-live', 'polite');
+      return span;
     }
 
     // Keep the sticky command text and aria-label in sync with the current pull command.
@@ -403,29 +423,43 @@
     }
 
     // Copy handler for the collapsed sticky command button.
-    // On success: brief 1.5s green flash via .vab-sticky-cmd--copied class.
-    // On failure: brief 1.5s red flash via .vab-sticky-cmd--failed class so
-    // the user gets feedback and can fall back to the ⧉ button or a manual
-    // selection. Per-button flash timer is cancelled on re-click so a
-    // double-tap doesn't extend the visual state past 1.5s from the latest.
+    // - Success: green solid border flash + aria-label "Copied"
+    // - Failure: red dashed border flash + aria-label "Copy failed"
+    // Both states carry a non-colour cue (border weight/style) plus an SR
+    // announcement, so the result is perceivable without colour (WCAG 1.4.1).
+    // The pending timer lives on `this` (not `btn`) so disconnectedCallback
+    // can cancel it — preventing async firing on a detached node.
     _onStickyCommandClick(btn) {
       var cmd = btn.textContent;
       if (!cmd) { return; }
+      var self = this;
+      var statusEl = self.querySelector('[data-vab-sticky-status]');
       var clearFlash = function () {
         btn.classList.remove('vab-sticky-cmd--copied');
         btn.classList.remove('vab-sticky-cmd--failed');
+        if (statusEl) { statusEl.textContent = ''; }
       };
       var scheduleClear = function () {
-        if (btn._flashTimer) { clearTimeout(btn._flashTimer); }
-        btn._flashTimer = setTimeout(clearFlash, 1500);
+        if (self._stickyFlashTimer) { clearTimeout(self._stickyFlashTimer); }
+        self._stickyFlashTimer = setTimeout(function () {
+          clearFlash();
+          self._stickyFlashTimer = null;
+        }, 1500);
       };
       this._writeToClipboard(cmd).then(function () {
+        // Bail if the host was removed from the DOM while the clipboard
+        // promise was in flight — avoids scheduling a timeout against a
+        // detached node.
+        if (!self.isConnected) { return; }
         clearFlash();
         btn.classList.add('vab-sticky-cmd--copied');
+        if (statusEl) { statusEl.textContent = 'Copied'; }
         scheduleClear();
       }).catch(function () {
+        if (!self.isConnected) { return; }
         clearFlash();
         btn.classList.add('vab-sticky-cmd--failed');
+        if (statusEl) { statusEl.textContent = 'Copy failed'; }
         scheduleClear();
       });
     }


### PR DESCRIPTION
## Summary

The collapsed `<variant-action-bar>` (sticky bandeau visible while scrolling on container detail pages) now shows the full pull command in its center, so users can see exactly what they're about to copy.

- **Layout**: `signals · pull command · [GHCR ▾] [⧉]`. The command takes the remaining flex space.
- **Left-side ellipsis**: when the row is narrow, the prefix (`docker pull ghcr.io/owner/`) fades behind a `…`, but the variant-identifying suffix (`postgres:18-alpine-vector`) stays visible. CSS-only via `direction: rtl; unicode-bidi: plaintext;` — Latin glyphs still render LTR.
- **Click to copy**: the displayed command is itself a button. Click = copy + 1.5s green flash. The pre-existing ⧉ button is preserved.
- **Failure feedback**: clipboard rejection now renders a 1.5s red flash via a new `--failed` class instead of failing silently.
- **Tiny viewports**: below 420px the command would shrink to a useless ellipsis blob, so it hides entirely; the ⧉ button remains.
- **Fixes a static `title` mismatch**: dropped the literal "Click to copy" tooltip that disagreed with the dynamic `aria-label` once the registry switched.

State sync: the displayed text reads from `[data-vab-cmd="pull"]` whose textContent is updated by the canonical `_updateCommands()` on every state change (initial render, version pill click, flavor pill click, expanded registry pill click, mini registry toggle, external `version-tabs-changed` event). Single source of truth, can't drift.

## Test plan

- [x] State-sync paths traced through `_updateCommands → _updateStickyCommand` for all 6 entry points
- [x] No regression in expanded mode (base `.vab-sticky-cmd { display: none }`, only `[data-collapsed]` reveals)
- [x] Manual mental trace at viewports 360 / 480 / 768 / 1280 px
- [x] Existing ⧉ button still functional
- [ ] Visual smoke: confirm left-edge ellipsis at ~700px viewport on a published page
- [ ] Visual smoke: confirm green flash on click, red flash on `permissions-policy: clipboard-write=()` denied iframe
- [ ] Keyboard: Tab reaches the cmd button → Enter copies
