### PR TITLE
fix(dashboard): resolve lineage_json before sizes lookup (#515)

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -515,6 +515,21 @@ collect_variant_json() {
     fi
     [[ "$is_default" != "true" ]] && is_default="false"
 
+    # Lineage (build_digest + base_image with version mismatch check + #515 enrichment fields)
+    # Use variant_tag for lineage file lookup, version for mismatch check
+    # (NOT current_version — that's the container's latest published version,
+    # which may differ from this variant's PG major version).
+    # Resolved EARLY so the lineage-first reads below can consume it; resolve
+    # is cheap (file read + jq) and idempotent under repeated calls.
+    local flavor
+    if [[ "$is_versioned" == "true" ]]; then
+        flavor=$(variant_property "$container_dir" "$variant_name" "flavor" "$version")
+    else
+        flavor=$(variant_property "$container_dir" "$variant_name" "flavor")
+    fi
+    local lineage_json
+    lineage_json=$(resolve_variant_lineage_json "$container" "$variant_tag" "$version" "$fallback_base_image" "$flavor")
+
     # Sizes — prefer lineage (post-#515 enriched fields), fall back to network
     local size_amd64="" size_arm64=""
     if [[ "$current_version" != "no-published-version" ]]; then
@@ -537,19 +552,6 @@ collect_variant_json() {
             fi
         fi
     fi
-
-    # Lineage (build_digest + base_image with version mismatch check)
-    # Use variant_tag for lineage file lookup, version for mismatch check
-    # (NOT current_version — that's the container's latest published version,
-    # which may differ from this variant's PG major version)
-    local flavor
-    if [[ "$is_versioned" == "true" ]]; then
-        flavor=$(variant_property "$container_dir" "$variant_name" "flavor" "$version")
-    else
-        flavor=$(variant_property "$container_dir" "$variant_name" "flavor")
-    fi
-    local lineage_json
-    lineage_json=$(resolve_variant_lineage_json "$container" "$variant_tag" "$version" "$fallback_base_image" "$flavor")
 
     # Build args
     local build_args_json


### PR DESCRIPTION
## Summary

Fourth fix in the #515 chain. Verification run 26394614535 (post-#516/#517/#518/#521) crashed with `lineage_json: unbound variable` on every variant. Under `set -u` (nounset) the script falls back silently and continues with network calls. Symptom: dashboard step still ~22min (cancelled during run; would have been ~70min).

## Root cause

`collect_variant_json` (in `generate-dashboard.sh`) was structured as:
- (line 519) sizes lookup reading `$lineage_json`
- (line 552) `local lineage_json` declaration + assignment from `resolve_variant_lineage_json`

The sizes section read `$lineage_json` before it was declared. `set -u` raised `unbound variable`. Same pattern would have failed the platforms/digests section too if execution reached it.

## The fix

Move the flavor + `lineage_json` resolution to run immediately after the variant-tag setup, before any lineage-first reads. Now the sizes lookup, platforms/digests, and attestation lookup all see an initialized `lineage_json`.

## Integration smoke (added one)

Local smoke at `~/.claude/jobs/.../smoke-test/run-smoke.sh` exercises `collect_variant_json` end-to-end with a synthetic enriched lineage file and mocked network functions. Asserts:
- ✅ `rc=0` (no unbound variable error)
- ✅ Output JSON contains all 8 enrichment fields (`multi_arch_index_digest`, `manifest_digest_amd64/arm64`, `multi_arch_platforms`, `size_amd64_bytes`/`size_arm64_bytes` converted to MB, `attestation_id`, `attestation_url`)
- ✅ Normalized overrides correctly applied (`build_digest`, `base_image`, `oci_subject_digest`)
- ✅ **Zero network calls detected** — fast path activated

Smoke output:
```
=== Output JSON ===
{
  "size_amd64": "11.8MB",
  "size_arm64": "64.7MB",
  "multi_arch_index_digest": "sha256:idx789",
  "manifest_digest_amd64": "sha256:amd111",
  "manifest_digest_arm64": "sha256:arm222",
  "multi_arch_platforms": ["amd64","arm64"],
  "attestation_id": "att-001",
  "attestation_url": "https://example.com/att/001",
  ...
}
=== Network calls ===
✅ Zero network calls — fast path activated
```

## Lessons captured to memory

- `feedback_perf_integration_smoke_test.md` — when a perf fix shifts work between layers, unit tests of each side are insufficient; require an end-to-end smoke that asserts the fast path activates.
- Each previous fix was correct on its own merit but didn't deliver perf because subsequent bugs blocked the fast path. Without the integration smoke, only CI verification (15 min cycle) could expose each issue.

## Refs

- Refs #515 (parent perf issue)
- Refs #516 / #517 / #518 / #521 (prior PRs in the chain — all needed, but none alone delivered the perf gain)
- Pre-push orthogonal gate: codex + copilot both CLEAN
- Local integration smoke passes
