### PR TITLE
fix(ci): resolve GHCR base-cache check tag from version (root-cause of full-matrix 429)

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -395,8 +395,7 @@ runs:
               entry_count=$(yq -r '.base_image_cache | length' "./$container/config.yaml")
               for ((i = 0; i < entry_count; i++)); do
                 ghcr_repo=$(yq -r ".base_image_cache[$i].ghcr_repo" "./$container/config.yaml")
-                raw_tag=$(yq -r ".base_image_cache[$i].tags[0] // \"latest\"" "./$container/config.yaml")
-                resolved_tag=$(_resolve_tag_template "$raw_tag" "$build_version" "./$container/config.yaml" "./$container")
+                resolved_tag=$(resolve_cache_check_tag "./$container/config.yaml" "$i" "$build_version")
                 check_image="ghcr.io/${{ github.repository_owner }}/${ghcr_repo}:${resolved_tag}"
                 if docker manifest inspect "$check_image" &>/dev/null; then
                   cache_ok=true

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -210,5 +210,33 @@ get_cache_build_args() {
     echo "$args"
 }
 
+# Resolve the tag to use when verifying a GHCR cache entry is accessible.
+# For tags_from_versions entries (e.g. postgres), there is no tags[] array —
+# the GHCR copy uses the build_version as the tag (e.g. "18-alpine").
+# For tags[] entries, resolves tags[0] via _resolve_tag_template.
+# Falls back to "latest" if tags[] is absent and tags_from_versions is false.
+# Usage: resolve_cache_check_tag <config_file> <entry_index> <build_version>
+# Output: the tag string to use in the docker manifest inspect check
+resolve_cache_check_tag() {
+    local config_file="$1"
+    local entry_index="$2"
+    local build_version="$3"
+    local container_dir
+    container_dir="$(dirname "$config_file")"
+
+    local tags_from_versions
+    tags_from_versions=$(yq -r ".base_image_cache[$entry_index].tags_from_versions // false" "$config_file")
+
+    if [[ "$tags_from_versions" == "true" ]]; then
+        # Tags are derived from versions: the GHCR copy uses build_version as the tag
+        printf '%s' "$build_version"
+        return
+    fi
+
+    local raw_tag
+    raw_tag=$(yq -r ".base_image_cache[$entry_index].tags[0] // \"latest\"" "$config_file")
+    _resolve_tag_template "$raw_tag" "$build_version" "$config_file" "$container_dir"
+}
+
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images get_cache_build_args
+export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images get_cache_build_args resolve_cache_check_tag

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/base-cache-utils.sh
+# Covers: resolve_cache_check_tag — tag resolution for GHCR accessibility checks
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    source "$ORIG_DIR/helpers/logging.sh"
+    source "$ORIG_DIR/helpers/variant-utils.sh"
+    source "$ORIG_DIR/helpers/base-cache-utils.sh"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+# --- resolve_cache_check_tag ---
+
+# BCU-01: regression lock for the docker.io 429 bug
+# tags_from_versions: true → must return build_version, NOT "latest"
+@test "BCU-01: tags_from_versions=true returns build_version (regression lock: not 'latest')" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: BASE_IMAGE
+    source: postgres
+    ghcr_repo: postgres-base
+    tags_from_versions: true
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 0 "18-alpine"
+    [ "$status" -eq 0 ]
+    [ "$output" = "18-alpine" ]
+
+    # Mutation guard: revert would return "latest" — verify it is NOT "latest"
+    [ "$output" != "latest" ]
+}
+
+# BCU-02: tags_from_versions=true with a different build_version
+@test "BCU-02: tags_from_versions=true returns whatever build_version is passed" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: BASE_IMAGE
+    source: postgres
+    ghcr_repo: postgres-base
+    tags_from_versions: true
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 0 "17-alpine"
+    [ "$status" -eq 0 ]
+    [ "$output" = "17-alpine" ]
+}
+
+# BCU-03: tags[] literal array → returns the literal tag (existing behaviour preserved)
+@test "BCU-03: literal tags[0] entry returns the literal tag" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: BASE_IMAGE
+    source: ubuntu
+    ghcr_repo: ubuntu-base
+    tags: ["latest"]
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 0 "22.04"
+    [ "$status" -eq 0 ]
+    [ "$output" = "latest" ]
+}
+
+# BCU-04: tags[] with a template that uses ${VERSION}
+@test "BCU-04: tags[0] template using \${VERSION} is resolved to build_version" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: TERRAFORM_BASE
+    source: hashicorp/terraform
+    ghcr_repo: terraform-base
+    tags: ["${VERSION}"]
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 0 "1.9.5"
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.9.5" ]
+}
+
+# BCU-05: no tags key and tags_from_versions absent → falls back to "latest"
+@test "BCU-05: absent tags and no tags_from_versions defaults to 'latest'" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: BASE_IMAGE
+    source: alpine
+    ghcr_repo: alpine-base
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 0 "3.21"
+    [ "$status" -eq 0 ]
+    [ "$output" = "latest" ]
+}
+
+# BCU-06: second entry (index=1) is resolved correctly
+@test "BCU-06: entry at index 1 is resolved independently" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - arg: BASE_IMAGE
+    source: hashicorp/terraform
+    ghcr_repo: terraform-base
+    tags: ["${VERSION}"]
+  - arg: ALPINE_BASE
+    source: alpine
+    ghcr_repo: alpine-base
+    tags: ["3.21"]
+EOF
+
+    run resolve_cache_check_tag "config.yaml" 1 "1.9.5"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3.21" ]
+}


### PR DESCRIPTION
## What

Root-cause fix for the recurring full-matrix `docker.io HTTP 429` (the original motivation behind #488 / ADR-009).

## Root cause (evidence-pinned)

On a full-matrix run, `Build postgres:base` failed with
`load metadata for docker.io/library/postgres:18-alpine → 429`. The GHCR
base-cache accessibility check in `build-container` verified
`ghcr.io/<owner>/postgres-base:latest`, but `postgres` uses
`base_image_cache.tags_from_versions: true` — its GHCR copy is tagged
`16-alpine/17-alpine/18-alpine`, never `latest`. The check failed → the
(correct) `--build-arg BASE_IMAGE=ghcr.io/.../postgres-base` override was
dropped → `FROM` fell back to the docker.io default base → 429 under
full-matrix volume. So postgres bypassed its own valid GHCR copy.

## Fix

New `resolve_cache_check_tag` helper resolves the accessibility-check tag from
the **build version** for `tags_from_versions` entries (`18-alpine`, matching
the GHCR copy), preserving the existing template/`latest` behaviour for
`tags:`-array entries. Wired into the `build-container` action (one-line
replacement). 6 bats tests incl. a regression lock (tags_from_versions →
version tag, not `latest`).

This eliminates the 429 at the source: postgres (and any `tags_from_versions`
container) now resolves its base from GHCR — docker.io is not touched. The
transparent mirror (#488) remains the safety net for any other override gap.

Orthogonal pre-push gate: codex CLEAN + copilot CLEAN. Relates to #488.
