### PR TITLE
fix(web-shell): Two-ARG base image with tag from base_image_cache (fixes rocky cache miss)

### DIFF
--- a/tests/unit/web-shell-base-image.bats
+++ b/tests/unit/web-shell-base-image.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# web-shell base-image generation: Two-ARG pattern with the tag sourced from
+# base_image_cache[].tags[0]. Guards against the rocky cache-miss regression
+# (tag-less FROM resolving to an implicit :latest that the GHCR cache lacks)
+# and against re-hardcoding the tag literal in the generator.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    GEN="$REPO_ROOT/web-shell/generate-dockerfile.sh"
+    CONFIG="$REPO_ROOT/web-shell/config.yaml"
+    # The generator reads the template path relative to CWD; pass it absolute so
+    # the test is location-independent.
+    TEMPLATE="$REPO_ROOT/web-shell/Dockerfile"
+}
+
+@test "web-shell: alpine/ubuntu/rocky FROM uses Two-ARG \${BASE}:\${TAG} pattern" {
+    for distro in alpine ubuntu rocky; do
+        local from_line
+        from_line=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -E '^FROM ' | head -1)
+        case "$distro" in
+            alpine) [[ "$from_line" == 'FROM ${ALPINE_BASE}:${ALPINE_TAG}' ]] || { echo "alpine FROM wrong: $from_line"; return 1; } ;;
+            ubuntu) [[ "$from_line" == 'FROM ${UBUNTU_BASE}:${UBUNTU_TAG}' ]] || { echo "ubuntu FROM wrong: $from_line"; return 1; } ;;
+            rocky)  [[ "$from_line" == 'FROM ${ROCKY_BASE}:${ROCKY_TAG}' ]]   || { echo "rocky FROM wrong: $from_line";  return 1; } ;;
+        esac
+    done
+}
+
+@test "web-shell: generated default tag equals base_image_cache[].tags[0] (no hardcode, no drift)" {
+    # Mutation trace: hardcode a tag literal in generate-dockerfile.sh that
+    # differs from config → this test goes RED. Proves the tag is sourced from
+    # config, the single source of truth shared with the cache-population job.
+    for arg in ALPINE_BASE UBUNTU_BASE ROCKY_BASE; do
+        local distro tag_arg cfg_tag gen_tag
+        case "$arg" in
+            ALPINE_BASE) distro=alpine; tag_arg=ALPINE_TAG ;;
+            UBUNTU_BASE) distro=ubuntu; tag_arg=UBUNTU_TAG ;;
+            ROCKY_BASE)  distro=rocky;  tag_arg=ROCKY_TAG ;;
+        esac
+        cfg_tag=$(YQ_ARG="$arg" yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0]' "$CONFIG")
+        gen_tag=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -E "^ARG ${tag_arg}=" | head -1 | cut -d= -f2)
+        [[ "$gen_tag" == "$cfg_tag" ]] || { echo "$distro: generated ${tag_arg}=$gen_tag != config tags[0]=$cfg_tag"; return 1; }
+    done
+}
+
+@test "web-shell: CI tag-less cache override resolves to the cached tag" {
+    # Simulate get_cache_build_args (tag-less ROCKY_BASE) + the generated
+    # ROCKY_TAG default → the effective FROM must target rocky-base:<cached-tag>,
+    # NOT an implicit :latest. This is the exact rocky cache-miss the fix closes.
+    local rocky_tag
+    rocky_tag=$(YQ_ARG=ROCKY_BASE yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0]' "$CONFIG")
+    # Default ROCKY_BASE in the generated Dockerfile is "rockylinux"; CI overrides
+    # it to ghcr.io/owner/rocky-base (tag-less). With Two-ARG, the tag stays.
+    local gen_tag
+    gen_tag=$(bash "$GEN" "$TEMPLATE" rocky 2>/dev/null | grep -E '^ARG ROCKY_TAG=' | head -1 | cut -d= -f2)
+    [[ "$gen_tag" == "$rocky_tag" ]] || { echo "ROCKY_TAG=$gen_tag != cached $rocky_tag"; return 1; }
+    [[ -n "$gen_tag" && "$gen_tag" != "latest" ]] || { echo "ROCKY_TAG resolved to empty/latest — cache miss risk"; return 1; }
+}

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -66,23 +66,48 @@ _wrap_list() {
 # ============================================================
 # @@BASE_IMAGE@@ — Distro-specific ARGs + FROM instruction
 # Values like ${DEBIAN_TAG} are Docker ARG references — output literally
+#
+# Two-ARG pattern (base repo + tag as separate ARGs): the CI cache override
+# (helpers/base-cache-utils.sh get_cache_build_args) emits a TAG-LESS
+# ALPINE_BASE=ghcr.io/owner/alpine-base, so the tag must come from a separate
+# ARG. A one-ARG `FROM ${ALPINE_BASE}` would resolve to an implicit :latest
+# against the GHCR cache, which is not guaranteed to exist (rocky-base only
+# publishes :9). The default tag is read from base_image_cache[].tags[0] in
+# config.yaml — the SAME value the cache-population job uses — so the FROM tag
+# and the cached tag stay in lockstep with no duplicated literal.
 # ============================================================
+
+# Read the pinned base-image tag for a given build-arg from base_image_cache.
+_base_cache_tag() {
+    local arg="$1"
+    YQ_ARG="$arg" yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0] // ""' "$config"
+}
+
 case "$distro" in
     debian)
         base_block='ARG DEBIAN_TAG="trixie"
 FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}'
         ;;
     alpine)
