### PR TITLE
fix(dashboard): preserve enriched lineage against artifact clobber (#515)

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -396,6 +396,16 @@ jobs:
               target=".build-lineage/$fname"
               src_has_digest=$(jq -e '(.oci_subject_digest // "") != ""' "$src" >/dev/null 2>&1 && echo true || echo false)
               if [[ -f "$target" ]]; then
+                # Preserve enrichment written by auto-build's cache-lineage job (#515).
+                # Per-arch build artifacts are uploaded before enrichment runs and lack
+                # multi_arch_index_digest. When the cached file is enriched, never let
+                # an unenriched per-arch source clobber it.
+                tgt_enriched=$(jq -e '(.multi_arch_index_digest // null) != null' "$target" >/dev/null 2>&1 && echo true || echo false)
+                if [[ "$tgt_enriched" == "true" ]]; then
+                  echo "::notice::Preserving enriched cached lineage for $fname (per-arch artifact would clobber multi_arch fields)"
+                  lineage_locked[$fname]=1
+                  continue
+                fi
                 tgt_has_digest=$(jq -e '(.oci_subject_digest // "") != ""' "$target" >/dev/null 2>&1 && echo true || echo false)
                 if [[ "$tgt_has_digest" == "true" && "$src_has_digest" == "false" ]]; then
                   # Cache has digest, source doesn't — preserve cache, lock the slot.


### PR DESCRIPTION
## Summary

Follow-up to #516 (merged `c7541f5`). Verification dashboard run 26371574539 produced **83.2 min** (vs 79.7 min baseline) — **worse than before** the fix.

Root cause: dashboard's lineage hydration step in `update-dashboard.yaml` (re-downloads `build-lineage-*` artifacts from recent auto-build runs to bridge cache races) overwrites the enriched cached lineage with the per-arch source, which is uploaded by build-and-push **before** cache-lineage's enrichment runs. Per-arch artifacts lack `multi_arch_index_digest`/`size_*`/`attestation_*` → cache loses enrichment after merge → `collect_variant_json` falls back to network → 80 min wall time.

## What changed

A small addition to `update-dashboard.yaml` inside the lineage merge loop. New guard: if the cached file already has `multi_arch_index_digest`, treat it as definitive and `continue` — per-arch source cannot improve on enriched cache for these fields.

```bash
# Preserve enrichment written by auto-build's cache-lineage job (#515).
# Per-arch build artifacts are uploaded before enrichment runs and lack
# multi_arch_index_digest. When the cached file is enriched, never let
# an unenriched per-arch source clobber it.
tgt_enriched=$(jq -e '(.multi_arch_index_digest // null) != null' "$target" >/dev/null 2>&1 && echo true || echo false)
if [[ "$tgt_enriched" == "true" ]]; then
  echo "::notice::Preserving enriched cached lineage for $fname (per-arch artifact would clobber multi_arch fields)"
  lineage_locked[$fname]=1
  continue
fi
```

Sits BEFORE the existing `tgt_has_digest` check — fires first, before the digest comparison branches.

## Why the test missed this

The bats tests for `enrich-lineage.sh` validated the helper script in isolation. They didn't cover the workflow's hydration-step interaction with enriched lineage because the hydration step lives in `update-dashboard.yaml`, not in `scripts/`. Cross-workflow integration is hard to bats-test directly.

The orthogonal gate also missed it because the change is semantic (workflow runtime interaction), not structural.

The verification dashboard run caught it — that's exactly why we verify.

## Verification plan post-merge

- Trigger auto-build on a small container (e.g. `ansible rebuild=all`) to populate enriched lineage in cache
- Trigger `update-dashboard.yaml` workflow_dispatch
- Measure `Generate dashboard data` step duration
- Expected: <5 min for the fully-enriched case; falls back gracefully for any unenriched variant

## Refs

- Refs #515 (parent perf issue)
- Refs #516 (the main enrichment PR that needs this fix to deliver the perf gain)
- Pre-push orthogonal gate: codex + copilot both CLEAN
