### PR TITLE
fix(mirror): remove non-functional port input from dockerhub-mirror action

### DIFF
--- a/.github/actions/dockerhub-mirror/README.md
+++ b/.github/actions/dockerhub-mirror/README.md
@@ -1,7 +1,7 @@
 # dockerhub-mirror
 
 Composite action that starts a per-job `registry:2` pull-through proxy sidecar, routing
-`docker.io` base-image pulls through a local cache at `127.0.0.1:<port>`. Eliminates
+`docker.io` base-image pulls through a local cache at `127.0.0.1:5000`. Eliminates
 `docker.io HTTP 429` on the `docker buildx build` base-image pull path without modifying
 Dockerfiles. Implements ADR-009 / issue #488.
 
@@ -14,7 +14,6 @@ not the docker.io 429 source).
 |-------|----------|---------|-------------|
 | `dockerhub_username` | yes | — | Docker Hub username (proxy backend credentials) |
 | `dockerhub_token` | yes | — | Docker Hub token (proxy backend credentials) |
-| `port` | no | `5000` | Host port for the proxy (bound to `127.0.0.1` only) |
 | `registry_image` | no | `ghcr.io/<owner>/registry:2` | Proxy sidecar image (GHCR copy preferred) |
 | `cache_key_prefix` | no | `dockerhub-mirror` | `actions/cache` key prefix for the proxy store |
 | `allow_self_hosted` | no | `false` | Explicit opt-in to run on a self-hosted runner despite `REGISTRY_PROXY_PASSWORD` being visible via `docker inspect`. Only set to `true` on a trusted single-tenant ephemeral runner. The action fails-closed by default on any non-GitHub-hosted environment. |

--- a/.github/actions/dockerhub-mirror/action.yaml
+++ b/.github/actions/dockerhub-mirror/action.yaml
@@ -14,10 +14,6 @@ inputs:
   dockerhub_token:
     description: Docker Hub token (passed as REGISTRY_PROXY_PASSWORD to the proxy)
     required: true
-  port:
-    description: Host port the proxy listens on (published to 127.0.0.1 only)
-    required: false
-    default: '5000'
   registry_image:
     description: >
       Image to use for the registry:2 proxy sidecar. Defaults to the GHCR-hosted
@@ -66,7 +62,10 @@ runs:
       env:
         DOCKERHUB_USERNAME: ${{ inputs.dockerhub_username }}
         DOCKERHUB_TOKEN: ${{ inputs.dockerhub_token }}
-        PORT: ${{ inputs.port }}
+        # Port is fixed at 5000: buildkitd-mirror.toml hardcodes 127.0.0.1:5000 as the mirror
+        # target (a static file); a configurable port would require generating that config inline.
+        # 5000 is conflict-free on ephemeral GitHub-hosted runners.
+        PORT: '5000'
         REGISTRY_IMAGE: ${{ inputs.registry_image }}
         ALLOW_SELF_HOSTED: ${{ inputs.allow_self_hosted }}
         # digest-pinned docker.io fallback (refresh via command above when registry:2 releases)
@@ -110,7 +109,7 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       env:
-        PORT: ${{ inputs.port }}
+        PORT: '5000'
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
## What

Removes the non-functional `port` input from the `dockerhub-mirror` composite
action (follow-up to #488). The action published the proxy on `127.0.0.1:${port}:5000`
but the buildkitd mirror target in `.github/buildkitd-mirror.toml` is hardcoded to
`127.0.0.1:5000`, so overriding the port left BuildKit pointed at 5000 while the proxy
listened elsewhere — silently breaking the mirror. The port is now fixed at 5000 in the
action (conflict-free on ephemeral runners); the library functions keep their `port`
parameter for unit-test coverage. 17 bats green; shellcheck clean.

## Orthogonal gate

- **codex (xhigh): CLEAN.**
- copilot: flagged "removing the port input is a breaking interface change for existing
  callers." **Verified false-positive** — the action is a relative-path local action
  (`./.github/actions/dockerhub-mirror`, not a published `owner/repo@ref`), it has
  exactly two consumers (`build-container` action, `build-extensions` job), neither
  passes `port`, and no external consumer is possible. Removing the input breaks zero
  callers. Operator-arbitrated proceed.

Follow-up to #488.
