### PR TITLE
ci(base-cache): #493 Slice 3a — migrate web-shell alpine/ubuntu/rocky

### DIFF
--- a/tests/unit/web-shell-base-image.bats
+++ b/tests/unit/web-shell-base-image.bats
@@ -44,13 +44,27 @@ setup() {
 }
 
 @test "web-shell: ARG REMOTE_CR present in generator output for alpine/ubuntu/rocky (regression lock)" {
-    # Regression lock: Slice 3a requires REMOTE_CR ARG in migrated distros so
-    # CI can inject the GHCR mirror URL at build time. If the generator stops
-    # emitting it, the FROM line becomes unresolvable in CI.
+    # Regression lock: migrated distros require BOTH a template-global
+    # `ARG REMOTE_CR=docker.io` AND a stage-scope `ARG REMOTE_CR` re-import
+    # (no default) immediately before the FROM line, so ${REMOTE_CR} resolves
+    # inside the FROM. The FROM line itself must reference ${REMOTE_CR}/library/<distro>.
+    # If the stage re-import is dropped, ${REMOTE_CR} in FROM resolves to empty
+    # despite the global ARG existing — Docker scopes ARG to stages.
     for distro in alpine ubuntu rocky; do
-        local has_remote_cr
-        has_remote_cr=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -cE '^ARG REMOTE_CR' || true)
-        [[ "$has_remote_cr" -ge 1 ]] || { echo "$distro: ARG REMOTE_CR missing from generated Dockerfile"; return 1; }
+        local gen
+        gen=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null)
+        # Expect ≥ 2 ARG REMOTE_CR lines (template global + stage re-import)
+        local count
+        count=$(echo "$gen" | grep -cE '^ARG REMOTE_CR' || true)
+        [[ "$count" -ge 2 ]] || { echo "$distro: expected ≥ 2 ARG REMOTE_CR lines, found $count"; return 1; }
+        # Expect the FROM line to reference ${REMOTE_CR}/library/<distro>
+        local from_uses_remote_cr
+        case "$distro" in
+            alpine) from_uses_remote_cr=$(echo "$gen" | grep -cE '^FROM \$\{REMOTE_CR\}/library/alpine:') ;;
+            ubuntu) from_uses_remote_cr=$(echo "$gen" | grep -cE '^FROM \$\{REMOTE_CR\}/library/ubuntu:') ;;
+            rocky)  from_uses_remote_cr=$(echo "$gen" | grep -cE '^FROM \$\{REMOTE_CR\}/library/rockylinux:') ;;
+        esac
+        [[ "$from_uses_remote_cr" -ge 1 ]] || { echo "$distro: FROM does not reference \${REMOTE_CR}/library/<distro>"; return 1; }
     done
 }
 

--- a/tests/unit/web-shell-base-image.bats
+++ b/tests/unit/web-shell-base-image.bats
@@ -1,9 +1,8 @@
 #!/usr/bin/env bats
 #
