### PR TITLE
ci(matrix): #502 latest-only matrix default + dep-driven retained rebuild

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -27,24 +27,21 @@ inputs:
     required: false
     default: ''
   event_name:
-    description: |
-      GitHub event name (push|pull_request|workflow_dispatch|schedule).
-      Pass `${{ github.event_name }}` from calling workflows.
-
-      SCOPE: this input is consumed ONLY by the compute_expand_retained_map
-      helper to classify the event (PR carve-out vs dep-driven matrix
-      expansion vs operator override). It does NOT control which git diff
-      branch the find-containers step takes — diff-branch selection uses
-      the ambient `github.event_name` and event-specific properties
+    description: >
+      GitHub event name (push, pull_request, workflow_dispatch, schedule).
+      Pass the github.event_name context from calling workflows.
+      SCOPE: this input is consumed only by the compute_expand_retained_map
+      helper to classify the event (PR carve-out, dep-driven matrix
+      expansion, operator override). It does NOT control which git diff
+      branch the find-containers step takes; diff-branch selection reads
+      the ambient github.event_name and event-specific properties
       (event.before/after for push, pull_request.base/head for pull_request)
       that are only populated for those actual events. A workflow_call
-      caller passing `event_name: push` will still fall into the manual
+      caller passing event_name=push will still fall into the manual
       detection path because event.before/after are not accessible from a
-      workflow_call context.
-
-      When missing/unknown, treats as legacy caller and expands all retained
-      versions for every container (defensive fallback — see
-      compute_expand_retained_map priority chain).
+      workflow_call context. When missing or unknown, treats as legacy
+      caller and expands all retained versions for every container
+      (defensive fallback, see compute_expand_retained_map priority chain).
     required: false
     default: ""
   build_all_retained:

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -77,6 +77,7 @@ runs:
       shell: bash
       run: |
         set -e
+        diff_rc=0
         containers_to_build=()
 
         # Get list of valid containers from make script (source of truth)
@@ -232,6 +233,14 @@ runs:
         # shellcheck disable=SC1091
         source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
 
+        # Fail-loud: empty container list combined with diff-failure sentinel means git
+        # diff failed BEFORE container detection could populate the list. This would
+        # otherwise silently skip every build. Surface the failure instead.
+        if [[ -f "${CHANGED_FILES_FILE}.diff_failed" && ( "$CONTAINERS_JSON" == "[]" || -z "$CONTAINERS_JSON" ) ]]; then
+          echo "::error::detect-containers: git diff failed AND no containers detected. Refusing to silently skip all builds. Check the runner's git checkout state and base ref availability."
+          exit 1
+        fi
+
         # Empty containers list short-circuits to empty map (no work).
         if [[ "$CONTAINERS_JSON" == "[]" || -z "$CONTAINERS_JSON" ]]; then
           echo "map={}" >> "$GITHUB_OUTPUT"
@@ -297,6 +306,11 @@ runs:
           echo "📦 Expanding builds for $container (version: $version)..."
 
           expand_for_container=$(echo "$EXPAND_RETAINED_MAP" | jq -r --arg c "$container" '.[$c] // "false"')
+          # scope_versions is an explicit user request for specific versions. Pre-filtering
+          # to latest-only would defeat it. Bypass the filter when scope_versions is set.
+          if [[ -n "$SCOPE_VERSIONS" ]]; then
+            expand_for_container="true"
+          fi
           container_builds=$(list_container_builds "$container" "$version" "$expand_for_container")
 
           # Apply scope_versions / scope_flavors filters (legacy inputs)

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -29,9 +29,22 @@ inputs:
   event_name:
     description: |
       GitHub event name (push|pull_request|workflow_dispatch|schedule).
-      When missing/unknown, treats as legacy caller and expands all retained
-      versions for every container (defensive — ERR-06 / SC-15).
       Pass `${{ github.event_name }}` from calling workflows.
+
+      SCOPE: this input is consumed ONLY by the compute_expand_retained_map
+      helper to classify the event (PR carve-out vs dep-driven matrix
+      expansion vs operator override). It does NOT control which git diff
+      branch the find-containers step takes — diff-branch selection uses
+      the ambient `github.event_name` and event-specific properties
+      (event.before/after for push, pull_request.base/head for pull_request)
+      that are only populated for those actual events. A workflow_call
+      caller passing `event_name: push` will still fall into the manual
+      detection path because event.before/after are not accessible from a
+      workflow_call context.
+
+      When missing/unknown, treats as legacy caller and expands all retained
+      versions for every container (defensive fallback — see
+      compute_expand_retained_map priority chain).
     required: false
     default: ""
   build_all_retained:

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -26,6 +26,22 @@ inputs:
     description: 'Comma-separated flavors to build (e.g., "distributed,full"). Empty = all.'
     required: false
     default: ''
+  event_name:
+    description: |
+      GitHub event name (push|pull_request|workflow_dispatch|schedule).
+      When missing/unknown, treats as legacy caller and expands all retained
+      versions for every container (defensive — ERR-06 / SC-15).
+      Pass `${{ github.event_name }}` from calling workflows.
+    required: false
+    default: ""
+  build_all_retained:
+    description: |
+      Force expand all retained versions for every container.
+      Operator override (workflow_dispatch). Defaults to "false".
+      MUST be passed as a string — boolean coercion through workflow_call is
+      unreliable. Helper compares with explicit string equality.
+    required: false
+    default: "false"
 
 outputs:
   containers_list:
@@ -46,6 +62,12 @@ outputs:
   builds_count:
     description: 'Total number of builds (including variants)'
     value: ${{ steps.expand-variants.outputs.builds_count }}
+  expand_retained_map:
+    description: |
+      JSON object mapping container name to boolean. true = expand all retained
+      versions, false = latest version only. Computed by compute_expand_retained_map
+      helper. Consumed downstream by the Expand variants step.
+    value: ${{ steps.compute-expand-map.outputs.map }}
 
 runs:
   using: 'composite'
@@ -82,18 +104,31 @@ runs:
           echo "🔍 Detecting containers that need building based on changed files..."
           
           # Determine what files changed in this push/PR
+          diff_rc=0
           if [[ "${{ github.event_name }}" == "push" ]]; then
             # For push events, use event SHAs (handles initial commit with all-zeros before SHA gracefully)
             if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
               # Initial commit - diff against empty tree
               # The SHA '4b825dc642cb6eb9a060e54bf8d69288fbee4904' is Git's canonical empty tree object hash, used for initial commit diffs.
