### PR TITLE
feat(dashboard): read base_image from per-variant lineage

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,40 @@
+# Architectural Decisions
+
+Lightweight decision log for changes that don't warrant a full ADR.
+Cross-reference: `docs/adr/` for major structural decisions.
+
+---
+
+## #530 — Per-variant base_image truth pipeline
+
+### Design
+
+Five atomic fixes address base_image_ref leaking `${...}` placeholders into lineage files:
+
+- **A1** (`scripts/build-container.sh::_resolve_base_image` ~line 191): Extended the substitution pipeline with a `_BUILD_ARGS_RESOLVED` pass (Step 2.5). After CUSTOM_BUILD_ARGS overrides are applied, iterates the associative array populated by `_prepare_build_args` — up to 10 passes to resolve cross-arg chains (A→B→C). Covers ARGs from `config.yaml::build_args` that are invisible to both CUSTOM_BUILD_ARGS and Dockerfile ARG defaults.
+
+- **A2** (`scripts/build-container.sh::_resolve_base_image` ~line 131, `build_container` caller ~line 456): `_resolve_base_image` is now called post-template-generation when `_RESOLVE_FROM_GENERATED=1`. For template containers (web-shell, github-runner), the generated per-flavor Dockerfile's `FROM` line is the authoritative base image source. Calling before template generation reads the default-distro value from `config.yaml`, not the per-flavor value.
+
+- **B** (`generate-dashboard.sh::resolve_lineage_file`): Lineage file lookup now uses the container's default variant (via `variant_property default_variant`) when no flavor-specific file is found, rather than falling back to unversioned or network-fetched data.
+
+- **C** (`scripts/build-container.sh::_emit_build_lineage`): `jq -n` with `--arg` / `--argjson` replaces inline JSON string construction, eliminating shell-metacharacter injection and quoting hazards in the emitted lineage JSON.
+
+- **D** (`scripts/build-container.sh::_resolve_base_image` ~line 260): `printf -v` replaces `eval` for appending the base digest to `label_args`. Removes the eval-based injection vector with no behavioral change.
+
+- **E** (`scripts/build-container.sh::_emit_build_lineage`, `generate-dashboard.sh::resolve_lineage_file`): Lineage files now carry `lineage_schema_version: 2`. Dashboard read sanitizes v1 files (strips any surviving `${...}` placeholders, replaces with empty string) before surfacing to the UI.
+
+### Rejected alternatives
+
+**(a) Backfill corrupted lineage files in-repo.** Not viable: `.gitignore` lines 70-71 exclude the `.build-lineage/` directory from version control. Lineage files are build artifacts, not source. Patching them at rest would require a CI-run trigger per affected container anyway — identical cost to letting the next build self-heal.
+
+**(b) Dashboard-side substitution (resolve `${...}` at regen time).** Rejected because `generate-dashboard.sh` does not have access to the build-time ARG values. The dashboard reads already-written lineage files; it cannot reconstruct the `_prepare_build_args` resolved set from `config.yaml` without re-implementing the entire build pipeline. The bug is a write-time omission — the fix belongs at write time (A1/A2).
+
+**(c) Per-distro `yq` read at build time (alternative to A2 relocation).** Equivalent in outcome to relocating `_resolve_base_image` post-template-generation, but requires threading `flavor` as a new parameter through the call chain and adding a yq lookup that duplicates what `generate-dockerfile.sh` already does. The A2 relocation uses the generated Dockerfile as the single authoritative source, which is simpler and less coupled.
+
+### Post-merge expectation
+
+Affected containers (sslh, web-shell, wordpress) currently have v1 lineage files with `${...}` placeholders. Until their next CI rebuild writes a v2 file, the dashboard sanitize-at-read path (Fix E) will surface an empty `base_image_ref` rather than a raw placeholder. Each container self-heals on its next triggered build with no manual intervention required.
+
+### Integration smoke origin
+
+`tests/unit/dashboard-integration-smoke.bats` was added per `feedback_perf_integration_smoke_test.md`: a layer-shifting refactor (base_image written at build time, read at dashboard-regen time) requires an end-to-end mutation guard. Unit tests of each individual function are insufficient because the bug manifests at the seam between the write phase and the read phase. The smoke's SMOKE-01 and SMOKE-07 tests guard Fix A1 specifically: disabling the `_BUILD_ARGS_RESOLVED` substitution loop causes `base_image_ref` to read `${OS_IMAGE_BASE}:${OS_IMAGE_TAG}` in the written lineage file, which SMOKE-01 catches via a concrete-value assertion.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,7 +13,7 @@ Five atomic fixes address base_image_ref leaking `${...}` placeholders into line
 
 - **A1** (`scripts/build-container.sh::_resolve_base_image` ~line 191): Extended the substitution pipeline with a `_BUILD_ARGS_RESOLVED` pass (Step 2.5). After CUSTOM_BUILD_ARGS overrides are applied, iterates the associative array populated by `_prepare_build_args` — up to 10 passes to resolve cross-arg chains (A→B→C). Covers ARGs from `config.yaml::build_args` that are invisible to both CUSTOM_BUILD_ARGS and Dockerfile ARG defaults.
 
-- **A2** (`scripts/build-container.sh::_resolve_base_image` ~line 131, `build_container` caller ~line 456): `_resolve_base_image` is now called post-template-generation when `_RESOLVE_FROM_GENERATED=1`. For template containers (web-shell, github-runner), the generated per-flavor Dockerfile's `FROM` line is the authoritative base image source. Calling before template generation reads the default-distro value from `config.yaml`, not the per-flavor value.
+- **A2** (`scripts/build-container.sh::_resolve_base_image` ~line 131, `build_container` caller ~line 456): `_resolve_base_image` is now called post-template-generation with `from_generated=1` (4th positional parameter). For template containers (web-shell, github-runner), the generated per-flavor Dockerfile's `FROM` line is the authoritative base image source. Calling before template generation reads the default-distro value from `config.yaml`, not the per-flavor value.
 
 - **B** (`generate-dashboard.sh::resolve_lineage_file`): Lineage file lookup now uses the container's default variant (via an inline yq query equivalent to `default_variant()`) when no flavor-specific file is found, rather than falling back to unversioned or network-fetched data.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -15,7 +15,7 @@ Five atomic fixes address base_image_ref leaking `${...}` placeholders into line
 
 - **A2** (`scripts/build-container.sh::_resolve_base_image` ~line 131, `build_container` caller ~line 456): `_resolve_base_image` is now called post-template-generation when `_RESOLVE_FROM_GENERATED=1`. For template containers (web-shell, github-runner), the generated per-flavor Dockerfile's `FROM` line is the authoritative base image source. Calling before template generation reads the default-distro value from `config.yaml`, not the per-flavor value.
 
-- **B** (`generate-dashboard.sh::resolve_lineage_file`): Lineage file lookup now uses the container's default variant (via `variant_property default_variant`) when no flavor-specific file is found, rather than falling back to unversioned or network-fetched data.
+- **B** (`generate-dashboard.sh::resolve_lineage_file`): Lineage file lookup now uses the container's default variant (via an inline yq query equivalent to `default_variant()`) when no flavor-specific file is found, rather than falling back to unversioned or network-fetched data.
 
 - **C** (`scripts/build-container.sh::_emit_build_lineage`): `jq -n` with `--arg` / `--argjson` replaces inline JSON string construction, eliminating shell-metacharacter injection and quoting hazards in the emitted lineage JSON.
 
@@ -30,6 +30,19 @@ Five atomic fixes address base_image_ref leaking `${...}` placeholders into line
 **(b) Dashboard-side substitution (resolve `${...}` at regen time).** Rejected because `generate-dashboard.sh` does not have access to the build-time ARG values. The dashboard reads already-written lineage files; it cannot reconstruct the `_prepare_build_args` resolved set from `config.yaml` without re-implementing the entire build pipeline. The bug is a write-time omission — the fix belongs at write time (A1/A2).
 
 **(c) Per-distro `yq` read at build time (alternative to A2 relocation).** Equivalent in outcome to relocating `_resolve_base_image` post-template-generation, but requires threading `flavor` as a new parameter through the call chain and adding a yq lookup that duplicates what `generate-dockerfile.sh` already does. The A2 relocation uses the generated Dockerfile as the single authoritative source, which is simpler and less coupled.
+
+### lineage_schema_version: 2 — consumer audit
+
+`lineage_schema_version: 2` is new as of #530. Audit of all `.build-lineage/*.json` consumers (scripts/, helpers/, .github/):
+
+| Consumer | Fields read | Handles schema v2? |
+|----------|-------------|-------------------|
+| `generate-dashboard.sh` | all fields incl. `base_image_ref`, `lineage_schema_version` | Yes — primary consumer; sanitize-at-read keyed on placeholder presence, not version field |
+| `scripts/enrich-lineage.sh` | `.container`, `.tag`, `.multi_arch_index_digest` | Yes — uses `// empty` guards; ignores unknown fields |
+| `helpers/extension-duration-utils.sh` | `.duration_seconds` | Yes — uses `// 0` guard; ignores unknown fields |
+| `.github/actions/build-container/action.yaml` | file existence check only (no jq field reads) | Yes — additive fields are transparent |
+
+Schema v2 currently has only the dashboard as a semantic consumer of the new fields. Future tools that read `base_image_ref` or `lineage_schema_version` must handle the field with a `// default` guard for backward compatibility with v1 files still present in the GHA cache.
 
 ### Post-merge expectation
 

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -52,10 +52,16 @@ resolve_lineage_file() {
     #    Only attempted when variants.yaml exists and is valid; malformed/missing → fall through.
     local variants_file="$SCRIPT_DIR/$container/variants.yaml"
     if [[ -f "$variants_file" ]]; then
-        # Validate YAML and get the latest version tag (versions[0].tag)
-        # yq exits non-zero on malformed YAML → skip to legacy fallback
-        local latest_version
-        latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || latest_version=""
+        # Validate YAML and get the latest version tag (versions[0].tag).
+        # Detect yq parse failure explicitly: malformed variants.yaml must cause an
+        # early return with no fallback to the legacy rollup — operator must fix the YAML.
+        local latest_version _yq_rc
+        latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null)
+        _yq_rc=$?
+        if [[ $_yq_rc -ne 0 ]]; then
+            log_warning "resolve_lineage_file: variants.yaml parse error for $container (yq rc=$_yq_rc) — returning empty"
+            return 0
+        fi
 
         if [[ -n "$latest_version" ]]; then
             # Get the default variant name for the latest version
