### PR TITLE
fix(dashboard): contain README code blocks on mobile

### DIFF
--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -493,8 +493,21 @@
     .readme-content pre {
       background: var(--color-readme-pre-bg); border-radius: 8px;
       padding: 1rem; overflow-x: auto; margin: 1em 0;
+      max-width: 100%;
+      min-width: 0;
+      -webkit-overflow-scrolling: touch;
     }
     .readme-content pre code { background: none; padding: 0; color: var(--text-secondary); }
+    /* Jekyll/rouge block code wrappers — constrain max-width so they don't push the page wide; pre handles scroll */
+    .readme-content div.highlighter-rouge,
+    .readme-content div.highlight {
+      max-width: 100%;
+      min-width: 0;
+    }
+    .readme-content div.highlighter-rouge {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
     .readme-content ul, .readme-content ol { margin: 1em 0; padding-left: 1.5em; }
     .readme-content li { margin-bottom: 0.5em; }
     .readme-content a { color: var(--accent-blue); text-decoration: none; }


### PR DESCRIPTION
## Summary

Mobile (<480px) detail pages still had ~212-250px page-level horizontal overflow even after #429 (navbar + variants table) and #430 (variant-action-bar). Root cause: Jekyll/rouge syntax-highlighted code blocks inside `.readme-content` wrap the `<pre>` in `<div class="highlighter-rouge"><div class="highlight">`, and those wrappers had no max-width constraint, so they could expand to the intrinsic content width of nowrap code lines and push the page wider than the viewport.

### Fixes

- `.readme-content pre` → `max-width: 100%; min-width: 0; -webkit-overflow-scrolling: touch` (pre is the canonical scroll surface, existing `overflow-x: auto` now actually triggers because the parent constrains its width).
- `.readme-content div.highlighter-rouge, .readme-content div.highlight` → `max-width: 100%; min-width: 0` (block-level rouge wrappers). Uses `div.` qualifier to avoid matching inline `<code class="...rouge">` elements.
- `.readme-content div.highlighter-rouge` → `overflow-x: auto` defensive fallback when nested rouge wrappers stack.

Together with #429 and #430, this eliminates all sources of page-level horizontal scroll on mobile detail pages.

## Test plan

- [ ] CI passes
- [ ] Pages deploy succeeds
- [ ] At 375px on `/container/postgres/` and `/container/terraform/`: `document.documentElement.scrollWidth === clientWidth` (no page-level horizontal scrollbar)
- [ ] Long code lines in README scroll internally within `<pre>` (horizontal scrollbar on the pre, not the page)
- [ ] No regression at 1280px (desktop): code blocks render with original styling
- [ ] Inline `<code>` elements (`<code class="language-plaintext highlighter-rouge">`) unaffected
