### PR TITLE
feat(dashboard): chart total build cost including extensions

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -305,6 +305,18 @@ jobs:
             done
           done
 
+      - name: Upload extension lineage files
+        if: always() && hashFiles('.build-lineage/ext-*.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: ext-lineage-${{ github.run_id }}
+          path: .build-lineage/ext-*.json
+          retention-days: 1
+          if-no-files-found: ignore
+          # `.build-lineage/` is a dot-prefixed directory; v4 of upload-artifact
+          # silently skips files inside hidden directories unless this is set.
+          include-hidden-files: true
+
   # Cache Docker Hub base images to GHCR to avoid rate limits during builds
   cache-base-images:
     name: Cache base images
@@ -463,6 +475,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download extension lineage (postgres only)
+        if: matrix.build.container == 'postgres'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: ext-lineage-${{ github.run_id }}
+          path: .build-lineage/
+        continue-on-error: true
 
       # yq is pre-installed on ubuntu-latest. On Windows we download the binary
       # directly (no Chocolatey — avoids flaky 503s). Action mikefarah/yq is

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -582,12 +582,17 @@
         return isNaN(d.getTime()) ? '?' : d.toISOString().slice(5, 10);
       });
       var pkgData = sorted.map(function(b) { return b.packages_total || null; });
-      var durData = sorted.map(function(b) { return b.duration_seconds || null; });
-      var hasDuration = durData.some(function(v) { return v !== null; });
+      var containerData = sorted.map(function(b) { return b.duration_seconds || null; });
+      var extData = sorted.map(function(b) { return b.extensions_build_seconds != null ? b.extensions_build_seconds : null; });
+      var hasContainer = containerData.some(function(v) { return v !== null; });
+      var hasExt = extData.some(function(v) { return v !== null; });
 
       var isDark = document.documentElement.getAttribute('data-theme') !== 'light';
       var gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
       var textColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)';
+
+      // Convert seconds → minutes for Y1 axis display
+      var toMin = function(v) { return v != null ? +(v / 60).toFixed(1) : null; };
 
       var datasets = [{
         label: 'Packages',
@@ -601,18 +606,31 @@
         pointHoverRadius: 5
       }];
 
-      if (hasDuration) {
+      if (hasContainer) {
         datasets.push({
-          label: 'Build (min)',
-          data: durData.map(function(v) { return v != null ? +(v / 60).toFixed(1) : null; }),
+          label: 'Container build (min)',
+          data: containerData.map(toMin),
           borderColor: '#f59e0b',
-          backgroundColor: 'rgba(245,158,11,0.1)',
-          fill: false,
+          backgroundColor: 'rgba(245,158,11,0.25)',
+          fill: 'origin',
           tension: 0.3,
           yAxisID: 'y1',
-          pointRadius: 3,
-          pointHoverRadius: 5,
-          borderDash: [4, 2]
+          pointRadius: 2,
+          pointHoverRadius: 4
+        });
+      }
+
+      if (hasExt) {
+        datasets.push({
+          label: 'Extensions build (min)',
+          data: extData.map(toMin),
+          borderColor: '#a855f7',
+          backgroundColor: 'rgba(168,85,247,0.25)',
+          fill: hasContainer ? '-1' : 'origin',
+          tension: 0.3,
+          yAxisID: 'y1',
+          pointRadius: 2,
+          pointHoverRadius: 4
         });
       }
 
@@ -625,12 +643,14 @@
           ticks: { color: textColor, font: { size: 10 } }
         }
       };
