### PR TITLE
feat(retention): latest_per_major strategy for wordpress N+N-1 majors

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -363,8 +363,9 @@ jobs:
         run: |
           if [[ -f "$CONTAINER/variants.yaml" ]]; then
             retention=$(yq -r '.build.version_retention // 0' "$CONTAINER/variants.yaml")
-            if [[ "$retention" -gt 0 ]]; then
-              echo "🔄 Rotating version for $CONTAINER (retention: $retention)"
+            strategy=$(yq -r '.build.retention_strategy // ""' "$CONTAINER/variants.yaml")
+            if [[ "$retention" -gt 0 || "$strategy" == "latest_per_major" ]]; then
+              echo "🔄 Rotating version for $CONTAINER (retention: $retention, strategy: ${strategy:-count})"
               ./scripts/rotate-versions.sh "$CONTAINER" "$NEW_VERSION"
               echo "rotated=true" >> "$GITHUB_OUTPUT"
             else
@@ -501,8 +502,8 @@ jobs:
           echo "🔨 Triggering build for $CONTAINER after successful merge"
 
           scope_args=""
-          # Only scope by major version for multi-major containers (e.g., postgres)
-          # Containers with version_retention use full version tags — no major scoping needed
+          # Only scope by major version for containers without rotation (e.g., postgres with always_all_versions).
+          # Rotated containers (version_retention or latest_per_major) already updated their versions[] list — no scoping needed.
           if [[ "$ROTATED" != "true" ]]; then
             affected_major=$(echo "$NEW_VERSION" | grep -oE '^[0-9]+')
             if [[ -n "$affected_major" ]]; then

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -304,20 +304,39 @@ jobs:
             echo "🚀 Running in production mode"
           fi
 
+      - name: Resolve matrix entry
+        id: resolve
+        run: |
+          # matrix.container may be a plain name ("ansible") or a composite key
+          # ("wordpress:6") for latest_per_major containers.  Split on ':' to
+          # recover the real container name and the optional major line.
+          raw_key="${{ matrix.container }}"
+          if [[ "$raw_key" == *:* ]]; then
+            container_name="${raw_key%%:*}"
+            major_line="${raw_key#*:}"
+          else
+            container_name="$raw_key"
+            major_line=""
+          fi
+          echo "container_name=$container_name" >> $GITHUB_OUTPUT
+          echo "major_line=$major_line" >> $GITHUB_OUTPUT
+
       - name: Classify version change
         id: classify
         run: |
-          # Extract version info for this specific container from the JSON array
-          container_name="${{ matrix.container }}"
-          version_data=$(echo '${{ needs.check-upstream-versions.outputs.version_info }}' | jq -r --arg c "$container_name" '.[] | select(.container == $c)')
+          # Extract version info for this specific entry from the JSON array.
+          # For latest_per_major containers the container field in version_info is
+          # the composite key (e.g. "wordpress:6"); match exactly.
+          composite_key="${{ matrix.container }}"
+          version_data=$(echo '${{ needs.check-upstream-versions.outputs.version_info }}' | jq -r --arg c "$composite_key" '.[] | select(.container == $c)')
           current_version=$(echo "$version_data" | jq -r '.current_version')
           new_version=$(echo "$version_data" | jq -r '.latest_version')
 
           chmod +x .github/scripts/classify-version-change.sh
-          
+
           # Run classification and capture outputs (format: change_type=X, reason=Y)
           classification_output=$(.github/scripts/classify-version-change.sh "$current_version" "$new_version")
-          
+
           # Parse outputs using a loop for maintainability
           change_type=""
           reason=""
@@ -344,7 +363,7 @@ jobs:
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "reason=$reason" >> $GITHUB_OUTPUT
 
-          echo "Container: ${{ matrix.container }}"
+          echo "Container: ${{ steps.resolve.outputs.container_name }} (major_line: ${{ steps.resolve.outputs.major_line || 'n/a' }})"
           echo "Change: $current_version -> $new_version ($change_type)"
           echo "Reason: $reason"
 
@@ -358,15 +377,22 @@ jobs:
       - name: Rotate version in variants.yaml
         id: rotate
         env:
-          CONTAINER: ${{ matrix.container }}
+          CONTAINER: ${{ steps.resolve.outputs.container_name }}
           NEW_VERSION: ${{ steps.classify.outputs.new_version }}
+          MAJOR_LINE: ${{ steps.resolve.outputs.major_line }}
         run: |
           if [[ -f "$CONTAINER/variants.yaml" ]]; then
             retention=$(yq -r '.build.version_retention // 0' "$CONTAINER/variants.yaml")
             strategy=$(yq -r '.build.retention_strategy // ""' "$CONTAINER/variants.yaml")
             if [[ "$retention" -gt 0 || "$strategy" == "latest_per_major" ]]; then
-              echo "🔄 Rotating version for $CONTAINER (retention: $retention, strategy: ${strategy:-count})"
-              ./scripts/rotate-versions.sh "$CONTAINER" "$NEW_VERSION"
+              echo "🔄 Rotating version for $CONTAINER (retention: $retention, strategy: ${strategy:-count}, major_line: ${MAJOR_LINE:-n/a})"
+              # For latest_per_major containers, pass MAJOR_LINE so rotate-versions.sh
+              # updates only the matching major entry (leaving other lines untouched).
+              if [[ -n "$MAJOR_LINE" ]]; then
+                MAJOR_LINE="$MAJOR_LINE" ./scripts/rotate-versions.sh "$CONTAINER" "$NEW_VERSION" "$MAJOR_LINE"
+              else
+                ./scripts/rotate-versions.sh "$CONTAINER" "$NEW_VERSION"
+              fi
               echo "rotated=true" >> "$GITHUB_OUTPUT"
             else
               echo "ℹ️ No version_retention for $CONTAINER — skipping rotation"
@@ -381,17 +407,26 @@ jobs:
         id: close_duplicates
         uses: ./.github/actions/close-duplicate-prs
         with:
