### PR TITLE
fix(dashboard): render extensions stack even with isolated data point

### DIFF
--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -629,7 +629,7 @@
         // resolves itself once a few rebuilds populate the new field.
         datasets.push({
           label: 'Extensions build (min)',
-          data: extData.map(function (v) { return v != null ? +(v / 60).toFixed(1) : 0; }),
+          data: extData.map(function (v) { return toMin(v) || 0; }),
           borderColor: '#a855f7',
           backgroundColor: 'rgba(168,85,247,0.25)',
           fill: hasContainer ? '-1' : 'origin',

--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -621,9 +621,15 @@
       }
 
       if (hasExt) {
+        // Null entries (history rows from before extensions_build_seconds was
+        // recorded) are mapped to 0 instead of null for the chart data so the
+        // fill polygon stays continuous: Chart.js cannot fill from a single
+        // isolated non-null point with `spanGaps:false` + `fill:'-1'`. The
+        // visual lie ("0 contribution that build" vs. "we didn't measure")
+        // resolves itself once a few rebuilds populate the new field.
         datasets.push({
           label: 'Extensions build (min)',
-          data: extData.map(toMin),
+          data: extData.map(function (v) { return v != null ? +(v / 60).toFixed(1) : 0; }),
           borderColor: '#a855f7',
           backgroundColor: 'rgba(168,85,247,0.25)',
           fill: hasContainer ? '-1' : 'origin',


### PR DESCRIPTION
## Summary

After yesterday's force-rebuild populated `extensions_build_seconds` for the latest postgres-18-full history entry (~42 min for the actual paradedb compile), the violet "Extensions build (min)" stacked area still wasn't visible on the chart. The previous 9 history entries had `null` for the field and Chart.js's `fill: '-1'` + `spanGaps: false` cannot generate a fill polygon from a single isolated non-null point.

Three things were correct: dataset registered (Chart.js had 3 datasets), legend showed the violet entry, tooltip at the rightmost point listed all three values. The visual fill simply never rendered because there was no line segment for the fill plugin to anchor to.

The fix maps `null` to `0` for chart rendering only — the underlying data field stays `null`, the `hasExt` gate that decides whether to add the dataset at all still keys off real measurements. The fill polygon now spans the full chart width with a flat 0 baseline through the unrecorded portion of history and rises to the actual value at the most recent build.

## Test plan

- [x] Branch built locally; the diff is +7 / -1 in `container-detail.js`
- [ ] After merge: verify the violet area is visible end-to-end at https://oorabona.github.io/docker-containers/container/postgres/ on the 18-alpine-full and 18-alpine-vector flavors
- [ ] Verify postgres-18-alpine-base still has only 2 datasets (no Extensions data ever → `hasExt` false → dataset not added)
- [ ] Verify other containers (terraform, ansible, etc.) without extensions still render only the Container line
