### PR TITLE
fix(dashboard): prevent horizontal page scroll on mobile (<480px)

### DIFF
--- a/docs/site/_includes/site-nav.html
+++ b/docs/site/_includes/site-nav.html
@@ -15,7 +15,7 @@
         <i class="ti ti-moon" aria-hidden="true"></i>
       </button>
       <a href="https://github.com/{{ site.github_username | default: site.github.owner_name }}/{{ site.repository | default: site.github.repository_name }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer" aria-label="View repository on GitHub (opens in new tab)">
-        <i class="ti ti-brand-github" aria-hidden="true"></i> Repository
+        <i class="ti ti-brand-github" aria-hidden="true"></i> <span class="btn-label">Repository</span>
       </a>
     </div>
   </div>

--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -252,11 +252,14 @@
     }
     .all-variants-table-wrap {
       overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      max-width: 100%;
       border-radius: var(--radius-md, 8px);
       border: 1px solid var(--color-border-subtle, rgba(255,255,255,0.08));
     }
     .all-variants-table {
-      width: 100%;
+      width: max-content;
+      min-width: 100%;
       border-collapse: collapse;
       font-size: var(--font-size-body-sm, 14px);
     }

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -658,6 +658,14 @@ body {
   }
 }
 
+@media (max-width: 480px) {
+  /* Hide "Repository" label at 375px — icon remains as affordance */
+  .site-nav-actions .btn .btn-label { display: none; }
+  /* Shrink button padding and inner gap to prevent overflow */
+  .site-nav-actions .btn { padding: 0.4rem 0.55rem; }
+  .site-nav-inner { gap: 0.5rem; }
+}
+
 /* Animated background shapes — suppress on tablet/phone (cross-layout) */
 @media (max-width: 768px) {
   .shape {


### PR DESCRIPTION
## Summary

Mobile viewport (<480px) had a page-level horizontal scrollbar caused by two elements pushing past the viewport edge:

- **Navbar "Repository" button**: bare text node couldn't be targeted by CSS; wrapped in `<span class="btn-label">` and hidden below 480px so only the GitHub icon (with existing aria-label) remains. Button padding + nav gap also tightened.
- **Variants table**: `.all-variants-table` had `width: 100%` which combined with `white-space: nowrap` headers expanded the wrap beyond viewport width despite `overflow-x: auto`. Switched to the deterministic `width: max-content; min-width: 100%` pattern on the table + added `-webkit-overflow-scrolling: touch` on the wrap so the table scrolls internally instead of overflowing the page.

Codex xhigh review surfaced that the original `min-width: 0` defensive idiom was a no-op outside flex/grid context; replaced per their suggestion.

## Test plan

- [ ] CI passes (lint, typecheck if any)
- [ ] Pages deploy succeeds
- [ ] No page-level horizontal scrollbar on `/` and `/container/postgres/` at 375px viewport
- [ ] No page-level horizontal scrollbar at 375px on `/container/terraform/`
- [ ] Variants table scrolls internally at 375px (not page)
- [ ] Navbar shows GitHub icon-only below 480px, accessible name preserved (aria-label)
- [ ] No regressions at 1280px / 768px on dashboard or detail pages