-# web-shell base-image generation: Two-ARG pattern with the tag sourced from
-# base_image_cache[].tags[0]. Guards against the rocky cache-miss regression
-# (tag-less FROM resolving to an implicit :latest that the GHCR cache lacks)
-# and against re-hardcoding the tag literal in the generator.
+# web-shell base-image generation: guards against tag and pattern regressions
+# after the Slice 3a migration (alpine/ubuntu/rocky → ${REMOTE_CR}/library/<distro>
+# pattern). Debian is unchanged (ghcr.io/oorabona/debian fixed FROM).
 
 setup() {
     REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -14,45 +13,59 @@ setup() {
     TEMPLATE="$REPO_ROOT/web-shell/Dockerfile"
 }
 
-@test "web-shell: alpine/ubuntu/rocky FROM uses Two-ARG \${BASE}:\${TAG} pattern" {
+@test "web-shell: alpine/ubuntu/rocky FROM uses \${REMOTE_CR}/library/<distro>:\${TAG} pattern" {
     for distro in alpine ubuntu rocky; do
         local from_line
         from_line=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -E '^FROM ' | head -1)
         case "$distro" in
-            alpine) [[ "$from_line" == 'FROM ${ALPINE_BASE}:${ALPINE_TAG}' ]] || { echo "alpine FROM wrong: $from_line"; return 1; } ;;
-            ubuntu) [[ "$from_line" == 'FROM ${UBUNTU_BASE}:${UBUNTU_TAG}' ]] || { echo "ubuntu FROM wrong: $from_line"; return 1; } ;;
-            rocky)  [[ "$from_line" == 'FROM ${ROCKY_BASE}:${ROCKY_TAG}' ]]   || { echo "rocky FROM wrong: $from_line";  return 1; } ;;
+            alpine) [[ "$from_line" == 'FROM ${REMOTE_CR}/library/alpine:${ALPINE_TAG}' ]]     || { echo "alpine FROM wrong: $from_line"; return 1; } ;;
+            ubuntu) [[ "$from_line" == 'FROM ${REMOTE_CR}/library/ubuntu:${UBUNTU_TAG}' ]]     || { echo "ubuntu FROM wrong: $from_line"; return 1; } ;;
+            rocky)  [[ "$from_line" == 'FROM ${REMOTE_CR}/library/rockylinux:${ROCKY_TAG}' ]]  || { echo "rocky FROM wrong: $from_line";  return 1; } ;;
         esac
     done
 }
 
-@test "web-shell: generated default tag equals base_image_cache[].tags[0] (no hardcode, no drift)" {
+@test "web-shell: generated default tag equals base_image_cache[].source tags[0] (no hardcode, no drift)" {
     # Mutation trace: hardcode a tag literal in generate-dockerfile.sh that
     # differs from config → this test goes RED. Proves the tag is sourced from
     # config, the single source of truth shared with the cache-population job.
-    for arg in ALPINE_BASE UBUNTU_BASE ROCKY_BASE; do
+    # Uses .source (new schema) instead of .arg (old Two-ARG schema).
+    for source in library/alpine library/ubuntu library/rockylinux; do
         local distro tag_arg cfg_tag gen_tag
-        case "$arg" in
-            ALPINE_BASE) distro=alpine; tag_arg=ALPINE_TAG ;;
-            UBUNTU_BASE) distro=ubuntu; tag_arg=UBUNTU_TAG ;;
-            ROCKY_BASE)  distro=rocky;  tag_arg=ROCKY_TAG ;;
+        case "$source" in
+            library/alpine)     distro=alpine; tag_arg=ALPINE_TAG ;;
+            library/ubuntu)     distro=ubuntu; tag_arg=UBUNTU_TAG ;;
+            library/rockylinux) distro=rocky;  tag_arg=ROCKY_TAG  ;;
         esac
-        cfg_tag=$(YQ_ARG="$arg" yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0]' "$CONFIG")
+        cfg_tag=$(YQ_SOURCE="$source" yq -r '.base_image_cache[] | select(.source == strenv(YQ_SOURCE)) | .tags[0]' "$CONFIG")
         gen_tag=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -E "^ARG ${tag_arg}=" | head -1 | cut -d= -f2)
         [[ "$gen_tag" == "$cfg_tag" ]] || { echo "$distro: generated ${tag_arg}=$gen_tag != config tags[0]=$cfg_tag"; return 1; }
     done
 }
 
