### PR TITLE
perf(dashboard): add profiling of dashboard-data generation

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -79,8 +79,9 @@ jobs:
        github.event.workflow_run.event != 'pull_request' &&
        github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -482,6 +483,7 @@ jobs:
       - name: Generate dashboard data
         env:
           GH_TOKEN: ${{ github.token }}
+          DASHBOARD_PROFILE: "1"
         run: |
           chmod +x generate-dashboard.sh
 

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1115,6 +1115,89 @@ EOF
 generate_data() {
     log_info "Generating Jekyll data files..."
 
+    # --- Profiling instrumentation (DASHBOARD_PROFILE gate) ---
+    # Default OFF — zero behavior change when unset/empty.
+    # All telemetry goes to $PROF temp dir + stderr.  Stdout fidelity is
+    # preserved: shims pass through exit-code and stdout unchanged.
+    # Shims use `command curl/jq/yq` to avoid infinite recursion.
+    local _PROF_ENABLED=0
+    local PROF=""
+    if [[ -n "${DASHBOARD_PROFILE:-}" ]]; then
+        _PROF_ENABLED=1
+        PROF="${TMPDIR:-/tmp}/dash-prof-$$"
+        ( umask 077; mkdir -p "$PROF" ) 2>/dev/null || true
+
+        # --- curl shim ---
+        # Classifies by URL, records elapsed + class to $PROF/curl.log.
+        # Stdout/stderr/exit-code of the real curl are passed through unchanged.
+        # set -e safety: `command curl "$@" || _rc=$?` — the left side of ||
+        # is exempt from set -e abort; rc is captured regardless of success/failure.
+        # A stalled curl (exit 28, --max-time hit) records a ge9-bucket entry —
+        # that is the H2 (latency-bound) discriminator and MUST be recorded.
+        # Telemetry write guarded by [ -n "${PROF:-}" ] so an unset/empty PROF
+        # is a clean no-op rather than a set -u fatal expansion.
+        curl() {
+            local _t0 _t1 _rc _elapsed _class _url _arg
+            _rc=0
+            _t0=$(date +%s.%N 2>/dev/null || date +%s)
+            command curl "$@" || _rc=$?
+            _t1=$(date +%s.%N 2>/dev/null || date +%s)
+            # Classify by scanning args for the last https: URL
+            _url=""
+            for _arg in "$@"; do
+                case "$_arg" in https://*) _url="$_arg" ;; esac
+            done
+            case "$_url" in
+                */manifests/sha256:*) _class="perarch"  ;;
+                */manifests/*)        _class="indextag" ;;
+                */token*)             _class="token"    ;;
+                */blobs/*)            _class="blob"     ;;
+                *)                    _class="other"    ;;
+            esac
+            # Compute elapsed with awk (handles both fractional and integer timestamps)
+            _elapsed=$(awk "BEGIN{printf \"%.3f\", ${_t1} - ${_t0}}" 2>/dev/null || echo "0")
+            [ -n "${PROF:-}" ] && { printf '%s %s\n' "$_class" "$_elapsed" >> "$PROF/curl.log"; } 2>/dev/null || true
+            return $_rc
+        }
+
+        # --- jq shim (count only — no per-call date; thousands of calls) ---
+        # set -e safety: `command jq "$@" || _rc=$?` — non-zero exit (e.g. from
+        # `jq -e` boolean tests that return 1) is captured, not aborted.
+        # This ensures jq -e "false-path" calls are counted — critical for H3.
+        jq() {
+            local _rc=0
+            command jq "$@" || _rc=$?
+            [ -n "${PROF:-}" ] && { printf 'x' >> "$PROF/jq.count"; } 2>/dev/null || true
+            return $_rc
+        }
+
+        # --- yq shim (count only) ---
+        # set -e safety: same || _rc=$? idiom.
+        yq() {
+            local _rc=0
+            command yq "$@" || _rc=$?
+            [ -n "${PROF:-}" ] && { printf 'x' >> "$PROF/yq.count"; } 2>/dev/null || true
+            return $_rc
+        }
+
+        # NO export -f: registry-utils.sh is sourced into this same shell —
+        # function shadowing works without export.  NOT exporting intentionally
+        # prevents shim leakage into child version.sh processes: those run under
+        # their own set -euo pipefail and do not have $PROF exported, so a leaked
+        # shim would hit an unbound-variable abort on "$PROF/..." expansion.
+        # Child version.sh cost (~1 upstream curl/container) is captured by the
+        # per-container phase timer, not the curl/jq shims (which target the ~150
+        # manifest fetches inside registry-utils, all in-process).
+    else
+        # Disabled path: actively remove any shims left from a prior enabled call
+        # in the same shell, restoring the real binaries.  This makes the invariant
+        # literally true: disabled ⇒ no curl/jq/yq shell functions, zero overhead.
+        unset -f curl jq yq 2>/dev/null || true
+    fi
+
+    local _ts_start _ts_loop_start _ts_loop_end _ts_finalize_end
+    [[ "$_PROF_ENABLED" -eq 1 ]] && _ts_start=$(date +%s)
+
     cd "$SCRIPT_DIR"
 
     # Pre-populate build status cache (once, before the loop)
@@ -1127,7 +1210,12 @@ generate_data() {
     mkdir -p "$CONTAINERS_DIR"
     rm -f "$CONTAINERS_DIR"/*.md
 
+    [[ "$_PROF_ENABLED" -eq 1 ]] && _ts_loop_start=$(date +%s)
+
     for container in */; do