-              changed_files=$(git diff --name-only 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.event.after }}" 2>/dev/null) || { echo "⚠️ Git diff failed (initial commit)"; changed_files=""; }
+              set +e
+              changed_files=$(git diff --name-only 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.event.after }}" 2>/dev/null)
+              diff_rc=$?
+              set -e
+              [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (initial commit)"; changed_files=""; }
             else
-              changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" 2>/dev/null) || { echo "⚠️ Git diff failed (push event)"; changed_files=""; }
+              set +e
+              changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" 2>/dev/null)
+              diff_rc=$?
+              set -e
+              [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (push event)"; changed_files=""; }
             fi
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # For PRs, compare with base and head SHAs from the event (robust, does not require fetch)
-            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null) || { echo "⚠️ Git diff failed (pull request event)"; changed_files=""; }
+            set +e
+            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null)
+            diff_rc=$?
+            set -e
+            [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (pull request event)"; changed_files=""; }
           else
             # For manual triggers (workflow_dispatch)
             # rebuild != none OR force_rebuild=true → build ALL containers
@@ -175,6 +210,43 @@ runs:
           echo "📋 Found containers to build: ${containers_to_build[*]}"
         fi
 
+        # Write changed_files to a temp file for compute-expand-map step consumption.
+        # Clean any stale sentinel from a prior step attempt (self-hosted runners reuse RUNNER_TEMP).
+        rm -f "${RUNNER_TEMP}/changed_files.txt.diff_failed"
+        printf '%s\n' "$changed_files" > "${RUNNER_TEMP}/changed_files.txt"
+        if [[ $diff_rc -ne 0 ]]; then
+          touch "${RUNNER_TEMP}/changed_files.txt.diff_failed"
+        fi
+        echo "changed_files_file=${RUNNER_TEMP}/changed_files.txt" >> "$GITHUB_OUTPUT"
+
+    - name: Compute expand_retained map
+      id: compute-expand-map
+      shell: bash
+      env:
+        EVENT_NAME: ${{ inputs.event_name }}
+        BUILD_ALL_RETAINED: ${{ inputs.build_all_retained }}
+        CHANGED_FILES_FILE: ${{ steps.find-containers.outputs.changed_files_file }}
+        CONTAINERS_JSON: ${{ steps.find-containers.outputs.containers }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
+
+        # Empty containers list short-circuits to empty map (no work).
+        if [[ "$CONTAINERS_JSON" == "[]" || -z "$CONTAINERS_JSON" ]]; then
+          echo "map={}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        map=$(compute_expand_retained_map \
+          "$EVENT_NAME" \
+          "$BUILD_ALL_RETAINED" \
+          "$CHANGED_FILES_FILE" \
+          "$CONTAINERS_JSON")
+
+        echo "map=$map" >> "$GITHUB_OUTPUT"
+        echo "::notice::Expand-retained map: $map"
+
     - name: Compute versions for detected containers
       id: compute-versions
       if: steps.find-containers.outputs.count != '0'
@@ -209,9 +281,11 @@ runs:
         SCOPE_VERSIONS: ${{ inputs.scope_versions }}
         SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
         BUILD_SCOPE: ${{ inputs.scope }}
+        EXPAND_RETAINED_MAP: ${{ steps.compute-expand-map.outputs.map }}
       run: |
         set -e
-        source ./helpers/variant-utils.sh
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
         containers_json='${{ steps.find-containers.outputs.containers }}'
         versions_json='${{ steps.compute-versions.outputs.versions }}'
 
@@ -222,7 +296,8 @@ runs:
           version=$(echo "$versions_json" | jq -r --arg c "$container" '.[$c]')
           echo "📦 Expanding builds for $container (version: $version)..."
 
-          container_builds=$(list_container_builds "$container" "$version")
+          expand_for_container=$(echo "$EXPAND_RETAINED_MAP" | jq -r --arg c "$container" '.[$c] // "false"')
+          container_builds=$(list_container_builds "$container" "$version" "$expand_for_container")
 
           # Apply scope_versions / scope_flavors filters (legacy inputs)
           if [[ -n "$SCOPE_VERSIONS" || -n "$SCOPE_FLAVORS" ]]; then

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -53,6 +53,13 @@ on:
         required: false
         default: false
         type: boolean
+      build_all_retained:
+        description: |
+          Override the latest-only default — build all retained versions for
+          every container in the matrix. See workflow_dispatch.inputs for details.
+        type: boolean
+        default: false
+        required: false
   # Triggered by container file changes (main automation via PR)
   pull_request:
     branches: [main, master]
@@ -152,6 +159,14 @@ on:
         required: false
         default: false
         type: boolean
+      build_all_retained:
+        description: |
+          Override the latest-only default — build all retained versions for
+          every container in the matrix. Equivalent to pre-#502 behavior.
+          Operator override for manual runs (security CVE fan-out, force resync).
+        type: boolean
+        default: false
+        required: false
 
 # NOTE: No workflow-level concurrency — serialization is per-container/per-job
 # (see `concurrency` blocks on individual jobs below). This lets unrelated
@@ -210,6 +225,8 @@ jobs:
           scope: ${{ env.BUILD_SCOPE }}
           scope_versions: ${{ github.event.inputs.scope_versions || inputs.scope_versions }}
           scope_flavors: ${{ github.event.inputs.scope_flavors || inputs.scope_flavors }}
+          event_name: ${{ github.event_name }}
+          build_all_retained: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || false }}
 
   # Build and push PostgreSQL extension images if postgres is in the build list
   build-extensions:

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -86,6 +86,7 @@ on:
       - '!**/CHANGELOG*'                        # Changelogs
       - '!**/docs/**'                           # Nested docs subdirs inside container dirs
       - '!**/tests/**'                          # Nested test subdirs inside container dirs
+      - '**/LAST_REBUILD.md'                    # Re-include — upstream-monitor's explicit retained-rebuild trigger marker (overrides !**/*.md)
   # Triggered on merge to master (actual deployment)
   push:
     branches: [main, master]
@@ -112,6 +113,7 @@ on:
       - '!**/CHANGELOG*'                        # Changelogs
       - '!**/docs/**'                           # Nested docs subdirs inside container dirs
       - '!**/tests/**'                          # Nested test subdirs inside container dirs
+      - '**/LAST_REBUILD.md'                    # Re-include — upstream-monitor's explicit retained-rebuild trigger marker (overrides !**/*.md)
   # Manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -64,52 +64,42 @@ on:
   pull_request:
     branches: [main, master]
     paths:
-      - '*/Dockerfile'
-      - '*/Dockerfile.*'
-      - '*/Dockerfile.windows'
-      - '*/Dockerfile.template'
-      - '*/generate-dockerfile.sh'
-      - '*/version.sh'
-      - '*/config.yaml'
-      - '*/variants.yaml'
-      - '*/build'              # per-container build-hook script (consumed by build-container.sh)
-      - '*/LAST_REBUILD.md'    # marker file dropped by upstream-monitor to force retained-version rebuild
-      - '*/docker-compose.yml'
-      - '*/compose.yml'
-      - '*/extensions/config.yaml'
-      - 'helpers/**'
-      - 'scripts/build-container.sh'
-      - 'scripts/build-extensions.sh'
-      - 'scripts/audit-base-image-cache.sh'
-      - '.github/actions/build-container/**'
-      - '.github/actions/dockerhub-mirror/**'
-      - 'make'
-      - '!archive/**'  # Exclude archived containers
+      # Match the detection logic: ANY file inside a first-level subdir is a
+      # potential build input (Dockerfile, build hook, entrypoint, prepare-build
+      # scripts, COPYed assets, generated context, etc.). Explicit allowlist
+      # was brittle — new file types kept slipping through (e.g. build hooks,
+      # prepare-build-context.sh). The denylist below excludes non-container
+      # top-level dirs.
+      - '*/**'
+      - 'make'                                  # Top-level build orchestrator
+      - '.github/actions/build-container/**'    # Composite action used by build matrix
+      - '.github/actions/dockerhub-mirror/**'   # Composite action used by build pipeline
+      - '!docs/**'                              # Jekyll site + ADRs (no build impact)
+      - '!examples/**'                          # Docker Compose usage examples
+      - '!tests/**'                             # Test suite (has its own CI)
+      - '!test-harness/**'                      # Test fixtures
+      - '!test-logs/**'                         # Generated test logs
+      - '!archive/**'                           # Archived containers
   # Triggered on merge to master (actual deployment)
   push:
     branches: [main, master]
     paths:
