### PR TITLE
feat(provenance): render multi-arch index + per-arch digest rows (PR-B of #407)

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -258,7 +258,9 @@
                 {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
                 {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
                 {%- unless _prov_var.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-                {%- if prov_empty_count < 4 -%}
+                {%- unless _prov_var.manifest_digest_amd64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+                {%- unless _prov_var.manifest_digest_arm64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+                {%- if prov_empty_count < 6 -%}
           <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
             <dl class="evidence-list">
               {%- if page.last_commit_short or site.github.build_revision -%}
@@ -383,7 +385,9 @@
               {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
               {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
               {%- unless _prov_var.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-              {%- if prov_empty_count < 4 -%}
+              {%- unless _prov_var.manifest_digest_amd64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- unless _prov_var.manifest_digest_arm64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- if prov_empty_count < 6 -%}
           <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
             <dl class="evidence-list">
               {%- if page.last_commit_short or site.github.build_revision -%}
@@ -502,7 +506,9 @@
             {%- unless prov_variant.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
             {%- unless prov_variant.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
             {%- unless prov_variant.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-            {%- if prov_empty_count < 4 -%}
+            {%- unless prov_variant.manifest_digest_amd64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- unless prov_variant.manifest_digest_arm64 -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- if prov_empty_count < 6 -%}
           <section class="provenance" aria-labelledby="provenance-heading">
             <header class="provenance-header">
               <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -257,7 +257,8 @@
                 {%- unless _prov_var.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
                 {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
                 {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-                {%- if prov_empty_count < 3 -%}
+                {%- unless _prov_var.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+                {%- if prov_empty_count < 4 -%}
           <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
             <dl class="evidence-list">
               {%- if page.last_commit_short or site.github.build_revision -%}
@@ -273,6 +274,36 @@
                 <dd>
                   <code class="hash hash-long">{{ _prov_bd }}</code>
                   <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_bd }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.multi_arch_index_digest != blank -%}
+              {%- assign _prov_idx = _prov_var.multi_arch_index_digest | strip -%}
+              <div class="evidence-row">
+                <dt>Index digest</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_idx | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy index digest" aria-label="Copy index digest" data-copy="{{ _prov_idx | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.manifest_digest_amd64 != blank -%}
+              {%- assign _prov_amd = _prov_var.manifest_digest_amd64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (amd64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_amd | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy amd64 manifest digest" aria-label="Copy amd64 manifest digest" data-copy="{{ _prov_amd | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.manifest_digest_arm64 != blank -%}
+              {%- assign _prov_arm = _prov_var.manifest_digest_arm64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (arm64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_arm | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_arm | escape }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -351,7 +382,8 @@
               {%- unless _prov_var.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
               {%- unless _prov_var.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
               {%- unless _prov_var.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-              {%- if prov_empty_count < 3 -%}
+              {%- unless _prov_var.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+              {%- if prov_empty_count < 4 -%}
           <section class="provenance" data-variant-tag="{{ _prov_var.tag }}"{% unless _prov_first %} style="display:none"{% endunless %} aria-labelledby="provenance-heading">
             <dl class="evidence-list">
               {%- if page.last_commit_short or site.github.build_revision -%}
@@ -367,6 +399,36 @@
                 <dd>
                   <code class="hash hash-long">{{ _prov_bd }}</code>
                   <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _prov_bd }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.multi_arch_index_digest != blank -%}
+              {%- assign _prov_idx = _prov_var.multi_arch_index_digest | strip -%}
+              <div class="evidence-row">
+                <dt>Index digest</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_idx | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy index digest" aria-label="Copy index digest" data-copy="{{ _prov_idx | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.manifest_digest_amd64 != blank -%}
+              {%- assign _prov_amd = _prov_var.manifest_digest_amd64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (amd64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_amd | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy amd64 manifest digest" aria-label="Copy amd64 manifest digest" data-copy="{{ _prov_amd | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if _prov_var.manifest_digest_arm64 != blank -%}
+              {%- assign _prov_arm = _prov_var.manifest_digest_arm64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (arm64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _prov_arm | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _prov_arm | escape }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}
@@ -439,7 +501,8 @@
             {%- unless prov_variant.attestation_url -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
             {%- unless prov_variant.trivy_summary -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
             {%- unless prov_variant.build_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
-            {%- if prov_empty_count < 3 -%}
+            {%- unless prov_variant.multi_arch_index_digest -%}{%- assign prov_empty_count = prov_empty_count | plus: 1 -%}{%- endunless -%}
+            {%- if prov_empty_count < 4 -%}
           <section class="provenance" aria-labelledby="provenance-heading">
             <header class="provenance-header">
               <p class="eyebrow">VERIFIABLE TRUST ARTIFACTS</p>
@@ -459,6 +522,36 @@
                 <dd>
                   <code class="hash hash-long">{{ _pv_bd }}</code>
                   <button class="provenance-copy-btn" type="button" data-aria-label="Copy build digest" aria-label="Copy build digest" data-copy="{{ _pv_bd }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if prov_variant.multi_arch_index_digest != blank -%}
+              {%- assign _pv_idx = prov_variant.multi_arch_index_digest | strip -%}
+              <div class="evidence-row">
+                <dt>Index digest</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _pv_idx | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy index digest" aria-label="Copy index digest" data-copy="{{ _pv_idx | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if prov_variant.manifest_digest_amd64 != blank -%}
+              {%- assign _pv_amd = prov_variant.manifest_digest_amd64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (amd64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _pv_amd | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy amd64 manifest digest" aria-label="Copy amd64 manifest digest" data-copy="{{ _pv_amd | escape }}">⧉</button>
+                </dd>
+              </div>
+              {%- endif -%}
+              {%- if prov_variant.manifest_digest_arm64 != blank -%}
+              {%- assign _pv_arm = prov_variant.manifest_digest_arm64 | strip -%}
+              <div class="evidence-row">
+                <dt>Manifest digest (arm64)</dt>
+                <dd>
+                  <code class="hash hash-long">{{ _pv_arm | escape }}</code>
+                  <button class="provenance-copy-btn" type="button" data-aria-label="Copy arm64 manifest digest" aria-label="Copy arm64 manifest digest" data-copy="{{ _pv_arm | escape }}">⧉</button>
                 </dd>
               </div>
               {%- endif -%}


### PR DESCRIPTION
## Summary

**PR-B** of #407 — render the multi-arch digests that PR #442 (merged) surfaced into `containers.yml`.

For multi-arch images, three new conditional `evidence-row` blocks are added after the existing "Build digest" row in the Provenance section, in **each of the 3 Liquid render contexts** (`page.versions`, `page.variants`, no-variant):

| Row | Meaning |
|---|---|
| Index digest | What `docker pull <tag>` (no `--platform`) resolves to |
| Manifest digest (amd64) | What `docker pull --platform linux/amd64 <tag>` returns |
| Manifest digest (arm64) | What `docker pull --platform linux/arm64 <tag>` returns |

Each row is independently `!= blank`-guarded (PR #442 omits null fields), so single-arch images render only the present arch's row — no empty rows, no dead branches. Reuses existing `.evidence-row` / `.hash.hash-long` / `.provenance-copy-btn` styling (zero CSS change).

The existing "Build digest" row is **kept unchanged** — it's the attestation/SBOM/Trivy subject (amd64-scoped) and remains meaningful.

## Codex xhigh hardening (applied pre-push)

- **P3a — escaping**: `| escape` on every new digest interpolation (both `<code>` text and `data-copy` attr). Jekyll Liquid does NOT auto-escape `{{ }}`; digests are third-party registry-API values → defense-in-depth per Contract-First "third-party responses untrusted". (Existing Build-digest rows left unescaped — out of PR-B scope; consistency follow-up tracked below.)
- **P3b — visibility gate**: Provenance section empty-count now also counts the multi-arch digest fields. After Copilot review (asymmetric-registry case: a variant can have only a per-arch manifest digest with no index digest), the gate counts ALL 6 signals — `attestation_url`, `trivy_summary`, `build_digest`, `multi_arch_index_digest`, `manifest_digest_amd64`, `manifest_digest_arm64` — threshold `< 6` in all 3 render contexts (render if at least one signal present). Without this, a variant with registry digest fields but no attestation/trivy/build_digest would have its entire Provenance section suppressed.

P2 (single-arch contract nuance) reviewed: rendering is correct — a truly single-manifest image emits only `index_digest` and renders just that row, which is honest (the index digest IS its pull digest). No action.

## Validation

- Liquid if/endif balance preserved (each block self-balanced: 3 if/endif pairs).
- Grep: render blocks reference each of the 3 fields ×6 (2 lines × 3 contexts); 18 `| escape` on new vars; 3 visibility gates each counting 6 signals at threshold `< 6`, 0 at `< 4`/`< 3`.
- Codex xhigh: 1×P2 (no action) + 2×P3 (both fixed pre-push).

## Test plan

- [ ] CI passes (Jekyll build, lint)
- [ ] Pages deploy succeeds
- [ ] `/container/postgres/` (multi-arch) shows: Build digest + Index digest + Manifest digest (amd64) + Manifest digest (arm64) — 4 digest rows
- [ ] `/container/terraform/` (multi-arch) same 4 rows, correct values matching `ghcr_get_multi_arch_digests`
- [ ] A single-arch / Windows variant (github-runner) shows fewer rows, no empty rows
- [ ] Copy buttons work for each new row (data-copy populated, escaped)
- [ ] No regression at 1280px and 375px (mobile) on the Provenance section layout
- [ ] Provenance section still hidden when ALL signals (attestation/trivy/build_digest/index) absent

## Follow-up (#407, not in this PR)

- Rename "Build digest" → "Attestation subject (amd64)" for label clarity now that explicit manifest digests sit alongside it (touches the existing row — deferred to keep PR-B scoped).
- Apply `| escape` to the existing Build-digest rows for consistency (same deferral rationale).

