### PR TITLE
feat(wordpress): standardize base_image to ${REMOTE_CR}/php:${PHP_TAG} pattern

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -395,7 +395,7 @@ runs:
                   # or the resolved tags[0] template — the same tag the build will actually use.
                   source_path=$(yq -r ".base_image_cache[$i].source" "./$container/config.yaml")
                   explicit_tag=$(resolve_cache_check_tag "./$container/config.yaml" "$i" "$build_version")
-                  check_image="ghcr.io/${owner}/${source_path}:${explicit_tag}"
+                  check_image="ghcr.io/${owner}/${source_path#/}:${explicit_tag}"
                 else
                   # OLD style: dedicated GHCR repo with resolved tag.
                   resolved_tag=$(resolve_cache_check_tag "./$container/config.yaml" "$i" "$build_version")

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -129,7 +129,14 @@ _collect_entry_tags() {
             local leaf="${source#/}"
             # Normalize any residual double slash (defensive: //foo → /foo → foo)
             leaf="${leaf//\/\//\/}"
-            sync_dest_path="library/${leaf}"
+            # Only prepend library/ when the leaf is a single-segment path (e.g. "php").
+            # Multi-segment leaves (e.g. "library/postgres" from source="/library/postgres")
+            # must use the leaf as-is to avoid the double-library path "library/library/postgres".
+            if [[ "$leaf" == */* ]]; then
+                sync_dest_path="$leaf"
+            else
+                sync_dest_path="library/${leaf}"
+            fi
             probe_dest_path="${leaf}"
         else
             # Normal NEW style: path-preserving mirror

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -546,13 +546,22 @@ sync_base_images_to_ghcr() {
             continue
         fi
 
-        if [[ "$source_img" == */* ]]; then
-            # Normalize double slash: leading-slash source (e.g. /php) concatenated with
-            # source_registry produces "docker.io//php" — collapse // → / in the path.
-            source_ref="${source_registry}/${source_img}:${tag}"
-            source_ref="${source_ref//\/\//\/}"
+        # Strip leading slash for chained-on-own markers (e.g. source: /php).
+        # This must happen BEFORE the slash-presence check so that single-segment
+        # chained sources (/php → php) route to the library/ branch, not the
+        # multi-segment branch. Without this strip, /php would match */* and
+        # produce docker.io/php:tag via double-slash collapse — which works for
+        # the Docker daemon (client-side aliasing) but NOT for skopeo or imagetools,
+        # breaking the idempotent-mirror goal.
+        local src="${source_img#/}"
+        if [[ "$src" == */* ]]; then
+            # Multi-segment path (e.g. library/postgres or /library/postgres after strip):
+            # use as-is — the caller has already provided the full registry path.
+            source_ref="${source_registry}/${src}:${tag}"
         else
-            source_ref="${source_registry}/library/${source_img}:${tag}"
+            # Single-segment (e.g. php, debian): prepend explicit library/ so the
+            # resulting ref is docker.io/library/php:tag, not docker.io/php:tag.
+            source_ref="${source_registry}/library/${src}:${tag}"
         fi
 
         echo ""

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -22,7 +22,16 @@
 #     - source: library/postgres   # FULL upstream path (used as GHCR dest path)
 #       tags_from_versions: true   # or tags: ["..."]
 #   → emit_reachable_cache_args emits --build-arg REMOTE_CR=ghcr.io/<owner> (once per container)
-#   → collect_all_cache_images dest: ghcr.io/<owner>/library/postgres:<tag>
+#   → collect_all_cache_images sync_image: ghcr.io/<owner>/library/postgres:<tag>
+#
+# CHAINED-ON-OWN-BUILD marker (leading-slash source):
+#   base_image_cache:
+#     - source: /php               # Leading slash = chained-on-own-build semantic marker.
+#       tags: ["latest"]           # Declares the container consumes a project-produced image
+#   → sync_image: ghcr.io/<owner>/library/php:<tag>  (mirror path, shared with upstream cache)
+#   → probe_image: ghcr.io/<owner>/php:<tag>          (project's own published custom container)
+#   Sync writes to the library/ path (idempotent with upstream mirror). Probe checks the
+#   project-published leaf path to determine REMOTE_CR applicability.
 #
 # Discriminator: ghcr_repo present and non-empty ⇒ OLD style; absent / null / empty ⇒ NEW style.
 # Build-arg emission: emit_reachable_cache_args is the SOLE emitter (per-entry probe-gated,
@@ -106,14 +115,31 @@ _collect_entry_tags() {
     # Discriminate entry style: ghcr_repo PRESENT (non-empty, non-null) → OLD style (unchanged dest).
     # ghcr_repo ABSENT ("null"), explicit nil (yq renders as "null"), or empty string ("") → NEW style:
     # dest path is source (path-preserving mirror).
-    local dest_path
+    #
+    # Leading-slash source (e.g. source: /php) is the "chained-on-own-build" marker.
+    # For such entries the two image paths diverge:
+    #   sync_image  → ghcr.io/<owner>/library/<leaf>:<tag>  (mirror dest, shared with upstream cache)
+    #   probe_image → ghcr.io/<owner>/<leaf>:<tag>          (project's published custom container)
+    # For all other NEW-style entries: sync_image == probe_image == ghcr.io/<owner>/<source>:<tag>
+    # For OLD-style entries: sync_image == probe_image == ghcr.io/<owner>/<ghcr_repo>:<tag>
+    local sync_dest_path probe_dest_path
     if [[ "$ghcr_repo" == "null" || -z "$ghcr_repo" ]]; then
-        # NEW style: source is the full upstream path (e.g. library/postgres)
-        # ghcr_image dest: ghcr.io/<owner>/<source>:<tag>
-        dest_path="$source"
+        if [[ "$source" == /* ]]; then
+            # Leading-slash: chained-on-own-build marker
+            local leaf="${source#/}"
+            # Normalize any residual double slash (defensive: //foo → /foo → foo)
+            leaf="${leaf//\/\//\/}"
+            sync_dest_path="library/${leaf}"
+            probe_dest_path="${leaf}"
+        else
+            # Normal NEW style: path-preserving mirror
+            sync_dest_path="$source"
+            probe_dest_path="$source"
+        fi
     else
-        # OLD style: dest is the dedicated GHCR repo name
-        dest_path="$ghcr_repo"
+        # OLD style: dedicated GHCR repo name
+        sync_dest_path="$ghcr_repo"
+        probe_dest_path="$ghcr_repo"
     fi
 
     if [[ "$tags_from_versions" == "true" ]]; then
@@ -126,8 +152,9 @@ _collect_entry_tags() {
                 --arg source "$source" \
                 --arg tag "$full_tag" \
                 --arg ghcr_repo "$ghcr_repo" \
-                --arg ghcr_image "ghcr.io/$owner/$dest_path:$full_tag" \
-                '. + [{source: $source, tag: $tag, ghcr_repo: $ghcr_repo, ghcr_image: $ghcr_image}]')
+                --arg sync_image "ghcr.io/$owner/$sync_dest_path:$full_tag" \
+                --arg probe_image "ghcr.io/$owner/$probe_dest_path:$full_tag" \
+                '. + [{source: $source, tag: $tag, ghcr_repo: $ghcr_repo, sync_image: $sync_image, probe_image: $probe_image}]')
         done
     else
         local tag_count
@@ -143,8 +170,9 @@ _collect_entry_tags() {
                 --arg source "$source" \
                 --arg tag "$tag" \
                 --arg ghcr_repo "$ghcr_repo" \
-                --arg ghcr_image "ghcr.io/$owner/$dest_path:$tag" \
-                '. + [{source: $source, tag: $tag, ghcr_repo: $ghcr_repo, ghcr_image: $ghcr_image}]')
+                --arg sync_image "ghcr.io/$owner/$sync_dest_path:$tag" \
+                --arg probe_image "ghcr.io/$owner/$probe_dest_path:$tag" \
+                '. + [{source: $source, tag: $tag, ghcr_repo: $ghcr_repo, sync_image: $sync_image, probe_image: $probe_image}]')
         done
     fi
 
@@ -166,7 +194,9 @@ has_base_cache() {
 #   containers_json: JSON array of container names, e.g. '["ansible","postgres"]'
 #   versions_json:   JSON object of {container: version}, e.g. '{"ansible":"latest","postgres":"18.1"}'
 #   owner:           GHCR owner, e.g. "oorabona"
-# Output: JSON array of {source, tag, ghcr_repo, ghcr_image} for each unique image to cache
+# Output: JSON array of {source, tag, ghcr_repo, sync_image, probe_image} for each unique image to cache.
+#   sync_image:  GHCR dest used by sync_base_images_to_ghcr (copy target)
+#   probe_image: GHCR ref used for reachability probing (differs for chained-on-own-build sources)
 collect_all_cache_images() {
     local containers_json="$1"
     local versions_json="$2"
@@ -202,8 +232,8 @@ collect_all_cache_images() {
         done
     done
 
-    # Deduplicate by ghcr_image (same repo+tag cached once)
-    echo "$all_images" | jq -c 'unique_by(.ghcr_image)'
+    # Deduplicate by sync_image (same repo+tag synced once)
+    echo "$all_images" | jq -c 'unique_by(.sync_image)'
 }
 
 # Resolve the tag to use when verifying a GHCR cache entry is accessible.
@@ -491,10 +521,10 @@ sync_base_images_to_ghcr() {
 
     local synced=0 failed=0
     while IFS= read -r img; do
-        local source_img tag ghcr_image source_ref output
+        local source_img tag sync_image source_ref output
         source_img=$(echo "$img" | jq -r '.source')
         tag=$(echo "$img" | jq -r '.tag')
-        ghcr_image=$(echo "$img" | jq -r '.ghcr_image')
+        sync_image=$(echo "$img" | jq -r '.sync_image')
 
         # Reject control characters in any ref. base_image_cache.source is not
         # schema-validated upstream (see top-of-file docstring); a value with
@@ -503,22 +533,25 @@ sync_base_images_to_ghcr() {
         # line). Belt-and-suspenders alongside _escape_gha_command below.
         if [[ "$source_img" =~ [[:cntrl:]] ]] \
             || [[ "$tag" =~ [[:cntrl:]] ]] \
-            || [[ "$ghcr_image" =~ [[:cntrl:]] ]]; then
+            || [[ "$sync_image" =~ [[:cntrl:]] ]]; then
             echo "::warning::sync_base_images_to_ghcr: refusing image entry with control characters in ref (possible injection)"
             failed=$((failed + 1))
             continue
         fi
 
         if [[ "$source_img" == */* ]]; then
+            # Normalize double slash: leading-slash source (e.g. /php) concatenated with
+            # source_registry produces "docker.io//php" — collapse // → / in the path.
             source_ref="${source_registry}/${source_img}:${tag}"
+            source_ref="${source_ref//\/\//\/}"
         else
             source_ref="${source_registry}/library/${source_img}:${tag}"
         fi
 
         echo ""
-        echo "🔄 ${source_ref} → ${ghcr_image}"
+        echo "🔄 ${source_ref} → ${sync_image}"
 
-        if output=$(_sync_one_with_backoff "$source_ref" "$ghcr_image"); then
+        if output=$(_sync_one_with_backoff "$source_ref" "$sync_image"); then
             echo "  ✅ Synced"
             synced=$((synced + 1))
         else
@@ -535,10 +568,10 @@ sync_base_images_to_ghcr() {
             # Refs come from base_image_cache.source which is not schema-
             # validated (see top-of-file docstring); escape to prevent a
             # newline-bearing value from injecting a second workflow command.
-            local safe_source_ref safe_ghcr_image
+            local safe_source_ref safe_sync_image
             safe_source_ref=$(_escape_gha_command "$source_ref")
-            safe_ghcr_image=$(_escape_gha_command "$ghcr_image")
-            echo "::warning::sync_base_images_to_ghcr: failed to sync ${safe_source_ref} → ${safe_ghcr_image}"
+            safe_sync_image=$(_escape_gha_command "$sync_image")
+            echo "::warning::sync_base_images_to_ghcr: failed to sync ${safe_source_ref} → ${safe_sync_image}"
             failed=$((failed + 1))
         fi
     done < <(echo "$images_json" | jq -c '.[]')

--- a/helpers/validate-base-cache-schema.sh
+++ b/helpers/validate-base-cache-schema.sh
@@ -10,7 +10,11 @@
 #   R3. New-style source with registry prefix (dot or colon before first /) → REJECT
 #   R4. New-style source with tag (:) or digest (@) → REJECT
 #   R5. New-style source with uppercase letters → REJECT
-#   R6. New-style source with empty path component (leading/, trailing/, //) → REJECT
+#   R6. New-style source with trailing slash (*/), or double slash (*//*) → REJECT
+#       Leading slash (/…) is ALLOWED as a "chained-on-own-build" semantic marker:
+#         source: /php  →  sync target ghcr.io/<owner>/library/php (shared with upstream
+#                          mirror), probe target ghcr.io/<owner>/php (project-produced).
+#       Trailing slash and double slash remain invalid (empty path component).
 #   R6d. New-style source allowlist ^[a-z0-9._/-]+$ → REJECT glob/shell metacharacters
 #   R7. REMOTE_CR in build_args → REJECT (trust-boundary: must only come from CI override)
 #   R7c (allowlist). build_args values must match ^[A-Za-z0-9._/:@+=-]+$ → REJECT
@@ -112,10 +116,14 @@ _vbc_validate_new_style_source() {
         ok=1
     fi
 
-    # R6: empty path components — leading slash, trailing slash, or double slash
-    if [[ "$source" == /* || "$source" == */ || "$source" == *//* ]]; then
+    # R6: empty path components — trailing slash or double slash.
+    # Leading slash (/…) is explicitly ALLOWED as a "chained-on-own-build" semantic
+    # marker (e.g. source: /php declares wordpress consumes our project-produced PHP
+    # image, not a raw Docker Hub library mirror). Trailing slash and double slash
+    # remain invalid because they produce malformed OCI image refs.
+    if [[ "$source" == */ || "$source" == *//* ]]; then
         _vbc_error "$container" "$idx" \
-            "new-style source '${source}' has an empty path component (leading slash, trailing slash, or '//'). Each path component must be non-empty."
+            "new-style source '${source}' has an empty path component (trailing slash or '//'). Each path component must be non-empty. Note: a leading slash (e.g. /php) is allowed as a chained-on-own-build marker."
         ok=1
     fi
 

--- a/scripts/audit-base-image-cache.sh
+++ b/scripts/audit-base-image-cache.sh
@@ -131,6 +131,10 @@ is_cached() {
   for ((i = 0; i < count; i++)); do
     local cache_source
     cache_source=$(yq -r ".base_image_cache[$i].source" "$config")
+    # Strip leading slash: chained-on-own-build markers store source as "/php"
+    # but the normalized candidates list strips the slash (e.g. "php").
+    # Without this strip the comparison always fails for chained entries.
+    cache_source="${cache_source#/}"
     local cand
     for cand in "${candidates[@]}"; do
       if [[ "$cache_source" == "$cand" ]]; then

--- a/tests/unit/audit-base-image-cache.bats
+++ b/tests/unit/audit-base-image-cache.bats
@@ -199,6 +199,35 @@ build_args:
     [ "$status" -ne 0 ]
 }
 
+# ABA-11: chained-on-own-build marker — source: /php → is_cached returns 0 (CACHED)
+# Regression lock for gate r4 Bug 1: the yq-read source value retained the leading slash
+# while the candidates list stripped it, so the comparison always failed.  The fix adds
+# cache_source="${cache_source#/}" after the yq read so "/php" == "php" comparison works.
+@test "ABA-11: chained-on-own-build source:/php matches FROM php: — CACHED (gate r4 regression lock)" {
+    write_config "mywp/config.yaml" \
+'base_image_cache:
+  - source: /php
+    tags: ["8.2-fpm-alpine"]'
+
+    # FROM php:8.2-fpm-alpine resolves to bare "php:8.2-fpm-alpine" after normalization.
+    # is_cached must return 0 (cached); without the leading-slash strip it returns 1 (gap).
+    run is_cached "php:8.2-fpm-alpine" "mywp/config.yaml"
+    [ "$status" -eq 0 ]
+}
+
+# ABA-12: chained-on-own-build marker with REMOTE_CR prefix — same invariant
+@test "ABA-12: chained-on-own-build source:/php matches unresolved REMOTE_CR/php: — CACHED" {
+    write_config "mywp2/config.yaml" \
+'base_image_cache:
+  - source: /php
+    tags: ["8.2-fpm-alpine"]'
+
+    # In wordpress Dockerfile: FROM ${REMOTE_CR}/php:${VERSION}
+    # resolve_image_ref emits "<unresolved:REMOTE_CR>/php:<unresolved:VERSION>"
+    run is_cached "<unresolved:REMOTE_CR>/php:<unresolved:VERSION>" "mywp2/config.yaml"
+    [ "$status" -eq 0 ]
+}
+
 # ─── is_expected_uncached ─────────────────────────────────────────────────────
 
 @test "ABA-07: ghcr.io/oorabona/* self-ref matches expected-uncached pattern" {

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -1008,3 +1008,51 @@ EOF
     [ "$check_image" = "ghcr.io/myowner/php:8.2-fpm-alpine" ]
     [[ "$check_image" != *'//'* ]]
 }
+
+# --- gate r4 Bug 2 regression: multi-segment leading-slash source must not double library/ ---
+
+# BCU-MULTISEG-01: source="/library/postgres" → sync_dest_path must be "library/postgres"
+# Regression lock for gate r4 Bug 2: the unconditional "library/${leaf}" prepend produced
+# "library/library/postgres" when source="/library/postgres" (leaf="library/postgres").
+# Fix: prepend library/ only when leaf has no slash (single-segment, like "php").
+@test "BCU-MULTISEG-01: source=/library/postgres → sync_image is library/postgres NOT library/library/postgres" {
+    mkdir -p pgchained
+    cat > pgchained/config.yaml <<'EOF'
+base_image_cache:
+  - source: /library/postgres
+    tags: ["18-alpine"]
+EOF
+
+    local containers_json='["pgchained"]'
+    local versions_json='{"pgchained":"18-alpine"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # sync_image must use library/postgres (multi-segment leaf used as-is)
+    [[ "$output" == *'"sync_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
+    # Must NOT contain the doubled path
+    [[ "$output" != *'"sync_image":"ghcr.io/myowner/library/library/postgres:18-alpine"'* ]]
+    # probe_image must also be correct (leaf without leading slash)
+    [[ "$output" == *'"probe_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
+}
+
+# BCU-MULTISEG-02: source="/php" (single-segment) still gets library/ prepend
+# Regression guard: the multi-segment fix must NOT break the original /php → library/php behaviour.
+@test "BCU-MULTISEG-02: source=/php (single-segment) still uses library/php for sync_image" {
+    mkdir -p phpchained
+    cat > phpchained/config.yaml <<'EOF'
+base_image_cache:
+  - source: /php
+    tags: ["8.2-fpm-alpine"]
+EOF
+
+    local containers_json='["phpchained"]'
+    local versions_json='{"phpchained":"latest"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # Single-segment leaf: sync_image must retain library/ prefix
+    [[ "$output" == *'"sync_image":"ghcr.io/myowner/library/php:8.2-fpm-alpine"'* ]]
+    # probe_image is leaf-only
+    [[ "$output" == *'"probe_image":"ghcr.io/myowner/php:8.2-fpm-alpine"'* ]]
+}

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -243,8 +243,8 @@ EOF
     [[ "$output" == *'"probe_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
 }
 
-# BCU-15b: sync_base_images_to_ghcr with leading-slash source — source_ref normalised (no double slash)
-@test "BCU-15b: sync_base_images_to_ghcr leading-slash source — source_ref has no double slash" {
+# BCU-15b: sync_base_images_to_ghcr with leading-slash source — source_ref has explicit library/ prefix
+@test "BCU-15b: sync_base_images_to_ghcr leading-slash source — source_ref has explicit library/ prefix" {
     docker() {
         if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
             echo "MOCK_DOCKER_ARGS: $*"
@@ -254,15 +254,35 @@ EOF
     }
     export -f docker
 
-    # Leading-slash source /php: sync target is library/php, source field is /php
+    # Leading-slash source /php must produce docker.io/library/php:latest (not docker.io/php:latest).
+    # The Docker daemon silently aliases docker.io/php → docker.io/library/php, but skopeo and
+    # imagetools do not; the explicit prefix is required for idempotent mirroring.
     local input='[{"source":"/php","tag":"latest","sync_image":"ghcr.io/myowner/library/php:latest","probe_image":"ghcr.io/myowner/php:latest"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 0 ]
-    # Source ref must be docker.io/php:latest (// normalized to /), NOT docker.io//php:latest
-    [[ "$output" == *"docker.io/php:latest"* ]]
+    # Source ref must carry the explicit library/ segment
+    [[ "$output" == *"docker.io/library/php:latest"* ]]
     [[ "$output" != *"docker.io//php:latest"* ]]
+    [[ "$output" != *"docker.io/php:latest "* ]]
     # Dest must be the sync_image (library/php path)
     [[ "$output" == *"ghcr.io/myowner/library/php:latest"* ]]
+}
+
+# BCU-15d: mutation guard — single-segment chained source must never produce an alias-only ref
+@test "BCU-15d: sync_base_images_to_ghcr single-segment chained source — no bare alias (library/ always explicit)" {
+    docker() { return 0; }
+    export -f docker
+
+    # /debian is another single-segment chained marker.  The constructed source_ref
+    # must be docker.io/library/debian:bullseye, not docker.io/debian:bullseye.
+    # Revert the leading-slash strip in sync_base_images_to_ghcr and this test fails.
+    local input='[{"source":"/debian","tag":"bullseye","sync_image":"ghcr.io/myowner/library/debian:bullseye","probe_image":"ghcr.io/myowner/debian:bullseye"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"docker.io/library/debian:bullseye"* ]]
+    # The bare alias form must be absent (no double-slash collapse residue either)
+    [[ "$output" != *"docker.io/debian:bullseye"* ]]
+    [[ "$output" != *"docker.io//debian:bullseye"* ]]
 }
 
 # BCU-15c: dedup by sync_image — entries with same sync_image path are deduplicated

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -122,8 +122,8 @@ EOF
 
 # --- collect_all_cache_images / _collect_entry_tags: new-style dest path ---
 
-# BCU-11: NEW-style entry → ghcr_image dest preserves source path (library/postgres)
-# ghcr_image must be ghcr.io/<owner>/library/postgres:<tag> — NOT ghcr.io/<owner>/postgres:<tag>
+# BCU-11: NEW-style entry → sync_image dest preserves source path (library/postgres)
+# sync_image must be ghcr.io/<owner>/library/postgres:<tag> — NOT ghcr.io/<owner>/postgres:<tag>
 @test "BCU-11: NEW-style collect_all_cache_images dest preserves full source path with slash" {
     mkdir -p pgcontainer
     cat > pgcontainer/variants.yaml <<'EOF'
@@ -142,14 +142,14 @@ EOF
 
     run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
     [ "$status" -eq 0 ]
-    # ghcr_image must contain the two-segment path library/postgres (NOT just postgres)
+    # sync_image must contain the two-segment path library/postgres (NOT just postgres)
     [[ "$output" == *"ghcr.io/myowner/library/postgres:"* ]]
     # Distinctness assertion: the path portion after owner must contain a '/'
     # i.e. library/postgres not just postgres
     [[ "$output" != *"ghcr.io/myowner/postgres:"* ]]
 }
 
-# BCU-12: OLD-style entry → ghcr_image dest uses ghcr_repo (regression lock)
+# BCU-12: OLD-style entry → sync_image dest uses ghcr_repo (regression lock)
 @test "BCU-12: OLD-style collect_all_cache_images dest uses ghcr_repo (regression lock)" {
     mkdir -p ubuntucontainer
     cat > ubuntucontainer/config.yaml <<'EOF'
@@ -168,7 +168,7 @@ EOF
     [[ "$output" == *"ghcr.io/myowner/ubuntu-base:latest"* ]]
 }
 
-# BCU-13: MIXED collect_all_cache_images — both old and new dests correct
+# BCU-13: MIXED collect_all_cache_images — both old and new sync_image dests correct
 @test "BCU-13: MIXED collect_all_cache_images — old uses ghcr_repo, new uses source path" {
     mkdir -p mixcontainer
     cat > mixcontainer/variants.yaml <<'EOF'
@@ -196,7 +196,102 @@ EOF
     [[ "$output" == *"ghcr.io/myowner/library/postgres:"* ]]
 }
 
-# --- F-001 discriminator robustness: empty-string and explicit-nil ghcr_repo ---
+# --- Leading-slash (chained-on-own-build) source path splitting ---
+
+# BCU-14: leading-slash source → sync_image has library/ prefix, probe_image is leaf-only
+@test "BCU-14: leading-slash source (/php) → sync_image uses library/php, probe_image uses php" {
+    mkdir -p wpcontainer
+    cat > wpcontainer/config.yaml <<'EOF'
+base_image_cache:
+  - source: /php
+    tags: ["latest"]
+EOF
+
+    local containers_json='["wpcontainer"]'
+    local versions_json='{"wpcontainer":"latest"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # sync_image must use library/ prefix (mirror dest)
+    [[ "$output" == *'"sync_image":"ghcr.io/myowner/library/php:latest"'* ]]
+    # probe_image must be leaf-only (project's published container)
+    [[ "$output" == *'"probe_image":"ghcr.io/myowner/php:latest"'* ]]
+    # Distinctness: sync_image must not equal the probe_image path
+    [[ "$output" != *'"sync_image":"ghcr.io/myowner/php:latest"'* ]]
+}
+
+# BCU-15: normal NEW-style source → sync_image == probe_image
+@test "BCU-15: normal NEW-style source (library/postgres) → sync_image equals probe_image" {
+    mkdir -p pgcontainer2
+    cat > pgcontainer2/variants.yaml <<'EOF'
+versions:
+  - tag: "18-alpine"
+EOF
+    cat > pgcontainer2/config.yaml <<'EOF'
+base_image_cache:
+  - source: library/postgres
+    tags_from_versions: true
+EOF
+
+    local containers_json='["pgcontainer2"]'
+    local versions_json='{"pgcontainer2":"18-alpine"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # Both fields must be identical for normal NEW-style entries
+    [[ "$output" == *'"sync_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
+    [[ "$output" == *'"probe_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
+}
+
+# BCU-15b: sync_base_images_to_ghcr with leading-slash source — source_ref normalised (no double slash)
+@test "BCU-15b: sync_base_images_to_ghcr leading-slash source — source_ref has no double slash" {
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            echo "MOCK_DOCKER_ARGS: $*"
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+
+    # Leading-slash source /php: sync target is library/php, source field is /php
+    local input='[{"source":"/php","tag":"latest","sync_image":"ghcr.io/myowner/library/php:latest","probe_image":"ghcr.io/myowner/php:latest"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 0 ]
+    # Source ref must be docker.io/php:latest (// normalized to /), NOT docker.io//php:latest
+    [[ "$output" == *"docker.io/php:latest"* ]]
+    [[ "$output" != *"docker.io//php:latest"* ]]
+    # Dest must be the sync_image (library/php path)
+    [[ "$output" == *"ghcr.io/myowner/library/php:latest"* ]]
+}
+
+# BCU-15c: dedup by sync_image — entries with same sync_image path are deduplicated
+@test "BCU-15c: collect_all_cache_images dedup uses sync_image field" {
+    mkdir -p dedup1 dedup2
+    cat > dedup1/config.yaml <<'EOF'
+base_image_cache:
+  - source: /php
+    tags: ["latest"]
+EOF
+    cat > dedup2/config.yaml <<'EOF'
+base_image_cache:
+  - source: library/php
+    tags: ["latest"]
+EOF
+
+    local containers_json='["dedup1","dedup2"]'
+    local versions_json='{"dedup1":"latest","dedup2":"latest"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # dedup1 sync_image=ghcr.io/myowner/library/php:latest
+    # dedup2 sync_image=ghcr.io/myowner/library/php:latest — same → deduped to 1 entry
+    local count
+    count=$(echo "$output" | jq 'length')
+    [ "$count" -eq 1 ]
+}
+
+# --- discriminator robustness: empty-string and explicit-nil ghcr_repo ---
 # These cases are fully covered via emit_reachable_cache_args + remote_cr_applicable tests below.
 
 # --- remote_cr_applicable: pure decision helper ---
@@ -632,7 +727,7 @@ EOF
     }
     export -f docker
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 0 ]
     [[ "$output" == *"docker.io/library/alpine:3.18"* ]]
@@ -651,7 +746,7 @@ EOF
     export -f docker
 
     # Source has no slash — should be auto-prefixed with library/
-    local input='[{"source":"alpine","tag":"3.18","ghcr_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
+    local input='[{"source":"alpine","tag":"3.18","sync_image":"ghcr.io/oorabona/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 0 ]
     [[ "$output" == *"docker.io/library/alpine:3.18"* ]]
@@ -668,7 +763,7 @@ EOF
     }
     export -f docker
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"},{"source":"library/postgres","tag":"18-alpine","ghcr_image":"ghcr.io/x/library/postgres:18-alpine"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"},{"source":"library/postgres","tag":"18-alpine","sync_image":"ghcr.io/x/library/postgres:18-alpine"}]'
     run sync_base_images_to_ghcr "$input"
     # Non-zero so the GitHub Actions UI surfaces the failure; the caller's
     # job-level `continue-on-error: true` keeps dependent jobs unblocked.
@@ -691,7 +786,7 @@ EOF
     }
     export -f docker
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 1 ]
     # The injected line must never appear at column 0 — every stderr line is
@@ -712,7 +807,7 @@ EOF
     }
     export -f docker
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 1 ]
     # The CR-injected `::stop-commands::` must not appear preceded by raw CR.
@@ -736,7 +831,7 @@ EOF
     local malicious_source="library/alpine"$'\n'"::stop-commands::xx"
     local input
     input=$(jq -nc --arg s "$malicious_source" \
-        '[{"source":$s,"tag":"3.18","ghcr_image":"ghcr.io/x/lib/a:3.18"}]')
+        '[{"source":$s,"tag":"3.18","sync_image":"ghcr.io/x/lib/a:3.18"}]')
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 1 ]
     # The injected `::stop-commands::xx` line must NOT appear as a standalone
@@ -844,7 +939,7 @@ EOF
     export -f docker
     export SLEEP_CMD=:
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/lib/a:3.18"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/lib/a:3.18"}]'
     local malicious_registry=$'docker.io\n::stop-commands::xx'
     run sync_base_images_to_ghcr "$input" "$malicious_registry"
     [ "$status" -eq 1 ]
@@ -863,7 +958,7 @@ EOF
     }
     export -f docker
 
-    local input='[{"source":"library/alpine","tag":"3.18","ghcr_image":"ghcr.io/x/library/alpine:3.18"}]'
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input" "127.0.0.1:5000"
     [ "$status" -eq 0 ]
     [[ "$output" == *"127.0.0.1:5000/library/alpine:3.18"* ]]

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -963,3 +963,48 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"127.0.0.1:5000/library/alpine:3.18"* ]]
 }
