### PR TITLE
feat(dashboard): variant tag in chart title + zero-extensions line visible

### DIFF
--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -566,7 +566,7 @@
       return m + 'm' + (s > 0 ? s + 's' : '');
     }
 
-    function renderHistoryChart(history) {
+    function renderHistoryChart(history, variantTag) {
       var chartWrap = document.getElementById('history-chart-wrap');
       var canvas = document.getElementById('history-trend-chart');
       if (!chartWrap || !canvas || typeof Chart === 'undefined') return;
@@ -585,7 +585,17 @@
       var containerData = sorted.map(function(b) { return b.duration_seconds || null; });
       var extData = sorted.map(function(b) { return b.extensions_build_seconds != null ? b.extensions_build_seconds : null; });
       var hasContainer = containerData.some(function(v) { return v !== null; });
-      var hasExt = extData.some(function(v) { return v !== null; });
+      // hasExt: dataset is rendered when ANY history row carries the
+      // extensions_build_seconds field (postgres-style containers). Containers
+      // without extensions/config.yaml omit the field entirely.
+      var hasExt = sorted.some(function(b) { return Object.prototype.hasOwnProperty.call(b, 'extensions_build_seconds'); });
+      // hasPositiveExt: at least one row has a non-zero extension cost. Drives
+      // both the dataset's fill mode AND the y1 `stacked` flag so a flavor
+      // with zero compiled extensions (postgres-base) renders the Extensions
+      // line at y=0 instead of being absorbed into the Container stack.
+      var hasPositiveExt = hasExt && sorted.some(function (b) {
+        return b.extensions_build_seconds != null && b.extensions_build_seconds > 0;
+      });
 
       var isDark = document.documentElement.getAttribute('data-theme') !== 'light';
       var gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
@@ -622,17 +632,18 @@
 
       if (hasExt) {
         // Null entries (history rows from before extensions_build_seconds was
-        // recorded) are mapped to 0 instead of null for the chart data so the
-        // fill polygon stays continuous: Chart.js cannot fill from a single
-        // isolated non-null point with `spanGaps:false` + `fill:'-1'`. The
-        // visual lie ("0 contribution that build" vs. "we didn't measure")
-        // resolves itself once a few rebuilds populate the new field.
+        // recorded) are mapped to 0 for the chart so the fill polygon stays
+        // continuous (Chart.js cannot fill from a single isolated non-null
+        // point with `spanGaps:false` + `fill:'-1'`). When ALL values are 0
+        // (postgres-base etc.) the fill is dropped AND the y1 axis is
+        // un-stacked so the line renders at y=0 along the X axis instead of
+        // being painted along the Container value.
         datasets.push({
           label: 'Extensions build (min)',
           data: extData.map(function (v) { return toMin(v) || 0; }),
           borderColor: '#a855f7',
           backgroundColor: 'rgba(168,85,247,0.25)',
-          fill: hasContainer ? '-1' : 'origin',
+          fill: hasPositiveExt ? (hasContainer ? '-1' : 'origin') : false,
           tension: 0.3,
           yAxisID: 'y1',
           pointRadius: 2,
@@ -655,7 +666,11 @@
           title: { display: true, text: 'Build (min)', color: textColor, font: { size: 10 } },
           grid: { drawOnChartArea: false },
           ticks: { color: textColor, font: { size: 10 } },
-          stacked: true,
+          // Stack only when Extensions has positive values — otherwise an
+          // all-zero Extensions dataset would be drawn ON TOP of Container's
+          // line (Chart.js stacks values, not just fills), making the "0" cue
+          // invisible. Un-stacked, the line settles at y=0.
+          stacked: hasPositiveExt,
           beginAtZero: true
         };
       }
@@ -669,6 +684,14 @@
           maintainAspectRatio: false,
           interaction: { mode: 'index', intersect: false },
           plugins: {
+            title: variantTag ? {
+              display: true,
+              text: 'Build history — ' + variantTag,
+              color: textColor,
+              font: { size: 12, weight: '500' },
+              align: 'start',
+              padding: { bottom: 8 }
+            } : { display: false },
             legend: { labels: { color: textColor, font: { size: 11 }, usePointStyle: true, pointStyle: 'circle' } }
           },
           scales: scales
@@ -689,8 +712,14 @@
 
       section.style.display = '';
 
-      // Render trend chart
-      renderHistoryChart(history);
+      // Render trend chart — title shows "container:tag" so the user always
+      // knows which variant the chart reflects (default landing page may be
+      // a flavor without extensions data, hence the explicit identifier).
+      var rawTag = (variantEl && variantEl.dataset && variantEl.dataset.tag) || '';
+      var vab = document.querySelector('variant-action-bar');
+      var containerName = (vab && vab.dataset && vab.dataset.container) || '';
+      var variantTag = rawTag ? (containerName ? containerName + ':' + rawTag : rawTag) : '';
+      renderHistoryChart(history, variantTag);
 
       // Render table
       var wrap = document.getElementById('history-table-wrap');

--- a/helpers/extension-duration-utils.sh
+++ b/helpers/extension-duration-utils.sh
@@ -43,8 +43,10 @@ sum_flavor_extension_durations() {
     ext_list=$(get_flavor_extensions "$config_file" "$flavor" "$pg_major" 2>/dev/null || true)
 
     if [[ -z "$ext_list" ]]; then
-        # Flavor has no extensions (e.g. "base" flavor with no entries)
-        echo "null"
+        # Flavor exists but has no compiled extensions → genuinely zero contribution
+        # this build (vs. "null" which signals "container has no extensions concept
+        # at all" — handled by the missing config_file branch above).
+        echo "0"
         return 0
     fi
 

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -207,12 +207,19 @@ append_build_history() {
     mkdir -p "$output_dir"
 
     # Extract metadata from lineage file
-    local built_at version build_digest duration_seconds extensions_build_seconds
+    local built_at version build_digest duration_seconds extensions_build_seconds extensions_present
+    extensions_present="false"
     if [[ -f "$lineage_file" ]]; then
         built_at=$(jq -r '.built_at // empty' "$lineage_file" 2>/dev/null || echo "")
         version=$(jq -r '.version // empty' "$lineage_file" 2>/dev/null || echo "")
         build_digest=$(jq -r '.build_digest // empty' "$lineage_file" 2>/dev/null || echo "")
         duration_seconds=$(jq '.duration_seconds // null' "$lineage_file" 2>/dev/null || echo "null")
+        # Only emit extensions_build_seconds when the source lineage actually
+        # carries it. Containers without `extensions/config.yaml` (terraform,
+        # ansible, …) don't write the field, and we must not synthesise a
+        # null entry — the dashboard frontend keys "container has extensions
+        # concept" off field presence (Object.hasOwnProperty), not value.
+        extensions_present=$(jq 'has("extensions_build_seconds")' "$lineage_file" 2>/dev/null || echo "false")
         extensions_build_seconds=$(jq '.extensions_build_seconds // null' "$lineage_file" 2>/dev/null || echo "null")
     fi
 
@@ -246,7 +253,10 @@ append_build_history() {
         changes_summary="+${added} -${removed} ~${updated}"
     fi
 
-    # Create new entry and prepend to history, keeping max_entries
+    # Create new entry and prepend to history, keeping max_entries.
+    # extensions_build_seconds is conditionally added only when the source
+    # lineage carried it — preserves the "container has no extensions concept"
+    # signal for non-postgres containers.
     jq -n \
         --argjson history "$existing_history" \
         --arg built_at "$built_at" \
@@ -256,19 +266,19 @@ append_build_history() {
         --argjson packages_by_type "$packages_by_type" \
         --arg changes_summary "$changes_summary" \
         --argjson duration "$duration_seconds" \
+        --argjson ext_present "$extensions_present" \
         --argjson ext_duration "$extensions_build_seconds" \
         --argjson max "$max_entries" \
     '
-        [{
+        [({
             built_at: $built_at,
             version: $version,
             build_digest: $build_digest,
             packages_total: $packages_total,
             packages_by_type: $packages_by_type,
             changes_summary: $changes_summary,
-            duration_seconds: $duration,
-            extensions_build_seconds: $ext_duration
-        }] + $history |
+            duration_seconds: $duration
+        } + (if $ext_present then {extensions_build_seconds: $ext_duration} else {} end))] + $history |
         .[:$max]
     ' > "$history_file"
 

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -194,7 +194,6 @@ _emit_build_lineage() {
   "base_image_digest": "${_BASE_DIGEST:-unresolved}",
   "built_at": "$build_ts",
   "duration_seconds": ${_BUILD_DURATION_SECONDS:-null},
-  "extensions_build_seconds": ${extensions_build_seconds},
   "github_actions": ${GITHUB_ACTIONS:-false},
   "images": {
     "dockerhub": "$dockerhub_image:$tag",
@@ -203,6 +202,24 @@ _emit_build_lineage() {
   "build_args": $build_args_data
 }
 LINEAGE_EOF
+
+    # Conditionally merge extensions_build_seconds when the caller actually
+    # measured it. The field's PRESENCE (not its value) is the signal that
+    # downstream consumers (sbom-utils.sh::append_build_history, the dashboard
+    # frontend) use to detect "container has extensions concept". Containers
+    # without extensions/config.yaml pass the literal string "null" as the
+    # 10th arg — for those we omit the field entirely so the signal stays
+    # honest.
+    if [[ "$extensions_build_seconds" != "null" ]]; then
+        local _lineage_tmp="${lineage_file}.tmp"
+        if jq --argjson ext "$extensions_build_seconds" \
+            '. + {extensions_build_seconds: $ext}' "$lineage_file" > "$_lineage_tmp" 2>/dev/null; then
+            mv "$_lineage_tmp" "$lineage_file"
+        else
+            rm -f "$_lineage_tmp"
+            log_warning "Failed to merge extensions_build_seconds=$extensions_build_seconds into $lineage_file"
+        fi
+    fi
     log_info "Build lineage: $lineage_file"
 }
 

--- a/tests/unit/extension-duration-utils.bats
+++ b/tests/unit/extension-duration-utils.bats
@@ -5,7 +5,7 @@
 # 6-case truth table:
 #   1. flavor with 3 extensions, all 3 lineage files present → sum of durations
 #   2. flavor with 3 extensions, 2 lineage files present (1 skipped) → sum of 2
-#   3. flavor with 0 extensions (e.g. "base" flavor with no entries) → "null"
+#   3. flavor with 0 extensions (e.g. "base" flavor with no entries) → 0
 #   4. flavor with 3 extensions, 0 lineage files (all skipped) → 0
 #   5. config.yaml missing → "null"
 #   6. ext_config returns empty version (version unset) → skipped, no error
@@ -165,13 +165,13 @@ _write_ext_lineage() {
     [ "$output" -eq 300 ]
 }
 
-# Case 3: "base" flavor has no extensions → "null"
-@test "3: flavor=base with no extensions → null" {
+# Case 3: "base" flavor has no extensions → 0 (flavor exists, just no compiled extensions)
+@test "3: flavor=base with no extensions → 0" {
     _mock_flavor_base_empty
 
     run sum_flavor_extension_durations "postgres" "base" "$MAJOR_VER"
     [ "$status" -eq 0 ]
-    [ "$output" = "null" ]
+    [ "$output" -eq 0 ]
 }
 
 # Case 4: all 3 lineage files absent (all extensions cached/skipped) → 0


### PR DESCRIPTION
## Summary

Two UX clarifications on the postgres detail page build history chart, plus the data-pipeline plumbing to keep them honest:

- **Chart title with variant tag**: reads "Build history — postgres:18-alpine-full" so users know exactly which variant the chart reflects, regardless of what they landed on.
- **Zero-extensions line visible**: postgres flavors with no compiled extensions (e.g. base) now render the Extensions dataset as a flat line at y=0, instead of dropping it. When `hasPositiveExt` is false, the dataset's fill is removed AND the y1 axis un-stacks so the violet line sits on the X axis rather than being absorbed into the Container stack.

The plumbing makes "container has extensions concept" a field-presence signal rather than a value signal:

- `scripts/build-container.sh` no longer hardcodes `extensions_build_seconds: null` in the lineage heredoc. The field is conditionally merged via jq AFTER the heredoc, only when the caller measured a value.
- `helpers/sbom-utils.sh::append_build_history` preserves field absence: it checks `has("extensions_build_seconds")` on the source lineage and conditionally builds the history entry with or without the key.
- `helpers/extension-duration-utils.sh::sum_flavor_extension_durations` now returns `0` (not the string "null") when the flavor exists but has no compiled extensions. The `null` return path remains reserved for "container has no extensions/config.yaml at all".
- `docs/site/assets/js/container-detail.js` keys `hasExt` off `Object.prototype.hasOwnProperty.call(b, 'extensions_build_seconds')` so terraform/ansible/etc. (no field) correctly never render the Extensions dataset.

## Test plan

- [x] `bats tests/unit/extension-duration-utils.bats` 6/6 (assertion updated for the new `0` return on empty flavor)
- [x] `bats tests/unit/build-extensions.bats` 8/8 (regression check)
- [x] `bash -n` clean on the 3 modified shell files
- [x] Senior + 3 codex (xhigh) passes — final verdict SHIP modulo commit
- [ ] After merge: rebuild postgres so postgres-base flavor lineage gets the `0` value, then visually confirm the violet line appears at y=0 on the chart for that flavor
- [ ] Verify terraform / ansible / web-shell etc. detail pages still show only 2 datasets (Packages + Container), no Extensions
- [ ] Verify the chart title shows "container:tag" format on all detail pages