@@ -115,7 +121,14 @@ resolve_lineage_file() {
         legacy_tag=$(jq -r '.tag // ""' "$lineage_file" 2>/dev/null) || legacy_tag=""
         local current_latest
         current_latest=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || current_latest=""
-        if [[ -n "$legacy_tag" && -n "$current_latest" && "$legacy_tag" == "$current_latest" ]]; then
+        # Prefix match: lineage_file.tag may be "1.7.7-debian" while
+        # variants_file.versions[0].tag is the version component "1.7.7".
+        # Accept the legacy rollup when its tag equals current_latest OR
+        # when it starts with "$current_latest-" (version prefix, different variant suffix).
+        # This prevents false positives (11.0-alpine vs 1.0) while allowing
+        # multi-variant containers where the tag carries a distro suffix.
+        if [[ -n "$legacy_tag" && -n "$current_latest" && \
+              ( "$legacy_tag" == "$current_latest" || "$legacy_tag" == "${current_latest}-"* ) ]]; then
             echo "$lineage_file"
             return
         fi

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -48,53 +48,80 @@ resolve_lineage_file() {
     local container="$1"
     local lineage_dir="$SCRIPT_DIR/.build-lineage"
 
-    # 1. Legacy: {container}.json exists → return directly (no variants.yaml needed)
-    local lineage_file="$lineage_dir/${container}.json"
-    if [[ -f "$lineage_file" ]]; then
-        echo "$lineage_file"
-        return
-    fi
-
-    # 2. Parse variants.yaml (malformed or missing → empty sentinel)
+    # 1. Per-tag resolution via variants.yaml (preferred — new builds write per-tag files).
+    #    Only attempted when variants.yaml exists and is valid; malformed/missing → fall through.
     local variants_file="$SCRIPT_DIR/$container/variants.yaml"
-    [[ -f "$variants_file" ]] || return 0
+    if [[ -f "$variants_file" ]]; then
+        # Validate YAML and get the latest version tag (versions[0].tag)
+        # yq exits non-zero on malformed YAML → skip to legacy fallback
+        local latest_version
+        latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || latest_version=""
 
-    # Validate YAML and get the latest version tag (versions[0].tag)
-    # yq exits non-zero on malformed YAML → return empty (never filesystem-first)
-    local latest_version
-    latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || return 0
-    [[ -n "$latest_version" ]] || return 0
+        if [[ -n "$latest_version" ]]; then
+            # Get the default variant name for the latest version
+            local default_name
+            default_name=$(yq -r '.versions[0].variants[] | select(.default == true) | .name' \
+                "$variants_file" 2>/dev/null | head -1) || true
 
-    # Get the default variant name for the latest version
-    local default_name
-    default_name=$(yq -r '.versions[0].variants[] | select(.default == true) | .name' \
-        "$variants_file" 2>/dev/null | head -1) || true
+            # Compute the on-disk tag for the default variant using variant_image_tag, which
+            # applies base_suffix correctly. Example: postgres version=18, variant=base,
+            # base_suffix=-alpine → tag "18-alpine" → file postgres-18-alpine.json (no -base suffix).
+            # Using a raw-name glob (*base.json) would incorrectly match postgres-18-alpine-base.json.
+            local found_file=""
+            if [[ -n "$default_name" ]]; then
+                local default_tag
+                default_tag=$(variant_image_tag "$latest_version" "$default_name" "$SCRIPT_DIR/$container" 2>/dev/null) || true
+                if [[ -n "$default_tag" && -f "$lineage_dir/${container}-${default_tag}.json" ]]; then
+                    found_file="$lineage_dir/${container}-${default_tag}.json"
+                fi
+            fi
 
-    # Compute the on-disk tag for the default variant using variant_image_tag, which
-    # applies base_suffix correctly. Example: postgres version=18, variant=base,
-    # base_suffix=-alpine → tag "18-alpine" → file postgres-18-alpine.json (no -base suffix).
-    # Using a raw-name glob (*base.json) would incorrectly match postgres-18-alpine-base.json.
-    local found_file=""
-    if [[ -n "$default_name" ]]; then
-        local default_tag
-        default_tag=$(variant_image_tag "$latest_version" "$default_name" "$SCRIPT_DIR/$container" 2>/dev/null) || true
-        if [[ -n "$default_tag" && -f "$lineage_dir/${container}-${default_tag}.json" ]]; then
-            found_file="$lineage_dir/${container}-${default_tag}.json"
+            # Fallback within per-tag resolution: any non-sidecar lineage file for the latest
+            # version (when default variant file missing, or for versions-only containers).
+            # Excludes .sbom.json, .history.json, .changelog.json to avoid false-positive matches.
+            if [[ -z "$found_file" ]]; then
+                found_file=$(find "$lineage_dir" -maxdepth 1 \
+                    -name "${container}-${latest_version}*.json" \
+                    -not -name "*.sbom.json" \
+                    -not -name "*.history.json" \
+                    -not -name "*.changelog.json" \
+                    2>/dev/null | sort | head -1)
+            fi
+
+            if [[ -n "$found_file" ]]; then
+                echo "$found_file"
+                return
+            fi
+
+            # Per-tag resolution found nothing for this version — fall through to legacy.
         fi
     fi
 
-    # Fallback: any lineage file for the latest version (when default variant file missing,
-    # or for versions-only containers that have no variants key)
-    if [[ -z "$found_file" ]]; then
-        for _f in "$lineage_dir/${container}-${latest_version}"*.json; do
-            if [[ -f "$_f" ]]; then
-                found_file="$_f"
-                break
-            fi
-        done
+    # 2. Legacy: {container}.json — only used when no variants.yaml exists (versions-only
+    #    containers pre-variants, or containers not yet migrated) OR when the legacy rollup's
+    #    embedded .tag field matches the current default tag (i.e. it IS the latest build's output).
+    #    A stale legacy file whose .tag does NOT match is skipped to avoid shadowing newer per-tag files.
+    local lineage_file="$lineage_dir/${container}.json"
+    if [[ -f "$lineage_file" ]]; then
+        if [[ ! -f "$variants_file" ]]; then
+            # No variants.yaml at all → legacy file is the only source of truth
+            echo "$lineage_file"
+            return
+        fi
+        # variants.yaml exists but per-tag resolution above returned nothing.
+        # Only use the legacy rollup if its embedded .tag matches the latest version
+        # (i.e. it was written for the current build, not a stale prior-era rollup).
+        local legacy_tag
+        legacy_tag=$(jq -r '.tag // ""' "$lineage_file" 2>/dev/null) || legacy_tag=""
+        local current_latest
+        current_latest=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || current_latest=""
+        if [[ -n "$legacy_tag" && -n "$current_latest" && "$legacy_tag" == *"$current_latest"* ]]; then
+            echo "$lineage_file"
+            return
+        fi
     fi
 
-    [[ -n "$found_file" ]] && echo "$found_file" || true
+    true
 }
 
 # Resolve lineage file for a specific variant of a container

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -70,18 +70,17 @@ resolve_lineage_file() {
     default_name=$(yq -r '.versions[0].variants[] | select(.default == true) | .name' \
         "$variants_file" 2>/dev/null | head -1) || true
 
-    # Try exact match for default variant:
-    # Pattern: {container}-{version}*{default_name}.json
-    # The glob handles any base_suffix inserted between version and variant name
-    # (e.g. postgres-18-alpine-base.json where version=18, variant=base, base_sfx=-alpine)
+    # Compute the on-disk tag for the default variant using variant_image_tag, which
+    # applies base_suffix correctly. Example: postgres version=18, variant=base,
+    # base_suffix=-alpine → tag "18-alpine" → file postgres-18-alpine.json (no -base suffix).
+    # Using a raw-name glob (*base.json) would incorrectly match postgres-18-alpine-base.json.
     local found_file=""
     if [[ -n "$default_name" ]]; then
-        for _f in "$lineage_dir/${container}-${latest_version}"*"${default_name}.json"; do
-            if [[ -f "$_f" ]]; then
-                found_file="$_f"
-                break
-            fi
-        done
+        local default_tag
+        default_tag=$(variant_image_tag "$latest_version" "$default_name" "$SCRIPT_DIR/$container" 2>/dev/null) || true
+        if [[ -n "$default_tag" && -f "$lineage_dir/${container}-${default_tag}.json" ]]; then
+            found_file="$lineage_dir/${container}-${default_tag}.json"
+        fi
     fi
 
     # Fallback: any lineage file for the latest version (when default variant file missing,
@@ -359,7 +358,17 @@ resolve_variant_lineage_json() {
 
     if [[ -n "$lineage_file" ]]; then
         build_digest=$(jq -r '.build_digest // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
-        base_image=$(jq -r '.base_image_ref // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
+        local _raw_base_image
+        _raw_base_image=$(jq -r '.base_image_ref // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
+        # Sanitize-at-read: pre-v2 lineage files may have leaked ${...} placeholders in
+        # base_image_ref. Detect by checking lineage_schema_version and the value itself.
+        local _schema_ver
+        _schema_ver=$(jq -r '.lineage_schema_version // ""' "$lineage_file" 2>/dev/null || echo "")
+        if [[ -z "$_schema_ver" || "$_raw_base_image" == *'${'* ]]; then
+            base_image="unknown"
+        else
+            base_image="$_raw_base_image"
+        fi
         oci_subject_digest=$(jq -r '.oci_subject_digest // empty' "$lineage_file" 2>/dev/null || echo "")
         # Version mismatch check: lineage file may be from a different version
         if [[ "$base_image" != "unknown" ]]; then

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -34,21 +34,68 @@ CONTAINERS_DIR="$SCRIPT_DIR/docs/site/_containers"
 # --- Lineage resolution helpers ---
 
 # Resolve the lineage JSON file for a container
-# Tries {container}.json first, then falls back to {container}-*.json (first match)
+# Fix B: uses default_variant() selection from variants.yaml (NEVER filesystem-first).
+#
+# Precedence:
+#   1. {container}.json exists → return it (legacy rollup path)
+#   2. variants.yaml exists → parse it:
+#      a. Malformed YAML → return empty sentinel (never fall back to filesystem-first)
+#      b. Latest version (versions[0]) + default variant name → try exact match
+#      c. Default variant file missing → fallback to any file for the latest version
+#      d. No variants key (versions-only) → any file for the latest version
+#   3. No variants.yaml → return empty
 resolve_lineage_file() {
     local container="$1"
     local lineage_dir="$SCRIPT_DIR/.build-lineage"
+
+    # 1. Legacy: {container}.json exists → return directly (no variants.yaml needed)
     local lineage_file="$lineage_dir/${container}.json"
     if [[ -f "$lineage_file" ]]; then
         echo "$lineage_file"
         return
     fi
-    # Fallback: flavored lineage files (e.g. postgres-base.json)
-    local fallback
-    fallback=$(find "$lineage_dir" -maxdepth 1 -name "${container}-*.json" -print -quit 2>/dev/null)
-    if [[ -n "$fallback" ]]; then
-        echo "$fallback"
+
+    # 2. Parse variants.yaml (malformed or missing → empty sentinel)
+    local variants_file="$SCRIPT_DIR/$container/variants.yaml"
+    [[ -f "$variants_file" ]] || return 0
+
+    # Validate YAML and get the latest version tag (versions[0].tag)
+    # yq exits non-zero on malformed YAML → return empty (never filesystem-first)
+    local latest_version
+    latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || return 0
+    [[ -n "$latest_version" ]] || return 0
+
+    # Get the default variant name for the latest version
+    local default_name
+    default_name=$(yq -r '.versions[0].variants[] | select(.default == true) | .name' \
+        "$variants_file" 2>/dev/null | head -1) || true
+
+    # Try exact match for default variant:
+    # Pattern: {container}-{version}*{default_name}.json
+    # The glob handles any base_suffix inserted between version and variant name
+    # (e.g. postgres-18-alpine-base.json where version=18, variant=base, base_sfx=-alpine)
+    local found_file=""
+    if [[ -n "$default_name" ]]; then
+        for _f in "$lineage_dir/${container}-${latest_version}"*"${default_name}.json"; do
+            if [[ -f "$_f" ]]; then
+                found_file="$_f"
+                break
+            fi
+        done
     fi
+
+    # Fallback: any lineage file for the latest version (when default variant file missing,
+    # or for versions-only containers that have no variants key)
+    if [[ -z "$found_file" ]]; then
+        for _f in "$lineage_dir/${container}-${latest_version}"*.json; do
+            if [[ -f "$_f" ]]; then
+                found_file="$_f"
+                break
+            fi
+        done
+    fi
+
+    [[ -n "$found_file" ]] && echo "$found_file" || true
 }
 
 # Resolve lineage file for a specific variant of a container
@@ -82,14 +129,24 @@ resolve_variant_lineage_file() {
 }
 
 # Get a field from the build lineage JSON for a container
-# Falls back to "unknown" if lineage data doesn't exist
+# Falls back to "unknown" if lineage data doesn't exist.
+# Fix E: sanitize-at-read — if the field value contains "${" (leaked build-arg placeholder
+# from pre-v2 lineage entries), treat it as empty ("") so the dashboard shows
+# "not available" rather than a literal unexpanded shell expression.
 get_build_lineage_field() {
     local container="$1"
     local field="$2"
     local lineage_file
     lineage_file=$(resolve_lineage_file "$container")
     if [[ -n "$lineage_file" ]]; then
-        jq -r ".[\"$field\"] // \"unknown\"" "$lineage_file" 2>/dev/null || echo "unknown"
+        local _val
+        _val=$(jq -r ".[\"$field\"] // \"unknown\"" "$lineage_file" 2>/dev/null) || _val="unknown"
+        # Sanitize: leaked placeholder (e.g. "${OS_IMAGE_BASE}:${OS_IMAGE_TAG}") → empty
+        if [[ "$_val" == *'${'* ]]; then
+            echo ""
+        else
+            echo "$_val"
+        fi
     else
         echo "unknown"
     fi

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -57,11 +57,9 @@ resolve_lineage_file() {
         # Validate YAML and get the latest version tag (versions[0].tag).
         # Detect yq parse failure explicitly: malformed variants.yaml must cause an
         # early return with no fallback to the legacy rollup — operator must fix the YAML.
-        local latest_version _yq_rc
-        latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null)
-        _yq_rc=$?
-        if [[ $_yq_rc -ne 0 ]]; then
-            log_warning "resolve_lineage_file: variants.yaml parse error for $container (yq rc=$_yq_rc) — returning empty"
+        local latest_version
+        if ! latest_version=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null); then
+            log_warning "resolve_lineage_file: variants.yaml parse error for $container — returning empty"
             return 0
         fi
 
@@ -88,8 +86,9 @@ resolve_lineage_file() {
             # version (when default variant file missing, or for versions-only containers).
             # Excludes .sbom.json, .history.json, .changelog.json to avoid false-positive matches.
             if [[ -z "$found_file" ]]; then
-                found_file=$(find "$lineage_dir" -maxdepth 1 \
-                    -name "${container}-${latest_version}*.json" \
+                found_file=$(find "$lineage_dir" -maxdepth 1 \( \
+                    -name "${container}-${latest_version}.json" \
+                    -o -name "${container}-${latest_version}-*.json" \) \
                     -not -name "*.sbom.json" \
                     -not -name "*.history.json" \
                     -not -name "*.changelog.json" \

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -360,11 +360,11 @@ resolve_variant_lineage_json() {
         build_digest=$(jq -r '.build_digest // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
         local _raw_base_image
         _raw_base_image=$(jq -r '.base_image_ref // "unknown"' "$lineage_file" 2>/dev/null || echo "unknown")
-        # Sanitize-at-read: pre-v2 lineage files may have leaked ${...} placeholders in
-        # base_image_ref. Detect by checking lineage_schema_version and the value itself.
-        local _schema_ver
-        _schema_ver=$(jq -r '.lineage_schema_version // ""' "$lineage_file" 2>/dev/null || echo "")
-        if [[ -z "$_schema_ver" || "$_raw_base_image" == *'${'* ]]; then
+        # Sanitize-at-read: lineage files written before #530 may have leaked ${...}
+        # placeholders in base_image_ref. Sanitize only when the value actually
+        # contains an unresolved placeholder — the absence of lineage_schema_version
+        # is NOT a signal of corruption; v1 files can have concrete values.
+        if [[ "$_raw_base_image" == *'${'* ]]; then
             base_image="unknown"
         else
             base_image="$_raw_base_image"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -34,16 +34,18 @@ CONTAINERS_DIR="$SCRIPT_DIR/docs/site/_containers"
 # --- Lineage resolution helpers ---
 
 # Resolve the lineage JSON file for a container
-# Fix B: uses default_variant() selection from variants.yaml (NEVER filesystem-first).
+# Fix B: uses an inline yq query equivalent to default_variant() to select the
+# default variant from variants.yaml (NEVER filesystem-first).
 #
 # Precedence:
-#   1. {container}.json exists → return it (legacy rollup path)
-#   2. variants.yaml exists → parse it:
+#   1. variants.yaml exists → parse it (preferred — new builds write per-tag files):
 #      a. Malformed YAML → return empty sentinel (never fall back to filesystem-first)
-#      b. Latest version (versions[0]) + default variant name → try exact match
+#      b. Latest version (versions[0]) + default variant name (inline yq) → try exact match
 #      c. Default variant file missing → fallback to any file for the latest version
 #      d. No variants key (versions-only) → any file for the latest version
-#   3. No variants.yaml → return empty
+#   2. Legacy rollup: {container}.json — only when no variants.yaml exists, or when its
+#      embedded .tag matches the current default (i.e. it IS the latest build's output)
+#   3. No variants.yaml and no legacy rollup → return empty
 resolve_lineage_file() {
     local container="$1"
     local lineage_dir="$SCRIPT_DIR/.build-lineage"
@@ -119,16 +121,16 @@ resolve_lineage_file() {
         # (i.e. it was written for the current build, not a stale prior-era rollup).
         local legacy_tag
         legacy_tag=$(jq -r '.tag // ""' "$lineage_file" 2>/dev/null) || legacy_tag=""
-        local current_latest
-        current_latest=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || current_latest=""
+        # Reuse latest_version (already resolved at the top of this function) rather
+        # than issuing a second yq parse of variants_file.
         # Prefix match: lineage_file.tag may be "1.7.7-debian" while
         # variants_file.versions[0].tag is the version component "1.7.7".
-        # Accept the legacy rollup when its tag equals current_latest OR
-        # when it starts with "$current_latest-" (version prefix, different variant suffix).
+        # Accept the legacy rollup when its tag equals latest_version OR
+        # when it starts with "$latest_version-" (version prefix, different variant suffix).
         # This prevents false positives (11.0-alpine vs 1.0) while allowing
         # multi-variant containers where the tag carries a distro suffix.
-        if [[ -n "$legacy_tag" && -n "$current_latest" && \
-              ( "$legacy_tag" == "$current_latest" || "$legacy_tag" == "${current_latest}-"* ) ]]; then
+        if [[ -n "$legacy_tag" && -n "$latest_version" && \
+              ( "$legacy_tag" == "$latest_version" || "$legacy_tag" == "${latest_version}-"* ) ]]; then
             echo "$lineage_file"
             return
         fi

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -115,7 +115,7 @@ resolve_lineage_file() {
         legacy_tag=$(jq -r '.tag // ""' "$lineage_file" 2>/dev/null) || legacy_tag=""
         local current_latest
         current_latest=$(yq -r '.versions[0].tag // ""' "$variants_file" 2>/dev/null) || current_latest=""
-        if [[ -n "$legacy_tag" && -n "$current_latest" && "$legacy_tag" == *"$current_latest"* ]]; then
+        if [[ -n "$legacy_tag" && -n "$current_latest" && "$legacy_tag" == "$current_latest" ]]; then
             echo "$lineage_file"
             return
         fi

--- a/github-runner/generate-dockerfile.sh
+++ b/github-runner/generate-dockerfile.sh
@@ -97,7 +97,7 @@ generate_one() {
             local ubuntu_tag
             ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
             [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $CONFIG"; exit 1; }
-            base_block="ARG REMOTE_CR=docker.io"$'\n'
+            base_block="ARG REMOTE_CR=ghcr.io/oorabona"$'\n'
             base_block+="ARG UBUNTU_2404_TAG=${ubuntu_tag}"$'\n'
             base_block+="FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_2404_TAG}"$'\n'
             ;;

--- a/github-runner/generate-dockerfile.sh
+++ b/github-runner/generate-dockerfile.sh
@@ -97,7 +97,7 @@ generate_one() {
             local ubuntu_tag
             ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
             [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $CONFIG"; exit 1; }
-            base_block="ARG REMOTE_CR"$'\n'
+            base_block="ARG REMOTE_CR=docker.io"$'\n'
             base_block+="ARG UBUNTU_2404_TAG=${ubuntu_tag}"$'\n'
             base_block+="FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_2404_TAG}"$'\n'
             ;;

--- a/github-runner/generate-dockerfile.sh
+++ b/github-runner/generate-dockerfile.sh
@@ -97,8 +97,7 @@ generate_one() {
             local ubuntu_tag
             ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
             [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $CONFIG"; exit 1; }
-            base_block="ARG REMOTE_CR=ghcr.io/oorabona"$'\n'
-            base_block+="ARG UBUNTU_2404_TAG=${ubuntu_tag}"$'\n'
+            base_block="ARG UBUNTU_2404_TAG=${ubuntu_tag}"$'\n'
             base_block+="FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_2404_TAG}"$'\n'
             ;;
         *)

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -177,7 +177,8 @@ variant_property() {
 #   5. Multiple default: true entries → returns only the first match (yq | head -1).
 #      Callers checking for multi-default ambiguity should test the count separately.
 #
-# Used by: generate-dashboard.sh::resolve_lineage_file (Fix B, #530)
+# Note: generate-dashboard.sh::resolve_lineage_file (Fix B, #530) uses an inline yq
+#   query equivalent to this function rather than calling it directly.
 # Used by: build_container (future: per-variant tag routing)
 # Global consumed by _resolve_base_image: _BUILD_ARGS_RESOLVED (populated by
 #   _prepare_build_args — see scripts/build-container.sh Fix A1, #530).

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -166,7 +166,21 @@ variant_property() {
     fi
 }
 
-# Get the default variant name for a version
+# Get the default variant name for a container.
+#
+# Canonical precedence (used by resolve_lineage_file in generate-dashboard.sh):
+#   1. Single variant with default: true wins.
+#   2. If exactly one variant exists, it is the default.
+#   3. If multiple variants exist without default: true, returns "" (empty sentinel).
+#      Callers must treat "" as "unknown" — never fall back to filesystem-first.
+#   4. Malformed variants.yaml (yq parse error) → returns "" + caller sees empty.
+#   5. Multiple default: true entries → returns only the first match (yq | head -1).
+#      Callers checking for multi-default ambiguity should test the count separately.
+#
+# Used by: generate-dashboard.sh::resolve_lineage_file (Fix B, #530)
+# Used by: build_container (future: per-variant tag routing)
+# Global consumed by _resolve_base_image: _BUILD_ARGS_RESOLVED (populated by
+#   _prepare_build_args — see scripts/build-container.sh Fix A1, #530).
 default_variant() {
     local container_dir="$1"
     local pg_version="${2:-}"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -97,10 +97,22 @@ _configure_cache() {
     fi
 }
 
-# _prepare_build_args: thin wrapper for backward compatibility
-# Delegates to prepare_build_args() in helpers/build-args-utils.sh
+# _prepare_build_args: thin wrapper; also populates _BUILD_ARGS_RESOLVED global.
+# _BUILD_ARGS_RESOLVED maps ARG_NAME → value for every --build-arg in _BUILD_ARGS.
+# _resolve_base_image reads this global as its Fix-A1 substitution source (Step 2.5).
 _prepare_build_args() {
     prepare_build_args "$1" "$2"
+    # Populate _BUILD_ARGS_RESOLVED from the assembled _BUILD_ARGS string.
+    # Each --build-arg NAME=VALUE token is extracted; the map is consumed by
+    # _resolve_base_image to substitute ARGs whose values come from config.yaml
+    # build_args or version params (not visible via Dockerfile ARG defaults).
+    declare -gA _BUILD_ARGS_RESOLVED=()
+    local _ba_token
+    while IFS= read -r _ba_token; do
+        local _ba_name="${_ba_token%%=*}"
+        local _ba_value="${_ba_token#*=}"
+        [[ -n "$_ba_name" && "$_ba_name" != "$_ba_token" ]] && _BUILD_ARGS_RESOLVED["$_ba_name"]="$_ba_value"
+    done < <(echo "${_BUILD_ARGS:-}" | grep -oE -- '--build-arg [^ ]+' | sed 's/--build-arg //' || true)
 }
 
 # Resolve base image reference from config.yaml or Dockerfile, substitute variables
@@ -110,13 +122,24 @@ _resolve_base_image() {
     local version="$2"
     local label_args_var="$3"  # name of the label_args variable to append to
 
+    # Fix A2: when called with a generated Dockerfile (post-template-generation),
+    # the concrete FROM line is the authoritative source.  In that case, skip
+    # config.yaml::base_image — it contains the default-distro template value and
+    # would override the per-flavor FROM already baked into the generated file.
+    # Signal: caller sets _RESOLVE_FROM_GENERATED=1 before calling.
+    local _use_from_only="${_RESOLVE_FROM_GENERATED:-0}"
+
     _BASE_IMAGE_REF=""
-    if [[ -f "./config.yaml" ]]; then
+    if [[ "$_use_from_only" != "1" && -f "./config.yaml" ]]; then
         _BASE_IMAGE_REF=$(yq -r '.base_image // ""' ./config.yaml 2>/dev/null || true)
     fi
+    # Always pre-compute the FROM line; used as fallback and as the authoritative
+    # source when _use_from_only=1.
+    local _dockerfile_from=""
+    _dockerfile_from=$(grep -E '^FROM ' "$dockerfile" | grep -v ' AS ' | tail -1 | awk '{print $2}' 2>/dev/null || true)
+    [[ -z "$_dockerfile_from" ]] && _dockerfile_from=$(grep -E '^FROM ' "$dockerfile" | tail -1 | awk '{print $2}' 2>/dev/null || true)
     if [[ -z "$_BASE_IMAGE_REF" ]]; then
-        _BASE_IMAGE_REF=$(grep -E '^FROM ' "$dockerfile" | grep -v ' AS ' | tail -1 | awk '{print $2}' || true)
-        [[ -z "$_BASE_IMAGE_REF" ]] && _BASE_IMAGE_REF=$(grep -E '^FROM ' "$dockerfile" | tail -1 | awk '{print $2}' || true)
+        _BASE_IMAGE_REF="$_dockerfile_from"
     fi
 
     # Substitute known variables into the base image template.
@@ -129,9 +152,10 @@ _resolve_base_image() {
     # wrong base_image_ref in the lineage file because _UPSTREAM_VERSION (latest)
     # would be substituted first, and the CUSTOM_BUILD_ARGS override would arrive
     # too late to correct an already-expanded placeholder.
-    # Order: (1) parse CUSTOM_BUILD_ARGS, (2) apply overrides, (3) standard
-    # substitutions (no-ops for placeholders already consumed in step 2),
-    # (4) Dockerfile ARG defaults.
+    # Order: (1) parse CUSTOM_BUILD_ARGS, (2) apply overrides, (2.5) build_args
+    # resolved set from _prepare_build_args [Fix A1], (3) standard substitutions
+    # (no-ops for placeholders already consumed in steps 1-2.5), (4) Dockerfile
+    # ARG defaults.
     if [[ "$_BASE_IMAGE_REF" =~ \$ ]]; then
         # Step 1 + 2: Parse CUSTOM_BUILD_ARGS and apply overrides first so they win
         # over all subsequent substitutions. Docker semantics: last --build-arg wins.
@@ -150,6 +174,31 @@ _resolve_base_image() {
             _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$_ov_name\}/$_ov_value}"
             _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$_ov_name/$_ov_value}"
         done
+
+        # Step 2.5 [Fix A1]: Apply build_args resolved set from _prepare_build_args.
+        # This covers ARGs whose values come from config.yaml build_args or version
+        # params — invisible to both CUSTOM_BUILD_ARGS and Dockerfile ARG defaults.
+        # Iterates up to 10 times to resolve cross-arg chains (A→B→C).  On cap-hit,
+        # remaining placeholders survive to sanitize-at-read in the dashboard.
+        if [[ ${#_BUILD_ARGS_RESOLVED[@]} -gt 0 ]]; then
+            local _pass=0
+            while [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -lt 10 ]]; do
+                local _prev="$_BASE_IMAGE_REF"
+                for _ba_name in "${!_BUILD_ARGS_RESOLVED[@]}"; do
+                    # Skip args already handled by CUSTOM_BUILD_ARGS
+                    [[ -v _custom_arg_overrides["$_ba_name"] ]] && continue
+                    local _ba_val="${_BUILD_ARGS_RESOLVED[$_ba_name]}"
+                    _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$_ba_name\}/$_ba_val}"
+                    _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$_ba_name/$_ba_val}"
+                done
+                # Converged: no more substitutions possible
+                [[ "$_BASE_IMAGE_REF" == "$_prev" ]] && break
+                (( _pass++ )) || true
+            done
+            if [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -ge 10 ]]; then
+                log_warning "base_image_ref cross-arg expansion capped at 10 passes: $_BASE_IMAGE_REF"
+            fi
+        fi
 
         # Step 3: Standard substitutions. These are no-ops for any placeholder
         # already consumed by a CUSTOM_BUILD_ARGS override above.
@@ -177,6 +226,21 @@ _resolve_base_image() {
         done < <(grep -E '^ARG [A-Z_]+=' "$dockerfile" | sed 's/^ARG //' || true)
 
         unset _custom_arg_overrides
+
+        # Fix A2 post-substitution fallback: if config.yaml base_image had a template
+        # expression (e.g. distro-default like "${DEBIAN_TAG}") that still contains ${
+        # after all passes, fall back to the concrete FROM line in the Dockerfile.
+        # This fires for template-driven containers where the generated Dockerfile's FROM
+        # reflects the per-flavor base image — a more authoritative source than the
+        # config.yaml default-distro template.
+        if [[ "$_BASE_IMAGE_REF" =~ \$\{ && -n "$_dockerfile_from" && ! "$_dockerfile_from" =~ \$\{ ]]; then
+            _BASE_IMAGE_REF="$_dockerfile_from"
+        fi
+
+        # Emit warning when a placeholder survives all substitution passes
+        if [[ "$_BASE_IMAGE_REF" =~ \$\{ ]]; then
+            log_warning "base_image_ref left un-resolved: $_BASE_IMAGE_REF"
+        fi
     fi
 
     # Resolve digest if we have a concrete image reference
@@ -184,7 +248,8 @@ _resolve_base_image() {
     if [[ -n "$_BASE_IMAGE_REF" && ! "$_BASE_IMAGE_REF" =~ \$ ]]; then
         _BASE_DIGEST=$(docker manifest inspect "$_BASE_IMAGE_REF" 2>/dev/null | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
         if [[ -n "$_BASE_DIGEST" ]]; then
-            eval "$label_args_var=\"\$$label_args_var --label org.opencontainers.image.base.digest=\$_BASE_DIGEST\""
+            # Fix D: printf -v replaces eval; no shell-metacharacter injection vector
+            printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"
             log_info "Base image $_BASE_IMAGE_REF pinned: ${_BASE_DIGEST:0:19}..."
         fi
     fi
@@ -208,30 +273,50 @@ _emit_build_lineage() {
     local build_args_data
     build_args_data=$(build_args_json ".")
 
-    cat > "$lineage_file" <<LINEAGE_EOF
-{
-  "container": "$container",
-  "version": "$version",
-  "tag": "$tag",
-  "flavor": "${flavor:-}",
-  "dockerfile": "$dockerfile",
-  "platform": "$platforms",
-  "runtime": "$runtime_info",
-  "image_id": "${image_id:-unknown}",
-  "build_digest": "${BUILD_DIGEST:-unknown}",
-  "oci_subject_digest": "${OCI_SUBJECT_DIGEST:-}",
-  "base_image_ref": "${_BASE_IMAGE_REF:-unknown}",
-  "base_image_digest": "${_BASE_DIGEST:-unresolved}",
-  "built_at": "$build_ts",
-  "duration_seconds": ${_BUILD_DURATION_SECONDS:-null},
-  "github_actions": ${GITHUB_ACTIONS:-false},
-  "images": {
-    "dockerhub": "$dockerhub_image:$tag",
-    "ghcr": "$ghcr_image:$tag"
-  },
-  "build_args": $build_args_data
-}
-LINEAGE_EOF
+    # Fix C: use jq -n --arg so values with '"' or backslash are safely escaped.
+    # Fix E: include lineage_schema_version=2 for downstream schema detection.
+    jq -n \
+        --arg     container        "$container" \
+        --arg     version          "$version" \
+        --arg     tag              "$tag" \
+        --arg     flavor           "${flavor:-}" \
+        --arg     dockerfile       "$dockerfile" \
+        --arg     platform         "$platforms" \
+        --arg     runtime          "$runtime_info" \
+        --arg     image_id         "${image_id:-unknown}" \
+        --arg     build_digest     "${BUILD_DIGEST:-unknown}" \
+        --arg     oci_subject_digest "${OCI_SUBJECT_DIGEST:-}" \
+        --arg     base_image_ref   "${_BASE_IMAGE_REF:-unknown}" \
+        --arg     base_image_digest "${_BASE_DIGEST:-unresolved}" \
+        --arg     built_at         "$build_ts" \
+        --argjson duration_seconds "${_BUILD_DURATION_SECONDS:-null}" \
+        --argjson github_actions   "${GITHUB_ACTIONS:-false}" \
+        --arg     dockerhub_image  "$dockerhub_image:$tag" \
+        --arg     ghcr_image       "$ghcr_image:$tag" \
+        --argjson build_args       "$build_args_data" \
+        '{
+          lineage_schema_version: 2,
+          container:              $container,
+          version:                $version,
+          tag:                    $tag,
+          flavor:                 $flavor,
+          dockerfile:             $dockerfile,
+          platform:               $platform,
+          runtime:                $runtime,
+          image_id:               $image_id,
+          build_digest:           $build_digest,
+          oci_subject_digest:     $oci_subject_digest,
+          base_image_ref:         $base_image_ref,
+          base_image_digest:      $base_image_digest,
+          built_at:               $built_at,
+          duration_seconds:       $duration_seconds,
+          github_actions:         $github_actions,
+          images: {
+            dockerhub: $dockerhub_image,
+            ghcr:      $ghcr_image
+          },
+          build_args: $build_args
+        }' > "$lineage_file"
 
     # Conditionally merge extensions_build_seconds when the caller actually
     # measured it. The field's PRESENCE (not its value) is the signal that
@@ -311,9 +396,10 @@ build_container() {
 
     local label_args=""
 
-    _resolve_base_image "$dockerfile" "$version" "label_args"
-
-    # Generate Dockerfile from template if it contains @@MARKER@@ patterns
+    # Generate Dockerfile from template if it contains @@MARKER@@ patterns.
+    # Fix A2: _resolve_base_image is called AFTER this block so that template-driven
+    # containers (web-shell, github-runner) have their per-flavor Dockerfile generated
+    # before the base-image resolution reads the concrete FROM line.
     local _generated_dockerfile=""
     if has_template_markers "$dockerfile"; then
         _generated_dockerfile=$(mktemp "${TMPDIR:-/tmp}/Dockerfile.${container}.XXXXXX") || {
@@ -352,6 +438,14 @@ build_container() {
         fi
         dockerfile="$_generated_dockerfile"
     fi
+
+    # Fix A2: resolve base image AFTER template generation so the correct per-flavor
+    # FROM line (from the generated Dockerfile) is visible.  For monolithic containers
+    # _generated_dockerfile is empty and _RESOLVE_FROM_GENERATED stays 0 so
+    # config.yaml::base_image is still read — no behavior change for monolithic path.
+    local _rbi_generated=0
+    [[ -n "$_generated_dockerfile" ]] && _rbi_generated=1
+    _RESOLVE_FROM_GENERATED="$_rbi_generated" _resolve_base_image "$dockerfile" "$version" "label_args"
 
     # Pre-build context hook: download external artifacts needed by the Dockerfile
     # (e.g., github-runner downloads the runner agent tarball via gh CLI)

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -101,12 +101,14 @@ _configure_cache() {
 # _BUILD_ARGS_RESOLVED maps ARG_NAME → value for every --build-arg in _BUILD_ARGS.
 # _resolve_base_image reads this global as its Fix-A1 substitution source (Step 2.5).
 _prepare_build_args() {
+    # Reset the resolved map unconditionally so a failed call never contaminates
+    # the next call with stale values from the previous successful invocation.
+    declare -gA _BUILD_ARGS_RESOLVED=()
     prepare_build_args "$1" "$2" || return $?
     # Populate _BUILD_ARGS_RESOLVED from the assembled _BUILD_ARGS string.
     # Each --build-arg NAME=VALUE token is extracted; the map is consumed by
     # _resolve_base_image to substitute ARGs whose values come from config.yaml
     # build_args or version params (not visible via Dockerfile ARG defaults).
-    declare -gA _BUILD_ARGS_RESOLVED=()
     local _ba_token
     while IFS= read -r _ba_token; do
         local _ba_name="${_ba_token%%=*}"
@@ -117,17 +119,22 @@ _prepare_build_args() {
 
 # Resolve base image reference from config.yaml or Dockerfile, substitute variables
 # Sets: _BASE_IMAGE_REF, _BASE_DIGEST, adds to label_args
+# Args: <dockerfile> <version> <label_args_var> [<from_generated>]
+#   from_generated: 1 = use the concrete FROM line in the generated Dockerfile as the
+#     authoritative base-image source (Fix A2); 0 = use config.yaml::base_image (default).
+#     Pass this explicitly from every call site — callers that forget default to monolithic
+#     semantics (0), which is safe but may miss the per-flavor fix for template containers.
 _resolve_base_image() {
     local dockerfile="$1"
     local version="$2"
     local label_args_var="$3"  # name of the label_args variable to append to
+    local from_generated="${4:-0}"  # Fix A2 positional param (replaces _RESOLVE_FROM_GENERATED env)
 
     # Fix A2: when called with a generated Dockerfile (post-template-generation),
     # the concrete FROM line is the authoritative source.  In that case, skip
     # config.yaml::base_image — it contains the default-distro template value and
     # would override the per-flavor FROM already baked into the generated file.
-    # Signal: caller sets _RESOLVE_FROM_GENERATED=1 before calling.
-    local _use_from_only="${_RESOLVE_FROM_GENERATED:-0}"
+    local _use_from_only="$from_generated"
 
     # Fix A1: _BUILD_ARGS_RESOLVED is populated by _prepare_build_args (wrapper).
     # When _resolve_base_image is called directly in tests (without the wrapper),
@@ -205,9 +212,8 @@ _resolve_base_image() {
             done
             if [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -ge 10 ]]; then
                 log_warning "base_image_ref cross-arg expansion capped at 10 passes: $_BASE_IMAGE_REF"
-                # Clear the unresolved reference so the caller receives a clean empty
-                # signal rather than a leaked ${...} literal that would propagate into
-                # the lineage file and appear as "unknown" on the dashboard.
+                # On cap-hit, _BASE_IMAGE_REF is cleared to empty string.
+                # Sanitize-at-read in the dashboard displays "unknown" downstream.
                 _BASE_IMAGE_REF=""
             fi
         fi
@@ -458,11 +464,11 @@ build_container() {
 
     # Fix A2: resolve base image AFTER template generation so the correct per-flavor
     # FROM line (from the generated Dockerfile) is visible.  For monolithic containers
-    # _generated_dockerfile is empty and _RESOLVE_FROM_GENERATED stays 0 so
-    # config.yaml::base_image is still read — no behavior change for monolithic path.
+    # _generated_dockerfile is empty and from_generated=0 so config.yaml::base_image
+    # is still read — no behavior change for monolithic path.
     local _rbi_generated=0
     [[ -n "$_generated_dockerfile" ]] && _rbi_generated=1
-    _RESOLVE_FROM_GENERATED="$_rbi_generated" _resolve_base_image "$dockerfile" "$version" "label_args"
+    _resolve_base_image "$dockerfile" "$version" "label_args" "$_rbi_generated"
 
     # Pre-build context hook: download external artifacts needed by the Dockerfile
     # (e.g., github-runner downloads the runner agent tarball via gh CLI)

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -235,13 +235,18 @@ _resolve_base_image() {
 
         unset _custom_arg_overrides
 
-        # Fix A2 post-substitution fallback: if config.yaml base_image had a template
-        # expression (e.g. distro-default like "${DEBIAN_TAG}") that still contains ${
-        # after all passes, fall back to the concrete FROM line in the Dockerfile.
-        # This fires for template-driven containers where the generated Dockerfile's FROM
-        # reflects the per-flavor base image — a more authoritative source than the
-        # config.yaml default-distro template.
-        if [[ "$_BASE_IMAGE_REF" =~ \$\{ && -n "$_dockerfile_from" && ! "$_dockerfile_from" =~ \$\{ ]]; then
+        # Post-substitution fallback: if config.yaml base_image had a template
+        # expression that still contains ${ after all passes, fall back to the concrete
+        # FROM line in the Dockerfile — but ONLY when _RESOLVE_FROM_GENERATED=1 (the
+        # caller has already expanded the template, so the generated Dockerfile's FROM
+        # is the authoritative per-flavor base image).
+        #
+        # For monolithic containers (no template generation), config.yaml::base_image is
+        # the source of truth. If its placeholders remain unresolved, that is a build-time
+        # configuration error — substituting an unrelated concrete FROM line (e.g. a
+        # multi-stage final-stage "FROM scratch") would write false lineage silently.
+        # Instead, leave the unresolved literal so sanitize-at-read displays "unknown".
+        if [[ "$_BASE_IMAGE_REF" =~ \$\{ && "$_use_from_only" == "1" && -n "$_dockerfile_from" && ! "$_dockerfile_from" =~ \$\{ ]]; then
             _BASE_IMAGE_REF="$_dockerfile_from"
         fi
 

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -247,9 +247,9 @@ _resolve_base_image() {
 
         # Post-substitution fallback: if config.yaml base_image had a template
         # expression that still contains ${ after all passes, fall back to the concrete
-        # FROM line in the Dockerfile — but ONLY when _RESOLVE_FROM_GENERATED=1 (the
-        # caller has already expanded the template, so the generated Dockerfile's FROM
-        # is the authoritative per-flavor base image).
+        # FROM line in the Dockerfile — but ONLY when the 4th positional parameter
+        # from_generated=1 (the caller has already expanded the template, so the
+        # generated Dockerfile's FROM is the authoritative per-flavor base image).
         #
         # For monolithic containers (no template generation), config.yaml::base_image is
         # the source of truth. If its placeholders remain unresolved, that is a build-time

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -231,7 +231,7 @@ _resolve_base_image() {
                 _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$arg_name\}/$arg_default}"
                 _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$arg_name/$arg_default}"
             fi
-        done < <(grep -E '^ARG [A-Z_]+=' "$dockerfile" | sed 's/^ARG //' || true)
+        done < <(grep -E '^ARG [A-Za-z_][A-Za-z0-9_]*=' "$dockerfile" | sed 's/^ARG //' || true)
 
         unset _custom_arg_overrides
 

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -129,6 +129,14 @@ _resolve_base_image() {
     # Signal: caller sets _RESOLVE_FROM_GENERATED=1 before calling.
     local _use_from_only="${_RESOLVE_FROM_GENERATED:-0}"
 
+    # Fix A1: _BUILD_ARGS_RESOLVED is populated by _prepare_build_args (wrapper).
+    # When _resolve_base_image is called directly in tests (without the wrapper),
+    # declare the array as empty so ${#_BUILD_ARGS_RESOLVED[@]} doesn't trigger
+    # "unbound variable" under set -u.
+    if ! declare -p _BUILD_ARGS_RESOLVED &>/dev/null; then
+        declare -gA _BUILD_ARGS_RESOLVED=()
+    fi
+
     _BASE_IMAGE_REF=""
     if [[ "$_use_from_only" != "1" && -f "./config.yaml" ]]; then
         _BASE_IMAGE_REF=$(yq -r '.base_image // ""' ./config.yaml 2>/dev/null || true)

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -101,7 +101,7 @@ _configure_cache() {
 # _BUILD_ARGS_RESOLVED maps ARG_NAME → value for every --build-arg in _BUILD_ARGS.
 # _resolve_base_image reads this global as its Fix-A1 substitution source (Step 2.5).
 _prepare_build_args() {
-    prepare_build_args "$1" "$2"
+    prepare_build_args "$1" "$2" || return $?
     # Populate _BUILD_ARGS_RESOLVED from the assembled _BUILD_ARGS string.
     # Each --build-arg NAME=VALUE token is extracted; the map is consumed by
     # _resolve_base_image to substitute ARGs whose values come from config.yaml

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -205,6 +205,10 @@ _resolve_base_image() {
             done
             if [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -ge 10 ]]; then
                 log_warning "base_image_ref cross-arg expansion capped at 10 passes: $_BASE_IMAGE_REF"
+                # Clear the unresolved reference so the caller receives a clean empty
+                # signal rather than a leaked ${...} literal that would propagate into
+                # the lineage file and appear as "unknown" on the dashboard.
+                _BASE_IMAGE_REF=""
             fi
         fi
 

--- a/tests/fixtures/dashboard-530/monolithic/Dockerfile
+++ b/tests/fixtures/dashboard-530/monolithic/Dockerfile
@@ -1,0 +1,5 @@
+ARG OS_IMAGE_BASE
+ARG OS_IMAGE_TAG
+FROM ${OS_IMAGE_BASE}:${OS_IMAGE_TAG}
+
+RUN echo "monolithic fixture"

--- a/tests/fixtures/dashboard-530/monolithic/config.yaml
+++ b/tests/fixtures/dashboard-530/monolithic/config.yaml
@@ -1,0 +1,7 @@
+# Monolithic fixture: models sslh-style container
+# base_image uses ARGs that come only from _prepare_build_args (not inline Dockerfile defaults)
+base_image: "${OS_IMAGE_BASE}:${OS_IMAGE_TAG}"
+
+build_args:
+  OS_IMAGE_BASE: "alpine"
+  OS_IMAGE_TAG: "3.21"

--- a/tests/fixtures/dashboard-530/monolithic/variants.yaml
+++ b/tests/fixtures/dashboard-530/monolithic/variants.yaml
@@ -1,0 +1,5 @@
+build:
+  version_retention: 3
+
+versions:
+  - tag: "v2.3.1"

--- a/tests/fixtures/dashboard-530/template/Dockerfile.template
+++ b/tests/fixtures/dashboard-530/template/Dockerfile.template
@@ -1,0 +1,4 @@
+@@BASE_IMAGE@@
+
+ARG FLAVOR
+RUN echo "template fixture for @@FLAVOR@@"

--- a/tests/fixtures/dashboard-530/template/config.yaml
+++ b/tests/fixtures/dashboard-530/template/config.yaml
@@ -1,0 +1,17 @@
+# Template fixture: models web-shell-style multi-distro container
+base_image: "ghcr.io/oorabona/debian:${DEBIAN_TAG}"
+
+build_args:
+  DEBIAN_TAG: "trixie"
+
+distros:
+  debian:
+    base_image: "ghcr.io/oorabona/debian:${DEBIAN_TAG}"
+    pkg_manager: apt
+    install_cmd: "apt-get install -y"
+    cleanup_cmd: "rm -rf /var/lib/apt/lists/*"
+  alpine:
+    base_image: "alpine:3.21"
+    pkg_manager: apk
+    install_cmd: "apk add --no-cache"
+    cleanup_cmd: ""

--- a/tests/fixtures/dashboard-530/template/generate-dockerfile.sh
+++ b/tests/fixtures/dashboard-530/template/generate-dockerfile.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Minimal generate-dockerfile.sh for dashboard-530 template fixture.
+# Reads config.yaml::distros.<flavor>.base_image and expands the template.
+# Args: <template_file> <flavor> [<version>] [<build_flavor>]
+set -euo pipefail
+
+template_file="${1:?template file required}"
+flavor="${2:?flavor required}"
+# version and build_flavor are optional (used by real generators, not needed here)
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+config_file="$script_dir/config.yaml"
+
+if [[ ! -f "$config_file" ]]; then
+    echo "ERROR: config.yaml not found at $config_file" >&2
+    exit 1
+fi
+
+# Read base_image for this distro/flavor
+base_image=$(yq -r ".distros[\"$flavor\"].base_image // \"\"" "$config_file" 2>/dev/null || true)
+if [[ -z "$base_image" ]]; then
+    echo "ERROR: no distros.$flavor.base_image in $config_file" >&2
+    exit 1
+fi
+
+# Expand template: replace @@BASE_IMAGE@@ with FROM <base_image>
+while IFS= read -r line; do
+    case "$line" in
+        "@@BASE_IMAGE@@")
+            echo "FROM $base_image"
+            ;;
+        *)
+            echo "${line//@@FLAVOR@@/$flavor}"
+            ;;
+    esac
+done < "$template_file"

--- a/tests/fixtures/dashboard-530/template/variants.yaml
+++ b/tests/fixtures/dashboard-530/template/variants.yaml
@@ -1,0 +1,15 @@
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.0"
+    variants:
+      - name: alpine
+        suffix: "-alpine"
+        flavor: alpine
+        description: "Alpine — lightweight, default variant"
+        default: true
+      - name: debian
+        suffix: ""
+        flavor: debian
+        description: "Debian — APT package manager"

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -1,0 +1,317 @@
+#!/usr/bin/env bats
+
+# Integration smoke tests for the base_image truth pipeline (issue #530).
+# Tests the full chain: _prepare_build_args → _resolve_base_image → _emit_build_lineage
+# → resolve_lineage_file (dashboard read).
+#
+# Covers:
+#   - Monolithic fixture (sslh-style): build_args substitution via _BUILD_ARGS_RESOLVED
+#   - Template fixture (web-shell-style): post-template-generation FROM is authoritative
+#   - Dashboard read fast-path: network helpers are NOT called
+#   - Mutation guard: disabling A1 substitution pass causes base_image_ref to leak ${...}
+
+load "../test_helper"
+
+PROJECT_ROOT_REAL="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURE_MONO="$PROJECT_ROOT_REAL/tests/fixtures/dashboard-530/monolithic"
+FIXTURE_TPL="$PROJECT_ROOT_REAL/tests/fixtures/dashboard-530/template"
+
+setup() {
+    setup_temp_dir
+    export ORIG_DIR="$PWD"
+
+    # Build-container.sh and dashboard source into separate workspaces below.
+    # Keep global TEST_TEMP_DIR for assertions.
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# Helper: source build-container.sh and its deps into current shell.
+# Must be called from a directory that will serve as PROJECT_ROOT for that test.
+# ---------------------------------------------------------------------------
+source_build_container() {
+    # Source order mirrors scripts/build-container.sh dependencies
+    source "$PROJECT_ROOT_REAL/helpers/logging.sh"
+    source "$PROJECT_ROOT_REAL/helpers/build-args-utils.sh"
+    source "$PROJECT_ROOT_REAL/helpers/variant-utils.sh"
+    source "$PROJECT_ROOT_REAL/helpers/template-utils.sh"
+
+    pushd "$PROJECT_ROOT_REAL/scripts" > /dev/null 2>&1
+    # shellcheck source=/dev/null
+    source "./build-container.sh"
+    popd > /dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Helper: extract dashboard functions without propagating set -euo pipefail.
+# ---------------------------------------------------------------------------
+source_dashboard_fns() {
+    local _fn_defs
+    _fn_defs=$(
+        cd "$PROJECT_ROOT_REAL" 2>/dev/null
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT_REAL/generate-dashboard.sh" 2>/dev/null || true
+        declare -f resolve_lineage_file
+        declare -f get_build_lineage_field
+    )
+    eval "$_fn_defs"
+}
+
+# ---------------------------------------------------------------------------
+# Smoke 1 — Monolithic fixture (Fix A1 end-to-end)
+# Pipeline: _prepare_build_args → _resolve_base_image → _emit_build_lineage
+# Assert: base_image_ref concrete, lineage_schema_version=2
+# ---------------------------------------------------------------------------
+@test "SMOKE-01: Monolithic fixture produces concrete base_image_ref (Fix A1)" {
+    local work="$TEST_TEMP_DIR/mono"
+    mkdir -p "$work"
+    cp "$FIXTURE_MONO/config.yaml"   "$work/"
+    cp "$FIXTURE_MONO/Dockerfile"    "$work/"
+    cp "$FIXTURE_MONO/variants.yaml" "$work/"
+    mkdir -p "$work/.build-lineage"
+
+    # Source build-container.sh context from work dir
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    # Mock docker (no real Docker needed)
+    docker() { echo ""; }
+    export -f docker
+
+    # Run the substitution pipeline
+    _prepare_build_args "$work" "v2.3.1"
+    _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
+
+    # Emit lineage
+    _emit_build_lineage \
+        "mono-fixture" "v2.3.1" "v2.3.1-alpine" "" \
+        "$work/Dockerfile" "linux/amd64" "" \
+        "example/mono-fixture" "ghcr.io/test/mono-fixture"
+
+    local lineage_file="$work/.build-lineage/mono-fixture-v2.3.1-alpine.json"
+    [ -f "$lineage_file" ]
+
+    local base_image_ref
+    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
+    # Must be concrete (no ${...} placeholder)
+    [[ "$base_image_ref" == "alpine:3.21" ]]
+}
+
+@test "SMOKE-02: Monolithic fixture lineage_schema_version equals 2" {
+    local work="$TEST_TEMP_DIR/mono2"
+    mkdir -p "$work"
+    cp "$FIXTURE_MONO/config.yaml"   "$work/"
+    cp "$FIXTURE_MONO/Dockerfile"    "$work/"
+    cp "$FIXTURE_MONO/variants.yaml" "$work/"
+    mkdir -p "$work/.build-lineage"
+
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    docker() { echo ""; }
+    export -f docker
+
+    _prepare_build_args "$work" "v2.3.1"
+    _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
+    _emit_build_lineage \
+        "mono-fixture" "v2.3.1" "v2.3.1-alpine" "" \
+        "$work/Dockerfile" "linux/amd64" "" \
+        "example/mono-fixture" "ghcr.io/test/mono-fixture"
+
+    local lineage_file="$work/.build-lineage/mono-fixture-v2.3.1-alpine.json"
+    local schema_ver
+    schema_ver=$(jq -r '.lineage_schema_version' "$lineage_file")
+    [[ "$schema_ver" == "2" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke 3 — Template fixture (Fix A2 end-to-end)
+# Pipeline: template generation → _RESOLVE_FROM_GENERATED=1 → _resolve_base_image
+# Assert: base_image_ref = "alpine:3.21" (from generated Dockerfile, not config)
+# ---------------------------------------------------------------------------
+@test "SMOKE-03: Template fixture (alpine) produces alpine:3.21 (Fix A2)" {
+    local work="$TEST_TEMP_DIR/tpl"
+    mkdir -p "$work"
+    cp "$FIXTURE_TPL/config.yaml"          "$work/"
+    cp "$FIXTURE_TPL/Dockerfile.template"  "$work/"
+    cp "$FIXTURE_TPL/variants.yaml"        "$work/"
+    cp "$FIXTURE_TPL/generate-dockerfile.sh" "$work/"
+    chmod +x "$work/generate-dockerfile.sh"
+    mkdir -p "$work/.build-lineage"
+
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    docker() { echo ""; }
+    export -f docker
+
+    # Simulate what build_container does: generate the per-flavor Dockerfile
+    local generated_df="$work/Dockerfile.alpine"
+    bash "$work/generate-dockerfile.sh" "$work/Dockerfile.template" "alpine" > "$generated_df"
+    [ -f "$generated_df" ]
+
+    # Verify the generated Dockerfile has the correct FROM line
+    [[ "$(head -1 "$generated_df")" == "FROM alpine:3.21" ]]
+
+    # Prepare build args (populates _BUILD_ARGS_RESOLVED)
+    _prepare_build_args "$work" "1.0"
+
+    # Resolve base image POST-template-generation (Fix A2): use generated Dockerfile
+    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated_df" "1.0" "label_args"
+
+    # Emit lineage
+    _emit_build_lineage \
+        "tpl-fixture" "1.0" "1.0-alpine" "alpine" \
+        "$generated_df" "linux/amd64" "" \
+        "example/tpl-fixture" "ghcr.io/test/tpl-fixture"
+
+    local lineage_file="$work/.build-lineage/tpl-fixture-1.0-alpine.json"
+    [ -f "$lineage_file" ]
+
+    local base_image_ref
+    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
+    # Must be alpine:3.21 (from generated Dockerfile), NOT the debian template default
+    [[ "$base_image_ref" == "alpine:3.21" ]]
+}
+
+@test "SMOKE-04: Template fixture (debian) produces concrete debian base_image_ref" {
+    local work="$TEST_TEMP_DIR/tpl-deb"
+    mkdir -p "$work"
+    cp "$FIXTURE_TPL/config.yaml"          "$work/"
+    cp "$FIXTURE_TPL/Dockerfile.template"  "$work/"
+    cp "$FIXTURE_TPL/variants.yaml"        "$work/"
+    cp "$FIXTURE_TPL/generate-dockerfile.sh" "$work/"
+    chmod +x "$work/generate-dockerfile.sh"
+    mkdir -p "$work/.build-lineage"
+
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    docker() { echo ""; }
+    export -f docker
+
+    # Generate debian-flavor Dockerfile
+    local generated_df="$work/Dockerfile.debian"
+    bash "$work/generate-dockerfile.sh" "$work/Dockerfile.template" "debian" > "$generated_df"
+
+    _prepare_build_args "$work" "1.0"
+    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated_df" "1.0" "label_args"
+
+    _emit_build_lineage \
+        "tpl-fixture" "1.0" "1.0" "debian" \
+        "$generated_df" "linux/amd64" "" \
+        "example/tpl-fixture" "ghcr.io/test/tpl-fixture"
+
+    local lineage_file="$work/.build-lineage/tpl-fixture-1.0.json"
+    [ -f "$lineage_file" ]
+
+    local base_image_ref
+    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
+    # Must be concrete (no ${...} leak) and must mention debian
+    [[ "$base_image_ref" != *'${'* ]]
+    [[ "$base_image_ref" == *"debian"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke 5 — Dashboard read fast-path (Fix B)
+# resolve_lineage_file must NOT call any network helpers
+# ---------------------------------------------------------------------------
+@test "SMOKE-05: Dashboard resolve_lineage_file does NOT invoke network helpers" {
+    local work="$TEST_TEMP_DIR/dash"
+    local lineage_dir="$work/.build-lineage"
+    local container_dir="$work/test-container"
+    mkdir -p "$lineage_dir" "$container_dir"
+
+    # Write a v2 lineage file for a versioned container
+    jq -n \
+        '{lineage_schema_version:2, container:"test-container", base_image_ref:"alpine:3.21",
+          version:"1.0", tag:"1.0-alpine", multi_arch_index_digest:"sha256:mock-idx"}' \
+        > "$lineage_dir/test-container-1.0-alpine.json"
+
+    # Write variants.yaml: version 1.0, default variant = alpine
+    printf 'versions:\n  - tag: "1.0"\n    variants:\n      - name: alpine\n        default: true\n' \
+        > "$container_dir/variants.yaml"
+
+    # Extract dashboard functions without set -euo pipefail propagation
+    export SCRIPT_DIR="$work"
+    source_dashboard_fns
+
+    # Declare network helpers that increment a counter
+    local network_calls=0
+    ghcr_get_token()   { (( network_calls++ )) || true; echo "mock-token"; }
+    _ghcr_fetch_index() { (( network_calls++ )) || true; echo "{}"; }
+    export -f ghcr_get_token _ghcr_fetch_index
+
+    run resolve_lineage_file "test-container"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"test-container-1.0-alpine.json" ]]
+
+    # Network helpers must NOT have been called
+    [ "$network_calls" -eq 0 ]
+}
+
+@test "SMOKE-06: Dashboard resolves multi_arch_index_digest enriched field from lineage" {
+    local work="$TEST_TEMP_DIR/dash2"
+    local lineage_dir="$work/.build-lineage"
+    local container_dir="$work/enrich-test"
+    mkdir -p "$lineage_dir" "$container_dir"
+
+    jq -n \
+        '{lineage_schema_version:2, container:"enrich-test", base_image_ref:"alpine:3.21",
+          version:"2.0", tag:"2.0-alpine", multi_arch_index_digest:"sha256:abc123"}' \
+        > "$lineage_dir/enrich-test-2.0-alpine.json"
+
+    printf 'versions:\n  - tag: "2.0"\n    variants:\n      - name: alpine\n        default: true\n' \
+        > "$container_dir/variants.yaml"
+
+    export SCRIPT_DIR="$work"
+    source_dashboard_fns
+
+    run resolve_lineage_file "enrich-test"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+
+    local midx
+    midx=$(jq -r '.multi_arch_index_digest // "missing"' "$output")
+    [[ "$midx" == "sha256:abc123" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Mutation guard: disabling A1 substitution pass causes ${...} to survive
+# ---------------------------------------------------------------------------
+@test "SMOKE-07: Mutation guard — disabling A1 substitution pass leaks placeholder" {
+    local work="$TEST_TEMP_DIR/mut"
+    mkdir -p "$work"
+    cp "$FIXTURE_MONO/config.yaml"   "$work/"
+    cp "$FIXTURE_MONO/Dockerfile"    "$work/"
+    cp "$FIXTURE_MONO/variants.yaml" "$work/"
+    mkdir -p "$work/.build-lineage"
+
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    docker() { echo ""; }
+    export -f docker
+
+    _prepare_build_args "$work" "v2.3.1"
+
+    # Simulate pre-fix behavior: clear _BUILD_ARGS_RESOLVED before resolving
+    # (this mimics the state before Fix A1 was applied)
+    declare -gA _BUILD_ARGS_RESOLVED=()
+
+    _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
+
+    # Without _BUILD_ARGS_RESOLVED, _BASE_IMAGE_REF still has ${...} placeholders
+    # because the Dockerfile ARG lines have no defaults (ARG OS_IMAGE_BASE, not ARG OS_IMAGE_BASE=alpine)
+    # The mutation guard: _BASE_IMAGE_REF must still contain ${ when A1 is disabled
+    [[ "$_BASE_IMAGE_REF" == *'${'* ]]
+}

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -359,3 +359,49 @@ source_dashboard_fns() {
         return 1
     }
 }
+
+# ---------------------------------------------------------------------------
+# Regression: sanitize-at-read must key on placeholder presence, NOT on the
+# absence of lineage_schema_version (#530).
+# A v1 lineage file (no lineage_schema_version) with a CONCRETE base_image_ref
+# must be preserved, not blanked to "unknown".
+# ---------------------------------------------------------------------------
+@test "SMOKE-09: v1 lineage file with concrete base_image_ref is preserved, not blanked" {
+    local work="$TEST_TEMP_DIR/f1-concrete"
+    local lineage_dir="$work/.build-lineage"
+    local container_dir="$work/mycontainer"
+    mkdir -p "$lineage_dir" "$container_dir"
+
+    # Write a v1 lineage file (no lineage_schema_version field) with a CONCRETE base_image_ref.
+    # This simulates every cached lineage file that existed before #530 — they have concrete
+    # values and must NOT be downgraded to "unknown" just because the schema version field is absent.
+    jq -n \
+        '{container:"mycontainer", base_image_ref:"alpine:3.21", version:"1.0", tag:"1.0-alpine"}' \
+        > "$lineage_dir/mycontainer-1.0-alpine.json"
+
+    # Verify no lineage_schema_version is present in the fixture
+    local schema_ver
+    schema_ver=$(jq -r '.lineage_schema_version // "absent"' "$lineage_dir/mycontainer-1.0-alpine.json")
+    [[ "$schema_ver" == "absent" ]]
+
+    printf 'versions:\n  - tag: "1.0"\n    variants:\n      - name: alpine\n        default: true\n' \
+        > "$container_dir/variants.yaml"
+
+    export SCRIPT_DIR="$work"
+    source_dashboard_fns
+
+    # Invoke resolve_variant_lineage_json as the dashboard does
+    local result
+    result=$(resolve_variant_lineage_json "mycontainer" "1.0-alpine" "1.0" "unknown" "alpine")
+
+    local base_image_out
+    base_image_out=$(echo "$result" | jq -r '.base_image // ""')
+
+    # v1 file with concrete value must be preserved AS-IS ("alpine:3.21").
+    # Bug: the absent-schema-version check blanks it to "unknown" even when the value is concrete.
+    [[ "$base_image_out" == "alpine:3.21" ]] || {
+        echo "FAIL: expected 'alpine:3.21' (v1 concrete value preserved), got: '$base_image_out'"
+        echo "Full output: $result"
+        return 1
+    }
+}

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -405,3 +405,62 @@ source_dashboard_fns() {
         return 1
     }
 }
+
+# ---------------------------------------------------------------------------
+# Finding #3 (gate r5 copilot HIGH): Template-container lineage regression
+# Pre-fix: generated Dockerfile has ARG REMOTE_CR (no default) → ${REMOTE_CR}
+# survives all substitution passes → dashboard shows "unknown".
+# Post-fix: ARG REMOTE_CR=docker.io in generated Dockerfile → Step 4 substitutes
+# docker.io → _BASE_IMAGE_REF = "docker.io/library/alpine:3.21".
+# ---------------------------------------------------------------------------
+@test "SMOKE-10: Template container with ARG REMOTE_CR=docker.io default resolves to docker.io base" {
+    # Simulates web-shell alpine variant local build (no REMOTE_CR in env).
+    # The generated Dockerfile must declare ARG REMOTE_CR=docker.io so that
+    # _resolve_base_image Step 4 (Dockerfile ARG defaults) can resolve the placeholder.
+
+    local work="$TEST_TEMP_DIR/tpl-remote-cr"
+    mkdir -p "$work"
+    mkdir -p "$work/.build-lineage"
+
+    # Create a minimal generated Dockerfile as the real web-shell generator would,
+    # but WITH the fixed default (ARG REMOTE_CR=docker.io).
+    cat > "$work/Dockerfile.generated" <<'DOCKERFILE'
+ARG REMOTE_CR=docker.io
+ARG ALPINE_TAG=3.21
+FROM ${REMOTE_CR}/library/alpine:${ALPINE_TAG}
+RUN echo test
+DOCKERFILE
+
+    # No config.yaml base_image — this path uses _RESOLVE_FROM_GENERATED=1
+    # (config.yaml is absent, so the FROM line in the generated file is authoritative)
+
+    cd "$work" || return 1
+    source_build_container
+    export PROJECT_ROOT="$work"
+
+    docker() { echo ""; }
+    export -f docker
+
+    # Do NOT set CUSTOM_BUILD_ARGS (simulates local build without CI-injected REMOTE_CR)
+    unset CUSTOM_BUILD_ARGS
+    unset _BUILD_ARGS_RESOLVED
+
+    # No config.yaml in this fixture — _prepare_build_args must handle missing config gracefully
+    touch "$work/config.yaml"
+    _prepare_build_args "3.21" "" 2>/dev/null || true
+
+    local label_args=""
+    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$work/Dockerfile.generated" "3.21" "label_args" 2>/dev/null || true
+
+    # Post-fix: ARG REMOTE_CR=docker.io default is used → resolved to docker.io/library/alpine:3.21
+    [[ "$_BASE_IMAGE_REF" == "docker.io/library/alpine:3.21" ]] || {
+        echo "FAIL: expected 'docker.io/library/alpine:3.21', got: '$_BASE_IMAGE_REF'"
+        echo "  (pre-fix: ARG REMOTE_CR has no default → \${REMOTE_CR} unresolved → dashboard shows unknown)"
+        return 1
+    }
+    # Must not contain any leaked placeholder
+    [[ "$_BASE_IMAGE_REF" != *'${'* ]] || {
+        echo "FAIL: placeholder leaked in _BASE_IMAGE_REF: '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -85,8 +85,8 @@ source_dashboard_fns() {
     docker() { echo ""; }
     export -f docker
 
-    # Run the substitution pipeline
-    _prepare_build_args "$work" "v2.3.1"
+    # Run the substitution pipeline (version first, then flavor — matches production signature)
+    _prepare_build_args "v2.3.1" ""
     _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
 
     # Emit lineage
@@ -119,7 +119,7 @@ source_dashboard_fns() {
     docker() { echo ""; }
     export -f docker
 
-    _prepare_build_args "$work" "v2.3.1"
+    _prepare_build_args "v2.3.1" ""
     _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
     _emit_build_lineage \
         "mono-fixture" "v2.3.1" "v2.3.1-alpine" "" \
@@ -134,7 +134,7 @@ source_dashboard_fns() {
 
 # ---------------------------------------------------------------------------
 # Smoke 3 — Template fixture (Fix A2 end-to-end)
-# Pipeline: template generation → _RESOLVE_FROM_GENERATED=1 → _resolve_base_image
+# Pipeline: template generation → _resolve_base_image with from_generated=1
 # Assert: base_image_ref = "alpine:3.21" (from generated Dockerfile, not config)
 # ---------------------------------------------------------------------------
 @test "SMOKE-03: Template fixture (alpine) produces alpine:3.21 (Fix A2)" {
@@ -163,10 +163,10 @@ source_dashboard_fns() {
     [[ "$(head -1 "$generated_df")" == "FROM alpine:3.21" ]]
 
     # Prepare build args (populates _BUILD_ARGS_RESOLVED)
-    _prepare_build_args "$work" "1.0"
+    _prepare_build_args "1.0" ""
 
     # Resolve base image POST-template-generation (Fix A2): use generated Dockerfile
-    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated_df" "1.0" "label_args"
+    _resolve_base_image "$generated_df" "1.0" "label_args" "1"
 
     # Emit lineage
     _emit_build_lineage \
@@ -204,8 +204,8 @@ source_dashboard_fns() {
     local generated_df="$work/Dockerfile.debian"
     bash "$work/generate-dockerfile.sh" "$work/Dockerfile.template" "debian" > "$generated_df"
 
-    _prepare_build_args "$work" "1.0"
-    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated_df" "1.0" "label_args"
+    _prepare_build_args "1.0" ""
+    _resolve_base_image "$generated_df" "1.0" "label_args" "1"
 
     _emit_build_lineage \
         "tpl-fixture" "1.0" "1.0" "debian" \
@@ -304,7 +304,7 @@ source_dashboard_fns() {
     docker() { echo ""; }
     export -f docker
 
-    _prepare_build_args "$work" "v2.3.1"
+    _prepare_build_args "v2.3.1" ""
 
     # Simulate pre-fix behavior: clear _BUILD_ARGS_RESOLVED before resolving
     # (this mimics the state before Fix A1 was applied)
@@ -431,7 +431,7 @@ FROM ${REMOTE_CR}/library/alpine:${ALPINE_TAG}
 RUN echo test
 DOCKERFILE
 
-    # No config.yaml base_image — this path uses _RESOLVE_FROM_GENERATED=1
+    # No config.yaml base_image — this path passes from_generated=1 as 4th arg
     # (config.yaml is absent, so the FROM line in the generated file is authoritative)
 
     cd "$work" || return 1
@@ -450,7 +450,7 @@ DOCKERFILE
     _prepare_build_args "3.21" "" 2>/dev/null || true
 
     local label_args=""
-    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$work/Dockerfile.generated" "3.21" "label_args" 2>/dev/null || true
+    _resolve_base_image "$work/Dockerfile.generated" "3.21" "label_args" "1" 2>/dev/null || true
 
     # Post-fix: ARG REMOTE_CR=docker.io default is used → resolved to docker.io/library/alpine:3.21
     [[ "$_BASE_IMAGE_REF" == "docker.io/library/alpine:3.21" ]] || {
@@ -463,4 +463,50 @@ DOCKERFILE
         echo "FAIL: placeholder leaked in _BASE_IMAGE_REF: '$_BASE_IMAGE_REF'"
         return 1
     }
+}
+
+# ---------------------------------------------------------------------------
+# Finding #8: lineage_schema_version=2 consumer audit
+# Non-dashboard consumers (enrich-lineage.sh, extension-duration-utils.sh,
+# build-container action) read only fields that pre-date schema v2 and use
+# jq "// default" guards.  A v2 lineage file with the new fields must not
+# cause any consumer to error or silently skip.
+# ---------------------------------------------------------------------------
+@test "SMOKE-11: enrich-lineage and extension-duration consumers do not error on v2 lineage" {
+    local work="$TEST_TEMP_DIR/schema-v2-audit"
+    local lineage_dir="$work/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Write a schema-v2 lineage file (adds lineage_schema_version + base_image_ref
+    # fields that did not exist in v1).
+    jq -n '{
+        lineage_schema_version: 2,
+        container: "test-container",
+        version: "1.0",
+        tag: "1.0-alpine",
+        base_image_ref: "alpine:3.21",
+        base_image_digest: "sha256:aaaa",
+        multi_arch_index_digest: "sha256:bbbb",
+        duration_seconds: 42,
+        built_at: "2026-01-01T00:00:00+00:00"
+    }' > "$lineage_dir/test-container-1.0-alpine.json"
+
+    # Simulate enrich-lineage.sh read path: reads .container, .tag, .multi_arch_index_digest
+    local container_field tag_field midx_field
+    container_field=$(jq -re '.container // empty' "$lineage_dir/test-container-1.0-alpine.json" 2>/dev/null)
+    tag_field=$(jq -r '.tag // empty' "$lineage_dir/test-container-1.0-alpine.json" 2>/dev/null) || tag_field=""
+    midx_field=$(jq -r '.multi_arch_index_digest // empty' "$lineage_dir/test-container-1.0-alpine.json" 2>/dev/null) || midx_field=""
+
+    [[ "$container_field" == "test-container" ]] || { echo "FAIL: enrich-lineage .container read failed"; return 1; }
+    [[ "$tag_field" == "1.0-alpine" ]] || { echo "FAIL: enrich-lineage .tag read failed"; return 1; }
+    [[ "$midx_field" == "sha256:bbbb" ]] || { echo "FAIL: enrich-lineage .multi_arch_index_digest read failed"; return 1; }
+
+    # Simulate extension-duration-utils.sh read path: reads .duration_seconds
+    local duration_field
+    duration_field=$(jq -r '.duration_seconds // 0' "$lineage_dir/test-container-1.0-alpine.json" 2>/dev/null || echo 0)
+    [[ "$duration_field" == "42" ]] || { echo "FAIL: extension-duration .duration_seconds read failed"; return 1; }
+
+    # The new fields (lineage_schema_version, base_image_ref) are additive.
+    # Consumers using '// default' guards tolerate unknown fields transparently.
+    true
 }

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -57,6 +57,8 @@ source_dashboard_fns() {
         source "$PROJECT_ROOT_REAL/generate-dashboard.sh" 2>/dev/null || true
         declare -f resolve_lineage_file
         declare -f get_build_lineage_field
+        declare -f resolve_variant_lineage_file
+        declare -f resolve_variant_lineage_json
     )
     eval "$_fn_defs"
 }
@@ -314,4 +316,46 @@ source_dashboard_fns() {
     # because the Dockerfile ARG lines have no defaults (ARG OS_IMAGE_BASE, not ARG OS_IMAGE_BASE=alpine)
     # The mutation guard: _BASE_IMAGE_REF must still contain ${ when A1 is disabled
     [[ "$_BASE_IMAGE_REF" == *'${'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Regression: Finding #3 — resolve_variant_lineage_json must sanitize
+# base_image_ref containing ${...} (copilot HIGH finding)
+# Pre-v2 lineage files with leaked placeholders survive in multi-variant path.
+# ---------------------------------------------------------------------------
+@test "SMOKE-08: resolve_variant_lineage_json sanitizes pre-v2 leaked base_image_ref" {
+    local work="$TEST_TEMP_DIR/f3"
+    local lineage_dir="$work/.build-lineage"
+    local container_dir="$work/web-shell"
+    mkdir -p "$lineage_dir" "$container_dir"
+
+    # Write a pre-v2 lineage file (no lineage_schema_version) with leaked placeholder
+    # This simulates a web-shell variant lineage written before Fix E was applied.
+    jq -n \
+        '{container:"web-shell", base_image_ref:"${DEBIAN_TAG}", version:"1.7.7", tag:"1.7.7-debian"}' \
+        > "$lineage_dir/web-shell-1.7.7-debian.json"
+
+    export SCRIPT_DIR="$work"
+    source_dashboard_fns
+
+    # Invoke resolve_variant_lineage_json as the dashboard does for multi-variant containers
+    local result
+    result=$(resolve_variant_lineage_json "web-shell" "1.7.7-debian" "1.7.7" "unknown" "debian")
+
+    # The base_image field in the output must NOT contain ${ (sanitize-at-read)
+    local base_image_out
+    base_image_out=$(echo "$result" | jq -r '.base_image // ""')
+
+    [[ "$base_image_out" != *'${'* ]] || {
+        echo "FAIL: pre-v2 placeholder leaked into per-variant output: '$base_image_out'"
+        echo "Full output: $result"
+        return 1
+    }
+
+    # The value must be empty or "unknown" (not the leaked literal)
+    [[ -z "$base_image_out" || "$base_image_out" == "unknown" ]] || {
+        echo "FAIL: expected empty or 'unknown', got: '$base_image_out'"
+        echo "Full output: $result"
+        return 1
+    }
 }

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -24,6 +24,13 @@ setup() {
     # pipefail environment and any top-level side effects), then extract the
     # function bodies with "declare -f" and eval them in the parent shell where we
     # control the set options.
+    # Source variant-utils directly so variant_image_tag/variant_property/base_suffix
+    # are available for the post-fix resolve_lineage_file (Finding #2 fix calls variant_image_tag).
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT_REAL/helpers/logging.sh"
+    source "$PROJECT_ROOT_REAL/helpers/build-args-utils.sh"
+    source "$PROJECT_ROOT_REAL/helpers/variant-utils.sh"
+
     local _fn_defs
     _fn_defs=$(
         cd "$PROJECT_ROOT_REAL" 2>/dev/null
@@ -69,29 +76,40 @@ make_variants_yaml() {
 # =============================================================================
 
 @test "DRDV-01: Multi-variant single-version uses default_variant (debian is default)" {
-    # Create fake lineage files for all web-shell variants
+    # Production web-shell: debian has suffix: "" (no suffix) → lineage file = web-shell-1.7.7.json
+    # Non-default variants have explicit suffixes: -alpine, -ubuntu, -rocky
+    # Fix B: must return the default variant's suffixless file, not the first filesystem match.
+    make_lineage "web-shell-1.7.7" "ghcr.io/oorabona/debian:trixie"        # debian (default, no suffix)
     make_lineage "web-shell-1.7.7-alpine" "alpine:3.21"
-    make_lineage "web-shell-1.7.7-debian" "ghcr.io/oorabona/debian:trixie"
     make_lineage "web-shell-1.7.7-ubuntu" "ubuntu:noble"
     make_lineage "web-shell-1.7.7-rocky" "rockylinux:9"
 
-    # variants.yaml with debian as default
+    # variants.yaml matching production structure: debian default with empty suffix
     make_variants_yaml "$TEST_TEMP_DIR/web-shell" "$(cat <<'YAML'
 versions:
   - tag: "1.7.7"
     variants:
       - name: debian
+        suffix: ""
         default: true
       - name: alpine
+        suffix: "-alpine"
       - name: ubuntu
+        suffix: "-ubuntu"
       - name: rocky
+        suffix: "-rocky"
 YAML
 )"
 
     run resolve_lineage_file "web-shell"
     [ "$status" -eq 0 ]
-    # Fix B: must return the default variant (debian), not filesystem-first (may return alpine/rocky)
-    [[ "$output" == *"web-shell-1.7.7-debian.json" ]]
+    # Fix B: must return the default variant (debian, suffixless): web-shell-1.7.7.json
+    [[ "$output" == *"web-shell-1.7.7.json" ]] || {
+        echo "FAIL: expected *web-shell-1.7.7.json (debian default), got: '$output'"
+        return 1
+    }
+    # Must NOT return a variant-suffixed file
+    [[ "$output" != *"-alpine.json" && "$output" != *"-ubuntu.json" && "$output" != *"-rocky.json" ]]
 }
 
 @test "DRDV-02: Multi-version multi-flavor returns latest version default flavor" {
@@ -264,9 +282,10 @@ YAML
     make_lineage "postgres-18-alpine-base" "stale-wrong-base-image:should-not-be-selected"
 
     make_variants_yaml "$TEST_TEMP_DIR/postgres" "$(cat <<'YAML'
+build:
+  base_suffix: "-alpine"
 versions:
   - tag: "18"
-    base_suffix: "-alpine"
     variants:
       - name: base
         default: true

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -242,3 +242,49 @@ YAML
     # Fix E: sanitize-at-read: leaked placeholder should return empty, not the literal "${...}"
     [[ -z "$output" || "$output" == "unknown" ]]
 }
+
+# =============================================================================
+# Regression: Finding #2 — resolve_lineage_file must use variant_image_tag for
+# the default variant filename, not raw default_name in a glob.
+# (orthogonal gate codex MEDIUM finding)
+# =============================================================================
+
+@test "DRDV-10: Postgres default-variant (base) resolves suffixless file, not -base suffixed file" {
+    # Production postgres tags: base variant → "18-alpine" (NO -base suffix),
+    # vector variant → "18-alpine-vector". The current bug: the glob
+    # *{default_name}.json = *base.json matches "postgres-18-alpine-base.json"
+    # (if it exists) and picks it instead of the correct "postgres-18-alpine.json".
+    #
+    # This test deliberately creates BOTH the suffixless file AND a stale/wrong
+    # -base-suffixed file (which can arrive via a mis-tagged build), and verifies
+    # that resolve_lineage_file returns the CORRECT suffixless one.
+    make_lineage "postgres-18-alpine" "ghcr.io/oorabona/library/postgres:18-alpine"
+    make_lineage "postgres-18-alpine-vector" "ghcr.io/oorabona/library/postgres:18-alpine"
+    # Also create the wrong -base-suffixed stale file (the one the old glob would pick)
+    make_lineage "postgres-18-alpine-base" "stale-wrong-base-image:should-not-be-selected"
+
+    make_variants_yaml "$TEST_TEMP_DIR/postgres" "$(cat <<'YAML'
+versions:
+  - tag: "18"
+    base_suffix: "-alpine"
+    variants:
+      - name: base
+        default: true
+      - name: vector
+        suffix: "-vector"
+YAML
+)"
+
+    run resolve_lineage_file "postgres"
+    [ "$status" -eq 0 ]
+    # Must return the SUFFIXLESS file (postgres-18-alpine.json), NOT postgres-18-alpine-base.json
+    [[ "$output" == *"postgres-18-alpine.json" ]] || {
+        echo "FAIL: expected *postgres-18-alpine.json, got: '$output'"
+        return 1
+    }
+    # Explicitly must NOT end in -base.json (old glob would have picked this one)
+    [[ "$output" != *"-base.json" ]] || {
+        echo "FAIL: returned file has -base suffix (wrong): '$output'"
+        return 1
+    }
+}

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -5,6 +5,8 @@
 # Red on current code (pre-fix); green after fix.
 # Fix E: sanitize-at-read for base_image_ref with leaked ${...} placeholders.
 
+bats_require_minimum_version 1.5.0
+
 load "../test_helper"
 
 PROJECT_ROOT_REAL="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -176,7 +178,8 @@ YAML
     # Malformed YAML (invalid syntax)
     make_variants_yaml "$TEST_TEMP_DIR/foo" "$(printf 'versions:\n  - tag: [\nnot: valid: yaml')"
 
-    run resolve_lineage_file "foo"
+    # --separate-stderr: the yq-failure warning goes to stderr; $output must be empty
+    run --separate-stderr resolve_lineage_file "foo"
     [ "$status" -eq 0 ]
     # Fix B: must return empty (sentinel), NOT a filesystem-first fallback
     [[ -z "$output" ]]
@@ -425,11 +428,10 @@ YAML
     }
 }
 
-@test "DRDV-14: Legacy rollup tag 2.0-debian does NOT match current_latest 2.0-alpine (distro differs)" {
-    # Pre-fix: "2.0-debian" CONTAINS "2.0" where current_latest="2.0-alpine" ?
-    # Actually current_latest from variants[0].tag would be "2.0-alpine" as a full string.
-    # But consider current_latest = "2.0": "2.0-debian" contains "2.0" → false positive.
-    # This test verifies the exact-match fix prevents cross-distro collision.
+@test "DRDV-14: Legacy rollup tag 2.0-debian matches current_latest 2.0 via prefix (version same)" {
+    # Finding #2 (gate r5): prefix-match fix: legacy_tag="2.0-debian" starts with "2.0-"
+    # → returns the legacy rollup (the version matches, regardless of variant suffix).
+    # Note: prior to Finding #2, exact-match was used → empty; prefix-match is the r5 correction.
 
     jq -n '{lineage_schema_version: 2, container: "webapp", base_image_ref: "debian:trixie", version: "2.0", tag: "2.0-debian"}' \
         > "$TEST_TEMP_DIR/.build-lineage/webapp.json"
@@ -446,11 +448,10 @@ YAML
 
     run resolve_lineage_file "webapp"
     [ "$status" -eq 0 ]
-    # current_latest="2.0", legacy_tag="2.0-debian": substring "2.0" IN "2.0-debian" → pre-fix false positive
-    # post-fix exact match: "2.0-debian" != "2.0" → empty
-    [[ -z "$output" ]] || {
-        echo "FAIL: expected empty (cross-distro no match), got: '$output'"
-        echo "  (pre-fix: '2.0' substring found in '2.0-debian' → false positive)"
+    # Post-fix (r5 prefix match): legacy_tag "2.0-debian" starts with "2.0-" → rollup returned
+    # "2.0-debian" has the same version as current_latest "2.0" → valid legacy fallback
+    [[ "$output" == *"webapp.json" ]] || {
+        echo "FAIL: expected webapp.json (prefix match 2.0-debian starts-with 2.0-), got: '$output'"
         return 1
     }
 }
@@ -475,6 +476,71 @@ YAML
     # current_latest="3.21", legacy_tag="3.21": exact match → legacy rollup returned
     [[ "$output" == *"simpleapp.json" ]] || {
         echo "FAIL: expected simpleapp.json (exact match should return legacy rollup), got: '$output'"
+        return 1
+    }
+}
+
+# =============================================================================
+# Finding #2 (gate r5 copilot MEDIUM): Legacy rollup tag comparison mismatch
+# Pre-fix: exact match used, but lineage_file.tag="1.7.7-debian" and
+# variants_file.versions[0].tag="1.7.7" → never equal → correct rollup skipped.
+# Post-fix: prefix match allows "1.7.7-debian" to match "1.7.7" (version prefix).
+# =============================================================================
+
+@test "DRDV-16: Legacy rollup with full tag '1.7.7-debian' matches current_latest '1.7.7'" {
+    # web-shell-style: legacy web-shell.json was written with .tag="1.7.7-debian".
+    # variants.yaml has versions[0].tag="1.7.7".
+    # Per-tag resolution finds nothing (no web-shell-1.7.7*.json in .build-lineage/).
+    # Post-fix: prefix match "1.7.7-debian" starts with "1.7.7" → legacy rollup returned.
+    jq -n '{lineage_schema_version: 2, container: "web-shell", base_image_ref: "ghcr.io/oorabona/debian:trixie", version: "1.7.7", tag: "1.7.7-debian"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/web-shell.json"
+
+    # No per-tag file exists for 1.7.7
+    make_variants_yaml "$TEST_TEMP_DIR/web-shell" "$(cat <<'YAML'
+versions:
+  - tag: "1.7.7"
+    variants:
+      - name: debian
+        default: true
+      - name: alpine
+YAML
+)"
+
+    run resolve_lineage_file "web-shell"
+    [ "$status" -eq 0 ]
+    # Post-fix: prefix match must return the legacy rollup
+    [[ "$output" == *"web-shell.json" ]] || {
+        echo "FAIL: expected web-shell.json (prefix match 1.7.7-debian starts-with 1.7.7), got: '$output'"
+        echo "  (pre-fix: exact match '1.7.7-debian' != '1.7.7' → empty → correct rollup skipped)"
+        return 1
+    }
+}
+
+# =============================================================================
+# Finding #4 (gate r5 copilot MEDIUM): Malformed variants.yaml must fail closed
+# Pre-fix: yq failure → latest_version="" → falls through to legacy rollup silently.
+# Post-fix: detect yq exit code, emit stderr warning, return empty immediately.
+#           NEVER fall back to legacy rollup when variants.yaml is malformed.
+# =============================================================================
+
+@test "DRDV-17: Malformed variants.yaml with stale legacy rollup present — fails closed, not silent fallback" {
+    # Scenario: variants.yaml is malformed AND a stale {container}.json exists.
+    # Pre-fix: yq fails → latest_version="" → legacy fallback fires → stale rollup returned silently.
+    # Post-fix: detect yq failure → return empty AND emit stderr warning.
+    jq -n '{lineage_schema_version: 2, container: "broken-pkg", base_image_ref: "STALE:wrong", version: "1.0", tag: "1.0"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/broken-pkg.json"
+
+    # Deliberately malformed YAML
+    make_variants_yaml "$TEST_TEMP_DIR/broken-pkg" "$(printf 'versions:\n  - tag: [\nnot: valid: yaml')"
+
+    # --separate-stderr: the yq-failure warning goes to stderr; $output must be empty
+    run --separate-stderr resolve_lineage_file "broken-pkg"
+    [ "$status" -eq 0 ]
+
+    # Post-fix: must return empty (fail closed), NOT the stale legacy rollup
+    [[ -z "$output" ]] || {
+        echo "FAIL: expected empty output (fail closed), got: '$output'"
+        echo "  (pre-fix: malformed yaml causes silent fallback to stale legacy rollup)"
         return 1
     }
 }

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -307,3 +307,85 @@ YAML
         return 1
     }
 }
+
+# =============================================================================
+# Finding #1 (gate r3 codex MEDIUM): Legacy rollup must NOT shadow newer per-tag file
+# =============================================================================
+
+@test "DRDV-11: Per-tag lineage preferred over stale legacy rollup when both exist" {
+    # Scenario: cache contains an OLD {container}.json (legacy rollup from a prior-era build)
+    # AND a current {container}-{version}-{variant}.json (per-tag file from the new build).
+    # The legacy rollup carries a STALE base_image_ref; the per-tag file has the current truth.
+    # resolve_lineage_file must return the PER-TAG file, not the legacy rollup.
+
+    # Legacy rollup — stale base_image_ref
+    jq -n '{lineage_schema_version: 2, container: "myapp", base_image_ref: "OLD-stale-value", version: "2.0", tag: "myapp-2.0-alpine"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/myapp.json"
+
+    # Per-tag file — current truth
+    jq -n '{lineage_schema_version: 2, container: "myapp", base_image_ref: "CURRENT-fresh-value", version: "2.0", tag: "2.0-alpine"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/myapp-2.0-alpine.json"
+
+    make_variants_yaml "$TEST_TEMP_DIR/myapp" "$(cat <<'YAML'
+versions:
+  - tag: "2.0"
+    variants:
+      - name: alpine
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "myapp"
+    [ "$status" -eq 0 ]
+    # Must return the per-tag file, NOT the legacy rollup
+    [[ "$output" == *"myapp-2.0-alpine.json" ]] || {
+        echo "FAIL: expected per-tag file myapp-2.0-alpine.json, got: '$output'"
+        return 1
+    }
+    [[ "$output" != *"myapp.json" ]] || {
+        echo "FAIL: returned stale legacy rollup myapp.json instead of per-tag file"
+        return 1
+    }
+
+    # Confirm the resolved file actually carries the CURRENT base_image_ref
+    local resolved_base
+    resolved_base=$(jq -r '.base_image_ref' "$output")
+    [[ "$resolved_base" == "CURRENT-fresh-value" ]] || {
+        echo "FAIL: base_image_ref is stale: '$resolved_base' (expected CURRENT-fresh-value)"
+        return 1
+    }
+}
+
+# =============================================================================
+# Finding #2 (gate r3 codex LOW): Sidecar files must not be returned by fallback glob
+# =============================================================================
+
+@test "DRDV-12: Sidecar files excluded from fallback glob — no false-positive match" {
+    # Scenario: .build-lineage/ contains ONLY sidecar files for a container
+    # (e.g. foo-1.0-alpine.sbom.json, foo-1.0-alpine.history.json).
+    # No actual lineage file (foo-1.0-alpine.json) exists.
+    # resolve_lineage_file must return empty string, not a sidecar file.
+
+    mkdir -p "$TEST_TEMP_DIR/.build-lineage"
+    # Create sidecar files only — NOT a real lineage file
+    echo '{"type":"sbom"}' > "$TEST_TEMP_DIR/.build-lineage/foo-1.0-alpine.sbom.json"
+    echo '{"type":"history"}' > "$TEST_TEMP_DIR/.build-lineage/foo-1.0-alpine.history.json"
+    echo '{"type":"changelog"}' > "$TEST_TEMP_DIR/.build-lineage/foo-1.0-alpine.changelog.json"
+
+    make_variants_yaml "$TEST_TEMP_DIR/foo" "$(cat <<'YAML'
+versions:
+  - tag: "1.0"
+    variants:
+      - name: alpine
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "foo"
+    [ "$status" -eq 0 ]
+    # Must return empty — no real lineage file exists, sidecar files must not match
+    [[ -z "$output" ]] || {
+        echo "FAIL: expected empty output but got: '$output'"
+        return 1
+    }
+}

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -389,3 +389,92 @@ YAML
         return 1
     }
 }
+
+# =============================================================================
+# Finding #1 (gate r4 copilot MEDIUM): Legacy rollup substring false positives
+# Pre-fix: [[ "$legacy_tag" == *"$current_latest"* ]] (substring contains)
+# Post-fix: [[ "$legacy_tag" == "$current_latest" ]]  (exact match)
+# =============================================================================
+
+@test "DRDV-13: Legacy rollup tag 11.0-alpine does NOT match current_latest 1.0 (substring false positive)" {
+    # Pre-fix: "11.0-alpine" CONTAINS "1.0" → substring match fires → wrong rollup returned
+    # Post-fix: "11.0-alpine" != "1.0" → no match → empty returned (correct)
+
+    # Legacy rollup with tag "11.0-alpine"
+    jq -n '{lineage_schema_version: 2, container: "mypkg", base_image_ref: "old:11.0", version: "11.0", tag: "11.0-alpine"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/mypkg.json"
+
+    # Per-tag file for current latest 1.0 does NOT exist (that is the scenario)
+    # variants.yaml says current latest = "1.0"
+    make_variants_yaml "$TEST_TEMP_DIR/mypkg" "$(cat <<'YAML'
+versions:
+  - tag: "1.0"
+    variants:
+      - name: alpine
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "mypkg"
+    [ "$status" -eq 0 ]
+    # Post-fix: legacy_tag "11.0-alpine" does NOT equal current_latest "1.0" → empty
+    [[ -z "$output" ]] || {
+        echo "FAIL: expected empty (no match), got: '$output'"
+        echo "  (pre-fix: substring '1.0' found inside '11.0-alpine' → false positive)"
+        return 1
+    }
+}
+
+@test "DRDV-14: Legacy rollup tag 2.0-debian does NOT match current_latest 2.0-alpine (distro differs)" {
+    # Pre-fix: "2.0-debian" CONTAINS "2.0" where current_latest="2.0-alpine" ?
+    # Actually current_latest from variants[0].tag would be "2.0-alpine" as a full string.
+    # But consider current_latest = "2.0": "2.0-debian" contains "2.0" → false positive.
+    # This test verifies the exact-match fix prevents cross-distro collision.
+
+    jq -n '{lineage_schema_version: 2, container: "webapp", base_image_ref: "debian:trixie", version: "2.0", tag: "2.0-debian"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/webapp.json"
+
+    # Per-tag file for 2.0-alpine does NOT exist
+    make_variants_yaml "$TEST_TEMP_DIR/webapp" "$(cat <<'YAML'
+versions:
+  - tag: "2.0"
+    variants:
+      - name: alpine
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "webapp"
+    [ "$status" -eq 0 ]
+    # current_latest="2.0", legacy_tag="2.0-debian": substring "2.0" IN "2.0-debian" → pre-fix false positive
+    # post-fix exact match: "2.0-debian" != "2.0" → empty
+    [[ -z "$output" ]] || {
+        echo "FAIL: expected empty (cross-distro no match), got: '$output'"
+        echo "  (pre-fix: '2.0' substring found in '2.0-debian' → false positive)"
+        return 1
+    }
+}
+
+@test "DRDV-15: Legacy rollup exact match — tag equals current_latest exactly (valid use case)" {
+    # When legacy_tag == current_latest exactly, the legacy rollup SHOULD be returned.
+    # (This is the legitimate case: a versions-only container wrote {container}.json
+    #  but its per-tag file somehow didn't land in .build-lineage.)
+
+    jq -n '{lineage_schema_version: 2, container: "simpleapp", base_image_ref: "alpine:3.21", version: "3.21", tag: "3.21"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/simpleapp.json"
+
+    # Per-tag file simpleapp-3.21*.json does NOT exist
+    make_variants_yaml "$TEST_TEMP_DIR/simpleapp" "$(cat <<'YAML'
+versions:
+  - tag: "3.21"
+YAML
+)"
+
+    run resolve_lineage_file "simpleapp"
+    [ "$status" -eq 0 ]
+    # current_latest="3.21", legacy_tag="3.21": exact match → legacy rollup returned
+    [[ "$output" == *"simpleapp.json" ]] || {
+        echo "FAIL: expected simpleapp.json (exact match should return legacy rollup), got: '$output'"
+        return 1
+    }
+}

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+
+# Tests for resolve_lineage_file in generate-dashboard.sh
+# Covers Fix B: default_variant() selection instead of filesystem-first.
+# Red on current code (pre-fix); green after fix.
+# Fix E: sanitize-at-read for base_image_ref with leaked ${...} placeholders.
+
+load "../test_helper"
+
+PROJECT_ROOT_REAL="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    setup_temp_dir
+    export ORIG_DIR="$PWD"
+
+    mkdir -p "$TEST_TEMP_DIR/.build-lineage"
+
+    # Extract only the function definitions we need from generate-dashboard.sh,
+    # without activating the "set -euo pipefail" that the script sets at the top
+    # level (which would make failing test assertions crash the test process rather
+    # than report "not ok").
+    #
+    # Technique: source the script in a subshell (which can tolerate the set -euo
+    # pipefail environment and any top-level side effects), then extract the
+    # function bodies with "declare -f" and eval them in the parent shell where we
+    # control the set options.
+    local _fn_defs
+    _fn_defs=$(
+        cd "$PROJECT_ROOT_REAL" 2>/dev/null
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT_REAL/generate-dashboard.sh" 2>/dev/null || true
+        # Export function defs back to caller
+        declare -f resolve_lineage_file
+        declare -f get_build_lineage_field
+    )
+    eval "$_fn_defs"
+
+    # Override SCRIPT_DIR so resolve_lineage_file reads from our temp dir
+    SCRIPT_DIR="$TEST_TEMP_DIR"
+    export SCRIPT_DIR
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    teardown_temp_dir
+}
+
+# Helper: create a fake lineage file in .build-lineage/
+make_lineage() {
+    local name="$1"
+    local base_image="${2:-alpine:3.21}"
+    jq -n \
+        --arg base_image "$base_image" \
+        --arg name "$name" \
+        '{lineage_schema_version: 2, container: "test", base_image_ref: $base_image, version: "1.0", tag: $name}' \
+        > "$TEST_TEMP_DIR/.build-lineage/${name}.json"
+}
+
+# Helper: create variants.yaml with optional multi-version structure
+make_variants_yaml() {
+    local container_dir="$1"
+    local yaml_content="$2"
+    mkdir -p "$container_dir"
+    printf '%s\n' "$yaml_content" > "$container_dir/variants.yaml"
+}
+
+# =============================================================================
+# Fix B: default_variant selection (NEVER filesystem-first)
+# =============================================================================
+
+@test "DRDV-01: Multi-variant single-version uses default_variant (debian is default)" {
+    # Create fake lineage files for all web-shell variants
+    make_lineage "web-shell-1.7.7-alpine" "alpine:3.21"
+    make_lineage "web-shell-1.7.7-debian" "ghcr.io/oorabona/debian:trixie"
+    make_lineage "web-shell-1.7.7-ubuntu" "ubuntu:noble"
+    make_lineage "web-shell-1.7.7-rocky" "rockylinux:9"
+
+    # variants.yaml with debian as default
+    make_variants_yaml "$TEST_TEMP_DIR/web-shell" "$(cat <<'YAML'
+versions:
+  - tag: "1.7.7"
+    variants:
+      - name: debian
+        default: true
+      - name: alpine
+      - name: ubuntu
+      - name: rocky
+YAML
+)"
+
+    run resolve_lineage_file "web-shell"
+    [ "$status" -eq 0 ]
+    # Fix B: must return the default variant (debian), not filesystem-first (may return alpine/rocky)
+    [[ "$output" == *"web-shell-1.7.7-debian.json" ]]
+}
+
+@test "DRDV-02: Multi-version multi-flavor returns latest version default flavor" {
+    # Postgres-style: versions [18, 17, 16], default flavor = base
+    make_lineage "postgres-18-alpine" "ghcr.io/oorabona/library/postgres:18-alpine"
+    make_lineage "postgres-17-alpine" "ghcr.io/oorabona/library/postgres:17-alpine"
+    make_lineage "postgres-16-alpine" "ghcr.io/oorabona/library/postgres:16-alpine"
+    make_lineage "postgres-18-alpine-base" "ghcr.io/oorabona/library/postgres:18-alpine"
+
+    make_variants_yaml "$TEST_TEMP_DIR/postgres" "$(cat <<'YAML'
+versions:
+  - tag: "18"
+    variants:
+      - name: base
+        default: true
+      - name: vector
+  - tag: "17"
+    variants:
+      - name: base
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "postgres"
+    [ "$status" -eq 0 ]
+    # Should return the latest version (18) default variant (base)
+    # The key invariant: must include "18" and NOT "17" or "16"
+    [[ "$output" == *"postgres-18"* ]]
+}
+
+@test "DRDV-03: Versions-only container returns latest version lineage" {
+    # ansible: no variants, just versions
+    make_lineage "ansible-13.3.0-ubuntu" "ubuntu:noble"
+    make_lineage "ansible-13.4.0-ubuntu" "ubuntu:noble"
+
+    make_variants_yaml "$TEST_TEMP_DIR/ansible" "$(cat <<'YAML'
+versions:
+  - tag: "13.4.0"
+  - tag: "13.3.0"
+YAML
+)"
+
+    run resolve_lineage_file "ansible"
+    [ "$status" -eq 0 ]
+    # Should return latest version (first in list = 13.4.0)
+    [[ "$output" == *"13.4.0"* ]]
+}
+
+@test "DRDV-04: Legacy container-level rollup file preserved" {
+    # If container.json exists, return it directly (legacy path)
+    make_lineage "foo" "alpine:3.21"
+
+    # No variants.yaml needed — the container.json takes precedence
+    run resolve_lineage_file "foo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"foo.json" ]]
+}
+
+@test "DRDV-05: Malformed variants.yaml returns empty sentinel, never filesystem-first" {
+    # Create real lineage files that would be found by filesystem-first
+    make_lineage "foo-1.0-alpine" "alpine:3.21"
+    make_lineage "foo-1.0-debian" "debian:trixie"
+
+    # Malformed YAML (invalid syntax)
+    make_variants_yaml "$TEST_TEMP_DIR/foo" "$(printf 'versions:\n  - tag: [\nnot: valid: yaml')"
+
+    run resolve_lineage_file "foo"
+    [ "$status" -eq 0 ]
+    # Fix B: must return empty (sentinel), NOT a filesystem-first fallback
+    [[ -z "$output" ]]
+}
+
+@test "DRDV-06: Multiple default:true variants returns first match (no ambiguity crash)" {
+    make_lineage "bar-1.0-alpine" "alpine:3.21"
+    make_lineage "bar-1.0-debian" "debian:trixie"
+
+    # Two variants with default: true — first one should win (head -1 behavior)
+    make_variants_yaml "$TEST_TEMP_DIR/bar" "$(cat <<'YAML'
+versions:
+  - tag: "1.0"
+    variants:
+      - name: alpine
+        default: true
+      - name: debian
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "bar"
+    [ "$status" -eq 0 ]
+    # Should not crash; should return one of the defaults
+    # The key invariant: result must be one of the known lineage files (not empty crash)
+    [[ -z "$output" || "$output" == *"bar-1.0"* ]]
+}
+
+@test "DRDV-07: Default variant lineage missing, falls back to any present variant with notice" {
+    # debian is default but its lineage file doesn't exist — fall back to alpine
+    make_lineage "web-shell-1.7.7-alpine" "alpine:3.21"
+    # No web-shell-1.7.7-debian.json
+
+    make_variants_yaml "$TEST_TEMP_DIR/web-shell" "$(cat <<'YAML'
+versions:
+  - tag: "1.7.7"
+    variants:
+      - name: debian
+        default: true
+      - name: alpine
+YAML
+)"
+
+    run resolve_lineage_file "web-shell"
+    [ "$status" -eq 0 ]
+    # Falls back to any present variant
+    [[ "$output" == *"web-shell-1.7.7-alpine.json" ]]
+}
+
+@test "DRDV-08: All variant lineage files missing returns empty string" {
+    # No .json files exist for baz
+    make_variants_yaml "$TEST_TEMP_DIR/baz" "$(cat <<'YAML'
+versions:
+  - tag: "1.0"
+    variants:
+      - name: alpine
+        default: true
+YAML
+)"
+
+    run resolve_lineage_file "baz"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+# =============================================================================
+# Fix E: sanitize-at-read — base_image_ref with ${ returns empty
+# =============================================================================
+
+@test "DRDV-09: Pre-v2 entry with leaked base_image_ref treated as empty at read" {
+    # Create a pre-v2 lineage file with a leaked placeholder
+    jq -n '{container:"sslh","base_image_ref":"${OS_IMAGE_BASE}:${OS_IMAGE_TAG}","version":"v2.3.1","tag":"v2.3.1-alpine"}' \
+        > "$TEST_TEMP_DIR/.build-lineage/sslh-v2.3.1-alpine.json"
+
+    # make container.json for simple resolution
+    cp "$TEST_TEMP_DIR/.build-lineage/sslh-v2.3.1-alpine.json" \
+       "$TEST_TEMP_DIR/.build-lineage/sslh.json"
+
+    run get_build_lineage_field "sslh" "base_image_ref"
+    [ "$status" -eq 0 ]
+    # Fix E: sanitize-at-read: leaked placeholder should return empty, not the literal "${...}"
+    [[ -z "$output" || "$output" == "unknown" ]]
+}

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -544,3 +544,97 @@ YAML
         return 1
     }
 }
+
+# =============================================================================
+# Finding #1 (gate r9 codex MEDIUM): Delimiter-bound version glob in fallback
+# Pre-fix: -name "${container}-${latest_version}*.json" — matches version
+#   prefix without a delimiter, so "1.0" matches "1.0.1-alpine.json" (collision).
+# Post-fix: -name "${container}-${latest_version}.json" -o
+#            -name "${container}-${latest_version}-*.json"
+#   The hyphen delimiter ensures "1.0" only matches "1.0.json" or "1.0-*.json",
+#   not "1.0.1-alpine.json".
+# =============================================================================
+
+@test "DRDV-18: Version prefix-collision — '1.0' must NOT match '1.0.1-alpine.json' in fallback glob" {
+    # Scenario: latest_version="1.0" in variants.yaml.
+    # .build-lineage/ has foo-1.0.1-alpine.json (NEXT major patch, NOT the latest 1.0).
+    # Pre-fix glob: "${container}-${latest_version}*.json" matches "1.0.1-alpine.json"
+    #   because "1.0.1-alpine.json" starts with "1.0".
+    # Post-fix: delimiter-bound pattern requires hyphen after version → no match → empty returned.
+    #
+    # The default variant resolution path (variant_image_tag) also returns empty
+    # because foo/variants.yaml has no variants[] — so code falls into the
+    # "fallback within per-tag resolution" glob path being tested here.
+
+    # Only file present: the WRONG version (1.0.1, NOT 1.0)
+    make_lineage "foo-1.0.1-alpine" "alpine:3.21"
+
+    make_variants_yaml "$TEST_TEMP_DIR/foo" "$(cat <<'YAML'
+versions:
+  - tag: "1.0"
+YAML
+)"
+
+    run resolve_lineage_file "foo"
+    [ "$status" -eq 0 ]
+    # Post-fix: must return empty — "1.0.1-alpine.json" is NOT a valid match for version "1.0"
+    [[ -z "$output" ]] || {
+        echo "FAIL: prefix collision — version '1.0' matched '1.0.1-alpine.json' (wrong version)"
+        echo "  Got: '$output'"
+        echo "  (pre-fix: glob '1.0*.json' matches '1.0.1-alpine.json' — no delimiter boundary)"
+        return 1
+    }
+}
+
+# =============================================================================
+# Finding #2 (gate r9 copilot HIGH): Guarded yq assignment under set -e
+# Pre-fix: latest_version=$(yq ...) ; _yq_rc=$?
+#   Under set -euo pipefail, when yq exits non-zero the assignment line aborts
+#   the bash shell BEFORE _yq_rc=$? is evaluated — the guard is dead code.
+# Post-fix: if ! latest_version=$(yq ...); then ... fi
+#   The if-form suppresses set -e on the command substitution exit code,
+#   so the guard branch runs correctly.
+# =============================================================================
+
+@test "DRDV-19: Guarded yq assignment — malformed YAML does not abort parent shell under set -e" {
+    # This test asserts that resolve_lineage_file is callable from a set -e
+    # context without killing the parent shell on a yq parse failure.
+    # Technique: invoke the function from within an explicit set -e subshell,
+    # and verify the subshell exits 0 (function returns cleanly, not crashed).
+
+    # Create real lineage files that would be found if the guard were absent
+    make_lineage "grd-1.0-alpine" "alpine:3.21"
+
+    # Deliberately malformed YAML
+    make_variants_yaml "$TEST_TEMP_DIR/grd" "$(printf 'versions:\n  - tag: [\nnot: valid: yaml')"
+
+    # Run in a subshell with set -e to detect abort-vs-return distinction.
+    # If the fix is NOT applied: the yq assignment aborts the subshell → exit non-zero.
+    # If the fix IS applied: resolve_lineage_file returns 0 → subshell exits 0.
+    run bash -c "
+        set -euo pipefail
+        # Re-source the helpers and extract resolve_lineage_file exactly as setup() does
+        source '${PROJECT_ROOT_REAL}/helpers/logging.sh'
+        source '${PROJECT_ROOT_REAL}/helpers/build-args-utils.sh'
+        source '${PROJECT_ROOT_REAL}/helpers/variant-utils.sh'
+        _fn_defs=\$(
+            cd '${PROJECT_ROOT_REAL}'
+            source '${PROJECT_ROOT_REAL}/generate-dashboard.sh' 2>/dev/null || true
+            declare -f resolve_lineage_file
+        )
+        eval \"\$_fn_defs\"
+        SCRIPT_DIR='${TEST_TEMP_DIR}'
+        export SCRIPT_DIR
+        # Call the function — must return 0 (not abort the shell)
+        resolve_lineage_file 'grd' >/dev/null 2>&1
+        # If we reach here, the function did NOT abort the shell
+        echo 'SHELL_CONTINUED'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SHELL_CONTINUED"* ]] || {
+        echo "FAIL: subshell did not continue after resolve_lineage_file returned"
+        echo "  Status: $status, output: '$output'"
+        echo "  (pre-fix: yq failure aborted the shell; SHELL_CONTINUED never printed)"
+        return 1
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -357,3 +357,37 @@ ARG C" "FROM \${A}-base"
         return 1
     }
 }
+
+# =============================================================================
+# Regression: Finding #1 — _prepare_build_args must propagate prepare_build_args failure
+# (orthogonal gate codex HIGH finding)
+# =============================================================================
+
+@test "RBIS-11: _prepare_build_args propagates prepare_build_args failure; _BUILD_ARGS_RESOLVED stays empty" {
+    # Inject a config.yaml with a build_arg containing REMOTE_CR key — this triggers
+    # the validator inside prepare_build_args → build_args_flags → _vbc_validate_build_args_config
+    # to return non-zero. Pre-fix: _prepare_build_args ignores the error and populates
+    # _BUILD_ARGS_RESOLVED anyway. Post-fix: it must return the same non-zero code.
+    printf 'base_image: "alpine:3.21"\nbuild_args:\n  REMOTE_CR: "evil.example.com"\n' > ./config.yaml
+    make_dockerfile "" "FROM alpine:3.21"
+
+    # Ensure _BUILD_ARGS_RESOLVED starts empty
+    declare -gA _BUILD_ARGS_RESOLVED=()
+
+    # Call _prepare_build_args — it should fail because REMOTE_CR is a forbidden key
+    local rc=0
+    _prepare_build_args "1.0" "" 2>/dev/null || rc=$?
+
+    # Post-fix invariant: exit code must be non-zero
+    [[ "$rc" -ne 0 ]] || {
+        echo "FAIL: expected non-zero exit from _prepare_build_args when prepare_build_args fails, got rc=0"
+        echo "  _BUILD_ARGS_RESOLVED keys: ${!_BUILD_ARGS_RESOLVED[*]}"
+        return 1
+    }
+
+    # _BUILD_ARGS_RESOLVED must NOT be populated after a failed call
+    [[ "${#_BUILD_ARGS_RESOLVED[@]}" -eq 0 ]] || {
+        echo "FAIL: _BUILD_ARGS_RESOLVED was populated despite failure (${#_BUILD_ARGS_RESOLVED[@]} keys: ${!_BUILD_ARGS_RESOLVED[*]})"
+        return 1
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+
+# Tests for _resolve_base_image in scripts/build-container.sh
+# Covers Fix A1 (build_args set substitution) and Fix A2 (post-template-generation relocation).
+# Red on current code (pre-fix); green after fix.
+
+load "../test_helper"
+
+PROJECT_ROOT_REAL="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_530="$PROJECT_ROOT_REAL/tests/fixtures/dashboard-530"
+
+setup() {
+    setup_temp_dir
+    export TEST_DIR="$TEST_TEMP_DIR"
+    export ORIG_DIR="$PWD"
+    # Each test gets its own working dir that looks like a container directory
+    mkdir -p "$TEST_DIR/container"
+    cd "$TEST_DIR/container" || exit 1
+
+    # Source dependencies
+    source "$PROJECT_ROOT_REAL/helpers/logging.sh"
+    source "$PROJECT_ROOT_REAL/helpers/build-args-utils.sh"
+    source "$PROJECT_ROOT_REAL/helpers/variant-utils.sh"
+    source "$PROJECT_ROOT_REAL/helpers/template-utils.sh"
+
+    # Source build-container from its own directory so relative paths work
+    pushd "$PROJECT_ROOT_REAL/scripts" > /dev/null 2>&1
+    # shellcheck source=/dev/null
+    source "./build-container.sh"
+    popd > /dev/null 2>&1
+
+    export PROJECT_ROOT="$TEST_DIR"
+    unset CUSTOM_BUILD_ARGS
+    unset _BUILD_ARGS_RESOLVED
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    teardown_temp_dir
+    unset CUSTOM_BUILD_ARGS
+    unset _BUILD_ARGS_RESOLVED
+    unset _BASE_IMAGE_REF
+    unset _BASE_DIGEST
+    unset _BUILD_ARGS
+    unset _MAJOR_VERSION
+    unset _UPSTREAM_VERSION
+}
+
+# Helper: write a minimal config.yaml with base_image and optional build_args
+make_config() {
+    local base_image="$1"
+    local build_args_yaml="${2:-}"
+    {
+        printf 'base_image: "%s"\n' "$base_image"
+        if [[ -n "$build_args_yaml" ]]; then
+            printf 'build_args:\n%s\n' "$build_args_yaml"
+        fi
+    } > ./config.yaml
+}
+
+# Helper: write a Dockerfile with optional ARG lines
+make_dockerfile() {
+    local arg_lines="${1:-}"
+    local from_line="${2:-FROM scratch}"
+    {
+        printf '%s\n' "$arg_lines"
+        printf '%s\n' "$from_line"
+        printf 'RUN echo test\n'
+    } > ./Dockerfile
+}
+
+# =============================================================================
+# Fix A1: build_args set substitution (the sslh root cause)
+# =============================================================================
+
+@test "RBIS-01: ARG-without-default substituted via build_args set (sslh root cause)" {
+    # Dockerfile has ARG without defaults — values must come from _prepare_build_args
+    make_dockerfile "ARG OS_IMAGE_BASE
+ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
+    make_config '${OS_IMAGE_BASE}:${OS_IMAGE_TAG}' '  OS_IMAGE_BASE: "alpine"
+  OS_IMAGE_TAG: "3.21"'
+
+    # Simulate what _prepare_build_args produces for this container
+    _prepare_build_args "v2.3.1" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "v2.3.1" "label_args"
+
+    [[ "$_BASE_IMAGE_REF" == "alpine:3.21" ]] || {
+        echo "FAIL: _BASE_IMAGE_REF='$_BASE_IMAGE_REF', expected 'alpine:3.21'"
+        return 1
+    }
+    # Verify no leaked placeholder
+    [[ "$_BASE_IMAGE_REF" != *'${'* ]] || {
+        echo "FAIL: placeholder leaked into _BASE_IMAGE_REF: '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}
+
+@test "RBIS-02: CUSTOM_BUILD_ARGS precedence preserved (override wins over build_args set)" {
+    make_dockerfile "ARG REMOTE_CR=docker.io" "FROM \${REMOTE_CR}/library/alpine:3.21"
+    make_config '${REMOTE_CR}/library/alpine:3.21' '  REMOTE_CR: "ghcr.io/oorabona"'
+
+    export CUSTOM_BUILD_ARGS="--build-arg REMOTE_CR=custom.example.com"
+    _prepare_build_args "3.21" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "3.21" "label_args"
+
+    [[ "$_BASE_IMAGE_REF" == "custom.example.com/library/alpine:3.21" ]] || {
+        echo "FAIL: expected 'custom.example.com/library/alpine:3.21', got '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}
+
+@test "RBIS-03: build_args set wins over Dockerfile inline default" {
+    # Dockerfile has ARG with a default, but build_args in config.yaml overrides it
+    make_dockerfile "ARG DEBIAN_TAG=stable" "FROM ghcr.io/oorabona/debian:\${DEBIAN_TAG}"
+    make_config 'ghcr.io/oorabona/debian:${DEBIAN_TAG}' '  DEBIAN_TAG: "trixie"'
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "1.0" "label_args"
+
+    [[ "$_BASE_IMAGE_REF" == "ghcr.io/oorabona/debian:trixie" ]] || {
+        echo "FAIL: expected 'ghcr.io/oorabona/debian:trixie', got '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}
+
+@test "RBIS-04: Undefined ARG produces empty base_image_ref with stderr warning" {
+    make_dockerfile "ARG MYSTERY_TAG" "FROM \${MYSTERY_TAG}-base"
+    make_config '${MYSTERY_TAG}-base'  # no build_args
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    # Capture stderr to check for warning
+    local stderr_out
+    stderr_out=$(_resolve_base_image "./Dockerfile" "1.0" "label_args" 2>&1 >/dev/null || true)
+
+    # After all substitution passes, the placeholder should remain — sanitize-at-read
+    # converts this to empty at read time; the write should still emit the unresolved ref
+    # OR emit empty. Either way, _BASE_IMAGE_REF must NOT be a concrete valid image.
+    # The key invariant: if it still has ${, the sanitize-at-read path will catch it.
+    # If it's empty (implementation choice: clear on unresolved), that's also valid.
+    [[ -z "$_BASE_IMAGE_REF" || "$_BASE_IMAGE_REF" =~ \$\{ ]] || {
+        echo "FAIL: expected empty or leaked placeholder, got concrete '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}
+
+@test "RBIS-05: CUSTOM_BUILD_ARGS with shell metacharacters does NOT execute" {
+    local marker="$TEST_DIR/marker_was_created"
+    [[ ! -f "$marker" ]] || rm -f "$marker"
+
+    # EVIL value containing shell command injection attempt
+    local evil_value
+    evil_value="; touch $marker; #"
+    export CUSTOM_BUILD_ARGS="--build-arg EVIL=$evil_value"
+
+    make_dockerfile "ARG EVIL" "FROM \${EVIL}-alpine"
+    make_config '${EVIL}-alpine'
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>/dev/null || true
+
+    [[ ! -f "$marker" ]] || {
+        echo "FAIL: shell injection executed — marker file was created"
+        return 1
+    }
+}
+
+@test "RBIS-06: Cross-arg dependencies — chain resolves or terminates bounded" {
+    # A depends on B, B depends on C, C is concrete
+    make_dockerfile "ARG A
+ARG B
+ARG C" "FROM \${A}-base"
+    # build_args provides the chain
+    make_config '${A}-base' '  A: "x-${B}"
+  B: "y-${C}"
+  C: "z"'
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>/dev/null || true
+
+    # Valid outcomes: fully resolved (x-y-z-base) OR bounded iteration leaves unresolved
+    # Both are acceptable per spec; test asserts no crash and some deterministic value
+    [[ -n "$_BASE_IMAGE_REF" || true ]] # just asserts no crash
+    # Assert no infinite loop: function returned
+    echo "resolved to: '$_BASE_IMAGE_REF'"
+}
+
+# =============================================================================
+# Fix A2: post-template-generation relocation
+# =============================================================================
+
+@test "RBIS-07: Template-driven container reads generator's concrete FROM (Fix A2)" {
+    # Set up a template fixture in TEST_DIR
+    local fixture_dir="$TEST_DIR/template-fixture"
+    cp -r "$FIXTURES_530/template/." "$fixture_dir/"
+    chmod +x "$fixture_dir/generate-dockerfile.sh"
+
+    cd "$fixture_dir" || exit 1
+    export PROJECT_ROOT="$TEST_DIR"
+
+    # Reset _prepare_build_args context for template fixture
+    _prepare_build_args "1.0" "alpine"
+
+    # Simulate what build_container does: call _resolve_base_image BEFORE template gen
+    # This is the pre-fix behavior — should yield debian (config.yaml::base_image default)
+    local label_args_before=""
+    local ref_before
+    _resolve_base_image "./Dockerfile.template" "1.0" "label_args_before" 2>/dev/null || true
+    ref_before="$_BASE_IMAGE_REF"
+
+    # Now simulate post-template-gen: generate the Dockerfile first
+    local generated
+    generated=$(mktemp "$TEST_DIR/Dockerfile.XXXXXX")
+    "$fixture_dir/generate-dockerfile.sh" "./Dockerfile.template" "alpine" "1.0" > "$generated"
+
+    # Call _resolve_base_image on the GENERATED Dockerfile (post-fix behavior)
+    local label_args_after=""
+    _resolve_base_image "$generated" "1.0" "label_args_after" 2>/dev/null || true
+
+    rm -f "$generated"
+    cd "$TEST_DIR/container" || true
+
+    # Post-fix: should read the concrete FROM from generated Dockerfile
+    [[ "$_BASE_IMAGE_REF" == "alpine:3.21" ]] || {
+        echo "FAIL: post-template-gen expected 'alpine:3.21', got '$_BASE_IMAGE_REF'"
+        echo "Pre-template-gen ref was: '$ref_before'"
+        return 1
+    }
+}
+
+@test "RBIS-08: Monolithic container unaffected by A2 relocation" {
+    # Copy monolithic fixture
+    local fixture_dir="$TEST_DIR/monolithic-fixture"
+    cp -r "$FIXTURES_530/monolithic/." "$fixture_dir/"
+    cd "$fixture_dir" || exit 1
+    export PROJECT_ROOT="$TEST_DIR"
+
+    _prepare_build_args "v2.3.1" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "v2.3.1" "label_args" 2>/dev/null || true
+
+    [[ "$_BASE_IMAGE_REF" == "alpine:3.21" ]] || {
+        echo "FAIL: monolithic expected 'alpine:3.21', got '$_BASE_IMAGE_REF'"
+        return 1
+    }
+
+    cd "$TEST_DIR/container" || true
+}
+
+# =============================================================================
+# Fix C + D: JSON safety and eval removal (invoked indirectly via _emit_build_lineage)
+# =============================================================================
+
+@test "RBIS-09: build_arg with quote character produces valid lineage JSON" {
+    make_dockerfile "" "FROM alpine:3.21"
+    make_config "alpine:3.21" '  NOTE: '"'"'this has "quotes" in it'"'"
+
+    _prepare_build_args "1.0" ""
+    # _BASE_IMAGE_REF and _BASE_DIGEST must be set for lineage
+    _BASE_IMAGE_REF="alpine:3.21"
+    _BASE_DIGEST=""
+    _BUILD_DURATION_SECONDS="1"
+    BUILD_DIGEST="sha256:testdigest"
+    BUILD_DIGEST_LABEL="org.opencontainers.image.revision"
+
+    # Set up lineage dir
+    mkdir -p "$TEST_DIR/.build-lineage"
+    export PROJECT_ROOT="$TEST_DIR"
+
+    _emit_build_lineage "test-container" "1.0" "1.0" "" "./Dockerfile" \
+        "linux/amd64" "test-runtime" "docker.io/test/test-container" "ghcr.io/test/test-container" "null" \
+        2>/dev/null || true
+
+    local lineage_file="$TEST_DIR/.build-lineage/test-container-1.0.json"
+    [[ -f "$lineage_file" ]] || {
+        echo "FAIL: lineage file not created"
+        return 1
+    }
+
+    # Must be valid JSON
+    jq '.' "$lineage_file" > /dev/null 2>&1 || {
+        echo "FAIL: lineage file is not valid JSON"
+        cat "$lineage_file"
+        return 1
+    }
+}
+
+@test "RBIS-10: lineage_schema_version field equals 2 in emitted JSON" {
+    make_dockerfile "" "FROM alpine:3.21"
+    make_config "alpine:3.21"
+
+    _prepare_build_args "1.0" ""
+    _BASE_IMAGE_REF="alpine:3.21"
+    _BASE_DIGEST=""
+    _BUILD_DURATION_SECONDS="1"
+    BUILD_DIGEST="sha256:testdigest"
+    BUILD_DIGEST_LABEL="org.opencontainers.image.revision"
+
+    mkdir -p "$TEST_DIR/.build-lineage"
+    export PROJECT_ROOT="$TEST_DIR"
+
+    _emit_build_lineage "test-container" "1.0" "1.0" "" "./Dockerfile" \
+        "linux/amd64" "test-runtime" "docker.io/test/test-container" "ghcr.io/test/test-container" "null" \
+        2>/dev/null || true
+
+    local lineage_file="$TEST_DIR/.build-lineage/test-container-1.0.json"
+    [[ -f "$lineage_file" ]] || {
+        echo "FAIL: lineage file not created"
+        return 1
+    }
+
+    local schema_version
+    schema_version=$(jq -r '.lineage_schema_version // "missing"' "$lineage_file")
+    [[ "$schema_version" == "2" ]] || {
+        echo "FAIL: lineage_schema_version='$schema_version', expected '2'"
+        cat "$lineage_file"
+        return 1
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -98,11 +98,18 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
 }
 
 @test "RBIS-02: CUSTOM_BUILD_ARGS precedence preserved (override wins over build_args set)" {
+    # REMOTE_CR cannot appear in config.yaml build_args (validator blocks it).
+    # It arrives only via CUSTOM_BUILD_ARGS (CI-injected). Simulate that here:
+    # build_args set contributes REMOTE_CR=ghcr.io/oorabona, but CUSTOM_BUILD_ARGS
+    # overrides to custom.example.com — CUSTOM_BUILD_ARGS must win.
     make_dockerfile "ARG REMOTE_CR=docker.io" "FROM \${REMOTE_CR}/library/alpine:3.21"
-    make_config '${REMOTE_CR}/library/alpine:3.21' '  REMOTE_CR: "ghcr.io/oorabona"'
+    make_config '${REMOTE_CR}/library/alpine:3.21'
+
+    # Manually seed _BUILD_ARGS_RESOLVED to simulate what _prepare_build_args
+    # would produce if REMOTE_CR were a valid build_arg.
+    declare -gA _BUILD_ARGS_RESOLVED=([REMOTE_CR]="ghcr.io/oorabona")
 
     export CUSTOM_BUILD_ARGS="--build-arg REMOTE_CR=custom.example.com"
-    _prepare_build_args "3.21" ""
 
     local label_args=""
     _resolve_base_image "./Dockerfile" "3.21" "label_args"
@@ -136,18 +143,25 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     _prepare_build_args "1.0" ""
 
     local label_args=""
-    # Capture stderr to check for warning
+    # Call directly (not in subshell) so _BASE_IMAGE_REF is visible in parent shell
+    local stderr_file
+    stderr_file=$(mktemp)
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>"$stderr_file" || true
     local stderr_out
-    stderr_out=$(_resolve_base_image "./Dockerfile" "1.0" "label_args" 2>&1 >/dev/null || true)
+    stderr_out=$(cat "$stderr_file")
+    rm -f "$stderr_file"
 
     # After all substitution passes, the placeholder should remain — sanitize-at-read
     # converts this to empty at read time; the write should still emit the unresolved ref
     # OR emit empty. Either way, _BASE_IMAGE_REF must NOT be a concrete valid image.
     # The key invariant: if it still has ${, the sanitize-at-read path will catch it.
-    # If it's empty (implementation choice: clear on unresolved), that's also valid.
-    [[ -z "$_BASE_IMAGE_REF" || "$_BASE_IMAGE_REF" =~ \$\{ ]] || {
-        echo "FAIL: expected empty or leaked placeholder, got concrete '$_BASE_IMAGE_REF'"
+    [[ -z "${_BASE_IMAGE_REF:-}" || "${_BASE_IMAGE_REF:-}" =~ \$\{ ]] || {
+        echo "FAIL: expected empty or leaked placeholder, got concrete '${_BASE_IMAGE_REF:-}'"
         return 1
+    }
+    # Verify warning was emitted
+    [[ "$stderr_out" =~ "un-resolved" || "$stderr_out" =~ "left un-resolved" ]] || {
+        echo "NOTICE: no un-resolved warning (may be OK if _BASE_IMAGE_REF is already empty)"
     }
 }
 
@@ -175,24 +189,28 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
 }
 
 @test "RBIS-06: Cross-arg dependencies — chain resolves or terminates bounded" {
-    # A depends on B, B depends on C, C is concrete
+    # A depends on B, B depends on C, C is concrete.
+    # Values with ${...} fail the validator so we seed _BUILD_ARGS_RESOLVED directly
+    # (the production code path is: _prepare_build_args assembles the map; here we
+    # simulate the same result for the substitution-engine unit test).
     make_dockerfile "ARG A
 ARG B
 ARG C" "FROM \${A}-base"
-    # build_args provides the chain
-    make_config '${A}-base' '  A: "x-${B}"
-  B: "y-${C}"
-  C: "z"'
+    make_config '${A}-base'
 
-    _prepare_build_args "1.0" ""
+    # Manually construct the chain in _BUILD_ARGS_RESOLVED
+    declare -gA _BUILD_ARGS_RESOLVED=([A]='x-${B}' [B]='y-${C}' [C]='z')
 
     local label_args=""
     _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>/dev/null || true
 
     # Valid outcomes: fully resolved (x-y-z-base) OR bounded iteration leaves unresolved
     # Both are acceptable per spec; test asserts no crash and some deterministic value
-    [[ -n "$_BASE_IMAGE_REF" || true ]] # just asserts no crash
-    # Assert no infinite loop: function returned
+    # The fixed-point loop should resolve to x-y-z-base in ≤3 passes
+    [[ "$_BASE_IMAGE_REF" == "x-y-z-base" || "$_BASE_IMAGE_REF" =~ \$\{ ]] || {
+        echo "FAIL: unexpected value '$_BASE_IMAGE_REF' (expected x-y-z-base or remaining placeholder)"
+        return 1
+    }
     echo "resolved to: '$_BASE_IMAGE_REF'"
 }
 
@@ -224,9 +242,12 @@ ARG C" "FROM \${A}-base"
     generated=$(mktemp "$TEST_DIR/Dockerfile.XXXXXX")
     "$fixture_dir/generate-dockerfile.sh" "./Dockerfile.template" "alpine" "1.0" > "$generated"
 
-    # Call _resolve_base_image on the GENERATED Dockerfile (post-fix behavior)
+    # Call _resolve_base_image on the GENERATED Dockerfile (post-fix behavior).
+    # build_container sets _RESOLVE_FROM_GENERATED=1 when a template was expanded —
+    # this signals _resolve_base_image to skip config.yaml::base_image (default-distro)
+    # and use the concrete FROM line from the generated Dockerfile instead.
     local label_args_after=""
-    _resolve_base_image "$generated" "1.0" "label_args_after" 2>/dev/null || true
+    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated" "1.0" "label_args_after" 2>/dev/null || true
 
     rm -f "$generated"
     cd "$TEST_DIR/container" || true
@@ -265,9 +286,16 @@ ARG C" "FROM \${A}-base"
 
 @test "RBIS-09: build_arg with quote character produces valid lineage JSON" {
     make_dockerfile "" "FROM alpine:3.21"
-    make_config "alpine:3.21" '  NOTE: '"'"'this has "quotes" in it'"'"
-
+    # Values with quotes fail the build_args validator (correct: unsafe shell chars).
+    # We test _emit_build_lineage directly with a value injected after _prepare_build_args,
+    # simulating a hypothetical escaped value that could reach the write path.
+    # The real guard is: validator rejects such values in config.yaml. The Fix C test
+    # verifies that IF such a value reaches _emit_build_lineage, it produces valid JSON.
+    make_config "alpine:3.21"
     _prepare_build_args "1.0" ""
+    # Inject the test value directly into _BUILD_ARGS (bypasses validator) to simulate
+    # the JSON escaping behaviour under Fix C.
+    _BUILD_ARGS="$_BUILD_ARGS --build-arg NOTE=has-quotes-here"
     # _BASE_IMAGE_REF and _BASE_DIGEST must be set for lineage
     _BASE_IMAGE_REF="alpine:3.21"
     _BASE_DIGEST=""

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -495,3 +495,46 @@ DOCKER
         return 1
     }
 }
+
+# =============================================================================
+# Finding #1 (gate r5 copilot MEDIUM): ARG expansion cap must clear _BASE_IMAGE_REF
+# Pre-fix: cap fires, emits warning, but execution continues with unresolved literal.
+# Post-fix: cap fires → _BASE_IMAGE_REF is set to "" (or "unknown") AND a warning is
+# emitted.  Caller can detect failure via empty string.
+# =============================================================================
+
+@test "RBIS-15: Expanding build_args chain hits iteration cap and clears _BASE_IMAGE_REF" {
+    # A self-referential chain where each substitution introduces a new placeholder
+    # without converging: A=x${A}y — the value grows each iteration, never stabilising.
+    # The 10-iteration cap must fire AND _BASE_IMAGE_REF must be cleared to empty.
+    #
+    # A symmetric bidirectional chain (A=${B}, B=${A}) converges instantly because
+    # the value after each iteration equals the value before it — the cap is not reached.
+    # This test uses a growing chain to actually exercise the cap code path.
+    make_dockerfile "ARG A" "FROM \${A}-base"
+    make_config '${A}-base'
+
+    # Seed _BUILD_ARGS_RESOLVED: A expands to a new reference of itself, growing each iteration
+    declare -gA _BUILD_ARGS_RESOLVED=([A]='x${A}y')
+
+    local label_args=""
+    local stderr_file
+    stderr_file="$TEST_DIR/rbis15-stderr.txt"
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>"$stderr_file" || true
+    local stderr_out
+    stderr_out=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+
+    # Post-fix: _BASE_IMAGE_REF must be empty (not the leaked growing literal)
+    [[ -z "$_BASE_IMAGE_REF" ]] || {
+        echo "FAIL: expected empty _BASE_IMAGE_REF after cap hit, got: '$_BASE_IMAGE_REF'"
+        echo "  (pre-fix: unresolved literal propagates to lineage file)"
+        return 1
+    }
+
+    # A stderr warning must have been emitted
+    [[ "$stderr_out" =~ "capped" || "$stderr_out" =~ "cap" || "$stderr_out" =~ "expansion" || "$stderr_out" =~ "un-resolved" ]] || {
+        echo "FAIL: no cap/expansion warning in stderr: '$stderr_out'"
+        return 1
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -391,3 +391,59 @@ ARG C" "FROM \${A}-base"
         return 1
     }
 }
+
+# =============================================================================
+# Regression: FROM-line fallback must NOT substitute an unresolved config.yaml
+# placeholder with an unrelated Dockerfile FROM (e.g. final-stage "FROM scratch")
+# when _RESOLVE_FROM_GENERATED is not set (#530).
+# =============================================================================
+
+@test "RBIS-12: Unresolved placeholder in config.yaml is NOT replaced by multi-stage FROM scratch" {
+    # config.yaml::base_image contains an unresolvable ${MYSTERY_TAG}
+    # Dockerfile is multi-stage; final non-AS stage is "FROM scratch"
+    # Bug: the post-substitution fallback replaces the unresolved literal with "scratch"
+    # Fix: fallback only fires when _RESOLVE_FROM_GENERATED=1; otherwise leave unresolved as-is
+    cat > ./config.yaml <<'YAML'
+base_image: "${MYSTERY_TAG}-base"
+YAML
+
+    # Multi-stage Dockerfile: builder stage + final stage FROM scratch
+    cat > ./Dockerfile <<'DOCKER'
+ARG BUILDER_IMAGE=golang:1.21
+FROM ${BUILDER_IMAGE} AS builder
+RUN echo build
+FROM scratch
+COPY --from=builder /app /app
+DOCKER
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    local stderr_file
+    stderr_file=$(mktemp)
+    # Do NOT set _RESOLVE_FROM_GENERATED — this is a monolithic container, not template-generated
+    unset _RESOLVE_FROM_GENERATED
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>"$stderr_file" || true
+    local stderr_out
+    stderr_out=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+
+    # The unresolved placeholder must NOT be replaced by "scratch" from the final stage.
+    # The value must remain as the unresolved literal (containing ${) so that
+    # sanitize-at-read can display "unknown" on the dashboard.
+    [[ "$_BASE_IMAGE_REF" != "scratch" ]] || {
+        echo "FAIL: _BASE_IMAGE_REF was set to 'scratch' (FROM-line fallback fired incorrectly)"
+        echo "  Expected: literal containing \${ (e.g. '\${MYSTERY_TAG}-base')"
+        echo "  stderr: $stderr_out"
+        return 1
+    }
+    # The value must still contain the unresolved placeholder (or be empty — both acceptable)
+    [[ -z "$_BASE_IMAGE_REF" || "$_BASE_IMAGE_REF" =~ \$\{ ]] || {
+        echo "FAIL: expected unresolved literal or empty, got concrete: '$_BASE_IMAGE_REF'"
+        return 1
+    }
+    # A warning about the un-resolved placeholder should have been emitted
+    [[ "$stderr_out" =~ "un-resolved" || "$stderr_out" =~ "left un-resolved" ]] || {
+        echo "NOTICE: no un-resolved warning emitted (acceptable if _BASE_IMAGE_REF is empty)"
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -447,3 +447,51 @@ DOCKER
         echo "NOTICE: no un-resolved warning emitted (acceptable if _BASE_IMAGE_REF is empty)"
     }
 }
+
+# =============================================================================
+# Finding #1 (gate r4 codex+copilot MEDIUM): ARG names with digits must be parsed
+# Docker allows [A-Za-z_][A-Za-z0-9_]* for ARG names.
+# Pre-fix regex '^ARG [A-Z_]+=' skips names containing digits (e.g. UBUNTU_2404_TAG).
+# =============================================================================
+
+@test "RBIS-13: ARG name with embedded digits is parsed and substituted (UBUNTU_2404_TAG)" {
+    # github-runner ubuntu-2404 Dockerfile contains:
+    #   ARG UBUNTU_2404_TAG=24.04
+    # The pre-fix regex '^ARG [A-Z_]+=' skips this ARG entirely because '2404' contains digits,
+    # leaving _BASE_IMAGE_REF un-substituted with a leaked literal.
+    make_dockerfile "ARG UBUNTU_2404_TAG=24.04" "FROM ubuntu:\${UBUNTU_2404_TAG}"
+    make_config 'ubuntu:${UBUNTU_2404_TAG}'
+
+    _prepare_build_args "24.04" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "24.04" "label_args" 2>/dev/null || true
+
+    [[ "$_BASE_IMAGE_REF" == "ubuntu:24.04" ]] || {
+        echo "FAIL: expected 'ubuntu:24.04', got '$_BASE_IMAGE_REF'"
+        echo "  (pre-fix: digit in ARG name causes regex skip → un-substituted literal)"
+        return 1
+    }
+    # No leaked placeholder
+    [[ "$_BASE_IMAGE_REF" != *'${'* ]] || {
+        echo "FAIL: placeholder leaked into _BASE_IMAGE_REF: '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}
+
+@test "RBIS-14: ARG name with leading letter then digits-and-underscore mixed (R3_BASE=r3)" {
+    # Verify that a name starting with a letter followed by mixed digits/underscores
+    # is correctly parsed after the fix.
+    make_dockerfile "ARG R3_BASE=r3-img" "FROM \${R3_BASE}:latest"
+    make_config '${R3_BASE}:latest'
+
+    _prepare_build_args "1.0" ""
+
+    local label_args=""
+    _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>/dev/null || true
+
+    [[ "$_BASE_IMAGE_REF" == "r3-img:latest" ]] || {
+        echo "FAIL: expected 'r3-img:latest', got '$_BASE_IMAGE_REF'"
+        return 1
+    }
+}

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -243,11 +243,11 @@ ARG C" "FROM \${A}-base"
     "$fixture_dir/generate-dockerfile.sh" "./Dockerfile.template" "alpine" "1.0" > "$generated"
 
     # Call _resolve_base_image on the GENERATED Dockerfile (post-fix behavior).
-    # build_container sets _RESOLVE_FROM_GENERATED=1 when a template was expanded —
+    # build_container passes from_generated=1 (4th arg) when a template was expanded —
     # this signals _resolve_base_image to skip config.yaml::base_image (default-distro)
     # and use the concrete FROM line from the generated Dockerfile instead.
     local label_args_after=""
-    _RESOLVE_FROM_GENERATED=1 _resolve_base_image "$generated" "1.0" "label_args_after" 2>/dev/null || true
+    _resolve_base_image "$generated" "1.0" "label_args_after" "1" 2>/dev/null || true
 
     rm -f "$generated"
     cd "$TEST_DIR/container" || true
@@ -287,15 +287,25 @@ ARG C" "FROM \${A}-base"
 @test "RBIS-09: build_arg with quote character produces valid lineage JSON" {
     make_dockerfile "" "FROM alpine:3.21"
     # Values with quotes fail the build_args validator (correct: unsafe shell chars).
-    # We test _emit_build_lineage directly with a value injected after _prepare_build_args,
-    # simulating a hypothetical escaped value that could reach the write path.
-    # The real guard is: validator rejects such values in config.yaml. The Fix C test
-    # verifies that IF such a value reaches _emit_build_lineage, it produces valid JSON.
-    make_config "alpine:3.21"
-    _prepare_build_args "1.0" ""
-    # Inject the test value directly into _BUILD_ARGS (bypasses validator) to simulate
-    # the JSON escaping behaviour under Fix C.
-    _BUILD_ARGS="$_BUILD_ARGS --build-arg NOTE=has-quotes-here"
+    # We test _emit_build_lineage directly by writing config.yaml with special characters
+    # that the YAML parser accepts but that would break inline JSON string construction.
+    # Fix C uses jq --argjson to pass the build_args blob, so values with double-quotes
+    # and backslashes are safely escaped.
+    # Reverting Fix C to inline string construction would produce malformed JSON on this input.
+    #
+    # Write config.yaml with a YAML double-quoted string that contains " and \ chars.
+    # The YAML parser handles them; the test verifies jq --argjson writes valid JSON
+    # and that .build_args.NOTE round-trips the value losslessly.
+    cat > ./config.yaml << 'CONFIG'
+base_image: "alpine:3.21"
+build_args:
+  NOTE: "has \"double\" and \\back"
+CONFIG
+
+    # _prepare_build_args calls the validator which rejects these chars — bypass it
+    # and set state directly to simulate a value reaching _emit_build_lineage.
+    declare -gA _BUILD_ARGS_RESOLVED=()
+    _BUILD_ARGS=""
     # _BASE_IMAGE_REF and _BASE_DIGEST must be set for lineage
     _BASE_IMAGE_REF="alpine:3.21"
     _BASE_DIGEST=""
@@ -317,10 +327,18 @@ ARG C" "FROM \${A}-base"
         return 1
     }
 
-    # Must be valid JSON
+    # (a) Must be valid JSON
     jq '.' "$lineage_file" > /dev/null 2>&1 || {
         echo "FAIL: lineage file is not valid JSON"
         cat "$lineage_file"
+        return 1
+    }
+
+    # (b) NOTE field must round-trip losslessly — double-quote and backslash preserved
+    local note_val
+    note_val=$(jq -r '.build_args.NOTE // ""' "$lineage_file")
+    [[ "$note_val" == 'has "double" and \back' ]] || {
+        echo "FAIL: NOTE round-trip failed — expected 'has \"double\" and \\back', got: '$note_val'"
         return 1
     }
 }
@@ -393,16 +411,59 @@ ARG C" "FROM \${A}-base"
 }
 
 # =============================================================================
+# Finding #5 (senior review MEDIUM): _BUILD_ARGS_RESOLVED must not carry call-N
+# values into a failed call N+1 (cross-call contamination).
+# Pre-fix: declare -gA _BUILD_ARGS_RESOLVED=() was AFTER the || return $? guard,
+# so it was never executed on failure — stale values from call N survived into N+1.
+# Post-fix: the reset is unconditional (before prepare_build_args invocation).
+# =============================================================================
+
+@test "RBIS-16: _BUILD_ARGS_RESOLVED is empty after failed second call, not carrying call-1 values" {
+    # Call 1: valid config → populates _BUILD_ARGS_RESOLVED
+    make_dockerfile "ARG OS_IMAGE_BASE
+ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
+    make_config '${OS_IMAGE_BASE}:${OS_IMAGE_TAG}' '  OS_IMAGE_BASE: "alpine"
+  OS_IMAGE_TAG: "3.21"'
+
+    _prepare_build_args "1.0" ""
+
+    # Verify call 1 populated the map
+    [[ "${#_BUILD_ARGS_RESOLVED[@]}" -gt 0 ]] || {
+        echo "FAIL: call 1 did not populate _BUILD_ARGS_RESOLVED (prerequisite check)"
+        return 1
+    }
+
+    # Call 2: invalid config (REMOTE_CR is a forbidden key) → prepare_build_args fails
+    printf 'base_image: "alpine:3.21"\nbuild_args:\n  REMOTE_CR: "evil.example.com"\n' > ./config.yaml
+
+    local rc=0
+    _prepare_build_args "1.0" "" 2>/dev/null || rc=$?
+
+    # Failure expected
+    [[ "$rc" -ne 0 ]] || {
+        echo "FAIL: call 2 should have failed (REMOTE_CR forbidden), got rc=0"
+        return 1
+    }
+
+    # _BUILD_ARGS_RESOLVED must be EMPTY — not carrying call-1 values
+    [[ "${#_BUILD_ARGS_RESOLVED[@]}" -eq 0 ]] || {
+        echo "FAIL: _BUILD_ARGS_RESOLVED still has ${#_BUILD_ARGS_RESOLVED[@]} keys after failed call 2"
+        echo "  Keys (contamination from call 1): ${!_BUILD_ARGS_RESOLVED[*]}"
+        return 1
+    }
+}
+
+# =============================================================================
 # Regression: FROM-line fallback must NOT substitute an unresolved config.yaml
 # placeholder with an unrelated Dockerfile FROM (e.g. final-stage "FROM scratch")
-# when _RESOLVE_FROM_GENERATED is not set (#530).
+# when from_generated=0 (default; monolithic container, no template expansion, #530).
 # =============================================================================
 
 @test "RBIS-12: Unresolved placeholder in config.yaml is NOT replaced by multi-stage FROM scratch" {
     # config.yaml::base_image contains an unresolvable ${MYSTERY_TAG}
     # Dockerfile is multi-stage; final non-AS stage is "FROM scratch"
     # Bug: the post-substitution fallback replaces the unresolved literal with "scratch"
-    # Fix: fallback only fires when _RESOLVE_FROM_GENERATED=1; otherwise leave unresolved as-is
+    # Fix: fallback only fires when from_generated=1; otherwise leave unresolved as-is
     cat > ./config.yaml <<'YAML'
 base_image: "${MYSTERY_TAG}-base"
 YAML
@@ -421,8 +482,8 @@ DOCKER
     local label_args=""
     local stderr_file
     stderr_file=$(mktemp)
-    # Do NOT set _RESOLVE_FROM_GENERATED — this is a monolithic container, not template-generated
-    unset _RESOLVE_FROM_GENERATED
+    # Do NOT pass from_generated=1 — this is a monolithic container, not template-generated
+    # (default 4th arg of 0 means monolithic semantics)
     _resolve_base_image "./Dockerfile" "1.0" "label_args" 2>"$stderr_file" || true
     local stderr_out
     stderr_out=$(cat "$stderr_file")

--- a/tests/unit/web-shell-base-image.bats
+++ b/tests/unit/web-shell-base-image.bats
@@ -44,19 +44,18 @@ setup() {
 }
 
 @test "web-shell: ARG REMOTE_CR present in generator output for alpine/ubuntu/rocky (regression lock)" {
-    # Regression lock: migrated distros require BOTH a template-global
-    # `ARG REMOTE_CR=docker.io` AND a stage-scope `ARG REMOTE_CR` re-import
-    # (no default) immediately before the FROM line, so ${REMOTE_CR} resolves
-    # inside the FROM. The FROM line itself must reference ${REMOTE_CR}/library/<distro>.
-    # If the stage re-import is dropped, ${REMOTE_CR} in FROM resolves to empty
-    # despite the global ARG existing — Docker scopes ARG to stages.
+    # Regression lock: migrated distros require exactly ONE template-global
+    # `ARG REMOTE_CR=docker.io` declaration. The previous Two-ARG pattern (global +
+    # stage-local re-import) has been replaced by a single-ARG contract: CI overrides
+    # the value via --build-arg REMOTE_CR=...; the ARG is never re-declared in generated
+    # stages. The FROM line must reference ${REMOTE_CR}/library/<distro>.
     for distro in alpine ubuntu rocky; do
         local gen
         gen=$(bash "$GEN" "$TEMPLATE" "$distro" 2>/dev/null)
-        # Expect ≥ 2 ARG REMOTE_CR lines (template global + stage re-import)
+        # Expect exactly 1 ARG REMOTE_CR line (template-global only; no stage re-import)
         local count
         count=$(echo "$gen" | grep -cE '^ARG REMOTE_CR' || true)
-        [[ "$count" -ge 2 ]] || { echo "$distro: expected ≥ 2 ARG REMOTE_CR lines, found $count"; return 1; }
+        [[ "$count" -eq 1 ]] || { echo "$distro: expected exactly 1 ARG REMOTE_CR line, found $count"; return 1; }
         # Expect the FROM line to reference ${REMOTE_CR}/library/<distro>
         local from_uses_remote_cr
         case "$distro" in

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -96,22 +96,19 @@ FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}'
     alpine)
         alpine_tag=$(_base_cache_tag_new "library/alpine")
         [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for library/alpine in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=ghcr.io/oorabona
-ARG ALPINE_TAG=${alpine_tag}
+        base_block="ARG ALPINE_TAG=${alpine_tag}
 FROM \${REMOTE_CR}/library/alpine:\${ALPINE_TAG}"
         ;;
     ubuntu)
         ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
         [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=ghcr.io/oorabona
-ARG UBUNTU_TAG=${ubuntu_tag}
+        base_block="ARG UBUNTU_TAG=${ubuntu_tag}
 FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_TAG}"
         ;;
     rocky)
         rocky_tag=$(_base_cache_tag_new "library/rockylinux")
         [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for library/rockylinux in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=ghcr.io/oorabona
-ARG ROCKY_TAG=${rocky_tag}
+        base_block="ARG ROCKY_TAG=${rocky_tag}
 FROM \${REMOTE_CR}/library/rockylinux:\${ROCKY_TAG}"
         ;;
     *)

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -96,21 +96,21 @@ FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}'
     alpine)
         alpine_tag=$(_base_cache_tag_new "library/alpine")
         [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for library/alpine in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=docker.io
+        base_block="ARG REMOTE_CR=ghcr.io/oorabona
 ARG ALPINE_TAG=${alpine_tag}
 FROM \${REMOTE_CR}/library/alpine:\${ALPINE_TAG}"
         ;;
     ubuntu)
         ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
         [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=docker.io
+        base_block="ARG REMOTE_CR=ghcr.io/oorabona
 ARG UBUNTU_TAG=${ubuntu_tag}
 FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_TAG}"
         ;;
     rocky)
         rocky_tag=$(_base_cache_tag_new "library/rockylinux")
         [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for library/rockylinux in $config"; exit 1; }
-        base_block="ARG REMOTE_CR=docker.io
+        base_block="ARG REMOTE_CR=ghcr.io/oorabona
 ARG ROCKY_TAG=${rocky_tag}
 FROM \${REMOTE_CR}/library/rockylinux:\${ROCKY_TAG}"
         ;;

--- a/web-shell/generate-dockerfile.sh
+++ b/web-shell/generate-dockerfile.sh
@@ -96,21 +96,21 @@ FROM ghcr.io/oorabona/debian:${DEBIAN_TAG}'
     alpine)
         alpine_tag=$(_base_cache_tag_new "library/alpine")
         [[ -z "$alpine_tag" ]] && { log_error "No base_image_cache tag for library/alpine in $config"; exit 1; }
-        base_block="ARG REMOTE_CR
+        base_block="ARG REMOTE_CR=docker.io
 ARG ALPINE_TAG=${alpine_tag}
 FROM \${REMOTE_CR}/library/alpine:\${ALPINE_TAG}"
         ;;
     ubuntu)
         ubuntu_tag=$(_base_cache_tag_new "library/ubuntu")
         [[ -z "$ubuntu_tag" ]] && { log_error "No base_image_cache tag for library/ubuntu in $config"; exit 1; }
-        base_block="ARG REMOTE_CR
+        base_block="ARG REMOTE_CR=docker.io
 ARG UBUNTU_TAG=${ubuntu_tag}
 FROM \${REMOTE_CR}/library/ubuntu:\${UBUNTU_TAG}"
         ;;
     rocky)
         rocky_tag=$(_base_cache_tag_new "library/rockylinux")
         [[ -z "$rocky_tag" ]] && { log_error "No base_image_cache tag for library/rockylinux in $config"; exit 1; }
-        base_block="ARG REMOTE_CR
+        base_block="ARG REMOTE_CR=docker.io
 ARG ROCKY_TAG=${rocky_tag}
 FROM \${REMOTE_CR}/library/rockylinux:\${ROCKY_TAG}"
         ;;


### PR DESCRIPTION
Closes #530

## Summary

Foundation issue (A) of the 3-part architectural series (#530, #531, #532). Restores accurate `base_image` display on the dashboard by fixing both write-time substitution and read-time fallback selection across the lineage truth pipeline.

### Five atomic fixes

- **A1** — `_resolve_base_image` consumes the resolved build_args set from `_prepare_build_args` (closes the sslh + web-shell leak class where ARGs supplied via variants.yaml weren't seen by the substitution loop).
- **A2** — `_resolve_base_image` relocated post-template-generation so template-driven containers (web-shell, github-runner) read the concrete FROM from the generated Dockerfile, not the pre-substitution config.yaml::base_image.
- **B** — `generate-dashboard.sh::resolve_lineage_file` uses `default_variant()` instead of filesystem first-match for multi-variant rollups; deterministic latest-version fallback; never falls back to filesystem-first on malformed variants.yaml.
- **C** — `_emit_build_lineage` uses `jq -n --arg/--argjson` for JSON emission (closes shell-metacharacter injection risk on build_args values).
- **D** — `printf -v` replaces `eval ""=...""` in label_args assignment (defense-in-depth).
- **E** — `lineage_schema_version: 2` written at build time + sanitize-at-read in dashboard read paths (drops only `${...}` literals, preserves concrete legacy v1 values).

### Pre-PR orthogonal gate

8 rounds of codex xhigh + copilot parallel review. 3 → 2 → 1+L → 2M → 4 → 2H → 2H → 1H → CLEAN. Every round caught real defects; each was fixed with a regression test under red-then-green discipline. Final round (8) returned CLEAN from both engines.

### Test coverage

- 605/605 bats tests passing (3 new files: `resolve-base-image-substitution.bats`, `dashboard-rollup-default-variant.bats`, `dashboard-integration-smoke.bats`; updates to `web-shell-base-image.bats`).
- Integration smoke includes mutation guards for A1, A2, B: commenting out the new substitution loop / reverting the relocation / replacing default_variant with first-match all cause SMOKE-* to fail.
- Shellcheck info-only on touched scripts (no new warnings/errors).

### Post-merge expectation (documented)

Affected containers (sslh, web-shell, possibly wordpress, github-runner ubuntu-2404) currently display `unknown` in the dashboard's per-variant Base image field because their lineage cache contains pre-v2 unresolved `${...}` literals. The new sanitize-at-read keeps that display until each container's next CI rebuild produces a v2 lineage entry — at which point the actual concrete base image displays. Self-healing per-container, no manual intervention required.

### Architectural decisions captured

`docs/decisions.md` has a `#530 — Per-variant base_image truth pipeline` section documenting:
- The 5 atomic fixes and their rationale
- Rejected alternatives (backfill — `.build-lineage/` is gitignored; dashboard-side substitution — too late in the pipeline; per-distro yq read — hidden coupling vs the cleaner post-template-generation relocation)
- The integration-smoke origin (feedback-perf-integration-smoke-test learnings)
- Cache trust boundary preserved (REMOTE_CR remains injectable only by CI's emit_reachable_cache_args; templates' top-level `ARG REMOTE_CR=docker.io` is the graceful local-build fallback)

## Test plan

- [ ] CI passes (lint, typecheck, bats, shellcheck)
- [ ] Container build smoke (manual) for one affected container produces v2 lineage with concrete `base_image_ref`
- [ ] Dashboard regenerates without 'unknown' for containers that have v2 lineage
- [ ] No regression on monolithic containers (postgres, ansible, jekyll, ...) — confirmed via bats integration smoke
