### PR TITLE
ci(diag): throwaway SBOM-timing probe (workflow_dispatch)

### DIFF
--- a/.github/workflows/sbom-timing-probe.yaml
+++ b/.github/workflows/sbom-timing-probe.yaml
@@ -1,0 +1,687 @@
+name: SBOM Timing Probe (Diagnostic)
+
+# Diagnostic-only workflow: measures which operation inside the dashboard
+# collect_variant_json loop consumes ~20 min for the github-runner
+# windows-ltsc2022-dev variant in CI.  Suspect: unbounded jq over a
+# multi-GB Windows .sbom.json.  This probe measures it (no inference).
+# Removable after the measurement.
+#
+# Refs #453
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'github-runner windows-ltsc2022-dev tag (e.g. 2.334.0-windows-ltsc2022-dev)'
+        required: false
+        default: '2.334.0-windows-ltsc2022-dev'
+        type: string
+
+permissions:
+  contents: read
+  actions: read    # needed to list + download artifacts from other runs
+  packages: read
+
+jobs:
+  probe:
+    name: SBOM Timing Probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # ------------------------------------------------------------------
+      # Step 0: Validate tag input upfront.
+      # Allowed pattern: <semver>-windows-ltsc2022-dev
+      # A shell single-quote in the tag would break heredoc/script baking;
+      # we reject early so the probe never runs with an unvalidated value.
+      # ------------------------------------------------------------------
+      - name: Validate tag input
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -uo pipefail
+
+          TAG="${INPUT_TAG:-2.334.0-windows-ltsc2022-dev}"
+
+          TAG_REGEX='^[0-9]+\.[0-9]+\.[0-9]+-windows-ltsc2022-dev$'
+          if [[ ! "${TAG}" =~ ${TAG_REGEX} ]]; then
+            echo "::error::tag input '${TAG}' does not match required pattern '${TAG_REGEX}'"
+            echo "::error::Halting probe — PROBE_INVALID: tag validation failed"
+            exit 1
+          fi
+
+          echo "tag_valid=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Tag validated: ${TAG}"
+        id: validate-tag
+
+      # ------------------------------------------------------------------
+      # Step 1: Acquire .build-lineage files — mirrors update-dashboard.yaml.
+      #
+      # Primary:   restore the build-lineage Actions cache (same pinned SHA +
+      #            key idiom as update-dashboard.yaml "Restore build lineage cache").
+      # Secondary: gh run download sbom-* + lineage-derived-* artifacts from
+      #            recent auto-build runs (same logic as update-dashboard.yaml
+      #            "Re-download SBOM artifacts from recent auto-build runs").
+      # Both are attempted: cache first, then artifact overlay.  We record
+      # which source actually provided the target SBOM file.
+      # ------------------------------------------------------------------
+
+      - name: Restore build lineage cache
+        id: cache-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build-lineage
+          key: build-lineage-never-exact-match
+          restore-keys: build-lineage-
+
+      - name: Download SBOM artifacts from recent auto-build runs (overlay)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROBE_TAG: ${{ steps.validate-tag.outputs.tag_valid }}
+        run: |
+          set -uo pipefail
+
+          mkdir -p .build-lineage
+
+          # Window: last 48h (wider than update-dashboard.yaml's 24h to increase
+          # the chance of finding the windows-dev SBOM, which may not appear in
+          # every daily run).
+          cutoff=$(date -u -d '48 hours ago' --iso-8601=seconds)
+          if ! run_ids=$(gh run list \
+              --workflow=auto-build.yaml \
+              --branch=master \
+              --limit 100 \
+              --json databaseId,createdAt,conclusion \
+              --jq "[.[] | select(.createdAt >= \"$cutoff\" and (.conclusion == \"success\" or .conclusion == \"failure\"))] | .[].databaseId" \
+              2>/tmp/gh-stderr-probe.txt); then
+            echo "::warning::gh run list failed — SBOM hydration skipped. stderr:" >&2
+            cat /tmp/gh-stderr-probe.txt >&2 || true
+            rm -f /tmp/gh-stderr-probe.txt
+            exit 0
+          fi
+          rm -f /tmp/gh-stderr-probe.txt
+
+          if [[ -z "$run_ids" ]]; then
+            echo "::notice::No recent completed auto-build runs in the last 48h; relying on cache only."
+            exit 0
+          fi
+
+          staging=$(mktemp -d)
+          trap 'rm -rf "$staging"' EXIT
+
+          downloaded=0
+          for run_id in $run_ids; do
+            stderr_file=$(mktemp)
+            # Download sbom-* artifacts (contain the .sbom.json files)
+            if gh run download "$run_id" \
+                --pattern 'sbom-*' \
+                --dir "$staging/$run_id" 2>"$stderr_file"; then
+              downloaded=$((downloaded + 1))
+            else
+              grep -qi "no artifact" "$stderr_file" 2>/dev/null || \
+                echo "::warning::gh run download (sbom-*) failed for run $run_id" >&2
+            fi
+            rm -f "$stderr_file"
+
+            # Download lineage-derived-* artifacts (contain .history.json etc.)
+            stderr_file=$(mktemp)
+            if gh run download "$run_id" \
+                --pattern 'lineage-derived-*' \
+                --dir "$staging/$run_id-derived" 2>"$stderr_file"; then
+              :
+            else
+              grep -qi "no artifact" "$stderr_file" 2>/dev/null || \
+                echo "::warning::gh run download (lineage-derived-*) failed for run $run_id" >&2
+            fi
+            rm -f "$stderr_file"
+          done
+
+          # Merge SBOMs: newer .creationInfo.created wins (mirrors update-dashboard.yaml)
+          merged=0
+          while IFS= read -r -d '' src; do
+            fname=$(basename "$src")
+            target=".build-lineage/$fname"
+            src_created=$(jq -r '.creationInfo.created // empty' "$src" 2>/dev/null || true)
+            [[ -z "$src_created" ]] && continue
+            if [[ -f "$target" ]]; then
+              tgt_created=$(jq -r '.creationInfo.created // empty' "$target" 2>/dev/null || true)
+              [[ -n "$tgt_created" ]] && [[ ! "$src_created" > "$tgt_created" ]] && continue
+            fi
+            cp -- "$src" "$target"
+            merged=$((merged + 1))
+          done < <(find "$staging" -name '*.sbom.json' -print0)
+
+          # Merge derived files (first-seen from newest run wins)
+          declare -A derived_seen=()
+          for run_id in $run_ids; do
+            derived_dir="$staging/$run_id-derived"
+            [[ -d "$derived_dir" ]] || continue
+            while IFS= read -r -d '' src; do
+              fname=$(basename "$src")
+              dest=".build-lineage/$fname"
+              [[ -n "${derived_seen[$fname]:-}" ]] && continue
+              cp -- "$src" "$dest"
+              derived_seen[$fname]=1
+            done < <(find "$derived_dir" -name '*.json' -print0)
+          done
+
+          total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
+          echo "Downloaded from $downloaded run(s); merged $merged SBOM file(s); total SBOMs: $total"
+
+      # ------------------------------------------------------------------
+      # Step 2: Restore GHCR per-arch manifest cache (production-faithful).
+      #
+      # update-dashboard.yaml restores .ghcr-cache/perarch before calling
+      # generate-dashboard.sh; the probe must do the same so
+      # ghcr_get_manifest_sizes is measured WARM (same conditions as production).
+      # Mirroring update-dashboard.yaml "Restore GHCR per-arch manifest cache"
+      # step verbatim (same pinned SHA, same key idiom).
+      # ------------------------------------------------------------------
+      - name: Restore GHCR per-arch manifest cache (production-faithful warm state)
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.ghcr-cache/perarch
+          key: ghcr-perarch-never-exact-match
+          restore-keys: ghcr-perarch-
+
+      # ------------------------------------------------------------------
+      # Step 3: Resolve SBOM file + measure each dashboard operation.
+      #
+      # Function sourcing strategy (two-tier):
+      #
+      # Tier A — helpers sourced wholesale (same order as generate-dashboard.sh
+      #   lines 13-21): provides extract_sbom_summary (sbom-utils.sh) and
+      #   ghcr_get_manifest_sizes (registry-utils.sh).
+      #
+      # Tier B — dashboard-local wrappers extracted via eval+awk from the
+      #   workspace file ${REPO_ROOT}/generate-dashboard.sh (the checked-out
+      #   master version): get_sbom_summary, get_sbom_packages, get_build_history.
+      #   These 3 functions live inside generate-dashboard.sh itself, NOT in
+      #   any helper.  Sourcing the 9 helpers does NOT define them.
+      #   generate-dashboard.sh cannot be sourced wholesale (no source-guard;
+      #   top-level code runs under set -euo pipefail and would abort).
+      #   The awk range extractor is safe: each function starts at column 0
+      #   "fn()" and ends at the first column-0 "}" with no intermediate
+      #   column-0 "}" inside the body, so the range is unambiguous.
+      #   NOTE: No git show / git fetch / origin/master dependency — the
+      #   workflow runs on master (workflow_dispatch default branch) so the
+      #   checked-out workspace IS the master version we want to measure.
+      #
+      # Dependency map for the 3 extracted functions:
+      #   get_sbom_summary  → $SCRIPT_DIR (set to $REPO_ROOT), extract_sbom_summary
+      #   get_sbom_packages → $SCRIPT_DIR, jq (purl filter — NOT extract_sbom_summary)
+      #   get_build_history → $SCRIPT_DIR, jq
+      #
+      # Fix 2 — safe tag passing: tag is never baked into the op script via
+      #   string interpolation; passed as PROBE_OP_TAG env var instead.
+      #
+      # Fix 3 — no misleading fallback: if the exact windows-ltsc2022-dev
+      #   SBOM is absent → PROBE_INVALID=1 + loud banner; no silent fallback.
+      #
+      # Fix 4 — incremental summary + suspect-first ordering + per-op
+      #   timeouts: suspects (get_sbom_packages, get_sbom_summary) run first
+      #   with timeout 1500; cheaper ops use timeout 120.  Each op appends its
+      #   row to GITHUB_STEP_SUMMARY immediately after completing, so a later
+      #   job-level cancellation still preserves the prime-suspect rows.
+      #
+      # Fix 5 — correct guard messaging: no claim that a size guard is active
+      #   in production on origin/master.  The guard is a separate unmerged fix.
+      # ------------------------------------------------------------------
+      - name: Measure SBOM operations for windows-ltsc2022-dev
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROBE_TAG: ${{ steps.validate-tag.outputs.tag_valid }}
+        run: |
+          set -uo pipefail
+
+          REPO_ROOT="${GITHUB_WORKSPACE}"
+          TAG="${PROBE_TAG:-2.334.0-windows-ltsc2022-dev}"
+          CONTAINER="github-runner"
+
+          echo "=== SBOM Timing Probe ==="
+          echo "Target tag  : ${TAG}"
+          echo "Runner      : ${RUNNER_OS:-unknown} / $(uname -m)"
+          echo ""
+
+          # ----------------------------------------------------------------
+          # Fix 3 — Resolve SBOM file (exact path only; no silent fallback).
+          # The functions under test use SCRIPT_DIR/.build-lineage/<c>-<t>.sbom.json
+          # which with SCRIPT_DIR=REPO_ROOT resolves to:
+          #   .build-lineage/github-runner-<TAG>.sbom.json
+          # If that exact file is absent → PROBE_INVALID; rows tagged INVALID.
+          # ----------------------------------------------------------------
+          SBOM_FILE="${REPO_ROOT}/.build-lineage/${CONTAINER}-${TAG}.sbom.json"
+          PROBE_INVALID=0
+          ACQUISITION_SOURCE="unknown"
+
+          echo "Available SBOMs in .build-lineage/:"
+          set +e
+          find "${REPO_ROOT}/.build-lineage" -name '*.sbom.json' 2>/dev/null | sort | \
+            while read -r f; do
+              sz=$(stat -c%s "$f" 2>/dev/null || echo 0)
+              printf "  %-80s  %d bytes (%.1f MB)\n" \
+                "$f" "$sz" "$(awk "BEGIN{printf \"%.1f\", ${sz}/1048576}")"
+            done
+          set -e
+          echo ""
+
+          if [[ -f "${SBOM_FILE}" ]]; then
+            ACQUISITION_SOURCE="cache-or-artifact (exact tag match)"
+            echo "SBOM found (exact tag match): ${SBOM_FILE}"
+          else
+            PROBE_INVALID=1
+            echo "================================================================"
+            echo "  *** PROBE INVALID — windows-dev SBOM not obtained ***"
+            echo "  Expected: ${SBOM_FILE}"
+            echo "  This file was not present after cache restore + artifact"
+            echo "  download.  Measurement would be INVALID (wrong/empty file)."
+            echo "  All timed op rows will be marked INVALID."
+            echo "================================================================"
+          fi
+
+          SBOM_SIZE_BYTES=0
+          SBOM_SIZE_MB="0.00"
+          if [[ -f "${SBOM_FILE}" ]]; then
+            SBOM_SIZE_BYTES=$(stat -c%s "${SBOM_FILE}" 2>/dev/null || echo 0)
+            SBOM_SIZE_MB=$(awk "BEGIN{printf \"%.2f\", ${SBOM_SIZE_BYTES}/1048576}")
+          fi
+
+          echo "SBOM file   : ${SBOM_FILE}"
+          echo "SBOM size   : ${SBOM_SIZE_BYTES} bytes (${SBOM_SIZE_MB} MB)"
+          echo ""
+
+          # ----------------------------------------------------------------
+          # Write summary header + metadata BEFORE any ops
+          # (so even a job-level cancellation preserves this context).
+          # ----------------------------------------------------------------
+          {
+            printf '# SBOM Timing Probe Results\n\n'
+            printf '> Code under measurement is the checked-out workspace `generate-dashboard.sh` of the dispatched ref;\n'
+            printf '> see the **Measured against:** marker below for guarded/unguarded status.\n\n'
+            if [[ "${PROBE_INVALID}" -ne 0 ]]; then
+              printf '## *** PROBE INVALID — windows-dev SBOM not obtained ***\n\n'
+              printf '> Expected SBOM: `%s`\n' "${CONTAINER}-${TAG}.sbom.json"
+              printf '> File was absent after cache restore + artifact download.\n'
+              printf '> All op rows below are INVALID (no file = no faithful measurement).\n\n'
+            fi
+            printf '## Probe Target\n\n'
+            printf '| Field | Value |\n'
+            printf '|-------|-------|\n'
+            printf '| Requested tag | `%s` |\n' "${TAG}"
+            printf '| SBOM file | `%s` |\n' "${SBOM_FILE}"
+            printf '| SBOM size | `%d` bytes (**%s MB**) |\n' "${SBOM_SIZE_BYTES}" "${SBOM_SIZE_MB}"
+            printf '| Acquisition source | %s |\n' "${ACQUISITION_SOURCE}"
+            printf '| Runner | `%s` / `%s` |\n' "${RUNNER_OS:-unknown}" "$(uname -m)"
+            printf '| PROBE_INVALID | `%d` |\n' "${PROBE_INVALID}"
+            printf '| `ghcr_get_manifest_sizes` cache | WARM (`.ghcr-cache/perarch` restored — production-faithful) |\n\n'
+            printf '## Timing Results\n\n'
+            printf '| Operation | Wall seconds | RC | Notes |\n'
+            printf '|-----------|-------------|----|-------|\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # ----------------------------------------------------------------
+          # Tier A: source the 9 helpers (same order as generate-dashboard.sh
+          # lines 13-21).  Provides extract_sbom_summary (sbom-utils.sh) and
+          # ghcr_get_manifest_sizes (registry-utils.sh).
+          # ----------------------------------------------------------------
+          SCRIPT_DIR="${REPO_ROOT}"
+          export SCRIPT_DIR
+
+          GHCR_CACHE_DIR="${REPO_ROOT}/.ghcr-cache"
+          export GHCR_CACHE_DIR
+          mkdir -p "${GHCR_CACHE_DIR}"
+
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/logging.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/variant-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/build-args-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/registry-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/version-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/sbom-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/attestation-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/trivy-utils.sh"
+          # shellcheck disable=SC1091
+          source "${REPO_ROOT}/helpers/extension-utils.sh"
+
+          # ----------------------------------------------------------------
+          # Tier B: extract get_sbom_summary, get_sbom_packages,
+          # get_build_history from the workspace file
+          # ${REPO_ROOT}/generate-dashboard.sh via awk range extraction.
+          # These 3 functions are defined inside generate-dashboard.sh itself
+          # — NOT in any helper.  The file cannot be sourced wholesale (no
+          # source-guard; top-level code executes under set -euo pipefail).
+          # Each target function starts at column 0 "fn()" and ends at the
+          # first column-0 "}" with no intermediate column-0 "}" inside the
+          # body, so the awk range is safe and unambiguous.
+          # The workflow runs on the default branch (master), so the
+          # checked-out workspace IS the master version; no git show /
+          # git fetch / origin/master reference needed.
+          # ----------------------------------------------------------------
+          eval "$(awk '
+            /^get_sbom_summary\(\)/{in_fn=1}
+            /^get_sbom_packages\(\)/{in_fn=1}
+            /^get_build_history\(\)/{in_fn=1}
+            in_fn{print}
+            /^}/ && in_fn{in_fn=0}
+          ' "${REPO_ROOT}/generate-dashboard.sh")"
+
+          # ----------------------------------------------------------------
+          # Guard-marker: detect whether the extracted get_sbom_summary body
+          # contains SBOM_MAX_BYTES (the size-guard fix, not yet merged).
+          # Print exactly one line to the step log AND $GITHUB_STEP_SUMMARY
+          # so the result is never ambiguous about which code was timed.
+          # ----------------------------------------------------------------
+          if declare -f get_sbom_summary >/dev/null 2>&1 && \
+             declare -f get_sbom_summary | grep -q 'SBOM_MAX_BYTES'; then
+            GUARD_MARKER="Measured against: GUARDED code (size-guard present)"
+          else
+            GUARD_MARKER="Measured against: UNGUARDED baseline"
+          fi
+          echo "${GUARD_MARKER}"
+          printf '\n> **%s**\n' "${GUARD_MARKER}" >> "$GITHUB_STEP_SUMMARY"
+
+          # ----------------------------------------------------------------
+          # Verify all 4 timed ops are now defined (Tier A + Tier B together).
+          # ----------------------------------------------------------------
+          HELPERS_OK=1
+          for fn in get_sbom_summary get_sbom_packages get_build_history extract_sbom_summary; do
+            if ! declare -f "$fn" >/dev/null 2>&1; then
+              echo "::error::Function '$fn' not found after sourcing helpers + extraction — cannot proceed"
+              HELPERS_OK=0
+            fi
+          done
+          if ! declare -f ghcr_get_manifest_sizes >/dev/null 2>&1; then
+            echo "::error::Function 'ghcr_get_manifest_sizes' not found after sourcing helpers"
+            HELPERS_OK=0
+          fi
+
+          if [[ "${HELPERS_OK}" -eq 0 ]]; then
+            PROBE_INVALID=1
+            echo "================================================================"
+            echo "  *** PROBE INVALID — required functions not found after sourcing + extraction ***"
+            echo "  Cannot faithfully measure any operations."
+            echo "================================================================"
+            {
+              printf '| (all ops) | N/A | N/A | INVALID — functions absent after sourcing + extraction |\n'
+              printf '\n> **PROBE INVALID** — required functions absent after sourcing + extraction.\n'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "All helper functions and dashboard-local wrappers verified present."
+          echo ""
+
+          # ----------------------------------------------------------------
+          # Fix 4 — time each operation individually.
+          #
+          # Order: suspects first (those expected slow):
+          #   1. get_sbom_packages  (timeout 1500 — jq over full SBOM packages array)
+          #   2. get_sbom_summary   (timeout 1500 — jq over full SBOM)
+          #   3. get_build_history  (timeout 120  — just reads .history.json, no jq over SBOM)
+          #   4. ghcr_get_manifest_sizes (timeout 120 — network fetch, not SBOM jq)
+          #
+          # Fix 2 — tag is passed via PROBE_OP_TAG env var to each child bash
+          # process, never baked into the script text by string interpolation.
+          #
+          # Fix 4 — each op appends its result row to GITHUB_STEP_SUMMARY
+          # immediately after completing (incremental), so job-level
+          # cancellation preserves the rows that did complete.
+          #
+          # Fix 1 — rc=127 after any op → PROBE_INVALID + row marked INVALID.
+          # ----------------------------------------------------------------
+
+          # op_spec format: "op_name|timeout_sec|call_expression|notes"
+          # call_expression uses $PROBE_OP_TAG (env var, not interpolated)
+          declare -a OP_SPECS=(
+            'get_sbom_packages|1500|get_sbom_packages "${PROBE_OP_CONTAINER}" "${PROBE_OP_TAG}"|jq over full SBOM packages array (SUSPECT)'
+            'get_sbom_summary|1500|get_sbom_summary "${PROBE_OP_CONTAINER}" "${PROBE_OP_TAG}"|jq over full SBOM (SUSPECT)'
+            'get_build_history|120|get_build_history "${PROBE_OP_CONTAINER}" "${PROBE_OP_TAG}"|reads .history.json only (no SBOM jq)'
+            'ghcr_get_manifest_sizes|120|ghcr_get_manifest_sizes "oorabona/${PROBE_OP_CONTAINER}" "${PROBE_OP_TAG}"|GHCR manifest fetch + per-arch sub-manifests'
+          )
+
+          declare -A OP_WALL=()
+          declare -A OP_RC=()
+          declare -A OP_NOTES=()
+          declare -A OP_TIMEOUT=()
+
+          for op_spec in "${OP_SPECS[@]}"; do
+            IFS='|' read -r op_name op_timeout op_call op_note <<< "${op_spec}"
+
+            echo "--- Timing: ${op_name} (timeout ${op_timeout}s) ---"
+            echo "    Args : container=${CONTAINER}, tag=${TAG}"
+            echo "    Note : ${op_note}"
+
+            if [[ "${PROBE_INVALID}" -ne 0 ]]; then
+              echo "    SKIPPING (PROBE_INVALID=1 — no valid SBOM file)"
+              OP_WALL["${op_name}"]="N/A"
+              OP_RC["${op_name}"]="skipped"
+              OP_NOTES["${op_name}"]="${op_note} — INVALID (no valid SBOM)"
+              OP_TIMEOUT["${op_name}"]="${op_timeout}"
+              printf '| `%s` | N/A | skipped | %s — INVALID (no valid SBOM) |\n' \
+                "${op_name}" "${op_note}" >> "$GITHUB_STEP_SUMMARY"
+              echo ""
+              continue
+            fi
+
+            # ----------------------------------------------------------------
+            # Fix 2 — get_build_history: history.json existence gate.
+            # Production flow merges *.history.json across runs; if the exact
+            # file is absent or empty, get_build_history returns [] instantly
+            # (bogus "fast" timing).  Gate: only time if the file exists and
+            # is non-empty; otherwise mark INVALID for this op only (do NOT
+            # set PROBE_INVALID — SBOM ops can still be measured faithfully).
+            # ----------------------------------------------------------------
+            if [[ "${op_name}" == "get_build_history" ]]; then
+              HISTORY_FILE="${REPO_ROOT}/.build-lineage/${CONTAINER}-${TAG}.history.json"
+              if [[ ! -f "${HISTORY_FILE}" ]] || [[ ! -s "${HISTORY_FILE}" ]]; then
+                echo "    SKIPPING get_build_history — history.json absent or empty (non-faithful input)"
+                echo "    Expected: ${HISTORY_FILE}"
+                OP_WALL["${op_name}"]="N/A"
+                OP_RC["${op_name}"]="skipped"
+                OP_NOTES["${op_name}"]="INVALID (history.json absent/non-faithful — not measured)"
+                OP_TIMEOUT["${op_name}"]="${op_timeout}"
+                printf '| `%s` | N/A | skipped | INVALID (history.json absent/non-faithful — not measured) |\n' \
+                  "${op_name}" >> "$GITHUB_STEP_SUMMARY"
+                echo ""
+                continue
+              fi
+            fi
+
+            # Write per-op child script.
+            # Fix 2: PROBE_OP_TAG and PROBE_OP_CONTAINER are passed as env vars;
+            # the op_call expression references them as shell variables — no
+            # string baking of tag value into the script source.
+            op_script=$(mktemp /tmp/probe-op.XXXXXX.sh)
+
+            # shellcheck disable=SC2016
+            printf '%s\n' \
+              "set -euo pipefail" \
+              "SCRIPT_DIR='${REPO_ROOT}'" \
+              "GHCR_CACHE_DIR='${GHCR_CACHE_DIR}'" \
+              "export SCRIPT_DIR GHCR_CACHE_DIR" \
+              "source '${REPO_ROOT}/helpers/logging.sh'" \
+              "source '${REPO_ROOT}/helpers/variant-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/build-args-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/registry-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/version-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/sbom-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/attestation-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/trivy-utils.sh'" \
+              "source '${REPO_ROOT}/helpers/extension-utils.sh'" \
+              > "$op_script"
+            # Append Tier B extraction of dashboard-local wrappers from the
+            # workspace file (master checkout — no git show / origin/master dep).
+            # shellcheck disable=SC2016
+            printf '%s\n' \
+              "eval \"\$(awk '" \
+              "/^get_sbom_summary\\(\\)/{in_fn=1}" \
+              "/^get_sbom_packages\\(\\)/{in_fn=1}" \
+              "/^get_build_history\\(\\)/{in_fn=1}" \
+              "in_fn{print}" \
+              "/^}/ && in_fn{in_fn=0}" \
+              "' '${REPO_ROOT}/generate-dashboard.sh')\"" \
+              "${op_call}" \
+              >> "$op_script"
+
+            t0=$(date +%s.%N)
+            set +e
+            # Fix 6 (measurement-fidelity): capture stdout into a shell variable,
+            # mirroring the production command-substitution shape exactly:
+            #   sbom_packages=$(get_sbom_packages "$container" "$tag")
+            # The produce+capture+retain cost (bash materializing the full output
+            # in a subshell var — potentially multi-GB for the Windows SBOM) is
+            # exactly what we want to measure; >/dev/null short-circuits that
+            # backpressure and under-measures the real production path.
+            # Fix 2: PROBE_OP_TAG + PROBE_OP_CONTAINER exported for the child.
+            # shellcheck disable=SC2034
+            op_out=$(PROBE_OP_TAG="${TAG}" PROBE_OP_CONTAINER="${CONTAINER}" \
+              timeout "${op_timeout}" bash "$op_script" 2>/dev/null)
+            op_rc=$?
+            set -e
+            t1=$(date +%s.%N)
+            # Only report byte-length (safe); NEVER echo op_out to log or summary.
+            op_out_bytes=${#op_out}
+            unset op_out
+            wall=$(awk "BEGIN{printf \"%.3f\", ${t1} - ${t0}}")
+
+            rm -f "$op_script"
+
+            # Fix 1 — rc=127: command-not-found → PROBE_INVALID + mark row
+            ROW_INVALID=0
+            ROW_LABEL="${op_note}"
+            if [[ "${op_rc}" -eq 127 ]]; then
+              PROBE_INVALID=1
+              ROW_INVALID=1
+              ROW_LABEL="INVALID (rc127 — function not found; not faithfully measured)"
+              echo "::error::${op_name} returned rc=127 (command/function not found) — measurement INVALID"
+              echo "    RESULT: INVALID (rc127) — helper sourcing incomplete"
+            elif [[ "${op_rc}" -eq 124 ]]; then
+              echo "    RESULT: TIMEOUT (${op_timeout}s) after ${wall}s | captured ${op_out_bytes} bytes before timeout"
+              ROW_LABEL="${op_note} [TIMEOUT at ${op_timeout}s; captured ${op_out_bytes}B]"
+            else
+              echo "    RESULT: rc=${op_rc} in ${wall}s | captured ${op_out_bytes} bytes"
+              ROW_LABEL="${op_note} [captured ${op_out_bytes}B]"
+            fi
+
+            OP_WALL["${op_name}"]="${wall}"
+            OP_RC["${op_name}"]="${op_rc}"
+            OP_NOTES["${op_name}"]="${ROW_LABEL}"
+            OP_TIMEOUT["${op_name}"]="${op_timeout}"
+
+            # Fix 4 — append row IMMEDIATELY after each op (incremental summary)
+            if [[ "${ROW_INVALID}" -eq 1 ]]; then
+              printf '| `%s` | `%s` | `%s` | %s |\n' \
+                "${op_name}" "${wall}" "${op_rc}" "${ROW_LABEL}" >> "$GITHUB_STEP_SUMMARY"
+            elif [[ "${op_rc}" -eq 124 ]]; then
+              printf '| `%s` | TIMEOUT (%ss) | 124 | %s |\n' \
+                "${op_name}" "${op_timeout}" "${ROW_LABEL}" >> "$GITHUB_STEP_SUMMARY"
+            else
+              printf '| `%s` | `%s` | `%s` | %s |\n' \
+                "${op_name}" "${wall}" "${op_rc}" "${ROW_LABEL}" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            echo ""
+          done
+
+          # ----------------------------------------------------------------
+          # Find slowest op (among completed, non-INVALID ops)
+          # ----------------------------------------------------------------
+          SLOWEST_OP="N/A"
+          SLOWEST_WALL=0
+          for op in get_sbom_packages get_sbom_summary get_build_history ghcr_get_manifest_sizes; do
+            w="${OP_WALL[$op]:-0}"
+            rc="${OP_RC[$op]:-?}"
+            if [[ "$w" != "N/A" ]] && [[ "$rc" != "skipped" ]] && \
+               [[ "${rc}" != "127" ]] && \
+               awk "BEGIN{exit !(${w} > ${SLOWEST_WALL})}"; then
+              SLOWEST_WALL="$w"
+              SLOWEST_OP="$op"
+            fi
+          done
+
+          # ----------------------------------------------------------------
+          # Step-log timing summary
+          # ----------------------------------------------------------------
+          echo "================================================================"
+          echo "  TIMING SUMMARY"
+          echo "================================================================"
+          echo ""
+          echo "NOTE: Code under measurement is the checked-out workspace generate-dashboard.sh of the dispatched ref."
+          echo "See the 'Measured against:' marker (printed at function-extraction time) for guarded/unguarded status."
+          echo ""
+          printf "%-32s %12s %8s %8s  %s\n" "OPERATION" "WALL_SEC" "TIMEOUT" "RC" "NOTES"
+          printf -- "%.0s-" {1..90}; echo
+          for op in get_sbom_packages get_sbom_summary get_build_history ghcr_get_manifest_sizes; do
+            marker=""
+            [[ "${op}" == "${SLOWEST_OP}" ]] && marker=" <-- SLOWEST"
+            printf "%-32s %12s %8s %8s  %s%s\n" \
+              "${op}" "${OP_WALL[$op]:-N/A}" "${OP_TIMEOUT[$op]:-?}" \
+              "${OP_RC[$op]:-?}" "${OP_NOTES[$op]:-}" "${marker}"
+          done
+          echo ""
+          echo "SBOM file    : ${SBOM_FILE}"
+          echo "SBOM size    : ${SBOM_SIZE_BYTES} bytes (${SBOM_SIZE_MB} MB)"
+          echo "Acq. source  : ${ACQUISITION_SOURCE}"
+          echo "Tag          : ${TAG}"
+          echo "PROBE_INVALID: ${PROBE_INVALID}"
+          echo ""
+
+          if [[ "${PROBE_INVALID}" -ne 0 ]]; then
+            echo "================================================================"
+            echo "  *** PROBE INVALID — see details above ***"
+            echo "  One or more critical operations could not be faithfully measured."
+            echo "  Do NOT treat this run as a complete diagnostic."
+            echo "================================================================"
+          fi
+
+          # ----------------------------------------------------------------
+          # Append summary footer (slowest + methodology note)
+          # ----------------------------------------------------------------
+          {
+            printf '\n'
+            if [[ "${PROBE_INVALID}" -ne 0 ]]; then
+              printf '> **PROBE_INVALID=1** — one or more ops were not faithfully measured.\n'
+              printf '> Do NOT treat this run as a complete diagnostic.\n\n'
+            fi
+            printf 'Slowest completed op: `%s` (%ss)\n\n' "${SLOWEST_OP}" "${SLOWEST_WALL}"
+            printf 'RC key: 0=success, 124=timeout, 127=command-not-found (INVALID).\n\n'
+            printf '---\n'
+            printf '_Probe methodology (two-tier function loading):_\n'
+            printf '_**Tier A** — sources the 9 helpers (same order as `generate-dashboard.sh` lines 13–21):_\n'
+            printf '_logging, variant-utils, build-args-utils, **registry-utils** (→ `ghcr_get_manifest_sizes`),_\n'
+            printf '_version-utils, **sbom-utils** (→ `extract_sbom_summary`), attestation-utils,_\n'
+            printf '_trivy-utils, extension-utils._\n'
+            printf '_**Tier B** — extracts `get_sbom_summary`, `get_sbom_packages`, `get_build_history`_\n'
+            printf '_from the workspace file `generate-dashboard.sh` (checked-out workspace of the dispatched ref — no `git show`)._\n'
+            printf '_These 3 wrappers are defined inside `generate-dashboard.sh` itself, not in any helper._\n'
+            printf '_(`get_sbom_packages` uses a distinct jq purl filter, not `extract_sbom_summary`.)_\n'
+            printf '_Calls each function with container=`%s`, tag=`%s` (the real production args)._\n' \
+              "${CONTAINER}" "${TAG}"
+            printf '_Tag passed via env var (not string-baked) to prevent injection._\n'
+            printf '_**Each op timed via command-substitution capture** (`op_out=$(timeout N bash child)`) — mirrors the_\n'
+            printf '_production call shape exactly (`sbom_packages=$(get_sbom_packages …)` in `generate-dashboard.sh`)_\n'
+            printf '_so bash output-materialization / variable-assignment / backpressure is included in the wall time._\n'
+            printf '_Captured value (`op_out`) is never printed to log or summary; only byte-length is reported then `unset`._\n'
+            printf '_Each op appends its row immediately (incremental summary)._\n'
+            printf '_`get_build_history` gated: only timed when `.build-lineage/%s-%s.history.json` exists and is non-empty._\n' \
+              "${CONTAINER}" "${TAG}"
+            printf '_`ghcr_get_manifest_sizes` measured WARM: `.ghcr-cache/perarch` restored before measurement (production-faithful)._\n'
+            printf '_SBOM acquisition mirrors update-dashboard.yaml: cache restore +_\n'
+            printf '_`gh run download sbom-*` + `lineage-derived-*` overlay._\n'
+            printf '_Refs #453_\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Summary written to GITHUB_STEP_SUMMARY."


### PR DESCRIPTION
## Purpose (diagnostic, throwaway)

The `update-dashboard` "Generate dashboard data" CI step measured ~67min; forensic timestamps localized ~61min of it to processing the **github-runner `windows-ltsc2022-dev`** (~9.4GB image) variants, while the same script runs in ~4min locally (the Windows `.sbom.json` files don't exist locally). The leading hypothesis is unbounded `jq` over a very large Windows SBOM. This workflow **measures**, per-op, which operation actually consumes the time — instead of inferring (this investigation was mis-directed multiple times by inference).

## What it does

`workflow_dispatch`-only, `ubuntu-latest`, `timeout-minutes: 60`. For the github-runner windows-ltsc2022-dev variant it times — **mirroring the exact production call shape** (`var=$(get_sbom_packages …)` command-substitution capture, so bash materializes/retains the full output like `generate-dashboard.sh`) — `get_sbom_packages`, `get_sbom_summary` (suspects first, 1500s timeout each), then `get_build_history`, `ghcr_get_manifest_sizes` (120s). Production fidelity is enforced: the 3 dashboard-local functions are extracted from the checked-out `generate-dashboard.sh` (a dynamic marker reports UNGUARDED/GUARDED — sole provenance, no contradictory static claim); `SCRIPT_DIR` resolves the exact acquired `.build-lineage/github-runner-<tag>.sbom.json`; the `.ghcr-cache/perarch` cache is restored exactly as `update-dashboard.yaml` does so `ghcr_get_manifest_sizes` is timed warm. Self-protecting: tag regex-validated + env-passed (no injection); missing exact SBOM → `PROBE_INVALID` + loud banner (no misleading "fast"); `get_build_history` skipped/INVALID if its exact history.json is absent (without poisoning the SBOM timings); `rc=127` → INVALID; the captured (multi-GB) output is never echoed (only its byte length), no token/secret leak; per-op rows appended to `$GITHUB_STEP_SUMMARY` incrementally so a cap can't lose the prime-suspect numbers.

## Interpreting the result

The op with the dominant wall-time names the real ~20min/variant cost. This **validates or revises** the companion size-guard fix (which targets the SBOM jq) *before* that fix is merged.

## Lifecycle

Diagnostic only — **removable once the measurement is captured**. `workflow_dispatch`-only (never auto-runs), no deploy, no production path touched.

Pre-PR codex xhigh gate: GATE_OK, zero findings (after an exhaustive harden: gate → senior review → Copilot ×2 → codex; an inert-measurement defect and several fidelity gaps — subshell isolation, helper sourcing, history-merge, cache warmth, $()-capture materialization — all fixed and re-verified).

Refs #453
