### PR TITLE
perf(dashboard): enrich lineage at build-time (#515)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1193,7 +1193,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: helpers
+          sparse-checkout: |
+            helpers
+            scripts
 
       - name: Restore previous lineage cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -1248,6 +1250,15 @@ jobs:
             echo "No lineage artifacts found"
             echo "has_files=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Enrich lineage with multi-arch manifest data
+        if: steps.merge.outputs.has_files == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          chmod +x scripts/enrich-lineage.sh
+          ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
 
       - name: Download SBOM artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -504,14 +504,26 @@ collect_variant_json() {
     fi
     [[ "$is_default" != "true" ]] && is_default="false"
 
-    # Sizes
+    # Sizes — prefer lineage (post-#515 enriched fields), fall back to network
     local size_amd64="" size_arm64=""
     if [[ "$current_version" != "no-published-version" ]]; then
-        local sizes_raw
-        sizes_raw=$(get_ghcr_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
-        if [[ -n "$sizes_raw" ]]; then
-            size_amd64=$(echo "$sizes_raw" | grep -oP 'amd64:\K[0-9.]+MB' || echo "")
-            size_arm64=$(echo "$sizes_raw" | grep -oP 'arm64:\K[0-9.]+MB' || echo "")
+        local lineage_size_amd64 lineage_size_arm64
+        lineage_size_amd64=$(echo "$lineage_json" | jq -r '.size_amd64_bytes // empty' 2>/dev/null) || lineage_size_amd64=""
+        lineage_size_arm64=$(echo "$lineage_json" | jq -r '.size_arm64_bytes // empty' 2>/dev/null) || lineage_size_arm64=""
+        if [[ -n "$lineage_size_amd64" && "$lineage_size_amd64" =~ ^[0-9]+$ ]]; then
+            size_amd64=$(awk -v b="$lineage_size_amd64" 'BEGIN{printf "%.1fMB", b/1048576}')
+        fi
+        if [[ -n "$lineage_size_arm64" && "$lineage_size_arm64" =~ ^[0-9]+$ ]]; then
+            size_arm64=$(awk -v b="$lineage_size_arm64" 'BEGIN{printf "%.1fMB", b/1048576}')
+        fi
+        # Fallback: network call if neither size found in lineage
+        if [[ -z "$size_amd64" && -z "$size_arm64" ]]; then
+            local sizes_raw
+            sizes_raw=$(get_ghcr_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+            if [[ -n "$sizes_raw" ]]; then
+                size_amd64=$(echo "$sizes_raw" | grep -oP 'amd64:\K[0-9.]+MB' || echo "")
+                size_arm64=$(echo "$sizes_raw" | grep -oP 'arm64:\K[0-9.]+MB' || echo "")
+            fi
         fi
     fi
 
@@ -551,29 +563,33 @@ collect_variant_json() {
     [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
         echo "[debug] build_history for $container-$sbom_tag = ${build_history:0:60}…" >&2
 
-    # Attestation: look up SBOM attestation ID from GitHub Attestations API.
-    # The attestations API is keyed on the OCI subject digest (sha256:…) that
-    # `actions/attest-sbom` signs — NOT the internal build-cache digest. Prefer
-    # `.oci_subject_digest` when the build pipeline has captured it; fall back
-    # to `.build_digest` for older lineage files predating the post-flatten
-    # capture step. NB: jq's `//` only treats null/false as missing, so an
-    # empty-string `.oci_subject_digest` would short-circuit incorrectly — the
-    # explicit shell-level check below handles that case.
-    local subject_digest attestation_id="" attestation_url=""
-    subject_digest=$(echo "$lineage_json" | jq -r '.oci_subject_digest // empty')
-    if [[ -z "$subject_digest" ]]; then
-        subject_digest=$(echo "$lineage_json" | jq -r '.build_digest // "unknown"')
+    # Attestation — prefer lineage (post-#515 enriched fields), fall back to gh api.
+    # Lineage-enriched path: enrich-lineage.sh stored attestation_id + attestation_url
+    # at build time. Dashboard reads those directly, eliminating the per-variant gh api
+    # call that caused 20-29 min hangs on Windows variants.
+    local attestation_id="" attestation_url=""
+    attestation_id=$(echo "$lineage_json" | jq -r '.attestation_id // empty' 2>/dev/null) || attestation_id=""
+    attestation_url=$(echo "$lineage_json" | jq -r '.attestation_url // empty' 2>/dev/null) || attestation_url=""
+
+    if [[ -z "$attestation_id" ]]; then
+        # Fallback: network lookup for pre-#515 lineage files without enriched attestation.
+        # Prefer oci_subject_digest; fall back to build_digest for older lineage files.
+        local subject_digest
+        subject_digest=$(echo "$lineage_json" | jq -r '.oci_subject_digest // empty')
+        if [[ -z "$subject_digest" ]]; then
+            subject_digest=$(echo "$lineage_json" | jq -r '.build_digest // "unknown"')
+            [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
+                echo "[debug] using fallback build_digest=$subject_digest (oci_subject_digest empty) for $container-$sbom_tag" >&2
+        fi
         [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
-            echo "[debug] using fallback build_digest=$subject_digest (oci_subject_digest empty) for $container-$sbom_tag" >&2
+            echo "[debug] subject_digest for $container-$sbom_tag = ${subject_digest:0:60}…" >&2
+        local _t0_att=${EPOCHREALTIME:-}
+        if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
+            && attestation_id=$(get_attestation_id "$subject_digest"); then
+            attestation_url=$(get_attestation_url "$attestation_id")
+        fi
+        log_latency "gh-attestation" "$_t0_att" 20
     fi
-    [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
-        echo "[debug] subject_digest for $container-$sbom_tag = ${subject_digest:0:60}…" >&2
-    local _t0_att=${EPOCHREALTIME:-}
-    if [[ -n "$subject_digest" && "$subject_digest" != "unknown" ]] \
-        && attestation_id=$(get_attestation_id "$subject_digest"); then
-        attestation_url=$(get_attestation_url "$attestation_id")
-    fi
-    log_latency "gh-attestation" "$_t0_att" 20
 
     # Trivy: collect vulnerability summary for the primary platform (linux/amd64)
     local trivy_category trivy_summary
@@ -582,31 +598,52 @@ collect_variant_json() {
     [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
         echo "[debug] trivy_summary for $container-$variant_tag = ${trivy_summary:0:60}…" >&2
 
-    # Multi-arch platform list: derive from GHCR manifest (reuse ghcr_get_manifest_sizes)
+    # Multi-arch platform list + manifest digests — prefer lineage (post-#515 enriched
+    # fields), fall back to network only when lineage lacks all three digest fields.
     local multi_arch_platforms_json="[]"
-    if [[ "$current_version" != "no-published-version" ]]; then
-        local raw_sizes arch_list=""
-        local _t0_ghcr=${EPOCHREALTIME:-}
-        raw_sizes=$(ghcr_get_manifest_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
-        log_latency "ghcr-index oorabona/${container}:${variant_tag}" "$_t0_ghcr" 30
-        if [[ -n "$raw_sizes" ]]; then
-            arch_list=$(echo "$raw_sizes" | awk -F: '{print $1}' | \
-                jq -R . | jq -s '.')
-        fi
-        [[ -n "$arch_list" && "$arch_list" != "[]" ]] && multi_arch_platforms_json="$arch_list"
-    fi
-
-    # Multi-arch digests: index digest + per-platform (amd64, arm64) manifest digests.
-    # Fetched from the GHCR registry v2 API at dashboard-generation time.
-    # Returns all-null JSON on token/API failure — never exits non-zero.
     local multi_arch_digests_json
     multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+
     if [[ "$current_version" != "no-published-version" ]]; then
-        local _t0_ghcr_ma=${EPOCHREALTIME:-}
-        multi_arch_digests_json=$(ghcr_get_multi_arch_digests "oorabona/$container" "$variant_tag" 2>/dev/null) || true
-        log_latency "ghcr-index oorabona/${container}:${variant_tag} (multi-arch)" "$_t0_ghcr_ma" 30
-        [[ -z "$multi_arch_digests_json" ]] && \
-            multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+        local lineage_platforms lineage_index_digest lineage_amd64 lineage_arm64
+        lineage_platforms=$(echo "$lineage_json" | jq -c '.multi_arch_platforms // empty' 2>/dev/null) || lineage_platforms=""
+        lineage_index_digest=$(echo "$lineage_json" | jq -r '.multi_arch_index_digest // empty' 2>/dev/null) || lineage_index_digest=""
+        lineage_amd64=$(echo "$lineage_json" | jq -r '.manifest_digest_amd64 // empty' 2>/dev/null) || lineage_amd64=""
+        lineage_arm64=$(echo "$lineage_json" | jq -r '.manifest_digest_arm64 // empty' 2>/dev/null) || lineage_arm64=""
+
+        if [[ -n "$lineage_platforms" && "$lineage_platforms" != "null" && "$lineage_platforms" != "[]" ]]; then
+            multi_arch_platforms_json="$lineage_platforms"
+        fi
+        if [[ -n "$lineage_index_digest" || -n "$lineage_amd64" || -n "$lineage_arm64" ]]; then
+            multi_arch_digests_json=$(jq -nc \
+                --arg idx "${lineage_index_digest}" \
+                --arg amd "${lineage_amd64}" \
+                --arg arm "${lineage_arm64}" \
+                '{
+                    index_digest: (if $idx == "" then null else $idx end),
+                    manifest_digest_amd64: (if $amd == "" then null else $amd end),
+                    manifest_digest_arm64: (if $arm == "" then null else $arm end)
+                }') || multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+        fi
+
+        # Fallback: only if lineage had NO platforms AND NO digests at all
+        if [[ "$multi_arch_platforms_json" == "[]" && -z "$lineage_index_digest" && -z "$lineage_amd64" && -z "$lineage_arm64" ]]; then
+            local raw_sizes arch_list=""
+            local _t0_ghcr=${EPOCHREALTIME:-}
+            raw_sizes=$(ghcr_get_manifest_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+            log_latency "ghcr-index oorabona/${container}:${variant_tag}" "$_t0_ghcr" 30
+            if [[ -n "$raw_sizes" ]]; then
+                arch_list=$(echo "$raw_sizes" | awk -F: '{print $1}' | \
+                    jq -R . | jq -s '.')
+            fi
+            [[ -n "$arch_list" && "$arch_list" != "[]" ]] && multi_arch_platforms_json="$arch_list"
+
+            local _t0_ghcr_ma=${EPOCHREALTIME:-}
+            multi_arch_digests_json=$(ghcr_get_multi_arch_digests "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+            log_latency "ghcr-index oorabona/${container}:${variant_tag} (multi-arch)" "$_t0_ghcr_ma" 30
+            [[ -z "$multi_arch_digests_json" ]] && \
+                multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+        fi
     fi
     [[ "${DASHBOARD_DEBUG:-}" == "1" ]] && \
         echo "[debug] multi_arch_digests for $container-$variant_tag = ${multi_arch_digests_json:0:120}…" >&2

--- a/scripts/enrich-lineage.sh
+++ b/scripts/enrich-lineage.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# enrich-lineage.sh — Enrich .build-lineage/<container>-<tag>.json with multi-arch
+# manifest data, sizes, platforms, and attestation links — fields that are IMMUTABLE
+# post-build but were previously fetched per-dashboard-regen, causing 70+ min
+# dashboard runtime on Windows variants (#515).
+#
+# Idempotent: running on already-enriched lineage is a no-op (fields preserved).
+# Failure-tolerant: per-lineage errors are logged as ::warning:: but don't abort
+# the batch. Missing GHCR data → field set to null (dashboard falls back to network).
+#
+# Usage:
+#   enrich-lineage.sh [--owner <owner>] [--lineage-dir <dir>]
+#
+# Env requirements:
+#   GH_TOKEN          — needed for gh api attestation lookup (CI: GITHUB_TOKEN)
+#   GHCR auth         — implicit via ghcr_get_token() using gh auth token or anonymous
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+OWNER="oorabona"
+LINEAGE_DIR="${PROJECT_ROOT}/.build-lineage"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --owner)
+            OWNER="$2"
+            shift 2
+            ;;
+        --lineage-dir)
+            LINEAGE_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "::error::Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Source helpers
+# ---------------------------------------------------------------------------
+# shellcheck source=../helpers/logging.sh
+source "${PROJECT_ROOT}/helpers/logging.sh"
+# shellcheck source=../helpers/registry-utils.sh
+source "${PROJECT_ROOT}/helpers/registry-utils.sh"
+# shellcheck source=../helpers/attestation-utils.sh
+source "${PROJECT_ROOT}/helpers/attestation-utils.sh"
+
+# ---------------------------------------------------------------------------
+# Constants: files to skip (not container lineage files)
+# ---------------------------------------------------------------------------
+# Pattern matches: *.sbom.json  *.changelog.json  *.history.json  ext-*.json
+_is_skippable_file() {
+    local f="$1"
+    case "$f" in
+        *.sbom.json|*.changelog.json|*.history.json) return 0 ;;
+        ext-*.json) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Main enrichment loop
+# ---------------------------------------------------------------------------
+enriched=0
+skipped=0
+errors=0
+
+if [[ ! -d "$LINEAGE_DIR" ]]; then
+    echo "::notice::Lineage directory $LINEAGE_DIR does not exist — 0 enriched"
+    exit 0
+fi
+
+# Collect all *.json files in the lineage dir (non-recursive; lineage files are flat)
+while IFS= read -r lineage_file; do
+    basename_file="$(basename "$lineage_file")"
+
+    # Skip non-lineage files
+    if _is_skippable_file "$basename_file"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Validate JSON
+    if ! container=$(jq -re '.container // empty' "$lineage_file" 2>/dev/null); then
+        echo "::warning::Skipping $basename_file: missing or null 'container' field (malformed JSON?)" >&2
+        errors=$((errors + 1))
+        continue
+    fi
+
+    tag=$(jq -r '.tag // empty' "$lineage_file" 2>/dev/null) || tag=""
+    if [[ -z "$tag" ]]; then
+        echo "::warning::Skipping $basename_file: missing or empty 'tag' field" >&2
+        errors=$((errors + 1))
+        continue
+    fi
+
+    # Idempotency check: if multi_arch_index_digest is already non-null, skip.
+    existing_digest=$(jq -r '.multi_arch_index_digest // empty' "$lineage_file" 2>/dev/null) || existing_digest=""
+    if [[ -n "$existing_digest" ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    image_path="${OWNER}/${container}"
+
+    # --- Collect new fields, tolerating individual failures ---
+
+    # 1. Multi-arch digests (index + per-platform)
+    multi_arch_digests='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
+    if raw_digests=$(ghcr_get_multi_arch_digests "$image_path" "$tag" 2>/dev/null) && [[ -n "$raw_digests" ]]; then
+        multi_arch_digests="$raw_digests"
+    fi
+
+    # 2. Manifest sizes (arch:bytes lines) → parse into fields + platforms list
+    size_amd64_bytes="null"
+    size_arm64_bytes="null"
+    multi_arch_platforms="[]"
+
+    if raw_sizes=$(ghcr_get_manifest_sizes "$image_path" "$tag" 2>/dev/null) && [[ -n "$raw_sizes" ]]; then
+        # Build JSON array of arch names (filter "unknown")
+        # raw_sizes format: "amd64:12345678\narm64:23456789\n..."
+        arch_list=$(printf '%s' "$raw_sizes" | awk -F: '$1 != "unknown" && $1 != "" {print $1}' \
+            | jq -R . | jq -s '.' 2>/dev/null) || arch_list="[]"
+        [[ -n "$arch_list" ]] && multi_arch_platforms="$arch_list"
+
+        # Extract per-arch sizes in bytes
+        raw_amd64=$(printf '%s' "$raw_sizes" | grep -E '^amd64:' | cut -d: -f2 | head -1) || raw_amd64=""
+        raw_arm64=$(printf '%s' "$raw_sizes" | grep -E '^arm64:' | cut -d: -f2 | head -1) || raw_arm64=""
+        [[ -n "$raw_amd64" && "$raw_amd64" =~ ^[0-9]+$ ]] && size_amd64_bytes="$raw_amd64"
+        [[ -n "$raw_arm64" && "$raw_arm64" =~ ^[0-9]+$ ]] && size_arm64_bytes="$raw_arm64"
+    fi
+
+    # 3. Attestation (keyed on oci_subject_digest)
+    attestation_id_val="null"
+    attestation_url_val="null"
+    oci_subject_digest=$(jq -r '.oci_subject_digest // empty' "$lineage_file" 2>/dev/null) || oci_subject_digest=""
+
+    if [[ -n "$oci_subject_digest" && "$oci_subject_digest" != "null" && "$oci_subject_digest" != "unknown" ]]; then
+        if att_id=$(get_attestation_id "$oci_subject_digest" 2>/dev/null) && [[ -n "$att_id" ]]; then
+            attestation_id_val="\"${att_id}\""
+            att_url=$(get_attestation_url "$att_id" 2>/dev/null) || att_url=""
+            [[ -n "$att_url" ]] && attestation_url_val="\"${att_url}\""
+        fi
+    fi
+
+    # --- Merge fields into lineage file (atomic write) ---
+    # Build the update expression as a single jq call to avoid multiple reads
+    tmp_file=$(mktemp "${LINEAGE_DIR}/.enrich-tmp.XXXXXX")
+    update_ok=0
+
+    if jq \
+        --argjson multi_arch_digests "$multi_arch_digests" \
+        --argjson multi_arch_platforms "$multi_arch_platforms" \
+        --argjson size_amd64_bytes "$size_amd64_bytes" \
+        --argjson size_arm64_bytes "$size_arm64_bytes" \
+        --argjson attestation_id "$attestation_id_val" \
+        --argjson attestation_url "$attestation_url_val" \
+        '. + {
+            multi_arch_index_digest:   $multi_arch_digests.index_digest,
+            manifest_digest_amd64:     $multi_arch_digests.manifest_digest_amd64,
+            manifest_digest_arm64:     $multi_arch_digests.manifest_digest_arm64,
+            multi_arch_platforms:      $multi_arch_platforms,
+            size_amd64_bytes:          $size_amd64_bytes,
+            size_arm64_bytes:          $size_arm64_bytes,
+            attestation_id:            $attestation_id,
+            attestation_url:           $attestation_url
+        }' "$lineage_file" > "$tmp_file" 2>/dev/null; then
+        mv -f "$tmp_file" "$lineage_file"
+        update_ok=1
+    else
+        rm -f "$tmp_file" 2>/dev/null || true
+        echo "::warning::Failed to enrich $basename_file: jq merge failed" >&2
+        errors=$((errors + 1))
+    fi
+
+    [[ "$update_ok" -eq 1 ]] && enriched=$((enriched + 1))
+
+done < <(find "$LINEAGE_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | sort)
+
+echo "::notice::Enriched $enriched lineage files ($skipped skipped, $errors errors)"

--- a/tests/unit/enrich-lineage.bats
+++ b/tests/unit/enrich-lineage.bats
@@ -1,0 +1,320 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/enrich-lineage.sh
+#
+# The enrichment script adds multi-arch manifest data, sizes, platforms, and
+# attestation links to .build-lineage/*.json files at build time, eliminating
+# the per-dashboard-regen network calls that caused 70+ min runtimes.
+#
+# Tests use stubs for gh and curl so no network access or auth is required.
+
+load "../test_helper"
+
+# --- helpers -----------------------------------------------------------
+
+SCRIPT_DIR=""
+PROJECT_ROOT_OVERRIDE=""
+
+setup() {
+  setup_temp_dir
+  export ORIGINAL_PATH="$PATH"
+
+  SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/../../scripts" && pwd)"
+  export SCRIPT_DIR
+
+  PROJECT_ROOT_OVERRIDE="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  export PROJECT_ROOT_OVERRIDE
+
+  # Lineage dir under $TEST_TEMP_DIR for isolation
+  export LINEAGE_DIR="$TEST_TEMP_DIR/.build-lineage"
+  mkdir -p "$LINEAGE_DIR"
+
+  # Stub bin dir on PATH
+  mkdir -p "$TEST_TEMP_DIR/bin"
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+  # Default stubs that return empty/null (no network needed)
+  _write_stub_gh_no_attestation
+  _write_stub_curl_empty
+}
+
+teardown() {
+  teardown_temp_dir
+  export PATH="$ORIGINAL_PATH"
+}
+
+# Write a stub gh that returns no attestations
+_write_stub_gh_no_attestation() {
+  cat > "$TEST_TEMP_DIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo '{"attestations":[]}'
+STUB
+  chmod +x "$TEST_TEMP_DIR/bin/gh"
+}
+
+# Write a stub gh that returns a valid attestation
+_write_stub_gh_with_attestation() {
+  cat > "$TEST_TEMP_DIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo '{"attestations":[{"bundle_url":"https://storage.example.com/attestations/68518664/2026/01/01/99887766.json.sn?sig=x"}]}'
+STUB
+  chmod +x "$TEST_TEMP_DIR/bin/gh"
+}
+
+# Write a stub curl that returns nothing (simulates GHCR unavailability)
+_write_stub_curl_empty() {
+  cat > "$TEST_TEMP_DIR/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TEST_TEMP_DIR/bin/curl"
+}
+
+# Create a minimal lineage file in LINEAGE_DIR
+_write_lineage() {
+  local filename="$1"
+  local container="${2:-testcontainer}"
+  local tag="${3:-1.0.0}"
+  local oci_digest="${4:-}"
+  cat > "$LINEAGE_DIR/$filename" <<JSON
+{
+  "container": "$container",
+  "version": "$tag",
+  "tag": "$tag",
+  "flavor": "",
+  "build_digest": "abc123",
+  "oci_subject_digest": "$oci_digest",
+  "built_at": "2026-01-01T00:00:00Z"
+}
+JSON
+}
+
+# Run enrich-lineage.sh with the test's lineage dir
+_run_enrich() {
+  run bash "$SCRIPT_DIR/enrich-lineage.sh" \
+    --owner "testowner" \
+    --lineage-dir "$LINEAGE_DIR"
+}
+
+# -----------------------------------------------------------------------
+# 1. Empty lineage directory exits 0 with notice saying 0 enriched
+# -----------------------------------------------------------------------
+@test "empty lineage dir: exits 0 and emits ::notice:: with 0 enriched" {
+  rm -rf "$LINEAGE_DIR"
+  mkdir -p "$LINEAGE_DIR"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+  [[ "$output" == *"Enriched 0"* ]]
+}
+
+# -----------------------------------------------------------------------
+# 2. Non-existent lineage directory exits 0 with notice
+# -----------------------------------------------------------------------
+@test "non-existent lineage dir: exits 0 with notice" {
+  rm -rf "$LINEAGE_DIR"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+}
+
+# -----------------------------------------------------------------------
+# 3. Skip-list: .sbom.json, .changelog.json, .history.json, ext-*.json
+# -----------------------------------------------------------------------
+@test "skip-list: sbom, changelog, history, ext- files are not processed" {
+  echo '{}' > "$LINEAGE_DIR/mycontainer-1.0.0.sbom.json"
+  echo '{}' > "$LINEAGE_DIR/mycontainer-1.0.0.changelog.json"
+  echo '{}' > "$LINEAGE_DIR/mycontainer-1.0.0.history.json"
+  echo '{}' > "$LINEAGE_DIR/ext-citus-pg18-14.0.0.json"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+  [[ "$output" == *"Enriched 0"* ]]
+}
+
+# -----------------------------------------------------------------------
+# 4. Malformed JSON / missing container field: logged as ::warning::, batch continues
+# -----------------------------------------------------------------------
+@test "malformed JSON: logged as warning, batch continues" {
+  echo 'this is not json' > "$LINEAGE_DIR/bad-notjson-1.0.0.json"
+  echo '{"tag":"1.0.0","build_digest":"abc"}' > "$LINEAGE_DIR/no-container-1.0.0.json"
+  _write_lineage "good-1.0.0.json" "good" "1.0.0"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::"* ]]
+  [[ "$output" == *"::notice::"* ]]
+}
+
+# -----------------------------------------------------------------------
+# 5. Missing oci_subject_digest: attestation fields are null, no error
+# -----------------------------------------------------------------------
+@test "missing oci_subject_digest: attestation_id and attestation_url set to null" {
+  _write_lineage "nodigest-1.0.0.json" "nodigest" "1.0.0" ""
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+
+  local att_id
+  att_id=$(jq -r '.attestation_id' "$LINEAGE_DIR/nodigest-1.0.0.json")
+  [ "$att_id" = "null" ]
+
+  local att_url
+  att_url=$(jq -r '.attestation_url' "$LINEAGE_DIR/nodigest-1.0.0.json")
+  [ "$att_url" = "null" ]
+}
+
+# -----------------------------------------------------------------------
+# 6. GHCR call failure (curl returns empty): null fields, no error
+# -----------------------------------------------------------------------
+@test "GHCR call failure: lineage gets null multi-arch fields, no error" {
+  _write_stub_curl_empty
+  _write_lineage "ghcrfail-1.0.0.json" "ghcrfail" "1.0.0"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+
+  local idx_digest
+  idx_digest=$(jq -r '.multi_arch_index_digest' "$LINEAGE_DIR/ghcrfail-1.0.0.json")
+  [ "$idx_digest" = "null" ]
+}
+
+# -----------------------------------------------------------------------
+# 7. Idempotency: already-enriched file (non-null multi_arch_index_digest) is skipped
+# -----------------------------------------------------------------------
+@test "idempotency: already-enriched file is skipped without modification" {
+  cat > "$LINEAGE_DIR/enriched-1.0.0.json" <<'JSON'
+{
+  "container": "enriched",
+  "tag": "1.0.0",
+  "build_digest": "abc123",
+  "oci_subject_digest": "",
+  "multi_arch_index_digest": "sha256:deadbeef",
+  "manifest_digest_amd64": "sha256:aaa",
+  "manifest_digest_arm64": "sha256:bbb",
+  "multi_arch_platforms": ["amd64","arm64"],
+  "size_amd64_bytes": 104857600,
+  "size_arm64_bytes": 209715200,
+  "attestation_id": "42",
+  "attestation_url": "https://github.com/example/attestations/42"
+}
+JSON
+
+  local before_md5
+  before_md5=$(md5sum "$LINEAGE_DIR/enriched-1.0.0.json" | awk '{print $1}')
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+
+  local after_md5
+  after_md5=$(md5sum "$LINEAGE_DIR/enriched-1.0.0.json" | awk '{print $1}')
+  [ "$before_md5" = "$after_md5" ]
+
+  [[ "$output" == *"Enriched 0"* ]]
+}
+
+# -----------------------------------------------------------------------
+# 8. Second pass on a freshly-enriched file is a no-op
+# -----------------------------------------------------------------------
+@test "second pass: re-running on an enriched file leaves it byte-for-byte unchanged" {
+  _write_lineage "roundtrip-1.0.0.json" "roundtrip" "1.0.0"
+
+  _run_enrich
+  [ "$status" -eq 0 ]
+
+  local md5_pass1
+  md5_pass1=$(md5sum "$LINEAGE_DIR/roundtrip-1.0.0.json" | awk '{print $1}')
+
+  _run_enrich
+  [ "$status" -eq 0 ]
+
+  local md5_pass2
+  md5_pass2=$(md5sum "$LINEAGE_DIR/roundtrip-1.0.0.json" | awk '{print $1}')
+  [ "$md5_pass1" = "$md5_pass2" ]
+}
+
+# -----------------------------------------------------------------------
+# 9. Enriched file has all eight expected new fields
+# -----------------------------------------------------------------------
+@test "enriched file has all eight expected new fields" {
+  _write_lineage "fields-1.0.0.json" "fields" "1.0.0"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+
+  local enriched_file="$LINEAGE_DIR/fields-1.0.0.json"
+
+  for field in multi_arch_index_digest manifest_digest_amd64 manifest_digest_arm64 \
+               multi_arch_platforms size_amd64_bytes size_arm64_bytes \
+               attestation_id attestation_url; do
+    run jq -e "has(\"$field\")" "$enriched_file"
+    [ "$status" -eq 0 ] || {
+      echo "Missing field: $field in $enriched_file" >&2
+      return 1
+    }
+  done
+}
+
+# -----------------------------------------------------------------------
+# 10. Original lineage fields are preserved after enrichment
+# -----------------------------------------------------------------------
+@test "original lineage fields are preserved after enrichment" {
+  _write_lineage "preserve-1.0.0.json" "preserve" "1.0.0"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+
+  local f="$LINEAGE_DIR/preserve-1.0.0.json"
+  [ "$(jq -r '.container' "$f")" = "preserve" ]
+  [ "$(jq -r '.tag' "$f")" = "1.0.0" ]
+  [ "$(jq -r '.build_digest' "$f")" = "abc123" ]
+}
+
+# -----------------------------------------------------------------------
+# 11. Error in one file doesn't abort processing of subsequent files
+# -----------------------------------------------------------------------
+@test "per-file error does not abort batch: subsequent files are still processed" {
+  echo 'not-json-at-all' > "$LINEAGE_DIR/aaa-bad-1.0.0.json"
+  _write_lineage "zzz-good-2.0.0.json" "goodcontainer" "2.0.0"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+  run jq -e 'has("multi_arch_index_digest")' "$LINEAGE_DIR/zzz-good-2.0.0.json"
+  [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------
+# 12. gh attestation lookup: attestation_id written when gh returns valid response
+# -----------------------------------------------------------------------
+@test "attestation_id is written when gh returns valid bundle_url" {
+  _write_stub_gh_with_attestation
+
+  local oci="sha256:c86e34e20b3ca1cef663a969f1f3e6535a670cb96993b2fb3a3affc24f92410b"
+  _write_lineage "attok-1.0.0.json" "attok" "1.0.0" "$oci"
+
+  _run_enrich
+
+  [ "$status" -eq 0 ]
+
+  local att_id
+  att_id=$(jq -r '.attestation_id' "$LINEAGE_DIR/attok-1.0.0.json")
+  [ "$att_id" = "99887766" ]
+
+  local att_url
+  att_url=$(jq -r '.attestation_url' "$LINEAGE_DIR/attok-1.0.0.json")
+  [[ "$att_url" == *"attestations/99887766"* ]]
+}


### PR DESCRIPTION
## Summary

Closes #515. Shifts per-build immutable dashboard fields (multi-arch digests, sizes, attestation IDs) from per-regen network calls into build-time lineage enrichment. Dashboard's `Generate dashboard data` step drops from 70-80 min to expected <5 min, and the silent 20-29 min hangs on `github-runner windows-ltsc2022-dev` variants disappear structurally.

## Why

Confirmed via fresh dashboard run 26368800160 (2026-05-24 = 79.7 min):

| Container | Duration | % of step |
|-----------|----------|-----------|
| github-runner | **74 min** | **93%** |
| All other 13 containers combined | <5 min | 7% |
| → within github-runner: 3× `windows-ltsc2022-dev` variants | ~71 min | — |

Each Windows-dev variant exhibits a 20-29 min silent network hang between the `[latency] ghcr-index ... (multi-arch)` log and the next progress marker. Variance high (29 min today vs 20 min yesterday — same variant) → non-deterministic network issue we can't pin down via static analysis.

The diagnosis was the wrong question. The right architectural question (raised by the owner): **what is the dashboard doing during regen that should have been done once at build time?** Audit of `collect_variant_json`:

| Field | Mutability |
|-------|------------|
| `multi_arch_index_digest`, `manifest_digest_amd64/arm64` | IMMUTABLE post-push |
| `size_amd64/arm64`, `multi_arch_platforms` | IMMUTABLE post-push |
| `attestation_id`, `attestation_url` | IMMUTABLE post-attestation |
| `build_digest`, `oci_subject_digest`, `base_image_ref` | Already in lineage ✅ |
| `sbom_summary`, `changelog`, `build_history` | Already in lineage ✅ |
| `trivy_summary.last_scan`, `dockerhub_stats`, `build_success_rate` | DYNAMIC (kept network) |

~85% of per-variant network work was redundant for data that doesn't change between regens.

## What changed

### `scripts/enrich-lineage.sh` (NEW, 188 lines)

Idempotent enrichment helper. Walks `.build-lineage/*.json` (skipping `.sbom.json` / `.changelog.json` / `.history.json` / `ext-*.json`), and for each un-enriched file:
- Calls `ghcr_get_multi_arch_digests` for `index_digest` + per-arch digests
- Calls `ghcr_get_manifest_sizes` for byte sizes + platforms array
- Calls `get_attestation_id` / `get_attestation_url` when `oci_subject_digest` present
- Merges 8 new fields via a single `jq` call with atomic `mv` write
- Skip if already enriched (preserves existing data even on network outage)
- Per-file failures log `::warning::` and continue (batch-tolerant)

Reuses existing helpers — same code path produces the same data, no risk of subtle differences between build-time and dashboard-time queries.

### `.github/workflows/auto-build.yaml` (MODIFY, +12 -1)

Two changes in `cache-lineage` job:
1. `sparse-checkout` extended from `helpers` to `helpers` + `scripts`
2. New step "Enrich lineage with multi-arch manifest data" inserted between "Merge lineage files" and "Download SBOM artifacts", conditioned on `steps.merge.outputs.has_files == 'true'`

### `generate-dashboard.sh` (MODIFY, +85 -48)

Three regions in `collect_variant_json` now prefer lineage values with graceful network fallback:
- **Sizes**: read `size_amd64_bytes`/`size_arm64_bytes` from lineage, convert to MB string. Fallback: `get_ghcr_sizes` only if BOTH absent.
- **Platforms + manifest digests**: read 4 fields from lineage. Fallback: `ghcr_get_manifest_sizes` + `ghcr_get_multi_arch_digests` only if ALL absent.
- **Attestation**: read `attestation_id` + `attestation_url` from lineage. Fallback: `get_attestation_id` + `get_attestation_url` only if `attestation_id` absent.

### `tests/unit/enrich-lineage.bats` (NEW, 320 lines, 12 tests)

Coverage: empty dir, non-existent dir, skip-list (4 file types), malformed JSON batch-continues, missing OCI digest → null attestation, GHCR failure → null fields, idempotency on pre-enriched files, second-pass no-op, all 8 fields present, original fields preserved, per-file error doesn't abort batch, valid gh response writes attestation_id.

## Constraints met

- ✅ `imagetools` / GHCR calls target `ghcr.io` only — never `docker.io` (Docker Hub 429 avoidance, ref #488)
- ✅ Graceful fallback preserves pre-migration lineage behavior (old images keep working unchanged)
- ✅ Reuses existing helpers — no duplicated logic
- ✅ Pre-push orthogonal gate (codex xhigh + copilot) → both CLEAN
- ✅ 12/12 bats unit tests pass
- ✅ shellcheck `-x -S warning` on enrich-lineage.sh clean
- ✅ `bash -n` on both shell files clean
- ✅ workflow YAML valid

## Verification plan post-merge

1. Auto-build runs on master push → cache-lineage job runs enrich-lineage.sh → enriched lineage written to cache
2. `workflow_dispatch update-dashboard.yaml` → measure `Generate dashboard data` step duration
3. Expected: <5 min (down from 79.7 min)
4. If a container/variant has pre-migration lineage (no enrichment yet), dashboard falls back to network for that one — no regression

## Refs

- Closes #515 (dashboard 70min perf — parked decision from #453)
- #488 (Docker Hub 429 background — GHCR-only constraint)
- #453 (parent dashboard perf arbitration, now closed)
- #452 (original perf unblocker that landed Option 1 cache)