-      if (hasDuration) {
+      if (hasContainer || hasExt) {
         scales.y1 = {
           position: 'right',
           title: { display: true, text: 'Build (min)', color: textColor, font: { size: 10 } },
           grid: { drawOnChartArea: false },
-          ticks: { color: textColor, font: { size: 10 } }
+          ticks: { color: textColor, font: { size: 10 } },
+          stacked: true,
+          beginAtZero: true
         };
       }
 

--- a/helpers/extension-duration-utils.sh
+++ b/helpers/extension-duration-utils.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Sum per-extension build durations for a given flavor.
+#
+# Called by build-container.sh AFTER the per-extension lineage files have been
+# written by build-extensions.sh in the same CI run.  Extensions that were
+# skipped (image already in registry → no lineage file written) contribute 0
+# to the total, which accurately reflects "this build run cost".
+#
+# Usage: sum_flavor_extension_durations <container> <flavor> <pg_major>
+
+# Resolve helpers directory from this script's own location
+_EXT_DUR_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source extension-utils for get_flavor_extensions()
+# shellcheck source=./extension-utils.sh
+source "$_EXT_DUR_HELPERS_DIR/extension-utils.sh"
+
+# sum_flavor_extension_durations <container> <flavor> <pg_major>
+#
+# Reads .build-lineage/ext-<ext>-pg<pg_major>-<ext_version>.json files
+# written during this CI run by build-extensions.sh.
+#
+# Returns (stdout):
+#   integer — total seconds for all rebuilt extensions this run
+#   "null"  — container has no extension config, or the flavor has no extensions
+sum_flavor_extension_durations() {
+    local container="$1"
+    local flavor="$2"
+    local pg_major="$3"
+
+    # ROOT_DIR set by build-extensions.sh callers; PROJECT_ROOT set by build-container.sh;
+    # fall back to PWD for direct invocation/tests.
+    local root="${ROOT_DIR:-${PROJECT_ROOT:-.}}"
+    local config_file="${root}/${container}/extensions/config.yaml"
+
+    if [[ ! -f "$config_file" ]]; then
+        echo "null"
+        return 0
+    fi
+
+    # Collect the extension list for this flavor/pg_major combination
+    local ext_list
+    ext_list=$(get_flavor_extensions "$config_file" "$flavor" "$pg_major" 2>/dev/null || true)
+
+    if [[ -z "$ext_list" ]]; then
+        # Flavor has no extensions (e.g. "base" flavor with no entries)
+        echo "null"
+        return 0
+    fi
+
+    local total=0
+    while IFS= read -r ext; do
+        [[ -z "$ext" ]] && continue
+
+        local ext_version
+        ext_version=$(ext_config "$ext" "version" "$config_file" 2>/dev/null || true)
+        if [[ -z "${ext_version:-}" ]]; then
+            # Extension declared but version unset — skip without breaking
+            continue
+        fi
+
+        local _ver_safe="${ext_version//[^a-zA-Z0-9.-]/_}"
+        local lineage_file="${root}/.build-lineage/ext-${ext}-pg${pg_major}-${_ver_safe}.json"
+        if [[ -f "$lineage_file" ]]; then
+            local d
+            d=$(jq -r '.duration_seconds // 0' "$lineage_file" 2>/dev/null || echo 0)
+            # Guard against non-numeric output from jq
+            if [[ "$d" =~ ^[0-9]+$ ]]; then
+                total=$(( total + d ))
+            else
+                log_warning "$lineage_file: non-integer duration_seconds, treating as 0"
+            fi
+        fi
+        # No lineage file → extension was skipped (cached); contributes 0 this run
+    done <<< "$ext_list"
+
+    echo "$total"
+}

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -207,12 +207,13 @@ append_build_history() {
     mkdir -p "$output_dir"
 
     # Extract metadata from lineage file
-    local built_at version build_digest duration_seconds
+    local built_at version build_digest duration_seconds extensions_build_seconds
     if [[ -f "$lineage_file" ]]; then
         built_at=$(jq -r '.built_at // empty' "$lineage_file" 2>/dev/null || echo "")
         version=$(jq -r '.version // empty' "$lineage_file" 2>/dev/null || echo "")
         build_digest=$(jq -r '.build_digest // empty' "$lineage_file" 2>/dev/null || echo "")
         duration_seconds=$(jq '.duration_seconds // null' "$lineage_file" 2>/dev/null || echo "null")
+        extensions_build_seconds=$(jq '.extensions_build_seconds // null' "$lineage_file" 2>/dev/null || echo "null")
     fi
 
     # Fallback for missing fields
@@ -220,6 +221,7 @@ append_build_history() {
     [[ -z "${version:-}" ]] && version="unknown"
     [[ -z "${build_digest:-}" ]] && build_digest="unknown"
     [[ -z "${duration_seconds:-}" ]] && duration_seconds="null"
+    [[ -z "${extensions_build_seconds:-}" ]] && extensions_build_seconds="null"
 
     # Extract totals from summary
     local packages_total
@@ -254,6 +256,7 @@ append_build_history() {
         --argjson packages_by_type "$packages_by_type" \
         --arg changes_summary "$changes_summary" \
         --argjson duration "$duration_seconds" \
+        --argjson ext_duration "$extensions_build_seconds" \
         --argjson max "$max_entries" \
     '
         [{
@@ -263,7 +266,8 @@ append_build_history() {
             packages_total: $packages_total,
             packages_by_type: $packages_by_type,
             changes_summary: $changes_summary,
-            duration_seconds: $duration
+            duration_seconds: $duration,
+            extensions_build_seconds: $ext_duration
         }] + $history |
         .[:$max]
     ' > "$history_file"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/helpers/build-cache-utils.sh"
 source "$PROJECT_ROOT/helpers/build-args-utils.sh"
 source "$PROJECT_ROOT/helpers/template-utils.sh"
 source "$PROJECT_ROOT/helpers/extension-utils.sh"
+# shellcheck source=../helpers/extension-duration-utils.sh
+[[ -f "$PROJECT_ROOT/helpers/extension-duration-utils.sh" ]] && source "$PROJECT_ROOT/helpers/extension-duration-utils.sh"
 
 # Function to check if multi-platform builds are supported (QEMU emulation)
 check_multiplatform_support() {
@@ -162,6 +164,7 @@ _resolve_base_image() {
 _emit_build_lineage() {
     local container="$1" version="$2" tag="$3" flavor="$4" dockerfile="$5"
     local platforms="$6" runtime_info="$7" dockerhub_image="$8" ghcr_image="$9"
+    local extensions_build_seconds="${10:-null}"
 
     local lineage_dir="${PROJECT_ROOT:-.}/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -191,6 +194,7 @@ _emit_build_lineage() {
   "base_image_digest": "${_BASE_DIGEST:-unresolved}",
   "built_at": "$build_ts",
   "duration_seconds": ${_BUILD_DURATION_SECONDS:-null},
+  "extensions_build_seconds": ${extensions_build_seconds},
   "github_actions": ${GITHUB_ACTIONS:-false},
   "images": {
     "dockerhub": "$dockerhub_image:$tag",
@@ -395,9 +399,17 @@ build_container() {
     fi
 
     _BUILD_DURATION_SECONDS=$(( SECONDS - _build_start ))
+
+    # Sum extension build times for this flavor (only for containers with extensions/)
+    local _ext_seconds="null"
+    if [[ -d "$PROJECT_ROOT/$container/extensions" ]]; then
+        _ext_seconds=$(sum_flavor_extension_durations "$container" "${flavor:-}" "$_MAJOR_VERSION" 2>/dev/null || echo "null")
+        [[ -z "${_ext_seconds:-}" ]] && _ext_seconds="null"
+    fi
+
     if [[ "${DRY_RUN:-false}" != "true" ]]; then
         _emit_build_lineage "$container" "$version" "$tag" "$flavor" "$dockerfile" \
-            "$_PLATFORMS" "$_RUNTIME_INFO" "$dockerhub_image" "$ghcr_image"
+            "$_PLATFORMS" "$_RUNTIME_INFO" "$dockerhub_image" "$ghcr_image" "$_ext_seconds"
     else
         log_info "[DRY-RUN] Would write lineage: .build-lineage/${container}-${tag}.json"
     fi

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -347,6 +347,8 @@ build_tag_push_extensions() {
         echo ""
         log_info "Processing: $ext"
 
+        local _ext_start=$SECONDS
+
         if ! build_extension "$ext" "$config_file" "$major_ver" "$container_dir"; then
             log_error "$ext build failed"
             failed+=("$ext")
@@ -365,10 +367,31 @@ build_tag_push_extensions() {
             else
                 log_error "$ext push failed"
                 failed+=("$ext")
+                continue
             fi
         else
             log_success "$ext built and tagged locally"
         fi
+
+        # Write per-extension lineage file (only on successful build+tag+push)
+        local _ext_duration=$(( SECONDS - _ext_start ))
+        local _ext_version
+        _ext_version=$(ext_config "$ext" "version" "$config_file")
+        local _ext_image
+        _ext_image=$(ext_image_name "$ext" "$_ext_version" "$major_ver")
+        local _ver_safe="${_ext_version//[^a-zA-Z0-9.-]/_}"
+        local _ext_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-${_ver_safe}.json"
+        mkdir -p "${ROOT_DIR}/.build-lineage"
+        jq -nc \
+            --arg ext "$ext" \
+            --arg version "$_ext_version" \
+            --arg pg_major "$major_ver" \
+            --arg image "$_ext_image" \
+            --argjson duration "$_ext_duration" \
+            --arg built_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            '{ext:$ext, version:$version, pg_major:$pg_major, image:$image, duration_seconds:$duration, built_at:$built_at}' \
+            > "$_ext_lineage_file"
+        log_info "Extension lineage: $_ext_lineage_file (${_ext_duration}s)"
     done
 
     echo ""

--- a/tests/unit/extension-duration-utils.bats
+++ b/tests/unit/extension-duration-utils.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+
+# Unit tests for sum_flavor_extension_durations() in helpers/extension-duration-utils.sh
+#
+# 6-case truth table:
+#   1. flavor with 3 extensions, all 3 lineage files present → sum of durations
+#   2. flavor with 3 extensions, 2 lineage files present (1 skipped) → sum of 2
+#   3. flavor with 0 extensions (e.g. "base" flavor with no entries) → "null"
+#   4. flavor with 3 extensions, 0 lineage files (all skipped) → 0
+#   5. config.yaml missing → "null"
+#   6. ext_config returns empty version (version unset) → skipped, no error
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Source helper: push to helpers/ so _EXT_DUR_HELPERS_DIR resolves correctly.
+# ---------------------------------------------------------------------------
+_source_ext_dur_utils() {
+    pushd "$HELPERS_DIR" > /dev/null 2>&1
+    # shellcheck disable=SC1091
+    source "./extension-duration-utils.sh"
+    popd > /dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    setup_temp_dir
+
+    # Create a minimal postgres container directory tree
+    CONTAINER_DIR="$TEST_TEMP_DIR/postgres"
+    EXT_DIR="$CONTAINER_DIR/extensions"
+    LINEAGE_DIR="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$EXT_DIR" "$LINEAGE_DIR"
+
+    MAJOR_VER="17"
+
+    # Default config: three extensions for flavor "full", none for "base"
+    cat > "$EXT_DIR/config.yaml" <<'EOF'
+flavors:
+  full:
+    - pgvector
+    - paradedb
+    - pg_cron
+  base: []
+extensions:
+  pgvector:
+    version: "0.8.0"
+    priority: 1
+  paradedb:
+    version: "0.15.0"
+    priority: 2
+  pg_cron:
+    version: "1.6.4"
+    priority: 3
+EOF
+
+    # Point ROOT_DIR at our temp tree so extension-duration-utils.sh resolves paths correctly
+    export ROOT_DIR="$TEST_TEMP_DIR"
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+
+    _source_ext_dur_utils
+
+    # Install mocks AFTER sourcing — extension-utils.sh defines the real functions;
+    # mocks declared before sourcing would be overwritten.
+    _setup_default_mocks
+}
+
+teardown() {
+    teardown_temp_dir
+    unset ROOT_DIR PROJECT_ROOT
+}
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+# Override get_flavor_extensions to return deterministic extension lists
+# for "full" and "base" flavors — avoids yq dependency in tests
+_mock_flavor_full() {
+    get_flavor_extensions() {
+        # config_file=$1, flavor=$2, pg_major=$3
+        if [[ "$2" == "full" ]]; then
+            printf '%s\n' pgvector paradedb pg_cron
+        fi
+    }
+    export -f get_flavor_extensions
+}
+
+_mock_flavor_base_empty() {
+    get_flavor_extensions() {
+        # "base" flavor has no extensions — return nothing
+        true
+    }
+    export -f get_flavor_extensions
+}
+
+# Override ext_config to return deterministic versions
+_mock_ext_config_default() {
+    ext_config() {
+        local ext="$1" key="$2"
+        # Only version key matters for our function
+        if [[ "$key" == "version" ]]; then
+            case "$ext" in
+                pgvector)  echo "0.8.0"  ;;
+                paradedb)  echo "0.15.0" ;;
+                pg_cron)   echo "1.6.4"  ;;
+                *)         echo ""       ;;
+            esac
+        fi
+    }
+    export -f ext_config
+}
+
+# ext_config returns empty version for all extensions
+_mock_ext_config_no_version() {
+    ext_config() { echo ""; }
+    export -f ext_config
+}
+
+_setup_default_mocks() {
+    _mock_flavor_full
+    _mock_ext_config_default
+}
+
+# Write a per-extension lineage JSON file to the temp .build-lineage directory
+_write_ext_lineage() {
+    local ext="$1" pg_major="$2" version="$3" duration="$4"
+    local file="$LINEAGE_DIR/ext-${ext}-pg${pg_major}-${version}.json"
+    jq -nc \
+        --arg ext "$ext" \
+        --arg version "$version" \
+        --arg pg_major "$pg_major" \
+        --argjson duration "$duration" \
+        --arg built_at "2026-01-01T00:00:00Z" \
+        '{ext:$ext, version:$version, pg_major:$pg_major, duration_seconds:$duration, built_at:$built_at}' \
+        > "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Case 1: all 3 lineage files present → sum = 100 + 200 + 50 = 350
+@test "1: flavor=full, all 3 lineage files present → sum of durations" {
+    _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.8.0"  100
+    _write_ext_lineage "paradedb"  "$MAJOR_VER" "0.15.0" 200
+    _write_ext_lineage "pg_cron"   "$MAJOR_VER" "1.6.4"  50
+
+    run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 350 ]
+}
+
+# Case 2: 2 lineage files present, 1 skipped (pg_cron absent) → 100 + 200 = 300
+@test "2: flavor=full, 2 of 3 lineage files present (1 skipped) → sum of 2" {
+    _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.8.0"  100
+    _write_ext_lineage "paradedb"  "$MAJOR_VER" "0.15.0" 200
+    # pg_cron lineage NOT written (cached, skipped)
+
+    run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 300 ]
+}
+
+# Case 3: "base" flavor has no extensions → "null"
+@test "3: flavor=base with no extensions → null" {
+    _mock_flavor_base_empty
+
+    run sum_flavor_extension_durations "postgres" "base" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" = "null" ]
+}
+
+# Case 4: all 3 lineage files absent (all extensions cached/skipped) → 0
+@test "4: flavor=full, 0 lineage files (all skipped) → 0" {
+    # No lineage files written
+
+    run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 0 ]
+}
+
+# Case 5: config.yaml missing → "null"
+@test "5: config.yaml missing → null" {
+    rm -f "$EXT_DIR/config.yaml"
+
+    run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" = "null" ]
+}
+
+# Case 6: ext_config returns empty version for all → all skipped, returns 0
+# (get_flavor_extensions still returns the 3 extensions, but ext_config yields no version)
+@test "6: ext_config returns empty version → all extensions skipped, returns 0" {
+    _mock_ext_config_no_version
+    # Even with lineage files present, they can't be looked up without a version
+    _write_ext_lineage "pgvector"  "$MAJOR_VER" "" 100  # wrong name, won't match
+    _write_ext_lineage "paradedb"  "$MAJOR_VER" "" 200
+
+    run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The container detail page's history chart now reflects the **true total build cost** including extension compile time, not just the final container assembly step.

Before: postgres-full's "Build (min)" line displayed ~0.9 min — only the docker build itself, with extensions already pre-built and just `COPY --from=...`'d in. Hides the ~1h45 paradedb pgrx compile that lived invisibly in the upstream `build-extensions` job.

After: stacked area on the chart's right axis. Container assembly (amber) at the base, Extensions compile (violet) stacked on top. Total bar height = real build cost for that run. When the violet segment is small/absent, the skip-as-existing mechanism (#416) caught the extension and saved the compile time.

## Implementation

- **Per-extension lineage**: `scripts/build-extensions.sh` times each successful extension build and emits `.build-lineage/ext-<name>-pg<major>-<version>.json` with `duration_seconds`. Skipped (already-in-registry) extensions write nothing — accurate "this run cost zero" semantic.
- **Aggregator**: `helpers/extension-duration-utils.sh` (NEW) sums the flavor's extension durations using `get_flavor_extensions` from existing helper. Returns `null` when the flavor has no extensions.
- **CI artifact handoff** (the part that took two review rounds to nail): `build-extensions` job uploads `.build-lineage/ext-*.json` as artifact; `build-and-push` downloads it before the container build runs so the aggregator finds the files on a fresh runner. `include-hidden-files: true` is required on upload because `.build-lineage/` is dot-prefixed (v4 silently skips hidden directories otherwise).
- **Lineage propagation**: `scripts/build-container.sh` calls the aggregator after the docker build; `helpers/sbom-utils.sh::append_build_history` threads `extensions_build_seconds` into the per-variant history file.
- **Frontend**: `container-detail.js` adds an Extensions dataset with `fill: '-1'` (relative stack on Container) and marks the right Y axis stacked. Old history rows default to `null` → segment absent for past builds, visible from the first new build forward.

## Test plan

- [x] `bats tests/unit/extension-duration-utils.bats` — 6/6 (truth-table cases: no extensions / all skipped / partial / present / null fields / missing config)
- [x] `bats tests/unit/build-extensions.bats` — 8/8 (regression check)
- [x] `bash -n` + `shellcheck -S warning` clean across the 4 modified shell files
- [x] `yq` parses the workflow YAML; new upload + download steps land in the right jobs
- [x] Senior code review (opus) + 3 codex (xhigh) passes — final verdict `SHIP` modulo the codex-flagged hidden-files quirk that is now fixed
- [ ] Live CI smoke: trigger a `rebuild=force` postgres run and confirm the lineage artifact uploads, downloads, and the final history JSON has a non-zero `extensions_build_seconds`
- [ ] Visual smoke on the regenerated dashboard: confirm the violet stacked area appears on postgres-full's chart with realistic minute values

## Backward compatibility

Old history entries pre-PR have no `extensions_build_seconds` field. Frontend reads `null` → segment absent. Mixed history (some old, some new) renders as gaps for older entries and stacked area starting from the first new build. No backfill needed.
