### PR TITLE
ci: remove Trivy DB cache wrapper to eliminate collision warnings

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -463,20 +463,7 @@ runs:
 
     # Security Scanning with Trivy
     # Note: Image is tagged as ghcr.io/owner/container:version by the build step
-    - name: Ensure Trivy cache directory exists
-      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' }}
-      shell: bash
-      run: mkdir -p ~/.cache/trivy
-
-    - name: Restore Trivy vulnerability database cache
-      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' }}
-      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      with:
-        path: ~/.cache/trivy
-        key: trivy-db-${{ runner.os }}-${{ hashFiles('.github/actions/build-container/action.yaml') }}
-        restore-keys: |
-          trivy-db-${{ runner.os }}-
-
+    # trivy-action manages its own DB cache (cache-trivy-YYYY-MM-DD) — no project-level wrapper needed.
     - name: Scan for vulnerabilities (Trivy)
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' }}
       id: trivy-scan
@@ -577,13 +564,6 @@ runs:
         category: 'container-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}-${{ inputs.platform }}'
         wait-for-processing: false
       # No continue-on-error: SARIF upload to Security tab must succeed for visibility
-
-    - name: Save Trivy vulnerability database cache
-      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' }}
-      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      with:
-        path: ~/.cache/trivy
-        key: trivy-db-${{ runner.os }}-${{ hashFiles('.github/actions/build-container/action.yaml') }}
 
     - name: Check scan result
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary

Removes the project-controlled `actions/cache` wrapper around the Trivy DB in `.github/actions/build-container/action.yaml`. The wrapper duplicated functionality `aquasecurity/trivy-action` already provides internally, and used a content-hashed cache key shared across every matrix job in a run — producing a `##[warning]Cache save failed.Unable to reserve cache with key trivy-db-Linux-<hash>, another job may be creating this cache` warning on every concurrent build.

Observed in 12 of 13 sampled recent master runs. No functional impact (warning only, scans always completed normally) — pure log noise.

## Change

3 steps deleted from `.github/actions/build-container/action.yaml`:
- `Ensure Trivy cache directory exists`
- `Restore Trivy vulnerability database cache`
- `Save Trivy vulnerability database cache`

Net `-20 / +1` lines (added a 1-line comment marking the simplification). Step count goes 24 → 21.

`aquasecurity/trivy-action` invocations (2 calls: table + SARIF) are preserved unchanged. The action's built-in date-keyed cache (`cache-trivy-YYYY-MM-DD`) remains as the only Trivy DB caching mechanism — at most one collision per calendar day across parallel jobs, fully benign.

## Why not fold the two trivy-action calls into one

Checked: `aquasecurity/trivy-action` accepts a single `format` value per invocation; it does not natively support simultaneous `table` + `sarif` output. The two calls remain necessary. Out of scope for this PR.

## Test plan

- [ ] CI passes (shellcheck, validate-version-scripts, all build jobs)
- [ ] Post-merge master `auto-build` run shows ZERO `Cache save failed` warnings in any build job
- [ ] Trivy scans still complete normally and SARIF artifacts still upload
