### PR TITLE
ci(dashboard): disable profiling instrumentation + restore 50m timeout

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -79,7 +79,7 @@ jobs:
        github.event.workflow_run.event != 'pull_request' &&
        github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 50
     steps:
 
       - name: Checkout
@@ -483,7 +483,6 @@ jobs:
       - name: Generate dashboard data
         env:
           GH_TOKEN: ${{ github.token }}
-          DASHBOARD_PROFILE: "1"
         run: |
           chmod +x generate-dashboard.sh
 


### PR DESCRIPTION
Refs #453 (performance investigation continues there; this PR does not close it).

## Summary

The GitHub Pages dashboard deploy has been cancelled on every recent run, so the already-merged container Provenance digests and page table-of-contents have not reached the live site.

This runs the dashboard-data generation step **without the optional profiling instrumentation**, at its normal duration (~40 min), and sets the build job timeout to **50 min** (normal duration plus headroom). With profiling disabled the step behaves byte-identically to before it was added, so the deploy completes and the merged content ships live.

The env-gated profiling code stays in `generate-dashboard.sh`, dormant by default — it added too much in-run overhead to be enabled on the time-budgeted CI deploy. The slowness is investigated separately (offline, no CI time limit) under #453; unblocking the deploy and measuring the slow path are now decoupled.

## Changes

- `.github/workflows/update-dashboard.yaml`: remove `DASHBOARD_PROFILE: "1"` from the "Generate dashboard data" step env (profiling off → baseline duration); build job `timeout-minutes` 60 → 50.

## Test plan

- [ ] CI shellcheck workflow passes
- [ ] Post-merge `update-dashboard` run completes under 50 min (no profiling)
- [ ] Live `/container/terraform/` and `/container/php/` show the multi-arch Provenance digest rows; postgres page table-of-contents renders
- [ ] No behaviour change vs the pre-profiling baseline (profiling disabled)
