### PR TITLE
refactor(ci): #498 consolidate base-image seed into sync-base-images

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -58,7 +58,7 @@ inputs:
     required: false
     default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
   use_base_cache:
-    description: 'Use GHCR base image cache (skip on PRs where cache-base-images is not run)'
+    description: 'Use GHCR base image cache (skip on fork PRs where sync-base-images is not run)'
     required: false
     default: 'true'
 outputs:
@@ -122,13 +122,6 @@ runs:
       run: echo "${{ inputs.dockerhub_token }}" | docker login docker.io -u ${{ inputs.dockerhub_username }} --password-stdin
       continue-on-error: true
 
-    - name: Start Docker Hub pull-through mirror
-      if: runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success'
-      uses: ./.github/actions/dockerhub-mirror
-      with:
-        dockerhub_username: ${{ inputs.dockerhub_username }}
-        dockerhub_token: ${{ inputs.dockerhub_token }}
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
@@ -145,14 +138,6 @@ runs:
         # Without this, the Windows runner's outdated stock buildx would keep running and
         # reject `--tag` / `-t` for imagetools create. Pinned on both OS for reproducibility.
         version: 'v0.33.0'
-        # Linux with creds: route docker.io pulls through the local pull-through mirror
-        # (network=host allows BuildKit container to reach 127.0.0.1:5000 on the runner).
-        # buildkitd-config (NOT config) is the correct input for setup-buildx-action@v4;
-        # using config: is silently ignored and the mirror would never be used.
-        # Windows or secretless (fork PR): no mirror — leave driver-opts and buildkitd-config
-        # empty so the build falls back to direct docker.io pulls as before.
-        driver-opts: ${{ (runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success') && 'network=host' || '' }}
-        buildkitd-config: ${{ (runner.os != 'Windows' && steps.dockerhub-login.outcome == 'success') && '.github/buildkitd-mirror.toml' || '' }}
       # GitHub runners cache moby/buildkit images, so Docker Hub dependency is minimal.
       # Retry logic handles intermittent Docker Hub issues.
 
@@ -377,9 +362,10 @@ runs:
           fi
         fi
 
-        # Use GHCR-cached base images (seeded by upstream-monitor workflow)
-        # Skip on PRs: cache-base-images job is not run for pull_request events,
-        # so GHCR cache images may not exist yet — fall back to Docker Hub defaults.
+        # Use GHCR-cached base images (seeded by sync-base-images in auto-build
+        # on push, and refreshed daily by sync-base-images in upstream-monitor).
+        # Skip on fork PRs: sync-base-images is gated to own-repo PRs only, so
+        # GHCR cache images may not exist there — fall back to Docker Hub defaults.
         if [[ "${{ inputs.use_base_cache }}" == "true" ]]; then
           source ./helpers/base-cache-utils.sh
           if has_base_cache "./$container"; then

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -214,22 +214,23 @@ jobs:
   # Build and push PostgreSQL extension images if postgres is in the build list
   build-extensions:
     name: Build PostgreSQL Extensions
-    needs: [detect-containers, cache-base-images]
-    # Ordered after cache-base-images so the per-major-version GHCR probe below
+    needs: [detect-containers, sync-base-images]
+    # Ordered after sync-base-images so the per-major-version GHCR probe below
     # (docker manifest inspect ghcr.io/<owner>/library/postgres:<ver>-alpine) runs
-    # AFTER cache-base-images has seeded that tag — fulfilling SC-18 (extensions use
+    # AFTER sync-base-images has seeded that tag — fulfilling SC-18 (extensions use
     # GHCR). The always() + result-in-(success,skipped) guard mirrors build-and-push
     # exactly: a skipped seed (fork PRs) or a failed seed (continue-on-error: true
     # means the job reports 'success' to dependents even on failure — but we guard
     # 'skipped' too for future-proofing) never blocks extensions. When the probe
-    # finds the mirror absent it falls back to docker.io via the #488 registry:2
-    # sidecar — graceful degradation is preserved; only the race is eliminated.
+    # finds the GHCR cache absent it falls back to direct docker.io (authenticated
+    # via the existing docker-login step) — graceful degradation is preserved;
+    # only the race is eliminated.
     if: |
       always() &&
       needs.detect-containers.outputs.count > 0 &&
       contains(needs.detect-containers.outputs.containers, 'postgres') &&
       (github.event.inputs.skip_extensions || inputs.skip_extensions) != 'true' &&
-      (needs.cache-base-images.result == 'success' || needs.cache-base-images.result == 'skipped')
+      (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
     # Serialize extension builds across runs — shared builder images race otherwise.
     concurrency:
       group: build-extensions-${{ github.ref }}
@@ -266,19 +267,9 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Start Docker Hub pull-through mirror
-        if: steps.login.outputs.dockerhub_authed == 'true'
-        uses: ./.github/actions/dockerhub-mirror
-        with:
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         timeout-minutes: 10
-        with:
-          driver-opts: ${{ steps.login.outputs.dockerhub_authed == 'true' && 'network=host' || '' }}
-          buildkitd-config: ${{ steps.login.outputs.dockerhub_authed == 'true' && '.github/buildkitd-mirror.toml' || '' }}
 
       - name: Get versions requiring extensions
         id: ext-versions
@@ -296,7 +287,7 @@ jobs:
           REBUILD: ${{ env.REBUILD_MODE }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
           # USE_BASE_CACHE mirrors the use_base_cache gate in build-container: true only for
-          # non-fork push/dispatch events (where GHCR write access and cache-base-images ran).
+          # non-fork push/dispatch events (where GHCR write access and sync-base-images ran).
           # REMOTE_CR is NOT set here at job level — it is probed per major_version below.
           USE_BASE_CACHE: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -331,13 +322,14 @@ jobs:
               fi
 
               # Probe the GHCR postgres library mirror per major_version.
-              # build-extensions is ordered after cache-base-images (see job needs:), so
-              # the mirror is likely seeded by the time this probe runs; however the probe
-              # is still required as the graceful-degradation fallback for fork PRs (where
-              # cache-base-images is skipped) and any seed failure. Probe each version
-              # individually and set REMOTE_CR only when the mirror is confirmed reachable;
-              # otherwise leave it unset so build-extensions falls back to docker.io via
-              # the #488 registry:2 sidecar (no hard-fail).
+              # build-extensions is ordered after sync-base-images (see job needs:), so
+              # the GHCR cache is likely seeded by the time this probe runs; however the
+              # probe is still required as the graceful-degradation fallback for fork PRs
+              # (where sync-base-images is skipped) and any seed failure. Probe each
+              # version individually and set REMOTE_CR only when the GHCR cache is
+              # confirmed reachable; otherwise leave it unset so build-extensions falls
+              # back to direct docker.io (authenticated) — no hard-fail, single auth'd
+              # cold pull per missing tag, well under the rate limit.
               # Tag format: <major_version>-alpine  (matches the postgres base_suffix and
               # the tag the extension Dockerfiles reference via FROM ${REMOTE_CR}/library/postgres).
               REMOTE_CR=""
@@ -348,7 +340,7 @@ jobs:
                   REMOTE_CR="ghcr.io/${REPO_OWNER}"
                   echo "✅ postgres library mirror reachable for ${mirror_tag} — extensions use GHCR"
                 else
-                  echo "::warning::postgres library mirror missing for ${mirror_tag} — extensions fall back to docker.io via #488 mirror"
+                  echo "::warning::postgres GHCR cache missing for ${mirror_tag} — extensions fall back to direct docker.io (authenticated)"
                 fi
               fi
               export REMOTE_CR
@@ -380,27 +372,26 @@ jobs:
           # silently skips files inside hidden directories unless this is set.
           include-hidden-files: true
 
-  # Cache Docker Hub base images to GHCR to avoid rate limits during builds
-  cache-base-images:
-    name: Cache base images
+  # Sync base images: blind-copy detected containers' base images from Docker Hub
+  # to GHCR on every push. Consolidated with the daily upstream-monitor sync via
+  # the shared sync_base_images_to_ghcr helper (#498). The whole flow is
+  # ~N=25 imagetools calls per run, well under the auth'd 200/6h rate limit;
+  # `continue-on-error: true` absorbs the rare per-image 429 spike.
+  sync-base-images:
+    name: Sync base images (push scope)
     needs: [detect-containers]
-    # Run on push, workflow_dispatch, and own-repo PRs. Fork PRs are skipped
-    # because they lack GHCR write permission — they fall through to Docker Hub
-    # (and may 429, but that is GitHub's per-fork-PR limitation, not ours).
-    # Note: head.repo.full_name is read in an `if:` evaluation context only,
-    # never piped to shell — no injection surface.
+    # Run on push and workflow_dispatch only. PR events lack GHCR
+    # `write:packages` scope on `GITHUB_TOKEN` (the default token permission
+    # downgrades to read-only for pull_request, regardless of fork status),
+    # so the helper would always 403 trying to push base-image tags to GHCR.
+    # PR builds fall through to direct Docker Hub via the build-container
+    # action's existing fallback (auth'd, ~one cold pull per missing tag,
+    # well under the rate limit).
     if: |
-      needs.detect-containers.outputs.count > 0 &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name != 'pull_request' &&
+      needs.detect-containers.outputs.count > 0
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Non-blocking for build-and-push: ADR-009 / spec §C1b. The DockerHub mirror
-    # (B3) is the safety net — if GHCR base cache is absent, Dockerfiles pull
-    # FROM docker.io through the per-job sidecar proxy. Failure here therefore
-    # degrades performance (no cache hit) but never breaks the build. GitHub
-    # semantics: continue-on-error: true causes this job's result to appear as
-    # 'success' to dependent jobs even when it fails, so build-and-push is never
-    # skipped by a cache-population 429.
     continue-on-error: true
     steps:
       - name: Checkout repository
@@ -414,12 +405,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      # Authenticate BOTH registries: GHCR (push the cache) AND Docker Hub
-      # (the `docker buildx imagetools create` below PULLS from docker.io —
-      # anonymous pulls share the GitHub-runner IP rate limit and 429 under
-      # load). Docker Hub auth raises the ceiling for cache-population pulls;
-      # the registry-mirror in #488 removes Docker Hub from the path entirely
-      # as the durable fix.
+      # Authenticate BOTH registries: GHCR (push the sync results) AND Docker Hub
+      # (the imagetools-create source). Auth raises the per-IP rate-limit ceiling
+      # for the sync — per #498, the design is "blind copy ~N=25 images per
+      # run, accept occasional 429 via continue-on-error" rather than maintaining
+      # a sidecar cache layer or presence-check gymnastics.
       - name: Log in to container registries
         uses: ./.github/actions/docker-login
         with:
@@ -428,7 +418,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Collect and cache base images
+      - name: Sync base images to GHCR
         env:
           OWNER: ${{ github.repository_owner }}
           CONTAINERS: ${{ needs.detect-containers.outputs.containers }}
@@ -437,68 +427,8 @@ jobs:
           set -euo pipefail
           source ./helpers/base-cache-utils.sh
 
-          echo "📦 Collecting base images to cache..."
           images=$(collect_all_cache_images "$CONTAINERS" "$VERSIONS" "$OWNER")
-          count=$(echo "$images" | jq 'length')
-          echo "Found $count unique base images to cache (deduplicated)"
-
-          if [[ "$count" -eq 0 ]]; then
-            echo "No base images to cache"
-            exit 0
-          fi
-
-          # Copy each base image from Docker Hub to GHCR
-          cached=0
-          failed=0
-          echo "$images" | jq -c '.[]' | while IFS= read -r img; do
-            source_img=$(echo "$img" | jq -r '.source')
-            tag=$(echo "$img" | jq -r '.tag')
-            ghcr_image=$(echo "$img" | jq -r '.ghcr_image')
-
-            echo ""
-            echo "🔄 Caching $source_img:$tag → $ghcr_image"
-
-            if output=$(docker buildx imagetools create \
-              --tag "$ghcr_image" \
-              "docker.io/$source_img:$tag" 2>&1); then
-              echo "  ✅ Cached successfully"
-            else
-              echo "  ⚠️ Failed to cache $source_img:$tag → $ghcr_image"
-              echo "  Error: $output"
-            fi
-          done
-
-          echo ""
-          echo "✅ Base image caching complete"
-
-      - name: Seed registry:2 proxy image to GHCR
-        # ADR-009 / spec §C2. Copies the digest-pinned registry:2 image to GHCR
-        # so the dockerhub-mirror action (B1) can pull its sidecar proxy
-        # intra-GitHub, avoiding a per-job docker.io pull.
-        # IMPORTANT: digest must stay in sync with
-        # .github/actions/dockerhub-mirror/action.yaml fallback pin.
-        env:
-          OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-
-          # Lowercase owner: GHCR refs are case-sensitive in tooling and
-          # require lowercase. Must match the ${owner,,} resolution in
-          # .github/actions/dockerhub-mirror (dhm_resolve_registry_image).
-          owner="${OWNER,,}"
-          ghcr_image="ghcr.io/${owner}/registry:2"
-          source_img="docker.io/library/registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
-
-          echo "🔄 Seeding registry:2 → ${ghcr_image}"
-
-          if output=$(docker buildx imagetools create \
-            --tag "${ghcr_image}" \
-            "${source_img}" 2>&1); then
-            echo "  ✅ registry:2 seeded to GHCR successfully"
-          else
-            echo "  ⚠️ Failed to seed registry:2 to GHCR"
-            echo "  Error: ${output}"
-          fi
+          sync_base_images_to_ghcr "$images"
 
   sync-registries:
     name: Sync ${{ matrix.build.container }}:${{ matrix.build.tag }} GHCR→DockerHub
@@ -548,13 +478,13 @@ jobs:
 
   build-and-push:
     name: Build ${{ matrix.build.container }}${{ matrix.build.variant && format(':{0}', matrix.build.variant) || '' }} (${{ matrix.arch }})
-    needs: [detect-containers, build-extensions, cache-base-images]
+    needs: [detect-containers, build-extensions, sync-base-images]
     if: |
       always() &&
       inputs.rebuild != 'sync' &&
       needs.detect-containers.outputs.builds_count > 0 &&
       (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
-      (needs.cache-base-images.result == 'success' || needs.cache-base-images.result == 'skipped')
+      (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
     # NOTE: No job-level concurrency here — caused unexpected mid-build cancellations
     # (observed 2026-04-23). Workflow-level concurrency is already removed so
     # different-container runs parallelize. Same-container races are rare in practice

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -19,7 +19,7 @@ permissions:
   contents: write      # Push version bumps and merge PRs
   pull-requests: write # Create and merge PRs
   actions: write       # Trigger auto-build and update-dashboard workflows
-  packages: write      # Push base images to GHCR (refresh-base-image-cache job)
+  packages: write      # Push base images to GHCR (sync-base-images job)
   pages: write         # Required by update-dashboard reusable workflow (deploy to Pages)
   id-token: write      # Required by update-dashboard reusable workflow (OIDC for Pages)
   attestations: read   # Required by update-dashboard reusable workflow (trust-strip attestation_url)
@@ -545,13 +545,22 @@ jobs:
     with:
       trigger_reason: "Post upstream-monitor PR merge"
 
-  # Cache all Docker Hub base images to GHCR to avoid rate limits during builds
-  # Reads base_image_cache from each container's config.yaml, deduplicates,
-  # and copies/updates images using buildx imagetools (with digest comparison)
-  # This is the ONLY place base images are seeded — builds always pull from GHCR
-  refresh-base-image-cache:
+  # Sync base images: daily blind-copy of all containers' base images from Docker
+  # Hub to GHCR. Shares the sync_base_images_to_ghcr helper with the push-trigger
+  # job in auto-build.yaml (#498). Scope = ALL containers (via ./make list)
+  # rather than the detect-containers subset, so this catches drift for containers
+  # not touched by recent pushes.
+  sync-base-images:
+    name: Sync base images (daily, all containers)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # sync_base_images_to_ghcr exits non-zero when any per-image copy fails so
+    # the Actions UI surfaces the issue (transient 429, registry blip, etc.).
+    # Job-level continue-on-error keeps the scheduled upstream-monitor workflow
+    # from failing on those bounded errors — the next sync recovers any missed
+    # tag, and the per-image ::warning:: lines from the helper provide the
+    # signal for maintainer attention.
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -579,97 +588,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Refresh base image cache
+      - name: Sync base images to GHCR (all containers)
         shell: bash
         env:
           OWNER: ${{ github.repository_owner }}
         run: |
+          set -euo pipefail
           source ./helpers/base-cache-utils.sh
 
-          # Discover all containers
+          # Discover all containers and their current versions
           containers_json=$(./make list 2>/dev/null | jq -Rc '[inputs]' || echo '[]')
 
-          # Build a versions map (best-effort, "latest" as fallback)
           versions_json="{}"
           for c in $(echo "$containers_json" | jq -r '.[]'); do
-            v=$(./make version "$c" 2>/dev/null || echo "latest")
-            [[ -z "$v" || "$v" == "unknown" ]] && v="latest"
-            versions_json=$(echo "$versions_json" | jq -c --arg c "$c" --arg v "$v" '. + {($c): $v}')
+              v=$(./make version "$c" 2>/dev/null || echo "latest")
+              [[ -z "$v" || "$v" == "unknown" ]] && v="latest"
+              versions_json=$(echo "$versions_json" | jq -c --arg c "$c" --arg v "$v" '. + {($c): $v}')
           done
 
-          # Collect and deduplicate all base images
-          cache_images=$(collect_all_cache_images "$containers_json" "$versions_json" "$OWNER")
-          total=$(echo "$cache_images" | jq 'length')
-
-          if [[ "$total" -eq 0 ]]; then
-            echo "ℹ️ No base images to cache"
-            exit 0
-          fi
-
-          echo "📦 Refreshing $total base images (deduplicated across all containers)"
-
-          updated=0
-          skipped=0
-          failed=0
-
-          for ((i = 0; i < total; i++)); do
-            source_name=$(echo "$cache_images" | jq -r ".[$i].source")
-            tag=$(echo "$cache_images" | jq -r ".[$i].tag")
-            ghcr_image=$(echo "$cache_images" | jq -r ".[$i].ghcr_image")
-
-            # Construct Docker Hub source
-            if [[ "$source_name" == */* ]]; then
-              source_image="docker.io/${source_name}:${tag}"
-            else
-              source_image="docker.io/library/${source_name}:${tag}"
-            fi
-
-            echo ""
-            echo "🔍 Checking ${source_name}:${tag}..."
-
-            # Compare digests to detect upstream changes
-            source_digest=$(docker buildx imagetools inspect "$source_image" 2>/dev/null | grep -m1 "Digest:" | awk '{print $2}' || echo "")
-
-            if [[ -z "$source_digest" ]]; then
-              echo "  ⚠️ Could not inspect Docker Hub image (rate limit?)"
-              ((failed++)) || true
-              continue
-            fi
-
-            cache_digest=$(docker buildx imagetools inspect "$ghcr_image" 2>/dev/null | grep -m1 "Digest:" | awk '{print $2}' || echo "")
-
-            if [[ "$source_digest" == "$cache_digest" ]]; then
-              echo "  ✓ Up-to-date (${source_digest:0:20}...)"
-              ((skipped++)) || true
-              continue
-            fi
-
-            if [[ -z "$cache_digest" ]]; then
-              echo "  → Seeding cache..."
-            else
-              echo "  → Upstream changed, updating..."
-            fi
-
-            if docker buildx imagetools create \
-              --tag "$ghcr_image" \
-              "$source_image" 2>&1; then
-              echo "  ✅ Cached $(echo "$ghcr_image" | sed 's|.*/||')"
-              ((updated++)) || true
-            else
-              echo "  ⚠️ Failed to cache (rate limit?)"
-              ((failed++)) || true
-            fi
-          done
-
-          echo ""
-          echo "📊 Cache summary: $updated updated, $skipped up-to-date, $failed failed"
-
-          if [[ $failed -gt 0 ]]; then
-            echo "::warning::$failed images couldn't be cached (Docker Hub rate limit?)"
-          fi
-          if [[ $updated -gt 0 ]]; then
-            echo "::notice::Refreshed $updated base image(s) in GHCR cache"
-          fi
+          images=$(collect_all_cache_images "$containers_json" "$versions_json" "$OWNER")
+          sync_base_images_to_ghcr "$images"
 
   # Check 3rd party dependency versions (runs in parallel with base image checks)
   check-dependency-updates:

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -101,7 +101,7 @@ Builds and pushes containers when triggered by upstream monitor or code changes.
 
 **Pipeline stages:**
 1. `detect-containers` — Smart change detection via git diff or force input
-2. `cache-base-images` — Cache Docker Hub base images to GHCR (avoids rate limits)
+2. `sync-base-images` — Mirror Docker Hub base images to GHCR (avoids rate limits during builds)
 3. `build-extensions` — Build PostgreSQL extension images (if postgres detected)
 4. `build-and-push` — Multi-platform builds (native amd64 + arm64 runners) + SBOM generation + GitHub attestation
 5. `create-manifest` — Multi-arch manifest lists (GHCR primary, Docker Hub via cross-registry from GHCR sources)

--- a/docs/WORKFLOW_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ARCHITECTURE.md
@@ -97,8 +97,8 @@ This document describes the complete CI/CD architecture: version detection, mult
 | Job | Purpose | Depends On |
 |-----|---------|------------|
 | `detect-containers` | Smart change detection via git diff or force input | - |
-| `cache-base-images` | Cache postgres base images (avoids Docker Hub rate limits) | detect |
-| `build-extensions` | Build PostgreSQL extension images (pgvector, etc.) | cache |
+| `sync-base-images` | Mirror Docker Hub base images to GHCR (avoids rate limits during builds) | detect |
+| `build-extensions` | Build PostgreSQL extension images (pgvector, etc.) | sync |
 | `build-and-push` | Multi-platform builds per container (amd64 + arm64 runners) + SBOM + attestation | extensions |
 | `create-manifest` | Create multi-arch manifest lists and push | build |
 | `cache-lineage` | Cache `.build-lineage/` artifacts + process SBOMs (changelog, history) | manifest |

--- a/docs/adr/ADR-009-dockerhub-pullthrough-mirror.md
+++ b/docs/adr/ADR-009-dockerhub-pullthrough-mirror.md
@@ -1,6 +1,6 @@
 # ADR-009: Transparent Docker Hub pull-through mirror on the runners (eliminate 429 without touching Dockerfiles)
 
-**Status:** Accepted
+**Status:** Superseded by #498 (2026-05-23) — see "Why this was removed" below
 **Date:** 2026-05-21
 
 ## Context
@@ -148,3 +148,49 @@ Once the mirror is observed eliminating the rate-limit on full-matrix runs, the 
 base-image-copy repos, the skopeo-copy job, and the `get_cache_build_args` build-arg
 override become redundant for rate-limit avoidance and are slated for removal in a
 follow-up (they are kept until then). Design + hardening: `docs/plans/488-dockerhub-mirror.md`.
+
+## Why this was removed (#498, 2026-05-23)
+
+The pull-through sidecar was introduced to protect the build path from 429s
+when Dockerfiles referenced `FROM docker.io/...`. Two subsequent changes made
+this protection redundant:
+
+- **#492** fixed the root cause that was forcing builds into the docker.io
+  fallback (the GHCR cache check used `:latest` instead of the version tag,
+  so the override was silently dropped and builds went straight to docker.io
+  even when GHCR was warm).
+- **#493 / #497** migrated containers to `FROM ${REMOTE_CR}/<upstream-path>`,
+  where `REMOTE_CR` resolves to `ghcr.io/<owner>` when the GHCR cache is
+  reachable for that tag. Builds with a warm cache no longer touch docker.io
+  at all.
+
+After these two changes, the only remaining docker.io consumers were the
+seed jobs (`cache-base-images` and `refresh-base-image-cache`). These two
+jobs did near-identical work on different triggers (push vs daily cron),
+each with its own ~70-line inline shell loop. #498 consolidated them into
+a single `sync-base-images` job in each workflow, both calling a shared
+`sync_base_images_to_ghcr` helper in `helpers/base-cache-utils.sh`.
+
+The helper performs a blind copy: each base image is unconditionally
+mirrored from `docker.io/<path>:<tag>` to `ghcr.io/<owner>/<path>:<tag>`
+via `docker buildx imagetools create`. No presence-check, no digest-compare,
+no sidecar cache layer. The math justifies this simplicity:
+
+- N ≈ 15 unique base images per run today (sum of deduped `base_image_cache`
+  entries across detected containers, or all containers for the daily run).
+  Headroom for growth: even at N = 30 the budget still holds.
+- Auth'd Docker Hub rate limit: 200 pulls per 6h per user.
+- Steady-state load (N = 15): ~15 pulls × ~5 runs / 6h = ~75 pulls per 6h
+  window, ~38% of the 200 budget.
+- Burst (release flurry): the helper retries each rate-limited call with
+  exponential backoff (5s, 10s, 20s; max 3 retries) before giving up. Non-
+  429 failures (auth, network) fail fast. Persistent failures after backoff
+  are bounded by `continue-on-error: true` on the job and per-image error
+  handling, so any spike that exceeds the per-IP budget just degrades to
+  a missing/stale GHCR tag — which the next push or the daily sync recovers.
+  Dependent jobs are never blocked.
+
+The `dockerhub-mirror` composite action and `.github/buildkitd-mirror.toml`
+are kept on disk in case a future use case re-surfaces, but no workflow
+currently invokes them. A future cleanup PR may remove them entirely once
+the new design has run in production for a stable observation window.

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Base image cache utilities
 # Reads base_image_cache from config.yaml and provides helpers for:
-# - Caching Docker Hub base images to GHCR (CI cache job)
+# - Syncing Docker Hub base images to GHCR (CI sync job — sync_base_images_to_ghcr)
 # - Resolving cached base image build args (build action)
 #
 # Config schema supports TWO entry styles (discriminated by ghcr_repo presence):
@@ -376,5 +376,186 @@ resolve_cache_check_tag() {
     _resolve_tag_template "$raw_tag" "$build_version" "$config_file" "$container_dir"
 }
 
+# _sync_one_with_backoff <source_ref> <ghcr_image>
+#
+# Run a single `docker buildx imagetools create` with exponential backoff on
+# rate-limit (429) errors. Other failures (auth, network, malformed ref) fail
+# fast — backoff only burns wall-time when it cannot help.
+#
+# Backoff schedule: 5s, 10s, 20s (3 retries max, then give up).
+# Sleep is performed via the injectable $SLEEP_CMD (defaults to `sleep`); tests
+# pass `:` or `true` to skip real sleeps.
+#
+# stdout: docker stderr from the last attempt (success or final failure)
+# stderr: backoff progress messages
+# exit:   0 on eventual success, 1 on persistent failure
+_sync_one_with_backoff() {
+    local source_ref="$1"
+    local ghcr_image="$2"
+    local sleep_cmd="${SLEEP_CMD:-sleep}"
+
+    local max_retries=3
+    local base_delay=5
+    local attempt=0
+    local output
+
+    while true; do
+        if output=$(docker buildx imagetools create \
+            --tag "$ghcr_image" \
+            "$source_ref" 2>&1); then
+            printf '%s' "$output"
+            return 0
+        fi
+
+        # Only retry rate-limit / 429 — anything else is non-transient.
+        # `toomanyrequests` is Docker Hub's literal error code; the broader
+        # phrasing variants are matched too for resilience to future wording.
+        if [[ "$output" != *"toomanyrequests"* ]] \
+            && [[ "$output" != *"rate limit"* ]] \
+            && [[ "$output" != *"429"* ]]; then
+            printf '%s' "$output"
+            return 1
+        fi
+
+        attempt=$((attempt + 1))
+        if (( attempt > max_retries )); then
+            printf '%s' "$output"
+            return 1
+        fi
+
+        # 5s, 10s, 20s — sublinear total wait (~35s worst case per image)
+        local delay=$((base_delay * (1 << (attempt - 1))))
+        echo "  ⏳ rate-limited; backing off ${delay}s (retry ${attempt}/${max_retries})" >&2
+        ${sleep_cmd} "$delay"
+    done
+}
+
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command. Without this, a newline/CR/`%` in the value could
+# terminate the command early and inject another (e.g. `::stop-commands::`,
+# `::add-mask::`, `::error::`). Mapping per GitHub's runner spec:
+#   %  → %25
+#   \n → %0A
+#   \r → %0D
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    printf '%s' "$s"
+}
+
+# sync_base_images_to_ghcr <images_json> [source_registry]
+#
+# Copy each base image from <source_registry> (default: docker.io) to GHCR
+# via `docker buildx imagetools create`. Blind copy — no presence check,
+# no digest compare. Per-image failures are logged but non-fatal so a single
+# 429 (or transient registry error) does not halt the whole sync run; the
+# outer job's `continue-on-error: true` further insulates dependent jobs.
+#
+# Args:
+#   $1 = images_json (output of collect_all_cache_images)
+#   $2 = source_registry (optional; default "docker.io")
+#
+# Output: progress lines printed to stdout, one section per image
+# Exit:   0 when all images synced; 1 when any failed (caller's
+#         `continue-on-error: true` keeps dependents unblocked while the
+#         non-zero exit surfaces the failure in the Actions UI)
+#
+# Normalization: docker.io implicitly maps single-segment names (`alpine`) to
+# `library/alpine`; for parity with arbitrary registries we always emit the
+# explicit `library/` prefix when the source name has no slash.
+sync_base_images_to_ghcr() {
+    local images_json="$1"
+    local source_registry="${2:-docker.io}"
+
+    # Same injection-prevention guard we apply to per-image refs, but at the
+    # function boundary so an attacker-influenced source_registry override
+    # cannot reach echo/log lines either.
+    if [[ "$source_registry" =~ [[:cntrl:]] ]]; then
+        echo "::warning::sync_base_images_to_ghcr: refusing source_registry with control characters (possible injection)"
+        return 1
+    fi
+
+    local count
+    count=$(echo "$images_json" | jq 'length')
+
+    if [[ "$count" -eq 0 ]]; then
+        echo "ℹ️ No base images to sync"
+        return 0
+    fi
+
+    echo "📦 Syncing $count unique base images to GHCR (source: $source_registry)"
+
+    local synced=0 failed=0
+    while IFS= read -r img; do
+        local source_img tag ghcr_image source_ref output
+        source_img=$(echo "$img" | jq -r '.source')
+        tag=$(echo "$img" | jq -r '.tag')
+        ghcr_image=$(echo "$img" | jq -r '.ghcr_image')
+
+        # Reject control characters in any ref. base_image_cache.source is not
+        # schema-validated upstream (see top-of-file docstring); a value with
+        # a newline / CR would otherwise inject GitHub Actions workflow
+        # commands the next time we echo it (e.g. an embedded `::stop-commands::`
+        # line). Belt-and-suspenders alongside _escape_gha_command below.
+        if [[ "$source_img" =~ [[:cntrl:]] ]] \
+            || [[ "$tag" =~ [[:cntrl:]] ]] \
+            || [[ "$ghcr_image" =~ [[:cntrl:]] ]]; then
+            echo "::warning::sync_base_images_to_ghcr: refusing image entry with control characters in ref (possible injection)"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        if [[ "$source_img" == */* ]]; then
+            source_ref="${source_registry}/${source_img}:${tag}"
+        else
+            source_ref="${source_registry}/library/${source_img}:${tag}"
+        fi
+
+        echo ""
+        echo "🔄 ${source_ref} → ${ghcr_image}"
+
+        if output=$(_sync_one_with_backoff "$source_ref" "$ghcr_image"); then
+            echo "  ✅ Synced"
+            synced=$((synced + 1))
+        else
+            echo "  ⚠️ Failed (continuing; daily sync will retry)"
+            # Prefix every line of $output (docker stderr) with "  Error: " so
+            # no line can begin at column 0 with `::` and be interpreted as a
+            # GitHub Actions workflow command. The upstream registry response
+            # is technically attacker-influenced, even if remote. Normalize
+            # CR → LF first so a bare carriage return (which GHA also treats
+            # as a line terminator) cannot bypass the prefix.
+            printf '%s\n' "$output" | tr '\r' '\n' | sed 's/^/  Error: /'
+            # Surface in the workflow summary so the maintainer notices that
+            # a stale GHCR tag may persist until the next successful sync.
+            # Refs come from base_image_cache.source which is not schema-
+            # validated (see top-of-file docstring); escape to prevent a
+            # newline-bearing value from injecting a second workflow command.
+            local safe_source_ref safe_ghcr_image
+            safe_source_ref=$(_escape_gha_command "$source_ref")
+            safe_ghcr_image=$(_escape_gha_command "$ghcr_image")
+            echo "::warning::sync_base_images_to_ghcr: failed to sync ${safe_source_ref} → ${safe_ghcr_image}"
+            failed=$((failed + 1))
+        fi
+    done < <(echo "$images_json" | jq -c '.[]')
+
+    echo ""
+    echo "📊 Sync summary: $synced succeeded, $failed failed"
+
+    # Non-zero exit when any image failed so the GitHub Actions UI surfaces the
+    # sync run as red. Dependent jobs are kept unblocked by the caller's
+    # `continue-on-error: true`; this signal is for maintainer attention, not
+    # for build gating. The daily sync picks up anything missed.
+    if (( failed > 0 )); then
+        echo "::warning::sync_base_images_to_ghcr: ${failed} image(s) failed to sync; stale GHCR tags may persist until the next successful sync"
+        return 1
+    fi
+    return 0
+}
+
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args
+export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff _escape_gha_command sync_base_images_to_ghcr

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -612,3 +612,259 @@ EOF
         }
     done
 }
+
+# --- sync_base_images_to_ghcr ---
+
+@test "sync_base_images_to_ghcr: empty input returns 0 and no-op message" {
+    run sync_base_images_to_ghcr '[]'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No base images to sync"* ]]
+}
+
+@test "sync_base_images_to_ghcr: single library/X image uses explicit library/ prefix" {
+    # Mock docker to capture the source_ref argument
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "MOCK_DOCKER_ARGS: $*"
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"docker.io/library/alpine:3.18"* ]]
+    [[ "$output" == *"ghcr.io/oorabona/library/alpine:3.18"* ]]
+    [[ "$output" == *"Synced"* ]]
+}
+
+@test "sync_base_images_to_ghcr: single-segment source normalized to library/X" {
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "MOCK_DOCKER_ARGS: $*"
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+
+    # Source has no slash — should be auto-prefixed with library/
+    local input='[{"source":"alpine","tag":"3.18","ghcr_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"docker.io/library/alpine:3.18"* ]]
+}
+
+@test "sync_base_images_to_ghcr: per-image failures exit non-zero with workflow warning" {
+    # Mock docker to fail
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "simulated registry error" >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"},{"source":"library/postgres","tag":"18-alpine","ghcr_image":"ghcr.io/x/library/postgres:18-alpine"}]'
+    run sync_base_images_to_ghcr "$input"
+    # Non-zero so the GitHub Actions UI surfaces the failure; the caller's
+    # job-level `continue-on-error: true` keeps dependent jobs unblocked.
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"⚠️ Failed"* ]]
+    [[ "$output" == *"0 succeeded, 2 failed"* ]]
+    # Workflow warning surfaced for each image AND for the summary
+    [[ "$output" == *"::warning::sync_base_images_to_ghcr: failed to sync"* ]]
+    [[ "$output" == *"::warning::sync_base_images_to_ghcr: 2 image(s) failed to sync"* ]]
+}
+
+@test "sync_base_images_to_ghcr: multiline docker stderr cannot inject workflow commands" {
+    # Mock docker to return multiline stderr containing a fake workflow command
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            printf 'fake error line1\n::stop-commands::xx\nline3\n' >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 1 ]
+    # The injected line must never appear at column 0 — every stderr line is
+    # prefixed with "  Error: " so it's quoted text, not a workflow command.
+    [[ "$output" != *$'\n::stop-commands::'* ]]
+    [[ "$output" == *"  Error: ::stop-commands::xx"* ]]
+}
+
+@test "sync_base_images_to_ghcr: carriage return in docker stderr cannot inject workflow commands" {
+    # CR (\\r) is also a line terminator for the GHA workflow-command parser.
+    # Mock docker to embed a CR-prefixed injection attempt.
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            printf 'first line\r::stop-commands::xx\r\nlast line\n' >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 1 ]
+    # The CR-injected `::stop-commands::` must not appear preceded by raw CR.
+    [[ "$output" != *$'\r::stop-commands::'* ]]
+    # And it must appear in prefixed form.
+    [[ "$output" == *"  Error: ::stop-commands::xx"* ]]
+}
+
+@test "sync_base_images_to_ghcr: newline in image ref is refused (injection prevention)" {
+    # Mock docker — should NOT be called for the malicious entry
+    local docker_call_count=0
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            docker_call_count=$((docker_call_count + 1))
+        fi
+        return 0
+    }
+    export -f docker
+
+    # Embed a newline + a fake workflow command in the source field
+    local malicious_source="library/alpine"$'\n'"::stop-commands::xx"
+    local input
+    input=$(jq -nc --arg s "$malicious_source" \
+        '[{"source":$s,"tag":"3.18","ghcr_image":"ghcr.io/x/lib/a:3.18"}]')
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 1 ]
+    # The injected `::stop-commands::xx` line must NOT appear as a standalone
+    # line at column 0 (which would be interpreted as a workflow command).
+    [[ "$output" != *$'\n::stop-commands::'* ]]
+    # The validation guard fires and the entry is counted as failed
+    [[ "$output" == *"refusing image entry with control characters"* ]]
+    [[ "$output" == *"0 succeeded, 1 failed"* ]]
+}
+
+@test "_sync_one_with_backoff: succeeds on first attempt without retry" {
+    local call_count=0
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            call_count=$((call_count + 1))
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+    export SLEEP_CMD=:  # no-op sleep
+
+    run _sync_one_with_backoff "docker.io/library/alpine:3.18" "ghcr.io/x/lib/a:3.18"
+    [ "$status" -eq 0 ]
+    # Should NOT have retried (no backoff message)
+    [[ "$output" != *"backing off"* ]]
+}
+
+@test "_sync_one_with_backoff: retries on 429 then succeeds" {
+    # Use a real file as a counter so the mock survives subshells (docker is
+    # called inside command substitution which forks).
+    local counter_file
+    counter_file=$(mktemp)
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            local n
+            n=$(<"$COUNTER_FILE")
+            n=$((n + 1))
+            echo "$n" > "$COUNTER_FILE"
+            if (( n < 3 )); then
+                echo "toomanyrequests: You have reached your pull rate limit" >&2
+                return 1
+            fi
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run _sync_one_with_backoff "docker.io/library/alpine:3.18" "ghcr.io/x/lib/a:3.18"
+    [ "$status" -eq 0 ]
+    # Should have emitted at least one backoff message (retries 1 and 2 hit the limit)
+    [[ "$output" == *"backing off 5s (retry 1/3)"* ]]
+    [[ "$output" == *"backing off 10s (retry 2/3)"* ]]
+
+    rm -f "$counter_file"
+}
+
+@test "_sync_one_with_backoff: gives up after max retries on persistent 429" {
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "toomanyrequests: persistent rate limit" >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run _sync_one_with_backoff "docker.io/library/alpine:3.18" "ghcr.io/x/lib/a:3.18"
+    [ "$status" -eq 1 ]
+    # All three backoff messages emitted before giving up
+    [[ "$output" == *"backing off 5s"* ]]
+    [[ "$output" == *"backing off 10s"* ]]
+    [[ "$output" == *"backing off 20s"* ]]
+    # Final stderr from docker is returned on stdout (by the function's contract)
+    [[ "$output" == *"toomanyrequests"* ]]
+}
+
+@test "_sync_one_with_backoff: non-429 errors fail fast without retry" {
+    local call_count=0
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            call_count=$((call_count + 1))
+            echo "unauthorized: authentication required" >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run _sync_one_with_backoff "docker.io/library/alpine:3.18" "ghcr.io/x/lib/a:3.18"
+    [ "$status" -eq 1 ]
+    # No backoff for non-429
+    [[ "$output" != *"backing off"* ]]
+}
+
+@test "sync_base_images_to_ghcr: control character in source_registry param is refused" {
+    docker() { return 0; }
+    export -f docker
+    export SLEEP_CMD=:
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/lib/a:3.18"}]'
+    local malicious_registry=$'docker.io\n::stop-commands::xx'
+    run sync_base_images_to_ghcr "$input" "$malicious_registry"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refusing source_registry with control characters"* ]]
+    # The injected line must not appear at column 0
+    [[ "$output" != *$'\n::stop-commands::'* ]]
+}
+
+@test "sync_base_images_to_ghcr: source_registry override changes the source URL" {
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "MOCK_DOCKER_ARGS: $*"
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input" "127.0.0.1:5000"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"127.0.0.1:5000/library/alpine:3.18"* ]]
+}


### PR DESCRIPTION
Closes #498.

## Summary

Replaces `cache-base-images` (push) and `refresh-base-image-cache` (daily cron) with a single `sync-base-images` job in each workflow, both delegating to a shared `sync_base_images_to_ghcr` helper in `helpers/base-cache-utils.sh`. The helper does a blind copy from docker.io to GHCR — no presence-check, no digest-compare, no sidecar cache layer.

Also removes the `dockerhub-mirror` sidecar invocations from the build path (`build-container/action.yaml` and `build-extensions` job). The build path's previous reliance on the mirror was made redundant by #492 (cache-check root-cause fix) and #493/#497 (`${REMOTE_CR}` migration).

The `dockerhub-mirror` composite action and `.github/buildkitd-mirror.toml` remain on disk as deprecated; a future cleanup PR may remove them entirely once this design has stabilized in production.

## Rate-limit math

- N ≈ 15 unique base images per run today (deduped `base_image_cache` entries across detected/all containers). Headroom for growth: even at N = 30 the budget still holds.
- Auth'd Docker Hub rate limit: 200 pulls / 6h / user.
- Steady-state (N = 15): ~15 pulls × ~5 runs / 6h ≈ 75 pulls per 6h window, ~38% of the 200 budget.
- Burst (release flurry): `_sync_one_with_backoff` retries each 429 with exponential backoff (5s, 10s, 20s; max 3 retries) before giving up. Non-429 failures (auth, network) fail fast.
- Persistent failures bounded by job-level `continue-on-error: true` + per-image `::warning::`, so dependent jobs are never blocked and the maintainer sees the signal.

## Job topology

- `auto-build.yaml` → `sync-base-images` runs on `push` and `workflow_dispatch` only. PR events skip the job (the default `GITHUB_TOKEN` permission for PRs is read-only on packages, so writes to GHCR fail with 403 — there's nothing to do that won't fail). PR builds rely on the GHCR cache populated by prior master pushes plus the build-container action's direct docker.io fallback.
- `upstream-monitor.yaml` → `sync-base-images` runs daily and on `workflow_dispatch`, scoped to ALL containers via `./make list`.

## Files changed

- `helpers/base-cache-utils.sh` — new `sync_base_images_to_ghcr`, `_sync_one_with_backoff`, `_escape_gha_command` functions. Input validation (control-char refusal on source/tag/ghcr_image/source_registry params, output sanitization to prevent GHA workflow-command injection from upstream registry stderr).
- `.github/workflows/auto-build.yaml` — `cache-base-images` → `sync-base-images`. Inline jq-loop reduces to a 5-line helper call. `needs:`/`if:` references updated across build-extensions and build-and-push. PR events excluded from the trigger condition.
- `.github/workflows/upstream-monitor.yaml` — `refresh-base-image-cache` → `sync-base-images`. Same delegation pattern; `continue-on-error: true` added (helper exits non-zero on per-image failures to surface in the Actions UI).
- `.github/actions/build-container/action.yaml` — remove `Start Docker Hub pull-through mirror` step + mirror options on `Set up Docker Buildx`.
- `docs/adr/ADR-009-dockerhub-pullthrough-mirror.md` — status flipped to `Superseded by #498`; rationale rewritten.
- `docs/GITHUB_ACTIONS.md`, `docs/WORKFLOW_ARCHITECTURE.md` — job-name table entries updated.
- `tests/unit/base-cache-utils.bats` — 13 new tests covering happy path, library/ normalization, source_registry override, non-fatal failures, exponential backoff (success-after-retry, persistent-429 give-up, non-429 fast-fail), and 4 control-char / CR / multiline injection prevention scenarios. 44/44 pass.

## Architecture rationale

The previous design had two near-duplicate ~70-line shell loops (cache + refresh) and a dependency on the registry:2 sidecar with a 168h manifest TTL. The 168h TTL would have caused refresh to detect upstream drift up to 7 days late, breaking the daily security-update propagation guarantee. We considered several alternative architectures (presence-check with age guard, 24h-TTL mirror via custom config file, per-run mirror invalidation) before converging on the simplest correct design: blind copy with retry+backoff, accepting the bounded rate-limit cost in exchange for zero staleness, code-level fail-soft behavior, and one consolidated helper instead of two near-duplicate loops.

## Test status

- 44/44 bats tests pass (`bats tests/unit/base-cache-utils.bats`).
- `shellcheck helpers/base-cache-utils.sh` passes (no errors).
- `yq eval '.' .github/workflows/*.yaml` passes on both workflow files.

## Post-merge validation

1. Push triggers `auto-build.yaml` → observe `sync-base-images` job log shows `🔄 → ✅ Synced` lines for each detected base image; no `toomanyrequests` errors in steady state.
2. Daily cron triggers `upstream-monitor.yaml` → same job, scope = all containers, drift detected and copied.
3. Builds (`build-extensions`, `build-container`) succeed via `${REMOTE_CR}=ghcr.io/<owner>` resolution; no mirror sidecar in the logs.