+        local _ts_iter_start=0
+        [[ "$_PROF_ENABLED" -eq 1 ]] && _ts_iter_start=$(date +%s)
+
         container=${container%/}
 
         is_skip_directory "$container" && continue
@@ -1350,7 +1438,17 @@ generate_data() {
 
         # Accumulate for containers.yml
         all_containers_json=$(printf '%s\n%s' "$all_containers_json" "$container_json" | jq -s '.[0] + [.[1]]')
+
+        # Per-container timing (profiling gate)
+        if [[ "$_PROF_ENABLED" -eq 1 ]]; then
+            local _ts_iter_end
+            _ts_iter_end=$(date +%s)
+            local _iter_elapsed=$(( _ts_iter_end - _ts_iter_start ))
+            { printf '%s %s\n' "$container" "$_iter_elapsed" >> "$PROF/containers.log"; } 2>/dev/null || true
+        fi
     done
+
+    [[ "$_PROF_ENABLED" -eq 1 ]] && _ts_loop_end=$(date +%s)
 
     # Write containers.yml from accumulated JSON
     {
@@ -1378,6 +1476,82 @@ generate_data() {
 
     log_info "Generated $DATA_FILE with $total containers"
     log_info "Stats: $up_to_date/$total up-to-date, $updates_available updates, build jobs success ${build_success_rate}% ($build_success/$build_total)"
+
+    # --- Profiling summary (emitted to stderr AFTER data file is written) ---
+    if [[ "$_PROF_ENABLED" -eq 1 ]]; then
+        _ts_finalize_end=$(date +%s)
+
+        # step_wall_s
+        local _step_wall=$(( _ts_finalize_end - _ts_start ))
+
+        # phase timings (integer seconds)
+        local _setup_s=$(( _ts_loop_start - _ts_start ))
+        local _loop_s=$(( _ts_loop_end - _ts_loop_start ))
+        local _finalize_s=$(( _ts_finalize_end - _ts_loop_end ))
+
+        # curl stats — parse $PROF/curl.log with awk (avoid jq/yq — they are shimmed)
+        local _curl_total_s=0 _curl_n=0
+        local _curl_perarch=0 _curl_indextag=0 _curl_token=0 _curl_blob=0 _curl_other=0
+        local _curl_lt1=0 _curl_b1_5=0 _curl_b5_9=0 _curl_ge9=0
+        if [[ -f "$PROF/curl.log" ]]; then
+            eval "$(awk '
+                BEGIN { n=0; tot=0; pa=0; it=0; tk=0; bl=0; ot=0; lt1=0; b15=0; b59=0; ge9=0 }
+                NF==2 {
+                    n++
+                    tot += $2
+                    if      ($1=="perarch")  pa++
+                    else if ($1=="indextag") it++
+                    else if ($1=="token")    tk++
+                    else if ($1=="blob")     bl++
+                    else                     ot++
+                    e=$2+0
+                    if      (e <  1) lt1++
+                    else if (e <  5) b15++
+                    else if (e <  9) b59++
+                    else             ge9++
+                }
+                END {
+                    printf "_curl_n=%d; _curl_total_s=%.3f; _curl_perarch=%d; _curl_indextag=%d; _curl_token=%d; _curl_blob=%d; _curl_other=%d; _curl_lt1=%d; _curl_b1_5=%d; _curl_b5_9=%d; _curl_ge9=%d\n",
+                        n, tot, pa, it, tk, bl, ot, lt1, b15, b59, ge9
+                }
+            ' "$PROF/curl.log" 2>/dev/null || echo ':')"
+        fi
+
+        # fork counts (wc -c on accumulation files)
+        local _jq_n=0 _yq_n=0
+        if [[ -f "$PROF/jq.count" ]]; then
+            _jq_n=$(wc -c < "$PROF/jq.count" 2>/dev/null || echo 0)
+        fi
+        if [[ -f "$PROF/yq.count" ]]; then
+            _yq_n=$(wc -c < "$PROF/yq.count" 2>/dev/null || echo 0)
+        fi
+
+        # top-5 slowest containers (awk sort by elapsed desc)
+        local _top_containers=""
+        if [[ -f "$PROF/containers.log" ]]; then
+            _top_containers=$(awk '{print $2, $1}' "$PROF/containers.log" 2>/dev/null | \
+                sort -rn | head -5 | awk '{printf "%s=%s ", $2, $1}' 2>/dev/null || echo "")
+            _top_containers="${_top_containers% }"
+        fi
+
+        # Emit PROFILE block to stderr (stable PROFILE prefix, greppable from gh run view --log)
+        {
+            printf 'PROFILE step_wall_s=%d\n'       "$_step_wall"
+            printf 'PROFILE curl calls=%d total_s=%.3f perarch=%d indextag=%d token=%d blob=%d other=%d\n' \
+                "$_curl_n" "$_curl_total_s" "$_curl_perarch" "$_curl_indextag" \
+                "$_curl_token" "$_curl_blob" "$_curl_other"
+            printf 'PROFILE curl_lat lt1=%d b1_5=%d b5_9=%d ge9=%d\n' \
+                "$_curl_lt1" "$_curl_b1_5" "$_curl_b5_9" "$_curl_ge9"
+            printf 'PROFILE forks jq_calls=%d yq_calls=%d\n' "$_jq_n" "$_yq_n"
+            printf 'PROFILE phase setup_s=%d loop_s=%d finalize_s=%d\n' \
+                "$_setup_s" "$_loop_s" "$_finalize_s"
+            printf 'PROFILE top_containers %s\n' "${_top_containers:-none}"
+            printf 'PROFILE END\n'
+        } >&2
+
+        # Clean up temp profiling dir
+        rm -rf "$PROF" 2>/dev/null || true
+    fi
 }
 
 # Only run when executed directly (not when sourced for testing)

--- a/tests/unit/dashboard-helpers.bats
+++ b/tests/unit/dashboard-helpers.bats
@@ -8,11 +8,31 @@ setup() {
     ORIG_DIR="$PWD"
     cd "$TEST_DIR" || exit 1
 
+    # Save bats' EXIT trap before sourcing generate-dashboard.sh.
+    # generate-dashboard.sh sets its own EXIT trap at source-time (to clean
+    # TRIVY_CACHE_FILE); if we let it replace bats' trap, failing tests exit
+    # silently without writing their TAP "not ok" line.
+    local _saved_exit_trap
+    _saved_exit_trap=$(trap -p EXIT 2>/dev/null) || true
+
     # Source generate-dashboard.sh — the BASH_SOURCE guard prevents
     # generate_data from running when sourced, only functions are defined
     source "$ORIG_DIR/helpers/logging.sh" 2>/dev/null || true
     source "$ORIG_DIR/helpers/variant-utils.sh" 2>/dev/null || true
     source "$ORIG_DIR/generate-dashboard.sh" 2>/dev/null || true
+
+    # Capture the trivy cache file created by generate-dashboard.sh at source-time
+    # (TRIVY_CACHE_FILE=$(mktemp ...)).  teardown() must clean it explicitly because
+    # the EXIT trap that would have done so is about to be replaced.
+    _SOURCED_TRIVY_CACHE="${TRIVY_CACHE_FILE:-}"
+    export _SOURCED_TRIVY_CACHE
+
+    # Restore bats' EXIT trap, which generate-dashboard.sh just replaced.
+    if [[ -n "$_saved_exit_trap" ]]; then
+        eval "$_saved_exit_trap" 2>/dev/null || true
+    else
+        trap - EXIT 2>/dev/null || true
+    fi
 
     # Override SCRIPT_DIR AFTER sourcing — generate-dashboard.sh line 11
     # sets it to dirname "$0", we need it pointing to our test dir
@@ -21,6 +41,8 @@ setup() {
 
 teardown() {
     cd "$ORIG_DIR" || true
+    # Clean source-time trivy cache file (would orphan without this).
+    rm -f "${_SOURCED_TRIVY_CACHE:-}" 2>/dev/null || true
     rm -rf "$TEST_DIR"
 }
 

--- a/tests/unit/dashboard-profiling.bats
+++ b/tests/unit/dashboard-profiling.bats
@@ -1,0 +1,330 @@
+#!/usr/bin/env bats
+
+# Tests for DASHBOARD_PROFILE instrumentation in generate-dashboard.sh
+#
+# Verifies four contracts:
+#  1. Profiling-ON: all 7 PROFILE keys emitted to stderr
+#  2. Profiling-ON: PROFILE key=value lines are parseable
+#  3. Profiling-OFF: no PROFILE lines on stderr, byte-identical yml to profiling-ON
+#  4. STRUCTURAL: set-e-safe || _rc=$? idiom present on all three shims (no bare form)
+#  5. Profiling data does NOT appear in containers.yml
+#  6. STRUCTURAL: curl shim stdout passthrough -- no pipe/redirect/capture on wrapped call
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    # Source in same pattern as dashboard-helpers.bats.
+    # IMPORTANT: generate-dashboard.sh runs `trap '...' EXIT` at the top level,
+    # which replaces bats' own EXIT trap (bats_teardown_trap as-exit-trap).
+    # Without the trap, failing tests exit without writing the "not ok N" TAP line
+    # (0 tests executed).  We save and restore bats' trap around the source call.
+    local _saved_exit_trap
+    _saved_exit_trap=$(trap -p EXIT 2>/dev/null) || true
+    source "$ORIG_DIR/helpers/logging.sh" 2>/dev/null || true
+    source "$ORIG_DIR/helpers/variant-utils.sh" 2>/dev/null || true
+    source "$ORIG_DIR/generate-dashboard.sh" 2>/dev/null || true
+    # Capture the trivy cache file created by generate-dashboard.sh at source-time
+    # (line: TRIVY_CACHE_FILE=$(mktemp ...)).  setup() will overwrite TRIVY_CACHE_FILE
+    # below with its own tmpfile; the file created at source-time would orphan in /tmp
+    # unless we save and clean it.  The source-time EXIT trap that would have cleaned
+    # it is about to be replaced, so we own this cleanup.
+    _SOURCED_TRIVY_CACHE="${TRIVY_CACHE_FILE:-}"
+    # Restore bats' EXIT trap, which generate-dashboard.sh just replaced.
+    if [[ -n "$_saved_exit_trap" ]]; then
+        eval "$_saved_exit_trap" 2>/dev/null || true
+    else
+        trap - EXIT 2>/dev/null || true
+    fi
+
+    # Override SCRIPT_DIR after sourcing
+    export SCRIPT_DIR="$TEST_DIR"
+
+    # ---- Fixture: minimal non-variant container dir + lineage ----
+    mkdir -p "$TEST_DIR/myprof"
+    printf '#!/bin/bash\necho "2.0.0"\n' > "$TEST_DIR/myprof/version.sh"
+    chmod +x "$TEST_DIR/myprof/version.sh"
+    printf 'FROM alpine:3.19\n' > "$TEST_DIR/myprof/Dockerfile"
+
+    mkdir -p "$TEST_DIR/.build-lineage"
+    cat > "$TEST_DIR/.build-lineage/myprof-2.0.0.json" <<'EOF'
+{
+  "container": "myprof",
+  "version": "2.0.0",
+  "build_digest": "sha256:prof123abc",
+  "oci_subject_digest": "sha256:subjdigest456",
+  "base_image_ref": "alpine:3.19",
+  "built_at": "2026-05-17T00:00:00+00:00"
+}
+EOF
+
+    # Output dirs expected by generate_data
+    mkdir -p "$TEST_DIR/docs/site/_data"
+    mkdir -p "$TEST_DIR/docs/site/_containers"
+
+    DATA_FILE="$TEST_DIR/docs/site/_data/containers.yml"
+    CONTAINERS_DIR="$TEST_DIR/docs/site/_containers"
+    STATS_FILE="$TEST_DIR/docs/site/_data/stats.yml"
+    TRIVY_CACHE_FILE=$(mktemp)
+    export DATA_FILE CONTAINERS_DIR STATS_FILE TRIVY_CACHE_FILE
+
+    # ---- Mock external helpers (same pattern as dashboard-helpers.bats) ----
+    get_current_published_version() { echo "2.0.0"; }
+    get_container_build_status()     { echo "success"; }
+    populate_container_build_status_cache() { :; }
+    get_dockerhub_stats()            { echo "pulls:10 stars:2"; }
+    get_ghcr_sizes()                 { echo ""; }
+    ghcr_get_manifest_sizes()        { echo ""; }
+    get_sbom_summary()               { echo "{}"; }
+    get_sbom_packages()              { echo "{}"; }
+    get_changelog()                  { echo "{}"; }
+    get_build_history()              { echo "[]"; }
+    build_trivy_category()           { echo "myprof:2.0.0"; }
+    get_attestation_id()             { echo "att-prof-id"; }
+    get_attestation_url()            { echo "https://example.com/att/att-prof-id"; }
+    get_trivy_summary()              { echo '{"last_scan":"2026-05-17T12:00:00Z","counts":{"critical":0,"high":0,"medium":0,"low":1,"info":0},"top_advisories":[]}'; }
+    generate_container_page()        { :; }
+    fetch_recent_activity()          { echo "[]"; }
+    calculate_build_success_rate()   { echo "3:3:100"; }
+    write_stats_file()               { :; }
+    export -f get_current_published_version get_container_build_status \
+              populate_container_build_status_cache get_dockerhub_stats \
+              get_ghcr_sizes ghcr_get_manifest_sizes get_sbom_summary \
+              get_sbom_packages get_changelog get_build_history \
+              build_trivy_category get_attestation_id get_attestation_url \
+              get_trivy_summary generate_container_page fetch_recent_activity \
+              calculate_build_success_rate write_stats_file
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    # Clean both the setup()-assigned trivy cache file AND the one created by
+    # generate-dashboard.sh at source-time (saved in _SOURCED_TRIVY_CACHE).
+    # The source-time EXIT trap is replaced in setup() so we must clean it here.
+    rm -f "${TRIVY_CACHE_FILE:-}" 2>/dev/null || true
+    rm -f "${_SOURCED_TRIVY_CACHE:-}" 2>/dev/null || true
+    rm -rf "$TEST_DIR"
+}
+
+# ===================================================================
+# @test 1: profiling-ON emits all 7 PROFILE keys on stderr
+# ===================================================================
+
+@test "profiling-ON: all 7 PROFILE keys present in stderr" {
+    # Mutation caught: deleting or renaming any of the 7 printf 'PROFILE X' lines
+    # in the profiling summary block of generate-dashboard.sh makes one grep fail.
+    # Capture stderr separately; stdout is suppressed (yml written to file)
+    DASHBOARD_PROFILE=1 generate_data 2>"$TEST_DIR/prof_stderr.txt"
+
+    prof_out="$TEST_DIR/prof_stderr.txt"
+
+    # All 7 required PROFILE lines
+    grep -q '^PROFILE step_wall_s=' "$prof_out"
+    grep -q '^PROFILE curl '       "$prof_out"
+    grep -q '^PROFILE curl_lat '   "$prof_out"
+    grep -q '^PROFILE forks '      "$prof_out"
+    grep -q '^PROFILE phase '      "$prof_out"
+    grep -q '^PROFILE top_containers' "$prof_out"
+    grep -q '^PROFILE END$'        "$prof_out"
+}
+
+# ===================================================================
+# @test 2: profiling-ON emits parseable key=value lines
+# ===================================================================
+
+@test "profiling-ON: PROFILE lines have correct key=value format" {
+    # Mutation caught: changing any key name (e.g. calls= -> count=, jq_calls= -> jq=)
+    # in the printf statements of the profiling summary block makes a grep fail.
+    DASHBOARD_PROFILE=1 generate_data 2>"$TEST_DIR/prof_stderr2.txt"
+
+    prof_out="$TEST_DIR/prof_stderr2.txt"
+
+    # step_wall_s must be an integer
+    step_val=$(grep '^PROFILE step_wall_s=' "$prof_out" | sed 's/PROFILE step_wall_s=//')
+    [[ "$step_val" =~ ^[0-9]+$ ]]
+
+    # curl line has calls= key
+    grep -q 'PROFILE curl calls=' "$prof_out"
+
+    # curl_lat line has lt1= key
+    grep -q 'PROFILE curl_lat lt1=' "$prof_out"
+
+    # forks line has jq_calls= and yq_calls= keys
+    grep -q 'PROFILE forks jq_calls=' "$prof_out"
+    grep -q 'yq_calls=' "$prof_out"
+
+    # phase line has setup_s= loop_s= finalize_s= keys
+    grep -q 'PROFILE phase setup_s=' "$prof_out"
+    grep -q 'loop_s=' "$prof_out"
+    grep -q 'finalize_s=' "$prof_out"
+}
+
+# ===================================================================
+# @test 3: profiling-OFF: no PROFILE lines; yml byte-identical to profiling-ON
+# ===================================================================
+
+@test "profiling-OFF: no PROFILE output; yml byte-identical to profiling-ON run" {
+    # Mutation caught: any code that writes PROFILE lines unconditionally (outside the
+    # _PROF_ENABLED gate) makes the stderr check fail; any stdout side-effect of the
+    # shims (writing to DATA_FILE) makes the cmp check fail.  This is the primary
+    # differential lock between profiling-ON and profiling-OFF behavior.
+    # Run with profiling ON first; capture yml
+    DASHBOARD_PROFILE=1 generate_data 2>/dev/null
+    cp "$DATA_FILE" "$TEST_DIR/containers_prof_on.yml"
+
+    # Remove yml so next run recreates it cleanly
+    rm -f "$DATA_FILE"
+
+    # Run with profiling OFF
+    unset DASHBOARD_PROFILE
+    generate_data 2>"$TEST_DIR/off_stderr.txt"
+    cp "$DATA_FILE" "$TEST_DIR/containers_prof_off.yml"
+
+    # No PROFILE line must appear in stderr of the OFF run
+    if grep -q 'PROFILE ' "$TEST_DIR/off_stderr.txt" 2>/dev/null; then
+        echo "FAIL: PROFILE line found in stderr when DASHBOARD_PROFILE unset:"
+        grep 'PROFILE ' "$TEST_DIR/off_stderr.txt"
+        return 1
+    fi
+
+    # yml output must be byte-identical (zero behavior change)
+    if ! cmp -s "$TEST_DIR/containers_prof_on.yml" "$TEST_DIR/containers_prof_off.yml"; then
+        echo "FAIL: containers.yml differs between profiling-ON and profiling-OFF runs"
+        diff "$TEST_DIR/containers_prof_on.yml" "$TEST_DIR/containers_prof_off.yml" || true
+        return 1
+    fi
+}
+
+# ===================================================================
+# @test 4: STRUCTURAL: curl shim stdout passthrough
+# ===================================================================
+
+@test "STRUCTURAL: curl shim stdout passthrough -- no pipe/redirect/capture on wrapped call" {
+    # STRUCTURAL lock for stdout fidelity. Behavioral corruption is not catchable
+    # through the mocked size path; locked at source: the shim must pass the wrapped
+    # command's stdout through verbatim (no pipe/redirect/capture on the
+    # `command curl` line).
+    local script="$ORIG_DIR/generate-dashboard.sh"
+
+    # The wrapped-call line must be present as an EXECUTABLE line.
+    # Anchored to `^[[:space:]]*command[[:space:]]+curl` so comment lines (starting
+    # with `#`) are excluded — the comment-hole is closed at the presence check too.
+    local safe_line=0
+    safe_line=$(grep -cE '^[[:space:]]*command[[:space:]]+curl[[:space:]]+"[$]@"[[:space:]]*\|\|[[:space:]]*_rc=[$][?]' "$script" 2>/dev/null) || true
+    if [[ "$safe_line" -lt 1 ]]; then
+        echo "FAIL: no executable 'command curl \"\$@\" || _rc=\$?' line found (comment lines excluded)"
+        return 1
+    fi
+
+    # No stdout pipe on the command curl line (exclude || which is OR, not pipe;
+    # pattern \|[^|] matches single pipe followed by non-pipe, e.g. "| sed")
+    local piped=0
+    piped=$(grep -cE 'command curl "\$@"[[:space:]]*\|[^|]' "$script" 2>/dev/null) || true
+    if [[ "$piped" -ne 0 ]]; then
+        echo "FAIL: command curl stdout piped ($piped occurrences)"
+        return 1
+    fi
+
+    # No redirect on the command curl line
+    local redirected=0
+    redirected=$(grep -cE 'command curl "\$@"[[:space:]]*>' "$script" 2>/dev/null) || true
+    if [[ "$redirected" -ne 0 ]]; then
+        echo "FAIL: command curl stdout redirected ($redirected occurrences)"
+        return 1
+    fi
+
+    # No capture (command curl inside $(...))
+    local captured=0
+    captured=$(grep -cE '\$\(command curl' "$script" 2>/dev/null) || true
+    if [[ "$captured" -ne 0 ]]; then
+        echo "FAIL: command curl stdout captured in \$() ($captured occurrences)"
+        return 1
+    fi
+}
+
+# ===================================================================
+# @test 5: profiling data is NOT written into yml (no PROFILE in data file)
+# ===================================================================
+
+@test "profiling-ON: PROFILE telemetry does not appear in containers.yml" {
+    # Mutation caught: any code that writes profiling output to stdout (DATA_FILE)
+    # instead of stderr makes the `*"PROFILE "* ` check fail.
+    DASHBOARD_PROFILE=1 generate_data 2>/dev/null
+
+    yml_content=$(cat "$DATA_FILE")
+
+    # Profiling output must not leak into the data file
+    if [[ "$yml_content" == *"PROFILE "* ]]; then
+        echo "FAIL: PROFILE string found in containers.yml"
+        grep 'PROFILE' "$DATA_FILE" || true
+        return 1
+    fi
+}
+
+# ===================================================================
+# @test 6: STRUCTURAL: set-e-safe || _rc=$? idiom on all three shims
+# ===================================================================
+
+@test "STRUCTURAL: set-e-safe || _rc=\$? idiom present on all three shims -- no bare form" {
+    # STRUCTURAL lock. The runtime set-e abort this guards is NOT reproducible in the
+    # bats harness (errexit is not effective in generate_data's $(...) call path), so
+    # a behavioral RED->GREEN test is impossible and would be vacuous. The invariant is
+    # therefore locked at SOURCE level: the set-e-safe `|| _rc=$?` idiom must be
+    # present on all three shims; the bare `command X; _rc=$?` form is forbidden.
+    # Runtime behavior is additionally guarded by code review (Test Validity Gate /
+    # codex). Reverting the fix changes this source text -> this test goes RED
+    # (empirically verified).
+    local script="$ORIG_DIR/generate-dashboard.sh"
+
+    # Each shim must have the safe form on an EXECUTABLE line.
+    # Patterns are anchored to `^[[:space:]]*command[[:space:]]+X` so a comment
+    # line (which starts with `#`, possibly after spaces) can NEVER satisfy them.
+    # This closes the "comment hole": a doc comment containing the idiom text would
+    # NOT satisfy these patterns, so the lock cannot be gamed by adding a comment.
+    #
+    # Safe-idiom pattern: `^[[:space:]]*command[[:space:]]+X[[:space:]]+"$@"[[:space:]]*||[[:space:]]*_rc=$?`
+    # (EOL-anchored so "|| _rc=$? # comment" still matches — only leading `#` is excluded)
+    #
+    # Pattern: `local var=0; var=$(grep ...) || true` -- safe under set -eET:
+    # grep exits 1 on no-match; || true absorbs it; var retains grep's "0" output.
+    local curl_safe=0 jq_safe=0 yq_safe=0
+    curl_safe=$(grep -cE '^[[:space:]]*command[[:space:]]+curl[[:space:]]+"[$]@"[[:space:]]*\|\|[[:space:]]*_rc=[$][?]' "$script" 2>/dev/null) || true
+    jq_safe=$(grep -cE   '^[[:space:]]*command[[:space:]]+jq[[:space:]]+"[$]@"[[:space:]]*\|\|[[:space:]]*_rc=[$][?]'   "$script" 2>/dev/null) || true
+    yq_safe=$(grep -cE   '^[[:space:]]*command[[:space:]]+yq[[:space:]]+"[$]@"[[:space:]]*\|\|[[:space:]]*_rc=[$][?]'   "$script" 2>/dev/null) || true
+
+    if [[ "$curl_safe" -lt 1 ]]; then
+        echo "FAIL: curl shim missing executable || _rc=\$? idiom (comment lines do not count)"
+        return 1
+    fi
+    if [[ "$jq_safe" -lt 1 ]]; then
+        echo "FAIL: jq shim missing executable || _rc=\$? idiom (comment lines do not count)"
+        return 1
+    fi
+    if [[ "$yq_safe" -lt 1 ]]; then
+        echo "FAIL: yq shim missing executable || _rc=\$? idiom (comment lines do not count)"
+        return 1
+    fi
+
+    # No bare executable form allowed.
+    # Bare pattern: `^[[:space:]]*command[[:space:]]+X[[:space:]]+"$@"[[:space:]]*$`
+    # (line-ends immediately after "$@", possibly with trailing spaces — no `||`).
+    # A comment mentioning the bare form would start with `#` and cannot match.
+    local curl_bare=0 jq_bare=0 yq_bare=0
+    curl_bare=$(grep -cE '^[[:space:]]*command[[:space:]]+curl[[:space:]]+"[$]@"[[:space:]]*$' "$script" 2>/dev/null) || true
+    jq_bare=$(grep -cE   '^[[:space:]]*command[[:space:]]+jq[[:space:]]+"[$]@"[[:space:]]*$'   "$script" 2>/dev/null) || true
+    yq_bare=$(grep -cE   '^[[:space:]]*command[[:space:]]+yq[[:space:]]+"[$]@"[[:space:]]*$'   "$script" 2>/dev/null) || true
+
+    if [[ "$curl_bare" -ne 0 ]]; then
+        echo "FAIL: curl has $curl_bare bare executable 'command curl \"\$@\"' line without || _rc=\$?"
+        return 1
+    fi
+    if [[ "$jq_bare" -ne 0 ]]; then
+        echo "FAIL: jq has $jq_bare bare executable 'command jq \"\$@\"' line without || _rc=\$?"
+        return 1
+    fi
+    if [[ "$yq_bare" -ne 0 ]]; then
+        echo "FAIL: yq has $yq_bare bare executable 'command yq \"\$@\"' line without || _rc=\$?"
+        return 1
+    fi
+}


### PR DESCRIPTION
Refs #453

## Summary

The GitHub Pages dashboard deploy has been timing out on every run. The dashboard-data CI step exceeds its 40-minute time budget. This change adds profiling to identify where the time is spent.

It adds env-gated (`DASHBOARD_PROFILE`) profiling to `generate-dashboard.sh` that attributes the time across the candidate causes:

- per-architecture GHCR manifest fetch volume (`curl … perarch=N`)
- curl latency / rate-limit stalls (`curl_lat ge9=K`; operation-timeout exits are recorded, not lost to errexit)
- jq/yq subprocess spawn counts (`forks jq_calls/yq_calls`)
- per-container loop duration (`phase loop_s` + a top-slowest-containers list)

The build job timeout is raised from 40 to 60 minutes to allow a profiled run to complete and emit the breakdown.

## Behaviour and verification

- Profiling is off by default with byte-identical output — verified by a differential test (generated YAML identical on/off; telemetry goes to stderr only; the summary is aggregated with awk, never the wrapped jq/yq).
- The profiling test suite includes two source-level invariant checks: the set-e-safe `command X "$@" || _rc=$?` form is present on all three shims (no bare form), and the curl shim does not pipe/redirect/capture the wrapped command's stdout. Both were validated by reverting the guarded code and confirming the check fails, then restoring and confirming it passes; the checks are anchored so a comment containing the idiom cannot mask a real regression.
- `dashboard-helpers.bats` regression suite passes; `shellcheck` clean.

## Incidental fix

`generate-dashboard.sh` registers a top-level `trap … EXIT`. When sourced into bats it replaced bats' own teardown trap and silently swallowed test output. Both bats `setup()`s now save `$(trap -p EXIT)` before sourcing and restore it after, and clean the source-time temporary cache file.

## Known limitations (deferred, low impact)

- The negative curl check (no-pipe) is not line-anchored, so a future comment mentioning a pipe form could fail the test spuriously — a noisy false failure, never a silent pass. The load-bearing positive checks are comment-immune.
- On a `setup()` failure path, `dashboard-helpers.bats` can leave a single empty `/tmp` cache file; the success path is clean.
- Per-architecture curl time is attributed by count, not per-class seconds; unambiguous one-run per-class time attribution would need a small awk addition. Sufficient for identifying the current bottleneck.
