### PR TITLE
fix(dashboard): scope build success rate to master pushes only

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1120,8 +1120,12 @@ calculate_build_success_rate() {
     local thirty_days_ago
     thirty_days_ago=$(date -u -d "30 days ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-30d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
 
+    # Filter to master-push runs only. Without this, the rate dilutes with PR-CI
+    # failures from iterative development cycles (six PRs of #515 alone added 40+
+    # expected-fail jobs to the rolling window) which aren't representative of
+    # production health. The dashboard signal should reflect shipped-master state.
     local build_runs_json
-    build_runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=20&created=>$thirty_days_ago" 30 || true)
+    build_runs_json=$(github_api_get "repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?per_page=20&branch=master&event=push&created=>$thirty_days_ago" 30 || true)
 
     if [[ -n "$build_runs_json" ]] && echo "$build_runs_json" | jq -e '.workflow_runs' >/dev/null 2>&1; then
         local run_ids
@@ -1133,7 +1137,7 @@ calculate_build_success_rate() {
 
             if [[ -n "$jobs_json" ]] && echo "$jobs_json" | jq -e '.jobs' >/dev/null 2>&1; then
                 local run_build_total run_build_success
-                run_build_total=$(echo "$jobs_json" | jq '[.jobs[] | select(.name | startswith("Build")) | select(.status == "completed" and .conclusion != "skipped")] | length' 2>/dev/null || echo "0")
+                run_build_total=$(echo "$jobs_json" | jq '[.jobs[] | select(.name | startswith("Build")) | select(.status == "completed" and .conclusion != "skipped" and .conclusion != "cancelled")] | length' 2>/dev/null || echo "0")
                 run_build_success=$(echo "$jobs_json" | jq '[.jobs[] | select(.name | startswith("Build")) | select(.status == "completed" and .conclusion == "success")] | length' 2>/dev/null || echo "0")
 
                 build_total=$((build_total + run_build_total))


### PR DESCRIPTION
## Summary

Dashboard 'Build failures detected' alert was firing because `calculate_build_success_rate` counted ALL auto-build workflow runs in the rolling 30-day window — including PR-CI failures from iterative development cycles. Six PRs of #515 alone added 40+ expected-fail jobs (sync skipped on PR events, retained-variant builds 404 until merge). This dragged the rate to 64% (red threshold <80%).

The signal should reflect shipped-master state, not dev churn. Two changes:

1. Filter the workflow runs query to `branch=master&event=push`. Iterative PR retries no longer count.
2. Exclude `cancelled` jobs from the total. They were being counted as part of `build_total` (since the existing filter excluded only `skipped`), inflating the failure base.

## Numbers

Before this PR (rolling 30 days, all events):
- 74/114 build jobs successful → 64% → 'Build failures detected' (red)

After (rolling 30 days, master pushes, excluding cancelled):
- Will recover quickly as recent clean master pushes (post-#525) dilute the saga's 6 master failures
- Each subsequent green master push pulls one old failed run out of the 20-run window

## Test

Local URL probe confirms the query returns master pushes only:
```
gh api 'repos/oorabona/docker-containers/actions/workflows/auto-build.yaml/runs?branch=master&event=push&per_page=20'
→ workflow_runs: 14 success, 6 failure (vs 35/14 with all events)
```

Job-level recovery will be even sharper since partial-pass runs contribute mostly success.

## Refs

#515 (the saga whose iteration polluted the metric), #525 (final fix of the underlying terraform retained-version bug)
Pre-push orthogonal gate: codex + copilot both CLEAN