### PR TITLE
fix(dashboard): contain README tables on mobile

### DIFF
--- a/docs/site/assets/css/container-detail.css
+++ b/docs/site/assets/css/container-detail.css
@@ -522,6 +522,17 @@
     .readme-content img { max-width: 100%; border-radius: 8px; }
     .table-wrapper { overflow-x: auto; -webkit-overflow-scrolling: touch; margin: 1em 0; }
     .table-wrapper table { margin: 0; }
+    /* Kramdown emits bare <table> without a wrapper; make it its own scroll container on mobile
+       so wide tables (extensions, dependencies, etc.) don't push the page wider than the viewport.
+       Breakpoint aligned with the file's existing mobile responsive section (max-width: 768px). */
+    @media (max-width: 768px) {
+      .readme-content table {
+        display: block;
+        max-width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+    }
 
     /* ============================================================
        SBOM / Package Summary (inside disclosure body)


### PR DESCRIPTION
## Summary

Mobile (<768px) detail pages still had ~212-250px page-level horizontal overflow even after #429/#430/#431. Final culprit: kramdown emits bare `<table>` elements in the README without a `.table-wrapper`, so wide tables (postgres extensions, terraform dependencies, etc.) expand to their intrinsic content width and push the page wider than the viewport.

### Fix

At ≤768px, turn `.readme-content table` into a `display: block` scroll container with `overflow-x: auto`. The table grid still lays out internally via anonymous table boxes (columns stay aligned), but the table element itself contains the horizontal scroll instead of pushing the page.

Trade-off: on mobile, the table no longer participates as a true table formatting box — `width: 100%` sizes the scroll container, not the internal grid. For ≤10-row tables with 3-4 columns this is acceptable and is the standard CSS-only containment pattern (vs. adding a render plugin to wrap every table).

Breakpoint aligned with the file's existing mobile responsive section (`@media (max-width: 768px)`).

### Series completion

Completes the mobile overflow series:
- #429 navbar + variants table
- #430 variant-action-bar command blocks
- #431 README code blocks (`<pre>` + Jekyll/rouge wrappers)
- **this PR** README tables

At 375px viewport, `document.documentElement.scrollWidth` should now equal `clientWidth` on all three URLs (dashboard, postgres, terraform).

## Test plan

- [ ] CI passes
- [ ] Pages deploy succeeds
- [ ] At 375px on `/container/postgres/` and `/container/terraform/`: `document.documentElement.scrollWidth - clientWidth <= 1` (NO page-level horizontal scrollbar)
- [ ] Wide README tables scroll horizontally inside themselves on mobile
- [ ] No regression at 1280px: tables render with full width and original styling
- [ ] Inline `<code>` and other markdown elements unaffected
