### PR TITLE
docs(blog): postscript — the #453 lessons, acted on

### DIFF
--- a/docs/site/_posts/2026-05-18-the-fix-that-worked-by-coincidence.md
+++ b/docs/site/_posts/2026-05-18-the-fix-that-worked-by-coincidence.md
@@ -76,3 +76,12 @@ A transient external degradation has no code signature. Reading the code or re-r
 - **Reviews check diffs; they do not check premises.** The most consequential error here was upstream of every line anyone reviewed.
 
 The headline number — 67 minutes to 10 — was real. The story attached to it was not. The most useful thing this project can publish is not the fix; it is the six rounds of measurement it took to disprove our own published root cause, and the admission that the thing that "fixed" the stall was GitHub having a bad hour, and us being there to take the credit.
+
+## Postscript (2026-05-19): the lessons, acted on
+
+A post-mortem that only writes lessons is itself a kind of archaeology. Two follow-ups closed the loop:
+
+- **The data-dropping guard was removed** (PR #471). The 25 MiB SBOM cutoff — the regression this post criticised — is gone; only the cheap `timeout 60 jq` backstop remains, and the `github-runner` windows-dev package breakdown is back on the dashboard.
+- **The "instrument the failing operation while it fails" lesson was shipped** (PR #475, commit `7fd8428`). The dashboard generator now emits a per-call latency line to the run log for every `gh api`, GHCR, skopeo, and attestation call — plus a `::warning::` annotation when a single call exceeds its threshold. If GitHub has another bad hour, it will show up *as it happens*, as a labelled slow call, not as a silent 22-minute gap reconstructed days later. The exact instrumentation this incident lacked is now always on.
+
+The number we could not explain post-hoc is now one we will be able to see live.


### PR DESCRIPTION
Amends the published #453 post-mortem with a dated Postscript (2026-05-19) noting the two follow-ups that closed the loop: the 25 MiB data-dropping guard removed (#471) and the always-on per-call latency observability the post itself prescribed, shipped (#475, commit 7fd8428, closing #473). Demonstrates the project acted on its own lessons rather than only writing them. Pure-markdown change → pre-PR codex/orthogonal gate N/A by its own carve-out. Merge gated on owner wording approval (public post). Refs #470, #471, #475, #473.