### PR TITLE
ci(dashboard): increase build timeout to 90 minutes

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -79,7 +79,7 @@ jobs:
        github.event.workflow_run.event != 'pull_request' &&
        github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 90
     steps:
 
       - name: Checkout


### PR DESCRIPTION
Refs #453 (the generation-time investigation continues there; this PR does not close it).

## Summary

The GitHub Pages dashboard deploy keeps being cancelled. On the current codebase the dashboard-data generation step takes ~50 minutes, and the build job timeout was set right at that edge, so the run is cancelled before it finishes and the already-merged container Provenance digests and page table-of-contents never reach the live site.

This raises the build job `timeout-minutes` from 50 to 90 — a deliberately generous ceiling (a stopgap), not a fitted estimate, chosen so the run completes with comfortable margin regardless of run-to-run variance and the post-generation steps (Jekyll build, OG image generation, artifact upload) whose duration has not yet been observed.

The cap is a ceiling, not the runtime: the run will finish in roughly its real duration and consume only that. A long ceiling on the daily refresh is an accepted stopgap; the underlying generation slowness is being investigated and fixed separately under #453, after which the timeout can be tightened again.

## Changes

- `.github/workflows/update-dashboard.yaml`: build job `timeout-minutes` 50 → 90. No other change.

## Test plan

- [ ] CI shellcheck workflow passes
- [ ] Post-merge `update-dashboard` run completes within 90 min (first run that should reach the post-generation steps)
- [ ] Live `/container/terraform/` and `/container/php/` show the multi-arch Provenance digest rows; postgres page table-of-contents renders
- [ ] Record the observed full-job duration and per-step timings (input to the #453 fix)