+
+# --- check_image construction guard (gate r3 fix — action.yaml ${source_path#/} strip) ---
+
+# BCU-ACTIONSTRIP-01: leading-slash source → probe_image has no double slash
+# Mirrors the action.yaml inline check_image construction: check_image="ghcr.io/${owner}/${source_path#/}:${tag}"
+# Without the #/ strip, source: /php would yield ghcr.io/owner//php:tag.
+@test "BCU-ACTIONSTRIP-01: leading-slash source (/php) → probe_image contains no double slash" {
+    mkdir -p wpstrip
+    cat > wpstrip/config.yaml <<'EOF'
+base_image_cache:
+  - source: /php
+    tags: ["8.2-fpm-alpine"]
+EOF
+
+    local containers_json='["wpstrip"]'
+    local versions_json='{"wpstrip":"latest"}'
+
+    run collect_all_cache_images "$containers_json" "$versions_json" "myowner"
+    [ "$status" -eq 0 ]
+    # probe_image must not contain double slash
+    [[ "$output" != *'"//'* ]]
+    # probe_image must be leaf-only (no leading slash, no library/ prefix)
+    [[ "$output" == *'"probe_image":"ghcr.io/myowner/php:8.2-fpm-alpine"'* ]]
+}
+
+# BCU-ACTIONSTRIP-02: bash strip pattern sanity — ${source_path#/} is idempotent for non-slash sources
+@test "BCU-ACTIONSTRIP-02: strip pattern \${source_path#/} is idempotent for normal (non-leading-slash) source" {
+    # Direct bash expansion check: verifies the fix applied in action.yaml does not
+    # mangle normal sources like "library/postgres".
+    local source_path="library/postgres"
+    local stripped="${source_path#/}"
+    [ "$stripped" = "library/postgres" ]
+
+    local check_image="ghcr.io/myowner/${source_path#/}:18-alpine"
+    [ "$check_image" = "ghcr.io/myowner/library/postgres:18-alpine" ]
+    [[ "$check_image" != *'//'* ]]
+}
+
+# BCU-ACTIONSTRIP-03: bash strip pattern — ${source_path#/} strips exactly the leading slash for /php
+@test "BCU-ACTIONSTRIP-03: strip pattern \${source_path#/} produces clean path for leading-slash source /php" {
+    local source_path="/php"
+    local check_image="ghcr.io/myowner/${source_path#/}:8.2-fpm-alpine"
+    [ "$check_image" = "ghcr.io/myowner/php:8.2-fpm-alpine" ]
+    [[ "$check_image" != *'//'* ]]
+}

