### PR TITLE
fix(dashboard): guard build history rendering against non-array payload

### DIFF
--- a/docs/site/assets/js/container-detail.js
+++ b/docs/site/assets/js/container-detail.js
@@ -708,7 +708,10 @@
 
       var history;
       try { history = JSON.parse(attr); } catch(e) { section.style.display = 'none'; return; }
-      if (!history || history.length === 0) { section.style.display = 'none'; return; }
+      // Defensive: if the data-build-history attribute carries a non-array
+      // payload (Liquid template misuse, future schema drift), bail out
+      // instead of crashing on `history.slice()` later.
+      if (!Array.isArray(history) || history.length === 0) { section.style.display = 'none'; return; }
 
       section.style.display = '';
 


### PR DESCRIPTION
## Summary

Some container detail pages (terraform observed today) load a non-array value into `data-build-history`, crashing `renderHistoryChart` at `history.slice is not a function` and hiding the chart entirely with no surfaced error.

Add an `Array.isArray` guard at the existing length check. The chart now bails cleanly instead of blowing up when the payload is malformed.

The Liquid path that produces the malformed attribute is a separate bug worth chasing; this PR just stops the crash.

## Test plan

- [x] +4 / -1 in `container-detail.js`, no other diff
- [ ] After merge: re-visit https://oorabona.github.io/docker-containers/container/terraform/ — chart should be hidden cleanly (no JS error in console) instead of crashing