### PR TITLE
fix(openresty): migrate PCRE 8.45 → PCRE2 10.47 with SHA256 verification

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -18,6 +18,7 @@ ARG RESTY_OPENSSL_VERSION
 ARG RESTY_OPENSSL_PATCH_VERSION
 ARG RESTY_OPENSSL_URL_BASE="https://www.openssl.org/source"
 ARG RESTY_PCRE_VERSION
+ARG RESTY_PCRE_SHA256
 ARG RESTY_J
 ARG RESTY_CONFIG_OPTIONS="\
     --with-compat \
@@ -57,21 +58,22 @@ ARG RESTY_ADD_PACKAGE_RUNDEPS=""
 
 # These are not intended to be user-specified
 ARG _RESTY_CONFIG_DEPS="--with-pcre \
-    --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/local/openresty/pcre/include -I/usr/local/openresty/openssl/include' \
-    --with-ld-opt='-L/usr/local/openresty/pcre/lib -L/usr/local/openresty/openssl/lib -Wl,-rpath,/usr/local/openresty/pcre/lib:/usr/local/openresty/openssl/lib' \
+    --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I/usr/local/openresty/pcre2/include -I/usr/local/openresty/openssl/include' \
+    --with-ld-opt='-L/usr/local/openresty/pcre2/lib -L/usr/local/openresty/openssl/lib -Wl,-rpath,/usr/local/openresty/pcre2/lib:/usr/local/openresty/openssl/lib' \
     "
 
 # For Luarocks
 ARG LUAROCKS_VERSION
 
 # Validate required build args
-RUN : "${RESTY_VERSION:?required}" "${RESTY_OPENSSL_VERSION:?required}" "${RESTY_OPENSSL_PATCH_VERSION:?required}" "${RESTY_PCRE_VERSION:?required}" "${RESTY_J:?required}" "${NGX_PROXY_CONNECT_VERSION:?required}" "${LUAROCKS_VERSION:?required}"
+RUN : "${RESTY_VERSION:?required}" "${RESTY_OPENSSL_VERSION:?required}" "${RESTY_OPENSSL_PATCH_VERSION:?required}" "${RESTY_PCRE_VERSION:?required}" "${RESTY_PCRE_SHA256:?required}" "${RESTY_J:?required}" "${NGX_PROXY_CONNECT_VERSION:?required}" "${LUAROCKS_VERSION:?required}"
 
 LABEL resty_image_base="${RESTY_IMAGE_BASE}"
 LABEL resty_image_tag="${RESTY_IMAGE_TAG}"
 LABEL resty_version="${RESTY_VERSION}"
 LABEL resty_openssl_version="${RESTY_OPENSSL_VERSION}"
 LABEL resty_pcre_version="${RESTY_PCRE_VERSION}"
+LABEL resty_pcre_sha256="${RESTY_PCRE_SHA256}"
 LABEL resty_config_options="${RESTY_CONFIG_OPTIONS}"
 LABEL resty_config_options_more="${RESTY_CONFIG_OPTIONS_MORE}"
 LABEL resty_config_deps="${_RESTY_CONFIG_DEPS}"
@@ -121,17 +123,39 @@ RUN set -ex \
     && make -j${RESTY_J} \
     && make -j${RESTY_J} install_sw \
     && cd /tmp \