-        base_block='ARG ALPINE_BASE=alpine:3.21
-FROM ${ALPINE_BASE}'
+        alpine_tag=$(_base_cache_tag "ALPINE_BASE")
+        [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for ALPINE_BASE in $config"; exit 1; }
+        base_block="ARG ALPINE_BASE=alpine
+ARG ALPINE_TAG=${alpine_tag}
+FROM \${ALPINE_BASE}:\${ALPINE_TAG}"
         ;;
     ubuntu)
-        base_block='ARG UBUNTU_BASE=ubuntu:noble
-FROM ${UBUNTU_BASE}'
+        ubuntu_tag=$(_base_cache_tag "UBUNTU_BASE")
+        [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for UBUNTU_BASE in $config"; exit 1; }
+        base_block="ARG UBUNTU_BASE=ubuntu
+ARG UBUNTU_TAG=${ubuntu_tag}
+FROM \${UBUNTU_BASE}:\${UBUNTU_TAG}"
         ;;
     rocky)
-        base_block='ARG ROCKY_BASE=rockylinux:9
-FROM ${ROCKY_BASE}'
+        rocky_tag=$(_base_cache_tag "ROCKY_BASE")
+        [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for ROCKY_BASE in $config"; exit 1; }
+        base_block="ARG ROCKY_BASE=rockylinux
+ARG ROCKY_TAG=${rocky_tag}
+FROM \${ROCKY_BASE}:\${ROCKY_TAG}"
         ;;
     *)
         log_error "No BASE_IMAGE template for distro: $distro"


### PR DESCRIPTION
## What

web-shell's generated Dockerfiles used a one-ARG base pattern
(`ARG ALPINE_BASE=alpine:3.21` + `FROM ${ALPINE_BASE}`). The CI cache
override (`get_cache_build_args`) emits a **tag-less**
`ALPINE_BASE=ghcr.io/owner/alpine-base`, so `FROM` resolved to an
implicit `:latest` against the GHCR cache. alpine/ubuntu/debian-base
carry a `:latest` tag (populated by other containers that share those
bases) so they built fine; **rocky-base is web-shell-exclusive with
`tags: ["9"]` only**, so rocky builds failed with
`ghcr.io/oorabona/rocky-base:latest not found`.

## Fix

Emit the **Two-ARG pattern** that openresty / sslh / vector / php
already use — `ARG X_BASE=<repo>` + `ARG X_TAG=<tag>` +
`FROM ${X_BASE}:${X_TAG}`. The default tag is read from
`base_image_cache[].tags[0]` in `config.yaml` (the same value the
cache-population job uses) so the FROM tag and the cached tag stay in
lockstep with **no duplicated literal** (no hardcode). The tag-less CI
override then resolves to `<cache-repo>:<configured-tag>`, which exists.

## Orthogonal gate

- **codex: clean.**
- **copilot: refuse** — flagged that a *tagged* `ALPINE_BASE=alpine:3.21`
  override would now expand to `alpine:3.21:3.21`. **HEAD-verified
  latent, not an active break**: no automated path passes a tagged
  `*_BASE` — `get_cache_build_args` is tag-less, `docker-compose.yml`
  passes only `TTYD_VERSION`, `config.yaml build_args` set
  `ALPINE_BASE: "alpine"` (tag-less), `_resolve_base_image` reads the
  `base_image` field for lineage metadata only (not a build-arg), and
  the documented override form is tag-less. The break would only occur
  for a manual `docker build --build-arg ALPINE_BASE=alpine:3.21` using
  the pre-existing tagged convention. The canonical ARG naming/contract
  (reuse `ALPINE_BASE` vs distinct `OS_IMAGE_BASE`+`OS_IMAGE_TAG` like
  the reference containers) is deferred to the base-image convergence
  effort below.

## Convergence context

This converges web-shell onto the de-facto majority pattern
(Two-ARG-from-config; reference: openresty/sslh/vector/php). The
remaining divergent containers — terraform (hardcoded ALPINE_BASE /
PYTHON_BASE tags), github-runner (incomplete cache coverage),
debian/ansible (version/tag conflation), jekyll (composite tag) — are
tracked for a dedicated convergence effort (ADR + unified shared
helper). wordpress is a genuine exception (downstream php consumer).

## Tests

`tests/unit/web-shell-base-image.bats`: asserts the Two-ARG FROM, the
default tag equals `base_image_cache[].tags[0]` (no hardcode / no
drift), and the tag-less override resolving to the cached tag (not an
implicit `:latest`).
