### PR TITLE
ci(base-cache): #493 Slice 3b — migrate github-runner ubuntu-2404 to REMOTE_CR

### DIFF
--- a/github-runner/Dockerfile.linux
+++ b/github-runner/Dockerfile.linux
@@ -8,6 +8,7 @@
 #
 # Build: generate-dockerfile.sh <distro> <build_flavor> > Dockerfile.<distro>-<build_flavor>
 #        docker buildx build --build-arg VERSION=2.332.0 -f Dockerfile.<distro>-<build_flavor> .
+ARG REMOTE_CR=docker.io
 # @@BASE_IMAGE@@
 
 # Ensure root for package installation (some base images set a non-root USER)

--- a/github-runner/config.yaml
+++ b/github-runner/config.yaml
@@ -39,9 +39,7 @@ dockerfile_generator: generate-dockerfile.sh
 # Base image cache for Docker Hub rate limiting
 # NOTE: debian-trixie comes from ghcr.io/oorabona/debian — no caching needed
 base_image_cache:
-  - arg: UBUNTU_2404_BASE
-    source: ubuntu
-    ghcr_repo: ubuntu-base
+  - source: library/ubuntu
     tags: ["24.04"]
 # NOTE: windows/server cannot be cached via skopeo (MCR auth required)
 # Dev stage pulls directly from MCR during build

--- a/github-runner/generate-dockerfile.sh
+++ b/github-runner/generate-dockerfile.sh
@@ -30,6 +30,16 @@ TEMPLATE="$SCRIPT_DIR/Dockerfile.linux"
 [[ -f "$TEMPLATE" ]] || { log_error "Dockerfile.linux not found: $TEMPLATE"; exit 1; }
 
 # ---------------------------------------------------------------------------
