### PR TITLE
fix(page-toc): re-enable TOC with scroll+rAF active-highlight + accurate click offset (#405)

### DIFF
--- a/docs/site/_includes/page-toc.html
+++ b/docs/site/_includes/page-toc.html
@@ -2,21 +2,20 @@
   page-toc.html — noscript fallback nav for the <page-toc> custom element.
   Included inside <noscript> from container-detail layout.
   The outer <page-toc data-anchors='...'> element in the layout drives the
-  interactive sidebar (IntersectionObserver, mobile drawer) for JS-enabled browsers.
+  interactive sidebar (scroll+rAF active highlight, mobile drawer) for JS-enabled browsers.
   This file provides the static accessible fallback for JS-disabled browsers.
 {%- endcomment -%}
 <nav class="page-toc-noscript" aria-label="On this page">
   <h2 class="page-toc-eyebrow">On this page</h2>
   <ul>
-    <li><a href="#variants-pull">Variant &amp; Pull</a></li>
-    <li><a href="#all-variants">All variants</a></li>
     <li><a href="#trust-posture">Trust posture</a></li>
     <li><a href="#container-stats">Stats</a></li>
     <li><a href="#provenance">Provenance</a></li>
-    <li><a href="#build-history">Build history</a></li>
-    <li><a href="#dep-health">Dep health</a></li>
     <li><a href="#security-scan">Security scan</a></li>
+    <li><a href="#all-variants">Variants</a></li>
+    <li><a href="#dep-health">Package summary</a></li>
+    <li><a href="#build-history">Build history</a></li>
+    <li><a href="#dependency-health">Dependency health</a></li>
     <li><a href="#readme">README</a></li>
-    <li><a href="#extensions-reference">Extensions</a></li>
   </ul>
 </nav>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -20,7 +20,7 @@
   <!-- tokens.css MUST load before theme.css — defines variables theme.css references -->
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/tokens.css">
   <!-- Component CSS — load after tokens, before theme -->
-  <!-- page-toc.css disabled pending issue #405 -->
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/page-toc.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/variant-action-bar.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/version-tabs.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/components/security-scan-card.css">
@@ -103,14 +103,20 @@
 
         </header>{%- comment -%} /Zone 1 — Identity {%- endcomment -%}
 
-        {%- comment -%}
-          page-toc disabled pending fix — see issue #405.
-          Click offset and scroll-active-highlight bugs make navigation worse than no TOC.
-          Component files preserved in repo (assets/js/components/page-toc.js,
-          assets/css/components/page-toc.css, _includes/page-toc.html) ready to
-          re-enable once the IntersectionObserver + smooth-scroll offset are
-          corrected.
-        {%- endcomment -%}
+        {%- comment -%} Right-side TOC sidebar — fixed position, >=1280px only (page-toc.css). {%- endcomment -%}
+        <page-toc data-anchors='[
+          {"id":"trust-posture","label":"Trust posture"},
+          {"id":"container-stats","label":"Stats"},
+          {"id":"provenance","label":"Provenance"},
+          {"id":"security-scan","label":"Security scan"},
+          {"id":"all-variants","label":"Variants"},
+          {"id":"dep-health","label":"Package summary"},
+          {"id":"build-history","label":"Build history"},
+          {"id":"dependency-health","label":"Dependency health"},
+          {"id":"readme","label":"README"}
+        ]'>
+          <noscript>{% include page-toc.html %}</noscript>
+        </page-toc>
 
         {%- comment -%} Zone 2 — Trust posture (always visible) {%- endcomment -%}
         <section id="trust-posture" class="detail-zone detail-zone--trust" aria-label="Trust posture">
@@ -1096,7 +1102,7 @@
           {%- assign _dep_disabled_count = dm.disabled | default: 0 -%}
           {%- assign _dep_trackable = dm.total | default: 0 | minus: _dep_disabled_count -%}
           {%- if _dep_trackable > 0 -%}
-          <details class="disclosure">
+          <details id="dependency-health" class="disclosure">
             <summary>
               <span class="disclosure__title">Dependency health</span>
               <span class="disclosure__metric">{{ _dep_metric }}</span>
@@ -1243,7 +1249,7 @@
   </div>
 
   <!-- Vanilla web components — CSP-clean, no eval -->