--- a/tests/unit/validate-base-cache-schema.bats
+++ b/tests/unit/validate-base-cache-schema.bats
@@ -20,7 +20,11 @@
 #   VBC-11d: valid old-style with namespaced source (hashicorp/terraform) → PASS [regression lock]
 #   VBC-11e: valid new-style with non-library namespace (hashicorp/terraform) → PASS
 #   VBC-12: container dir name with slash → REJECT (defensive invariant)
-#   VBC-13: new-style source with leading slash → REJECT (empty path component)
+#   VBC-13: new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)
+#   VBC-13b: new-style source with leading slash (multi-segment /library/postgres) → PASS
+#   VBC-13c: wordpress-real: source: /php → PASS (regression lock for #531)
+#   VBC-13d: source: /php/ (trailing slash after leading slash) → REJECT
+#   VBC-13e: source: //php (double slash) → REJECT
 #   VBC-14: new-style source with trailing slash → REJECT (empty path component)
 #   VBC-R7C-GLOB-01: build_args value with glob * → REJECT (R7c allowlist)
 #   VBC-R7C-GLOB-02: build_args value with glob ? → REJECT (R7c allowlist)
@@ -287,10 +291,58 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-13: new-style source with leading slash → REJECT" {
+@test "VBC-13: new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)" {
+    make_container "myapp" "$(cat <<'EOF'
+base_image_cache:
+  - source: /php
+    tags: ["latest"]
+EOF
+)"
+    run validate_container_base_cache_schema "myapp"
+    [ "$status" -eq 0 ]
+}
+
+@test "VBC-13b: new-style source with leading slash (multi-segment /library/postgres) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: /library/postgres
+    tags: ["latest"]
+EOF
+)"
+    run validate_container_base_cache_schema "myapp"
+    [ "$status" -eq 0 ]
+}
+
+@test "VBC-13c: wordpress real config — source: /php → PASS (regression lock #531)" {
+    make_container "wordpress" "$(cat <<'EOF'
+base_image: "${REMOTE_CR}/php:${PHP_TAG}"
+base_image_cache:
+  - source: /php
+    tags: ["latest"]
+build_args:
+  PHP_TAG: "latest"
+EOF
+)"
+    run validate_container_base_cache_schema "wordpress"
+    [ "$status" -eq 0 ]
+}
+
+@test "VBC-13d: new-style source with trailing slash after leading slash (/php/) → REJECT" {
+    make_container "myapp" "$(cat <<'EOF'
+base_image_cache:
+  - source: /php/
+    tags: ["latest"]
+EOF
+)"
+    run validate_container_base_cache_schema "myapp"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "myapp" ]]
+}
+
+@test "VBC-13e: new-style source with double slash (//php) → REJECT" {
+    make_container "myapp" "$(cat <<'EOF'
+base_image_cache:
+  - source: //php
     tags: ["latest"]
 EOF
 )"

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,7 +1,8 @@
 # WordPress container based on our PHP image
 # All PHP extensions (gd, mysqli, opcache, zip) are already included
