### PR TITLE
fix(manifest): protect rolling tags from single-arch fallback pollution

### DIFF
--- a/helpers/create-manifest.sh
+++ b/helpers/create-manifest.sh
@@ -29,7 +29,8 @@ _compute_tag_args() {
 
     # Version-specific tag (e.g., 18.2-alpine alongside rolling 18-alpine)
     # Enables dashboard version tracking via registry pattern matching
-    if [[ -n "${FULL_VERSION:-}" && "$FULL_VERSION" != "$TAG" ]]; then
+    # Guard: TAG must start with VERSION to safely strip the prefix (P3 fix)
+    if [[ -n "${FULL_VERSION:-}" && "$FULL_VERSION" != "$TAG" && "$TAG" == "$VERSION"* ]]; then
         local rest="${TAG#$VERSION}"
         local full_numeric
         full_numeric=$(echo "$FULL_VERSION" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
@@ -39,6 +40,21 @@ _compute_tag_args() {
                 tag_args="$tag_args -t $target_image:$full_tag"
                 echo "::notice::Adding version-specific tag: $full_tag" >&2
             fi
+        fi
+    fi
+
+    # Major-version rolling tag (e.g., 18-alpine-vector derived from TAG=18.3-alpine-vector).
+    # Triggers when VERSION matches a clean numeric pattern (X.Y or X.Y.Z).
+    # This protects against future divergence if the matrix ever produces a TAG in
+    # full-version form (the inverse of the FULL_VERSION-derived block above).
+    # Guard: TAG must start with VERSION to safely strip the prefix (P3 fix)
+    if [[ "${VERSION:-}" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ && "$TAG" == "$VERSION"* ]]; then
+        local major="${VERSION%%.*}"
+        local rest_from_tag="${TAG#"$VERSION"}"
+        local rolling_tag="${major}${rest_from_tag}"
+        if [[ "$rolling_tag" != "$TAG" ]]; then
+            tag_args="$tag_args -t $target_image:$rolling_tag"
+            echo "::notice::Adding major-version rolling tag: $rolling_tag" >&2
         fi
     fi
 
@@ -56,6 +72,47 @@ _compute_tag_args() {
     echo "$tag_args"
 }
 
+# Compute ONLY the version-specific (most precise) tag argument.
+# Used by fallback paths to avoid polluting rolling/latest tags with single-arch manifests.
+#
+# Logic mirrors the FULL_VERSION-derived block of `_compute_tag_args`:
+#   - If FULL_VERSION provides a numeric prefix more specific than TAG → use the
+#     derived full_tag (e.g., 18.3-alpine-vector when TAG=18-alpine-vector).
+#   - Else → TAG itself IS the version-specific form (terraform case).
+#
+# Args: $1 = target image (e.g., ghcr.io/owner/container)
+# Output: a single `-t target:tag` argument string (no rolling/latest aliases)
+_compute_version_specific_tag_args() {
+    local target_image="$1"
+
+    # Path A: derive version-specific from FULL_VERSION
+    #   e.g., 18.3-alpine-vector from TAG=18-alpine-vector + FULL_VERSION=18.3-alpine
+    # Guard: TAG must start with VERSION to safely strip the prefix (P3 fix)
+    if [[ -n "${FULL_VERSION:-}" && "$FULL_VERSION" != "$TAG" && "$TAG" == "$VERSION"* ]]; then
+        local rest="${TAG#"$VERSION"}"
+        local full_numeric
+        full_numeric=$(echo "$FULL_VERSION" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
+        if [[ -n "$full_numeric" ]]; then
+            local full_tag="${full_numeric}${rest}"
+            if [[ "$full_tag" != "$TAG" ]]; then
+                echo "-t $target_image:$full_tag"
+                return 0
+            fi
+        fi
+    fi
+
+    # Path B: VERSION is a single major integer → TAG IS the rolling form.
+    # No precise anchor can be derived without FULL_VERSION; refuse so the caller
+    # skips the single-arch fallback and avoids polluting the rolling tag (P2 fix).
+    if [[ "${VERSION:-}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    # Path C: TAG itself is version-specific (e.g., terraform-style VERSION=1.15.3-alpine)
+    echo "-t $target_image:$TAG"
+    return 0
+}
+
 # Create multi-arch manifest with automatic fallback to single platform
 # Args:
 #   $1 = target image base (e.g., ghcr.io/owner/container)
@@ -66,8 +123,9 @@ create_registry_manifest() {
     local source_image="$2"
     local fail_on_error="${3:-true}"
 
-    local tag_args
+    local tag_args version_specific_tag_args
     tag_args=$(_compute_tag_args "$target_image")
+    version_specific_tag_args=$(_compute_version_specific_tag_args "$target_image" 2>/dev/null) || true
 
     # Try multi-arch manifest first (amd64 + arm64)
     local err_output
@@ -79,21 +137,29 @@ create_registry_manifest() {
     fi
     echo "::warning::Multi-arch attempt failed: $err_output"
 
-    # Fallback to single platform (amd64)
-    if err_output=$($DOCKER buildx imagetools create $tag_args \
-        "$source_image:$TAG-amd64" 2>&1); then
-        echo "::warning::Manifest created with amd64 only for $target_image:$TAG (arm64 not available)"
-        return 0
+    # Fallback amd64-only — skip if no safe version-specific anchor (P2 fix)
+    if [[ -n "$version_specific_tag_args" ]]; then
+        if err_output=$($DOCKER buildx imagetools create $version_specific_tag_args \
+            "$source_image:$TAG-amd64" 2>&1); then
+            echo "::warning::Manifest created with amd64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
+            return 0
+        fi
+        echo "::warning::amd64-only attempt failed: $err_output"
+    else
+        echo "::warning::Skipping amd64-only fallback for $target_image:$TAG (no version-specific anchor — would pollute rolling tag)"
     fi
-    echo "::warning::amd64-only attempt failed: $err_output"
 
-    # Fallback to single platform (arm64)
-    if err_output=$($DOCKER buildx imagetools create $tag_args \
-        "$source_image:$TAG-arm64" 2>&1); then
-        echo "::warning::Manifest created with arm64 only for $target_image:$TAG (amd64 not available)"
-        return 0
+    # Fallback arm64-only — skip if no safe version-specific anchor (P2 fix)
+    if [[ -n "$version_specific_tag_args" ]]; then
+        if err_output=$($DOCKER buildx imagetools create $version_specific_tag_args \
+            "$source_image:$TAG-arm64" 2>&1); then
+            echo "::warning::Manifest created with arm64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
+            return 0
+        fi
+        echo "::warning::arm64-only attempt failed: $err_output"
+    else
+        echo "::warning::Skipping arm64-only fallback for $target_image:$TAG (no version-specific anchor — would pollute rolling tag)"
     fi
-    echo "::warning::arm64-only attempt failed: $err_output"
 
     # All attempts failed
     if [[ "$fail_on_error" == "true" ]]; then


### PR DESCRIPTION
## Summary

GHCR survey (post #442) revealed that **`postgres:18-alpine` is single-arch amd64** while **`postgres:18-alpine-vector` is single-arch arm64** — with the version-specific siblings (`18.3-alpine`, `18.3-alpine-vector`) being properly multi-arch. Different index digests confirm they were created in separate `imagetools create` calls.

### Root cause

`create_registry_manifest`'s 3-tier fallback in `helpers/create-manifest.sh` reused `$tag_args` (rolling + version-specific + latest aliases) for the single-arch fallback paths. A partial build downgraded ALL aliases — including the rolling tag — to single-arch. Subsequent partial builds with a different arch flipped which arch the rolling tag points to.

This makes the multi-arch happy path the **only writer of rolling and latest aliases**. Single-arch fallbacks write ONLY the version-specific anchor, preserving previously-healthy rolling state.

## Changes

### `helpers/create-manifest.sh` (+80/-14)

1. **New helper `_compute_version_specific_tag_args`** — returns ONLY the most-precise tag. Three resolution paths:

   | Path | Trigger | Output |
   |---|---|---|
   | A | `FULL_VERSION` more specific than TAG (postgres convention) | derived full_tag (e.g. `18.3-alpine-vector`) |
   | B | VERSION is single major integer (rolling-form) AND no FULL_VERSION | **non-zero exit, empty stdout** → caller SKIPS fallback |
   | C | TAG itself is version-specific (terraform-style) | TAG as-is |

   Path B is the critical anti-pollution guard.

2. **Bidirectional derivation in `_compute_tag_args`** — symmetric to the existing FULL_VERSION-derived block. When VERSION matches `^[0-9]+\.[0-9]+(\.[0-9]+)?$`, derives the major-rolling tag from TAG. NO-OP today (postgres VERSION="18", terraform VERSION includes alpha suffix) — defensive against future matrix convention changes.

3. **Fallback paths use `$version_specific_tag_args`** with skip-when-empty guards. Multi-arch happy path unchanged. Log messages updated.

4. **TAG prefix guards `[[ "$TAG" == "$VERSION"* ]]`** on all blocks that use `${TAG#"$VERSION"}` — prevents whole-TAG return when TAG doesn't start with VERSION.

## Validation

- `bash -n` ✅, `shellcheck -x` ✅ (no new warnings)
- **7 smoke test cases** including the empty-FULL_VERSION pollution scenario (Path B refuses) and a pathological TAG-prefix scenario (P3 guards short-circuit). All pass.
- Codex xhigh: 2 findings (P2 pollution hole + P3 prefix guard) — **both addressed pre-push**.

## One-time heal needed post-merge

The existing stale rolling tags on the registry (`postgres:18-alpine`, `postgres:18-alpine-vector`, etc.) will **not auto-heal** — they need a manual trigger of the `recreate-manifests` workflow post-merge. That workflow will exercise the now-protected happy path and re-tag them with proper multi-arch indexes.

To execute post-merge:
```bash
gh workflow run recreate-manifests --repo oorabona/docker-containers
```
(or via the GitHub Actions UI)

Then verify with:
```bash
source helpers/registry-utils.sh
ghcr_get_multi_arch_digests "oorabona/postgres" "18-alpine"
```
should return both `manifest_digest_amd64` and `manifest_digest_arm64`.

## Test plan

- [ ] CI passes (shellcheck, lint)
- [ ] Pages deploy succeeds — dashboard regeneration runs `ghcr_get_multi_arch_digests` for all variants without errors
- [ ] After post-merge `recreate-manifests` run, postgres `18-alpine` and `18-alpine-vector` are multi-arch (both arch digests present)
- [ ] No regression on the existing healthy multi-arch tags (terraform `1.15.3-alpine`, etc.)
- [ ] No regression on terraform's single-arch-of-its-own-kind behavior (VERSION="1.15.3-alpine" with alpha suffix → Path C, NOT Path B refusal)

## Follow-up

After this PR + recreate-manifests heal:
- PR-B of #407: re-add Liquid blocks rendering all 3 digest rows on container detail pages
- Optional: surface the "tag pollution" detection in dashboard as a per-variant health badge