-      - '*/Dockerfile'
-      - '*/Dockerfile.*'
-      - '*/Dockerfile.windows'
-      - '*/Dockerfile.template'
-      - '*/generate-dockerfile.sh'
-      - '*/version.sh'
-      - '*/config.yaml'
-      - '*/variants.yaml'
-      - '*/build'              # per-container build-hook script (consumed by build-container.sh)
-      - '*/LAST_REBUILD.md'    # marker file dropped by upstream-monitor to force retained-version rebuild
-      - '*/docker-compose.yml'
-      - '*/compose.yml'
-      - '*/extensions/config.yaml'
-      - 'helpers/**'
-      - 'scripts/build-container.sh'
-      - 'scripts/build-extensions.sh'
-      - 'scripts/audit-base-image-cache.sh'
-      - '.github/actions/build-container/**'
-      - '.github/actions/dockerhub-mirror/**'
-      - 'make'
-      - '!archive/**'  # Exclude archived containers
+      # Match the detection logic: ANY file inside a first-level subdir is a
+      # potential build input (Dockerfile, build hook, entrypoint, prepare-build
+      # scripts, COPYed assets, generated context, etc.). Explicit allowlist
+      # was brittle — new file types kept slipping through (e.g. build hooks,
+      # prepare-build-context.sh). The denylist below excludes non-container
+      # top-level dirs.
+      - '*/**'
+      - 'make'                                  # Top-level build orchestrator
+      - '.github/actions/build-container/**'    # Composite action used by build matrix
+      - '.github/actions/dockerhub-mirror/**'   # Composite action used by build pipeline
+      - '!docs/**'                              # Jekyll site + ADRs (no build impact)
+      - '!examples/**'                          # Docker Compose usage examples
+      - '!tests/**'                             # Test suite (has its own CI)
+      - '!test-harness/**'                      # Test fixtures
+      - '!test-logs/**'                         # Generated test logs
+      - '!archive/**'                           # Archived containers
   # Manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -72,6 +72,8 @@ on:
       - '*/version.sh'
       - '*/config.yaml'
       - '*/variants.yaml'
+      - '*/build'              # per-container build-hook script (consumed by build-container.sh)
+      - '*/LAST_REBUILD.md'    # marker file dropped by upstream-monitor to force retained-version rebuild
       - '*/docker-compose.yml'
       - '*/compose.yml'
       - '*/extensions/config.yaml'
@@ -95,6 +97,8 @@ on:
       - '*/version.sh'
       - '*/config.yaml'
       - '*/variants.yaml'
+      - '*/build'              # per-container build-hook script (consumed by build-container.sh)
+      - '*/LAST_REBUILD.md'    # marker file dropped by upstream-monitor to force retained-version rebuild
       - '*/docker-compose.yml'
       - '*/compose.yml'
       - '*/extensions/config.yaml'

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -80,6 +80,12 @@ on:
       - '!test-harness/**'                      # Test fixtures
       - '!test-logs/**'                         # Generated test logs
       - '!archive/**'                           # Archived containers
+      - '!**/*.md'                              # Markdown anywhere — READMEs, ADRs, notes (never a build input)
+      - '!**/README*'                           # README without .md suffix
+      - '!**/LICENSE*'                          # License files
+      - '!**/CHANGELOG*'                        # Changelogs
+      - '!**/docs/**'                           # Nested docs subdirs inside container dirs
+      - '!**/tests/**'                          # Nested test subdirs inside container dirs
   # Triggered on merge to master (actual deployment)
   push:
     branches: [main, master]
@@ -100,6 +106,12 @@ on:
       - '!test-harness/**'                      # Test fixtures
       - '!test-logs/**'                         # Generated test logs
       - '!archive/**'                           # Archived containers
+      - '!**/*.md'                              # Markdown anywhere — READMEs, ADRs, notes (never a build input)
+      - '!**/README*'                           # README without .md suffix
+      - '!**/LICENSE*'                          # License files
+      - '!**/CHANGELOG*'                        # Changelogs
+      - '!**/docs/**'                           # Nested docs subdirs inside container dirs
+      - '!**/tests/**'                          # Nested test subdirs inside container dirs
   # Manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -53,6 +53,12 @@ jobs:
         with:
           container: ${{ inputs.container }}
           force_rebuild: true
+          event_name: ${{ github.event_name }}
+          # Manifest recreation re-creates the multi-arch manifest list for EVERY supported
+          # version (latest + retained). Without this, the matrix collapses to latest-only and
+          # retained-version manifests would be silently abandoned. force_rebuild=true implies
+          # the operator wants the full set rebuilt.
+          build_all_retained: true
 
       - name: Summary
         env:

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -511,7 +511,10 @@ jobs:
             fi
           fi
 
-          gh workflow run auto-build.yaml -f container="$CONTAINER" -f force_rebuild=true $scope_args
+          # build_all_retained=true: workflow_dispatch has no diff; without this flag, the
+          # latest-only default would silently skip retained-version rebuilds — defeating
+          # upstream-monitor's "propagate dep update to every supported version" purpose.
+          gh workflow run auto-build.yaml -f container="$CONTAINER" -f force_rebuild=true -f build_all_retained=true $scope_args
           echo "✅ Build workflow triggered for $CONTAINER"
 
       - name: Cleanup outdated registry images
@@ -1023,7 +1026,10 @@ jobs:
             fi
           fi
 
-          gh workflow run auto-build.yaml -f container="$CONTAINER" -f force_rebuild=true $scope_args
+          # build_all_retained=true: workflow_dispatch has no diff; without this flag, the
+          # latest-only default would silently skip retained-version rebuilds — defeating
+          # upstream-monitor's "propagate dep update to every supported version" purpose.
+          gh workflow run auto-build.yaml -f container="$CONTAINER" -f force_rebuild=true -f build_all_retained=true $scope_args
           echo "✅ Build workflow triggered for $CONTAINER"
 
       - name: Show PR details (test mode)

--- a/.github/workflows/validate-version-scripts.yaml
+++ b/.github/workflows/validate-version-scripts.yaml
@@ -80,6 +80,9 @@ jobs:
         uses: ./.github/actions/detect-containers
         with:
           force_rebuild: "true"  # Get all containers for comprehensive testing
+          event_name: ${{ github.event_name }}
+          # Comprehensive testing requires all retained versions, not just the latest line.
+          build_all_retained: true
 
       - name: Test upstream monitoring action
         if: steps.detect-containers.outputs.count > 0

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -600,18 +600,27 @@ compute_expand_retained_map() {
             continue
         fi
 
-        # Priority 5: dep-driven trigger via exact-line match
-        local triggered="false"
+        # Rule 5: dep-driven trigger — any file inside the container directory.
+        # A file `<c>/anything` (Dockerfile, build, variants.yaml, version.sh,
+        # config.yaml, LAST_REBUILD.md, custom helper, generated assets, etc.)
+        # implies the container's build inputs changed and ALL retained versions
+        # must rebuild to lock the new state. Exact-line prefix match via bash
+        # `case` — anchored at start, no regex interpolation hazard.
+        local found_match=false
         if [[ -f "$changed_files_file" ]]; then
-            if grep -Fxq "${container}/config.yaml" "$changed_files_file" 2>/dev/null; then
-                triggered="true"
-            elif grep -Fxq "${container}/LAST_REBUILD.md" "$changed_files_file" 2>/dev/null; then
-                triggered="true"
-            fi
+            while IFS= read -r changed_path; do
+                [[ -z "$changed_path" ]] && continue
+                case "$changed_path" in
+                    "${container}/"*)
+                        found_match=true
+                        break
+                        ;;
+                esac
+            done < "$changed_files_file"
         fi
 
