### PR TITLE
fix(dashboard): tolerate transient GitHub API failures

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -896,7 +896,7 @@ calculate_build_success_rate() {
     thirty_days_ago=$(date -u -d "30 days ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-30d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
 
     local build_runs_json
-    build_runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=20&created=>$thirty_days_ago" 30)
+    build_runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=20&created=>$thirty_days_ago" 30 || true)
 
     if [[ -n "$build_runs_json" ]] && echo "$build_runs_json" | jq -e '.workflow_runs' >/dev/null 2>&1; then
         local run_ids
@@ -904,7 +904,7 @@ calculate_build_success_rate() {
 
         for run_id in $run_ids; do
             local jobs_json
-            jobs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs/$run_id/jobs?per_page=50" 10)
+            jobs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs/$run_id/jobs?per_page=50" 10 || true)
 
             if [[ -n "$jobs_json" ]] && echo "$jobs_json" | jq -e '.jobs' >/dev/null 2>&1; then
                 local run_build_total run_build_success
@@ -932,8 +932,11 @@ populate_container_build_status_cache() {
     log_info "Fetching per-container build status from GitHub Actions..."
 
     # Get the most recent completed auto-build run
+    # `|| true` shields against transient GitHub API failures (502/rate-limit/network).
+    # The defensive `[[ -z "$runs_json" ]] || ...` check below handles empty output gracefully;
+    # without `|| true`, `set -e` propagates the non-zero exit and kills the script silently.
     local runs_json
-    runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=5&status=completed" 15)
+    runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=5&status=completed" 15 || true)
 
     if [[ -z "$runs_json" ]] || ! echo "$runs_json" | jq -e '.workflow_runs[0]' >/dev/null 2>&1; then
         log_warning "Could not fetch workflow runs, using lineage-based status"
@@ -952,7 +955,7 @@ populate_container_build_status_cache() {
 
     # Get all jobs from this run
     local jobs_json
-    jobs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs/$run_id/jobs?per_page=100" 20)
+    jobs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs/$run_id/jobs?per_page=100" 20 || true)
 
     if [[ -z "$jobs_json" ]] || ! echo "$jobs_json" | jq -e '.jobs' >/dev/null 2>&1; then
         CONTAINER_BUILD_STATUS_CACHE="{}"
@@ -1010,7 +1013,7 @@ get_container_build_status() {
 # Output: YAML fragment for recent_activity
 fetch_recent_activity() {
     local runs_json activity_yaml=""
-    runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs?per_page=5&status=completed")
+    runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/runs?per_page=5&status=completed" || true)
 
     if [[ -n "$runs_json" ]] && echo "$runs_json" | jq -e '.workflow_runs' >/dev/null 2>&1; then
         activity_yaml="recent_activity:"


### PR DESCRIPTION
## Summary

The scheduled dashboard re-deploy at **2026-05-15 07:58Z** failed silently while the workflow_run-triggered deploy 24min earlier on the **same sha** (`b25427f`) had succeeded. Root cause: GitHub REST API transient HTTP 502 burst.

Under `set -euo pipefail`, the two-line pattern in `generate-dashboard.sh`
```bash
local var
var=$(github_api_get "...")
```
propagates the non-zero exit of `gh api` / `curl` and kills the script. The existing defensive `[[ -z "$var" ]] || ...` guards just below each call site never get to run because `set -e` already exited. The script logs `Fetching per-container build status from GitHub Actions...` and then dies 12s later with `exit code 1` and no error message.

This is a **latent bug exposed by transient API instability** — same script, same sha, only the GitHub API health differed between the two runs.

### Fix

Append `|| true` inside each of the 5 `$(github_api_get ...)` substitutions. The substitution now returns empty on API failure; the defensive guards then fall back to the "lineage-based status" / "empty stats" paths **exactly as originally designed**.

| Site | Function | Degrade-on-failure path |
|---|---|---|
| L899 | `calculate_build_success_rate` (outer runs) | 30-day stats → `0:0:0` |
| L907 | `calculate_build_success_rate` (inner jobs) | this run's contribution skipped |
| L939 | `populate_container_build_status_cache` (runs) | `log_warning` + `CACHE={}` |
| L958 | `populate_container_build_status_cache` (jobs) | `CACHE={}` |
| L1013 | `fetch_recent_activity` | `recent_activity: []` |

Added a 3-line comment in `populate_container_build_status_cache` documenting the rationale at the most representative site.

### Validation

- `bash -n generate-dashboard.sh` ✅
- `shellcheck -x generate-dashboard.sh` ✅
- Codex xhigh review confirmed diagnosis + fix; no blocking finding
- Idiom matches existing defensive pattern in `helpers/attestation-utils.sh` and `helpers/trivy-utils.sh` (both wrap `gh api` with `|| { ... return; }`)

### Follow-up (optional, not in scope here)

`calculate_build_success_rate` and `fetch_recent_activity` still degrade **silently** (no log_warning on the failure path). Only `populate_container_build_status_cache` already logs. If observability matters, a follow-up could add log_warning lines to the other two functions — codex flagged this as Info-level, not blocking.

Closes #438.

## Test plan

- [ ] CI passes (lint, shellcheck)
- [ ] Auto-build push completes
- [ ] Dashboard deploy (workflow_run trigger) succeeds on next push
- [ ] **Next scheduled dashboard deploy (07:34Z tomorrow) succeeds OR degrades gracefully** (warning + empty cache fallback) instead of failing the workflow
- [ ] Dashboard page on live site still shows accurate container statuses (since we DO have a workflow_run-triggered deploy on every push, scheduled-only failures would only delay nightly refresh)
