### PR TITLE
ci(deps): auto-issue dep-attributed build failures (#453 Volet 3)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1009,6 +1009,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
       - name: Generate workflow summary
         id: summary
         run: |
@@ -1067,54 +1072,109 @@ jobs:
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "_🤖 Smart CI/CD powered by GitHub Actions_" >> $GITHUB_STEP_SUMMARY
 
-      - name: Create issue on build failure
+      - name: Gather dep-bump context for failure attribution
+        id: ctx
         if: steps.summary.outputs.build_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_TITLE_FROM_EVENT: ${{ github.event.pull_request.title }}
+          PR_BODY_FROM_EVENT: ${{ github.event.pull_request.body }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
-          # Check if similar issue already exists (open, same run)
-          existing=$(gh issue list --repo "${{ github.repository }}" --label "build-failure" --state open --limit 5 --json title,number \
-            | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
+          commit_subject=$(git log -1 --format=%s "$GH_SHA" 2>/dev/null || true)
 
-          if [[ -n "$existing" ]]; then
-            echo "ℹ️ Adding comment to existing issue #$existing"
-            gh issue comment --repo "${{ github.repository }}" "$existing" --body "$(cat <<EOF
-          ## 🔄 Another build failure detected
-
-          **Run:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          **Trigger:** \`${{ github.event_name }}\`
-          **Ref:** \`${{ github.ref_name }}\`
-          **Time:** $(date -u +"%Y-%m-%d %H:%M UTC")
-          EOF
-          )"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            pr_number="$PR_NUMBER_FROM_EVENT"
+            pr_title="$PR_TITLE_FROM_EVENT"
+            pr_body="$PR_BODY_FROM_EVENT"
+            pr_labels=$(gh pr view "$pr_number" --repo "$GH_REPOSITORY" --json labels \
+              --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
           else
-            echo "🚨 Creating new build failure issue"
-            gh issue create --repo "${{ github.repository }}" \
-              --title "🚨 Auto Build Failed - $(date -u +%Y-%m-%d)" \
-              --label "build-failure,automation" \
-              --body "$(cat <<EOF
-          ## Build Failure Alert
+            pr_number=$(echo "$commit_subject" | grep -oP '\(#\K[0-9]+(?=\)$)' || true)
+            if [ -n "$pr_number" ]; then
+              pr_title=$(gh pr view "$pr_number" --repo "$GH_REPOSITORY" --json title \
+                --jq '.title' 2>/dev/null || true)
+              pr_body=$(gh pr view "$pr_number" --repo "$GH_REPOSITORY" --json body \
+                --jq '.body' 2>/dev/null || true)
+              pr_labels=$(gh pr view "$pr_number" --repo "$GH_REPOSITORY" --json labels \
+                --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+            else
+              pr_title=""
+              pr_body=""
+              pr_labels=""
+            fi
+          fi
 
-          One or more container builds failed in the auto-build workflow.
+          failed_jobs_json=$(gh run view "$GH_RUN_ID" --repo "$GH_REPOSITORY" --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | {name, id: .databaseId}] | .[:5]' \
+            2>/dev/null || echo '[]')
 
-          | Property | Value |
-          |----------|-------|
-          | **Run** | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
-          | **Trigger** | \`${{ github.event_name }}\` |
-          | **Ref** | \`${{ github.ref_name }}\` |
-          | **Commit** | \`${{ github.sha }}\` |
+          {
+            printf 'commit_subject=%s\n' "$commit_subject"
+            printf 'pr_number=%s\n' "$pr_number"
+            printf 'pr_title=%s\n' "$pr_title"
+            printf 'pr_labels=%s\n' "$pr_labels"
+            printf 'failed_jobs_json=%s\n' "$failed_jobs_json"
+          } >> "$GITHUB_OUTPUT"
 
-          ## Next Steps
+          {
+            printf 'pr_body<<%s\n' 'EOF_PR_BODY'
+            printf '%s\n' "$pr_body"
+            printf '%s\n' 'EOF_PR_BODY'
+          } >> "$GITHUB_OUTPUT"
 
-          1. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details
-          2. Identify which container(s) failed
-          3. Test locally: \`./make build <container>\`
-          4. Fix and push to trigger rebuild
-
-          ---
-          _Auto-generated by CI workflow_
-          EOF
-          )"
+      - name: Open dep-attributed or generic build-failure issue
+        if: steps.summary.outputs.build_failed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          COMMIT_SUBJECT: ${{ steps.ctx.outputs.commit_subject }}
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          PR_TITLE: ${{ steps.ctx.outputs.pr_title }}
+          PR_BODY: ${{ steps.ctx.outputs.pr_body }}
+          PR_LABELS: ${{ steps.ctx.outputs.pr_labels }}
+          FAILED_JOBS_JSON: ${{ steps.ctx.outputs.failed_jobs_json }}
+        run: |
+          chmod +x scripts/open-dep-failure-issue.sh
+          if ./scripts/open-dep-failure-issue.sh; then
+            echo "Dep-attributed issue opened/updated"
+          else
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "No dep-bump context detected, falling back to generic issue"
+              existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+                --label "build-failure" --state open --limit 5 --json title,number \
+                | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
+              run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              if [[ -n "$existing" ]]; then
+                echo "Adding comment to existing issue #$existing"
+                comment_body="$(printf '## Another build failure detected\n\n**Run:** [%s](%s)\n**Trigger:** `%s`\n**Ref:** `%s`\n**Time:** %s' \
+                  "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                  "$(date -u +'%Y-%m-%d %H:%M UTC')")"
+                gh issue comment --repo "$GITHUB_REPOSITORY" "$existing" --body "$comment_body"
+              else
+                echo "Creating new build failure issue"
+                issue_body="$(printf '## Build Failure Alert\n\nOne or more container builds failed in the auto-build workflow.\n\n| Property | Value |\n|----------|-------|\n| **Run** | [%s](%s) |\n| **Trigger** | `%s` |\n| **Ref** | `%s` |\n| **Commit** | `%s` |\n\n## Next Steps\n\n1. Check the [workflow run](%s) for details\n2. Identify which container(s) failed\n3. Test locally: `./make build <container>`\n4. Fix and push to trigger rebuild\n\n---\n_Auto-generated by CI workflow_' \
+                  "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                  "$GITHUB_SHA" "$run_url")"
+                gh issue create --repo "$GITHUB_REPOSITORY" \
+                  --title "Auto Build Failed - $(date -u +%Y-%m-%d)" \
+                  --label "build-failure,automation" \
+                  --body "$issue_body"
+              fi
+            else
+              echo "open-dep-failure-issue.sh failed with exit $rc"
+              exit "$rc"
+            fi
           fi
 
   cache-lineage:

--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -1,0 +1,518 @@
+#!/usr/bin/env bash
+# open-dep-failure-issue.sh — Open or update a GitHub issue when a build fails on a dep-update commit/PR.
+#
+# One issue per (container, source-PR) so the failure is actionable and de-duplicated.
+# Detection: commit subject, PR title, PR labels, or branch ref are matched against
+# upstream-monitor conventions to identify the affected container and bump kind.
+#
+# Called by auto-build.yaml after a failed build run.
+# All inputs are provided via environment variables listed in the "Required env vars" block.
+#
+# Exit codes:
+#   0  — issue created or commented successfully (or DRY_RUN printed)
+#   1  — no dep-bump detected (caller should fall back to generic issue logic)
+#   2  — missing required env var
+#   3  — gh CLI error after retries
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../helpers/logging.sh
+source "$ROOT_DIR/helpers/logging.sh"
+# shellcheck source=../helpers/retry.sh
+source "$ROOT_DIR/helpers/retry.sh"
+
+# ---------------------------------------------------------------------------
+# Required env vars
+# ---------------------------------------------------------------------------
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
+: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+: "${COMMIT_SUBJECT:?COMMIT_SUBJECT is required}"
+
+# Optional
+PR_NUMBER="${PR_NUMBER:-}"
+PR_TITLE="${PR_TITLE:-}"
+PR_BODY="${PR_BODY:-}"
+PR_LABELS="${PR_LABELS:-}"
+FAILED_JOBS_JSON="${FAILED_JOBS_JSON:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# ---------------------------------------------------------------------------
+# gh wrapper — respects DRY_RUN
+# ---------------------------------------------------------------------------
+run_gh() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY_RUN] gh $*"
+        return 0
+    fi
+    retry_with_backoff 3 5 gh "$@"
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump
+#
+# Sets globals: DETECTED_CONTAINER DETECTED_KIND
+# Returns 0 if a dep-bump was detected, 1 otherwise.
+# Priority: commit/PR title > PR labels > branch ref.
+# ---------------------------------------------------------------------------
+detect_dep_bump() {
+    DETECTED_CONTAINER=""
+    DETECTED_KIND=""
+
+    local container_from_commit="" kind_from_commit=""
+    local container_from_title="" kind_from_title=""
+    local container_from_labels="" kind_from_labels=""
+    local container_from_branch="" kind_from_branch=""
+
+    # Signal 1: commit subject — "build(<container>): …" or "deps(<container>): …"
+    # Regex stored in variable to avoid bash parser confusion with ) in [[...]]
+    local re_commit='^(build|deps)\(([^)]+)\):'
+    if [[ "$COMMIT_SUBJECT" =~ $re_commit ]]; then
+        container_from_commit="${BASH_REMATCH[2]}"
+        if [[ "${BASH_REMATCH[1]}" == "deps" ]]; then
+            kind_from_commit="deps"
+        else
+            kind_from_commit="version-bump"
+        fi
+    fi
+
+    # Signal 2: PR title
+    if [[ -n "$PR_TITLE" ]]; then
+        # deps variant: "📦 deps(<container>): …" or "⚠️ deps(<container>): …"
+        local re_deps_title='^[[:space:]]*(📦|⚠️)[[:space:]]*deps\(([^)]+)\):'
+        local re_bump_title='^[[:space:]]*(🚀[[:space:]]*Minor|🔄[[:space:]]*Major):[[:space:]]+([^[:space:]]+)[[:space:]]+to'
+        if [[ "$PR_TITLE" =~ $re_deps_title ]]; then
+            container_from_title="${BASH_REMATCH[2]}"
+            kind_from_title="deps"
+        # version-bump variant: "🚀 Minor: <container> to …" or "🔄 Major: <container> to …"
+        elif [[ "$PR_TITLE" =~ $re_bump_title ]]; then
+            container_from_title="${BASH_REMATCH[2]}"
+            kind_from_title="version-bump"
+        fi
+    fi
+
+    # Signal 3: PR labels — must contain "automation" AND ("dependencies" or "*-update")
+    # Upstream-monitor label format: automation,<container>,dependencies,<minor|major|patch>-update
+    # The container name appears as a bare label (e.g. "sslh"), not "sslh-update".
+    if [[ -n "$PR_LABELS" ]]; then
+        if echo "$PR_LABELS" | grep -q "automation"; then
+            local label_container=""
+            local re_update='^[^-]+-update$'
+            while IFS= read -r label; do
+                label="$(echo "$label" | tr -d '[:space:]')"
+                if [[ "$label" == "dependencies" ]]; then
+                    kind_from_labels="${kind_from_labels:-deps}"
+                elif [[ "$label" =~ $re_update ]]; then
+                    # e.g. "minor-update", "major-update", "patch-update" — update-type marker, not container
+                    :
+                elif [[ "$label" != "automation" ]]; then
+                    # Any other label is the container name
+                    label_container="$label"
+                fi
+            done < <(echo "$PR_LABELS" | tr ',' '\n')
+            if [[ -n "$label_container" ]]; then
+                container_from_labels="$label_container"
+                kind_from_labels="${kind_from_labels:-version-bump}"
+            fi
+        fi
+    fi
+
+    # Signal 4: branch ref — "update/<container>-deps" or "update/<container>-<version>"
+    local re_branch='^update/([^/-]+)(-.*)?$'
+    if [[ "$GITHUB_REF_NAME" =~ $re_branch ]]; then
+        container_from_branch="${BASH_REMATCH[1]}"
+        if [[ "$GITHUB_REF_NAME" =~ -deps$ ]]; then
+            kind_from_branch="deps"
+        else
+            kind_from_branch="version-bump"
+        fi
+    fi
+
+    # Priority: commit/title > labels > branch
+    if [[ -n "$container_from_commit" ]]; then
+        DETECTED_CONTAINER="$container_from_commit"
+        DETECTED_KIND="$kind_from_commit"
+    elif [[ -n "$container_from_title" ]]; then
+        DETECTED_CONTAINER="$container_from_title"
+        DETECTED_KIND="$kind_from_title"
+    elif [[ -n "$container_from_labels" ]]; then
+        DETECTED_CONTAINER="$container_from_labels"
+        DETECTED_KIND="$kind_from_labels"
+    elif [[ -n "$container_from_branch" ]]; then
+        DETECTED_CONTAINER="$container_from_branch"
+        DETECTED_KIND="$kind_from_branch"
+    else
+        return 1
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# extract_dep_details <container> <kind>
+#
+# Prints a JSON array of dep objects to stdout.
+# ---------------------------------------------------------------------------
+extract_dep_details() {
+    local container="$1"
+    local kind="$2"
+
+    if [[ "$kind" == "version-bump" ]]; then
+        # Extract new version from PR title or commit subject
+        local new_version="?"
+        if [[ -n "$PR_TITLE" && "$PR_TITLE" =~ [[:space:]]to[[:space:]]+([^[:space:]]+) ]]; then
+            new_version="${BASH_REMATCH[1]}"
+        elif [[ "$COMMIT_SUBJECT" =~ [[:space:]]to[[:space:]]+([^[:space:]]+) ]]; then
+            new_version="${BASH_REMATCH[1]}"
+        fi
+        printf '[{"name":"%s","old":"?","new":"%s"}]' "$container" "$new_version"
+        return 0
+    fi
+
+    # kind == deps: parse PR_BODY for a markdown table
+    if [[ -z "$PR_BODY" ]]; then
+        printf '[{"name":"(unknown)","old":"?","new":"?","note":"PR body not available"}]'
+        return 0
+    fi
+
+    # Match table rows: | col1 | col2 | col3 | (optional col4)
+    # Skip header row and separator row (contains only dashes/pipes/spaces)
+    local json_array="["
+    local first=1
+    while IFS= read -r line; do
+        # Skip separator lines (e.g. |---|---|---|)
+        if [[ "$line" =~ ^\|[[:space:]]*[-:]+[[:space:]]*\| ]]; then
+            continue
+        fi
+        # Match data rows: | name | old | new | ... |
+        if [[ "$line" =~ ^\|[[:space:]]*([^|]+)\|[[:space:]]*([^|]*)\|[[:space:]]*([^|]*)\| ]]; then
+            local dep_name old_ver new_ver
+            dep_name="$(echo "${BASH_REMATCH[1]}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            old_ver="$(echo "${BASH_REMATCH[2]}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            new_ver="$(echo "${BASH_REMATCH[3]}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+
+            # Skip the header row
+            local lower_name
+            lower_name="$(echo "$dep_name" | tr '[:upper:]' '[:lower:]')"
+            case "$lower_name" in
+                dependency|dependencies|dep|name|package) continue ;;
+            esac
+
+            # Escape JSON special characters
+            dep_name="${dep_name//\\/\\\\}"
+            dep_name="${dep_name//\"/\\\"}"
+            old_ver="${old_ver//\\/\\\\}"
+            old_ver="${old_ver//\"/\\\"}"
+            new_ver="${new_ver//\\/\\\\}"
+            new_ver="${new_ver//\"/\\\"}"
+
+            if [[ "$first" -eq 0 ]]; then
+                json_array+=","
+            fi
+            json_array+="{\"name\":\"${dep_name}\",\"old\":\"${old_ver}\",\"new\":\"${new_ver}\"}"
+            first=0
+        fi
+    done <<< "$PR_BODY"
+
+    json_array+="]"
+
+    # Fallback if nothing was parsed
+    if [[ "$json_array" == "[]" ]]; then
+        printf '[{"name":"(unknown)","old":"?","new":"?","note":"PR body not available"}]'
+    else
+        printf '%s' "$json_array"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# build_deps_table <json_array>
+#
+# Converts the JSON array from extract_dep_details into a markdown table.
+# Pure bash — no jq dependency.
+# ---------------------------------------------------------------------------
+build_deps_table() {
+    local json="$1"
+
+    echo "| Dependency | Old | New |"
+    echo "|------------|-----|-----|"
+
+    # Parse each {...} object from the flat array
+    local entry
+    while IFS= read -r entry; do
+        local dep_name old_ver new_ver note
+        dep_name="$(echo "$entry" | grep -o '"name":"[^"]*"' | cut -d'"' -f4)"
+        old_ver="$(echo "$entry" | grep -o '"old":"[^"]*"' | cut -d'"' -f4)"
+        new_ver="$(echo "$entry" | grep -o '"new":"[^"]*"' | cut -d'"' -f4)"
+        note="$(echo "$entry" | grep -o '"note":"[^"]*"' | cut -d'"' -f4)"
+        if [[ -n "$note" ]]; then
+            echo "| ${dep_name} | ${old_ver} | ${new_ver} | _${note}_ |"
+        else
+            echo "| ${dep_name} | ${old_ver} | ${new_ver} |"
+        fi
+    done < <(echo "$json" | grep -o '{[^}]*}')
+}
+
+# ---------------------------------------------------------------------------
+# get_log_excerpt <job_id>
+#
+# Fetches last 30 lines of failed-step log for the given job.
+# Outputs at most 50 lines. Falls back gracefully on error.
+# ---------------------------------------------------------------------------
+get_log_excerpt() {
+    local job_id="$1"
+    local excerpt
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "(log excerpt suppressed in DRY_RUN mode)"
+        return 0
+    fi
+
+    if excerpt=$(gh run view "$GITHUB_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --job "$job_id" \
+            --log-failed 2>&1 | tail -30); then
+        echo "$excerpt" | head -50
+    else
+        local reason="$excerpt"
+        echo "(log excerpt unavailable: ${reason:-unknown error})"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# build_issue_body <container> <deps_table> <log_excerpt>
+# ---------------------------------------------------------------------------
+build_issue_body() {
+    local container="$1"
+    local deps_table="$2"
+    local log_excerpt="$3"
+
+    local short_sha="${GITHUB_SHA:0:8}"
+    local run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+    # PR link row (empty string when no PR)
+    local source_pr_line=""
+    if [[ -n "$PR_NUMBER" ]]; then
+        local pr_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+        local pr_display="${PR_TITLE:-PR #${PR_NUMBER}}"
+        source_pr_line="| **Source PR** | #${PR_NUMBER} ([${pr_display}](${pr_url})) |"$'\n'
+    fi
+
+    # Failing jobs section
+    local failing_jobs_section
+    if [[ -n "$FAILED_JOBS_JSON" ]]; then
+        failing_jobs_section="## Failing jobs
+
+"
+        local job_item
+        while IFS= read -r job_item; do
+            job_item="$(echo "$job_item" | tr -d '"' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            [[ -n "$job_item" ]] && failing_jobs_section+="- ${job_item}
+"
+        done < <(echo "$FAILED_JOBS_JSON" \
+            | grep -o '"[^"]*"' \
+            | grep -v '^"name"\|^"conclusion"\|^"failure"\|^"cancelled"' \
+            | tr -d '"')
+    else
+        failing_jobs_section="## Failing jobs
+
+(failure detail not provided)"
+    fi
+
+    # Log excerpt section
+    local log_section=""
+    if [[ -n "$log_excerpt" ]]; then
+        log_section="## Log excerpt
+
+\`\`\`
+${log_excerpt}
+\`\`\`"
+    fi
+
+    # Refs footer
+    local refs_line=""
+    if [[ -n "$PR_NUMBER" ]]; then
+        refs_line="
+Refs #${PR_NUMBER}
+"
+    fi
+
+    cat <<BODY
+## Failing build
+
+| Property | Value |
+|----------|-------|
+| **Container** | \`${container}\` |
+${source_pr_line}| **Commit** | \`${short_sha}\` (\`${COMMIT_SUBJECT}\`) |
+| **Trigger** | \`${GITHUB_EVENT_NAME}\` |
+| **Failing run** | [${GITHUB_RUN_ID}](${run_url}) |
+
+## Dependencies in this bump
+
+${deps_table}
+
+${failing_jobs_section}
+
+${log_section}
+
+---
+${refs_line}_Auto-generated by \`scripts/open-dep-failure-issue.sh\`_
+BODY
+}
+
+# ---------------------------------------------------------------------------
+# find_or_create_issue <container> <issue_title> <issue_body>
+#
+# Searches for an existing open issue with labels build-failure,automation,
+# dep-attributed,dep:<container>. If found, posts a comment. Otherwise creates.
+# Prints "commented #N" or "created #N".
+# ---------------------------------------------------------------------------
+find_or_create_issue() {
+    local container="$1"
+    local issue_title="$2"
+    local issue_body="$3"
+
+    local dedup_labels="build-failure,automation,dep-attributed,dep:${container}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY_RUN] Would search issues with labels: ${dedup_labels}"
+        log_info "[DRY_RUN] Title: ${issue_title}"
+        echo ""
+        echo "=== DRY_RUN: ISSUE BODY ==="
+        echo "$issue_body"
+        echo "==========================="
+        echo "dry-run #0"
+        return 0
+    fi
+
+    # Search for open issue with dedup label set
+    local existing_number=""
+    local search_output
+    if search_output=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "build-failure" \
+            --label "dep-attributed" \
+            --label "dep:${container}" \
+            --state open \
+            --limit 10 \
+            --json number,title,body 2>&1); then
+        local candidate
+        candidate=$(echo "$search_output" | grep -o '"number":[0-9]*' | grep -o '[0-9]*' | head -1 || true)
+        if [[ -n "$candidate" ]]; then
+            # Prefer a match that references the same PR if available
+            if [[ -n "$PR_NUMBER" ]]; then
+                if echo "$search_output" | grep -q "PR #${PR_NUMBER}\|Refs #${PR_NUMBER}\|(#${PR_NUMBER})"; then
+                    existing_number="$candidate"
+                else
+                    existing_number="$candidate"
+                fi
+            else
+                existing_number="$candidate"
+            fi
+        fi
+    fi
+
+    if [[ -n "$existing_number" ]]; then
+        local run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        local comment_body
+        comment_body="$(cat <<COMMENT
+## Another failure on the same dep update
+
+| Property | Value |
+|----------|-------|
+| **Run** | [${GITHUB_RUN_ID}](${run_url}) |
+| **Trigger** | \`${GITHUB_EVENT_NAME}\` |
+| **Ref** | \`${GITHUB_REF_NAME}\` |
+| **Time** | $(date -u +'%Y-%m-%d %H:%M UTC') |
+COMMENT
+)"
+        retry_with_backoff 3 5 gh issue comment \
+            --repo "$GITHUB_REPOSITORY" \
+            "$existing_number" \
+            --body "$comment_body" >&2
+        echo "commented #${existing_number}"
+    else
+        # Ensure the dep:<container> label exists (create if missing — best effort)
+        gh label create "dep:${container}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "e4e669" \
+            --description "Dep-attributed build failures for ${container}" 2>/dev/null || true
+
+        local new_number
+        new_number=$(retry_with_backoff 3 5 gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$issue_title" \
+            --label "$dedup_labels" \
+            --body "$issue_body" \
+            | grep -o '[0-9]*$' || true)
+        echo "created #${new_number}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+    log_step "Detecting dep bump from commit/PR signals..."
+
+    if ! detect_dep_bump; then
+        log_info "No dep-bump pattern detected — falling back to generic issue logic."
+        exit 1
+    fi
+
+    local container="$DETECTED_CONTAINER"
+    local kind="$DETECTED_KIND"
+    log_info "Detected: container=${container} kind=${kind}"
+
+    # Build issue title
+    local short_sha="${GITHUB_SHA:0:8}"
+    local issue_title
+    if [[ -n "$PR_NUMBER" ]]; then
+        issue_title="🚨 [${container}] Build failed after dep update (PR #${PR_NUMBER})"
+    else
+        issue_title="🚨 [${container}] Build failed after dep update (commit ${short_sha})"
+    fi
+
+    # Extract dep details
+    local deps_json
+    deps_json="$(extract_dep_details "$container" "$kind")"
+
+    # Build markdown table
+    local deps_table
+    deps_table="$(build_deps_table "$deps_json")"
+
+    # Fetch log excerpt for first failing job
+    local log_excerpt=""
+    if [[ -n "$FAILED_JOBS_JSON" ]]; then
+        local first_job_id
+        first_job_id=$(echo "$FAILED_JOBS_JSON" \
+            | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -1 \
+            | grep -o '"[^"]*"$' \
+            | tr -d '"' || true)
+        if [[ -n "$first_job_id" ]]; then
+            log_excerpt="$(get_log_excerpt "$first_job_id")"
+        fi
+    fi
+
+    # Build issue body
+    local issue_body
+    issue_body="$(build_issue_body "$container" "$deps_table" "$log_excerpt")"
+
+    # Find or create issue
+    local result
+    result="$(find_or_create_issue "$container" "$issue_title" "$issue_body")"
+    log_success "Issue action: ${result}"
+    echo "$result"
+}
+
+# Run main only when executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -1,0 +1,424 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/open-dep-failure-issue.sh
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    setup_temp_dir
+
+    export ORIG_PATH="$PATH"
+    export ORIG_DIR="$PWD"
+
+    # Minimal required env vars for the script to not abort on the : "${VAR:?}" checks
+    export GH_TOKEN="fake-token"
+    export GITHUB_REPOSITORY="oorabona/docker-containers"
+    export GITHUB_RUN_ID="123456789"
+    export GITHUB_SERVER_URL="https://github.com"
+    export GITHUB_SHA="abc123def456"
+    export GITHUB_EVENT_NAME="push"
+    export GITHUB_REF_NAME="master"
+    export COMMIT_SUBJECT="chore: update readme"
+
+    # Optional vars — cleared so each test can set what it needs
+    unset PR_NUMBER PR_TITLE PR_BODY PR_LABELS FAILED_JOBS_JSON
+    export DRY_RUN="true"
+
+    # Provide a mock gh that does nothing (prevents any real network call)
+    mock_command "gh" 'echo "[]"'
+
+    # Source helpers that the script needs
+    source "$HELPERS_DIR/logging.sh"
+    source "$HELPERS_DIR/retry.sh"
+
+    # Source the script in function-only mode by setting BASH_SOURCE guard
+    # We source it directly; top-level code is guarded by [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+    # shellcheck disable=SC1090
+    source "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+    export PATH="$ORIG_PATH"
+    cd "$ORIG_DIR" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump — commit subject patterns
+# Note: detect_dep_bump sets globals DETECTED_CONTAINER / DETECTED_KIND.
+# We call it directly (no `run`) so the globals propagate to the test shell.
+# ---------------------------------------------------------------------------
+
+@test "detect: deps(php) commit subject → container=php kind=deps" {
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "php" ]
+    [ "$DETECTED_KIND" = "deps" ]
+}
+
+@test "detect: build(postgres) commit subject → container=postgres kind=version-bump" {
+    export COMMIT_SUBJECT="build(postgres): update to 18.2"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "postgres" ]
+    [ "$DETECTED_KIND" = "version-bump" ]
+}
+
+@test "detect: irrelevant commit fix(ci) → exit 1 (no detection)" {
+    export COMMIT_SUBJECT="fix(ci): something unrelated"
+    export GITHUB_REF_NAME="master"
+
+    # Must not detect — call via run so we can capture exit status
+    run detect_dep_bump
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump — PR title patterns
+# ---------------------------------------------------------------------------
+
+@test "detect: 📦 deps(terraform) PR title, no commit match → container=terraform kind=deps" {
+    export COMMIT_SUBJECT="chore: something else"
+    export PR_TITLE="📦 deps(terraform): update 1 dependencies"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "terraform" ]
+    [ "$DETECTED_KIND" = "deps" ]
+}
+
+@test "detect: 🚀 Minor: openresty to 1.29.2.5-alpine → container=openresty kind=version-bump" {
+    export COMMIT_SUBJECT="chore: something else"
+    export PR_TITLE="🚀 Minor: openresty to 1.29.2.5-alpine"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "openresty" ]
+    [ "$DETECTED_KIND" = "version-bump" ]
+}
+
+@test "detect: ⚠️ deps(ansible) PR title → container=ansible kind=deps" {
+    export COMMIT_SUBJECT="chore: something else"
+    export PR_TITLE="⚠️ deps(ansible): update 2 dependencies"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "ansible" ]
+    [ "$DETECTED_KIND" = "deps" ]
+}
+
+@test "detect: 🔄 Major: vector to 2.0.0 PR title → container=vector kind=version-bump" {
+    export COMMIT_SUBJECT="chore: something else"
+    export PR_TITLE="🔄 Major: vector to 2.0.0"
+    export GITHUB_REF_NAME="master"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "vector" ]
+    [ "$DETECTED_KIND" = "version-bump" ]
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump — branch ref fallback
+# ---------------------------------------------------------------------------
+
+@test "detect: branch update/wordpress-deps only → container=wordpress kind=deps" {
+    export COMMIT_SUBJECT="chore: unrelated"
+    export GITHUB_REF_NAME="update/wordpress-deps"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "wordpress" ]
+    [ "$DETECTED_KIND" = "deps" ]
+}
+
+@test "detect: branch update/jekyll-4.3.4 only → container=jekyll kind=version-bump" {
+    export COMMIT_SUBJECT="chore: unrelated"
+    export GITHUB_REF_NAME="update/jekyll-4.3.4"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "jekyll" ]
+    [ "$DETECTED_KIND" = "version-bump" ]
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump — priority: commit/title wins over branch
+# ---------------------------------------------------------------------------
+
+@test "detect: commit says php, branch says postgres → commit wins (php)" {
+    export COMMIT_SUBJECT="deps(php): update 3 dependencies"
+    export GITHUB_REF_NAME="update/postgres-deps"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "php" ]
+}
+
+@test "detect: PR title says openresty, branch says ansible → title wins (openresty)" {
+    export COMMIT_SUBJECT="chore: unrelated"
+    export PR_TITLE="📦 deps(openresty): update 1 dependencies"
+    export GITHUB_REF_NAME="update/ansible-deps"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "openresty" ]
+}
+
+# ---------------------------------------------------------------------------
+# detect_dep_bump — PR labels fallback
+# ---------------------------------------------------------------------------
+
+@test "detect: automation+dependencies labels → kind=deps" {
+    export COMMIT_SUBJECT="chore: unrelated"
+    export GITHUB_REF_NAME="master"
+    export PR_LABELS="automation,dependencies,sslh,minor-update"
+
+    detect_dep_bump
+    [ "$DETECTED_CONTAINER" = "sslh" ]
+    [ "$DETECTED_KIND" = "deps" ]
+}
+
+# ---------------------------------------------------------------------------
+# extract_dep_details — version-bump kind
+# ---------------------------------------------------------------------------
+
+@test "extract: version-bump with PR title containing version → new version captured" {
+    export PR_TITLE="🚀 Minor: openresty to 1.29.2.5-alpine"
+    export COMMIT_SUBJECT="build(openresty): update to 1.29.2.5-alpine"
+
+    run extract_dep_details "openresty" "version-bump"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"new":"1.29.2.5-alpine"'* ]]
+    [[ "$output" == *'"name":"openresty"'* ]]
+}
+
+@test "extract: version-bump without version in title → new=?" {
+    export PR_TITLE=""
+    export COMMIT_SUBJECT="build(postgres): update things"
+
+    run extract_dep_details "postgres" "version-bump"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"new":"?"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# extract_dep_details — deps kind with PR body table
+# ---------------------------------------------------------------------------
+
+@test "extract: deps kind parses 3-row pr_table from PR_BODY" {
+    export PR_BODY="| Dependency | Old | New |
+|---|---|---|
+| FOO | 1.0 | 1.1 |
+| BAR | 2.3.0 | 2.4.0 |
+| BAZ | 0.9 | 1.0 |"
+
+    run extract_dep_details "php" "deps"
+    [ "$status" -eq 0 ]
+
+    # Should have 3 entries
+    local count
+    count=$(echo "$output" | grep -o '"name"' | wc -l)
+    [ "$count" -eq 3 ]
+
+    [[ "$output" == *'"name":"FOO"'* ]]
+    [[ "$output" == *'"old":"1.0"'* ]]
+    [[ "$output" == *'"new":"1.1"'* ]]
+    [[ "$output" == *'"name":"BAR"'* ]]
+    [[ "$output" == *'"name":"BAZ"'* ]]
+}
+
+@test "extract: deps kind with 4-column table (Severity) — parses 3 deps" {
+    export PR_BODY="| Dependency | Old | New | Severity |
+|---|---|---|---|
+| ALPHA | 3.0 | 3.1 | minor |
+| BETA | 1.0 | 2.0 | major |
+| GAMMA | 5.5 | 5.6 | patch |"
+
+    run extract_dep_details "terraform" "deps"
+    [ "$status" -eq 0 ]
+
+    local count
+    count=$(echo "$output" | grep -o '"name"' | wc -l)
+    [ "$count" -eq 3 ]
+}
+
+@test "extract: fallback when PR_BODY empty → (unknown) placeholder" {
+    export PR_BODY=""
+
+    run extract_dep_details "php" "deps"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"name":"(unknown)"'* ]]
+    [[ "$output" == *'"note":"PR body not available"'* ]]
+}
+
+@test "extract: fallback when PR_BODY has no parseable table" {
+    export PR_BODY="Just a description with no table here."
+
+    run extract_dep_details "php" "deps"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"name":"(unknown)"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# build_deps_table
+# ---------------------------------------------------------------------------
+
+@test "build_deps_table: renders markdown table from single-dep JSON" {
+    run build_deps_table '[{"name":"FOO","old":"1.0","new":"1.1"}]'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| FOO | 1.0 | 1.1 |"* ]]
+    [[ "$output" == *"| Dependency | Old | New |"* ]]
+}
+
+@test "build_deps_table: renders note column when present" {
+    run build_deps_table '[{"name":"(unknown)","old":"?","new":"?","note":"PR body not available"}]'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PR body not available"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# DRY_RUN end-to-end
+# ---------------------------------------------------------------------------
+
+@test "DRY_RUN: prints title+body to stdout, no real gh invocation" {
+    # Replace gh mock with a strict one that fails if called with issue create
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/gh" << 'GHEOF'
+#!/bin/bash
+if [[ "$*" == *"issue create"* ]] || [[ "$*" == *"issue comment"* ]]; then
+    echo "ERROR: gh should not be called in DRY_RUN mode" >&2
+    exit 99
+fi
+# issue list returns empty
+echo "[]"
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export PR_NUMBER="999"
+    export PR_TITLE="📦 deps(php): update 4 dependencies"
+    export PR_BODY="| Dependency | Old | New |
+|---|---|---|
+| FOO | 1.0 | 1.1 |"
+    export PR_LABELS="automation,dependencies,php,minor-update"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+
+    # Must contain the expected issue title marker
+    [[ "$output" == *"🚨 [php]"* ]]
+    # Must contain dep data from PR_BODY
+    [[ "$output" == *"FOO"* ]]
+    [[ "$output" == *"1.0"* ]]
+    [[ "$output" == *"1.1"* ]]
+}
+
+@test "DRY_RUN: version-bump prints container and new version" {
+    export COMMIT_SUBJECT="build(postgres): update to 18.2"
+    export PR_TITLE="🚀 Minor: postgres to 18.2"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"🚨 [postgres]"* ]]
+    [[ "$output" == *"18.2"* ]]
+}
+
+@test "DRY_RUN: no-match exits 1 (caller uses generic issue logic)" {
+    export COMMIT_SUBJECT="fix(ci): corrected shellcheck warning"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Dedup: mock gh issue list returns existing issue → "commented"
+# ---------------------------------------------------------------------------
+
+@test "dedup: existing open issue found → result contains 'commented'" {
+    # Override gh mock: issue list returns one match; issue comment succeeds
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/gh" << 'GHEOF'
+#!/bin/bash
+case "$*" in
+    *"issue list"*)
+        cat <<JSON
+[{"number":999,"title":"🚨 [php] Build failed after dep update (PR #100)","body":"Refs #100"}]
+JSON
+        ;;
+    *"issue comment"*)
+        echo "https://github.com/oorabona/docker-containers/issues/999#issuecomment-1"
+        ;;
+    *"label create"*)
+        echo "label created" >&2
+        ;;
+    *)
+        echo "unexpected gh args: $*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export PR_NUMBER="100"
+    export PR_TITLE="📦 deps(php): update 4 dependencies"
+    export PR_BODY="| Dependency | Old | New |
+|---|---|---|
+| FOO | 1.0 | 1.1 |"
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"commented"* ]]
+    [[ "$output" == *"#999"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Dedup: mock gh issue list returns empty → "created"
+# ---------------------------------------------------------------------------
+
+@test "dedup: no existing issue → result contains 'created'" {
+    # Override gh mock: issue list returns empty; issue create returns URL
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/gh" << 'GHEOF'
+#!/bin/bash
+case "$*" in
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *"issue create"*)
+        echo "https://github.com/oorabona/docker-containers/issues/42"
+        ;;
+    *"label create"*)
+        echo "label created" >&2
+        ;;
+    *)
+        echo "unexpected gh args: $*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export PR_NUMBER="200"
+    export PR_TITLE="📦 deps(php): update 4 dependencies"
+    export PR_BODY="| Dependency | Old | New |
+|---|---|---|
+| LIBSSL | 1.1.1w | 3.5.6 |"
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created"* ]]
+    [[ "$output" == *"#42"* ]]
+}


### PR DESCRIPTION
## Summary

Volet 3 of #453: when an auto-build fails on a commit/PR that bumped a dependency or container version, automatically open a **dependency-attributed** GitHub issue with the dep name, old→new version, failing container, log excerpt, and link back to the source PR — instead of the existing generic "Auto Build Failed" tracker.

Volets 1 (OpenSSL 1.1.1→3.5.6 LTS, #477) and 2 (PCRE→PCRE2 + lifecycle taxonomy + liveness checks, #479/#480) already shipped. This closes the third acceptance criterion of #453.

## What changed

**New: `scripts/open-dep-failure-issue.sh`** (518 lines)
- Detection: composite signal — commit subject `^(build|deps)\(...\):`, PR title `📦 deps(...)` / `⚠️ deps(...)` / `🚀 Minor:` / `🔄 Major:`, branch prefix `update/`, or PR labels containing `automation` + `dependencies`. Any match triggers; conflicting signals are resolved by precedence (commit/title > branch).
- Extraction: parses the upstream-monitor PR body markdown table to list each dep with `old → new`. Falls back to placeholder if body is unavailable.
- Dedup: searches open issues with label combo `build-failure,automation,dep-attributed,dep:<container>` matching the source PR (via `Refs #N` in body or `(PR #N)` in title). Match → comment with new run details. No match → create.
- Issue body: container, source PR link, commit subject, failing run link, dep table, failing jobs list (up to 5), log excerpt (last ~30 lines from first failing job, capped at 50 lines total).
- `DRY_RUN=true` mode prints the proposed issue body without calling `gh issue create/comment` — for local testing.
- shellcheck clean, `set -euo pipefail`, sources `helpers/logging.sh` and `helpers/retry.sh`.

**New: `tests/unit/open-dep-failure-issue.bats`** (424 lines, 25 tests)
- 8 detection scenarios: deps commit, build commit, deps PR title, version-bump PR title, branch-only fallback, irrelevant commit (no detection), conflicting signals, container-update labels
- Extraction: markdown table parsing, empty-body fallback
- DRY_RUN: title + body shape verification, version-bump variant, no-match exits 1
- Dedup: existing-match → comment, no-match → create
- All 25 pass on local bats runner; shellcheck `-x -S warning` clean.

**Modified: `.github/workflows/auto-build.yaml`** (+103 / -43)
- Added `Checkout repository` step at top of `summary` job (needed for `git log` + script access)
- Split the original "Create issue on build failure" into two steps:
  1. `Gather dep-bump context for failure attribution` (id: `ctx`) — extracts `commit_subject`, `pr_number`, `pr_title`, `pr_body`, `pr_labels`, `failed_jobs_json` (capped to 5 jobs). Pulls PR via `gh pr view` when the commit subject contains a `(#N)` suffix (squash-merge format).
  2. `Open dep-attributed or generic build-failure issue` — calls `scripts/open-dep-failure-issue.sh`. On exit 1 (no dep-bump detected), falls back to the original generic-issue logic (preserved verbatim — same title `Auto Build Failed - YYYY-MM-DD`, labels `build-failure,automation`, body structure).

## Test plan
- [x] 25/25 bats unit tests pass
- [x] `shellcheck -x scripts/open-dep-failure-issue.sh` clean (only SC1091 info-level on relative source paths)
- [x] DRY_RUN smoke confirms issue body shape with sample inputs
- [x] Pre-push orthogonal gate (codex xhigh + copilot) → both CLEAN
- [ ] In-CI validation: will exercise on next genuine build failure (or via workflow_dispatch with a forced failure for testing)

## Known minor cosmetic regressions on generic-fallback path

The generic-fallback issue title was `🚨 Auto Build Failed - <date>` before this PR; the printf-based reformulation in the workflow yaml drops the 🚨 emoji prefix (printf format strings don't carry emojis cleanly). Same for the comment header `🔄 Another build failure detected` → `## Another build failure detected`. Dedup logic uses `contains("Auto Build Failed")` which matches both old and new titles — no functional regression. If the emojis matter, trivial follow-up: switch to bash array + `gh ... --body-file <(echo "...")` to preserve them.

## Closes / Refs
- Closes #453 acceptance criterion 4 ("Dep-bump build failures auto-open a dependency-attributed issue")
- Refs #448 (the OpenSSL 1.1.1w incident that motivated #453)
- Refs #480 (Volet 2 — lifecycle taxonomy + liveness checks)