-    && curl -fSL https://sourceforge.net/projects/pcre/files/pcre/${RESTY_PCRE_VERSION}/pcre-${RESTY_PCRE_VERSION}.tar.gz/download -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && cd /tmp/pcre-${RESTY_PCRE_VERSION} \
-    && ./configure \
-        --prefix=/usr/local/openresty/pcre \
-        --disable-cpp \
+    && curl -fSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${RESTY_PCRE_VERSION}/pcre2-${RESTY_PCRE_VERSION}.tar.gz" -o pcre2-${RESTY_PCRE_VERSION}.tar.gz \
+    && echo "${RESTY_PCRE_SHA256}  pcre2-${RESTY_PCRE_VERSION}.tar.gz" | shasum -a 256 --check \
+    && tar xzf pcre2-${RESTY_PCRE_VERSION}.tar.gz \
+    && cd /tmp/pcre2-${RESTY_PCRE_VERSION} \
+    && CFLAGS="-g -O3" ./configure \
+        --prefix=/usr/local/openresty/pcre2 \
+        --libdir=/usr/local/openresty/pcre2/lib \
         --enable-jit \
-        --enable-utf \
-        --enable-unicode-properties \
-    && make -j${RESTY_J} \
-    && make -j${RESTY_J} install \
+        --enable-pcre2grep-jit \
+        --disable-bsr-anycrlf \
+        --disable-coverage \
+        --disable-ebcdic \
+        --disable-fuzz-support \
+        --disable-jit-sealloc \
+        --disable-never-backslash-C \
+        --enable-newline-is-lf \
+        --enable-pcre2-8 \
+        --enable-pcre2-16 \
+        --enable-pcre2-32 \
+        --enable-pcre2grep-callout \
+        --enable-pcre2grep-callout-fork \
+        --disable-pcre2grep-libbz2 \
+        --disable-pcre2grep-libz \
+        --disable-pcre2test-libedit \
+        --enable-percent-zt \
+        --disable-rebuild-chartables \
+        --enable-shared \
+        --disable-static \
+        --disable-silent-rules \
+        --enable-unicode \
+        --disable-valgrind \
+    && CFLAGS="-g -O3" make -j${RESTY_J} \
+    && CFLAGS="-g -O3" make -j${RESTY_J} install \
     && cd /tmp \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -128,7 +128,8 @@ docker exec openresty luarocks list
 | `RESTY_VERSION` | OpenResty version (same as VERSION) | ${VERSION} |
 | `RESTY_OPENSSL_VERSION` | OpenSSL version (3.5 LTS) | 3.5.6 |
 | `RESTY_OPENSSL_PATCH_VERSION` | OpenResty OpenSSL patch version | 3.5.5 |
-| `RESTY_PCRE_VERSION` | PCRE version (frozen at 8.x) | 8.45 |
+| `RESTY_PCRE_VERSION` | PCRE2 version | 10.47 |
+| `RESTY_PCRE_SHA256` | SHA256 digest for the PCRE2 .tar.gz (must match `RESTY_PCRE_VERSION`; update both together) | (see config.yaml) |
 | `RESTY_J` | Parallel build jobs | 4 |
 | `RESTY_CONFIG_OPTIONS` | Nginx build options | (see Dockerfile) |
 | `RESTY_CONFIG_OPTIONS_MORE` | Additional configure options | -j${RESTY_J} |
