### PR TITLE
ci(mirror): Docker Hub pull-through cache via buildkitd sidecar (#488)

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -92,25 +92,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      with:
-        # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
-        # Windows: docker driver (native daemon's BuildKit) — required because Linux containers
-        # for BuildKit aren't available on Windows runners. We don't need a builder for the
-        # imagetools create calls anyway — they operate on registry manifests, not on a builder.
-        # Per #357: this step is now also run on Windows so `docker buildx imagetools create`
-        # uses the action-installed buildx (recent), not the runner's outdated stock buildx
-        # which rejects `--tag` and `-t` for imagetools create.
-        driver: ${{ runner.os == 'Windows' && 'docker' || 'docker-container' }}
-        # Pin buildx version: setup-buildx-action does NOT replace an already-installed
-        # buildx unless `version` is set explicitly (it only configures the builder otherwise).
-        # Without this, the Windows runner's outdated stock buildx would keep running and
-        # reject `--tag` / `-t` for imagetools create. Pinned on both OS for reproducibility.
-        version: 'v0.33.0'
-      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal.
-      # Retry logic handles intermittent Docker Hub issues.
-
     - name: Log in to GitHub Container Registry
       if: runner.os != 'Windows'
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -140,6 +121,40 @@ runs:
       shell: bash
       run: echo "${{ inputs.dockerhub_token }}" | docker login docker.io -u ${{ inputs.dockerhub_username }} --password-stdin
       continue-on-error: true
+
+    - name: Start Docker Hub pull-through mirror
+      if: runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success'
+      uses: ./.github/actions/dockerhub-mirror
+      with:
+        dockerhub_username: ${{ inputs.dockerhub_username }}
+        dockerhub_token: ${{ inputs.dockerhub_token }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      with:
+        # Linux: docker-container driver (BuildKit container) — supports --push, multi-platform.
+        # Windows: docker driver (native daemon's BuildKit) — required because Linux containers
+        # for BuildKit aren't available on Windows runners. We don't need a builder for the
+        # imagetools create calls anyway — they operate on registry manifests, not on a builder.
+        # Per #357: this step is now also run on Windows so `docker buildx imagetools create`
+        # uses the action-installed buildx (recent), not the runner's outdated stock buildx
+        # which rejects `--tag` and `-t` for imagetools create.
+        driver: ${{ runner.os == 'Windows' && 'docker' || 'docker-container' }}
+        # Pin buildx version: setup-buildx-action does NOT replace an already-installed
+        # buildx unless `version` is set explicitly (it only configures the builder otherwise).
+        # Without this, the Windows runner's outdated stock buildx would keep running and
+        # reject `--tag` / `-t` for imagetools create. Pinned on both OS for reproducibility.
+        version: 'v0.33.0'
+        # Linux with creds: route docker.io pulls through the local pull-through mirror
+        # (network=host allows BuildKit container to reach 127.0.0.1:5000 on the runner).
+        # buildkitd-config (NOT config) is the correct input for setup-buildx-action@v4;
+        # using config: is silently ignored and the mirror would never be used.
+        # Windows or secretless (fork PR): no mirror — leave driver-opts and buildkitd-config
+        # empty so the build falls back to direct docker.io pulls as before.
+        driver-opts: ${{ (runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success') && 'network=host' || '' }}
+        buildkitd-config: ${{ (runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success') && '.github/buildkitd-mirror.toml' || '' }}
+      # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal.
+      # Retry logic handles intermittent Docker Hub issues.
 
     - name: Check if build is needed and get version
       id: check-build

--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -15,6 +15,11 @@ inputs:
     description: Docker Hub token (optional)
     required: false
     default: ""
+outputs:
+  dockerhub_authed:
+    description: Whether Docker Hub login succeeded (true/false)
+    value: ${{ steps.dockerhub.outcome == 'success' }}
+
 runs:
   using: composite
   steps:
@@ -27,6 +32,7 @@ runs:
 
     - name: Log in to Docker Hub
       if: inputs.dockerhub_username != '' && inputs.dockerhub_token != ''
+      id: dockerhub
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: docker.io

--- a/.github/actions/dockerhub-mirror/README.md
+++ b/.github/actions/dockerhub-mirror/README.md
@@ -1,0 +1,76 @@
+# dockerhub-mirror
+
+Composite action that starts a per-job `registry:2` pull-through proxy sidecar, routing
+`docker.io` base-image pulls through a local cache at `127.0.0.1:<port>`. Eliminates
+`docker.io HTTP 429` on the `docker buildx build` base-image pull path without modifying
+Dockerfiles. Implements ADR-009 / issue #488.
+
+**Linux-only.** All steps are no-ops on `runner.os == Windows` (Windows base images are
+not the docker.io 429 source).
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `dockerhub_username` | yes | — | Docker Hub username (proxy backend credentials) |
+| `dockerhub_token` | yes | — | Docker Hub token (proxy backend credentials) |
+| `port` | no | `5000` | Host port for the proxy (bound to `127.0.0.1` only) |
+| `registry_image` | no | `ghcr.io/<owner>/registry:2` | Proxy sidecar image (GHCR copy preferred) |
+| `cache_key_prefix` | no | `dockerhub-mirror` | `actions/cache` key prefix for the proxy store |
+| `allow_self_hosted` | no | `false` | Explicit opt-in to run on a self-hosted runner despite `REGISTRY_PROXY_PASSWORD` being visible via `docker inspect`. Only set to `true` on a trusted single-tenant ephemeral runner. The action fails-closed by default on any non-GitHub-hosted environment. |
+
+## Usage
+
+Call in this order at each build site: docker.io login → this action → setup-buildx.
+
+```yaml
+- name: Log in to Docker Hub
+  uses: ./.github/actions/docker-login
+  with:
+    ghcr_username: ${{ github.actor }}
+    ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+    dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+    dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+- name: Start Docker Hub mirror
+  uses: ./.github/actions/dockerhub-mirror
+  with:
+    dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+    dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+- name: Set up Docker Buildx
+  uses: docker/setup-buildx-action@<SHA> # v4
+  with:
+    driver: docker-container
+    driver-opts: network=host
+    buildkitd-config: .github/buildkitd-mirror.toml
+```
+
+## Security note (GH-hosted runners only)
+
+`REGISTRY_PROXY_PASSWORD` is passed as a container environment variable and is readable
+via `docker inspect dockerhub-mirror` by other processes within the same job. The action
+**enforces** this boundary: it checks `$RUNNER_ENVIRONMENT` at startup and fails-closed
+with `::error::` if the runner is not `github-hosted`, unless `allow_self_hosted: true`
+is set as an explicit opt-in. Use `allow_self_hosted: true` only on a trusted single-tenant
+ephemeral self-hosted runner where co-tenancy risk is absent. Use a least-privilege Docker
+Hub account (no private-repo access). The proxy port is bound to `127.0.0.1` (loopback)
+only — not exposed to the network.
+
+The action is **always fail-closed** on an unhealthy proxy: there is no escape hatch.
+`setup-buildx` (run after this action) applies the `buildkitd-config` pointing at the
+proxy — so a dead proxy cannot be transparently bypassed; any attempt to continue would
+silently route pulls through a broken mirror. A healthcheck failure emits `::error::` and
+exits non-0, causing the job to fail loudly.
+
+## Architecture
+
+The `registry:2` sidecar is pulled from a GHCR copy (`registry_image` default) to keep
+bootstrap intra-GitHub. The fallback `registry:2@sha256:...` (digest-pinned docker.io)
+is used only when the GHCR copy is absent (first run before B5 seeds it). The proxy
+store (`$RUNNER_TEMP/registry-mirror`) is persisted via `actions/cache` with a per-job
+save key (avoids parallel-matrix collision) and a broad restore prefix (warms from any
+prior same-OS job). `REGISTRY_PROXY_TTL=168h` lets the proxy serve cached manifests for
+a week without revalidating against docker.io.
+
+See `docs/adr/ADR-009-dockerhub-pullthrough-mirror.md` for the design rationale.

--- a/.github/actions/dockerhub-mirror/action.yaml
+++ b/.github/actions/dockerhub-mirror/action.yaml
@@ -1,0 +1,139 @@
+name: Docker Hub Mirror
+description: >
+  Start a per-job registry:2 pull-through proxy sidecar for Docker Hub.
+  Caches the proxy's /var/lib/registry store via actions/cache so warm hits
+  are served locally. Requires a prior docker.io login so the proxy can
+  authenticate cold-miss upstream fetches (higher Hub rate limit).
+  Linux-only: all steps are no-ops on Windows (Windows base images are not
+  the docker.io 429 source).
+
+inputs:
+  dockerhub_username:
+    description: Docker Hub username (passed as REGISTRY_PROXY_USERNAME to the proxy)
+    required: true
+  dockerhub_token:
+    description: Docker Hub token (passed as REGISTRY_PROXY_PASSWORD to the proxy)
+    required: true
+  port:
+    description: Host port the proxy listens on (published to 127.0.0.1 only)
+    required: false
+    default: '5000'
+  registry_image:
+    description: >
+      Image to use for the registry:2 proxy sidecar. Defaults to the GHCR-hosted
+      copy (intra-GitHub, no docker.io pull). Fall back to the digest-pinned
+      docker.io image only when the GHCR copy is absent (first-run before B5 seeds it).
+    required: false
+    default: ''
+  cache_key_prefix:
+    description: Prefix for the actions/cache key used to persist the proxy store
+    required: false
+    default: 'dockerhub-mirror'
+  allow_self_hosted:
+    description: >
+      Explicit opt-in to run on a trusted single-tenant self-hosted runner
+      despite REGISTRY_PROXY_PASSWORD being visible via docker inspect.
+      Default 'false' (fail-closed on self-hosted). Only set to 'true' when
+      the self-hosted runner is single-tenant and ephemeral (no co-tenancy risk).
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # ── Step 1: Restore cached proxy store ────────────────────────────────────
+    # sha → exact rerun hits (same commit, different run); job + job-index →
+    # collision-free across parallel matrix jobs (each GH job = separate runner VM);
+    # restore-keys prefix → cross-commit warm from any prior job in the same OS bucket.
+    - name: Restore Docker Hub mirror cache
+      if: runner.os != 'Windows'
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: ${{ runner.temp }}/registry-mirror
+        key: ${{ inputs.cache_key_prefix }}-${{ runner.os }}-${{ github.sha }}-${{ github.job }}-${{ strategy.job-index }}
+        restore-keys: |
+          ${{ inputs.cache_key_prefix }}-${{ runner.os }}-
+
+    # ── Step 2: Start registry:2 pull-through proxy sidecar ───────────────────
+    # Pulls the sidecar image from GHCR (intra-GitHub) when available; falls back
+    # to a digest-pinned docker.io/library/registry:2 image for first-run bootstrap
+    # (before B5 seeds the GHCR copy via cache-base-images).
+    # To refresh the digest pin: skopeo inspect --raw docker://docker.io/library/registry:2
+    # | python3 -c "import sys,hashlib; d=sys.stdin.buffer.read(); print('sha256:'+hashlib.sha256(d).hexdigest())"
+    - name: Start Docker Hub mirror proxy
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub_username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub_token }}
+        PORT: ${{ inputs.port }}
+        REGISTRY_IMAGE: ${{ inputs.registry_image }}
+        ALLOW_SELF_HOSTED: ${{ inputs.allow_self_hosted }}
+        # digest-pinned docker.io fallback (refresh via command above when registry:2 releases)
+        REGISTRY_FALLBACK_IMAGE: registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+      run: |
+        set -euo pipefail
+
+        # DRY_RUN support: source helpers/logging.sh when available for $DOCKER indirection.
+        # If helpers are absent (e.g. future reuse outside this repo), fall back to an
+        # inline guard so the action stays self-contained.
+        if [ -f "${GITHUB_WORKSPACE}/helpers/logging.sh" ]; then
+          # shellcheck source=helpers/logging.sh
+          source "${GITHUB_WORKSPACE}/helpers/logging.sh"
+        else
+          DOCKER="docker"
+          [[ "${DRY_RUN:-false}" == "true" ]] && DOCKER="echo docker"
+        fi
+
+        # shellcheck source=.github/actions/dockerhub-mirror/mirror-lib.sh
+        source "${GITHUB_ACTION_PATH}/mirror-lib.sh"
+
+        # Safety gate: REGISTRY_PROXY_PASSWORD is visible via docker inspect.
+        # Fail-closed on self-hosted runners unless the caller has explicitly opted in.
+        dhm_assert_ephemeral_runner "${RUNNER_ENVIRONMENT:-}" "${ALLOW_SELF_HOSTED:-false}"
+
+        # Pull sidecar image (GHCR first, digest-pinned docker.io fallback) and start proxy.
+        # Pass GITHUB_REPOSITORY_OWNER (built-in env var, always lowercase-safe via ${owner,,}
+        # inside the function) so the GHCR ref is resolved in shell, not in a composite
+        # input default (which does NOT reliably evaluate ${{ github.* }} expressions).
+        REGISTRY_IMAGE="$(dhm_resolve_registry_image "${REGISTRY_IMAGE}" "${REGISTRY_FALLBACK_IMAGE}" "${GITHUB_REPOSITORY_OWNER}")"
+        dhm_start_proxy "${PORT}" "${RUNNER_TEMP}" "${REGISTRY_IMAGE}" \
+          "${DOCKERHUB_USERNAME}" "${DOCKERHUB_TOKEN}"
+
+    # ── Step 3: Healthcheck — always fail-closed ──────────────────────────────
+    # Poll /v2/ up to 30×1 s. A dead proxy fails the step (no escape hatch:
+    # buildkitd-config is already applied by setup-buildx so an unhealthy proxy
+    # cannot be bypassed transparently — fail loudly instead).
+    # DRY_RUN: proxy was never started (step 2 only echoed the docker run
+    # command), so polling would always fail. Short-circuit immediately.
+    - name: Wait for Docker Hub mirror proxy to be healthy
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+
+        # DRY_RUN support: mirror the same detection as step 2 so the
+        # healthcheck is skipped when no real proxy was started.
+        if [ -f "${GITHUB_WORKSPACE}/helpers/logging.sh" ]; then
+          # shellcheck source=helpers/logging.sh
+          source "${GITHUB_WORKSPACE}/helpers/logging.sh"
+        else
+          [[ "${DRY_RUN:-false}" == "true" ]] && DOCKER="echo docker" || DOCKER="docker"
+        fi
+
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+          echo "DRY_RUN: skipping proxy healthcheck (proxy was not started)"
+          exit 0
+        fi
+
+        # shellcheck source=.github/actions/dockerhub-mirror/mirror-lib.sh
+        source "${GITHUB_ACTION_PATH}/mirror-lib.sh"
+
+        proxy_url="$(dhm_proxy_url "${PORT}")"
+
+        if ! dhm_healthcheck "${proxy_url}" 30; then
+          echo "::error::dockerhub-mirror proxy failed to become healthy"
+          exit 1
+        fi

--- a/.github/actions/dockerhub-mirror/mirror-lib.sh
+++ b/.github/actions/dockerhub-mirror/mirror-lib.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# mirror-lib.sh — Testable decision-logic library for the dockerhub-mirror action.
+#
+# Design: pure functions where possible; side-effecting commands go through
+# injectable vars so bats can stub without touching the network or docker daemon.
+#
+#   DOCKER  — defaults to the $DOCKER set by helpers/logging.sh (or "docker")
+#   CURL    — defaults to "curl"
+#
+# Source this file; do NOT execute it directly.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Injectable command vars (match helpers/logging.sh pattern for $DOCKER)
+# ---------------------------------------------------------------------------
+# $DOCKER is expected to be set by the caller (sourcing helpers/logging.sh
+# or the inline DRY_RUN guard in action.yaml).  If it is not set, fall back
+# to "docker" — same convention as logging.sh.
+: "${DOCKER:=docker}"
+# $CURL injectable for bats stubs (no DRY_RUN echo-wrapper needed; healthcheck
+# uses curl only for probing, not for side effects that must be suppressed).
+: "${CURL:=curl}"
+
+# ---------------------------------------------------------------------------
+# dhm_resolve_registry_image <registry_image> <fallback_image> [owner]
+#
+# Resolve the registry:2 sidecar image reference and pull it.
+#
+# <registry_image>: explicit image ref to use.  When empty (the default input),
+#   the GHCR candidate is derived from <fallback_image>'s digest and <owner>:
+#   ghcr.io/<owner-lowercased>/registry@<digest>
+#   where <digest> is extracted from the <fallback_image> arg (must contain @sha256:…).
+#   Using the same digest for both GHCR and docker.io is correct: B5 seeds GHCR
+#   from that exact docker.io digest, so the GHCR manifest resolves to it.
+# <fallback_image>: digest-pinned docker.io image used when the GHCR pull fails.
+#                   Must include a digest (@sha256:…) — used as the canonical pin
+#                   for both the GHCR candidate ref and the docker.io fallback.
+# [owner]:          GitHub repository owner — required when <registry_image> is
+#                   empty, optional otherwise (ignored when registry_image is set).
+#
+# stdout: the image reference that was successfully pulled
+# stderr: progress / warning messages
+# exit:   0 on success, non-0 if both pulls fail (propagates from $DOCKER pull)
+# ---------------------------------------------------------------------------
+dhm_resolve_registry_image() {
+    local registry_image="${1}"           # may be empty
+    local fallback_image="${2:?fallback_image required}"
+    local owner="${3:-}"                  # GITHUB_REPOSITORY_OWNER, required when registry_image is empty
+
+    # When registry_image is not provided, derive the GHCR candidate from owner.
+    # GHCR requires lowercase owner names.  Pin to the same digest as fallback_image
+    # (DRY: single digest source; B5 seeds GHCR from that exact docker.io digest).
+    if [[ -z "${registry_image}" ]]; then
+        if [[ -z "${owner}" ]]; then
+            echo "::error::dhm_resolve_registry_image: registry_image is empty and no owner supplied" >&2
+            return 1
+        fi
+        # Extract digest from fallback_image (everything after '@')
+        local digest="${fallback_image##*@}"
+        # Bash 4+ parameter expansion lowercase: ${var,,}
+        registry_image="ghcr.io/${owner,,}/registry@${digest}"
+    fi
+
+    # shellcheck disable=SC2086
+    # $DOCKER is intentionally word-split ("echo docker" in DRY_RUN mode).
+    # Redirect BOTH stdout and stderr to /dev/null so that under DRY_RUN
+    # ("echo docker pull <ref>") the echoed command does not pollute the
+    # function's stdout contract (callers capture output via command substitution).
+    if $DOCKER pull "${registry_image}" >/dev/null 2>&1; then
+        printf '%s\n' "${registry_image}"
+    else
+        echo "::warning::GHCR registry image ${registry_image} not yet available; falling back to digest-pinned docker.io image" >&2
+        # shellcheck disable=SC2086
+        $DOCKER pull "${fallback_image}" >/dev/null 2>&1 || return $?
+        printf '%s\n' "${fallback_image}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# dhm_assert_ephemeral_runner <runner_environment> <allow_self_hosted>
+#
+# Safety gate: REGISTRY_PROXY_PASSWORD is visible via docker inspect; it is
+# only safe on ephemeral GitHub-hosted runners.  Fail-closed on self-hosted
+# unless the caller has explicitly opted in.
+#
+# <runner_environment>: value of $RUNNER_ENVIRONMENT ("github-hosted" or
+#                       "self-hosted"; empty string treated as unknown).
+# <allow_self_hosted>:  explicit opt-in flag ("true" skips the block).
+#
+# stdout: nothing
+# stderr: ::error:: message on violation
+# exit:   0 when safe to proceed, 1 when blocked
+# ---------------------------------------------------------------------------
+dhm_assert_ephemeral_runner() {
+    local runner_environment="${1:-}"
+    local allow_self_hosted="${2:-false}"
+
+    if [[ "${runner_environment}" != "github-hosted" && "${allow_self_hosted}" != "true" ]]; then
+        echo "::error::dockerhub-mirror: REGISTRY_PROXY_PASSWORD is visible via docker inspect; only safe on ephemeral GitHub-hosted runners. Set allow_self_hosted: true to override on a trusted single-tenant runner." >&2
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# dhm_start_proxy <port> <runner_temp> <registry_image>
+#                 <dockerhub_username> <dockerhub_token>
+#
+# Start the registry:2 pull-through sidecar container.
+# Uses $DOCKER (injectable for DRY_RUN / stubs).
+#
+# exit: 0 on success (propagates $DOCKER run exit code)
+# ---------------------------------------------------------------------------
+dhm_start_proxy() {
+    local port="${1:?port required}"
+    local runner_temp="${2:?runner_temp required}"
+    local registry_image="${3:?registry_image required}"
+    local dockerhub_username="${4:?dockerhub_username required}"
+    local dockerhub_token="${5:?dockerhub_token required}"
+
+    local container_name="dockerhub-mirror"
+
+    mkdir -p "${runner_temp}/registry-mirror"
+
+    # Export creds so docker passes them by NAME only — the values never appear
+    # on the command line (no argv leak, no dry-run echo leak).
+    export REGISTRY_PROXY_USERNAME="${dockerhub_username}"
+    export REGISTRY_PROXY_PASSWORD="${dockerhub_token}"
+
+    # Remove any pre-existing container of the same name so retries and
+    # reused self-hosted runners do not fail with "name already in use".
+    # shellcheck disable=SC2086
+    # $DOCKER intentionally word-split (see top of file)
+    $DOCKER rm -f "${container_name}" >/dev/null 2>&1 || true
+
+    # shellcheck disable=SC2086
+    $DOCKER run -d --name "${container_name}" --restart=no \
+        -p "127.0.0.1:${port}:5000" \
+        -v "${runner_temp}/registry-mirror:/var/lib/registry" \
+        -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+        -e REGISTRY_PROXY_USERNAME \
+        -e REGISTRY_PROXY_PASSWORD \
+        -e REGISTRY_PROXY_TTL=168h \
+        "${registry_image}"
+    # NB: REGISTRY_PROXY_TTL is ignored by registry:2 v2.8.3 (proxy manifest TTL default is already
+    # 168h); kept as an intent marker for future versions.
+}
+
+# ---------------------------------------------------------------------------
+# dhm_healthcheck <proxy_url> <max_retries> [sleep_cmd]
+#
+# Poll <proxy_url> up to <max_retries> times (1 s apart).
+# /v2/ returns 200 (no auth) or 401 (auth required) — both mean proxy is up.
+# Uses $CURL (injectable for bats stubs).
+#
+# <sleep_cmd>: optional override for the sleep between retries (default: "sleep").
+#              Pass "true" or ":" in tests to skip real sleeps.
+#
+# stdout: nothing (progress messages on stderr)
+# exit:   0 if healthy before timeout, 1 if all retries exhausted
+# ---------------------------------------------------------------------------
+dhm_healthcheck() {
+    local proxy_url="${1:?proxy_url required}"
+    local max_retries="${2:?max_retries required}"
+    local sleep_cmd="${3:-sleep}"
+
+    local i healthy=false
+
+    for i in $(seq 1 "${max_retries}"); do
+        local http_status
+        # $CURL injectable; capture HTTP status code via -w; suppress body; -f makes
+        # curl exit non-0 on 4xx/5xx but we want 401 to count as healthy — so we
+        # capture the status code manually instead of relying on curl's exit code.
+        http_status=$(
+            # shellcheck disable=SC2086
+            $CURL -sS -o /dev/null -w "%{http_code}" "${proxy_url}" 2>/dev/null
+        ) || true  # curl may exit non-0 on connection refused — that's fine; check status below
+
+        if [[ "${http_status}" == "200" ]] || [[ "${http_status}" == "401" ]]; then
+            healthy=true
+            echo "::notice::Docker Hub mirror proxy is healthy on ${proxy_url} (HTTP ${http_status}, attempt ${i})" >&2
+            break
+        fi
+
+        echo "Waiting for mirror proxy (attempt ${i}/${max_retries}, HTTP ${http_status})..." >&2
+        ${sleep_cmd} 1
+    done
+
+    if [[ "${healthy}" == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# dhm_proxy_url <port>
+#
+# Print the proxy health-check URL for the given port.
+# Pure function — no side effects.
+# ---------------------------------------------------------------------------
+dhm_proxy_url() {
+    local port="${1:?port required}"
+    printf 'http://127.0.0.1:%s/v2/\n' "${port}"
+}

--- a/.github/buildkitd-mirror.toml
+++ b/.github/buildkitd-mirror.toml
@@ -1,0 +1,11 @@
+# buildkitd mirror config — single source of truth for the Docker Hub pull-through mirror.
+# Referenced via setup-buildx-action's `buildkitd-config` input (NOT `config` — that input
+# does not exist on v4 and would silently leave the builder unmirrored).
+# The proxy sidecar is started by .github/actions/dockerhub-mirror/action.yaml.
+# network=host on the builder (driver-opts) is required so 127.0.0.1:5000 reaches the host.
+
+[registry."docker.io"]
+  mirrors = ["127.0.0.1:5000"]
+
+[registry."127.0.0.1:5000"]
+  http = true

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -233,11 +233,8 @@ jobs:
           echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
           sudo chmod +x /usr/local/bin/yq
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        timeout-minutes: 10
-
       - name: Log in to container registries
+        id: login
         uses: ./.github/actions/docker-login
         timeout-minutes: 5
         with:
@@ -247,6 +244,20 @@ jobs:
           # Docker Hub so those base pulls are not anonymous (429 under load).
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Docker Hub pull-through mirror
+        if: steps.login.outputs.dockerhub_authed == 'true'
+        uses: ./.github/actions/dockerhub-mirror
+        with:
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        timeout-minutes: 10
+        with:
+          driver-opts: ${{ steps.login.outputs.dockerhub_authed == 'true' && 'network=host' || '' }}
+          buildkitd-config: ${{ steps.login.outputs.dockerhub_authed == 'true' && '.github/buildkitd-mirror.toml' || '' }}
 
       - name: Get versions requiring extensions
         id: ext-versions
@@ -334,6 +345,14 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Non-blocking for build-and-push: ADR-009 / spec §C1b. The DockerHub mirror
+    # (B3) is the safety net — if GHCR base cache is absent, Dockerfiles pull
+    # FROM docker.io through the per-job sidecar proxy. Failure here therefore
+    # degrades performance (no cache hit) but never breaks the build. GitHub
+    # semantics: continue-on-error: true causes this job's result to appear as
+    # 'success' to dependent jobs even when it fails, so build-and-push is never
+    # skipped by a cache-population 429.
+    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -402,6 +421,35 @@ jobs:
 
           echo ""
           echo "✅ Base image caching complete"
+
+      - name: Seed registry:2 proxy image to GHCR
+        # ADR-009 / spec §C2. Copies the digest-pinned registry:2 image to GHCR
+        # so the dockerhub-mirror action (B1) can pull its sidecar proxy
+        # intra-GitHub, avoiding a per-job docker.io pull.
+        # IMPORTANT: digest must stay in sync with
+        # .github/actions/dockerhub-mirror/action.yaml fallback pin.
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          # Lowercase owner: GHCR refs are case-sensitive in tooling and
+          # require lowercase. Must match the ${owner,,} resolution in
+          # .github/actions/dockerhub-mirror (dhm_resolve_registry_image).
+          owner="${OWNER,,}"
+          ghcr_image="ghcr.io/${owner}/registry:2"
+          source_img="docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
+
+          echo "🔄 Seeding registry:2 → ${ghcr_image}"
+
+          if output=$(docker buildx imagetools create \
+            --tag "${ghcr_image}" \
+            "${source_img}" 2>&1); then
+            echo "  ✅ registry:2 seeded to GHCR successfully"
+          else
+            echo "  ⚠️ Failed to seed registry:2 to GHCR"
+            echo "  Error: ${output}"
+          fi
 
   sync-registries:
     name: Sync ${{ matrix.build.container }}:${{ matrix.build.tag }} GHCR→DockerHub

--- a/docs/adr/ADR-009-dockerhub-pullthrough-mirror.md
+++ b/docs/adr/ADR-009-dockerhub-pullthrough-mirror.md
@@ -115,5 +115,36 @@ most complex.
 - The sidecar registry must be reachable from buildkitd (host networking /
   `docker` driver); verify per build driver during implementation.
 
-**Implementation tracking:** issue #488. Reference for the buildkitd config-inline
-and `registry:2` proxy wiring to be captured in the shared composite action.
+**Implementation tracking:** issue #488.
+
+## Implementation (issue #488)
+
+Shipped as the shared composite action [`.github/actions/dockerhub-mirror`](../../.github/actions/dockerhub-mirror/action.yaml)
+plus the buildkitd config [`.github/buildkitd-mirror.toml`](../../.github/buildkitd-mirror.toml).
+The action restores a `registry:2` pull-through store from `actions/cache`, starts
+the proxy on `127.0.0.1:5000` (`REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io`
+plus Docker Hub backend credentials), fail-closes on an unhealthy proxy, and lets
+`actions/cache` persist the store on a per-job key.
+
+Wiring (per job that pulls `docker.io` through `docker buildx build`):
+`docker.io login → dockerhub-mirror → setup-buildx-action` with
+`driver-opts: network=host` and **`buildkitd-config: .github/buildkitd-mirror.toml`**
+(the `network=host` driver-opt is how the `docker-container` buildkitd reaches the
+host-published proxy; `buildkitd-config` — not `config` — is the setup-buildx-action
+input that loads the mirror, the latter being silently ignored).
+
+Scope verified at implementation time (the "verify per build driver" step above):
+only the buildx-build pull path is mirrored — the **build matrix** (via the
+`build-container` action) and **build-extensions**. `cache-base-images` and
+`create-manifest` pull `docker.io` through `docker buildx imagetools create`, which
+resolves source manifests directly against the upstream registry and does not honor
+the buildkitd mirror; they remain on authenticated direct pull. `cache-base-images`
+is made non-blocking (`continue-on-error: true`) so its un-mirrorable rate-limit
+cannot fail the workflow — `build-and-push` carries the mirror as the safety net, and
+also seeds a digest-pinned `registry:2` into GHCR so the proxy image itself is pulled
+intra-GitHub.
+
+Once the mirror is observed eliminating the rate-limit on full-matrix runs, the GHCR
+base-image-copy repos, the skopeo-copy job, and the `get_cache_build_args` build-arg
+override become redundant for rate-limit avoidance and are slated for removal in a
+follow-up (they are kept until then). Design + hardening: `docs/plans/488-dockerhub-mirror.md`.

--- a/tests/unit/dockerhub-mirror.bats
+++ b/tests/unit/dockerhub-mirror.bats
@@ -1,0 +1,435 @@
+#!/usr/bin/env bats
+
+# Unit tests for .github/actions/dockerhub-mirror/mirror-lib.sh
+#
+# All tests use PATH stubs or injectable command vars ($DOCKER / $CURL).
+# No real docker daemon or network is required.
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    LIB="${PROJECT_ROOT}/.github/actions/dockerhub-mirror/mirror-lib.sh"
+
+    # Temporary directory for stubs and working files
+    setup_temp_dir
+
+    # Prepend stub bin dir to PATH so subprocesses can find stubs
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    export PATH="${TEST_TEMP_DIR}/bin:${PATH}"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Create a stub script that exits with a given code and optionally emits output.
+# Usage: make_stub <name> <exit_code> [stdout_content]
+make_stub() {
+    local name="${1}" ec="${2}" out="${3:-}"
+    cat > "${TEST_TEMP_DIR}/bin/${name}" <<STUB
+#!/usr/bin/env bash
+${out:+printf '%s\n' "${out}"}
+exit ${ec}
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/${name}"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — dhm_healthcheck: healthy when curl returns 200
+# ---------------------------------------------------------------------------
+
+@test "dhm_healthcheck returns 0 when curl yields HTTP 200" {
+    # Stub curl to emit "200" as the http_code write-out
+    make_stub curl 0 "200"
+    export CURL="${TEST_TEMP_DIR}/bin/curl"
+
+    # Source lib AFTER exporting injectable vars
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_healthcheck "http://127.0.0.1:5000/v2/" 3 ":"
+    [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# T2 — dhm_healthcheck: healthy when curl returns 401 (auth required)
+# ---------------------------------------------------------------------------
+
+@test "dhm_healthcheck returns 0 when curl yields HTTP 401" {
+    make_stub curl 0 "401"
+    export CURL="${TEST_TEMP_DIR}/bin/curl"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_healthcheck "http://127.0.0.1:5000/v2/" 3 ":"
+    [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# T3 — dhm_healthcheck: timeout → non-0 after N retries exhausted
+# ---------------------------------------------------------------------------
+
+@test "dhm_healthcheck returns non-0 after all retries exhausted" {
+    # Stub curl to always return connection-refused-like (exit 7, empty status)
+    # Emit empty string so http_status="" which is neither 200 nor 401
+    make_stub curl 7 ""
+    export CURL="${TEST_TEMP_DIR}/bin/curl"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    # max_retries=3, sleep_cmd=":" so the test runs fast
+    run dhm_healthcheck "http://127.0.0.1:5000/v2/" 3 ":"
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# T6 — dhm_resolve_registry_image: picks GHCR ref when docker pull succeeds
+# ---------------------------------------------------------------------------
+
+@test "dhm_resolve_registry_image returns GHCR ref when pull succeeds" {
+    # Stub docker to succeed on any pull
+    make_stub docker 0 ""
+    export DOCKER="${TEST_TEMP_DIR}/bin/docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_resolve_registry_image \
+        "ghcr.io/owner/registry:2" \
+        "registry:2@sha256:abc123"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "ghcr.io/owner/registry:2" ]
+}
+
+# ---------------------------------------------------------------------------
+# T7 — dhm_resolve_registry_image: falls back to digest-pinned docker.io ref
+#      when GHCR pull fails
+# ---------------------------------------------------------------------------
+
+@test "dhm_resolve_registry_image falls back to docker.io digest-pinned ref on GHCR failure" {
+    # Stub docker: first call (GHCR pull) exits 1; subsequent calls succeed
+    local call_count_file="${TEST_TEMP_DIR}/call_count"
+    echo "0" > "${call_count_file}"
+
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<STUB
+#!/usr/bin/env bash
+count=\$(cat "${call_count_file}")
+echo \$((count + 1)) > "${call_count_file}"
+if [ "\$count" -eq 0 ]; then
+    exit 1   # GHCR pull fails
+fi
+exit 0       # fallback docker.io pull succeeds
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+    export DOCKER="${TEST_TEMP_DIR}/bin/docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_resolve_registry_image \
+        "ghcr.io/owner/registry:2" \
+        "registry:2@sha256:abc123"
+    [ "${status}" -eq 0 ]
+    # bats `run` merges stderr into output; use contains rather than exact equality
+    # because the warning line is also present.
+    [[ "${output}" == *"registry:2@sha256:abc123"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# T8 — DRY_RUN guard: $DOCKER="echo docker" prints command instead of executing
+# ---------------------------------------------------------------------------
+
+@test "dhm_start_proxy prints docker run command when DOCKER='echo docker'" {
+    # DRY_RUN mode: DOCKER is the echo-docker sentinel from logging.sh
+    export DOCKER="echo docker"
+    export DRY_RUN=true
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_start_proxy "5000" "${TEST_TEMP_DIR}" "ghcr.io/owner/registry:2" \
+        "myuser" "supersecrettoken123"
+    [ "${status}" -eq 0 ]
+    # Should have printed the docker run command rather than executed it
+    [[ "${output}" == *"docker run"* ]]
+    [[ "${output}" == *"dockerhub-mirror"* ]]
+    [[ "${output}" == *"127.0.0.1:5000:5000"* ]]
+    # Regression lock: token value must NOT appear in the echoed output (credential leak guard).
+    # Mutation: reverting to -e "REGISTRY_PROXY_PASSWORD=${token}" would echo the value → RED.
+    [[ "${output}" != *"supersecrettoken123"* ]]
+    # The name-only flag must be present (values passed via exported env, not argv).
+    [[ "${output}" == *"-e REGISTRY_PROXY_PASSWORD"* ]]
+    [[ "${output}" == *"-e REGISTRY_PROXY_USERNAME"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# T8b — DRY_RUN healthcheck: step 3 short-circuit skips curl poll and exits 0
+#
+# Validates the fix for the DRY_RUN defect: when DRY_RUN=true the proxy
+# was never started, so the healthcheck must skip the curl poll entirely.
+# Mutation: removing the DRY_RUN guard would cause dhm_healthcheck to poll
+# a non-existent proxy → curl stub invoked → test fails on status or
+# call-log presence.
+# ---------------------------------------------------------------------------
+
+@test "DRY_RUN=true: healthcheck step logic skips curl poll and exits 0" {
+    # Stub curl to record calls and exit non-0 (simulates no proxy running).
+    # If the short-circuit guard were absent, dhm_healthcheck would invoke
+    # this stub and the test would detect it via the call log or non-0 exit.
+    local curl_call_log="${TEST_TEMP_DIR}/curl_calls.log"
+
+    cat > "${TEST_TEMP_DIR}/bin/curl" <<STUB
+#!/usr/bin/env bash
+echo "curl_called: \$*" >> "${curl_call_log}"
+exit 7
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/curl"
+
+    # Write the step-3 logic to a helper script so we can test it cleanly
+    # (same DRY_RUN guard that action.yaml step 3 uses).
+    local step_script="${TEST_TEMP_DIR}/step3.sh"
+    cat > "${step_script}" <<SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+LIB="${LIB}"
+CURL_STUB="${TEST_TEMP_DIR}/bin/curl"
+source "\${LIB}"
+export CURL="\${CURL_STUB}"
+if [[ "\${DRY_RUN:-false}" == "true" ]]; then
+    echo "DRY_RUN: skipping proxy healthcheck (proxy was not started)"
+    exit 0
+fi
+proxy_url="\$(dhm_proxy_url "5000")"
+dhm_healthcheck "\${proxy_url}" 3 ":"
+SCRIPT
+    chmod +x "${step_script}"
+
+    # Run with DRY_RUN=true
+    DRY_RUN=true run "${step_script}"
+
+    # Must exit 0 (short-circuit succeeded)
+    [ "${status}" -eq 0 ]
+    # Must emit the skip message
+    [[ "${output}" == *"DRY_RUN: skipping proxy healthcheck"* ]]
+    # curl must NOT have been called (no proxy was started)
+    [ ! -f "${curl_call_log}" ]
+}
+
+# ---------------------------------------------------------------------------
+# T9 — port templating: dhm_proxy_url produces correct loopback URL
+# ---------------------------------------------------------------------------
+
+@test "dhm_proxy_url returns correct loopback URL for given port" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_proxy_url "5000"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "http://127.0.0.1:5000/v2/" ]
+}
+
+# ---------------------------------------------------------------------------
+# T10 — dhm_proxy_url: alternate port is correctly templated
+# ---------------------------------------------------------------------------
+
+@test "dhm_proxy_url uses alternate port when specified" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_proxy_url "5555"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "http://127.0.0.1:5555/v2/" ]
+}
+
+# ---------------------------------------------------------------------------
+# T11 — dhm_resolve_registry_image: both pulls fail → non-0 (error propagation)
+# ---------------------------------------------------------------------------
+
+@test "dhm_resolve_registry_image returns non-0 when both GHCR and fallback pulls fail" {
+    # Stub docker: every call (both GHCR pull and digest-pinned fallback) exits 1
+    local call_count_file="${TEST_TEMP_DIR}/call_count"
+    echo "0" > "${call_count_file}"
+
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<STUB
+#!/usr/bin/env bash
+count=\$(cat "${call_count_file}")
+echo \$((count + 1)) > "${call_count_file}"
+exit 1   # all pulls fail
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+    export DOCKER="${TEST_TEMP_DIR}/bin/docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_resolve_registry_image \
+        "ghcr.io/owner/registry:2" \
+        "registry:2@sha256:abc123"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# T13 — dhm_resolve_registry_image: empty registry_image + mixed-case owner →
+#        derives lowercased digest-pinned ghcr.io/<owner>/registry@sha256:…
+#        (NOT a mutable :2 tag — same digest as the docker.io fallback, DRY)
+# ---------------------------------------------------------------------------
+
+@test "dhm_resolve_registry_image with empty registry_image derives lowercased digest-pinned GHCR ref from owner" {
+    # Stub docker: capture every pull invocation, succeed on all
+    local pull_log="${TEST_TEMP_DIR}/pull_args.log"
+
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<STUB
+#!/usr/bin/env bash
+# Log the image ref being pulled (the last arg)
+echo "\${@: -1}" >> "${pull_log}"
+exit 0
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+    export DOCKER="${TEST_TEMP_DIR}/bin/docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    # Pass empty registry_image and a mixed-case owner — function must lowercase it
+    # and pin to the digest extracted from fallback_image.
+    run dhm_resolve_registry_image \
+        "" \
+        "registry:2@sha256:abc123" \
+        "MyOrg"
+    [ "${status}" -eq 0 ]
+
+    # The resolved image returned on stdout must be the digest-pinned GHCR ref
+    # (digest extracted from fallback_image, owner lowercased, NO mutable :2 tag)
+    [ "${output}" = "ghcr.io/myorg/registry@sha256:abc123" ]
+
+    # Confirm the docker pull was attempted with the digest-pinned ref
+    [ -f "${pull_log}" ]
+    grep -q "^ghcr.io/myorg/registry@sha256:abc123$" "${pull_log}"
+}
+
+# ---------------------------------------------------------------------------
+# T12 — dhm_start_proxy: docker rm -f issued BEFORE docker run on retry/reuse
+# ---------------------------------------------------------------------------
+
+@test "dhm_start_proxy issues docker rm -f before docker run for idempotent restarts" {
+    # Capture every docker invocation (subcommand + args) into a log file,
+    # then assert the rm -f call appears before the run call.
+    local call_log="${TEST_TEMP_DIR}/docker_calls.log"
+
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<STUB
+#!/usr/bin/env bash
+# Append the full argument list as a single line so we can assert order.
+echo "\$*" >> "${call_log}"
+exit 0
+STUB
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+    export DOCKER="${TEST_TEMP_DIR}/bin/docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_start_proxy "5000" "${TEST_TEMP_DIR}" "ghcr.io/owner/registry:2" \
+        "myuser" "mytoken"
+    [ "${status}" -eq 0 ]
+
+    # The call log must exist and contain at least two entries.
+    [ -f "${call_log}" ]
+
+    # Extract the line numbers of the rm and run calls.
+    rm_line=$(grep -n "^rm -f " "${call_log}" | head -1 | cut -d: -f1)
+    run_line=$(grep -n "^run -d " "${call_log}" | head -1 | cut -d: -f1)
+
+    # Both commands must be present.
+    [ -n "${rm_line}" ]
+    [ -n "${run_line}" ]
+
+    # rm -f must appear BEFORE docker run (lower line number).
+    [ "${rm_line}" -lt "${run_line}" ]
+
+    # The rm -f call must reference the container name "dockerhub-mirror".
+    grep -q "^rm -f dockerhub-mirror" "${call_log}"
+
+    # The run call must also reference the same name via --name.
+    grep -q "^run -d .*--name dockerhub-mirror" "${call_log}"
+}
+
+# ---------------------------------------------------------------------------
+# T15 — DRY_RUN stdout guard: dhm_resolve_registry_image under DRY_RUN must
+#        return a single clean image ref with no "docker pull" prefix.
+#
+# Regression lock: if the >/dev/null redirect on the pull-test calls is
+# removed, DOCKER="echo docker" causes "echo docker pull <ref>" to write
+# "docker pull <ref>" to stdout, which the caller captures via $(...).
+# The returned value then becomes "docker pull ghcr.io/...\nghcr.io/..." —
+# a corrupt multi-line string.  This test uses exact-equality on $output so
+# that any stdout leakage turns it RED immediately.
+# ---------------------------------------------------------------------------
+
+@test "T15: DRY_RUN — dhm_resolve_registry_image returns single-line lowercase GHCR ref (no docker pull prefix)" {
+    # Simulate DRY_RUN by setting DOCKER to the echo-docker sentinel.
+    # Under DRY_RUN the pull-test must be silenced (>/dev/null 2>&1);
+    # only the intentional printf '%s\n' should reach stdout.
+    export DOCKER="echo docker"
+
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_resolve_registry_image "" "registry:2@sha256:abc" "MixedCaseOwner"
+    [ "${status}" -eq 0 ]
+    # Must be exactly the digest-pinned lowercased GHCR ref — single line, no "docker pull" prefix.
+    [ "${output}" = "ghcr.io/mixedcaseowner/registry@sha256:abc" ]
+}
+
+# ---------------------------------------------------------------------------
+# T16 — dhm_assert_ephemeral_runner: enforce self-hosted boundary
+#
+# Regression lock: if the guard is removed (or the condition inverted),
+# the self-hosted-no-opt-in branch no longer fails-closed and T16b turns RED.
+# ---------------------------------------------------------------------------
+
+@test "T16a: dhm_assert_ephemeral_runner passes on github-hosted regardless of allow_self_hosted" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_assert_ephemeral_runner "github-hosted" "false"
+    [ "${status}" -eq 0 ]
+}
+
+@test "T16b: dhm_assert_ephemeral_runner fails-closed on self-hosted without opt-in" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_assert_ephemeral_runner "self-hosted" "false"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"::error::"* ]]
+    [[ "${output}" == *"allow_self_hosted"* ]]
+}
+
+@test "T16c: dhm_assert_ephemeral_runner passes on self-hosted when allow_self_hosted=true" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_assert_ephemeral_runner "self-hosted" "true"
+    [ "${status}" -eq 0 ]
+}
+
+@test "T16d: dhm_assert_ephemeral_runner fails-closed on unknown/empty runner_environment without opt-in" {
+    # shellcheck disable=SC1090
+    source "${LIB}"
+
+    run dhm_assert_ephemeral_runner "" "false"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"::error::"* ]]
+}


### PR DESCRIPTION
## What

Routes Docker Hub base-image pulls through a transparent per-job **registry:2
pull-through cache** so full-matrix CI builds stop failing with `docker.io HTTP
429`. Implements **ADR-009** (decision locked there — transparent mirror, per-job
sidecar + `actions/cache`, 100% intra-GitHub).

`FROM <upstream>:<tag>` lines in Dockerfiles are unchanged (portable; respects a
consumer's own mirror config).

## How

- New shared composite action `.github/actions/dockerhub-mirror` + single-source
  `.github/buildkitd-mirror.toml`. The action restores a `registry:2` proxy store
  from `actions/cache`, starts the proxy on `127.0.0.1:5000`
  (`REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io` + Docker Hub backend
  creds), and fail-closes on an unhealthy proxy. Shell decision-logic extracted to
  `mirror-lib.sh` and covered by 19 bats tests.
- Wired into the two jobs that pull `docker.io` through `docker buildx build`: the
  **build matrix** (`build-container` action) and **build-extensions** — via
  setup-buildx-action `buildkitd-config` + `driver-opts: network=host`.
- `cache-base-images` made non-blocking (`continue-on-error: true`); it pulls via
  `imagetools create`, which does **not** honor the buildkit mirror, so the build
  matrix carries the mirror as the safety net. A digest-pinned `registry:2` is
  seeded into GHCR so the proxy image is pulled intra-GitHub.

## Verified scope (the "verify per build driver" step ADR-009 deferred)

`docker buildx imagetools create` resolves source manifests directly against the
upstream registry and ignores the buildkit mirror — so only the buildx-build pull
path is mirrored (build matrix + build-extensions). `cache-base-images` /
`create-manifest` stay on authenticated direct pull. Mirror is creds-gated on
**docker.io login success** (not mere secret presence), so fork PRs / missing or
invalid creds fall back to the pre-change direct-pull behavior. Non-ephemeral
runners are fail-closed (`allow_self_hosted` opt-in) because the proxy backend
credential is `docker inspect`-visible.

## Validation

Local proof: the proxy serves an `alpine` pull through `127.0.0.1:5000` (access log
confirmed). 19 bats unit tests green; shellcheck clean. Senior review APPROVE;
orthogonal pre-push gate **GATE_OK** (copilot CLEAN; codex was quota-exhausted /
exogenously unavailable → degraded-OK per gate semantics).

Full-matrix-green is unreachable **before** merge by design (the recurring 429 is
exactly what this fixes) — validate on the touched jobs + a targeted build.

Follow-up (tracked): once the mirror is observed eliminating the 429 on full-matrix
runs, deprecate the now-redundant GHCR base-image-copy repos + skopeo job +
`get_cache_build_args` override (ADR-009 Consequences).

Closes #488
