### PR TITLE
fix(dashboard): self-enrich lineage after merge (#515 cache race)

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -476,6 +476,15 @@ jobs:
           total=$(find .build-lineage -name '*.sbom.json' 2>/dev/null | wc -l)
           echo "::notice::SBOM hydration: downloaded from $downloaded/$run_count run(s); merged $merged SBOM file(s), $merged_lineage lineage file(s), $merged_derived derived file(s) (changelog/history); total SBOM entries: $total"
 
+      - name: Re-enrich lineage after merge (self-heal against concurrent cache races)
+        if: hashFiles('.build-lineage/*.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          chmod +x scripts/enrich-lineage.sh
+          ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
+
       - name: Snapshot pull/star counts (idempotent per day)
         run: |
           chmod +x scripts/snapshot-stats.sh


### PR DESCRIPTION
## Summary

Second follow-up to #516. Verification run 26373870220 (post-#517) produced **69.9 min** (vs 79.7 min baseline — modest 12% gain, far from <5 min target). Investigation traced this to a cache race that defeats the preservation guard.

## Root cause: cache race against concurrent cancelled dashboards

Timeline 2026-05-24:
- 21:58:30 — ansible auto-build's `cache-lineage` saved enriched cache `build-lineage-26373621326`
- 21:58:51 — a cancelled `workflow_run` dashboard (started 21:46, ran 12 min) saved **clobbered** cache `build-lineage-26373612236`. Build job completed before deploy was cancelled, so its lineage save step ran successfully.
- 21:59:15 — verification dashboard 26373870220 prefix-matched `build-lineage-` and restored the **most recent**, which was the clobbered one (later save time wins).

The preservation guard from #517 only fires when the **cached** file is enriched. When the restored cache is clobbered, the guard never sees an enriched file to preserve. The per-arch artifact merge proceeds → clobbered state perpetuated → saved as new latest cache.

## What changed

A new idempotent self-enrichment step in the dashboard's `build` job, immediately after the lineage merge loop:

```yaml
- name: Re-enrich lineage after merge (self-heal against concurrent cache races)
  if: hashFiles('.build-lineage/*.json') != ''
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    GITHUB_REPOSITORY: ${{ github.repository }}
  run: |
    chmod +x scripts/enrich-lineage.sh
    ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
```

The script is idempotent — skips files where `multi_arch_index_digest` is already populated. So:
- **Healthy case** (cache was already enriched, #517 preservation worked): 2-min no-op (all 78 files skipped)
- **Clobbered case** (cache had no enrichment): 2-min recovery (re-enriches 78 files via GHCR queries)

Either way, the cache that the dashboard saves at the end is **always enriched**. The race scenario no longer matters.

## How this complements #517

| Scenario | #517 alone | #517 + this PR |
|----------|-----------|----------------|
| Dashboard restores enriched cache, artifact merge tries to clobber | ✅ Preserved (early `continue`) | ✅ Preserved + idempotent re-enrich no-op |
| Dashboard restores clobbered cache (cache-race loss) | ❌ Guard never fires, falls through to clobber | ✅ Re-enriches after merge |

## Why bats tests didn't catch this

The enrich-lineage bats tests validate the script in isolation. They don't simulate the dashboard's full lifecycle (cache restore → artifact merge → cache save), nor do they simulate concurrent workflow runs. This class of failure surfaces only on the real CI infrastructure. The dashboard verification run is the only test that catches it — exactly the role of the verification step.

## Verification plan post-merge

- Trigger any auto-build to populate enriched cache
- Trigger `update-dashboard.yaml` workflow_dispatch
- Measure `Generate dashboard data` step. Target <5 min for the fully-enriched case (worst case <8 min if re-enrich runs for fresh files)
- The 2-min re-enrich overhead now becomes part of dashboard's baseline; this is acceptable vs the 70 min status quo

## Refs

- Refs #515 (parent perf issue)
- Refs #516 (the main enrichment PR)
- Refs #517 (preservation guard — necessary but insufficient)
- Pre-push orthogonal gate: codex + copilot both CLEAN
