### PR TITLE
fix(openresty): migrate OpenSSL 1.1.1w → 3.5.6 LTS to unblock the build

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -108,13 +108,8 @@ RUN set -ex \
     && curl -fSL "${RESTY_OPENSSL_URL_BASE}/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && cd openssl-${RESTY_OPENSSL_VERSION} \
-    && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-5) = "1.1.1" ] ; then \
-        echo 'patching OpenSSL 1.1.1 for OpenResty' \
-        && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
-    fi \
-    && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-5) = "1.1.0" ] ; then \
-        echo 'patching OpenSSL 1.1.0 for OpenResty' \
-        && curl -s https://raw.githubusercontent.com/openresty/openresty/ed328977028c3ec3033bc25873ee360056e247cd/patches/openssl-1.1.0j-parallel_build_fix.patch | patch -p1 \
+    && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-2) = "3." ] ; then \
+        echo 'patching OpenSSL 3.x for OpenResty' \
         && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
     fi \
     && ./config \

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -126,8 +126,8 @@ docker exec openresty luarocks list
 | `RESTY_IMAGE_BASE` | Base image name | alpine |
 | `RESTY_IMAGE_TAG` | Base image tag | latest |
 | `RESTY_VERSION` | OpenResty version (same as VERSION) | ${VERSION} |
-| `RESTY_OPENSSL_VERSION` | OpenSSL version (frozen at 1.1.1) | 1.1.1w |
-| `RESTY_OPENSSL_PATCH_VERSION` | OpenSSL patch version | 1.1.1f |
+| `RESTY_OPENSSL_VERSION` | OpenSSL version (3.5 LTS) | 3.5.6 |
+| `RESTY_OPENSSL_PATCH_VERSION` | OpenResty OpenSSL patch version | 3.5.5 |
 | `RESTY_PCRE_VERSION` | PCRE version (frozen at 8.x) | 8.45 |
 | `RESTY_J` | Parallel build jobs | 4 |
 | `RESTY_CONFIG_OPTIONS` | Nginx build options | (see Dockerfile) |
@@ -255,23 +255,21 @@ This container includes the following pinned dependencies:
 |------------|---------|-------------------|-------|
 | Alpine Linux | latest | Active | Base image |
 | OpenResty | (from version.sh) | Active | Main application |
-| OpenSSL | 1.1.1w | Frozen (EOL) | OpenSSL 1.1.1 series ended 2023-09-11 |
-| PCRE | 8.45 | Frozen (EOL) | PCRE 8.x is legacy, PCRE2 not used |
+| OpenSSL | 3.5.6 | Pinned (3.5 LTS) | LTS, supported to 2030-04-08; migrated from EOL 1.1.1w (#448) |
+| PCRE | 8.45 | Frozen (EOL) | PCRE 8.x is legacy, PCRE2 not used — migration tracked in #453 |
 | LuaRocks | 3.13.0 | Active | Lua package manager |
 | ngx_http_proxy_connect_module | 0.0.7 | Active | Optional forward proxy support |
 
-**Note on frozen dependencies:**
+**Note on pinned dependencies:**
 
-- **OpenSSL 1.1.1w**: Intentionally frozen at the final 1.1.1 release. OpenResty requires specific patches for this version. Migration to OpenSSL 3.x requires upstream OpenResty changes.
-- **PCRE 8.45**: Legacy PCRE library (not PCRE2). OpenResty builds against PCRE 8.x for compatibility.
-
-These frozen versions receive security backports through OpenResty's patching mechanism.
+- **OpenSSL 3.5.6**: Pinned to the OpenSSL 3.5 LTS series (supported to 2030-04-08). Migrated from the EOL 1.1.1w pin after openssl.org removed the 1.1.1w tarball and broke the build (#448). OpenResty's `sess_set_get_cb_yield` patch (version 3.5.5) is applied for Lua coroutine session-callback yield. `monitor: false` is retained for now; the tracked-source monitoring redesign is tracked in #453.
+- **PCRE 8.45**: Legacy PCRE library (not PCRE2). OpenResty builds against PCRE 8.x for compatibility. Same latent EOL-removal risk as the old OpenSSL pin — PCRE2 10.x migration is tracked in #453.
 
 ## Architecture
 
 ### Build Process
 
-1. **Bootstrap**: Downloads and compiles OpenSSL 1.1.1 with OpenResty patches
+1. **Bootstrap**: Downloads and compiles OpenSSL 3.5.x with OpenResty patches
 2. **PCRE Compilation**: Builds PCRE with JIT support
 3. **Optional Module**: Downloads ngx_http_proxy_connect_module if enabled
 4. **OpenResty Build**: Configures and compiles OpenResty with all modules

--- a/openresty/config.yaml
+++ b/openresty/config.yaml
@@ -10,8 +10,8 @@ base_image_cache:
 build_args:
   RESTY_IMAGE_BASE: "alpine"
   RESTY_IMAGE_TAG: "latest"
-  RESTY_OPENSSL_VERSION: "1.1.1w"
-  RESTY_OPENSSL_PATCH_VERSION: "1.1.1f"
+  RESTY_OPENSSL_VERSION: "3.5.6"
+  RESTY_OPENSSL_PATCH_VERSION: "3.5.5"
   RESTY_PCRE_VERSION: "8.45"
   LUAROCKS_VERSION: "3.13.0"
   NGX_PROXY_CONNECT_VERSION: "0.0.7"
@@ -29,10 +29,10 @@ dependency_sources:
     reason: "Base image tag fallback, not a version to track"
   RESTY_OPENSSL_VERSION:
     monitor: false
-    reason: "OpenSSL 1.1.1 is EOL, frozen"
+    reason: "OpenSSL 3.5 LTS (EOL 2030-04-08); pinned — tracked-source monitoring redesign tracked in #453"
   RESTY_OPENSSL_PATCH_VERSION:
     monitor: false
-    reason: "OpenSSL 1.1.1 is EOL, frozen"
+    reason: "OpenSSL 3.5 LTS (EOL 2030-04-08); pinned — tracked-source monitoring redesign tracked in #453"
   RESTY_PCRE_VERSION:
     monitor: false
     reason: "PCRE 8.x is legacy, frozen"


### PR DESCRIPTION
Closes #448. Refs #453.

The EOL openssl-1.1.1w tarball was removed by openssl.org → the from-source build 404s → openresty:1.29.2.4-alpine has failed multi-arch for ~6 days. Pin OpenSSL 3.5.6 (3.5 LTS, supported to 2030-04-08; version-freshness verified — NOT 3.0 which is near-EOL, NOT 4.0 which has no OpenResty patch) + RESTY_OPENSSL_PATCH_VERSION 3.5.5; replace the two dead 1.1.0/1.1.1 Dockerfile patch branches with the OpenResty 3.x branch (`cut -c 1-2 = "3."`, `sess_set_get_cb_yield` still required for Lua coroutine yield); correct the now-false "EOL frozen" dependency reasons and the stale openresty/README.md (5 refs). Mirrors the official openresty/docker-openresty pin (3.5.6/3.5.5 since 2026-05-18).

Deliberately out of scope (tracked #453-systemic): PCRE 8.45→PCRE2 10.x, monitor:false→tracked-source + liveness HEAD, auto-issue-on-dep-build-failure. monitor:false retained, PCRE untouched.

Pre-push orthogonal gate: codex xhigh CLEAN ×2 (post-README iteration byte-identical code/yaml). **Acceptance proof = the post-merge master multi-arch auto-build of openresty (will be verified at finalize).**