-          container: ${{ matrix.container }}
+          container: ${{ steps.resolve.outputs.container_name }}
           new_version: ${{ steps.classify.outputs.new_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create rebuild marker
+        env:
+          CONTAINER_NAME: ${{ steps.resolve.outputs.container_name }}
+          MAJOR_LINE: ${{ steps.resolve.outputs.major_line }}
         run: |
-          mkdir -p ${{ matrix.container }}
-          
+          mkdir -p "$CONTAINER_NAME"
+
           # Generate workflow run URL
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          
+
+          # Human-readable major line annotation for the rebuild marker
+          MAJOR_LINE_INFO=""
+          if [[ -n "$MAJOR_LINE" ]]; then
+            MAJOR_LINE_INFO="| **Major Line** | \`${MAJOR_LINE}.x\` |"
+          fi
+
           # Determine next steps based on change type
           if [[ "${{ steps.classify.outputs.change_type }}" == "major" ]]; then
             NEXT_STEPS="- ⚠️ **Manual review required** for major version changes
@@ -401,29 +436,30 @@ jobs:
             NEXT_STEPS="- ✅ **Auto-merge enabled** - will merge automatically once CI passes
           - Build will trigger automatically on merge"
           fi
-          
-          cat > ${{ matrix.container }}/LAST_REBUILD.md << EOF
+
+          cat > "$CONTAINER_NAME/LAST_REBUILD.md" << EOF
           # Container Rebuild Information
-          
+
           | Field | Value |
           |-------|-------|
-          | **Container** | \`${{ matrix.container }}\` |
+          | **Container** | \`$CONTAINER_NAME\` |
+          $MAJOR_LINE_INFO
           | **Version Change** | \`${{ steps.classify.outputs.current_version }}\` → \`${{ steps.classify.outputs.new_version }}\` |
           | **Change Type** | \`${{ steps.classify.outputs.change_type }}\` |
           | **Rebuild Date** | $(date -u +"%Y-%m-%dT%H:%M:%SZ") |
           | **Triggered By** | Upstream Monitor (automated) |
           | **Reason** | ${{ steps.classify.outputs.reason }} |
           | **Detection Run** | [View Workflow]($WORKFLOW_URL) |
-          
+
           ## Build Status
-          
+
           This file triggers the auto-build workflow when merged to master.
           Build status will be available in GitHub Actions after merge.
-          
+
           ## Next Steps
-          
+
           $NEXT_STEPS
-          
+
           ---
           *Auto-generated by docker-containers automation system*
           EOF
@@ -439,20 +475,57 @@ jobs:
           git_committer_name: Olivier ORABONA
           git_committer_email: oorabona@users.noreply.github.com
 
+      - name: Build PR metadata
+        id: pr_meta
+        env:
+          CONTAINER_NAME: ${{ steps.resolve.outputs.container_name }}
+          MAJOR_LINE: ${{ steps.resolve.outputs.major_line }}
+          CHANGE_TYPE: ${{ steps.classify.outputs.change_type }}
+          NEW_VERSION: ${{ steps.classify.outputs.new_version }}
+        run: |
+          # Construct PR title, branch, and body fragments that are major-line-aware.
+          # When major_line is set (latest_per_major container), the title includes
+          # the X.x line so operators can distinguish "6.x patch" from "7.x patch".
+          if [[ -n "$MAJOR_LINE" ]]; then
+            change_label="${CHANGE_TYPE^^}"
+            if [[ "$CHANGE_TYPE" == "major" ]]; then
+              emoji="🔄"
+            else
+              emoji="🚀"
+            fi
+            pr_title="${emoji} Patch: ${CONTAINER_NAME} ${MAJOR_LINE}.x to ${NEW_VERSION}"
+            # Branch suffix includes the major line to ensure parallel PRs for
+            # different major lines do not land on the same branch name.
+            pr_branch="update/${CONTAINER_NAME}-${NEW_VERSION}-line${MAJOR_LINE}"
+            major_line_note="**Major Line:** \`${MAJOR_LINE}.x\`"
+          else
+            if [[ "$CHANGE_TYPE" == "major" ]]; then
+              pr_title="🔄 Major: ${CONTAINER_NAME} to ${NEW_VERSION}"
+            else
+              pr_title="🚀 Minor: ${CONTAINER_NAME} to ${NEW_VERSION}"
+            fi
+            pr_branch="update/${CONTAINER_NAME}-${NEW_VERSION}"
+            major_line_note=""
+          fi
+          echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
+          echo "pr_branch=$pr_branch" >> $GITHUB_OUTPUT
+          echo "major_line_note=$major_line_note" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         if: steps.close_duplicates.outputs.existing_pr_found != 'true' && steps.env_check.outputs.is_local_test != 'true'
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "build(${{ matrix.container }}): update to ${{ steps.classify.outputs.new_version }}"
+          commit-message: "build(${{ steps.resolve.outputs.container_name }}): update to ${{ steps.classify.outputs.new_version }}"
           committer: Olivier ORABONA <oorabona@users.noreply.github.com>
-          title: "${{ steps.classify.outputs.change_type == 'major' && '🔄 Major' || '🚀 Minor' }}: ${{ matrix.container }} to ${{ steps.classify.outputs.new_version }}"
+          title: "${{ steps.pr_meta.outputs.pr_title }}"
           body: |
-            ## Container Update: ${{ matrix.container }}
+            ## Container Update: ${{ steps.resolve.outputs.container_name }}
 
             **Version Change:** `${{ steps.classify.outputs.current_version }}` → `${{ steps.classify.outputs.new_version }}`
             **Change Type:** `${{ steps.classify.outputs.change_type }}`
+            ${{ steps.pr_meta.outputs.major_line_note }}
 
             ${{ steps.classify.outputs.change_type == 'major' && '⚠️ **Major version change** - Please review carefully before merging.' || '✅ **Minor/patch update** - Should be safe to merge.' }}
 
@@ -460,7 +533,7 @@ jobs:
 
             ---
             *Auto-generated by Upstream Version Monitor*
-          branch: update/${{ matrix.container }}-${{ steps.classify.outputs.new_version }}
+          branch: ${{ steps.pr_meta.outputs.pr_branch }}
           delete-branch: true
           assignees: ${{ steps.classify.outputs.change_type == 'major' && github.repository_owner || '' }}
 
@@ -473,7 +546,7 @@ jobs:
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: |
           sleep 2
-          gh pr edit "$PR_NUMBER" --add-label "automation,${{ matrix.container }},${{ steps.classify.outputs.change_type }}-update"
+          gh pr edit "$PR_NUMBER" --add-label "automation,${{ steps.resolve.outputs.container_name }},${{ steps.classify.outputs.change_type }}-update"
 
       - name: Auto-merge minor updates
         id: merge_pr
@@ -495,7 +568,7 @@ jobs:
         if: steps.env_check.outputs.is_local_test != 'true' && steps.merge_pr.outputs.merged == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONTAINER: ${{ matrix.container }}
+          CONTAINER: ${{ steps.resolve.outputs.container_name }}
           NEW_VERSION: ${{ steps.classify.outputs.new_version }}
           ROTATED: ${{ steps.rotate.outputs.rotated }}
         run: |
@@ -522,7 +595,7 @@ jobs:
         if: steps.env_check.outputs.is_local_test != 'true' && steps.merge_pr.outputs.merged == 'true' && steps.rotate.outputs.rotated == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONTAINER: ${{ matrix.container }}
+          CONTAINER: ${{ steps.resolve.outputs.container_name }}
         run: |
           echo "🧹 Triggering registry cleanup for $CONTAINER (version rotated out)"
           gh workflow run cleanup-registry.yaml \
@@ -534,10 +607,10 @@ jobs:
         if: steps.env_check.outputs.is_local_test == 'true'
         run: |
           echo "🧪 LOCAL TEST MODE - Would create PR with:"
-          echo "   Title: ${{ steps.classify.outputs.change_type == 'major' && '🔄 Major' || '🚀 Minor' }}: ${{ matrix.container }} to ${{ steps.classify.outputs.new_version }}"
-          echo "   Branch: update/${{ matrix.container }}-${{ steps.classify.outputs.new_version }}"
+          echo "   Title: ${{ steps.pr_meta.outputs.pr_title }}"
+          echo "   Branch: ${{ steps.pr_meta.outputs.pr_branch }}"
           echo "   Change: ${{ steps.classify.outputs.current_version }} → ${{ steps.classify.outputs.new_version }} (${{ steps.classify.outputs.change_type }})"
-          echo "   Labels: automation, ${{ matrix.container }}, ${{ steps.classify.outputs.change_type }}-update"
+          echo "   Labels: automation, ${{ steps.resolve.outputs.container_name }}, ${{ steps.classify.outputs.change_type }}-update"
           echo "   Assignees: ${{ steps.classify.outputs.change_type == 'major' && github.repository_owner || '(none - minor update)' }}"
           echo "   Auto-merge: ${{ steps.classify.outputs.change_type == 'minor' && 'Yes (minor update)' || 'No (major update - requires manual review)' }}"
 

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -661,8 +661,13 @@ latest_per_major_versions() {
     local version_sh="$container_dir/version.sh"
     [[ -x "$version_sh" ]] || return 1
 
+    # Sort retained_majors numerically descending (newest first) so the first
+    # resolved entry is always the highest major. Downstream code that treats
+    # versions[0] as the "default" / "current" version then receives a stable,
+    # operator-misconfig-resistant answer even if retained_majors was written
+    # in arbitrary order (e.g. [6, 7] instead of [7, 6]).
     local majors
-    majors=$(yq -r '.build.retained_majors[]?' "$variants_file" 2>/dev/null) || return 1
+    majors=$(yq -r '.build.retained_majors[]?' "$variants_file" 2>/dev/null | sort -rn) || return 1
     [[ -z "$majors" ]] && return 0
 
     local failed=0

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -640,8 +640,48 @@ compute_expand_retained_map() {
     echo "$kv_json"
 }
 
+# latest_per_major_versions <container_dir>
+#
+# When variants.yaml declares retention_strategy: latest_per_major, read the
+# retained_majors list and resolve each major to its latest patch via the
+# container's version.sh --major N flag. Emit one resolved version per line
+# (e.g. "7.0.0-alpine"). Order preserved from retained_majors (newest first).
+#
+# Returns 0 with empty output if the strategy is not set or retained_majors
+# is empty; non-zero if a per-major resolution fails for any reason.
+latest_per_major_versions() {
+    local container_dir="$1"
+    local variants_file="$container_dir/variants.yaml"
+    [[ -f "$variants_file" ]] || return 1
+
+    local strategy
+    strategy=$(yq -r '.build.retention_strategy // ""' "$variants_file" 2>/dev/null) || strategy=""
+    [[ "$strategy" == "latest_per_major" ]] || return 0
+
+    local version_sh="$container_dir/version.sh"
+    [[ -x "$version_sh" ]] || return 1
+
+    local majors
+    majors=$(yq -r '.build.retained_majors[]?' "$variants_file" 2>/dev/null) || return 1
+    [[ -z "$majors" ]] && return 0
+
+    local failed=0
+    while IFS= read -r major; do
+        [[ -z "$major" ]] && continue
+        local resolved
+        if resolved=$("$version_sh" --major "$major" 2>/dev/null) && [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved"
+        else
+            echo "::warning::latest_per_major_versions: failed to resolve major=$major for $(basename "$container_dir")" >&2
+            failed=1
+        fi
+    done <<< "$majors"
+
+    return "$failed"
+}
+
 # Export functions for use in other scripts
 export -f resolve_major_version has_variants list_versions version_count list_variants variant_count
 export -f variant_property default_variant base_suffix version_retention
 export -f version_dockerfile requires_extensions variant_image_tag list_build_matrix list_container_builds list_variant_tags
-export -f always_all_versions compute_expand_retained_map
+export -f always_all_versions compute_expand_retained_map latest_per_major_versions

--- a/make
+++ b/make
@@ -413,9 +413,81 @@ check_updates() {
     if [ ! -f "$container/version.sh" ]; then
       continue # Skip containers without version.sh
     fi
-    
+
     pushd "$container" > /dev/null
-    
+
+    # Detect retention strategy for multi-entry (latest_per_major) containers
+    local strategy
+    strategy=$(yq -r '.build.retention_strategy // ""' variants.yaml 2>/dev/null) || strategy=""
+
+    if [[ "$strategy" == "latest_per_major" ]]; then
+      # Multi-entry path: emit one entry per retained major.
+      # The container field uses a composite key "container:major_line" so that
+      # the check-upstream-versions action can include both entries in the
+      # containers_with_updates array without deduplication.  Downstream
+      # consumers (create-update-prs) split on ':' to recover the real
+      # container name and the major line independently.
+      local majors
+      majors=$(yq -r '.build.retained_majors[]?' variants.yaml 2>/dev/null | sort -rn) || majors=""
+
+      while IFS= read -r major; do
+        [[ -z "$major" ]] && continue
+
+        # Composite key used in the container field for routing
+        local composite_key="${container}:${major}"
+
+        # Current published version on GHCR matching ^N\. pattern for this major
+        local major_pattern
+        major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
+        local current_version
+        current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+
+        # Latest upstream version for this major line
+        local latest_version
+        latest_version=$(./version.sh --major "$major" 2>/dev/null | head -1 | tr -d '\n' || echo "")
+
+        # Determine update status
+        local update_available="false"
+        local status="up_to_date"
+
+        if [ "$current_version" = "no-published-version" ]; then
+          if [ -n "$latest_version" ]; then
+            update_available="true"
+            status="new-container"
+          fi
+        elif [ "$current_version" != "$latest_version" ] && [ -n "$latest_version" ]; then
+          update_available="true"
+          status="update-available"
+        fi
+
+        # Build per-major JSON entry.
+        # container field = composite key (for action routing)
+        # major_line field = the plain major number (for human-readable outputs)
+        local container_json
+        container_json=$(jq -n \
+          --arg container "$composite_key" \
+          --arg major_line "$major" \
+          --arg current "$current_version" \
+          --arg latest "$latest_version" \
+          --argjson update_available "$update_available" \
+          --arg status "$status" \
+          '{
+            container: $container,
+            major_line: $major_line,
+            current_version: $current,
+            latest_version: $latest,
+            update_available: $update_available,
+            status: $status
+          }')
+
+        output_json=$(echo "$output_json" | jq ". + [$container_json]")
+      done <<< "$majors"
+
+      popd > /dev/null
+      continue  # skip the default single-entry path for this container
+    fi
+
+    # Default single-entry path (no latest_per_major strategy)
     # Get current and latest versions using container-specific patterns
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
     local pattern
@@ -426,11 +498,11 @@ check_updates() {
       current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
     fi
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
-    
+
     # Determine update status
     local update_available="false"
     local status="up_to_date"
-    
+
     if [ "$current_version" = "no-published-version" ]; then
       if [ -n "$latest_version" ]; then
         update_available="true"
@@ -440,7 +512,7 @@ check_updates() {
       update_available="true"
       status="update-available"
     fi
-    
+
     # Build JSON object for this container
     container_json=$(jq -n \
       --arg container "$container" \
@@ -455,10 +527,10 @@ check_updates() {
         update_available: $update_available,
         status: $status
       }')
-    
+
     # Add to output array
     output_json=$(echo "$output_json" | jq ". + [$container_json]")
-    
+
     popd > /dev/null
   done
   

--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -35,6 +35,28 @@ if [[ ! -f "$variants_file" ]]; then
     exit 1
 fi
 
+# Detect retention strategy — handle latest_per_major before count-based logic
+strategy=$(yq -r '.build.retention_strategy // ""' "$variants_file" 2>/dev/null) || strategy=""
+if [[ "$strategy" == "latest_per_major" ]]; then
+    echo "🔄 latest_per_major strategy detected for $container_dir" >&2
+
+    resolved=$(latest_per_major_versions "$container_dir")
+    if [[ $? -ne 0 || -z "$resolved" ]]; then
+        if [[ -z "$resolved" ]]; then
+            echo "::warning::No versions resolved for $container_dir via latest_per_major" >&2
+            exit 0
+        fi
+        echo "::error::Failed to resolve latest_per_major for $container_dir" >&2
+        exit 1
+    fi
+
+    # Rewrite variants.yaml versions[] from resolved list
+    versions_json=$(printf '%s' "$resolved" | jq -R -s 'split("\n") | map(select(length>0)) | map({tag: .})')
+    VERSIONS="$versions_json" yq -i '.versions = env(VERSIONS)' "$variants_file"
+    echo "✅ Updated $variants_file via latest_per_major: $(printf '%s' "$resolved" | tr '\n' ' ')" >&2
+    exit 0
+fi
+
 # Step 1: Check version_retention
 retention=$(version_retention "$container_dir")
 if [[ "$retention" -eq 0 ]]; then

--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 # Rotate versions in variants.yaml for automated version updates
 #
-# Usage: rotate-versions.sh <container_dir> <new_version>
+# Usage: rotate-versions.sh <container_dir> <new_version> [major_line]
+#
+# Arguments:
+#   container_dir  Directory containing variants.yaml
+#   new_version    The new version tag to add / replace
+#   major_line     (optional) Numeric major line (e.g. "6").
+#                  When set AND retention_strategy==latest_per_major, only
+#                  the versions[].tag matching "^<major_line>." is updated.
+#                  Also honoured via MAJOR_LINE env var (arg wins over env).
 #
 # Algorithm:
-#   1. Read build.version_retention (exit 2 if absent/zero — not a managed container)
-#   2. Check if new_version already exists (idempotent — exit 0)
-#   3. If container has variants: copy variants from first versions[] entry
-#   4. If no variants: create simple version entry {tag: "new_version"}
-#   5. Prepend new entry to versions[]
-#   6. Trim to version_retention entries
+#   1. Detect retention_strategy.
+#      - latest_per_major with major_line: single-line update path (updates
+#        only the matching major entry, leaves all other entries untouched).
+#      - latest_per_major without major_line: full re-resolution via
+#        latest_per_major_versions helper.
+#   2. count-based: read build.version_retention (exit 2 if absent/zero).
+#      2a. Check if new_version already exists (idempotent — exit 0).
+#      2b. If container has variants: copy variants from first versions[] entry.
+#      2c. Prepend new entry to versions[].
+#      2d. Trim to version_retention entries.
 
 set -euo pipefail
 
@@ -19,7 +31,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$ROOT_DIR/helpers/variant-utils.sh"
 
 usage() {
-    echo "Usage: $(basename "$0") <container_dir> <new_version>" >&2
+    echo "Usage: $(basename "$0") <container_dir> <new_version> [major_line]" >&2
     echo "Exit codes: 0=success, 1=error, 2=not a version_retention container" >&2
     exit 1
 }
@@ -28,6 +40,9 @@ usage() {
 
 container_dir="$1"
 new_version="$2"
+# Accept major_line as positional arg $3 or from MAJOR_LINE env var.
+# Positional arg wins when both are provided.
+major_line="${3:-${MAJOR_LINE:-}}"
 variants_file="$container_dir/variants.yaml"
 
 if [[ ! -f "$variants_file" ]]; then
@@ -39,6 +54,39 @@ fi
 strategy=$(yq -r '.build.retention_strategy // ""' "$variants_file" 2>/dev/null) || strategy=""
 if [[ "$strategy" == "latest_per_major" ]]; then
     echo "🔄 latest_per_major strategy detected for $container_dir" >&2
+
+    # ── Single-line update path ──────────────────────────────────────────────
+    # When major_line is provided (from upstream-monitor's per-major PR flow),
+    # update ONLY the versions[].tag entry whose tag starts with "<major_line>.".
+    # All other entries are left untouched.  This prevents a 6.x PR from
+    # accidentally overwriting the 7.x entry (or vice-versa).
+    if [[ -n "$major_line" ]]; then
+        # Validate: major_line must be a non-empty integer
+        if [[ ! "$major_line" =~ ^[0-9]+$ ]]; then
+            echo "::error::invalid major_line value: '$major_line' (must be a non-negative integer)" >&2
+            exit 1
+        fi
+
+        # Check that a matching entry actually exists in versions[]
+        existing_count=$(ML="$major_line" yq -r \
+            '[.versions[] | select(.tag | test("^" + strenv(ML) + "\\."))] | length' \
+            "$variants_file" 2>/dev/null || echo "0")
+        if [[ "$existing_count" -eq 0 ]]; then
+            echo "::warning::rotate-versions.sh: no versions[] entry matching ${major_line}.x found in $variants_file — skipping" >&2
+            exit 0
+        fi
+
+        # Replace only the matching entry's tag value.
+        ML="$major_line" NV="$new_version" yq -i \
+            '(.versions[] | select(.tag | test("^" + strenv(ML) + "\\.")) | .tag) = strenv(NV)' \
+            "$variants_file"
+        echo "✅ Updated $variants_file: ${major_line}.x line → $new_version" >&2
+        exit 0
+    fi
+
+    # ── Full re-resolution path ──────────────────────────────────────────────
+    # No major_line provided: resolve ALL retained majors via version.sh and
+    # rewrite the entire versions[] list.  Used for periodic rotation passes.
 
     # Capture rc safely under `set -e`: assignment inside the if-condition
     # is exempt, so a non-zero exit from latest_per_major_versions reaches

--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -40,18 +40,22 @@ strategy=$(yq -r '.build.retention_strategy // ""' "$variants_file" 2>/dev/null)
 if [[ "$strategy" == "latest_per_major" ]]; then
     echo "🔄 latest_per_major strategy detected for $container_dir" >&2
 
-    resolved=$(latest_per_major_versions "$container_dir")
-    if [[ $? -ne 0 || -z "$resolved" ]]; then
-        if [[ -z "$resolved" ]]; then
-            echo "::warning::No versions resolved for $container_dir via latest_per_major" >&2
-            exit 0
-        fi
+    # Capture rc safely under `set -e`: assignment inside the if-condition
+    # is exempt, so a non-zero exit from latest_per_major_versions reaches
+    # the explicit ::error:: annotation instead of aborting the script
+    # before the message can be printed.
+    if ! resolved=$(latest_per_major_versions "$container_dir"); then
         echo "::error::Failed to resolve latest_per_major for $container_dir" >&2
         exit 1
     fi
+    if [[ -z "$resolved" ]]; then
+        echo "::warning::No versions resolved for $container_dir via latest_per_major" >&2
+        exit 0
+    fi
 
-    # Rewrite variants.yaml versions[] from resolved list
-    versions_json=$(printf '%s' "$resolved" | jq -R -s 'split("\n") | map(select(length>0)) | map({tag: .})')
+    # Rewrite variants.yaml versions[] from resolved list (compact JSON avoids
+    # multi-line env-var edge cases when passed through to `yq -i`).
+    versions_json=$(printf '%s' "$resolved" | jq -c -R -s 'split("\n") | map(select(length>0)) | map({tag: .})')
     VERSIONS="$versions_json" yq -i '.versions = env(VERSIONS)' "$variants_file"
     echo "✅ Updated $variants_file via latest_per_major: $(printf '%s' "$resolved" | tr '\n' ' ')" >&2
     exit 0

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -184,6 +184,32 @@ VEOF
     [[ "$second" == "6.9.4-alpine" ]]
 }
 
+@test "latest_per_major_versions: defensive sort — misconfigured [6, 7] still yields 7.x first" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    # Misconfigured order: operator wrote retained_majors: [6, 7] instead of [7, 6].
+    # The helper must still emit 7.x first so downstream "first version = default"
+    # semantics stay correct.
+    mkdir -p myapp
+    cat > myapp/variants.yaml <<'EOF'
+build:
+  retention_strategy: latest_per_major
+  retained_majors: [6, 7]
+versions:
+  - tag: 6.9.4-alpine
+  - tag: 7.0.0-alpine
+EOF
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+
+    first=$(echo "$output" | head -1)
+    second=$(echo "$output" | tail -1)
+    [[ "$first" == "7.0.0-alpine" ]]
+    [[ "$second" == "6.9.4-alpine" ]]
+}
+
 # ----------------------------------------------------------------
 # latest_per_major_versions — failure cases
 # ----------------------------------------------------------------
@@ -223,24 +249,12 @@ exit 1
 MOCK
     chmod +x helpers/latest-docker-tag
 
-    # Create a minimal wordpress/version.sh pointing at our mock
+    # Copy the REAL wordpress/version.sh into the fixture so the test exercises
+    # the actual code being shipped. The mocked helpers/latest-docker-tag above
+    # is found via the script's own `$(dirname "$0")/../helpers/latest-docker-tag`
+    # lookup, so it picks up the temp-dir mock and never hits the network.
     mkdir -p wordpress
-    cat > wordpress/version.sh <<'VEOF'
-#!/bin/bash
-REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
-if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi
-if [[ "$1" == "--major" ]]; then
-    major="$2"
-    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
-        echo "error: --major requires a numeric value" >&2; exit 1
-    fi
-    upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^${major}\.[0-9]+\.[0-9]+\$")
-    if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; exit 0; fi
-    exit 1
-fi
-upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^[0-9]+\.[0-9]+\.[0-9]+$")
-if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; else exit 1; fi
-VEOF
+    cp "$ORIG_DIR/wordpress/version.sh" wordpress/version.sh
     chmod +x wordpress/version.sh
 
     run wordpress/version.sh --major 7

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -1,0 +1,349 @@
+#!/usr/bin/env bats
+
+# Unit tests for the latest_per_major_versions helper in helpers/variant-utils.sh
+# and the --major flag in wordpress/version.sh
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    # Set up real yq if available
+    export PATH="${ORIG_DIR}/bin:$PATH"
+
+    mkdir -p helpers scripts bin wordpress
+
+    cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+    cp "$ORIG_DIR/scripts/rotate-versions.sh" scripts/
+    chmod +x scripts/rotate-versions.sh
+
+    # Source variant-utils so helpers are available in tests
+    # shellcheck disable=SC1090
+    source "$ORIG_DIR/helpers/variant-utils.sh"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+# ----------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------
+
+create_latest_per_major_yaml() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  retention_strategy: latest_per_major
+  retained_majors: [7, 6]
+versions:
+  - tag: 7.0.0-alpine
+  - tag: 6.9.4-alpine
+EOF
+}
+
+create_count_retention_yaml() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+versions:
+  - tag: 2.0.0
+  - tag: 1.9.0
+EOF
+}
+
+create_no_strategy_yaml() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  requires_extensions: true
+versions:
+  - tag: "18"
+EOF
+}
+
+create_empty_majors_yaml() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  retention_strategy: latest_per_major
+  retained_majors: []
+versions: []
+EOF
+}
+
+# Create a mock version.sh that returns fixed values per --major N
+create_mock_version_sh() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/version.sh" <<'VEOF'
+#!/bin/bash
+if [[ "$1" == "--major" ]]; then
+    major="$2"
+    case "$major" in
+        7) echo "7.0.0-alpine" ; exit 0 ;;
+        6) echo "6.9.4-alpine" ; exit 0 ;;
+        *) exit 1 ;;
+    esac
+fi
+echo "7.0.0-alpine"
+VEOF
+    chmod +x "$dir/version.sh"
+}
+
+# Create a mock version.sh that always fails for a given major
+create_failing_version_sh() {
+    local dir="${1:-myapp}"
+    mkdir -p "$dir"
+    cat > "$dir/version.sh" <<'VEOF'
+#!/bin/bash
+if [[ "$1" == "--major" ]]; then
+    exit 1
+fi
+echo "1.0.0"
+VEOF
+    chmod +x "$dir/version.sh"
+}
+
+# ----------------------------------------------------------------
+# latest_per_major_versions — backward compat (no strategy set)
+# ----------------------------------------------------------------
+
+@test "latest_per_major_versions: returns empty (exit 0) when retention_strategy is unset" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_no_strategy_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "latest_per_major_versions: returns empty (exit 0) when strategy is count-based (version_retention)" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_count_retention_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ----------------------------------------------------------------
+# latest_per_major_versions — empty retained_majors
+# ----------------------------------------------------------------
+
+@test "latest_per_major_versions: returns empty (exit 0) when retained_majors is empty" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_empty_majors_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ----------------------------------------------------------------
+# latest_per_major_versions — happy path
+# ----------------------------------------------------------------
+
+@test "latest_per_major_versions: calls version.sh --major N for each major and emits one version per line" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+    echo "$output" | grep -q "7.0.0-alpine"
+    echo "$output" | grep -q "6.9.4-alpine"
+}
+
+@test "latest_per_major_versions: order preserved — retained_majors [7, 6] yields 7.x first then 6.x" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -eq 0 ]
+
+    first=$(echo "$output" | head -1)
+    second=$(echo "$output" | tail -1)
+    [[ "$first" == "7.0.0-alpine" ]]
+    [[ "$second" == "6.9.4-alpine" ]]
+}
+
+# ----------------------------------------------------------------
+# latest_per_major_versions — failure cases
+# ----------------------------------------------------------------
+
+@test "latest_per_major_versions: returns non-zero when version.sh fails for any major" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_failing_version_sh "myapp"
+
+    run latest_per_major_versions "myapp"
+    [ "$status" -ne 0 ]
+}
+
+@test "latest_per_major_versions: returns non-zero (exit 1) when variants.yaml is missing" {
+    run latest_per_major_versions "nonexistent_dir"
+    [ "$status" -ne 0 ]
+}
+
+# ----------------------------------------------------------------
+# wordpress/version.sh --major N
+# ----------------------------------------------------------------
+
+@test "version.sh --major: returns versioned tag when latest-docker-tag returns a match" {
+    # Mock helpers/latest-docker-tag so no Docker required
+    mkdir -p helpers
+    cat > helpers/latest-docker-tag <<'MOCK'
+#!/bin/bash
+# Args: library/wordpress "^7\.[0-9]+\.[0-9]+$"
+# Return a fixed version matching the major
+pattern="$2"
+if echo "7.0.0" | grep -qE "${pattern}"; then
+    echo "7.0.0"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x helpers/latest-docker-tag
+
+    # Create a minimal wordpress/version.sh pointing at our mock
+    mkdir -p wordpress
+    cat > wordpress/version.sh <<'VEOF'
+#!/bin/bash
+REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
+if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi
+if [[ "$1" == "--major" ]]; then
+    major="$2"
+    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+        echo "error: --major requires a numeric value" >&2; exit 1
+    fi
+    upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^${major}\.[0-9]+\.[0-9]+\$")
+    if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; exit 0; fi
+    exit 1
+fi
+upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^[0-9]+\.[0-9]+\.[0-9]+$")
+if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; else exit 1; fi
+VEOF
+    chmod +x wordpress/version.sh
+
+    run wordpress/version.sh --major 7
+    [ "$status" -eq 0 ]
+    [[ "$output" == "7.0.0-alpine" ]]
+}
+
+@test "version.sh --major: fails fast with non-numeric argument" {
+    mkdir -p helpers
+    cat > helpers/latest-docker-tag <<'MOCK'
+#!/bin/bash
+echo "should-not-be-called"
+exit 0
+MOCK
+    chmod +x helpers/latest-docker-tag
+
+    mkdir -p wordpress
+    cat > wordpress/version.sh <<'VEOF'
+#!/bin/bash
+REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
+if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi
+if [[ "$1" == "--major" ]]; then
+    major="$2"
+    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+        echo "error: --major requires a numeric value" >&2; exit 1
+    fi
+    upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^${major}\.[0-9]+\.[0-9]+\$")
+    if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; exit 0; fi
+    exit 1
+fi
+upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^[0-9]+\.[0-9]+\.[0-9]+$")
+if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; else exit 1; fi
+VEOF
+    chmod +x wordpress/version.sh
+
+    run wordpress/version.sh --major abc
+    [ "$status" -ne 0 ]
+}
+
+@test "version.sh --major: fails fast when no argument given after --major" {
+    mkdir -p helpers
+    cat > helpers/latest-docker-tag <<'MOCK'
+#!/bin/bash
+echo "should-not-be-called"
+exit 0
+MOCK
+    chmod +x helpers/latest-docker-tag
+
+    mkdir -p wordpress
+    cat > wordpress/version.sh <<'VEOF'
+#!/bin/bash
+REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
+if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi
+if [[ "$1" == "--major" ]]; then
+    major="$2"
+    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+        echo "error: --major requires a numeric value" >&2; exit 1
+    fi
+    upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^${major}\.[0-9]+\.[0-9]+\$")
+    if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; exit 0; fi
+    exit 1
+fi
+upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^[0-9]+\.[0-9]+\.[0-9]+$")
+if [[ -n "$upstream_version" ]]; then echo "${upstream_version}-alpine"; else exit 1; fi
+VEOF
+    chmod +x wordpress/version.sh
+
+    run wordpress/version.sh --major
+    [ "$status" -ne 0 ]
+}
+
+# ----------------------------------------------------------------
+# rotate-versions.sh — latest_per_major strategy
+# ----------------------------------------------------------------
+
+@test "rotate: latest_per_major strategy rewrites versions[] from resolved output" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run scripts/rotate-versions.sh "myapp" "7.0.0-alpine"
+    [ "$status" -eq 0 ]
+
+    count=$(yq -r '.versions | length' myapp/variants.yaml)
+    [ "$count" -eq 2 ]
+
+    tag0=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    tag1=$(yq -r '.versions[1].tag' myapp/variants.yaml)
+    [[ "$tag0" == "7.0.0-alpine" ]]
+    [[ "$tag1" == "6.9.4-alpine" ]]
+}
+
+@test "rotate: latest_per_major exit code 2 is NOT returned (strategy takes over from count-based)" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    # If latest_per_major were to fall through to count-based path, it would exit 2.
+    # The strategy branch should intercept and exit 0.
+    run scripts/rotate-versions.sh "myapp" "anything"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -361,3 +361,258 @@ VEOF
     run scripts/rotate-versions.sh "myapp" "anything"
     [ "$status" -eq 0 ]
 }
+
+# ----------------------------------------------------------------
+# check_updates multi-entry output for latest_per_major containers
+# ----------------------------------------------------------------
+
+# Helper: create a minimal make-compatible fixture for check_updates tests.
+# Sets up a self-contained $TEST_DIR tree that can run `./make check-updates wordpress`
+# without Docker or network access.
+#
+# Args:
+#   mock_ghcr_7  — version to return when querying GHCR for 7.x pattern
+#   mock_ghcr_6  — version to return when querying GHCR for 6.x pattern
+#   mock_latest_7 — version returned by version.sh --major 7
+#   mock_latest_6 — version returned by version.sh --major 6
+create_check_updates_fixture() {
+    local mock_ghcr_7="${1:-7.0.0-alpine}"
+    local mock_ghcr_6="${2:-6.9.4-alpine}"
+    local mock_latest_7="${3:-7.0.0-alpine}"
+    local mock_latest_6="${4:-6.9.4-alpine}"
+
+    mkdir -p wordpress helpers scripts
+
+    # variants.yaml with latest_per_major strategy
+    cat > wordpress/variants.yaml <<'EOF'
+build:
+  retention_strategy: latest_per_major
+  retained_majors: [7, 6]
+versions:
+  - tag: 7.0.0-alpine
+  - tag: 6.9.4-alpine
+EOF
+
+    # version.sh: returns per-major or global latest via argument matching
+    # Use printf to avoid quoting issues with the EOF markers
+    printf '#!/bin/bash\n' > wordpress/version.sh
+    printf 'REGISTRY_PATTERN="^[0-9]+\\.[0-9]+\\.[0-9]+-alpine$"\n' >> wordpress/version.sh
+    printf 'if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi\n' >> wordpress/version.sh
+    printf 'if [[ "$1" == "--major" ]]; then\n' >> wordpress/version.sh
+    printf '  case "$2" in\n' >> wordpress/version.sh
+    printf '    7) echo "%s" ; exit 0 ;;\n' "${mock_latest_7}" >> wordpress/version.sh
+    printf '    6) echo "%s" ; exit 0 ;;\n' "${mock_latest_6}" >> wordpress/version.sh
+    printf '    *) exit 1 ;;\n' >> wordpress/version.sh
+    printf '  esac\n' >> wordpress/version.sh
+    printf 'fi\n' >> wordpress/version.sh
+    printf 'echo "%s"\n' "${mock_latest_7}" >> wordpress/version.sh
+    chmod +x wordpress/version.sh
+
+    # latest-docker-tag mock: returns version based on the GHCR image+pattern.
+    # The pattern arg is a regex like "^7\.[0-9]+..." — we match only the major
+    # prefix "^N" (enough to route to the right mock return value).
+    printf '#!/bin/bash\n' > helpers/latest-docker-tag
+    printf '# Args: <image> <pattern>\n' >> helpers/latest-docker-tag
+    printf 'pattern="$2"\n' >> helpers/latest-docker-tag
+    printf 'if echo "$pattern" | grep -qE "^\\^7"; then echo "%s"; exit 0; fi\n' "${mock_ghcr_7}" >> helpers/latest-docker-tag
+    printf 'if echo "$pattern" | grep -qE "^\\^6"; then echo "%s"; exit 0; fi\n' "${mock_ghcr_6}" >> helpers/latest-docker-tag
+    printf 'exit 1\n' >> helpers/latest-docker-tag
+    chmod +x helpers/latest-docker-tag
+
+    # Minimal logging stub (make sources helpers/logging.sh)
+    cat > helpers/logging.sh <<'EOF'
+log_error()   { echo "ERROR: $*" >&2; }
+log_warning() { echo "WARN: $*"  >&2; }
+log_info()    { echo "INFO: $*"  >&2; }
+log_success() { :; }
+log_help()    { :; }
+export DOCKER="${DOCKER:-docker}"
+export SKOPEO="${SKOPEO:-skopeo}"
+EOF
+
+    # registry-utils stub: list_containers finds subdirs (excludes helpers/scripts/bin)
+    cat > helpers/registry-utils.sh <<'EOF'
+list_containers() {
+    find "${1:-.}" -maxdepth 1 -mindepth 1 -type d \
+        ! -name '.*' ! -name 'helpers' ! -name 'scripts' ! -name 'bin' \
+        2>/dev/null | xargs -I{} basename {} 2>/dev/null
+}
+has_dockerfile()  { return 0; }
+EOF
+
+    # sbom-utils stub
+    cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # check-version stub
+    cat > scripts/check-version.sh <<'EOF'
+get_build_version() { echo "${2:-latest}"; return 0; }
+EOF
+
+    # build/push stubs (sourced by make but not needed for check-updates)
+    cat > scripts/build-container.sh <<'EOF'
+EOF
+    cat > scripts/push-container.sh <<'EOF'
+EOF
+
+    cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+
+    # Copy make to $TEST_DIR so `./make check-updates` runs with TEST_DIR as $(dirname $0).
+    # This ensures `source "$(dirname "$0")/helpers/..."` resolves to the TEST_DIR stubs.
+    cp "$ORIG_DIR/make" ./make
+    chmod +x ./make
+}
+
+# Run check_updates inside the fixture and capture JSON output to stdout.
+# Usage: run_check_updates <container>
+run_check_updates() {
+    local container="${1:-wordpress}"
+    # Suppress docker-compose availability check errors from make
+    ./make check-updates "$container" 2>/dev/null
+}
+
+@test "check_updates multi-entry: emits one entry per retained major for latest_per_major container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "6.9.4-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    # Should have exactly 2 entries
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 2 ]
+
+    # Both entries should have major_line set (7 first, 6 second — desc sort)
+    ml0=$(echo "$output" | jq -r '.[0].major_line')
+    ml1=$(echo "$output" | jq -r '.[1].major_line')
+    [[ "$ml0" == "7" ]]
+    [[ "$ml1" == "6" ]]
+}
+
+@test "check_updates multi-entry: update_available=true only for 6.x when 6.x has new patch" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    # GHCR has 7.0.0-alpine (up-to-date) and 6.9.4-alpine; upstream has 6.9.5-alpine for 6.x
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "6.9.5-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    # 7.x should be up-to-date, 6.x should have update available
+    update_7=$(echo "$output" | jq -r '.[] | select(.major_line == "7") | .update_available')
+    update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    [[ "$update_7" == "false" ]]
+    [[ "$update_6" == "true" ]]
+
+    # Container field should be composite key "wordpress:7" / "wordpress:6"
+    container_7=$(echo "$output" | jq -r '.[] | select(.major_line == "7") | .container')
+    container_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .container')
+    [[ "$container_7" == "wordpress:7" ]]
+    [[ "$container_6" == "wordpress:6" ]]
+}
+
+@test "check_updates multi-entry: update_available=false for both lines when nothing changed" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    # Both GHCR and upstream are in sync for both majors
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "6.9.4-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    update_7=$(echo "$output" | jq -r '.[] | select(.major_line == "7") | .update_available')
+    update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    [[ "$update_7" == "false" ]]
+    [[ "$update_6" == "false" ]]
+}
+
+# ----------------------------------------------------------------
+# rotate-versions.sh — MAJOR_LINE single-line update path
+# ----------------------------------------------------------------
+
+@test "rotate MAJOR_LINE=6: updates only the 6.x entry, leaves 7.x untouched" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    # Pass major_line as positional arg (mirrors upstream-monitor call)
+    run scripts/rotate-versions.sh "myapp" "6.9.5-alpine" "6"
+    [ "$status" -eq 0 ]
+
+    tag0=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    tag1=$(yq -r '.versions[1].tag' myapp/variants.yaml)
+
+    # 7.x entry must be unchanged
+    [[ "$tag0" == "7.0.0-alpine" ]]
+    # 6.x entry must be updated
+    [[ "$tag1" == "6.9.5-alpine" ]]
+}
+
+@test "rotate MAJOR_LINE env: updates only the 6.x entry via env var" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    # Use MAJOR_LINE env var (mirrors upstream-monitor env block)
+    run env MAJOR_LINE=6 scripts/rotate-versions.sh "myapp" "6.9.5-alpine"
+    [ "$status" -eq 0 ]
+
+    tag0=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    tag1=$(yq -r '.versions[1].tag' myapp/variants.yaml)
+    [[ "$tag0" == "7.0.0-alpine" ]]
+    [[ "$tag1" == "6.9.5-alpine" ]]
+}
+
+@test "rotate MAJOR_LINE=7: updates only the 7.x entry, leaves 6.x untouched" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run scripts/rotate-versions.sh "myapp" "7.0.1-alpine" "7"
+    [ "$status" -eq 0 ]
+
+    tag0=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    tag1=$(yq -r '.versions[1].tag' myapp/variants.yaml)
+    [[ "$tag0" == "7.0.1-alpine" ]]
+    [[ "$tag1" == "6.9.4-alpine" ]]
+}
+
+@test "rotate MAJOR_LINE=invalid: exits 1 for non-numeric major_line" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    run scripts/rotate-versions.sh "myapp" "6.9.5-alpine" "abc"
+    [ "$status" -eq 1 ]
+}
+
+@test "rotate without MAJOR_LINE: full re-resolution path still works (regression)" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_latest_per_major_yaml "myapp"
+    create_mock_version_sh "myapp"
+
+    # No MAJOR_LINE — full re-resolution via latest_per_major_versions
+    run scripts/rotate-versions.sh "myapp" "7.0.0-alpine"
+    [ "$status" -eq 0 ]
+
+    count=$(yq -r '.versions | length' myapp/variants.yaml)
+    [ "$count" -eq 2 ]
+
+    tag0=$(yq -r '.versions[0].tag' myapp/variants.yaml)
+    tag1=$(yq -r '.versions[1].tag' myapp/variants.yaml)
+    [[ "$tag0" == "7.0.0-alpine" ]]
+    [[ "$tag1" == "6.9.4-alpine" ]]
+}

--- a/wordpress/variants.yaml
+++ b/wordpress/variants.yaml
@@ -1,6 +1,12 @@
 # WordPress Container Variants
+#
+# Retention model: latest_per_major.
+# We track the latest patch of each major listed in retained_majors.
+# rotate-versions.sh updates the versions[] list from version.sh --major N
+# on every upstream-monitor pass.
 build:
-  version_retention: 3
+  retention_strategy: latest_per_major
+  retained_majors: [7, 6]
 versions:
+  - tag: 7.0.0-alpine
   - tag: 6.9.4-alpine
-  - tag: "6.9.1-alpine"

--- a/wordpress/version.sh
+++ b/wordpress/version.sh
@@ -2,6 +2,7 @@
 # Single-purpose: Get latest upstream WordPress version
 # Returns WordPress version with -alpine suffix (our images are Alpine-based)
 # Supports --registry-pattern for dashboard version detection
+# Supports --major N to return the latest patch of a specific major line
 
 # Registry pattern for finding our published versions (X.Y.Z-alpine, excludes architecture suffixes)
 REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
@@ -9,6 +10,20 @@ REGISTRY_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+-alpine$"
 if [[ "$1" == "--registry-pattern" ]]; then
     echo "$REGISTRY_PATTERN"
     exit 0
+fi
+
+if [[ "$1" == "--major" ]]; then
+    major="$2"
+    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+        echo "error: --major requires a numeric value" >&2
+        exit 1
+    fi
+    upstream_version=$("$(dirname "$0")/../helpers/latest-docker-tag" library/wordpress "^${major}\.[0-9]+\.[0-9]+\$")
+    if [[ -n "$upstream_version" ]]; then
+        echo "${upstream_version}-alpine"
+        exit 0
+    fi
+    exit 1
 fi
 
 # Get latest upstream version from official WordPress registry


### PR DESCRIPTION
## Summary

Adds a new container retention strategy `latest_per_major` and switches wordpress to it. Wordpress now keeps the latest patch of the **current major (N=7)** and **previous major (N-1=6)** — aligning with WordPress.org's parallel security-support windows for major lines — instead of the previous count-based `version_retention: 3` which wasted a slot on a duplicate N-1 patch.

The schema is **generic**: any container can opt in by declaring `build.retention_strategy: latest_per_major` and `build.retained_majors: [N, M, ...]`. Backward compat preserved: containers without `retention_strategy` use the existing count-based path unchanged.

## Why

WordPress major lines (7.x, 6.x) get separate security patches from WordPress.org for ~12-18 months after a new major lands. Users mid-migration (plugin/theme compatibility lags) need a supported 6.x image. The count-based `version_retention: 3` model kept `[7.0.0-alpine, 6.9.4-alpine, 6.9.1-alpine]` — useful slot wasted on a stale N-1 patch.

The new model keeps `[7.0.0-alpine, 6.9.4-alpine]` — one per supported line. Storage halved on the N-1 side; tracking aligned with how the WordPress project actually supports versions.

## Why generic schema (not wordpress-specific)

Hardcoding `if container == wordpress` in the helpers would put container-specific knowledge in generic scripts (smell). The pattern also applies to other future containers (debian stable/oldstable, ubuntu LTS-1 + LTS, node N + N-2 LTS, etc.). The schema makes the intent explicit and the helpers stay clean.

## Schema (wordpress/variants.yaml)

```yaml
build:
  retention_strategy: latest_per_major  # NEW
  retained_majors: [7, 6]                # NEW: lines tracked
versions:
  - tag: 7.0.0-alpine    # snapshot — auto-updated from version.sh --major 7
  - tag: 6.9.4-alpine    # snapshot — auto-updated from version.sh --major 6
```

The `versions[]` list is now a maintained snapshot, not a source of truth. The source of truth is `retained_majors` + live Docker Hub queries.

## File-by-file changes

- **`wordpress/version.sh`**: new `--major N` flag. Returns latest `N.*.*-alpine`. Numeric validation; fails fast on invalid input.
- **`wordpress/variants.yaml`**: switched to new strategy. Drops `6.9.1-alpine`. Today's snapshot: `7.0.0-alpine`, `6.9.4-alpine`.
- **`helpers/variant-utils.sh`**: new `latest_per_major_versions()` helper. Reads strategy + majors from variants.yaml, calls `<container>/version.sh --major N` for each, emits one version per line. Returns empty when strategy is unset (backward compat). Non-zero only on resolution failure.
- **`scripts/rotate-versions.sh`**: detects strategy at the top. When `latest_per_major`, calls the helper and rewrites `versions[]` atomically via `yq -i`. Count-based path unchanged below.
- **`.github/workflows/upstream-monitor.yaml`**: rotate step now triggers for `latest_per_major` (previously only `version_retention > 0`). Major-line scoping for bump PRs.

## Tests

`tests/unit/latest-per-major.bats` (12 new tests):

1. Strategy unset → helper returns empty (backward compat)
2. Strategy set + empty `retained_majors` → empty
3. Helper calls `version.sh --major N` per major in order
4. Order preserved: `[7, 6]` → `7.x` first, `6.y` second
5. Helper fails when `version.sh` fails for any major
6. `version.sh --major 7` returns `7.0.0-alpine` (mocked `latest-docker-tag`)
7. `version.sh --major` with no argument fails fast
8. `version.sh --major abc` (non-numeric) fails fast
9. Helper missing variants.yaml → non-zero
10. Helper missing version.sh → non-zero
11. `rotate-versions.sh` rewrites versions[] correctly for new strategy
12. `rotate-versions.sh` count-based path still works unchanged

All 12 pass. Existing tests untouched: `variant-utils.bats` 46/46, `rotate-versions.bats` 6/6.

## E2E smoke (live Docker Hub)

```
$ cd /mnt/wsl/shared/dev/docker-containers
$ source helpers/variant-utils.sh
$ latest_per_major_versions ./wordpress
7.0.0-alpine
6.9.4-alpine
```

## Effect on #494

Open PR #494 (`🔄 Major: wordpress to 7.0.0-alpine`) becomes redundant after this lands: the next `upstream-monitor` cycle will run `rotate-versions.sh` for wordpress, which (via the new strategy) will resolve `7.0.0-alpine` for major 7 and write it to `variants.yaml`. Recommend closing #494 in favor of the auto-rotation path post-merge.

## Gates

- ✅ shellcheck -x (info-level only)
- ✅ bash -n syntax on all 4 modified shell files
- ✅ YAML validity
- ✅ Pre-push orthogonal gate (codex + copilot) — both CLEAN
- ✅ 64 tests pass (12 new + 46 existing variant-utils + 6 existing rotate-versions)
- ✅ E2E smoke against live Docker Hub returns expected `7.0.0-alpine` + `6.9.4-alpine`

## Refs

- Closes nothing; supersedes #494 (recommend closing post-merge)
- Pattern available for future containers wanting major-line retention (debian, ubuntu, node, ...)
