### PR TITLE
fix(dashboard): root overflow guard on <html> for mobile

### DIFF
--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -231,6 +231,17 @@
   box-sizing: border-box;
 }
 
+/* Root overflow guard: setting overflow on <html> is what actually prevents the
+   viewport from scrolling horizontally (relying on body→viewport propagation can
+   silently fail under certain layout combinations). Pairs with the per-element
+   scroll containers (`.readme-content pre`, `.all-variants-table-wrap`,
+   `.readme-content table` on mobile) so wide content scrolls internally instead.
+   `hidden` is the Safari <16 fallback; `clip` is preferred where supported. */
+html {
+  overflow-x: hidden;
+  overflow-x: clip;
+}
+
 body {
   font-family: var(--font-family-sans);
   min-height: 100vh;
@@ -242,6 +253,7 @@ body {
   background-size: 200px 200px, 100% 100%;
   color: var(--color-text-primary);
   overflow-x: hidden;
+  overflow-x: clip;
   transition: background var(--motion-duration-normal) var(--easing-standard),
               color      var(--motion-duration-normal) var(--easing-standard);
 }


### PR DESCRIPTION
## Summary

After PR series #429/#430/#431/#432 fixing per-element mobile overflows, the postgres detail page still scrolled horizontally by ~59px at 375px (`document.documentElement.scrollWidth - clientWidth = 59`). Body already had `overflow-x: hidden` but viewport propagation from body to `<html>` failed silently under this layout combination.

### Fix

Apply `overflow-x: clip` (with `hidden` Safari <16 fallback) directly to `<html>`. This is the canonical "page must never scroll horizontally" guarantee — `clip` does not establish a scrolling box, so programmatic horizontal scroll becomes impossible.

```css
html {
  overflow-x: hidden;  /* Safari <16 fallback */
  overflow-x: clip;
}
body {
  ...
  overflow-x: hidden;
  overflow-x: clip;
}
```

### Defensive ceiling, not a workaround

This is a root guard, not a substitute for the per-element fixes. The four prior PRs address overflow at the source. This one catches any remaining unanticipated wide descendant before it bubbles to the viewport. Sticky/fixed positioning unaffected (`clip` is not in the list of overflow values that affect sticky containing block).

### Series completion

- #429 navbar Repository label + variants-table wrap
- #430 variant-action-bar column-mode cross-axis stretch
- #431 README code blocks (`<pre>` + rouge wrappers)
- #432 README tables (`display: block` scroll container)
- **this PR**: `html { overflow-x: clip }` defensive root guard

## Test plan

- [ ] CI passes
- [ ] Pages deploy succeeds
- [ ] 375px viewport: `document.documentElement.scrollWidth - clientWidth <= 1` on ALL three pages (dashboard, postgres, terraform)
- [ ] No regression at 1280px desktop on layout, sticky elements, modals
- [ ] Vertical scrolling unaffected
- [ ] Sticky variant-action-bar still works correctly on detail pages