+# _base_cache_tag_new <source>
+# Read the pinned base-image tag for a given new-schema source path from
+# base_image_cache (new-style: no ghcr_repo, source is "library/foo" form).
+# ---------------------------------------------------------------------------
+_base_cache_tag_new() {
+    local source="$1"
+    YQ_SOURCE="$source" yq -r '.base_image_cache[] | select(.ghcr_repo == null or .ghcr_repo == "") | select(.source == strenv(YQ_SOURCE)) | .tags[0] // ""' "$CONFIG"
+}
+
+# ---------------------------------------------------------------------------
 # Generate a single distro+flavor combination — prints to stdout
 # ---------------------------------------------------------------------------
 generate_one() {
@@ -78,19 +88,31 @@ generate_one() {
 
     # ========================================================================
     # @@BASE_IMAGE@@ — ARG + FROM lines
-    # Strip the ${VAR:-default} shell syntax from base_image if present;
-    # we emit "ARG <arg>=<raw_default>" so Docker resolves it cleanly.
+    # ubuntu-2404: new-schema two-ARG pattern (REMOTE_CR + tag ARG).
+    # Other distros: generic single-ARG pattern from config base_image_arg.
     # ========================================================================
-    local raw_default
-    if [[ "$base_image" =~ ^\$\{[A-Za-z0-9_]+:-(.+)\}$ ]]; then
-        raw_default="${BASH_REMATCH[1]}"
-    else
-        raw_default="$base_image"
-    fi
-
     local base_block
-    base_block="ARG ${base_image_arg}=${raw_default}"$'\n'
-    base_block+="FROM \${${base_image_arg}}"$'\n'
+    case "$distro" in
+        ubuntu-2404)
+            local ubuntu_tag
+            ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
+            [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $CONFIG"; exit 1; }
+            base_block="ARG REMOTE_CR"$'\n'
+            base_block+="ARG UBUNTU_2404_TAG=${ubuntu_tag}"$'\n'
+            base_block+="FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_2404_TAG}"$'\n'
+            ;;
+        *)
+            # Generic single-ARG pattern: strip ${VAR:-default} shell syntax if present
+            local raw_default
+            if [[ "$base_image" =~ ^\$\{[A-Za-z0-9_]+:-(.+)\}$ ]]; then
+                raw_default="${BASH_REMATCH[1]}"
+            else
+                raw_default="$base_image"
+            fi
+            base_block="ARG ${base_image_arg}=${raw_default}"$'\n'
+            base_block+="FROM \${${base_image_arg}}"$'\n'
+            ;;
+    esac
 
     # ========================================================================
     # @@LABELS@@ — OCI image labels + runner metadata


### PR DESCRIPTION
Refs #493 (extends Slice 3a / PR #509). Closes the multi-variant phase of the REMOTE_CR migration: github-runner's ubuntu-2404 linux distro now uses `${REMOTE_CR}/library/ubuntu`. Other distros stay unchanged.

## Summary

| Distro | State |
|---|---|
| `ubuntu-2404` (linux) | **migrated** — `FROM ${REMOTE_CR}/library/ubuntu:${UBUNTU_2404_TAG}` |
| `debian-trixie` (linux) | unchanged — first-party `ghcr.io/oorabona/debian` (not a docker.io mirror) |
| `windows-ltsc2022` | unchanged — `mcr.microsoft.com/...` (out of REMOTE_CR scope) |

## Changes

- `github-runner/Dockerfile.linux` (template): `ARG REMOTE_CR=docker.io` added at top.
- `github-runner/generate-dockerfile.sh`: ubuntu-2404 case emits the new pattern (template-global `ARG REMOTE_CR=docker.io` + stage `ARG REMOTE_CR` re-import + `FROM ${REMOTE_CR}/library/ubuntu:${UBUNTU_2404_TAG}`). Tag pulled via new helper `_base_cache_tag_new()` (matches by `source` instead of `arg`). debian-trixie case unchanged.
- `github-runner/config.yaml`: `UBUNTU_2404_BASE` entry switches from old-schema to new-schema (`source: library/ubuntu, tags: ["24.04"]`).

## Generated Dockerfiles

`Dockerfile.ubuntu-2404-base` and `Dockerfile.ubuntu-2404-dev` are gitignored artifacts produced at build time by `prepare-build-context.sh`. They are NOT committed; the CI regenerates them on each run from the template + config. Local regeneration after this PR shows the correct REMOTE_CR pattern.

## GHCR setup

No new packages needed — `ghcr.io/oorabona/library/ubuntu:24.04` was already pre-populated as part of Slice 3a preparation (web-shell's ubuntu variant uses the same package). The mirror is multi-arch and public.

## Validation

- Schema validator (`helpers/validate-base-cache-schema.sh`) PASS on github-runner/config.yaml
- Generator end-to-end test per (distro, flavor):
  - `ubuntu-2404 base/dev` → emits new REMOTE_CR pattern
  - `debian-trixie base/dev` → unchanged internal ghcr.io reference
- Pre-PR orthogonal gate: CLEAN (both codex + copilot)

## Test plan

- [ ] CI passes (shellcheck, bats, github-runner builds)
- [ ] Post-merge: trigger `gh workflow run auto-build.yaml -f container=github-runner -f force_rebuild=true` and verify the ubuntu-2404 variant pulls from `ghcr.io/<owner>/library/ubuntu:24.04` (probe verdict in step logs)
- [ ] debian-trixie variant continues to pull from `ghcr.io/oorabona/debian:trixie` unchanged
- [ ] Windows variant continues to pull from mcr.microsoft.com unchanged

## Out of scope (deferred)

- Same all-or-nothing REMOTE_CR cross-variant limitation as Slice 3a applies here — but github-runner has only ONE migrated entry (ubuntu-2404), so the multi-variant gating issue does not bite in practice. If a future container adds a second new-schema entry, revisit.
- Deletion of `ubuntu-base` GHCR package — can be done after observation that no consumer (including github-runner now) still references it. Conservative: wait 1-2 weeks observation.