-@test "web-shell: CI tag-less cache override resolves to the cached tag" {
-    # Simulate get_cache_build_args (tag-less ROCKY_BASE) + the generated
-    # ROCKY_TAG default → the effective FROM must target rocky-base:<cached-tag>,
-    # NOT an implicit :latest. This is the exact rocky cache-miss the fix closes.
-    local rocky_tag
-    rocky_tag=$(YQ_ARG=ROCKY_BASE yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0]' "$CONFIG")
-    # Default ROCKY_BASE in the generated Dockerfile is "rockylinux"; CI overrides
-    # it to ghcr.io/owner/rocky-base (tag-less). With Two-ARG, the tag stays.
-    local gen_tag
+@test "web-shell: ARG REMOTE_CR present in generator output for alpine/ubuntu/rocky (regression lock)" {
+    # Regression lock: Slice 3a requires REMOTE_CR ARG in migrated distros so
+    # CI can inject the GHCR mirror URL at build time. If the generator stops
+    # emitting it, the FROM line becomes unresolvable in CI.
+    for distro in alpine ubuntu rocky; do
+        local has_remote_cr
+        has_remote_cr=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null | grep -cE '^ARG REMOTE_CR' || true)
+        [[ "$has_remote_cr" -ge 1 ]] || { echo "$distro: ARG REMOTE_CR missing from generated Dockerfile"; return 1; }
+    done
+}
+
+@test "web-shell: rocky ROCKY_TAG is non-empty and not 'latest' (cache-miss guard)" {
+    # Guards against the rocky cache-miss regression: a tag-less or :latest FROM
+    # would bypass the GHCR cache and hit docker.io rate limits.
+    local cfg_tag gen_tag
+    cfg_tag=$(YQ_SOURCE=library/rockylinux yq -r '.base_image_cache[] | select(.source == strenv(YQ_SOURCE)) | .tags[0]' "$CONFIG")
     gen_tag=$(bash "$GEN" "$TEMPLATE" rocky 2>/dev/null | grep -E '^ARG ROCKY_TAG=' | head -1 | cut -d= -f2)
-    [[ "$gen_tag" == "$rocky_tag" ]] || { echo "ROCKY_TAG=$gen_tag != cached $rocky_tag"; return 1; }
+    [[ "$gen_tag" == "$cfg_tag" ]] || { echo "ROCKY_TAG=$gen_tag != cached $cfg_tag"; return 1; }
     [[ -n "$gen_tag" && "$gen_tag" != "latest" ]] || { echo "ROCKY_TAG resolved to empty/latest — cache miss risk"; return 1; }
+}
+
+@test "web-shell: debian FROM unchanged — uses ghcr.io/oorabona/debian:\${DEBIAN_TAG}" {
+    local from_line
+    from_line=$(bash "$GEN" "$TEMPLATE" debian 2>/dev/null | grep -E '^FROM ' | head -1)
+    [[ "$from_line" == 'FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}' ]] || { echo "debian FROM wrong: $from_line"; return 1; }
 }

--- a/web-shell/Dockerfile
+++ b/web-shell/Dockerfile
@@ -6,6 +6,7 @@
 # NOTE: This is a template — markers are expanded by generate-dockerfile.sh.
 # Package lists are in config.yaml — do not add packages here.
 
+ARG REMOTE_CR=docker.io
 ARG VERSION
 ARG UPSTREAM_VERSION
 ARG TTYD_VERSION

--- a/web-shell/config.yaml
+++ b/web-shell/config.yaml
@@ -29,7 +29,8 @@ dependency_sources:
 
 # Base image cache for Docker Hub rate limiting
 # NOTE: Debian is already on GHCR (ghcr.io/oorabona/debian) — no caching needed
-# NOTE: rocky-base is a new GHCR cache repo — requires Write permissions setup
+# Alpine/Ubuntu/Rocky use the new-schema source: library/<distro> pattern; the
+# CI probe substitutes REMOTE_CR=ghcr.io/<owner> when the mirror is reachable.
 base_image_cache:
   - source: library/alpine
     tags: ["3.21"]

--- a/web-shell/config.yaml
+++ b/web-shell/config.yaml
@@ -31,17 +31,11 @@ dependency_sources:
 # NOTE: Debian is already on GHCR (ghcr.io/oorabona/debian) — no caching needed
 # NOTE: rocky-base is a new GHCR cache repo — requires Write permissions setup
 base_image_cache:
-  - arg: ALPINE_BASE
-    source: alpine
-    ghcr_repo: alpine-base
+  - source: library/alpine
     tags: ["3.21"]
-  - arg: UBUNTU_BASE
-    source: ubuntu
-    ghcr_repo: ubuntu-base
+  - source: library/ubuntu
     tags: ["noble"]