-ARG PHP_IMAGE
-FROM ${PHP_IMAGE}
+ARG REMOTE_CR=docker.io/oorabona
+ARG PHP_TAG
+FROM ${REMOTE_CR}/php:${PHP_TAG}
 
 # Switch to root for installation
 USER root

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -326,6 +326,8 @@ docker build \
 
 Chained-base container: consumes `ghcr.io/oorabona/php` (project-produced). Docker Hub mirror at `docker.io/oorabona/php` (429-rate-limited; default local fallback).
 
+`config.yaml` declares `source: /php` — the leading-slash marker signals "chained-on-own-build": sync writes to `ghcr.io/<owner>/library/php` (shared upstream mirror path), while reachability probing targets `ghcr.io/<owner>/php` (project's published container). This ensures `REMOTE_CR` is injected only when the project-produced PHP image is available.
+
 | Component | Version | Source | Monitoring |
 |-----------|---------|--------|------------|
 | PHP | latest | [oorabona/php](../php/) | Base image tag |

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -128,7 +128,8 @@ All variables support the `_FILE` suffix for Docker secrets (e.g. `WP_ADMIN_PASS
 
 | Argument | Description | Default |
 |----------|-------------|---------|
-| `PHP_IMAGE` | Base PHP-FPM image | `ghcr.io/oorabona/php:latest` |
+| `REMOTE_CR` | Registry root for the base PHP image | `docker.io/oorabona` |
+| `PHP_TAG` | Tag of the base PHP-FPM image | `latest` |
 | `WPCLI_VERSION` | WP-CLI version | `2.12.0` |
 | `VERSION` | WordPress version | latest |
 
@@ -314,13 +315,16 @@ WordPress 6.4+ introduced experimental SQLite support via a drop-in plugin. A fu
 
 # Build with specific versions
 docker build \
-  --build-arg PHP_IMAGE=ghcr.io/oorabona/php:latest \
+  --build-arg REMOTE_CR=ghcr.io/oorabona \
+  --build-arg PHP_TAG=latest \
   --build-arg WPCLI_VERSION=2.12.0 \
   --build-arg VERSION=6.9.1 \
   -t wordpress:custom .
 ```
 
 ## Dependencies
+
+Chained-base container: consumes `ghcr.io/oorabona/php` (project-produced). Docker Hub mirror at `docker.io/oorabona/php` (429-rate-limited; default local fallback).
 
 | Component | Version | Source | Monitoring |
 |-----------|---------|--------|------------|

--- a/wordpress/config.yaml
+++ b/wordpress/config.yaml
@@ -1,16 +1,12 @@
 # WordPress container configuration
 # Base image and third-party dependency versions
 
-base_image: "${PHP_IMAGE}"
+base_image: "${REMOTE_CR}/php:${PHP_TAG}"
 build_args:
-  PHP_IMAGE: "ghcr.io/oorabona/php:latest"
+  PHP_TAG: "latest"
   WPCLI_VERSION: "2.12.0"
   SQLITE_PLUGIN_VERSION: "2.2.23"
 dependency_sources:
-  PHP_IMAGE:
-    monitor: false
-    lifecycle: untracked
-    reason: "Base image fallback, not a version to track"
   WPCLI_VERSION:
     lifecycle: tracked
     type: github-release

--- a/wordpress/config.yaml
+++ b/wordpress/config.yaml
@@ -2,6 +2,9 @@
 # Base image and third-party dependency versions
 
 base_image: "${REMOTE_CR}/php:${PHP_TAG}"
+base_image_cache:
+  - source: php
+    tags: ["latest"]
 build_args:
   PHP_TAG: "latest"
   WPCLI_VERSION: "2.12.0"
@@ -17,4 +20,8 @@ dependency_sources:
     type: github-release
     repo: WordPress/sqlite-database-integration
     strip_v: true
+  PHP_TAG:
+    monitor: false
+    lifecycle: untracked
+    reason: "Base image tag for chained-base wordpress; follows project php container's latest stable PHP."
 value_proposition: WordPress with PHP-FPM, multi-version retention, ARM-native. Pre-built and SBOM-attested.

--- a/wordpress/config.yaml
+++ b/wordpress/config.yaml
@@ -3,7 +3,8 @@
 
 base_image: "${REMOTE_CR}/php:${PHP_TAG}"
 base_image_cache:
-  - source: php
+  - source: /php          # chained-on-own marker: sync upstream PHP into library/php cache,
+                          # but probe ghcr.io/<owner>/php (our customized published container)
     tags: ["latest"]
 build_args:
   PHP_TAG: "latest"


### PR DESCRIPTION
Closes #531

## Summary

Aligns wordpress with the `${REMOTE_CR}/<path>:${TAG}` pattern used by the other 13 containers (per #493). Wordpress was the last container still using `${PHP_IMAGE}` full-URL build-arg.

### Architectural extension: chained-on-own-build marker

Wordpress consumes our project-produced `ghcr.io/oorabona/php` container (NOT a Docker Hub library mirror like postgres/debian/alpine). This is the first chained-on-own-build container in the project. Existing `base_image_cache:` mechanism was designed for upstream library mirrors only.

This PR introduces a **leading-slash marker** semantic to express chained-on-own-build:

- `source: library/php` → mirror Docker Hub library/php to ghcr.io/<owner>/library/php (existing convention)
- `source: /php` → **chained-on-own-build**: probe ghcr.io/<owner>/php (project's published custom container); sync mirror at ghcr.io/<owner>/library/php (shared with library-mirror containers, idempotent)

### Changes

- **`helpers/validate-base-cache-schema.sh`**: relax R6 to allow leading slash as chained-on-own marker (trailing slash and double slash remain invalid).
- **`helpers/base-cache-utils.sh`**: split sync_image/probe_image fields in `_collect_entry_tags`. For chained markers, sync_image lands at `library/<leaf>` (idempotent with library-mirror containers); probe_image is leaf-only. Multi-segment guard prevents `library/library/X` doubling.
- **`.github/actions/build-container/action.yaml`**: strip leading slash at check_image construction (`${source_path#/}`).
- **`scripts/audit-base-image-cache.sh`**: strip leading slash in `is_cached()` comparison.
- **`wordpress/config.yaml`**: `base_image: "${REMOTE_CR}/php:${PHP_TAG}"`; `base_image_cache: [{source: /php, tags: [latest]}]`; `dependency_sources.PHP_TAG: { lifecycle: untracked }`.
- **`wordpress/Dockerfile`**: `ARG REMOTE_CR=docker.io/oorabona` (owner segment required), `ARG PHP_TAG`, `FROM ${REMOTE_CR}/php:${PHP_TAG}`.

### Path resolution

- **CI** (REMOTE_CR=ghcr.io/oorabona via emit_reachable_cache_args after probe): `ghcr.io/oorabona/php:latest` (project's published custom container).
- **Local fallback**: `docker.io/oorabona/php:latest` (project's Docker Hub mirror, same content; 429-risk acceptable per dual-publish architecture).

### Foundation for #532

The probe path `ghcr.io/oorabona/php` becomes trackable by future digest drift detection (#532). When the project rebuilds php → fresh digest → wordpress drift detected → auto-PR for wordpress rebuild → chain rebuild emerges naturally over 2 daily cycles.

### Pre-PR orthogonal gate

5 rounds (codex xhigh + copilot in parallel). Each round caught real defects with regression tests:
- r1: missing dependency_sources.PHP_TAG + missing base_image_cache → fixed e81d7aa
- r2: schema R6 strict + sync-helper double-owner bug → architectural marker design (efef3ab + 24a8518)
- r3: action.yaml check_image not stripping leading slash → fixed 33c47b1
- r4: audit script not stripping + multi-segment library doubling → fixed 43b25b1
- r5: CLEAN both engines

### Tests

71+ bats tests across audit + base-cache-utils + validate-base-cache-schema (4 new regression test pairs added for the chained marker).

## Test plan

- [ ] CI passes (lint, typecheck, bats, shellcheck)
- [ ] Wordpress build smoke: `./make build wordpress` produces image with `ghcr.io/oorabona/php` as base (when REMOTE_CR=ghcr.io/oorabona is set)
- [ ] audit-base-image-cache reports wordpress as cached (no UNCACHED gap)
- [ ] No regression on other containers (postgres, debian, ansible, etc.) using library/ paths