-  <!-- page-toc.js disabled pending issue #405 -->
+  <script defer src="{{ '/assets/js/components/page-toc.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/variant-action-bar.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/components/security-scan.js' | relative_url }}"></script>

--- a/docs/site/assets/js/components/page-toc.js
+++ b/docs/site/assets/js/components/page-toc.js
@@ -3,24 +3,15 @@
 // Vanilla custom element (light DOM). CSP-clean (no eval, no innerHTML).
 // Renders a sticky right-side TOC sidebar on desktop (>=1280px) and a
 // floating drawer-button on mobile (<1280px).
-// Active section tracking via IntersectionObserver.
+// Active section tracking via scroll + requestAnimationFrame (passive).
 // Smooth-scroll with prefers-reduced-motion support.
 
 (function () {
   'use strict';
 
-  // Approximate sticky nav height (px). Used as scroll offset.
+  // Fallback nav height (px) — used only when the nav element is not found.
   // Measured from .site-nav padding 0.85rem*2 + ~38px line-height ~ 64px total.
-  var NAV_HEIGHT = 64;
-
-  // Debounce helper for resize events.
-  function debounce(fn, ms) {
-    var t;
-    return function () {
-      clearTimeout(t);
-      t = setTimeout(fn, ms);
-    };
-  }
+  var NAV_HEIGHT_FALLBACK = 64;
 
   class PageToc extends HTMLElement {
 
@@ -30,10 +21,9 @@
 
     connectedCallback() {
       this._anchors = [];      // [{id, label}] filtered to sections present in DOM
-      this._sections = [];     // [Element] — observed section elements
+      this._sections = [];     // [Element] — section elements in DOM order
       this._links = [];        // [<a>] — TOC anchor elements (desktop)
       this._drawerLinks = [];  // [<a>] — TOC anchor elements (mobile drawer)
-      this._observer = null;
       this._activeId = null;
       this._isMobile = false;
       this._triggerBtn = null;
@@ -42,17 +32,27 @@
       this._mql = null;
       this._onMqlChange = null;
       this._onKeydown = null;
+      this._raf = null;        // pending requestAnimationFrame handle
+
+      // Corrective re-aim guards (P2-1)
+      this._clickSeq = 0;
+      this._clickRaf = null;   // pending click-defer rAF handle (cancelled on new click / disconnect)
+      this._reaimTimer = null;
+      this._reaimAborted = false;
+      this._reaimAbortListeners = null; // {wheel, touchstart, keydown} refs for cleanup
 
       this._parseAnchors();
       this._render();
-      this._setupObserver();
+      this._setupScrollHighlight();
       this._setupMobileQuery();
     }
 
     disconnectedCallback() {
-      if (this._observer) {
-        this._observer.disconnect();
-        this._observer = null;
+      window.removeEventListener('scroll', this._boundOnScroll);
+      window.removeEventListener('resize', this._boundOnScroll);
+      if (this._raf !== null) {
+        cancelAnimationFrame(this._raf);
+        this._raf = null;
       }
       if (this._mql && this._onMqlChange) {
         this._mql.removeEventListener('change', this._onMqlChange);
@@ -63,6 +63,16 @@
         document.removeEventListener('keydown', this._onKeydown);
         this._onKeydown = null;
       }
+      // Clean up pending click-defer rAF and corrective re-aim state.
+      if (this._clickRaf !== null) {
+        cancelAnimationFrame(this._clickRaf);
+        this._clickRaf = null;
+      }
+      if (this._reaimTimer !== null) {
+        clearTimeout(this._reaimTimer);
+        this._reaimTimer = null;
+      }
+      this._removeReaimAbortListeners();
     }
 
     // -------------------------------------------------------
@@ -212,54 +222,96 @@
     }
 
     // -------------------------------------------------------
-    // IntersectionObserver — active section tracking
+    // Live sticky offset — reads CURRENT rendered heights
     // -------------------------------------------------------
 
-    _setupObserver() {
-      if (!this._sections.length || typeof IntersectionObserver === 'undefined') { return; }
+    _stickyOffset() {
+      var navH = 0;
+      var barH = 0;
+
+      // header.site-nav — position: sticky (theme.css:400)
+      var nav = document.querySelector('header.site-nav');
+      if (nav) {
+        navH = nav.getBoundingClientRect().height || 0;
+      } else {
+        navH = NAV_HEIGHT_FALLBACK;
+      }
+
+      // variant-action-bar — when [data-collapsed], .vab-card gets position: fixed
+      // (variant-action-bar.css:53-54). Only count height when the card is actually
+      // occupying screen space (fixed or sticky).
+      var bar = document.querySelector('variant-action-bar');
+      if (bar) {
+        var card = bar.querySelector('.vab-card') || bar;
+        var cs = getComputedStyle(card);
+        if (cs.position === 'fixed' || cs.position === 'sticky') {
+          barH = card.getBoundingClientRect().height || 0;
+        }
+      }
+
+      return Math.round(navH + barH + 8);
+    }
+
+    // -------------------------------------------------------
+    // Active-section highlight via scroll + rAF (no IntersectionObserver)
+    // -------------------------------------------------------
+
+    _setupScrollHighlight() {
+      if (!this._sections.length) { return; }
 
       var self = this;
-      var intersections = {};
+      this._boundOnScroll = function () { self._onScroll(); };
 
-      this._observer = new IntersectionObserver(function (entries) {
-        entries.forEach(function (entry) {
-          intersections[entry.target.id] = entry.intersectionRatio;
-        });
+      window.addEventListener('scroll', this._boundOnScroll, { passive: true });
+      window.addEventListener('resize', this._boundOnScroll, { passive: true });
 
-        // Section with highest intersection ratio = active.
-        var bestId = null;
-        var bestRatio = 0;
-        self._sections.forEach(function (el) {
-          var ratio = intersections[el.id] || 0;
-          if (ratio > bestRatio) {
-            bestRatio = ratio;
-            bestId = el.id;
-          }
-        });
-
-        // If nothing meaningfully visible, keep previous active.
-        if (bestRatio < 0.05 && self._activeId) { return; }
-        if (bestId && bestId !== self._activeId) {
-          self._setActive(bestId);
-        }
-      }, {
-        rootMargin: '-' + self._computeOffset() + 'px 0px 0px 0px',
-        threshold: [0, 0.1, 0.5, 1.0]
-      });
-
-      this._sections.forEach(function (el) {
-        self._observer.observe(el);
+      // Prime the highlight after initial render (one rAF so layout is settled).
+      this._raf = requestAnimationFrame(function () {
+        self._raf = null;
+        self._updateActive();
       });
     }
 
-    _computeOffset() {
-      // Sticky nav + variant-action-bar (when collapsed/sticky).
-      var bar = document.querySelector('variant-action-bar');
-      var barH = 0;
-      if (bar) {
-        barH = bar.getBoundingClientRect().height || 0;
+    _onScroll() {
+      if (this._raf !== null) { return; } // already a frame pending — skip
+      var self = this;
+      this._raf = requestAnimationFrame(function () {
+        self._raf = null;
+        self._updateActive();
+      });
+    }
+
+    _updateActive() {
+      if (!this._sections.length) { return; }
+
+      // Probe line: just below the bottom edge of all sticky bands.
+      var line = this._stickyOffset() + 4;
+
+      // Last section whose top edge is at or above the probe line = active.
+      var activeEl = null;
+      for (var i = 0; i < this._sections.length; i++) {
+        var top = this._sections[i].getBoundingClientRect().top;
+        if (top <= line) {
+          activeEl = this._sections[i];
+        }
       }
-      return Math.round(NAV_HEIGHT + barH + 8);
+
+      // Scrolled to bottom — force last anchor active (short final sections
+      // may never cross the probe line on their own).
+      // P2-codex-nit: use scrollingElement (respects html { overflow-x: clip }).
+      var scrollEl = document.scrollingElement || document.documentElement;
+      if (scrollEl.scrollTop + window.innerHeight >= scrollEl.scrollHeight - 2) {
+        activeEl = this._sections[this._sections.length - 1];
+      }
+
+      // Nothing qualifies (above first section) — highlight first.
+      if (!activeEl) {
+        activeEl = this._sections[0];
+      }
+
+      if (activeEl.id !== this._activeId) {
+        this._setActive(activeEl.id);
+      }
     }
 
     _setActive(id) {
@@ -284,6 +336,34 @@
     }
 
     // -------------------------------------------------------
+    // P2-1 helpers: user-scroll-intent abort listeners
+    // -------------------------------------------------------
+
+    _addReaimAbortListeners(onAbort) {
+      // Keys that indicate the user is navigating with keyboard scroll intent.
+      var SCROLL_KEYS = { PageUp: 1, PageDown: 1, ArrowUp: 1, ArrowDown: 1, Home: 1, End: 1, ' ': 1 };
+
+      var wheelHandler = function () { onAbort(); };
+      var touchHandler = function () { onAbort(); };
+      var keyHandler   = function (e) { if (SCROLL_KEYS[e.key]) { onAbort(); } };
+
+      window.addEventListener('wheel',      wheelHandler, { once: true, passive: true });
+      window.addEventListener('touchstart', touchHandler, { once: true, passive: true });
+      window.addEventListener('keydown',    keyHandler,   { once: true, passive: true });
+
+      this._reaimAbortListeners = { wheel: wheelHandler, touch: touchHandler, key: keyHandler };
+    }
+
+    _removeReaimAbortListeners() {
+      if (!this._reaimAbortListeners) { return; }
+      var refs = this._reaimAbortListeners;
+      window.removeEventListener('wheel',      refs.wheel);
+      window.removeEventListener('touchstart', refs.touch);
+      window.removeEventListener('keydown',    refs.key);
+      this._reaimAbortListeners = null;
+    }
+
+    // -------------------------------------------------------
     // Smooth scroll on link click
     // -------------------------------------------------------
 
@@ -292,20 +372,74 @@
       var target = document.getElementById(id);
       if (!target) { return; }
 
-      // Auto-open any <details> at-or-ancestor of target so content is visible before scroll.
+      // Cancel any not-yet-fired click rAF from a prior click, then clear all
+      // in-flight re-aim state before computing anything for this new click.
+      if (this._clickRaf !== null) {
+        cancelAnimationFrame(this._clickRaf);
+        this._clickRaf = null;
+      }
+      if (this._reaimTimer !== null) {
+        clearTimeout(this._reaimTimer);
+        this._reaimTimer = null;
+      }
+      this._removeReaimAbortListeners();
+      this._reaimAborted = false;
+
+      // Monotonically-increasing click token — deferred callbacks check this to
+      // detect whether a newer click superseded them.
+      this._clickSeq = (this._clickSeq || 0) + 1;
+      var mySeq = this._clickSeq;  // captured BEFORE scheduling the rAF
+
+      // Auto-open any <details> at-or-ancestor of target so content is visible
+      // before scroll (preserves PR #404 auto-expand behavior).
       var node = target;
       while (node) {
-        if (node.tagName === 'DETAILS') {
+        if (node.tagName === 'DETAILS' && !node.open) {
           node.open = true;
         }
         node = node.parentElement;
       }
 
-      var offset = this._computeOffset();
-      var top = target.getBoundingClientRect().top + window.scrollY - offset;
-
+      var self = this;
       var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      window.scrollTo({ top: top, behavior: prefersReduced ? 'auto' : 'smooth' });
+
+      // Defer measurement to AFTER <details> open reflow (one rAF).
+      this._clickRaf = requestAnimationFrame(function () {
+        self._clickRaf = null;
+
+        // Bail before touching any state if a newer click superseded this one.
+        if (self._clickSeq !== mySeq) { return; }
+
+        var offset = self._stickyOffset();
+        var y = window.scrollY + target.getBoundingClientRect().top - offset;
+        // Always use 'auto' for reduced-motion (instant, no animation).
+        window.scrollTo({ top: y, behavior: prefersReduced ? 'auto' : 'smooth' });
+
+        // Install one-shot user-scroll-intent abort listeners.
+        self._addReaimAbortListeners(function () {
+          self._reaimAborted = true;
+          self._removeReaimAbortListeners();
+        });
+
+        // Corrective re-aim: after ~420ms the action-bar collapses (height shrinks)
+        // and the page has settled. Runs for BOTH motion modes:
+        //   - smooth: corrects residual offset from smooth-scroll + bar collapse
+        //   - reduced: instant initial scroll can still land under a newly-fixed bar
+        // The ONLY difference under reduced-motion is behavior:'auto' (always).
+        self._reaimTimer = setTimeout(function () {
+          self._reaimTimer = null;
+          self._removeReaimAbortListeners();
+
+          // Abort if user scrolled/clicked elsewhere during the wait (defense in depth).
+          if (self._reaimAborted || self._clickSeq !== mySeq) { return; }
+
+          var offset2 = self._stickyOffset();
+          var residual = target.getBoundingClientRect().top - offset2;
+          if (Math.abs(residual) > 6) {
+            window.scrollTo({ top: window.scrollY + residual, behavior: 'auto' });
+          }
+        }, 420);
+      });
 
       this._setActive(id);
     }


### PR DESCRIPTION
Closes #405

## Summary

Re-enables the right-side TOC sidebar (`<page-toc>`, ≥1280px, vanilla light-DOM web component) disabled in #406. Two simultaneous sticky bands broke it: `header.site-nav` (~60px, `position:sticky`) AND the variant-action-bar `.vab-card` (~36px collapsed / ~60px expanded, `position:fixed` when `[data-collapsed]`). The old IntersectionObserver baked `rootMargin` once at init and never re-evaluated on bar collapse; the click handler read the bar's expanded height but the bar collapses after the smooth-scroll → target landed ~24px off (worse for `<details>` links that auto-expand + reflow).

## Approach 1b — scroll + requestAnimationFrame (user-approved)

- **Active-highlight**: IntersectionObserver removed. Passive scroll/resize listener throttled by rAF (single pending frame) reads LIVE geometry of BOTH bands every frame via `_stickyOffset()` (counts `.vab-card` only when its computed position is fixed/sticky). Picks the last section whose top ≤ sticky line; above-first + bottom-of-page guards (bottom uses `document.scrollingElement || document.documentElement`, correct under the site-wide `html{overflow-x:clip}`).
- **Click offset**: opens ancestor `<details>` before measuring; defers position read to rAF (post-reflow); ~420ms corrective re-aim handles the async action-bar collapse. Re-aim guarded by a monotonic `_clickSeq` token + one-shot wheel/touch/scroll-key abort listeners + a cancellable click rAF, all reset at the top of every click and on disconnect — a superseded or user-interrupted click never yanks the viewport and never leaks listeners/timers.
- **Reduced-motion**: instant `behavior:'auto'` for both the initial jump and the (still-performed) correction — not skipped, because the collapse offset applies regardless of animation.
- **Anchor reconciliation**: removed dead `#variants-pull` + `#extensions-reference`; split the mislabeled `#dep-health` (it's the Package summary disclosure) from the real Dependency-health section (new `id="dependency-health"`); `data-anchors` JSON + noscript fallback now in exact DOM order (required by the last-section-at-line algorithm).
- **Re-enabled**: uncommented the page-toc CSS link, JS script, and `<page-toc>` element in container-detail.html.

No CSS change. Mobile drawer (<1280px), overlay, Escape, focus, light-DOM XSS-safe rendering preserved.

## Validation

- Codex xhigh reviewed across multiple gates (initial design, hardening, final) — all clean, no residual S/M findings. Specifically verified: rAF guard reset ordering, `self`-capture (not callback-`this`), listener add/remove reference symmetry, superseded-click state isolation, anchor list DOM-order, reduced-motion correction path, bottom-detection scrolling-element source.
- `node --check docs/site/assets/js/components/page-toc.js` passes.
- Branch rebased on current master (no `generate-dashboard.sh` pollution; clean 3-file diff).

## Test plan (post-deploy browser verify)

- [ ] CI passes; Pages deploy succeeds
- [ ] At 1280 / 1440 / 1920px: clicking each of the 9 TOC anchors lands within ±5px of the section heading top, regardless of action-bar collapsed/expanded state
- [ ] Clicking a `<details>` anchor (Package summary, Build history, Dependency health) auto-expands it AND the scroll lands on the disclosure summary (not inside)
- [ ] Scrolling top→bottom: the highlighted TOC item is always the section in the reader's primary zone (below sticky bands); changes at the moment a new section crosses the line
- [ ] Rapid double-click / click-then-scroll: no viewport yank-back; no console errors
- [ ] prefers-reduced-motion: instant jumps land accurately (no smooth animation), correction still accurate after bar collapse
- [ ] <1280px: no TOC sidebar; mobile drawer unaffected (overlay, Escape, focus)
- [ ] No regression on PR #404 behavior (ancestor `<details>` opens on click)
