### PR TITLE
fix(variant-action-bar): contain command blocks on mobile (<640px)

### DIFF
--- a/docs/site/assets/css/components/variant-action-bar.css
+++ b/docs/site/assets/css/components/variant-action-bar.css
@@ -111,6 +111,7 @@ variant-action-bar {
 
 .vab-row--commands {
   flex-direction: column;
+  align-items: stretch; /* cross-axis fill so command blocks don't content-size in column mode */
   gap: var(--space-sm, 8px);
 }
 
@@ -207,6 +208,7 @@ variant-action-bar {
   gap: var(--space-xs, 4px);
   flex: 1;
   min-width: 0; /* allow shrink in flex row */
+  max-width: 100%; /* belt-and-suspenders: prevent intrinsic content from blowing out cross-axis in column mode */
 }
 
 .vab-command-label {
@@ -228,6 +230,8 @@ variant-action-bar {
   border-radius: var(--radius-md, 8px);
   padding: var(--space-xs, 4px) var(--space-sm, 8px);
   overflow: hidden;
+  min-width: 0; /* allow flex children to shrink below intrinsic content width */
+  max-width: 100%;
 }
 
 .vab-command-code {


### PR DESCRIPTION
## Summary

Mobile (<640px) detail pages had ~1000px page-level horizontal overflow caused by `.vab-row--commands` in column flex mode: its parent `.vab-row` inherits `align-items: flex-start`, which in column-direction means the two `.vab-command-block` children (pull + verify) content-size on the cross-axis instead of stretching to the row width. With nowrap headers inside, the blocks grew to their full intrinsic content width and pushed the page wider than the viewport.

### Fixes

- `.vab-row--commands` → `align-items: stretch` so blocks fill cross-axis in column mode instead of inheriting `flex-start`
- `.vab-command-block` → `max-width: 100%` to prevent intrinsic-width regression
- `.vab-command-input-row` → `min-width: 0; max-width: 100%` defensive shrink in flex context; matches the collapsed `.vab-sticky-cmd` pattern that already worked correctly on mobile

Follow-up to #429 which fixed navbar `.btn-label` + variants-table wrap but did not catch the variant-action-bar command blocks.

## Test plan

- [ ] CI passes
- [ ] Pages deploy succeeds
- [ ] At 375px viewport on `/container/postgres/` and `/container/terraform/`: `document.documentElement.scrollWidth === clientWidth` (no page-level horizontal scrollbar)
- [ ] Pull command box still readable + ellipsizes long pull commands on mobile
- [ ] No regression at 1280px (desktop): pull/verify command blocks render side-by-side correctly
