### PR TITLE
ci(terraform): complete #493 REMOTE_CR migration residual

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -15,13 +15,12 @@ ARG AWS_CLI_VERSION
 ARG AZURE_CLI_VERSION
 ARG GCP_CLI_VERSION
 
-# Base image overrides for GHCR caching (CI sets these to avoid Docker Hub rate limits)
-ARG TERRAFORM_BASE
+# Registry root for GHCR caching (CI sets this to avoid Docker Hub rate limits)
 ARG REMOTE_CR=docker.io
 
 # Stage 1: Get Terraform binary
 # Use UPSTREAM_VERSION if provided (raw version without suffix), fallback to VERSION
-FROM ${TERRAFORM_BASE}:${UPSTREAM_VERSION:-${VERSION}} AS terraform
+FROM ${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION:-${VERSION}} AS terraform
 
 # Stage 2: Security tools (included in all flavors)
 ARG REMOTE_CR

--- a/terraform/config.yaml
+++ b/terraform/config.yaml
@@ -2,18 +2,15 @@
 # Base image and third-party dependency versions
 # NOTE: Tool versions are auto-updated during build by terraform/build script
 
-base_image: "hashicorp/terraform:${UPSTREAM_VERSION}"
+base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
 base_image_cache:
-  - arg: TERRAFORM_BASE
-    source: hashicorp/terraform
-    ghcr_repo: terraform-base
+  - source: hashicorp/terraform
     tags: ["${UPSTREAM_VERSION}"]
   - source: library/alpine
     tags: ["latest"]
   - source: library/python
     tags: ["3.12-alpine"]
 build_args:
-  TERRAFORM_BASE: "hashicorp/terraform"
   TFLINT_VERSION: "0.62.1"
   TRIVY_VERSION: "0.70.0"
   TERRAGRUNT_VERSION: "1.0.5"
@@ -28,10 +25,6 @@ build_args:
 # - monitored deps: type + source info
 # - frozen/excluded deps: monitor: false with reason
 dependency_sources:
-  TERRAFORM_BASE:
-    monitor: false
-    lifecycle: untracked
-    reason: "Base image fallback, not a version to track"
   TFLINT_VERSION:
     lifecycle: tracked
     type: github-release


### PR DESCRIPTION
## Summary

Completes the #493 REMOTE_CR migration for `terraform`, the only container left in the hybrid state after #506 (slice 2). The `hashicorp/terraform` base ref now follows the uniform `${REMOTE_CR}/<upstream-path>:${VERSION}` pattern like every other migrated container.

## What changed

**`terraform/Dockerfile`**
- Removed `ARG TERRAFORM_BASE` (no longer needed)
- `FROM ${TERRAFORM_BASE}:${UPSTREAM_VERSION:-${VERSION}}` → `FROM ${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION:-${VERSION}}`
- `ARG REMOTE_CR=docker.io` default preserved (makes raw `docker build` work locally without flags — one of #493's acceptance criteria)
- Other stages (security-tools, devops-tools, cloud-tools-gcp, final) already used `${REMOTE_CR}/library/...` — untouched

**`terraform/config.yaml`**
- `base_image: "hashicorp/terraform:..."` → `base_image: "${REMOTE_CR}/hashicorp/terraform:..."`
- `base_image_cache[0]`: dropped `arg: TERRAFORM_BASE` and `ghcr_repo: terraform-base` fields. The discriminator in `helpers/base-cache-utils.sh` switches the entry to NEW-style path-preserving mirror → writes go to `ghcr.io/<owner>/hashicorp/terraform` instead of `ghcr.io/<owner>/terraform-base`
- `build_args`: dropped `TERRAFORM_BASE: "hashicorp/terraform"` (no longer referenced)
- `dependency_sources`: dropped `TERRAFORM_BASE` entry (the ARG it tracked no longer exists)

## Effect

| | Before | After |
|---|--------|-------|
| Dockerfile FROM | `${TERRAFORM_BASE}:...` with CI overriding `TERRAFORM_BASE=ghcr.io/oorabona/terraform-base` | `${REMOTE_CR}/hashicorp/terraform:...` with CI setting `REMOTE_CR=ghcr.io/oorabona` |
| GHCR cache write path | `ghcr.io/oorabona/terraform-base:<tag>` (53 versions, last 2026-05-20) | `ghcr.io/oorabona/hashicorp/terraform:<tag>` (path-preserving mirror) |
| Local `docker build terraform/` | Fails (`ARG TERRAFORM_BASE` has no default → `InvalidDefaultArgInFrom`) | Works (REMOTE_CR defaults to docker.io → `docker.io/hashicorp/terraform:<tag>`) |

## Verification

- ✅ All 8 implementer verification gates passed (see commit body for details)
- ✅ Pre-push orthogonal gate (codex xhigh + copilot) → both CLEAN
- ✅ Diff: 2 files, +4 -12 lines

## Why this missed #506

Slice 2 (#506) migrated 9 mono-distro containers but their bases were all `library/<name>` (alpine, ubuntu, debian, ruby, php). The `hashicorp/terraform` non-library namespaced base case was explicitly listed in #493's viability table but not picked up in slice 2's mechanical sweep — easy miss since the `library/` containers were the bulk of the work.

## After merge

- Delete the now-fully-orphan `ghcr.io/oorabona/terraform-base` GHCR package (53 versions, no longer written)
- Same cleanup applies to `postgres-base` (341 versions, orphan since 2026-05-17) and `rocky-base` (9 versions, orphan since 2026-02-26)

Refs: #493 (parent), #506 (slice 2 that missed this), #492 (root-cause tag fix), ADR-009 (mirror, still safety net for fallback)
