### PR TITLE
docs(blog): #515 dashboard perf series — 3 scheduled posts

### DIFF
--- a/docs/site/_posts/2026-05-25-dashboard-perf-architecture-build-time-lineage.md
+++ b/docs/site/_posts/2026-05-25-dashboard-perf-architecture-build-time-lineage.md
@@ -1,0 +1,220 @@
+---
+layout: post
+title: "The dashboard that did 540 network calls per regen (part 1 of 3)"
+description: "Our containers dashboard step was taking 70+ minutes per refresh, almost entirely on per-variant GHCR fetches. This is the first of three posts on the fix: the architectural shift from per-regen network calls to build-time lineage enrichment — and why getting that shift right is harder than it looks."
+date: 2026-05-25 10:00:00 +0000
+tags: [ci, dashboard, perf, github-actions, jekyll, architecture, post-mortem, series-dashboard-perf]
+---
+
+The dashboard for [oorabona/docker-containers](https://github.com/oorabona/docker-containers) is a static Jekyll site that surfaces, for every container in the repo, its trust strip (digests, attestation links, SBOM packages, Trivy summary) and per-variant metadata. It is regenerated on every push to `master` and on every daily upstream-monitor cron. For about two weeks, that regen step had been quietly taking **between 70 and 80 minutes**.
+
+This is the first of three posts on what we found and what we did about it.
+
+- **Part 1 (this post)** — the diagnostic and the architectural shift: most of the work the dashboard did at regen time was wasted on data that does not change between regens.
+- **Part 2 — coming 2026-05-27** — six PRs and the integration smoke test that wasn't there: each fix passed its unit tests, then masked the next bug.
+- **Part 3 — coming 2026-05-29** — the bash builtin that hid a 30-minute hang.
+
+The full result is at the end of part 3. The work was real and the architectural shift is the right answer, but it took us a chain of PRs to actually deliver the perf gain it promised. The story of why that took six PRs is part 2; this post is about what the right architecture even looked like.
+
+## The symptom
+
+The `Generate dashboard data` step in `update-dashboard.yaml` is the heart of the regen. It walks every container directory, for each container its versions, for each version its variants, and for each variant it emits a JSON record consumed by Jekyll templates. The job timeout had been bumped 15 → 40 → 90 minutes over two months as the step kept growing. The most recent runs were landing in the 70-79 min range — well past every previous bump.
+
+A typical baseline run (`Generate dashboard data` step only):
+
+```
+Re-download SBOM artifacts:                            62s
+Restore GHCR per-arch manifest cache:                   1s
+Generate dashboard data:                             4780s   ← 79 min, the entire step
+```
+
+The first thing we did was look at the per-container time. The script logs `ℹ️  Processing <container>...` for every container as it enters its loop iteration, so the gap between two consecutive `Processing` lines is the cost of the previous container. Here it is in production:
+
+| Container | Wall time |
+|-----------|----------|
+| ansible | 25 s |
+| debian | 4 s |
+| **github-runner** | **74 min** |
+| jekyll | 5 s |
+| openresty | 6 s |
+| openvpn | 6 s |
+| php | 9 s |
+| postgres | 35 s |
+| sslh | 4 s |
+| terraform | 2 min |
+| vector | 7 s |
+| web-shell | 15 s |
+| wordpress | 9 s |
+
+One container, 93% of the step. We had a target, not a distributed problem.
+
+Going one level deeper — every variant of `github-runner`:
+
+```
+ghcr-index oorabona/github-runner:2.334.0                          0.080s
+ghcr-index oorabona/github-runner:2.334.0-dev                      0.080s
+ghcr-index oorabona/github-runner:2.334.0-debian-trixie            0.080s
+ghcr-index oorabona/github-runner:2.334.0-debian-trixie-dev        0.081s
+ghcr-index oorabona/github-runner:2.334.0-windows-ltsc2022         0.063s
+slurp guard fired for github-runner:2.334.0-windows-ltsc2022 … 38s after the line above
+ghcr-index oorabona/github-runner:2.334.0-windows-ltsc2022-dev     0.059s
+slurp guard fired for github-runner:2.334.0-windows-ltsc2022-dev … 22 minutes 50 seconds after the line above
+```
+
+Six Linux variants in ~3 seconds combined. Then a 38-second pause on the Windows base variant. Then **22 minutes** of total silence on Windows-dev. Three versions of `github-runner` were being retained (we keep the last three), so this was repeated three times.
+
+A second baseline run, the next day, came in slightly worse. The gap on the slowest Windows-dev variant was 29 min, not 22. The pattern was real but its duration was non-deterministic.
+
+## The audit
+
+The instinct on a slow loop is to make the loop faster. Before doing that, we audited what `collect_variant_json` does per variant. Each call produces a JSON record with these fields:
+
+| Field | Source | Mutable between regens? |
+|-------|--------|--|
+| `name`, `tag`, `description`, `is_default` | `variants.yaml` | No (config) |
+| `variant_deps`, `when_to_use`, `extensions` | `config.yaml` | No (config) |
+| `build_args` | `config.yaml` | No (config) |
+| `build_digest`, `oci_subject_digest`, `base_image` | `.build-lineage/<tag>.json` | No (build artifact) |
+| `size_amd64`, `size_arm64` | `ghcr_get_manifest_sizes` (network) | **No — set at push time** |
+| `multi_arch_platforms` | `ghcr_get_manifest_sizes` (network) | **No — set at push time** |
+| `multi_arch_index_digest`, `manifest_digest_{amd64,arm64}` | `ghcr_get_multi_arch_digests` (network) | **No — set at push time** |
+| `attestation_id`, `attestation_url` | `gh api repos/.../attestations/<digest>` (network) | **No — set at attestation time** |
+| `sbom_summary`, `sbom_packages` | `.build-lineage/<tag>.sbom.json` | No (SBOM artifact) |
+| `changelog`, `build_history` | `.build-lineage/<tag>.changelog.json` | No (build artifact) |
+| `trivy_summary.last_scan`, `counts` | code-scanning API (network) | Yes (scans run on schedule) |
+
+Of the fields requiring network calls, **only `trivy_summary` is genuinely dynamic between regens**. Everything else is locked the moment the image is pushed (sizes, platforms, manifest digests) or the attestation is registered (attestation IDs). Those values do not change until the image is rebuilt and re-pushed.
+
+Yet for every dashboard regen we were issuing, per variant:
+
+- One call to `ghcr_get_manifest_sizes` (for sizes + platforms list)
+- One call to `ghcr_get_multi_arch_digests` (for the index + per-arch digests)
+- One call to `gh api .../attestations/<digest>` (for the attestation ID)
+
+For 78 variant entries across the catalog, that is roughly 234 network calls per dashboard regen, **fetching data that has not changed since the last container build**. The dashboard regen runs many times per day (push events, cron, manual triggers). Most of those calls were producing the same answer as the previous regen.
+
+The Windows-dev variants happened to be the worst case for unrelated reasons we'll get to in part 3, but the architectural problem applies to every variant: we were paying GHCR-pull latency for data that should have been computed once at build time.
+
+The owner of the repo put it concisely:
+
+> *If `github-runner` is rebuilt once per month, its stats should move once per month — not once per dashboard regen.*
+
+## The contract
+
+The fix is structural, not algorithmic. We already write a lineage JSON file at build time: `scripts/build-container.sh::_emit_build_lineage` is called by the per-arch build job after the push, and it writes `.build-lineage/<container>-<tag>.json` with `build_digest`, `oci_subject_digest`, `base_image_ref`, `build_args`, and a few other fields. That file is then bundled into a GitHub Actions cache by the `cache-lineage` job and restored by the dashboard regen.
+
+The new contract: **add the 8 missing immutable fields to that same file, at the same time**. The dashboard reads them with a fallback to the network if the field is absent (for pre-migration lineage files, so the migration ships without invalidating any existing cache).
+
+```text
+                                         ┌──── enrich-lineage.sh ────┐
+                  build job              │                           │
+    push image  ──────────►  GHCR push   │  multi_arch_index_digest  │
+                                ▼        │  manifest_digest_amd64    │
+                   _emit_build_lineage:  │  manifest_digest_arm64    │
+                     build_digest        │  multi_arch_platforms     │
+                     oci_subject_digest  │  size_amd64_bytes         │
+                     base_image_ref      │  size_arm64_bytes         │
+                     build_args          │  attestation_id           │
+                                ▼        │  attestation_url          │
+                   cache-lineage job:    │                           │
+                     merge per-arch      │  read fields once,        │
+                     artifacts           │  write back to lineage    │
+                                ▼        │                           │
+                   .build-lineage/       └─────────── ▲ ─────────────┘
+                   <container>-<tag>.json    ────────►│
+                                ▼
+                   GH Actions cache
+                                ▼
+                   dashboard regen reads cache, calls collect_variant_json,
+                   variant_json reads lineage_first; network fallback only
+                   when fields are absent
+```
+
+The choice that made the implementation tractable: do the enrichment **once per build run**, inside the `cache-lineage` job, after the per-arch artifacts have been merged. That job already had GHCR auth via `GITHUB_TOKEN` and runs on `ubuntu-latest`. It also runs every time something gets built, so the lineage cache it saves is always at least as fresh as the most recent build.
+
+Two things make this safe to ship as a single PR:
+
+**Reuse the existing helpers.** `helpers/registry-utils.sh::ghcr_get_manifest_sizes` and `ghcr_get_multi_arch_digests` already implement the GHCR queries the dashboard was making. Same code path, called at a different time. No new query logic to validate.
+
+**Graceful fallback on the read side.** `generate-dashboard.sh::collect_variant_json` now checks each enrichment field in lineage_json; if any are absent, it falls through to the original network call. Pre-migration lineage files (which won't have the new fields until they're rebuilt) keep working unchanged.
+
+## The implementation
+
+`scripts/enrich-lineage.sh` is the new helper. It walks `.build-lineage/*.json`, skips auxiliary files (`*.sbom.json`, `*.changelog.json`, `*.history.json`, `ext-*.json`), and for each container lineage file:
+
+1. Reads `container`, `tag`, `oci_subject_digest` via `jq`.
+2. Checks idempotency: if `multi_arch_index_digest` is already non-null, the file is enriched — skip it. This makes the script safe to re-run.
+3. Calls `ghcr_get_multi_arch_digests "$image_path" "$tag"` for the index + per-arch digests.
+4. Calls `ghcr_get_manifest_sizes "$image_path" "$tag"` for the per-arch byte sizes and the platform list.
+5. Calls `get_attestation_id "$oci_subject_digest"` (and `get_attestation_url`) for the attestation pair.
+6. Merges all 8 fields into the lineage file in a single `jq` call, atomic `mktemp` + `mv`.
+
+A per-file failure (GHCR transient error, missing attestation) logs a soft notice and continues. The whole batch is fault-tolerant: one bad container's lineage cannot stop the others.
+
+The workflow change is two lines, one new step in the `cache-lineage` job:
+
+```yaml
+- name: Enrich lineage with multi-arch manifest data
+  if: steps.merge.outputs.has_files == 'true'
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+  run: |
+    chmod +x scripts/enrich-lineage.sh
+    ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
+```
+
+The `cache-lineage` job's `sparse-checkout` was extended to include `scripts/` (it only had `helpers/`). The enriched lineage is then saved back to the same Actions cache the dashboard restores.
+
+On the dashboard side, `collect_variant_json` reads lineage-first in three regions:
+
+```bash
+# Sizes — prefer lineage, fall back to network
+lineage_size_amd64=$(echo "$lineage_json" | jq -r '.size_amd64_bytes // empty')
+if [[ -n "$lineage_size_amd64" && "$lineage_size_amd64" =~ ^[0-9]+$ ]]; then
+    size_amd64=$(awk -v b="$lineage_size_amd64" 'BEGIN{printf "%.1fMB", b/1048576}')
+fi
+# (similar for arm64)
+
+if [[ -z "$size_amd64" && -z "$size_arm64" ]]; then
+    sizes_raw=$(get_ghcr_sizes "oorabona/$container" "$variant_tag" 2>/dev/null) || true
+    # ... existing network-derivation logic ...
+fi
+```
+
+Same idiom for the multi-arch digest fast path and the attestation lookup. The fallback is intentionally conservative: only when *every* expected field is absent do we fall through to the network call, so a partially-enriched lineage still uses the values it has.
+
+## What changed empirically
+
+After the PR landed and the next auto-build enriched the lineage cache, the per-variant network profile dropped sharply:
+
+| Metric | Before | After |
+|--|--|--|
+| `ghcr-index` latency entries per dashboard regen | 167 | 13 |
+| `gh-attestation` latency entries per dashboard regen | 77 | 12 |
+
+The remaining 13 + 12 are containers whose lineage hasn't been rebuilt yet (so the fallback fires) plus a handful of legitimate refreshes (a non-variant code path we left for follow-up). For every container with an enriched lineage, the per-variant work became a sequence of local file reads and one short `jq` invocation.
+
+This is the win. The architecture moved 95% of the per-variant work from "I do this on every dashboard regen" to "I do this once when the image gets built", which is where it belonged.
+
+## What didn't change
+
+The dashboard step duration. From 79.7 min to 83 min, to 70, to 72, depending on the run. There was a problem we had not yet found — and it was not visible from the network profile.
+
+The architectural shift turned out to be necessary but not sufficient. The next post in this series — **2026-05-27** — walks through six PRs of getting an architectural fix to actually pay off, and the integration smoke test we wished we had written.
+
+## What this post is also about
+
+If you read this and the only thing you take away is `enrich-lineage.sh`, you've taken the wrong lesson. The shape that applies to other systems:
+
+**Audit the loop, not the iteration.** Speeding up `collect_variant_json` by 2× would not have moved the needle. Asking "what is this loop doing that shouldn't run at all" did. Field-by-field mutability classification is a cheap exercise that finds wasted work.
+
+**Build-time computation is the cheapest cache.** If a value is locked at build time, it should be persisted by the build, not re-derived on every reader. The reader gets file I/O instead of network I/O, which is two to four orders of magnitude faster and survives the producer being offline.
+
+**Ship the fallback, not just the optimization.** A reader that prefers the cached value but can degrade to the network call when the cache is incomplete is shippable in a single PR. A reader that hard-requires the cache must wait for every producer in the catalog to be rebuilt first — a much slower migration story.
+
+The architectural answer was the right answer. Part 2 of this series is about the six PRs it took to make that answer actually arrive.
+
+---
+
+*Refs: [#515](https://github.com/oorabona/docker-containers/issues/515), [#516](https://github.com/oorabona/docker-containers/pull/516). Code: [`scripts/enrich-lineage.sh`](https://github.com/oorabona/docker-containers/blob/master/scripts/enrich-lineage.sh), [`generate-dashboard.sh::collect_variant_json`](https://github.com/oorabona/docker-containers/blob/master/generate-dashboard.sh).*

--- a/docs/site/_posts/2026-05-27-six-prs-to-deliver-one-perf-win.md
+++ b/docs/site/_posts/2026-05-27-six-prs-to-deliver-one-perf-win.md
@@ -1,0 +1,202 @@
+---
+layout: post
+title: "Six PRs to deliver one perf win (part 2 of 3)"
+description: "The architectural shift in part 1 was the right answer. It still took six PRs and a trace-bisection round to make it land. The story of how each fix passed its unit tests, then masked the next bug — and the integration smoke test that finally broke the chain."
+date: 2026-05-27 10:00:00 +0000
+tags: [ci, dashboard, perf, debugging, integration-testing, post-mortem, series-dashboard-perf]
+---
+
+Part 1 of this series ended with an architectural shift that, on paper, should have moved a dashboard regen from 80 minutes to under 5. The lineage cache was being enriched at build time; the dashboard read it preferentially with a network fallback; the unit tests for the new helper were green. We pushed.
+
+The next dashboard run took **83 minutes**. Three minutes *worse* than before the fix.
+
+This post is about the six PRs we needed after that — and why the obvious explanations were all wrong.
+
+## PR #517 — the artifact clobber
+
+The first dashboard run after the merge showed the enrich-lineage step writing 78 files. The network profile, though, was unchanged: 167 ghcr-index calls, same as before. Whatever the dashboard was reading, it was not the enriched lineage.
+
+Looking at the workflow that restores the lineage cache, we found a hydration step in `update-dashboard.yaml`. To bridge a race between auto-build's `cache-lineage` job and the dashboard's restore — both write the same cache key, and a fresh build might not have its lineage in the dashboard's restored cache yet — the dashboard re-downloads `build-lineage-*` artifacts from recent build runs and merges them into `.build-lineage/`.
+
+The merge loop overwrites cached files with artifact contents whenever the source artifact has an `oci_subject_digest`. That guard was there for a different problem (digest-less fallbacks from older runs), but it had a side effect we hadn't accounted for:
+
+**Per-arch build artifacts are uploaded *before* `enrich-lineage.sh` runs.** They contain `build_digest`, `oci_subject_digest`, the base fields — but not the eight enrichment fields, because those are added by the `cache-lineage` job *after* the per-arch artifacts have been merged. The dashboard's hydration then overwrites the enriched cached file with the raw per-arch artifact, silently undoing the enrichment.
+
+The fix was a five-line guard inserted before the existing logic:
+
+```bash
+if [[ -f "$target" ]]; then
+  tgt_enriched=$(jq -e '(.multi_arch_index_digest // null) != null' "$target" \
+    >/dev/null 2>&1 && echo true || echo false)
+  if [[ "$tgt_enriched" == "true" ]]; then
+    echo "::notice::Preserving enriched cached lineage for $fname"
+    lineage_locked[$fname]=1
+    continue
+  fi
+  # ... existing tgt_has_digest logic ...
+fi
+```
+
+If the cached file already has `multi_arch_index_digest`, it's enriched — let it through unchanged. We pushed.
+
+The dashboard ran. It now took 70 minutes. Twelve percent better than the 79.7 baseline. A real improvement. Still far, far from <5 min.
+
+## PR #518 — the cache race that defeats the guard
+
+The next investigation question: if the guard preserves enrichment per-file, why is `ghcr-index` latency still 167?
+
+It turned out the file-level preservation had a precondition that wasn't always true: **the cache the dashboard restores has to be enriched to begin with.** A timing trace told the story:
+
+```
+21:58:30  auto-build cache-lineage SAVED enriched cache build-lineage-26373621326
+21:58:51  workflow_run dashboard (cancelled by concurrency 12 min in) SAVED 
+          its own cache build-lineage-26373612236
+21:59:15  verification dashboard restored "most recent" cache via prefix match
+          → got the cancelled run's cache (saved 21 seconds later)
+          → that cache was clobbered (no enrichment to preserve)
+          → guard never fires
+          → entire dashboard runs on the network fallback
+```
+
+GitHub Actions cache prefix-match returns the most-recently-saved cache. If a concurrent workflow_run dashboard saves its cache state *after* the enriching auto-build saves its, the dashboard's clobbered state wins the race. The next dashboard restores the clobbered cache, sees no enrichment, the guard from #517 does not fire, the merge proceeds, the clobbered state is re-saved as the latest. The cache is now in a clobbered fixed point.
+
+The fix was to make the dashboard self-healing: re-run `enrich-lineage.sh` once per dashboard regen, immediately after the merge loop ends. The script is idempotent (it skips files where `multi_arch_index_digest` is already non-null), so on a healthy cache this is a 2-second no-op. On a clobbered cache, it's a 2-minute recovery. Either way, the cache the dashboard saves is always enriched.
+
+```yaml
+- name: Re-enrich lineage after merge (self-heal against cache races)
+  if: hashFiles('.build-lineage/*.json') != ''
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+  run: |
+    chmod +x scripts/enrich-lineage.sh
+    ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
+```
+
+We pushed. The next dashboard ran. The re-enrich step succeeded, populating 78 files. Step duration: **72 minutes**.
+
+## PR #521 — the synthesizer drops the data
+
+By this point we had four pieces of evidence that the enrichment was being written correctly: the bats tests, the enrich step's own `Enriched 78 lineage files (0 errors)` log, the cache save step succeeding, and a manual inspection of the lineage cache contents during the run. The data was on disk. The dashboard was reading the disk. And yet the dashboard was still hitting the network for every variant.
+
+So we read `collect_variant_json` more carefully, top to bottom. The lineage data comes from a helper called `resolve_variant_lineage_json`. Its job, as we had understood it, was to load the lineage file from disk and return its contents. What it actually did:
+
+```bash
+resolve_variant_lineage_json() {
+    # ... lookup file, read three fields, do version-mismatch normalization ...
+    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
+}
+```
+
+It read three fields from the file. Then it synthesized **a brand new JSON object containing only those three fields**, with `yq -n` (start from nothing). Every other field from the file — including the eight enrichment fields — was dropped.
+
+The caller stored the synthesized object in `lineage_json`. The fast-path lookups added in PR #516 (`jq -r '.multi_arch_index_digest // empty'` etc.) always returned empty, because the synthesizer had quietly stripped that field on the way through. The fallback to the network always fired. Every variant. Every regen.
+
+We had reviewed `resolve_variant_lineage_json` while writing #516. We had read those exact lines. We had not noticed that the function was rebuilding the JSON instead of passing it through, because at the time the function returned exactly what its three callers needed and the new callers were being added *around* it, not through it.
+
+The fix preserves all source fields and overrides only the three normalized ones:
+
+```bash
+if [[ -n "$lineage_file" ]]; then
+    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+        jq '. + {build_digest: env.BD, base_image: env.BI, oci_subject_digest: env.OCI}' "$lineage_file"
+else
+    BD="$build_digest" BI="$base_image" OCI="$oci_subject_digest" \
+        yq -n -o json '.build_digest = strenv(BD) | .base_image = strenv(BI) | .oci_subject_digest = strenv(OCI)'
+fi
+```
+
+We pushed. The next dashboard run got cancelled at 22 minutes. The logs were full of:
+
+```
+./generate-dashboard.sh: line 522: lineage_json: unbound variable
+./generate-dashboard.sh: line 523: lineage_json: unbound variable
+```
+
+## PR #522 — the read-before-init under `set -u`
+
+In `collect_variant_json`, the new fast-path reads I had added in #516 read `$lineage_json` to look up `size_amd64_bytes`, `size_arm64_bytes`, etc. The `local lineage_json` declaration and `resolve_variant_lineage_json` call were further down in the function, after the sizes section, because the sizes section had been a self-contained operation in the original code.
+
+`generate-dashboard.sh` runs under `set -euo pipefail`. Reading an unset variable kills the script. The script is wrapped in `2>/dev/null || true` at every variant call site (each variant runs in `$(collect_variant_json …)`), so the error was *silent* — the subshell crashed, the caller got an empty string, the dashboard happily fell back to the network for that variant. No log on stdout. No alert. Just the original perf bug, restored, behind a `set -u` violation.
+
+The fix moves the lineage resolution to the top of the function:
+
+```bash
+[[ "$is_default" != "true" ]] && is_default="false"
+
+# Lineage resolved EARLY so every lineage-first read below can consume it.
+local flavor
+if [[ "$is_versioned" == "true" ]]; then
+    flavor=$(variant_property "$container_dir" "$variant_name" "flavor" "$version")
+else
+    flavor=$(variant_property "$container_dir" "$variant_name" "flavor")
+fi
+local lineage_json
+lineage_json=$(resolve_variant_lineage_json "$container" "$variant_tag" "$version" "$fallback_base_image" "$flavor")
+
+# Sizes — prefer lineage, fall back to network
+# ... read $lineage_json safely ...
+```
+
+Before pushing, I wrote a real integration smoke test:
+
+```bash
+# Synthetic enriched lineage on disk
+mkdir -p /tmp/test/.build-lineage
+echo '{"container":"foo", "tag":"1.0", "build_digest":"abc",
+       "multi_arch_index_digest":"sha256:idx", "size_amd64_bytes":12345 ...}' \
+       > /tmp/test/.build-lineage/foo-1.0.json
+
+# Mock the network functions to record every call
+get_ghcr_sizes() { echo "NETWORK_CALL" >> "$NETCALLS"; }
+ghcr_get_manifest_sizes() { echo "NETWORK_CALL" >> "$NETCALLS"; }
+get_attestation_id() { echo "NETWORK_CALL" >> "$NETCALLS"; }
+
+# Run the full collect_variant_json end-to-end
+output=$(collect_variant_json "foo" "$TESTROOT/foo" "base" "1.0" "1.0" "alpine:3" "true")
+
+# Assertions: enrichment in output, zero network calls
+[[ $(jq -r '.multi_arch_index_digest' <<<"$output") == "sha256:idx" ]] || die FAIL
+[[ ! -s "$NETCALLS" ]] || die "Network calls leaked"
+```
+
+The test failed locally before the move. After the move it passed: zero network calls, enrichment reaches the output. We pushed.
+
+The next dashboard run ran the full step in **69 minutes**, but the network profile had finally dropped: 167 → 13 `ghcr-index` calls, 77 → 12 `gh-attestation`. The architectural fast path was active. And the dashboard was *still* taking 69 minutes.
+
+## What was left
+
+At this point we had a dashboard whose per-variant work was almost free (the 13 remaining ghcr-index calls were the genuine refreshes), and yet the step was still taking ~70 minutes. The trace markers we added next told the rest of the story — that's part 3 of the series.
+
+But first the lesson worth pulling out of these four PRs.
+
+## The integration smoke that wasn't there
+
+Look at how each PR shipped:
+
+- #516: 12 bats unit tests for `enrich-lineage.sh`. All green. Orthogonal gate clean. **Did not deliver the perf gain.**
+- #517: workflow yaml change, 10 lines. Orthogonal gate clean. **Marginal perf gain.**
+- #518: another 9-line workflow change. Orthogonal gate clean. **No perf gain.**
+- #521: 13-line shell change. Orthogonal gate clean. **Crashed the dashboard with unbound variable errors.**
+- #522: actual structural fix + integration smoke test. **Made the fast path activate.**
+
+The first four PRs all *should* have been the fix. Every one of them was a real bug. Every one passed every test we ran on it. The integration smoke from #522 — synthetic enriched lineage on disk, mock network functions, call the full `collect_variant_json`, assert no network call fires — would have caught the bug in #521 (synthesizer drops the data), would have caught the bug in #522 itself (read-before-init), and would have surfaced the bug in #516 by failing at the next layer.
+
+It would not have caught the bugs in #517 and #518 (those were workflow-level cache interactions that bats can't reach without simulating GitHub Actions cache semantics), but it would have caught the *script-level* issues much earlier in the chain.
+
+The shape that applies to other optimizations:
+
+**Unit tests for each side of a layer transition are insufficient.** If you have a producer (writes to a cache) and a consumer (reads from a cache), you need a test that synthesizes producer output, feeds it to the consumer, and asserts the fast path activates. Without that, the producer and consumer can be individually correct while their *handshake* is wrong — and there is no caller in production that does both in the test environment.
+
+**A passing test can mask a missing test.** The 12 bats tests for `enrich-lineage.sh` proved it wrote the fields. They did not prove the dashboard read them. Each PR in the chain passed its tests because each PR was tested at the level it touched. The architectural transition — write here, read there — was tested nowhere until #522.
+
+**`set -euo pipefail` plus per-call `2>/dev/null || true` is a silent-failure factory.** Strict mode catches bugs at the cost of crashing the subshell. The outer `|| true` then swallows the crash. The net effect is that bugs introduced under strict mode are *louder in logs* but *silent in behavior* than they would be in lax mode. Strict mode is still worth it; you just need linting or a smoke test to catch the silent-fallback class, because the script itself will not.
+
+**Six PRs, four genuine bugs, all individually correct.** Layered optimizations have many handshakes. Each handshake is a place where one side can be right and the other side can be right and the combination can still be wrong. The cure is not "more PRs". The cure is one PR that exercises the full chain.
+
+The dashboard was running at 69 minutes after #522. The architectural shift had landed, the cache was enriched, the dashboard was reading the cache, and the per-variant network work was gone. Yet the step was somehow nearly as slow as before. The next post — **2026-05-29** — is about what the trace markers found.
+
+---
+
+*Refs: [#515](https://github.com/oorabona/docker-containers/issues/515), [#517](https://github.com/oorabona/docker-containers/pull/517), [#518](https://github.com/oorabona/docker-containers/pull/518), [#521](https://github.com/oorabona/docker-containers/pull/521), [#522](https://github.com/oorabona/docker-containers/pull/522). Previous: [part 1]({% post_url 2026-05-25-dashboard-perf-architecture-build-time-lineage %}). Next: part 3 (2026-05-29).*

--- a/docs/site/_posts/2026-05-29-bash-parameter-expansion-hid-30-minutes.md
+++ b/docs/site/_posts/2026-05-29-bash-parameter-expansion-hid-30-minutes.md
@@ -1,0 +1,223 @@
+---
+layout: post
+title: "Nine bytes of bash hid a 30-minute hang (part 3 of 3)"
+description: "After five PRs, the dashboard's fast path was active, all unit tests were green, and the network profile had dropped 92%. The step still took 70 minutes. This is the story of how a bash parameter expansion you've probably used hundreds of times — ${var//pattern/replacement} — turned into an O(n) memory copy that ate 30 minutes per Windows-dev variant, and the nine-byte change that fixed it."
+date: 2026-05-29 10:00:00 +0000
+tags: [bash, perf, debugging, sbom, post-mortem, series-dashboard-perf]
+---
+
+Part 1 of this series moved 95% of the dashboard's per-regen work to build time. Part 2 took six PRs to actually make that shift land. After all of it, the dashboard step was still taking ~70 minutes — almost as slow as the 79.7-minute baseline before any of this work began. The architectural network calls were gone (167 ghcr-index → 13, 77 gh-attestation → 12) and yet the wall-clock time barely moved.
+
+Something was eating 70 minutes that had nothing to do with the network.
+
+This post is about how we found it, what it was, and why it's worth knowing about for any bash script that handles large JSON values.
+
+## The trace
+
+By PR #522 we had exhausted static analysis. Reading the script had told us where the bug *could* be, several times, and every place we had patched turned out to be a real bug that didn't move the bottom line. The remaining gap had to be measured.
+
+We added four conditional trace markers inside `collect_variant_json`, each timestamped, each gated on a `DASHBOARD_TRACE=1` env var, each printing the variant name:
+
+```bash
+[[ -n "${DASHBOARD_TRACE:-}" ]] && printf '[trace] %s pre-trivy %s:%s\n' \
+    "$(date -Iseconds)" "$container" "$variant_tag" >&2
+trivy_summary=$(get_trivy_summary "$trivy_category")
+[[ -n "${DASHBOARD_TRACE:-}" ]] && printf '[trace] %s post-trivy %s:%s\n' \
+    "$(date -Iseconds)" "$container" "$variant_tag" >&2
+
+# ... platforms + digests lineage-first lookup ...
+[[ -n "${DASHBOARD_TRACE:-}" ]] && printf '[trace] %s post-platforms %s:%s\n' \
+    "$(date -Iseconds)" "$container" "$variant_tag" >&2
+
+# ... variant_deps assembly ...
+[[ -n "${DASHBOARD_TRACE:-}" ]] && printf '[trace] %s pre-slurp %s:%s\n' \
+    "$(date -Iseconds)" "$container" "$variant_tag" >&2
+
+_slurp_guard lineage_json   '...'
+_slurp_guard build_args_json '[]'
+_slurp_guard sbom_summary    '{}'
+_slurp_guard sbom_packages   '{}'
+_slurp_guard changelog       '{}'
+_slurp_guard build_history   '[]'
+_slurp_guard trivy_summary   '{}'
+_slurp_guard multi_arch_platforms_json '[]'
+_slurp_guard multi_arch_digests_json   '{...}'
+```
+
+The workflow change to expose the gate was three lines (`DASHBOARD_TRACE: ${{ contains(...trigger_reason, 'TRACE') ... }}`), gated through both `github.event.inputs.trigger_reason` (for workflow_dispatch) and `inputs.trigger_reason` (for workflow_call) — the orthogonal review caught that the workflow_call path was missing before we pushed.
+
+We triggered a dashboard run with `TRACE` in the trigger reason and let it run for the full 79 minutes. Then we pulled the trace markers for the variant we knew was slow:
+
+```
+11:56:12.266  pre-trivy       github-runner:2.334.0-windows-ltsc2022-dev
+11:56:12.283  post-trivy      github-runner:2.334.0-windows-ltsc2022-dev
+11:56:12.303  post-platforms  github-runner:2.334.0-windows-ltsc2022-dev
+11:56:12.321  pre-slurp       github-runner:2.334.0-windows-ltsc2022-dev
+12:26:03.435  WARN: slurp guard fired: empty changelog for github-runner:2.334.0-windows-ltsc2022-dev
+```
+
+Three sections covering `pre-trivy → post-trivy → post-platforms → pre-slurp`, each 17-20 milliseconds apart. Then **29 minutes and 51 seconds** before the next event — which was the WARN print from inside `_slurp_guard` itself.
+
+Trivy was 17 ms. The platforms lookup was 20 ms. The variant_deps assembly was 18 ms. And then the slurp guards consumed half an hour.
+
+## What the slurp guards do
+
+The slurp guards exist because of a stream-shift bug in `jq -s`. The final variant record is assembled by piping nine JSON values into a single `jq -s` call:
+
+```bash
+printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' \
+    "$lineage_json" "$build_args_json" \
+    "$sbom_summary" "$sbom_packages" \
+    "$changelog" "$build_history" \
+    "$trivy_summary" "$multi_arch_platforms_json" \
+    "$multi_arch_digests_json" | \
+jq -s '
+    .[0] as $lineage |
+    .[1] as $build_args |
+    .[2] as $sbom_summary |
+    .[3] as $sbom_packages |
+    .[4] as $changelog |
+    # ...
+'
+```
+
+If any of the nine values is an empty string, `printf '%s\n' ""` produces a single newline. `jq -s` reads multiple JSON documents from a stream and bundles them into one array. An empty stream element gets *silently dropped*, the array collapses from 9 elements to 8, and every positional `.[N]` index shifts by one. We had hit this once already (terraform's provenance digest rows landed in the multi-arch-platforms slot), and the slurp guards were the defensive fix:
+
+```bash
+_slurp_guard() {
+    local _name="$1" _fallback="$2"
+    local _val="${!_name}"
+    if [[ -z "${_val//[[:space:]]/}" ]]; then
+        printf 'WARN: collect_variant_json slurp guard fired: empty %s for %s:%s — substituted fallback\n' \
+            "$_name" "$container" "$variant_tag" >&2
+        printf -v "$_name" '%s' "$_fallback"
+    fi
+}
+_slurp_guard lineage_json   '...'
+_slurp_guard build_args_json '[]'
+_slurp_guard sbom_summary    '{}'
+_slurp_guard sbom_packages   '{}'
+_slurp_guard changelog       '{}'
+# (and four more)
+```
+
+The check `[[ -z "${_val//[[:space:]]/}" ]]` is meant to catch empty or whitespace-only values: take the value, strip every whitespace character, see if anything remains. If not, the value was effectively empty, replace it with a safe JSON literal (`'[]'`, `'{}'`, etc.) so `jq -s` keeps nine elements.
+
+It's a defensive guard. It's the right idea. It is also where 30 minutes per Windows-dev variant were going.
+
+## What `${var//pattern/replacement}` actually does
+
+Bash's parameter expansion `${var//pattern/replacement}` performs a *global* substring substitution: it replaces every match of `pattern` in `var` with `replacement`. It does this by **allocating a new string** containing the result, and the original variable is left untouched. The expansion's value is the allocated copy.
+
+For `${val//[[:space:]]/}` — the pattern is "any whitespace character", the replacement is empty — bash walks the value character by character, builds a new string containing only the non-whitespace characters, and returns that. For a 10-character value the cost is negligible. For a 100-megabyte value, the cost is: allocate 100 MB, copy 100 MB byte by byte (skipping whitespace), and then immediately throw away the result because the only thing we want to know is whether it's empty.
+
+The `sbom_packages` value for Windows-dev variants of `github-runner` is exactly this case. The image includes a full Windows base layer plus a dev tooling stack. The SPDX SBOM enumerates every package: the syft scan produces a JSON file in the tens of megabytes. The dashboard's `get_sbom_packages` function reads that file with `jq` (a 60-second timeout, no warning was firing, the jq was completing), restructures it into a nested object grouped by package type, and the resulting value held in `sbom_packages` is *still* large — comfortably in the 50-100 MB range.
+
+When `_slurp_guard sbom_packages '{}'` runs, bash sees a multi-tens-of-MB string in `_val` and asks for a copy with all whitespace removed. On the runner this takes ~5-10 minutes. Multiply by nine `_slurp_guard` invocations per variant (each operating on its own value, but `sbom_packages` is the dominant one), times three Windows-dev variants per regen (we retain three versions of `github-runner`), and you have roughly 30 minutes per regen burned on a defensive whitespace strip.
+
+The architectural fast path from part 1 made the *network* part of the work negligible. It did nothing about this. The `sbom_packages` value was just as large after the fix as before — it had always been read from the SBOM file, which itself had always been written by the build job. The dashboard had always paid for the slurp-guard whitespace check; we just hadn't noticed because the network calls had been even more expensive.
+
+Once the network calls were gone, the slurp guard was suddenly the dominant cost.
+
+## A benchmark
+
+A 12.8 MB synthetic JSON-like string, OLD vs NEW check:
+
+```
+String size: 12800005 bytes
+
+OLD check (global substitution):
+  real    0m0.542s
+  user    0m0.471s
+  sys     0m0.072s
+
+NEW check (regex with short-circuit):
+  real    0m0.258s
+  user    0m0.163s
+  sys     0m0.095s
+```
+
+A 51 MB version:
+
+```
+String size: 51200005 bytes
+
+OLD check:
+  real    0m2.386s
+  user    0m1.986s
+  sys     0m0.400s
+
+NEW check:
+  real    0m1.245s
+  user    0m0.748s
+  sys     0m0.395s
+```
+
+Per call the old check is roughly twice as slow on these sizes. The gap on real `sbom_packages` payloads is larger — the runner is doing other work, allocating that much memory triggers paging and GC behavior these microbenchmarks don't capture, and bash's pattern-substitution implementation has non-linear performance on some pathological inputs depending on the alphabet size and the value's structure.
+
+What the benchmark *does* prove is that the new check, on the same input, never costs more than the old one and is meaningfully cheaper at large sizes. Whatever the constant factor in CI is, the new check pays less of it.
+
+## The fix
+
+Nine bytes, near enough:
+
+```diff
+ _slurp_guard() {
+     local _name="$1" _fallback="$2"
+     local _val="${!_name}"
+-    if [[ -z "${_val//[[:space:]]/}" ]]; then
++    if [[ -z "$_val" || "$_val" =~ ^[[:space:]]+$ ]]; then
+         printf 'WARN: collect_variant_json slurp guard fired: empty %s for %s:%s — substituted fallback\n' \
+             "$_name" "$container" "$variant_tag" >&2
+         printf -v "$_name" '%s' "$_fallback"
+     fi
+ }
+```
+
+The two checks are equivalent in semantics:
+
+- `[[ -z "$_val" ]]` — the value is truly empty (zero bytes).
+- `[[ "$_val" =~ ^[[:space:]]+$ ]]` — the value contains one or more characters and they are all whitespace.
+
+The disjunction covers the same set of inputs as `[[ -z "${_val//[[:space:]]/}" ]]`.
+
+The reason it is fast is that bash's regex engine, on a non-empty string starting with a non-whitespace character, **fails the anchor immediately**. The `^` requires the regex to match the entire string, the regex begins with `[[:space:]]+`, and the first character of a typical JSON value is `{` or `[`. The regex engine sees `{`, sees that `[[:space:]]+` cannot match `{`, fails the overall match, and returns. For a 100 MB string the time spent is the time to read one byte.
+
+The OLD check does no such short-circuit. It iterates the entire value, character by character, building the stripped copy as it goes, *even when the very first character has already told us the value is non-empty*. That's the design trade-off of `${var//pattern/replacement}`: it always produces a copy, because the caller might want the copy. We didn't. We wanted a boolean.
+
+The first commit message for this fix had a self-description that turned out to be the entire post-mortem in one line: *"the regex short-circuits on the first non-whitespace character"*. Bash had been giving us a tool that didn't short-circuit, and we had been calling it on values where the first character was almost always conclusive.
+
+## What the dashboard does now
+
+The next dashboard run after the merge:
+
+```
+Re-download SBOM artifacts:                                  41s
+Re-enrich lineage after merge (self-heal):                    2s
+Restore GHCR per-arch manifest cache:                         1s
+Generate dashboard data:                                    136s   ← 2 min 16 s
+```
+
+**79.7 min → 2.3 min, a 97% reduction.**
+
+Of the 136 seconds, roughly 60 seconds are the trivy-alerts fetch (one paginated `gh api code-scanning/alerts` call at the start of the run, cached across variants), 20-30 seconds are the per-variant orchestration overhead (shell loops, jq invocations, lineage reads), and the rest is the per-container container-level work that hasn't been moved to build time yet.
+
+We could optimize further. There's a remaining container-level `ghcr_get_manifest_sizes` at the top of each iteration that fires once per container regardless of variants. It contributes ~13 seconds total. We left it for follow-up — it's now the largest remaining piece, but it's no longer the bottleneck.
+
+## What this post is also about
+
+**Bash parameter expansions are not always free.** `${var//pattern/replacement}` is O(n) in the value's size, and the constant factor on large strings is high enough to matter. The substring forms (`${var#prefix}`, `${var%suffix}`) are usually fine because the comparison happens at the value's edges; the global form is the dangerous one because it touches every byte.
+
+**A "defensive" check is a hot path if it runs on every variant.** The slurp guard ran on nine variables per variant, dozens of times per regen. Its cost was directly proportional to the size of the value being guarded. Defensive code does not get an exemption from perf analysis just because it's defensive — if it's on the hot path, it's a hot path.
+
+**Static analysis ran out at a certain point.** Reading the script, we could see the slurp guard, we could see the check, we could see the values. We did not see that the check itself was the slow operation, because the check looked cheap. The trace markers told us the truth in five minutes.
+
+**Trace markers are worth their cost.** The markers added in the diagnostic commit were left in production. They are gated on `DASHBOARD_TRACE=1` via the trigger reason, produce no output in normal runs, and cost the workflow nothing. Adding them after a perf bug has surfaced is too late if there's no convenient harness; *keeping* them after the bug is found means the next bisection takes a `workflow_dispatch` instead of another PR cycle.
+
+The full chain — architectural shift in [part 1]({% post_url 2026-05-25-dashboard-perf-architecture-build-time-lineage %}), six PRs of fighting the layered handshakes in [part 2]({% post_url 2026-05-27-six-prs-to-deliver-one-perf-win %}), and this 9-byte fix — got the dashboard from 79.7 min to 2.3 min. The architecture did the real work; the bash builtin was hiding the result. The shape that surprised us is that the bash builtin's cost had always been there. Only when the architectural work removed everything else did it become visible.
+
+The lesson worth pulling out is uncomfortable but useful: an optimization that doesn't deliver might not be wrong. It might be right and *insufficient*. The next layer down can have a problem of its own. Keep going.
+
+---
+
+*Refs: [#515](https://github.com/oorabona/docker-containers/issues/515), [#523](https://github.com/oorabona/docker-containers/pull/523). Bash manual: [Shell Parameter Expansion §3.5.3](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html). Previous: [part 1]({% post_url 2026-05-25-dashboard-perf-architecture-build-time-lineage %}), [part 2]({% post_url 2026-05-27-six-prs-to-deliver-one-perf-win %}).*


### PR DESCRIPTION
## Summary

Three-part blog series on the #515 dashboard perf saga. Jekyll's `future: false` (deliberate, per `_config.yml` comment) means the posts will auto-reveal on their dates:

| Date | Article | Angle |
|------|---------|-------|
| 2026-05-25 (publishes immediately) | `dashboard-perf-architecture-build-time-lineage.md` | The architectural shift: move per-build immutable data from per-regen network calls to build-time lineage enrichment |
| 2026-05-27 | `six-prs-to-deliver-one-perf-win.md` | The six-PR chain: each fix passed unit tests, then masked the next bug. Integration smoke as the cure |
| 2026-05-29 | `bash-parameter-expansion-hid-30-minutes.md` | Deep dive on `${val//[[:space:]]/}` pathology on 50-100MB JSON; the regex short-circuit fix |

## Structure

Each post:
- Stands alone (a reader interested in CI archi reads #1, debugging methodology #2, bash deep dive #3)
- Cross-links to the others via `{% post_url %}` for Jekyll-native linking
- Shares the `series-dashboard-perf` tag for indexing
- Sticks to the existing blog tone (post-mortem narrative, evidence-heavy, lesson at end)

## Lengths

- Article 1: 15.7 KB / 220 lines (~5-7 min read)
- Article 2: 14.7 KB / 202 lines (~5-7 min read)
- Article 3: 15.3 KB / 223 lines (~5-7 min read)

Bounded per the editorial guideline of avoiding 20-min reads. Each ~half the length of `2026-05-14-docker-catalog-supply-chain-anatomy.md` (20.7 KB, the largest recent post).

## Refs

- Source incident: [#515](https://github.com/oorabona/docker-containers/issues/515)
- Six PRs covered: [#516](https://github.com/oorabona/docker-containers/pull/516), [#517](https://github.com/oorabona/docker-containers/pull/517), [#518](https://github.com/oorabona/docker-containers/pull/518), [#521](https://github.com/oorabona/docker-containers/pull/521), [#522](https://github.com/oorabona/docker-containers/pull/522), [#523](https://github.com/oorabona/docker-containers/pull/523)
- Result: 79.7 min → 2.3 min on the dashboard step (`Generate dashboard data`)
- Pre-push orthogonal gate: codex + copilot both CLEAN
