### PR TITLE
fix(dashboard): pass through enrichment fields in lineage resolution (#515)

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -327,8 +327,19 @@ resolve_variant_lineage_json() {
         fi
     fi
 
-    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
-        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
+    if [[ -n "$lineage_file" ]]; then
+        # Pass through ALL lineage fields (including #515 enrichment fields),
+        # overriding the 3 normalized fields with their resolved values.
+        # Without this pass-through, the synthesized JSON drops enrichment and
+        # the dashboard falls back to network for every variant.
+        BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+            jq '. + {build_digest: env.BD, base_image: env.BI, oci_subject_digest: env.OCI}' "$lineage_file"
+    else
+        # No lineage file on disk: synthesize a minimal object so callers still
+        # get the 3 fields they expect (with normalized values).
+        BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+            yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
+    fi
 }
 
 # --- SBOM data helpers ---


### PR DESCRIPTION
## Summary

Third fix in the #515 chain. Verification run 26375672862 (post-#517 + #518) measured **72 min** for `Generate dashboard data` (vs 79.7 baseline — barely better). The previous two fixes (#517 preserve guard, #518 dashboard self-enrich) work correctly: log shows `Enriched 78 lineage files (334 skipped, 0 errors)` confirming all enrichment IS written to disk.

But latency profile is unchanged (167 ghcr-index + 77 gh-attestation calls). The dashboard was never READING the enrichment — the bug is on the read side, in `resolve_variant_lineage_json`.

## Root cause

`generate-dashboard.sh::resolve_variant_lineage_json` (lines 297-332) reads 3 fields from the on-disk lineage file then synthesizes a NEW JSON object containing ONLY those 3 fields. The 8 enrichment fields written by `enrich-lineage.sh` (`multi_arch_index_digest`, `manifest_digest_amd64/arm64`, `multi_arch_platforms`, `size_amd64/arm64_bytes`, `attestation_id`, `attestation_url`) are dropped during this synthesis.

The caller `collect_variant_json` stores the synthesized result in `lineage_json`, and my fast-path lookups added in #516 (`jq -r '.multi_arch_index_digest // empty'` etc.) always returned empty → fallback to network → 80 min wall time.

## The fix

Replace the unconditional `yq -n -o json` synthesis with a conditional:
- **When lineage file exists**: `jq` pass-through ALL source fields, overriding only the 3 normalized ones
- **When no lineage file**: keep the original minimal synthesis (fallback path)

```bash
if [[ -n "$lineage_file" ]]; then
    # Pass through ALL lineage fields (including #515 enrichment fields),
    # overriding the 3 normalized fields with their resolved values.
    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
        jq '. + {build_digest: env.BD, base_image: env.BI, oci_subject_digest: env.OCI}' "$lineage_file"
else
    # No lineage file on disk: synthesize a minimal object.
    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
fi
```

Smoke test (synthetic lineage with all enrichment fields):
- Input: lineage file with `multi_arch_index_digest=sha256:idx1`, `manifest_digest_amd64=sha256:amd`, `size_amd64_bytes=12345`
- Output: `{"idx":"sha256:idx1","amd":"sha256:amd","size":12345,"bd":"abc123","bi":"alpine:3"}`
- All enrichment fields preserved ✅; normalized overrides applied ✅

## Why this took three PRs

Each PR fixed a real bug, but the chain of bugs masked each other:
- #516: introduced enrichment write + read path, but never tested integration
- #517: needed because dashboard merge step clobbers enriched cache (real issue)
- #518: needed because cancelled-dashboard cache race defeats #517 (real issue)
- #519 (this): the root cause — even with all caches enriched correctly, the dashboard's READ function dropped the data

Lessons (saving to memory):
- After a perf optimization, ALWAYS run a measured end-to-end before declaring victory
- An integration smoke test (write enriched lineage, then call the read path, assert non-null) would have caught this in the original PR

## Verification plan post-merge

- Trigger `update-dashboard.yaml` workflow_dispatch
- The previous #518 self-enrich step ensures lineage is enriched even if cache restoration returns clobbered state
- This PR ensures `collect_variant_json` actually USES the enrichment via `lineage_json`
- Target: <5 min for `Generate dashboard data` (the 2-min self-enrich step is acceptable; total step <8 min)

## Refs

- Refs #515 (parent perf issue)
- Refs #516 / #517 / #518 (prior PRs in the chain)
- Pre-push orthogonal gate: codex + copilot both CLEAN