@@ -256,21 +257,21 @@ This container includes the following pinned dependencies:
 | Alpine Linux | latest | Active | Base image |
 | OpenResty | (from version.sh) | Active | Main application |
 | OpenSSL | 3.5.6 | Pinned (3.5 LTS) | LTS, supported to 2030-04-08; migrated from EOL 1.1.1w (#448) |
-| PCRE | 8.45 | Frozen (EOL) | PCRE 8.x is legacy, PCRE2 not used — migration tracked in #453 |
+| PCRE2 | 10.47 | Active (pinned) | Migrated from EOL PCRE1 8.45 (#453 volet 1); tracked-source monitoring redesign tracked in #453 |
 | LuaRocks | 3.13.0 | Active | Lua package manager |
 | ngx_http_proxy_connect_module | 0.0.7 | Active | Optional forward proxy support |
 
 **Note on pinned dependencies:**
 
 - **OpenSSL 3.5.6**: Pinned to the OpenSSL 3.5 LTS series (supported to 2030-04-08). Migrated from the EOL 1.1.1w pin after openssl.org removed the 1.1.1w tarball and broke the build (#448). OpenResty's `sess_set_get_cb_yield` patch (version 3.5.5) is applied for Lua coroutine session-callback yield. `monitor: false` is retained for now; the tracked-source monitoring redesign is tracked in #453.
-- **PCRE 8.45**: Legacy PCRE library (not PCRE2). OpenResty builds against PCRE 8.x for compatibility. Same latent EOL-removal risk as the old OpenSSL pin — PCRE2 10.x migration is tracked in #453.
+- **PCRE2 10.47**: Migrated from EOL PCRE1 8.45 (#453 volet 1). Downloaded from `github.com/PCRE2Project/pcre2/releases` and integrity-verified via SHA256 (`RESTY_PCRE_SHA256`) before extraction. `RESTY_PCRE_VERSION` now refers to a PCRE2 version (PCRE1 is retired). When bumping the version, update both `RESTY_PCRE_VERSION` and `RESTY_PCRE_SHA256` together — they are coupled to the same `.tar.gz` asset. `monitor:false` is retained; tracked-source monitoring redesign is tracked in #453.
 
 ## Architecture
 
 ### Build Process
 
 1. **Bootstrap**: Downloads and compiles OpenSSL 3.5.x with OpenResty patches
-2. **PCRE Compilation**: Builds PCRE with JIT support
+2. **PCRE2 Compilation**: Downloads, SHA256-verifies, and builds PCRE2 10.47 with JIT support
 3. **Optional Module**: Downloads ngx_http_proxy_connect_module if enabled
 4. **OpenResty Build**: Configures and compiles OpenResty with all modules
 5. **LuaRocks Installation**: Installs Lua package manager
@@ -330,7 +331,7 @@ This container includes the following pinned dependencies:
 │   ├── html/               # Default web root
 │   └── logs/               # Logs (symlinked to stdout/stderr)
 ├── openssl/                # OpenSSL libraries
-└── pcre/                   # PCRE libraries
+└── pcre2/                  # PCRE2 libraries
 ```
 
 ## Common Use Cases

--- a/openresty/config.yaml
+++ b/openresty/config.yaml
@@ -12,7 +12,8 @@ build_args:
   RESTY_IMAGE_TAG: "latest"
   RESTY_OPENSSL_VERSION: "3.5.6"
   RESTY_OPENSSL_PATCH_VERSION: "3.5.5"
-  RESTY_PCRE_VERSION: "8.45"
+  RESTY_PCRE_VERSION: "10.47"
+  RESTY_PCRE_SHA256: "c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16"
   LUAROCKS_VERSION: "3.13.0"
   NGX_PROXY_CONNECT_VERSION: "0.0.7"
   RESTY_J: "4"
@@ -35,7 +36,10 @@ dependency_sources:
     reason: "OpenSSL 3.5 LTS (EOL 2030-04-08); pinned — tracked-source monitoring redesign tracked in #453"
   RESTY_PCRE_VERSION:
     monitor: false
-    reason: "PCRE 8.x is legacy, frozen"
+    reason: "PCRE2 10.47 (active); pinned — tracked-source monitoring redesign tracked in #453"
+  RESTY_PCRE_SHA256:
+    monitor: false
+    reason: "SHA256 integrity digest for RESTY_PCRE_VERSION .tar.gz; update both together when bumping RESTY_PCRE_VERSION"
   LUAROCKS_VERSION:
     type: github-release
     repo: luarocks/luarocks

--- a/openresty/tests/test-runner-linux.bats
+++ b/openresty/tests/test-runner-linux.bats
@@ -17,21 +17,47 @@
 # The build system tags as <container>:<version>; for the smoke test we
 # accept any locally-built tag that starts with "openresty:" (or the GHCR form).
 _find_image() {
-    # Prefer an explicit override (CI sets IMAGE_TAG)
+    # Deterministic image resolution — fail-closed on 0 or ambiguous images.
+    # $OPENRESTY_IMAGE is the explicit override: local runs and CI SHOULD set it
+    # (a tracked follow-up will wire it in the upstream workflow).
     if [[ -n "${OPENRESTY_IMAGE:-}" ]]; then
         echo "$OPENRESTY_IMAGE"
-        return
+        return 0
     fi
-    # Fall back to the most-recently-built openresty image
-    local img
-    img=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-          | grep -E '^(ghcr\.io/oorabona/openresty|openresty):' \
-          | head -1)
-    if [[ -z "$img" ]]; then
-        echo "ERROR: no openresty image found locally. Run: ./make build openresty" >&2
+
+    # Enumerate built openresty images by IMAGE ID, deduplicated.
+    # A single build produces multiple tag aliases (ghcr.io/…, docker.io/…, :latest)
+    # all sharing the SAME image ID — counting tags would wrongly report "multiple".
+    # The repo-component filter is anchored to avoid matching base-image cache repos
+    # or unrelated images that happen to contain "openresty" in a path component.
+    local ids
+    ids=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' \
+          | awk '$2 ~ /^(ghcr\.io\/oorabona\/openresty|docker\.io\/oorabona\/openresty|openresty):/ {print $1}' \
+          | sort -u)
+
+    local count
+    count=$(echo "$ids" | grep -c .) 2>/dev/null || count=0
+    # grep -c on empty string returns 1 (the empty line); guard for that:
+    if [[ -z "$ids" ]]; then
+        count=0
+    fi
+
+    if [[ "$count" -eq 0 ]]; then
+        echo "ERROR: no built openresty image found (run ./make build openresty, or set OPENRESTY_IMAGE)" >&2
         return 1
     fi
-    echo "$img"
+
+    if [[ "$count" -gt 1 ]]; then
+        echo "ERROR: ambiguous — ${count} distinct openresty images present; set OPENRESTY_IMAGE to the one under test" >&2
+        return 1
+    fi
+
+    # Exactly 1 distinct image ID — return the first matching tag (docker run <tag> works).
+    local tag
+    tag=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' \
+          | awk -v id="$ids" '$1 == id && $2 ~ /^(ghcr\.io\/oorabona\/openresty|docker\.io\/oorabona\/openresty|openresty):/ {print $2; exit}')
+    echo "$tag"
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -39,7 +65,7 @@ _find_image() {
 # ---------------------------------------------------------------------------
 
 setup() {
-    IMAGE=$(_find_image)
+    IMAGE=$(_find_image) || return 1
     CONTAINER_NAME="openresty-bats-smoke-$$"
     PORT=18080
 

--- a/openresty/tests/test-runner-linux.bats
+++ b/openresty/tests/test-runner-linux.bats
@@ -43,7 +43,7 @@ setup() {
     CONTAINER_NAME="openresty-bats-smoke-$$"
     PORT=18080
 
-    # Nginx config with a regex location that proves PCRE2 + JIT is functional.
+    # Nginx config with a regex location that proves PCRE2 regex matching is functional.
     # location ~ ^/re/(\d+)$  uses a PCRE2 pattern; if PCRE2 is absent nginx
     # either fails to start or falls back to PCRE1 (which this build does not
     # include), so the location would never match.
@@ -92,11 +92,14 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 1 (AC-5 behavioral): PCRE2 regex + JIT functional at runtime
+# Test 1 (AC-5 behavioral): PCRE2 regex + capture group functional at runtime
 # Mutation caught: nginx built without PCRE2 => /re/42 is 404/500, not "m=42"
+# Note: this proves PCRE2 regex matching and capture works at runtime.
+#   JIT presence is structurally guaranteed by --enable-jit + --with-pcre-jit
+#   configure flags (see Dockerfile) and is not separately asserted here.
 # ---------------------------------------------------------------------------
 
-@test "GET /re/42 returns exactly 'm=42' (PCRE2 + JIT regex functional)" {
+@test "GET /re/42 returns exactly 'm=42' (PCRE2 regex + capture group functional at runtime)" {
     local body
     body=$(curl -sf "http://127.0.0.1:${PORT}/re/42")
     [ "$body" = "m=42" ]
@@ -108,29 +111,24 @@ teardown() {
 #                  libpcre1) => RUNPATH does not contain /usr/local/openresty/pcre2/lib
 # ---------------------------------------------------------------------------
 
-@test "nginx binary RUNPATH contains /usr/local/openresty/pcre2/lib" {
+@test "nginx binary resolves libpcre2-8.so from /usr/local/openresty/pcre2/lib" {
     # Find the nginx binary path inside the container
     local nginx_bin
     nginx_bin=$(docker exec "$CONTAINER_NAME" sh -c \
         'command -v nginx || echo /usr/local/openresty/nginx/sbin/nginx')
 
-    # readelf -d shows RPATH/RUNPATH entries
-    local runpath_output
-    runpath_output=$(docker exec "$CONTAINER_NAME" sh -c \
-        "readelf -d \"$nginx_bin\" 2>/dev/null || true")
+    # ldd is the discriminating oracle here.
+    # readelf/binutils is stripped from the runtime image (apk del .build-deps),
+    # so readelf is never present at runtime — ldd (from musl libc) is always available.
+    local ldd_output
+    ldd_output=$(docker exec "$CONTAINER_NAME" sh -c \
+        "ldd \"$nginx_bin\" 2>/dev/null || true")
 
-    # If readelf is unavailable, fall back to checking ldd for libpcre2-8.so
-    if [[ -z "$runpath_output" ]]; then
-        local ldd_output
-        ldd_output=$(docker exec "$CONTAINER_NAME" sh -c \
-            "ldd \"$nginx_bin\" 2>/dev/null || true")
-        echo "ldd output: $ldd_output"
-        [[ "$ldd_output" == *"libpcre2-8"* ]]
-        [[ "$ldd_output" == *"/usr/local/openresty/pcre2"* ]]
-    else
-        echo "readelf output: $runpath_output"
-        [[ "$runpath_output" == *"/usr/local/openresty/pcre2/lib"* ]]
-    fi
+    echo "ldd output: $ldd_output"
+    # PCRE2 linked: nginx must resolve libpcre2-8.so (not libpcre.so / PCRE1)
+    [[ "$ldd_output" == *"libpcre2-8"* ]]
+    # Correct rpath: resolved from the bundled pcre2 install, not a system path
+    [[ "$ldd_output" == *"/usr/local/openresty/pcre2"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/openresty/tests/test-runner-linux.bats
+++ b/openresty/tests/test-runner-linux.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Runtime smoke tests for the openresty container (PCRE2 migration — #453 volet 1).
+# Runs against the LOCALLY BUILT image via ./make build openresty.
+# Requires: docker, bats-core >= 1.8.
+#
+# Mutation this test catches: nginx built without PCRE2 (or with PCRE1) =>
+#   - /re/42 returns 4xx/5xx instead of "m=42" (regex location never matched)
+#   - nginx -V does not mention PCRE2
+#   - ldd shows libpcre.so instead of libpcre2-8.so (wrong lib)
+# All three assertions must pass for the migration to be considered functional.
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Determine the image name that ./make build produces for openresty.
+# The build system tags as <container>:<version>; for the smoke test we
+# accept any locally-built tag that starts with "openresty:" (or the GHCR form).
+_find_image() {
+    # Prefer an explicit override (CI sets IMAGE_TAG)
+    if [[ -n "${OPENRESTY_IMAGE:-}" ]]; then
+        echo "$OPENRESTY_IMAGE"
+        return
+    fi
+    # Fall back to the most-recently-built openresty image
+    local img
+    img=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+          | grep -E '^(ghcr\.io/oorabona/openresty|openresty):' \
+          | head -1)
+    if [[ -z "$img" ]]; then
+        echo "ERROR: no openresty image found locally. Run: ./make build openresty" >&2
+        return 1
+    fi
+    echo "$img"
+}
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    IMAGE=$(_find_image)
+    CONTAINER_NAME="openresty-bats-smoke-$$"
+    PORT=18080
+
+    # Nginx config with a regex location that proves PCRE2 + JIT is functional.
+    # location ~ ^/re/(\d+)$  uses a PCRE2 pattern; if PCRE2 is absent nginx
+    # either fails to start or falls back to PCRE1 (which this build does not
+    # include), so the location would never match.
+    # Note: no "daemon off;" here — the image CMD already passes -g "daemon off;"
+    NGINX_CONF="$(mktemp /tmp/openresty-bats-nginx-XXXXXX.conf)"
+    cat > "$NGINX_CONF" <<'NGINX'
+worker_processes 1;
+events { worker_connections 64; }
+http {
+    server {
+        listen 8080;
+        location ~ ^/re/(\d+)$ {
+            return 200 "m=$1";
+        }
+        location /nginx_status {
+            stub_status on;
+            access_log off;
+        }
+    }
+}
+NGINX
+
+    # Start the container with the custom nginx config
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        -p "${PORT}:8080" \
+        -v "${NGINX_CONF}:/usr/local/openresty/nginx/conf/nginx.conf:ro" \
+        "$IMAGE"
+
+    # Wait up to 15 s for nginx to become ready
+    local waited=0
+    until curl -sf "http://127.0.0.1:${PORT}/nginx_status" >/dev/null 2>&1; do
+        sleep 1
+        waited=$((waited + 1))
+        if [[ $waited -ge 15 ]]; then
+            echo "ERROR: openresty container did not become ready within 15s" >&2
+            docker logs "$CONTAINER_NAME" >&2 || true
+            return 1
+        fi
+    done
+}
+
+teardown() {
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    rm -f "$NGINX_CONF" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Test 1 (AC-5 behavioral): PCRE2 regex + JIT functional at runtime
+# Mutation caught: nginx built without PCRE2 => /re/42 is 404/500, not "m=42"
+# ---------------------------------------------------------------------------
+
+@test "GET /re/42 returns exactly 'm=42' (PCRE2 + JIT regex functional)" {
+    local body
+    body=$(curl -sf "http://127.0.0.1:${PORT}/re/42")
+    [ "$body" = "m=42" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2 (AC-5 provenance): libpcre2-8.so resolved from /usr/local/openresty/pcre2/lib
+# Mutation caught: wrong rpath (PCRE2 built but nginx resolves system libpcre2 or
+#                  libpcre1) => RUNPATH does not contain /usr/local/openresty/pcre2/lib
+# ---------------------------------------------------------------------------
+
+@test "nginx binary RUNPATH contains /usr/local/openresty/pcre2/lib" {
+    # Find the nginx binary path inside the container
+    local nginx_bin
+    nginx_bin=$(docker exec "$CONTAINER_NAME" sh -c \
+        'command -v nginx || echo /usr/local/openresty/nginx/sbin/nginx')
+
+    # readelf -d shows RPATH/RUNPATH entries
+    local runpath_output
+    runpath_output=$(docker exec "$CONTAINER_NAME" sh -c \
+        "readelf -d \"$nginx_bin\" 2>/dev/null || true")
+
+    # If readelf is unavailable, fall back to checking ldd for libpcre2-8.so
+    if [[ -z "$runpath_output" ]]; then
+        local ldd_output
+        ldd_output=$(docker exec "$CONTAINER_NAME" sh -c \
+            "ldd \"$nginx_bin\" 2>/dev/null || true")
+        echo "ldd output: $ldd_output"
+        [[ "$ldd_output" == *"libpcre2-8"* ]]
+        [[ "$ldd_output" == *"/usr/local/openresty/pcre2"* ]]
+    else
+        echo "readelf output: $runpath_output"
+        [[ "$runpath_output" == *"/usr/local/openresty/pcre2/lib"* ]]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 3 (AC-9): nginx -V configure arguments reference pcre2 paths (not PCRE1)
+# Mutation caught: nginx compiled against PCRE1 8.45 =>
+#   configure args contain "/openresty/pcre/" (no "2"), or sourceforge in build;
+#   with PCRE2 they contain "/openresty/pcre2/" in cc-opt/ld-opt.
+# Note: OpenResty nginx uses --with-pcre (not --with-pcre2) and resolves the
+#   PCRE2 library via cc-opt/ld-opt paths, so the literal string "PCRE2" does
+#   not appear in nginx -V output. The /pcre2/ path in configure args is the proof.
+# ---------------------------------------------------------------------------
+
+@test "nginx -V configure arguments reference /usr/local/openresty/pcre2/ (PCRE2 linked, not PCRE1)" {
+    local version_output
+    # nginx -V writes to stderr
+    version_output=$(docker exec "$CONTAINER_NAME" sh -c \
+        'nginx -V 2>&1 || /usr/local/openresty/nginx/sbin/nginx -V 2>&1')
+
+    echo "nginx -V output: $version_output"
+
+    # PCRE2 linked: configure arguments contain pcre2 include/lib paths
+    [[ "$version_output" == *"/usr/local/openresty/pcre2/"* ]]
+    # PCRE1 NOT linked: no reference to the PCRE1 /pcre/ path (without trailing 2)
+    # (the PCRE1 path would be /openresty/pcre/include or /openresty/pcre/lib)
+    [[ "$version_output" != *"/usr/local/openresty/pcre/include"* ]]
+    [[ "$version_output" != *"/usr/local/openresty/pcre/lib"* ]]
+}


### PR DESCRIPTION
## Summary

Migrate the `openresty` container's regex engine from **PCRE1 8.45** (EOL,
fetched without integrity verification from a deletable SourceForge tarball,
"frozen") to **PCRE2 10.47**, downloaded from the official
`github.com/PCRE2Project/pcre2` release with **SHA256 fail-closed integrity
verification**, mirroring upstream `openresty/docker-openresty:master`.

This removes the same latent build-bomb class that broke this repo's build
in #448 (OpenSSL: an EOL from-source tarball silently removed upstream → red
CI six days later). PCRE1 8.45 is the terminal PCRE1 release; PCRE2 is the
only forward path. The current PCRE1 already linked shared+rpath, so the
PCRE2 `--enable-shared --disable-static` set is continuity, not a new link
model.

## Scope — Part of #453 (does NOT close it)

This is **volet 1 of 3** of #453. It deliberately does **not** touch the
version-monitoring mechanism: `monitor:false` is retained verbatim (the
tracked-source monitoring redesign is **volet 2**, a separate PR) and
auto-open-issue-on-dep-bump-failure is **volet 3**. Mirrors the #448/#477
OpenSSL precedent exactly (version migrated, monitoring redesign deferred,
cross-linked to #453).

`Refs #453` — please **do not auto-close**; volets 2 and 3 remain open work.

## What changed (4 files)

- **`openresty/Dockerfile`** — download source → PCRE2 GitHub release
  `.tar.gz`; SHA256 verification (strict order: `curl -f` → checksum-verify
  → only then `tar`; aborts the RUN layer on mismatch, no swallow); PCRE2
  configure flags + `CFLAGS` mirrored verbatim from upstream; all
  `/pcre/` link/include/rpath paths → `/pcre2/`; `ARG RESTY_PCRE_SHA256`
  added to required-arg validation + LABEL; zero PCRE1 residue.
- **`openresty/config.yaml`** — `RESTY_PCRE_VERSION` 8.45 → 10.47;
  `RESTY_PCRE_SHA256` digest added; `reason` corrected; `monitor:false`
  retained.
- **`openresty/README.md`** — corrected to PCRE2 10.47 throughout;
  documents the SHA256↔version coupling and that `RESTY_PCRE_VERSION` now
  denotes a PCRE2 version.
- **`openresty/tests/test-runner-linux.bats`** (new) — runtime smoke the
  CI workflow auto-detects (amd64): `GET /re/42` ⇒ `m=42` (PCRE2 + JIT
  functional at runtime), `nginx` RUNPATH resolves `libpcre2-8.so` from
  `/usr/local/openresty/pcre2/lib`, `nginx -V` references the pcre2 paths.

## Verification evidence

- Local `./make build openresty` succeeded; the runtime smoke passed 3/3
  against the built image.
- **Fail-closed proven**: with a wrong SHA256 the build exits non-zero,
  the success marker never prints, and `tar` never runs.
- No PCRE1 residue (`pcre-8.45`, SourceForge URL, `/openresty/pcre/`,
  `--disable-cpp`) anywhere.
- Pre-PR orthogonal review gate: GATE_OK — one engine returned clean; the
  second could not assess (exogenous, not a refusal). The standard
  automated PR review runs on this PR as usual.

## CI posture (stated honestly)

The amd64+arm64 build + Create Manifest is the genuine PR gate (a broken
PCRE2 build fails the job). The new bats runtime smoke is amd64-only (the
test step is gated to amd64 by the workflow matrix; arm64 is built on a
native runner but not smoke-tested) and advisory-in-CI + human-verified —
the same acceptance posture as the #477 OpenSSL migration.

## Deferred follow-ups (tracked, not dropped)

- `--enable-pcre2-16/32` image-slim optimization (volet 1 stays at upstream
  parity; optimizing past upstream is a follow-up).
- Repo-wide hardening so the runtime smoke step fails the PR rather than
  staying advisory (changes behaviour for every container — out of scope
  here).
- Volet 2 (tracked-source monitoring redesign) and volet 3
  (auto-open-issue on dep-bump build failure) — #453.

Spec: `docs/plans/453-pcre2-openresty.md`.
