### PR TITLE
feat(dashboard): per-call gh-api/GHCR/skopeo latency logging

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -209,7 +209,9 @@ get_container_versions() {
 
     local current_version latest_version status_color status_text
 
+    local _t0_skopeo=${EPOCHREALTIME:-}
     current_version=$(get_current_published_version "oorabona/$container")
+    log_latency "skopeo-list-tags oorabona/$container" "$_t0_skopeo" 60
     # Handle empty result
     [[ -z "$current_version" ]] && current_version="no-published-version"
 
@@ -552,10 +554,12 @@ collect_variant_json() {
     fi
     [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
         echo "[debug] subject_digest for $container-$sbom_tag = ${subject_digest:0:60}…" >&2
+    local _t0_att=${EPOCHREALTIME:-}
     if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
         && attestation_id=$(get_attestation_id "$subject_digest"); then
         attestation_url=$(get_attestation_url "$attestation_id")
     fi
+    log_latency "gh-attestation" "$_t0_att" 20
 
     # Trivy: collect vulnerability summary for the primary platform (linux/amd64)
     local trivy_category trivy_summary
@@ -568,7 +572,9 @@ collect_variant_json() {
     local multi_arch_platforms_json="[]"
     if [[ "$current_version" != "no-published-version" ]]; then
         local raw_sizes arch_list=""
+        local _t0_ghcr=${EPOCHREALTIME:-}
         raw_sizes=$(ghcr_get_manifest_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+        log_latency "ghcr-index oorabona/${container}:${variant_tag}" "$_t0_ghcr" 30
         if [[ -n "$raw_sizes" ]]; then
             arch_list=$(echo "$raw_sizes" | awk -F: '{print $1}' | \
                 jq -R . | jq -s '.')
@@ -582,7 +588,9 @@ collect_variant_json() {
     local multi_arch_digests_json
     multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
     if [[ "$current_version" != "no-published-version" ]]; then
+        local _t0_ghcr_ma=${EPOCHREALTIME:-}
         multi_arch_digests_json=$(ghcr_get_multi_arch_digests "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+        log_latency "ghcr-index oorabona/${container}:${variant_tag} (multi-arch)" "$_t0_ghcr_ma" 30
         [[ -z "$multi_arch_digests_json" ]] && \
             multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
     fi
@@ -922,8 +930,10 @@ get_ghcr_sizes() {
     local tag=${2:-latest}
     local sizes_output=""
 
+    local _t0_ghcr_sz=${EPOCHREALTIME:-}
     local raw_sizes
-    raw_sizes=$(ghcr_get_manifest_sizes "$image" "$tag") || return
+    raw_sizes=$(ghcr_get_manifest_sizes "$image" "$tag") || { log_latency "ghcr-index ${image}:${tag}" "$_t0_ghcr_sz" 30; return 1; }
+    log_latency "ghcr-index ${image}:${tag}" "$_t0_ghcr_sz" 30
 
     while IFS=':' read -r arch bytes; do
         [[ -z "$arch" || -z "$bytes" ]] && continue
@@ -945,12 +955,16 @@ github_api_get() {
     local endpoint="$1"
     local max_time="${2:-15}"
 
+    local _t0=${EPOCHREALTIME:-}
+    local _rc=0
     if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
-        gh api "$endpoint" 2>/dev/null
+        gh api "$endpoint" 2>/dev/null || _rc=$?
     else
         curl -s --max-time "$max_time" \
-            "https://api.github.com/$endpoint" 2>/dev/null
+            "https://api.github.com/$endpoint" 2>/dev/null || _rc=$?
     fi
+    log_latency "gh-api ${endpoint%%\?*}" "$_t0" 30
+    return $_rc
 }
 
 # --- Stats calculation functions ---
@@ -1407,10 +1421,12 @@ generate_data() {
                         echo "[debug] non-variant: using fallback build_digest=$subject_digest for $container-$current_version" >&2
                 fi
             fi
+            local _t0_att=${EPOCHREALTIME:-}
             if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
                 && attestation_id=$(get_attestation_id "$subject_digest"); then
                 attestation_url=$(get_attestation_url "$attestation_id")
             fi
+            log_latency "gh-attestation" "$_t0_att" 20
             trivy_category=$(build_trivy_category "$container" "$current_version" "linux/amd64")
             trivy_summary=$(get_trivy_summary "$trivy_category" || echo "{}")
             [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
@@ -1443,8 +1459,9 @@ generate_data() {
         # versions-only containers where per-variant platforms are not emitted.
         if [[ "$current_version" != "no-published-version" ]]; then
             local container_arch_list=""
-            local container_raw_sizes
+            local container_raw_sizes _t0_ghcr_cv=${EPOCHREALTIME:-}
             container_raw_sizes=$(ghcr_get_manifest_sizes "oorabona/$container" "$current_version" 2>/dev/null) || true
+            log_latency "ghcr-index oorabona/${container}:${current_version}" "$_t0_ghcr_cv" 30
             if [[ -n "$container_raw_sizes" ]]; then
                 container_arch_list=$(echo "$container_raw_sizes" | awk -F: '{print $1}' | \
                     jq -R . | jq -s '.')

--- a/helpers/logging.sh
+++ b/helpers/logging.sh
@@ -50,6 +50,46 @@ log_help() {
     printf "\033[36m%-25s\033[0m %s\n" "$1" "$2"
 }
 
+# Emit a per-network-call latency line to stderr.  Never touches stdout.
+# Usage: log_latency <label> <start_epochrealtime> [warn_threshold_seconds]
+# - label:                 short identifier for the call (e.g. "gh-api /repos/...")
+# - start_epochrealtime:   value of ${EPOCHREALTIME} captured before the call
+# - warn_threshold_seconds (optional): emit a ::warning:: annotation when dur > threshold
+# Safe under set -euo pipefail; returns 0 always; side-effect-free on stdout.
+log_latency() {
+    local label="${1:-unknown}"
+    local start="${2:-}"
+    local threshold="${3:-}"
+
+    # Compute duration.  Requires EPOCHREALTIME (bash 5+).
+    # On bash <5 or when start is empty, emit an explicit unavailability marker
+    # rather than a misleading number (SECONDS would reflect shell uptime, not
+    # call duration — that is worse than no data at all, per the #453 lesson).
+    local dur
+    if [[ -n "$start" && -n "${EPOCHREALTIME:-}" ]]; then
+        dur=$(awk -v a="$start" -v b="${EPOCHREALTIME}" 'BEGIN{printf "%.3f", b-a}' 2>/dev/null || true)
+    else
+        # bash <5 or caller passed empty start — timing genuinely unavailable.
+        printf '[latency] %s (timing unavailable: bash<5 lacks EPOCHREALTIME)\n' "$label" >&2
+        return 0
+    fi
+
+    # Normal latency line — always emitted (plain stderr, NOT ::notice::)
+    printf '[latency] %s %ss\n' "$label" "$dur" >&2
+
+    # Optional warning annotation when threshold given and duration exceeds it
+    if [[ -n "$threshold" ]]; then
+        local over
+        over=$(awk -v d="$dur" -v t="$threshold" 'BEGIN{print (d+0 > t+0) ? "1" : "0"}' 2>/dev/null || echo "0")
+        if [[ "$over" == "1" ]]; then
+            printf '::warning::[latency] %s took %ss (> %ss) — possible API/registry degradation\n' \
+                "$label" "$dur" "$threshold" >&2
+        fi
+    fi
+
+    return 0
+}
+
 # Check if a directory contains a Dockerfile (standard or template-based)
 # Usage: has_dockerfile <dir>
 has_dockerfile() {

--- a/tests/unit/log-latency.bats
+++ b/tests/unit/log-latency.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/logging.sh :: log_latency
+#
+# Each test names the mutation it catches so the Test Validity Gate is
+# satisfied: a test that cannot name what mutation it catches is invalid.
+#
+# Network instrumentation (the callers in registry-utils.sh, etc.) cannot be
+# unit-tested without live network mocks — those are out of scope here.
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    source "$PROJECT_ROOT/helpers/logging.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: portable sleep with sub-second support (bash 4+ / GNU coreutils).
+# Falls back to 1s on environments where `sleep 0.X` is unavailable.
+# ---------------------------------------------------------------------------
+_sleep_half() {
+    sleep 0.5 2>/dev/null || sleep 1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: always emits exactly one [latency] line to stderr, nothing to stdout
+#
+# Mutation caught: removing the `printf '[latency] ...' >&2` line would make
+# stderr empty — the test would fail on the stderr content check.
+# ---------------------------------------------------------------------------
+@test "log_latency emits [latency] line to stderr and nothing to stdout" {
+    local t0=${EPOCHREALTIME:-0}
+    _sleep_half
+    # `run` captures stdout in $output; stderr goes to $stderr when bats >= 1.5.
+    # For compatibility we redirect stderr to a temp file.
+    local tmp_stderr
+    tmp_stderr=$(mktemp)
+    local stdout_capture
+    stdout_capture=$(log_latency "test-label" "$t0" 2>"$tmp_stderr")
+    local rc=$?
+
+    # stdout must be empty
+    [ -z "$stdout_capture" ]
+    # stderr must contain the label and the [latency] marker
+    grep -qF '[latency] test-label' "$tmp_stderr"
+    rm -f "$tmp_stderr"
+    [ "$rc" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: threshold ABOVE duration → no ::warning:: line
+#
+# Mutation caught: if the threshold comparison were inverted (< instead of >),
+# a fast call with a high threshold would emit a spurious ::warning::.
+# ---------------------------------------------------------------------------
+@test "log_latency emits no warning when threshold is above duration" {
+    local t0=${EPOCHREALTIME:-0}
+    # Do NOT sleep — duration will be tiny (< 1ms).
+    local tmp_stderr
+    tmp_stderr=$(mktemp)
+    log_latency "fast-call" "$t0" 9999 2>"$tmp_stderr"
+    # Must not contain the warning annotation
+    ! grep -qF '::warning::' "$tmp_stderr"
+    rm -f "$tmp_stderr"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: threshold BELOW duration → ::warning:: line appears on stderr
+#
+# Mutation caught: removing the warning printf block would make grep fail to
+# find '::warning::' and the test would fail.
+# ---------------------------------------------------------------------------
+@test "log_latency emits ::warning:: when duration exceeds threshold" {
+    local t0=${EPOCHREALTIME:-0}
+    _sleep_half
+    local tmp_stderr
+    tmp_stderr=$(mktemp)
+    log_latency "slow-call" "$t0" 0 2>"$tmp_stderr"
+    # Must contain the warning annotation (threshold=0 always exceeded after any sleep)
+    grep -qF '::warning::' "$tmp_stderr"
+    grep -qF '[latency] slow-call' "$tmp_stderr"
+    rm -f "$tmp_stderr"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: EPOCHREALTIME empty/unset → emits explicit unavailability marker,
+#         returns 0, and does NOT emit a ::warning:: or a misleading number.
+#
+# Mutation caught:
+# - removing the early-return would let the function fall through and emit
+#   `n/as` (or a shell-uptime integer via SECONDS), both untrustworthy —
+#   the test asserts the exact "(timing unavailable…)" phrase.
+# - if the threshold/::warning:: branch were not guarded by the early-return,
+#   the `dur` variable would be unset and awk would produce a spurious warning.
+# ---------------------------------------------------------------------------
+@test "log_latency with EPOCHREALTIME unset emits unavailability marker, no warning" {
+    local tmp_stderr
+    tmp_stderr=$(mktemp)
+    # Run in a subshell so unsetting EPOCHREALTIME does not affect the parent.
+    # Pass empty start to simulate bash <5 caller.
+    (
+        unset EPOCHREALTIME 2>/dev/null || true
+        log_latency "no-epochrealtime" "" 30 2>"$tmp_stderr"
+    )
+    local rc=$?
+    # Must return 0
+    [ "$rc" -eq 0 ]
+    # Must emit the explicit unavailability phrase — NOT "n/as" or a number
+    grep -qF '(timing unavailable: bash<5 lacks EPOCHREALTIME)' "$tmp_stderr"
+    # Must NOT emit ::warning:: (threshold logic must be skipped)
+    ! grep -qF '::warning::' "$tmp_stderr"
+    # Must NOT emit the normal "%ss" latency line (early-return fires first)
+    ! grep -qE '\[latency\] no-epochrealtime [0-9]' "$tmp_stderr"
+    rm -f "$tmp_stderr"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: stdout from log_latency is empty (cannot corrupt a captured payload)
+#
+# Mutation caught: if log_latency accidentally wrote to stdout (e.g. missing
+# >&2 on a printf), command substitution callers would capture the timing noise
+# as part of their JSON/string payload — this test catches that regression.
+# ---------------------------------------------------------------------------
+@test "log_latency produces no stdout output" {
+    local t0=${EPOCHREALTIME:-0}
+    local captured
+    captured=$(log_latency "stdout-check" "$t0" 2>/dev/null)
+    [ -z "$captured" ]
+}


### PR DESCRIPTION
Closes #473. Adds an always-on stderr-only `log_latency` helper and brackets every network chokepoint in the dashboard generator (gh api, GHCR index fetch, skopeo list-tags via the get_current_published_version caller, attestations) so each call's duration is visible in the run log as it happens, with a `::warning::` annotation when a call exceeds its threshold — the direct lesson of the #453 saga (a transient API degradation that was invisible for days). Stderr-only, payloads/exit-codes untouched, `return 0` always; bash<5 emits an explicit "timing unavailable" marker rather than a misleading number. New `tests/unit/log-latency.bats` 5/5; full suite green (minus a pre-existing push-container.bats hang unrelated to this change). Pre-push orthogonal gate: codex xhigh — CLEAN after fixing 2 fidelity M (dead skopeo line relocated to the sourced caller; honest bash<5 fallback). Refs #470.