### PR TITLE
perf(dashboard): persist GHCR per-arch manifest cache across CI runs

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -480,9 +480,17 @@ jobs:
             ./scripts/audit-base-image-cache.sh --summary
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Restore GHCR per-arch manifest cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.ghcr-cache/perarch
+          key: ghcr-perarch-never-exact-match
+          restore-keys: ghcr-perarch-
+
       - name: Generate dashboard data
         env:
           GH_TOKEN: ${{ github.token }}
+          GHCR_CACHE_DIR: ${{ github.workspace }}/.ghcr-cache
         run: |
           chmod +x generate-dashboard.sh
 
@@ -606,6 +614,13 @@ jobs:
         with:
           path: .trivy-scan-history
           key: trivy-scan-history-dashboard-${{ github.run_id }}
+
+      - name: Save GHCR per-arch manifest cache
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.ghcr-cache/perarch
+          key: ghcr-perarch-${{ github.run_id }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## Problem
The dashboard "Generate dashboard data" CI step is ~100% of the Pages-deploy job wallclock (~57min, rising linearly with the container×variant matrix). #455 added a per-arch GHCR manifest file-cache whose logic and immutable `image@sha256:digest` key are correct — but `GHCR_CACHE_DIR` defaults to a per-process tmpdir (`${TMPDIR:-/tmp}/ghcr-cache-$$`) that is never persisted across runs. Cross-run hit rate was 0%: the cache was write-only in production, so #455 delivered ~0 measured speedup and the step kept rising. (Root-caused by read-only code trace 2026-05-18; the competing hypothesis that #442/#447 per-variant digest fetches regressed it was refuted — they predate the baseline.)

## Change (workflow-only)
`helpers/registry-utils.sh` already honours an externally-exported `GHCR_CACHE_DIR`, so no script change is needed. This PR:
1. Pins `GHCR_CACHE_DIR=${{ github.workspace }}/.ghcr-cache` (deterministic, no PID suffix) in the "Generate dashboard data" step `env:`.
2. Adds an `actions/cache/restore` step before it and an `actions/cache/save` step after it, mirroring the existing house split-cache pattern (same pinned `actions/cache@27d5ce7f… v5.0.5`, `never-exact-match` primary key + prefix `restore-keys`, `if: always()` on save — identical to the `build-lineage`/`trivy-scan-history` steps).
3. Scopes the persisted path to **only** the immutable `…/.ghcr-cache/perarch` subtree. The sibling `idx-*` (tag-mutable) and `tok-*` (TTL'd) files stay per-run by design — persisting a stale index would yield wrong dashboard provenance.

Per-arch manifests are `sha256`-digest-addressed and therefore content-immutable: a restored entry is never stale, so the cache needs no TTL and only changed images miss.

## Verification
- YAML parses; structural asserts hold (restore < generate < save ordering; correct keys/path/SHA); `helpers/registry-utils.sh` & `generate-dashboard.sh` byte-unchanged (`git diff --quiet`).
- codex xhigh pre-PR gate: **GATE_OK, zero findings** (independently verified step ordering, perarch-only scoping, and the GitHub cache restore-key/immutability/eviction model vs upstream docs).
- True cross-run speedup proof is post-merge CI-only (two consecutive deploy runs; 2nd is warm) and is the explicit gate for a separate, measurement-driven follow-up that tightens the build `timeout-minutes` back down from the current 90 — deliberately NOT bundled here (avoids repeating the #452/#455 change-without-measuring anti-pattern).

## Scope
Out of scope (tracked separately): build-lineage per-arch sizes (the structural alternative, ties into #407), curl parallelization, and the timeout tightening (gated on the post-merge measurement).

## Test plan
- [ ] CI green on the PR (shellcheck, validate-version-scripts, smoke build)
- [ ] Post-merge: 1st `update-dashboard` deploy populates `ghcr-perarch-*` cache (restore step shows miss → save writes snapshot)
- [ ] Post-merge: 2nd consecutive deploy shows `ghcr-perarch-` cache HIT in the restore step and a sharply reduced "Generate dashboard data" duration vs the ~57min baseline
- [ ] Follow-up issued: tighten build `timeout-minutes` from the measured warm duration

Refs #453