-  - arg: ROCKY_BASE
-    source: rockylinux
-    ghcr_repo: rocky-base
+  - source: library/rockylinux
     tags: ["9"]
 
 # Distro definitions for generate-dockerfile.sh

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -77,10 +77,16 @@ _wrap_list() {
 # and the cached tag stay in lockstep with no duplicated literal.
 # ============================================================
 
-# Read the pinned base-image tag for a given build-arg from base_image_cache.
+# Read the pinned base-image tag for a given build-arg from base_image_cache (old-schema: .arg lookup).
 _base_cache_tag() {
     local arg="$1"
     YQ_ARG="$arg" yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0] // ""' "$config"
+}
+
+# Read the pinned base-image tag for a given source path from base_image_cache (new-schema: .source lookup).
+_base_cache_tag_new() {
+    local source="$1"
+    YQ_SOURCE="$source" yq -r '.base_image_cache[] | select(.source == strenv(YQ_SOURCE)) | .tags[0] // ""' "$config"
 }
 
 case "$distro" in
@@ -89,25 +95,25 @@ case "$distro" in
 FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}'
         ;;
     alpine)
-        alpine_tag=$(_base_cache_tag "ALPINE_BASE")
-        [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for ALPINE_BASE in $config"; exit 1; }
-        base_block="ARG ALPINE_BASE=alpine
+        alpine_tag=$(_base_cache_tag_new "library/alpine")
+        [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for library/alpine in $config"; exit 1; }
+        base_block="ARG REMOTE_CR
 ARG ALPINE_TAG=${alpine_tag}
-FROM \${ALPINE_BASE}:\${ALPINE_TAG}"
+FROM \${REMOTE_CR}/library/alpine:\${ALPINE_TAG}"
         ;;
     ubuntu)
-        ubuntu_tag=$(_base_cache_tag "UBUNTU_BASE")
-        [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for UBUNTU_BASE in $config"; exit 1; }
-        base_block="ARG UBUNTU_BASE=ubuntu
+        ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
+        [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $config"; exit 1; }
+        base_block="ARG REMOTE_CR
 ARG UBUNTU_TAG=${ubuntu_tag}
-FROM \${UBUNTU_BASE}:\${UBUNTU_TAG}"
+FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_TAG}"
         ;;
     rocky)
-        rocky_tag=$(_base_cache_tag "ROCKY_BASE")
-        [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for ROCKY_BASE in $config"; exit 1; }
-        base_block="ARG ROCKY_BASE=rockylinux
+        rocky_tag=$(_base_cache_tag_new "library/rockylinux")
+        [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for library/rockylinux in $config"; exit 1; }
+        base_block="ARG REMOTE_CR
 ARG ROCKY_TAG=${rocky_tag}
-FROM \${ROCKY_BASE}:\${ROCKY_TAG}"
+FROM \${REMOTE_CR}/library/rockylinux:\${ROCKY_TAG}"
         ;;
     *)
         log_error "No BASE_IMAGE template for distro: $distro"

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -75,13 +75,12 @@ _wrap_list() {
 # publishes :9). The default tag is read from base_image_cache[].tags[0] in
 # config.yaml — the SAME value the cache-population job uses — so the FROM tag
 # and the cached tag stay in lockstep with no duplicated literal.
+#
+# For alpine/ubuntu/rocky, the FROM line now references ${REMOTE_CR}/library/<distro>:${TAG}
+# so the CI probe can override REMOTE_CR=ghcr.io/<owner> when the mirror is reachable.
+# The debian distro still resolves to ghcr.io/oorabona/debian directly (first-party
+# image, not a docker.io mirror — so no REMOTE_CR substitution applies there).
 # ============================================================
-
-# Read the pinned base-image tag for a given build-arg from base_image_cache (old-schema: .arg lookup).
-_base_cache_tag() {
-    local arg="$1"
-    YQ_ARG="$arg" yq -r '.base_image_cache[] | select(.arg == strenv(YQ_ARG)) | .tags[0] // ""' "$config"
-}
 
 # Read the pinned base-image tag for a given source path from base_image_cache (new-schema: .source lookup).
 _base_cache_tag_new() {


### PR DESCRIPTION
Refs #493 (extends Slice 2 / PR #506). Migrates web-shell's 3 docker.io-based distros (alpine, ubuntu, rocky) to the `${REMOTE_CR}/library/<distro>` pattern. github-runner migration deferred to Slice 3b.

## Summary

Pre-Slice 3a, web-shell's generator emitted a Two-ARG pattern per distro (e.g. `ARG ALPINE_BASE=alpine + FROM ${ALPINE_BASE}:${ALPINE_TAG}`), with per-distro CI overrides via `*_BASE` arg. This PR replaces the Two-ARG pattern with `FROM ${REMOTE_CR}/library/<distro>:${<DISTRO>_TAG}` (mirroring Slice 2 mono-distro containers).

The fourth distro (debian) stays internal — it sources from `ghcr.io/oorabona/debian` (a first-party image, not a docker.io mirror).

## Changes

- `web-shell/Dockerfile` (template): `ARG REMOTE_CR=docker.io` added at top.
- `web-shell/generate-dockerfile.sh`: alpine/ubuntu/rocky cases emit `ARG REMOTE_CR` (stage re-import) + `FROM ${REMOTE_CR}/library/<distro>:${<DISTRO>_TAG}`. Debian case unchanged. New helper `_base_cache_tag_new()` reads tags from new-schema entries (by `source` instead of `arg`).
- `web-shell/config.yaml`: alpine/ubuntu/rocky entries switch to new-schema (`source: library/<distro>, tags: [...]`). Debian entry stays old-schema.
- `tests/unit/web-shell-base-image.bats`: 5/5 pass, updated to match new generator output. Adds 1 regression-lock test ensuring `ARG REMOTE_CR` is always emitted for migrated distros.

## GHCR setup (one-time, already done before this PR)

`library/rockylinux:9` newly created via `skopeo copy --all ghcr.io/oorabona/rocky-base:9 ghcr.io/oorabona/library/rockylinux:9` + made public via UI. `library/alpine:3.21` and `library/ubuntu:noble` added as new tags on the existing public packages.

All 3 mirrors are multi-arch (`amd64 + arm64 + arm + ppc64le + s390x + riscv64` etc).

## Known limitation (accepted, not blocking)

`emit_reachable_cache_args` + `remote_cr_applicable` are all-or-nothing: REMOTE_CR is emitted only if **all** new-schema entries in a container's config are reachable on GHCR. For mono-distro containers (postgres, ansible, openresty, ...) this is fine — there's only one entry. For multi-variant containers like web-shell that build one distro per Dockerfile, this means a missing `library/ubuntu` mirror disables the GHCR override for the alpine and rocky variants too (they'd fall back to docker.io with rate-limit risk).

Risk in practice:
- All 3 library/<distro> mirrors are pre-populated multi-arch + public + stable.
- Disappearance scenario: someone deletes one of the packages OR GHCR has an outage on a specific package. Low probability.
- Fallback path: docker.io anonymous pull. Works, just rate-limited under load.

Proper fix would refactor `emit_reachable_cache_args` to support per-variant flagging for multi-variant containers. That's a generic CI improvement worth doing but out of scope for this PR. Filed mentally as future work; if observed in practice, file follow-up issue.

## Out of scope (deferred)

- **github-runner** (Slice 3b): similar pattern via `github-runner/Dockerfile.linux` template. Will get its own PR.
- `emit_reachable_cache_args` per-variant refactor: see "Known limitation" above.

## Test plan

- [ ] CI passes (shellcheck, bats, container builds)
- [ ] Post-merge: trigger `gh workflow run auto-build.yaml -f container=web-shell -f force_rebuild=true` and verify each distro variant pulls from `${REMOTE_CR}/library/<distro>` (probe verdict in step logs)
- [ ] Dashboard provenance still captures correct `base_image_digest` for each web-shell variant

## Validation

- Schema validator: `web-shell/config.yaml` PASS (hybrid old + new entries supported).
- Generator end-to-end test: all 4 distros produce expected FROM lines.
- Bats: 5/5 pass.
- Pre-PR orthogonal gate: codex CLEAN. Copilot REFUSE on the all-or-nothing concern (documented above as accepted limitation).
