### PR TITLE
refactor(ci): decouple update-dashboard from auto-build

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -150,11 +150,10 @@ on:
 # prevented (e.g. two postgres merges serialize, cancelling stale runs).
 
 permissions:
-  actions: read          # Required for #352 hydration step in update-dashboard reusable workflow
+  actions: read          # Required for #352 hydration step (gh run list/download in cache-lineage)
   contents: read         # Checkout only — no git push or PR creation
   packages: write        # Push container images to GHCR
-  pages: write           # Required by update-dashboard reusable workflow (deploy to Pages)
-  id-token: write        # OIDC for Pages deployment + SBOM attestation (Sigstore)
+  id-token: write        # OIDC for SBOM attestation (Sigstore)
   attestations: write    # GitHub SBOM attestations (actions/attest-sbom)
   security-events: write # Upload Trivy SARIF to GitHub Security (codeql-action/upload-sarif)
   issues: write          # summary job creates a build-failure issue when builds fail
@@ -1242,19 +1241,7 @@ jobs:
           path: .trivy-scan-history
           key: trivy-scan-history-${{ github.run_id }}
 
-  update-dashboard:
-    needs: [detect-containers, build-and-push, create-manifest, cache-lineage]
-    # Update dashboard after builds (even partial failures) on master
-    # Dashboard will show warnings for failed/missing builds
-    if: |
-      always() &&
-      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'failure') &&
-      (needs.create-manifest.result == 'success' || needs.create-manifest.result == 'skipped' || needs.create-manifest.result == 'failure') &&
-      (needs.cache-lineage.result == 'success' || needs.cache-lineage.result == 'skipped') &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/update-dashboard.yaml
-    with:
-      trigger_reason: "Post-build dashboard update"
-    secrets: inherit
 # Permissions are required for updating version files, committing changes, and publishing packages during the auto-build process.
+# Dashboard updates from this workflow are decoupled: update-dashboard.yaml listens via
+# workflow_run trigger instead of being called here. Other workflows
+# (upstream-monitor, recreate-manifests) still invoke it via workflow_call.

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -150,7 +150,7 @@ on:
 # prevented (e.g. two postgres merges serialize, cancelling stale runs).
 
 permissions:
-  actions: read          # Required for #352 hydration step (gh run list/download in cache-lineage)
+  actions: read          # Required by actions/download-artifact and actions/cache (artifact + cache restore steps below)
   contents: read         # Checkout only — no git push or PR creation
   packages: write        # Push container images to GHCR
   id-token: write        # OIDC for SBOM attestation (Sigstore)

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -634,6 +634,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_call' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event != 'pull_request' &&
        github.event.workflow_run.head_branch == 'master')
     steps:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -23,7 +23,6 @@ on:
 
   # Also trigger on pushes to master (for Jekyll site/doc updates).
   # NOTE: No overlap with auto-build.yaml push paths (container files).
-  # Container builds invoke this workflow via workflow_call instead.
   push:
     branches: ["master"]
     paths:
@@ -34,6 +33,19 @@ on:
       - "generate-dashboard.sh"
       - ".github/workflows/update-dashboard.yaml"
 
+  # Fires once after each Auto Build & Push completion on master.
+  # Combined with `concurrency.cancel-in-progress: true` below, a batch of
+  # parallel auto-builds collapses to a single dashboard deploy: each new
+  # auto-build completion supersedes any in-flight update-dashboard run,
+  # so only the LAST one in the batch actually deploys.
+  # The build/deploy `if:` clauses below add per-event filters so that
+  # PR-triggered Auto Build runs (smoke builds, no GHCR push) do not
+  # cause a stale-data Pages redeploy that could cancel a real one.
+  workflow_run:
+    workflows: ["Auto Build & Push"]
+    types: [completed]
+    branches: [master]
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   actions: read           # gh run list/download (#352 hydration step)
@@ -43,15 +55,29 @@ permissions:
   pages: write
   security-events: read   # gh api code-scanning/alerts for trust-strip trivy_summary
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment. With cancel-in-progress: true, a batch of parallel
+# auto-build completions collapses to a single dashboard deploy — each successive workflow_run
+# event supersedes any in-flight run so only the last one in the batch actually deploys.
+# Side effect for `workflow_call` callers (`upstream-monitor`, `recreate-manifests`):
+# their dashboard step may be terminated mid-flight by a later auto-build completion.
+# Acceptable by design — the later run redeploys with fresher data.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Build job with integrated dashboard generation
   build:
