### PR TITLE
fix(terraform): cache all retained versions, not just latest

### DIFF
--- a/terraform/config.yaml
+++ b/terraform/config.yaml
@@ -4,8 +4,14 @@
 
 base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
 base_image_cache:
+  # Cache must include ALL retained upstream versions, not just the latest.
+  # Each retained variant build (1.15.4, 1.15.3, 1.15.2) does
+  # `FROM ${REMOTE_CR}/hashicorp/terraform:<that-version>`; if the cache only
+  # has the latest tag, retained builds 404 on the new GHCR path. List the
+  # tags explicitly until rotate-versions.sh learns to update this array
+  # alongside variants.yaml — see #515 follow-up.
   - source: hashicorp/terraform
-    tags: ["${UPSTREAM_VERSION}"]
+    tags: ["1.15.4", "1.15.3", "1.15.2"]
   - source: library/alpine
     tags: ["latest"]
   - source: library/python


### PR DESCRIPTION
## Summary

Terraform's REMOTE_CR migration (#512) introduced a regression on retained version builds. The fix: list all retained upstream tags explicitly so the cache populates them at sync time.

## Background

Before #512, terraform's base was cached at `ghcr.io/oorabona/terraform-base` with this entry:

```yaml
base_image_cache:
  - arg: TERRAFORM_BASE
    source: hashicorp/terraform
    ghcr_repo: terraform-base
    tags: ["${UPSTREAM_VERSION}"]
```

The `terraform-base` package accumulated 53 versions over months of builds (each run added the current upstream version). Retained variant builds (1.15.3, 1.15.2) found their tags in the cache.

After #512 the path moved to `ghcr.io/oorabona/hashicorp/terraform` (a fresh package). The same `tags: ["${UPSTREAM_VERSION}"]` declaration now writes only one tag per sync — the latest upstream version. The package has version `1.15.4` only. Retained variants 1.15.3 and 1.15.2 are missing.

## Symptom

Master push of #512 (commit `f4764f3`) ran the auto-build for terraform. Sync wrote `ghcr.io/.../hashicorp/terraform:1.15.4`. Then matrix builds spread to 1.15.4 / 1.15.3 / 1.15.2:

```
#5 ERROR: ghcr.io/***/hashicorp/terraform:1.15.2: not found
ERROR: failed to build: failed to solve: ghcr.io/***/hashicorp/terraform:1.15.2: not found
```

Latent until now: nothing has touched `terraform/` since the broken merge, so the failure hasn't re-fired. The next upstream-monitor PR or any push touching the container would re-break it.

A reproducer via `workflow_dispatch container=terraform rebuild=all` confirmed the same failure.

## Fix

List the retained tags explicitly:

```yaml
- source: hashicorp/terraform
  tags: ["1.15.4", "1.15.3", "1.15.2"]
```

Sync now writes all three tags. Each variant build finds its tag. The REMOTE_CR fast path activates.

The comment in the diff documents the maintenance need: when `upstream-monitor` rotates retained versions in `variants.yaml`, this array must also be updated. `rotate-versions.sh` does not currently touch `base_image_cache.tags` — that automation is a separate follow-up (see "Follow-up" below).

## Why this isn't `tags_from_versions: true`

The existing helper for multi-version caching (`tags_from_versions: true` on postgres) iterates `variants.yaml::versions` and uses each tag as-is. For postgres, `library/postgres:18-alpine` exists upstream — the variant tag *is* the Docker Hub tag.

Terraform's `variants.yaml` uses `1.15.4-alpine` / `1.15.3-alpine` / `1.15.2-alpine` (internal naming: we layer alpine on top of `hashicorp/terraform`). Docker Hub does not have `hashicorp/terraform:1.15.4-alpine` — only `hashicorp/terraform:1.15.4`. Reusing `tags_from_versions` would 404 on every sync.

A proper "strip suffix" feature in the helper would generalize this, but that's a follow-up (see below). For now, hardcoded tags are the smallest viable fix.

## Why this isn't covered by the REMOTE_CR fallback

`emit_reachable_cache_args` in `helpers/base-cache-utils.sh` checks if the cached tag (from `tags[0]`) is reachable. For terraform pre-fix, `tags[0]` resolves to `1.15.4` (the latest), which **is** in the cache — so the check passes and REMOTE_CR is emitted as `ghcr.io/oorabona`. The Dockerfile then resolves `FROM ${REMOTE_CR}/hashicorp/terraform:1.15.2` and 404s.

The check is per-config, not per-variant. The fallback can't catch this class — the check sees the configured tag, not the build's actual tag.

## Follow-up (separate issue)

`rotate-versions.sh` updates `variants.yaml::versions` when a new upstream version lands. It does not update `base_image_cache.tags`. To make this fix self-maintaining:

- Option A: Extend `rotate-versions.sh` to also rewrite the `tags:` array in `base_image_cache` entries flagged for retention.
- Option B: Add a new helper feature `tags_from_versions_strip: "-alpine"` (or similar) that derives sync tags from `variants.yaml::versions` with suffix stripping.
- Option C: Accept manual maintenance (small terraform team, releases ~quarterly).

For now the comment in the config documents the constraint. A follow-up issue will track the automation choice.

## Test

`workflow_dispatch container=terraform rebuild=all` once this PR is on master to confirm sync populates all three tags and the retained variant builds (1.15.3, 1.15.2) succeed.

## Refs

- #512 — the slice that introduced the regression
- #515 — the parent dashboard perf series (architectural shift is part 1 of the chain)
- Pre-push orthogonal gate: codex + copilot both CLEAN
