### PR TITLE
chore: re-include docs/index.md from broad ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ docs/audit/
 
 # Generated dashboard files (recreated by generate-dashboard.sh)
 index.md
+# Exception: docs/index.md is a tracked Jekyll content page (permalink /docs/),
+# not a generated dashboard artifact. Without this re-include, the broad
+# `index.md` pattern above silently shadows it.
+!docs/index.md
 docs/site/_data/containers.yml
 docs/site/_data/stats.yml
 docs/site/_containers/


### PR DESCRIPTION
Tiny chore: the .gitignore rule `index.md` (line 25, intended for generated dashboard artifacts) was silently shadowing `docs/index.md` — a tracked Jekyll content page (permalink `/docs/`).

The file remained tracked only because git ignore rules do not apply to already-tracked files, but `git ls-files -c -i --exclude-standard` flagged it as the sole tracked-but-ignored entry in the repo.

Add an explicit `!docs/index.md` re-include immediately after the broad pattern. The tracked-but-ignored audit list is now empty.

## Test plan

- [x] `git ls-files -c -i --exclude-standard` returns empty
- [x] `git check-ignore --no-index docs/index.md` shows the `!docs/index.md` rule wins
- [ ] CI passes (no functional change — gitignore-only)