-        if [[ "$triggered" == "true" ]]; then
-            expand_map["$container"]="true"
+        if [[ "$found_match" == "true" ]]; then
+            expand_map[$container]=true
             continue
         fi
 

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -538,8 +538,9 @@ list_variant_tags() {
 #     2. event_name empty or unrecognized                       → c: true  (ERR-06 backward-compat)
 #     3. event_name == "pull_request"                           → c: true  (PR smoke matrix)
 #     4. build_all_retained == "true" (explicit string compare) → c: true  (operator override)
-#     5. changed_files contains "$c/config.yaml" or
-#        "$c/LAST_REBUILD.md" (grep -Fxq exact-line match)     → c: true  (dep-driven trigger)
+#     5. changed_files contains any path with prefix "$c/"
+#        (case-glob anchored prefix match, sibling-collision safe:
+#         "php-fpm/foo" does NOT match prefix "php/")            → c: true  (dep-driven trigger)
 #     6. otherwise                                              → c: false (default: latest only)
 #
 # Exit code: 0 on success, 1 on malformed containers_json.

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -270,16 +270,33 @@ variant_image_tag() {
     fi
 }
 
+# Check if a container always builds all retained versions (not just the latest)
+# Usage: always_all_versions <container_dir>
+# Returns: "true" or "false" on stdout
+always_all_versions() {
+    local container_dir="$1"
+    local variants_file="$container_dir/variants.yaml"
+
+    if [[ ! -f "$variants_file" ]]; then
+        echo "false"
+        return
+    fi
+
+    yq -r '.build.always_all_versions // false' "$variants_file" 2>/dev/null || echo "false"
+}
+
 # Get all version+variant combinations for CI matrix
 # Output: JSON array for GitHub Actions matrix
 # Format: [{"version":"18","variant":"base","tag":"18-alpine","flavor":"base","is_default":true,"is_latest_version":true,"dockerfile":"","priority":0}, ...]
-# Usage: list_build_matrix <container_dir> [real_version]
+# Usage: list_build_matrix <container_dir> [real_version] [include_all_retained]
 #   real_version: if provided, substitutes "latest" version tags with this value
+#   include_all_retained: if "true", emit all retained versions (overrides default latest-only)
 #   is_latest_version: true only for the first (newest) version in variants.yaml
 #   full_version: resolved upstream version (e.g., "18.2-alpine") for version-specific tags
 list_build_matrix() {
     local container_dir="$1"
     local real_version="${2:-}"
+    local include_all_retained="${3:-false}"
     local variants_file="$container_dir/variants.yaml"
 
     if [[ ! -f "$variants_file" ]]; then
@@ -383,16 +400,32 @@ list_build_matrix() {
     done < <(list_versions "$container_dir")
 
     result+="]"
-    echo "$result"
+
+    local always_all
+    always_all=$(always_all_versions "$container_dir")
+    if [[ "$always_all" == "true" || "$include_all_retained" == "true" ]]; then
+        printf '%s' "$result"
+    else
+        local filtered
+        filtered=$(printf '%s' "$result" | jq -c '[.[] | select(.is_latest_version == true)]')
+        local container_name skipped
+        container_name=$(basename "$container_dir")
+        skipped=$(printf '%s' "$result" | jq -r '[.[] | select(.is_latest_version != true) | .version] | unique | join(",")')
+        if [[ -n "$skipped" ]]; then
+            echo "::notice::Container ${container_name}: latest-only (skipped retained versions: ${skipped})" >&2
+        fi
+        printf '%s' "$filtered"
+    fi
 }
 
 # Get CI-ready build list for a container (single entry point for all container types)
-# Usage: list_container_builds <container_name> <real_version>
+# Usage: list_container_builds <container_name> <real_version> [include_all_retained]
 # Output: JSON array sorted by priority, with container name in each entry
 # Handles: multi-version (postgres), single-version with "latest" tag (terraform), no-variant (ansible)
 list_container_builds() {
     local container_name="$1"
     local real_version="$2"
+    local include_all_retained="${3:-false}"
     local container_dir="./$container_name"
 
     if has_variants "$container_dir"; then
@@ -401,7 +434,7 @@ list_container_builds() {
 
         if [[ "$vc" -gt 0 ]]; then
             # Multi-version or single "latest" version structure — use list_build_matrix
-            list_build_matrix "$container_dir" "$real_version" \
+            list_build_matrix "$container_dir" "$real_version" "$include_all_retained" \
               | jq -c --arg c "$container_name" \
                   '[.[] | . + {container: $c}] | sort_by(.priority, .container, .version)'
         else
@@ -486,7 +519,119 @@ list_variant_tags() {
     echo "$result"
 }
 
+# Compute per-container expand-retained signals from a git-diff-derived changed-files list.
+# This is the signal-computation layer for "matrix default to latest-only, expand on dep change".
+#
+# Usage: compute_expand_retained_map <event_name> <build_all_retained> <changed_files_file> <containers_json>
+#
+# Args:
+#   event_name           - GitHub event name (e.g. "push", "pull_request", "workflow_dispatch"). May be empty.
+#   build_all_retained   - String "true" or "false" (workflow input). MUST be compared as string, not bool.
+#   changed_files_file   - Path to a file with one changed path per line (output of `git diff --name-only`).
+#                          If file <changed_files_file>.diff_failed exists alongside, treat as diff failure.
+#   containers_json      - JSON array of detected container names, e.g. ["openresty","postgres"].
+#
+# Output (stdout):
+#   JSON object mapping container name -> boolean. true = expand retained versions, false = latest only.
+#   Priority chain (first match wins) for each container c:
+#     1. <changed_files_file>.diff_failed sentinel exists       → c: true  (ERR-01a defensive expand)
+#     2. event_name empty or unrecognized                       → c: true  (ERR-06 backward-compat)
+#     3. event_name == "pull_request"                           → c: true  (PR smoke matrix)
+#     4. build_all_retained == "true" (explicit string compare) → c: true  (operator override)
+#     5. changed_files contains "$c/config.yaml" or
+#        "$c/LAST_REBUILD.md" (grep -Fxq exact-line match)     → c: true  (dep-driven trigger)
+#     6. otherwise                                              → c: false (default: latest only)
+#
+# Exit code: 0 on success, 1 on malformed containers_json.
+compute_expand_retained_map() {
+    local event_name="$1"
+    local build_all_retained="$2"
+    local changed_files_file="$3"
+    local containers_json="$4"
+
+    # Validate containers_json is a valid JSON array
+    if ! echo "$containers_json" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
+        echo "compute_expand_retained_map: containers_json is not a valid JSON array" >&2
+        return 1
+    fi
+
+    # Determine global signals (same for all containers)
+
+    # Rule 1: diff_failed sentinel
+    local diff_failed="false"
+    if [[ -f "${changed_files_file}.diff_failed" ]]; then
+        diff_failed="true"
+    fi
+
+    # Rule 2: event_name empty or unrecognized
+    local unknown_event="false"
+    if [[ -z "$event_name" ]] || ! [[ "$event_name" =~ ^(push|pull_request|workflow_dispatch|schedule|repository_dispatch)$ ]]; then
+        unknown_event="true"
+    fi
+
+    # Build associative array: container -> bool string
+    declare -A expand_map
+
+    local container
+    while IFS= read -r container; do
+        [[ -z "$container" ]] && continue
+
+        # Priority 1: diff_failed sentinel
+        if [[ "$diff_failed" == "true" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Priority 2: unknown/empty event
+        if [[ "$unknown_event" == "true" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Priority 3: pull_request event
+        if [[ "$event_name" == "pull_request" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Priority 4: operator override (explicit string compare, NOT bash truthiness)
+        if [[ "$build_all_retained" == "true" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Priority 5: dep-driven trigger via exact-line match
+        local triggered="false"
+        if [[ -f "$changed_files_file" ]]; then
+            if grep -Fxq "${container}/config.yaml" "$changed_files_file" 2>/dev/null; then
+                triggered="true"
+            elif grep -Fxq "${container}/LAST_REBUILD.md" "$changed_files_file" 2>/dev/null; then
+                triggered="true"
+            fi
+        fi
+
+        if [[ "$triggered" == "true" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Priority 6: default — latest only
+        expand_map["$container"]="false"
+
+    done < <(echo "$containers_json" | jq -r '.[]')
+
+    # Convert associative array to compact JSON object
+    local kv_json="{}"
+    for container in "${!expand_map[@]}"; do
+        local bool_val="${expand_map[$container]}"
+        kv_json=$(echo "$kv_json" | jq -c --arg k "$container" --argjson v "$bool_val" '. + {($k): $v}')
+    done
+
+    echo "$kv_json"
+}
+
 # Export functions for use in other scripts
 export -f resolve_major_version has_variants list_versions version_count list_variants variant_count
 export -f variant_property default_variant base_suffix version_retention
 export -f version_dockerfile requires_extensions variant_image_tag list_build_matrix list_container_builds list_variant_tags
+export -f always_all_versions compute_expand_retained_map

--- a/make
+++ b/make
@@ -521,7 +521,10 @@ list_builds() {
         return 1
     fi
 
-    list_container_builds "$target" "$version"
+    # 3rd arg "true" = include all retained versions in the introspection output.
+    # The CI matrix's latest-only default is a workflow concern, not an introspection concern;
+    # local users and downstream consumers (cleanup-outdated-tags.sh) need the FULL set.
+    list_container_builds "$target" "$version" "true"
 }
 
 # Generate SBOM for a container image

--- a/openresty/build
+++ b/openresty/build
@@ -10,7 +10,17 @@ if ! command -v yq >/dev/null 2>&1; then
 fi
 
 # Get raw upstream version (without -alpine suffix) for source download
-RESTY_VERSION=$("$SCRIPT_DIR/version.sh" --upstream)
+# Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
+if [[ -n "${VERSION:-}" ]]; then
+    # Strip the -alpine suffix (set by version.sh's TAG_SUFFIX) to get the raw openresty source version.
+    RESTY_VERSION="${VERSION%-alpine}"
+    if [[ -z "$RESTY_VERSION" ]]; then
+        echo "ERROR: VERSION=$VERSION resolves to empty RESTY_VERSION after suffix strip" >&2
+        exit 1
+    fi
+else
+    RESTY_VERSION=$("$SCRIPT_DIR/version.sh" --upstream)
+fi
 
 echo "Building OpenResty ${VERSION} (source: ${RESTY_VERSION})"
 

--- a/openresty/build
+++ b/openresty/build
@@ -19,7 +19,14 @@ if [[ -n "${VERSION:-}" ]]; then
         exit 1
     fi
 else
-    RESTY_VERSION=$("$SCRIPT_DIR/version.sh" --upstream)
+    if ! RESTY_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
+        echo "ERROR: version.sh --upstream failed; cannot resolve RESTY_VERSION" >&2
+        exit 1
+    fi
+    if [[ -z "$RESTY_VERSION" ]]; then
+        echo "ERROR: version.sh --upstream returned empty; cannot resolve RESTY_VERSION" >&2
+        exit 1
+    fi
 fi
 
 echo "Building OpenResty ${VERSION} (source: ${RESTY_VERSION})"

--- a/postgres/variants.yaml
+++ b/postgres/variants.yaml
@@ -12,6 +12,9 @@ build:
   requires_extensions: true
   # Base image suffix (appended to version tag)
   base_suffix: "-alpine"
+  # Postgres builds all supported PG majors on every push (not just the latest line).
+  # Rationale: each major is a long-lived supported release stream, not a rolling history.
+  always_all_versions: true
 # Versions to build (all maintained PostgreSQL releases)
 versions:
   - tag: "18"

--- a/tests/unit/expand-retained-map.bats
+++ b/tests/unit/expand-retained-map.bats
@@ -6,6 +6,7 @@
 setup() {
     TEST_DIR=$(mktemp -d)
     ORIG_DIR="$PWD"
+    ORIG_PATH="$PATH"
     cd "$TEST_DIR" || exit 1
 
     # Provide a minimal yq mock (variant-utils.sh sources it but compute_expand_retained_map
@@ -28,6 +29,8 @@ MOCK
 teardown() {
     cd "$ORIG_DIR" || true
     rm -rf "$TEST_DIR"
+    # Restore PATH so successive tests don't accumulate stale temp-bin entries
+    export PATH="$ORIG_PATH"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/expand-retained-map.bats
+++ b/tests/unit/expand-retained-map.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+
+# Unit tests for compute_expand_retained_map in helpers/variant-utils.sh
+# Tests per-container expand-retained signal computation from git-diff-derived changed-files.
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    # Provide a minimal yq mock (variant-utils.sh sources it but compute_expand_retained_map
+    # does not use yq — the mock prevents accidental real-yq side-effects in tests)
+    mkdir -p bin
+    cat > bin/yq <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x bin/yq
+    export PATH="$TEST_DIR/bin:$PATH"
+
+    source "$ORIG_DIR/helpers/variant-utils.sh"
+
+    # Default fixture: an empty changed-files list
+    CHANGED_FILES="$TEST_DIR/changed_files.txt"
+    touch "$CHANGED_FILES"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# SC-02: config.yaml change for a container triggers expansion
+# ---------------------------------------------------------------------------
+
+@test "SC-02: config.yaml change for openresty → openresty:true" {
+    echo "openresty/config.yaml" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-03: LAST_REBUILD.md change for a container triggers expansion
+# ---------------------------------------------------------------------------
+
+@test "SC-03: LAST_REBUILD.md change for openresty → openresty:true" {
+    echo "openresty/LAST_REBUILD.md" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-04: pull_request event → all containers true regardless of diff
+# ---------------------------------------------------------------------------
+
+@test "SC-04: pull_request event → all containers true regardless of diff" {
+    # Only Dockerfile changed (not in trigger list), but PR event wins
+    echo "openresty/Dockerfile" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "pull_request" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-05: build_all_retained="true" → all containers true
+# ---------------------------------------------------------------------------
+
+@test "SC-05: build_all_retained=true → all containers true" {
+    # changed_files is empty; operator override must win
+    run compute_expand_retained_map "push" "true" "$CHANGED_FILES" '["openresty","postgres"]'
+    [ "$status" -eq 0 ]
+    or_val=$(echo "$output" | jq -r '.openresty')
+    pg_val=$(echo "$output" | jq -r '.postgres')
+    [ "$or_val" = "true" ]
+    [ "$pg_val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-11: sibling-name collision — php-fpm/config.yaml must NOT trigger php
+# ---------------------------------------------------------------------------
+
+@test "SC-11: php-fpm/config.yaml change does NOT trigger php expansion (exact-match regression-lock)" {
+    echo "php-fpm/config.yaml" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["php"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.php')
+    [ "$val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-12 / ERR-05: build_all_retained="false" (the STRING) must NOT expand
+# ---------------------------------------------------------------------------
+
+@test "SC-12/ERR-05: build_all_retained string 'false' does NOT incorrectly expand" {
+    # changed_files empty, build_all_retained is the literal string "false"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-13: empty changed_files (no sentinel) → all false
+# ---------------------------------------------------------------------------
+
+@test "SC-13: empty changed_files file (no sentinel) → all containers false" {
+    # CHANGED_FILES exists but is empty; no .diff_failed sentinel
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty","postgres"]'
+    [ "$status" -eq 0 ]
+    or_val=$(echo "$output" | jq -r '.openresty')
+    pg_val=$(echo "$output" | jq -r '.postgres')
+    [ "$or_val" = "false" ]
+    [ "$pg_val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-14: .diff_failed sentinel present → all containers true
+# ---------------------------------------------------------------------------
+
+@test "SC-14: .diff_failed sentinel present → all containers true" {
+    # Sentinel file alongside changed_files
+    touch "${CHANGED_FILES}.diff_failed"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty","postgres"]'
+    [ "$status" -eq 0 ]
+    or_val=$(echo "$output" | jq -r '.openresty')
+    pg_val=$(echo "$output" | jq -r '.postgres')
+    [ "$or_val" = "true" ]
+    [ "$pg_val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-15 / ERR-06: empty event_name → all containers true (legacy caller fallback)
+# ---------------------------------------------------------------------------
+
+@test "SC-15/ERR-06: empty event_name → all containers true" {
+    run compute_expand_retained_map "" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Extra: unknown event_name treated same as empty (ERR-06)
+# ---------------------------------------------------------------------------
+
+@test "unknown event_name treated as unrecognized → all containers true" {
+    run compute_expand_retained_map "some_made_up_event" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Mixed: only one of multiple containers has a dep-change trigger
+# ---------------------------------------------------------------------------
+
+@test "mixed: only openresty/config.yaml changed → openresty:true, postgres:false, debian:false" {
+    echo "openresty/config.yaml" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty","postgres","debian"]'
+    [ "$status" -eq 0 ]
+    or_val=$(echo "$output" | jq -r '.openresty')
+    pg_val=$(echo "$output" | jq -r '.postgres')
+    deb_val=$(echo "$output" | jq -r '.debian')
+    [ "$or_val" = "true" ]
+    [ "$pg_val" = "false" ]
+    [ "$deb_val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# schedule event without dep trigger → all false (recognized event, dep logic applies)
+# ---------------------------------------------------------------------------
+
+@test "schedule event, empty diff → all containers false" {
+    # "schedule" is recognized; no dep trigger; no sentinel; no operator override
+    run compute_expand_retained_map "schedule" "false" "$CHANGED_FILES" '["openresty","postgres"]'
+    [ "$status" -eq 0 ]
+    or_val=$(echo "$output" | jq -r '.openresty')
+    pg_val=$(echo "$output" | jq -r '.postgres')
+    [ "$or_val" = "false" ]
+    [ "$pg_val" = "false" ]
+}

--- a/tests/unit/expand-retained-map.bats
+++ b/tests/unit/expand-retained-map.bats
@@ -31,10 +31,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-02: config.yaml change for a container triggers expansion
+# SC-02: container-dir file (config.yaml) change triggers expansion
 # ---------------------------------------------------------------------------
 
-@test "SC-02: config.yaml change for openresty → openresty:true" {
+@test "SC-02: container-dir file (config.yaml) change for openresty → openresty:true" {
     echo "openresty/config.yaml" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -43,10 +43,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-03: LAST_REBUILD.md change for a container triggers expansion
+# SC-03: container-dir file (LAST_REBUILD.md) change triggers expansion
 # ---------------------------------------------------------------------------
 
-@test "SC-03: LAST_REBUILD.md change for openresty → openresty:true" {
+@test "SC-03: container-dir file (LAST_REBUILD.md) change for openresty → openresty:true" {
     echo "openresty/LAST_REBUILD.md" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -184,4 +184,40 @@ teardown() {
     pg_val=$(echo "$output" | jq -r '.postgres')
     [ "$or_val" = "false" ]
     [ "$pg_val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-16: Dockerfile change in container dir triggers expansion (gate finding regression-lock)
+# ---------------------------------------------------------------------------
+
+@test "SC-16: Dockerfile change in container dir → openresty:true" {
+    echo "openresty/Dockerfile" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-17: variants.yaml change in container dir triggers expansion (gate finding regression-lock)
+# ---------------------------------------------------------------------------
+
+@test "SC-17: variants.yaml change in container dir → openresty:true" {
+    echo "openresty/variants.yaml" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# SC-18: build script change in container dir triggers expansion (gate finding regression-lock)
+# ---------------------------------------------------------------------------
+
+@test "SC-18: build script change in container dir → openresty:true" {
+    echo "openresty/build" >> "$CHANGED_FILES"
+    run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
+    [ "$status" -eq 0 ]
+    val=$(echo "$output" | jq -r '.openresty')
+    [ "$val" = "true" ]
 }

--- a/tests/unit/openresty-build-version.bats
+++ b/tests/unit/openresty-build-version.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+# Unit tests for openresty/build — version-resolution logic.
+#
+# Strategy: copy the build script into a temp dir alongside a stubbed version.sh,
+# then stub yq via PATH injection. The build script sets SCRIPT_DIR=$(dirname "$0"),
+# so running it from a temp dir with a version.sh stub makes the conditional branch
+# testable without touching the real openresty/version.sh or making network calls.
+#
+# The script emits: "Building OpenResty ${VERSION} (source: ${RESTY_VERSION})"
+# We extract RESTY_VERSION from that line for assertions.
+#
+# Mutation each test catches:
+#   TC1: removing the VERSION branch → version.sh called, returns STUB-UPSTREAM-VAL ≠ "1.29.2.4"
+#   TC2: removing suffix strip → RESTY_VERSION would equal "1.29.2.5-alpine" ≠ "1.29.2.5"
+#   TC3: removing the else branch → version.sh never called, RESTY_VERSION empty or wrong
+#   TC4: removing the -z guard → script exits 0 and emits "(source: )" instead of error exit 1
+#   TC5: suffix strip using sed/grep instead of %-alpine → "1.29.2.4" (no suffix) would break
+
+bats_require_minimum_version 1.5.0
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Setup: per-test temp dir with stubbed version.sh and yq
+# ---------------------------------------------------------------------------
+
+setup() {
+    setup_temp_dir
+
+    # PROJECT_ROOT is exported by test_helper; derive build script path from it.
+    local build_script="$PROJECT_ROOT/openresty/build"
+
+    # Copy the real build script into the temp dir so SCRIPT_DIR resolves to temp dir.
+    cp "$build_script" "$TEST_TEMP_DIR/build"
+    chmod +x "$TEST_TEMP_DIR/build"
+
+    # Default stub: version.sh echoes a sentinel when called with --upstream.
+    _write_version_stub "STUB-UPSTREAM-VAL"
+
+    # Stub yq: the build script checks for yq but does not use it; stub satisfies
+    # the `command -v yq` guard without installing the real binary.
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/yq" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/yq"
+
+    export ORIGINAL_PATH="$PATH"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+teardown() {
+    teardown_temp_dir
+    export PATH="$ORIGINAL_PATH"
+    unset VERSION CUSTOM_BUILD_ARGS
+}
+
+# Write version.sh stub into temp dir with a given --upstream return value.
+_write_version_stub() {
+    local upstream_val="$1"
+    cat > "$TEST_TEMP_DIR/version.sh" <<EOF
+#!/bin/bash
+if [[ "\$1" == "--upstream" ]]; then
+    echo "$upstream_val"
+else
+    echo "UNEXPECTED_CALL: \$*" >&2
+    exit 1
+fi
+EOF
+    chmod +x "$TEST_TEMP_DIR/version.sh"
+}
+
+# Run the build script and capture output + stderr separately.
+# Sets: $status, $output, $stderr (via bats --separate-stderr).
+_run_build() {
+    run --separate-stderr bash "$TEST_TEMP_DIR/build"
+}
+
+# Extract the RESTY_VERSION resolved by the build script from its stdout line:
+# "Building OpenResty <VERSION> (source: <RESTY_VERSION>)"
+# Prints the captured RESTY_VERSION or fails if the line is absent.
+_extract_resty_version() {
+    local line
+    line=$(echo "$output" | grep "^Building OpenResty") || {
+        echo "MISSING_BUILD_LINE" >&2
+        return 1
+    }
+    # Extract content inside "(source: ...)"
+    local resty
+    resty=$(echo "$line" | sed 's/.*source: \([^)]*\)).*/\1/')
+    echo "$resty"
+}
+
+# =============================================================================
+# TC1: VERSION="1.29.2.4-alpine" → RESTY_VERSION="1.29.2.4"
+# =============================================================================
+
+@test "TC1: VERSION=1.29.2.4-alpine sets RESTY_VERSION to 1.29.2.4" {
+    export VERSION="1.29.2.4-alpine"
+    _run_build
+
+    [ "$status" -eq 0 ]
+    local resty
+    resty=$(_extract_resty_version)
+    [ "$resty" = "1.29.2.4" ]
+}
+
+# =============================================================================
+# TC2: VERSION="1.29.2.5-alpine" → RESTY_VERSION="1.29.2.5" (latest retained)
+# =============================================================================
+
+@test "TC2: VERSION=1.29.2.5-alpine sets RESTY_VERSION to 1.29.2.5" {
+    export VERSION="1.29.2.5-alpine"
+    _run_build
+
+    [ "$status" -eq 0 ]
+    local resty
+    resty=$(_extract_resty_version)
+    [ "$resty" = "1.29.2.5" ]
+}
+
+# =============================================================================
+# TC3: VERSION unset → RESTY_VERSION comes from version.sh --upstream stub
+# =============================================================================
+
+@test "TC3: VERSION unset falls back to version.sh --upstream" {
+    unset VERSION
+    _write_version_stub "STUB-UPSTREAM-VAL"
+    _run_build
+
+    [ "$status" -eq 0 ]
+    local resty
+    resty=$(_extract_resty_version)
+    [ "$resty" = "STUB-UPSTREAM-VAL" ]
+}
+
+# =============================================================================
+# TC4: VERSION="-alpine" (empty after strip) → exit 1 + "resolves to empty" in stderr
+# =============================================================================
+
+@test "TC4: VERSION=-alpine (empty after strip) exits 1 with error in stderr" {
+    export VERSION="-alpine"
+    _run_build
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"resolves to empty"* ]]
+}
+
+# =============================================================================
+# TC5: VERSION="1.29.2.4" (no -alpine suffix) → RESTY_VERSION="1.29.2.4" (no-op strip)
+# =============================================================================
+
+@test "TC5: VERSION=1.29.2.4 (no -alpine suffix) sets RESTY_VERSION to 1.29.2.4" {
+    export VERSION="1.29.2.4"
+    _run_build
+
+    [ "$status" -eq 0 ]
+    local resty
+    resty=$(_extract_resty_version)
+    [ "$resty" = "1.29.2.4" ]
+}

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -342,7 +342,7 @@ EOF
     hash -r
 
     create_postgres_variants "pg"
-    run list_build_matrix "pg" "18.4-alpine"
+    run --separate-stderr list_build_matrix "pg" "18.4-alpine" "true"
     [ "$status" -eq 0 ]
     # Postgres tags are "18" and "17", not "latest" — real_version should NOT change them
     local v18_count
@@ -462,7 +462,7 @@ EOF
     hash -r
 
     create_postgres_variants "pg"
-    run list_build_matrix "pg"
+    run --separate-stderr list_build_matrix "pg"
     [ "$status" -eq 0 ]
     # PG 18 (first in YAML) should have is_latest_version=true
     local v18_latest
@@ -552,7 +552,7 @@ EOF
     hash -r
 
     create_simple_container_variants "simple"
-    run list_build_matrix "simple" "2.0.0"
+    run --separate-stderr list_build_matrix "simple" "2.0.0" "true"
     [ "$status" -eq 0 ]
     local count
     count=$(echo "$output" | jq 'length')
@@ -580,7 +580,7 @@ EOF
     hash -r
 
     create_simple_container_variants "simple"
-    run list_container_builds "simple" "2.0.0"
+    run --separate-stderr list_container_builds "simple" "2.0.0" "true"
     [ "$status" -eq 0 ]
     local count
     count=$(echo "$output" | jq 'length')
@@ -604,4 +604,225 @@ EOF
     local full_version
     full_version=$(echo "$output" | jq -r '.[0].full_version')
     [ "$full_version" = "1.14.6-alpine" ]
+}
+
+# --- always_all_versions ---
+
+# Helper: multi-version variants.yaml with 3 versions (for filter tests)
+create_three_version_variants() {
+    local dir="${1:-.}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  base_suffix: ""
+  version_retention: 3
+
+versions:
+  - tag: "3.0.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+  - tag: "2.9.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+  - tag: "2.8.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+EOF
+}
+
+@test "always_all_versions: returns false when build key missing" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "nokey"
+    cat > "nokey/variants.yaml" <<'EOF'
+versions:
+  - tag: "1.0.0"
+EOF
+    run always_all_versions "nokey"
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+}
+
+@test "always_all_versions: returns false when always_all_versions key missing from build block" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "nobuildkey"
+    cat > "nobuildkey/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.0.0"
+EOF
+    run always_all_versions "nobuildkey"
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+}
+
+@test "always_all_versions: returns true when explicitly set to true" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "allver"
+    cat > "allver/variants.yaml" <<'EOF'
+build:
+  always_all_versions: true
+
+versions:
+  - tag: "1.0.0"
+EOF
+    run always_all_versions "allver"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "always_all_versions: returns false when variants.yaml missing" {
+    mkdir -p "missingdir"
+    run always_all_versions "missingdir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+}
+
+# --- list_build_matrix filtering ---
+
+@test "list_build_matrix: default (no 3rd arg) emits only is_latest_version=true entries" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_three_version_variants "threevers"
+    # Use --separate-stderr so the ::notice:: stderr line doesn't pollute $output
+    run --separate-stderr list_build_matrix "threevers"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 1 ]
+    local all_latest
+    all_latest=$(echo "$output" | jq 'all(.is_latest_version == true)')
+    [ "$all_latest" = "true" ]
+}
+
+@test "list_build_matrix: include_all_retained=true emits all versions" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_three_version_variants "threevers"
+    run list_build_matrix "threevers" "" "true"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 3 ]
+}
+
+@test "list_build_matrix: always_all_versions=true in yaml overrides include_all_retained=false" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "alwaysall"
+    cat > "alwaysall/variants.yaml" <<'EOF'
+build:
+  always_all_versions: true
+  version_retention: 3
+
+versions:
+  - tag: "3.0.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+  - tag: "2.9.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+  - tag: "2.8.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+EOF
+    # Call with include_all_retained=false — always_all_versions=true in yaml must win
+    run list_build_matrix "alwaysall" "" "false"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 3 ]
+}
+
+@test "list_build_matrix: include_all_retained string 'false' emits filtered output" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_three_version_variants "threevers"
+    # Explicit string "false" must NOT be treated as truthy
+    # Use --separate-stderr so the ::notice:: stderr line doesn't pollute $output
+    run --separate-stderr list_build_matrix "threevers" "" "false"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 1 ]
+    local all_latest
+    all_latest=$(echo "$output" | jq 'all(.is_latest_version == true)')
+    [ "$all_latest" = "true" ]
+}
+
+@test "list_build_matrix: single-version container emits 1 entry with is_latest_version=true" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "singlever"
+    cat > "singlever/variants.yaml" <<'EOF'
+build:
+  base_suffix: ""
+
+versions:
+  - tag: "1.0.0"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+EOF
+    run list_build_matrix "singlever"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 1 ]
+    local is_latest
+    is_latest=$(echo "$output" | jq '.[0].is_latest_version')
+    [ "$is_latest" = "true" ]
+}
+
+@test "list_build_matrix: emits ::notice:: to stderr when versions are skipped" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    create_three_version_variants "threevers"
+    # bats `run` captures stdout in $output; stderr goes to fd 3 (bats captures it in $stderr with run --)
+    # Use process substitution to capture stderr separately
+    local stderr_out
+    stderr_out=$(list_build_matrix "threevers" "" "false" 2>&1 >/dev/null)
+    [[ "$stderr_out" == *"::notice::Container threevers: latest-only (skipped retained versions:"* ]]
 }


### PR DESCRIPTION
Closes #502

## Summary

Every push to master previously rebuilt **all** retained versions of every container (e.g. `openresty` 1.29.2.5 + 1.29.2.4 + 1.29.2.3 × 2 archs = 6 jobs), wasting runner time and registry rate-limit budget. The retention list is meant for **dependency-driven rebuilds** (propagating a security patch in alpine/openssl to every supported line), not for every code push.

This PR ships the matrix-default change and the openresty/build `$VERSION` fix called out in #502.

## Matrix logic

- `helpers/variant-utils.sh:list_build_matrix` gains 3rd arg `include_all_retained` (default `false` → filters to `is_latest_version=true`).
- New `compute_expand_retained_map` helper computes per-container expand signal from git diff. Priority chain: diff-failed sentinel → unknown event → `pull_request` (full smoke) → `build_all_retained=true` override → any file in `<container>/...` changed → default false.
- `.github/actions/detect-containers/action.yaml` wires the map through to the per-container `list_container_builds` call. New `event_name` + `build_all_retained` inputs; new `expand_retained_map` output.
- `auto-build.yaml` gains `workflow_dispatch.inputs.build_all_retained` (mirrored in `workflow_call.inputs`) for operator override — CVE fan-out, resync after a registry incident.

## Postgres opt-out

`postgres/variants.yaml` declares `build.always_all_versions: true`. All 4 supported PG majors (15/16/17/18) rebuild on every push — they're separate long-lived release streams, not a rolling history. The flag wins over `include_all_retained=false` inside `list_build_matrix`.

## openresty/build $VERSION fix

`openresty/build:14` previously called `version.sh --upstream` unconditionally — wrong artifacts for any retained-version rebuild. Now honors `$VERSION` when set (strips `-alpine` suffix, fails loud on empty result), falls back to `version.sh --upstream` for local/manual invocation.

## Consumer / caller wiring

- `make:524` passes `"true"` 3rd arg so `./make list-builds` and `scripts/cleanup-outdated-tags.sh` get the full retained set. Without it, the monthly cleanup workflow would have purged retained tags.
- `recreate-manifests.yaml` + `validate-version-scripts.yaml` pass `build_all_retained: true`. Their `force_rebuild: true` intent requires full retained matrix; otherwise they would silently collapse to latest-only.
- `upstream-monitor.yaml` (lines 514, 1026) passes `-f build_all_retained=true` on its `gh workflow run auto-build.yaml` dispatches. `workflow_dispatch` carries no `before..after` diff context.
- `auto-build.yaml` path filters broadened from per-file allowlist to `*/**` plus denylist (`docs/**`, `examples/**`, `tests/**`, `test-harness/**`, `test-logs/**`, `archive/**`). The narrow allowlist had been brittle — new build-input file types (build hooks, prepare-build-context scripts, Dockerfile-COPYed assets) slipped past the trigger.

## detect-containers edge cases

- `diff_rc` initialized to 0 at find-containers entry so the sentinel-write step runs safely when `inputs.container` is set (single-container target path).
- Fail-loud guard in compute-expand-map: when the diff-failed sentinel is present AND no containers were detected, emit `::error::` and exit 1 instead of silently producing `map={}`.
- `scope_versions` being set bypasses the latest-only filter for that container's matrix expansion. Otherwise `scope_versions=1.29.2.4-alpine` targeting a retained version would return zero builds.

## Tests

- 15 new bats tests for `compute_expand_retained_map` (event types, build_all_retained string compare, exact-prefix match, sentinel handling, Dockerfile / variants.yaml / build trigger regression-locks).
- 10 new bats tests for `always_all_versions` + `list_build_matrix include_all_retained` (default latest-only, single-version container, postgres opt-out, stderr notice emission).
- 5 new bats tests for `openresty/build $VERSION` resolution + fallback + edge cases.
- 4 pre-existing tests adjusted to `run --separate-stderr` because the new observability `::notice::` on stderr was polluting jq output capture in the older tests.

All bats green (63 passing on this branch); `shellcheck` clean on modified shell.

## Post-merge expectations

- `openresty` matrix on master push: **6 jobs → 2 jobs** (3 versions × 2 archs → latest × 2 archs).
- `postgres` matrix: unchanged (all 4 majors always build via opt-out).
- `upstream-monitor` dep-bump flow: unchanged (still propagates to all retained versions via explicit `build_all_retained=true` dispatch).
- PR smoke builds: unchanged (full retained-version matrix preserved).
- Operator override available via `workflow_dispatch` form: `build_all_retained=true`.

## Out of scope (deferred)

- Investigation of the 0.1s fail-fast on `openresty 1.29.2.5-alpine` build (#502 Fix C) — likely self-resolves once the matrix stops compounding the flake noise; will observe master after merge and file a follow-up if the build still fails.
- Architectural inversion of `list_container_builds`'s 3rd arg default (full output → opt-in filter) — recorded as follow-up to prevent future "consumer forgot the arg → silent data loss" regressions.

## Test plan

- [ ] CI passes (shellcheck, bats, validate-version-scripts)
- [ ] First post-merge master `auto-build` run shows openresty matrix = 2 jobs (latest × 2 archs), not 6
- [ ] First post-merge master `auto-build` run shows postgres matrix unchanged (all 4 majors)
- [ ] Manual `workflow_dispatch` with `build_all_retained=true` produces full retained matrix
- [ ] Next upstream-monitor dep bump correctly rebuilds all retained versions of the affected container