+    # workflow_run path:
+    #   - skip failed/cancelled auto-build runs (regenerating from a broken build = waste)
+    #   - skip pull_request-event runs (PR smoke builds don't push to GHCR; would publish stale data)
+    #   - skip non-master head branch (defense-in-depth; the trigger filters branches: [master] already)
+    # Other triggers (push, schedule, workflow_call, workflow_dispatch) pass through unconditionally.
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'pull_request' &&
+       github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -595,9 +621,21 @@ jobs:
     needs: build
     # Only deploy if:
     # 1. Triggered by push to master branch, OR
-    # 2. Manually dispatched from workflow_dispatch, OR  
-    # 3. Called from workflow_call but NOT from a pull request context
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_call' && github.ref == 'refs/heads/master')
+    # 2. Manually dispatched from workflow_dispatch, OR
+    # 3. Daily schedule cron (so a 7am cron always reaches Pages and isn't
+    #    just a build-and-discard — otherwise it could cancel a real deploy
+    #    via the shared `pages` concurrency group), OR
+    # 4. Called from workflow_call but NOT from a pull request context, OR
+    # 5. Triggered by a successful Auto Build & Push completion on master,
+    #    excluding PR-triggered upstream runs (smoke builds, stale data risk)
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_call' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event != 'pull_request' &&
+       github.event.workflow_run.head_branch == 'master')
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

Every `Auto Build & Push` run used to call `update-dashboard.yaml` as its final reusable job. Triggering 12 manual rebuilds in parallel (observed earlier today) therefore generated 12 dashboard deploys all fighting the GitHub Pages deployment environment — 11 got cancelled, only the last won.

This change makes the dashboard a **passive consumer** of upstream completions instead of a tail responsibility of every container build.

- **`auto-build.yaml`** drops the `update-dashboard` job and its `pages: write` permission. Pure container build now.
- **`update-dashboard.yaml`** gains a `workflow_run` trigger (scoped to `branches: [master]`) plus `cancel-in-progress: true` on the `pages` concurrency group. A batch of N workflow_run events collapses to a single deploy — the latest in the batch wins. Per-job `if:` guards filter out PR-event upstream runs (smoke builds, no GHCR push) and non-success conclusions.
- The `deploy` job's `if:` now also covers `schedule`, so the daily 7 AM UTC cron actually reaches Pages instead of being cancellable mid-flight without ever deploying.

`upstream-monitor.yaml` and `recreate-manifests.yaml` are unchanged — they still invoke `update-dashboard.yaml` via `workflow_call` after their own matrices, which is the right place for batch orchestration.

## Test plan

- [x] `yq` parses both files cleanly
- [x] Senior code review (opus) + 2 codex (xhigh) passes — final verdict SHIP after addressing 1 BLOCKING (PR-event filter) + 4 S items
- [ ] Trigger a manual `workflow_dispatch` rebuild on a small container — confirm the auto-build run no longer has a `update-dashboard` job in its run summary
- [ ] Observe a subsequent `Update Dashboard & Deploy Jekyll Site` run with `event=workflow_run` triggered, and verify it succeeds and deploys
- [ ] Trigger 3-4 `workflow_dispatch` rebuilds rapidly in succession — verify only ONE update-dashboard run survives (the latest)
- [ ] Daily cron at 7 AM UTC: confirm the deploy job runs (was previously a build-only path on the cron)
- [ ] Open a PR that touches a Dockerfile — confirm the PR's Auto Build smoke run does NOT trigger a Pages deploy
