### PR TITLE
fix(dashboard): guard collect_variant_json against jq -s empty-string stream-shift

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -600,6 +600,34 @@ collect_variant_json() {
             '$vd | map(select(. as $n | $ba | index($n) != null))')
     fi
 
+    # --- jq -s stream-shift guard (Option A) -------------------------------
+    # `jq -s` silently DROPS empty-string stream elements. If ANY of the 9
+    # values below is empty, the slurp array collapses and positional
+    # indices (.[0]..[8]) shift, corrupting the per-variant record (observed:
+    # terraform Provenance digest rows rendered empty — the multi_arch_digests
+    # object landed in the multi_arch_platforms slot). Normalize every input
+    # to its valid-JSON fallback so the stream always has exactly 9 elements.
+    # A fired guard is logged to stderr (rare = upstream producer broke).
+    _slurp_guard() {  # $1=slot name  $2=fallback ; operates on named var via $1
+        local _name="$1" _fallback="$2"
+        local _val="${!_name}"
+        if [[ -z "${_val//[[:space:]]/}" ]]; then
+            printf 'WARN: collect_variant_json slurp guard fired: empty %s for %s:%s — substituted fallback\n' \
+                "$_name" "$container" "$variant_tag" >&2
+            printf -v "$_name" '%s' "$_fallback"
+        fi
+    }
+    _slurp_guard lineage_json '{"build_digest":"unknown","base_image":"unknown","oci_subject_digest":""}'
+    _slurp_guard build_args_json '[]'
+    _slurp_guard sbom_summary '{}'
+    _slurp_guard sbom_packages '{}'
+    _slurp_guard changelog '{}'
+    _slurp_guard build_history '[]'
+    _slurp_guard trivy_summary '{}'
+    _slurp_guard multi_arch_platforms_json '[]'
+    _slurp_guard multi_arch_digests_json '{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+    # ----------------------------------------------------------------------
+
     # Assemble JSON — pipe large data via stdin to avoid ARG_MAX limits
     # (SBOM packages can be very large for containers with many dependencies)
     printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' \


### PR DESCRIPTION
## Summary

`collect_variant_json` (in `generate-dashboard.sh`) assembles a per-variant record by streaming 9 values through `printf '%s\n…(9 args)' … | jq -s` and reading them **positionally**: `.[0]=lineage … .[8]=multi_arch_digests`.

**`jq -s` silently drops any empty-string stream element.** If ANY one of the 9 inputs is `""` (or whitespace-only), the slurped array collapses to 8, every index after the gap shifts down by one — `.[8]` (multi_arch_digests) becomes `null` and the digest object lands in the `.[7]` (multi_arch_platforms) slot.

### Live impact

`terraform` — and every versioned non-postgres container whose lineage/sbom/trivy cache is incomplete on the CI runner — rendered **empty Provenance digest rows** (Index/amd64/arm64 labels present, values blank). `postgres` was unaffected (per-tag cache files keep all 9 inputs non-empty). Introduced by #442 (added the 9th slurp element). Most fragile input: `lineage_json` (`.[0]`) — the only one of the 9 with no upstream `|| fallback` (`resolve_variant_lineage_json`'s `yq -n -o json` can emit nothing on the runner).

This unblocks the PR-B (#447) deploy verification — the terraform Provenance rows were the FAIL there; root cause was here, not in PR-B's Liquid.

## Fix — Option A (user-approved): defense-in-depth, closes the whole class

A local `_slurp_guard` helper normalizes **all 9** inputs to their valid-JSON fallback immediately before the printf, so the stream always has exactly 9 elements regardless of which producer returned empty. Each fired guard logs a plain `WARN:` line to **stderr** with slot/container/tag — a fired guard is rare and means an upstream producer broke, so it's surfaced as signal (not silently masked) without failing dashboard generation.

| slot | fallback |
|---|---|
| `.[0]` lineage_json | `{"build_digest":"unknown","base_image":"unknown","oci_subject_digest":""}` |
| `.[1]` build_args_json | `[]` |
| `.[2]` sbom_summary | `{}` |
| `.[3]` sbom_packages | `{}` |
| `.[4]` changelog | `{}` |
| `.[5]` build_history | `[]` |
| `.[6]` trivy_summary | `{}` |
| `.[7]` multi_arch_platforms_json | `[]` |
| `.[8]` multi_arch_digests_json | `{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}` |

Each fallback matches how the downstream jq filter consumes that index (verified field-by-field).

## Validation

- **Harness proof**: with `lineage_json=""` — BEFORE: slurp len 8, `.[8].index_digest` null, digest object corrupted into the platforms slot. AFTER: len 9, digests intact, platforms intact, exactly one stderr `WARN:` line, stdout unaffected.
- `bash -n generate-dashboard.sh` ✅ · `shellcheck -x generate-dashboard.sh` ✅ (0 new warnings)
- **Codex xhigh ×2** (initial fix + observability-delta re-gate): no blocking findings. Indirect `printf -v "$name"` / `${!name}` write-back correctness and `_slurp_guard`'s `set -e` return-status both explicitly confirmed safe.

## Follow-up (not blocking, deferred)

The positional `printf | jq -s` design is the root fragility. Migrating the 9 inputs to named `--argjson`/`--arg` (no stream → no shift possible; fails fast on multi-document input instead of silently shifting) is the durable hardening — deferred to keep this fix minimal and reviewable. Codex concurs it's optional, not mandatory.

Companion lineage-quality nit (codex): when the lineage guard fires it substitutes `"unknown"` rather than `resolve_variant_lineage_json`'s own derived `base_image` fallback — acceptable because the guard should fire rarely and the WARN surfaces it; improving `resolve_variant_lineage_json`'s own empty-output path is orthogonal.

## Test plan

- [ ] CI passes (shellcheck)
- [ ] Pages deploy / dashboard regen succeeds; stderr WARN count is ~0 (if high → an upstream producer is broken, investigate)
- [ ] `/container/terraform/` Provenance shows Index digest + Manifest digest (amd64) + Manifest digest (arm64) populated with real `sha256:` values for the base variant (cross-check vs `ghcr_get_multi_arch_digests "oorabona/terraform" "1.15.3-alpine-base"`)
- [ ] postgres Provenance unchanged (still correct)
- [ ] Spot-check another versioned non-postgres container (e.g. php, web-shell) Provenance digests now populated
- [ ] No regression: variants legitimately single-arch / never-built still render correctly (rows omitted, not empty)
