### PR TITLE
ci(auth): authenticate Docker Hub pulls across the full build chain

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -243,6 +243,10 @@ jobs:
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          # Extension images build FROM the postgres base; authenticate
+          # Docker Hub so those base pulls are not anonymous (429 under load).
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Get versions requiring extensions
         id: ext-versions
@@ -342,12 +346,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      # Authenticate BOTH registries: GHCR (push the cache) AND Docker Hub
+      # (the `docker buildx imagetools create` below PULLS from docker.io —
+      # anonymous pulls share the GitHub-runner IP rate limit and 429 under
+      # load). Docker Hub auth raises the ceiling for cache-population pulls;
+      # the registry-mirror in #488 removes Docker Hub from the path entirely
+      # as the durable fix.
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Collect and cache base images
         env:


### PR DESCRIPTION
ci(auth): authenticate Docker Hub pulls across the full build chain

Two jobs pulled from docker.io anonymously, sharing the GitHub-runner IP
rate limit and hitting HTTP 429 under full-matrix load:

- cache-base-images: `docker buildx imagetools create` pulls
  `docker.io/<base>:<tag>` to populate the GHCR cache, but the job only
  logged into GHCR.
- build-extensions: extension images build FROM the postgres base but
  the docker-login step passed only GHCR credentials.

Both now use the docker-login composite action with the existing
DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets (the composite skips the
docker.io login gracefully when the secrets are unset). build-and-push,
sync-registries, and create-manifest already authenticated both
registries.

This raises the Docker Hub pull ceiling for the whole chain. It does NOT
fully eliminate 429 — the matrix postgres builds still pull docker.io
directly when the GHCR cache override does not apply (a routing issue,
not an auth gap). The durable fix is the registry-mirror tracked in #488
(docker.io/* resolved transparently via GHCR, removing Docker Hub from
the matrix-build path entirely).
