### PR TITLE
feat(ci): #532 universal base-image digest drift detection cron

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1255,6 +1255,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      packages: read  # Required: detect-base-digest-drift.sh re-runs inside this job and probes GHCR digests
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1126,7 +1126,12 @@ jobs:
     # upstream rebase that happened since the previous sync would be invisible for
     # the current day's run.
     needs: [create-dependency-update-prs, sync-base-images]
-    if: always()
+    # Run when sync-base-images succeeded (probes compare fresh GHCR state) or
+    # was skipped (e.g. workflow_dispatch without sync step).  Do NOT run when
+    # sync-base-images failed: stale mirror would produce silent misreports.
+    if: |
+      needs.sync-base-images.result == 'success' ||
+      needs.sync-base-images.result == 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)
@@ -1135,6 +1140,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: read
+      packages: read
     outputs:
       drift_containers: ${{ steps.detect.outputs.drift_containers }}
     steps:
@@ -1246,6 +1252,25 @@ jobs:
           path: .build-lineage
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
+
+      - name: Log in to Docker Hub
+        # Re-detect probes registry anonymously without this; anonymous Docker Hub
+        # requests are rate-limited and can silently fail → false "no drift" result.
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Log in to GitHub Container Registry
+        # Required when base_image_ref points to the GHCR mirror (ghcr.io/owner/*).
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
       - name: Re-detect drift for this container (idempotent)
         id: drift-data

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1121,7 +1121,11 @@ jobs:
 
   detect-digest-drift:
     name: Detect base image digest drift
-    needs: [create-dependency-update-prs]
+    # Wait for sync-base-images so probes compare against today's freshly-synced
+    # GHCR mirror rather than yesterday's copy.  Without this ordering, a real
+    # upstream rebase that happened since the previous sync would be invisible for
+    # the current day's run.
+    needs: [create-dependency-update-prs, sync-base-images]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1145,16 +1149,49 @@ jobs:
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
 
+      - name: Log in to Docker Hub
+        # Authenticated probes avoid 429 rate-limiting that would silently drop
+        # drift signals for busy Docker Hub images.
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Log in to GitHub Container Registry
+        # GHCR login avoids rate-limiting for base_image_ref values pointing at
+        # the GHCR mirror (ghcr.io/owner/*).
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
       - name: Detect drift
         id: detect
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
-          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/dev/null)
+          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/tmp/drift-detect-stderr.log)
 
           echo "$drift_json" > /tmp/drift.json
+
+          # Surface any probe errors so supply-chain monitoring failures are visible
+          error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' || echo 0)
+          if [[ "$error_count" -gt 0 ]]; then
+            echo "::warning::${error_count} digest probe(s) failed — drift may be undetected for those variants"
+            while IFS= read -r line; do
+              echo "::warning::probe-error: ${line}"
+            done < <(echo "$drift_json" | jq -r '[.[] | .variants[] | select(.status == "error") | "\(.variant_tag): \(.error_reason // "unknown")"][]' 2>/dev/null || true)
+          fi
+
+          # Also surface any ::error:: lines from the script's stderr
+          if [[ -s /tmp/drift-detect-stderr.log ]]; then
+            while IFS= read -r line; do
+              echo "$line"
+            done < /tmp/drift-detect-stderr.log >&2
+          fi
 
           # Extract container names with actionable drift (drift or legacy status)
           drift_containers=$(echo "$drift_json" | jq -c \
@@ -1280,6 +1317,20 @@ jobs:
           } > "$pr_body_file"
 
           echo "pr_body_file=${pr_body_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Import GPG key
+        # Repo requires signed commits (SECURITY.md §branch-protection). Mirror the
+        # pattern used by the dep-monitor PR step (lines ~467, ~1008) to ensure
+        # drift PRs also satisfy the signed-commit requirement.
+        if: steps.drift-data.outputs.has_drift == 'true'
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: Olivier ORABONA
+          git_committer_email: oorabona@users.noreply.github.com
 
       - name: Open or update PR (branch-upsert)
         if: steps.drift-data.outputs.has_drift == 'true'

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1236,7 +1236,7 @@ jobs:
           # ::error::probe-error: lines for each failed probe.
           if [[ -s /tmp/drift-detect-stderr.log ]]; then
             while IFS= read -r line; do
-              echo "$line"
+              printf '%s\n' "$line"
             done < /tmp/drift-detect-stderr.log >&2
           fi
 

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1222,25 +1222,34 @@ jobs:
         id: detect
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
-          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/tmp/drift-detect-stderr.log)
+          detect_rc=0
+          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/tmp/drift-detect-stderr.log) || detect_rc=$?
+
+          # Always replay buffered stderr — per-variant ::error:: diagnostics must
+          # be visible regardless of whether the detector succeeded or failed.
+          # Under bash -e, the bare command substitution above would abort the step
+          # immediately on non-zero exit, leaving the replay block unreachable.
+          # Capturing the exit code first ensures the replay always runs.
+          if [[ -s /tmp/drift-detect-stderr.log ]]; then
+            while IFS= read -r line; do
+              printf '%s\n' "$line"
+            done < /tmp/drift-detect-stderr.log >&2
+          fi
+
+          if [[ $detect_rc -ne 0 ]]; then
+            echo "::error::Drift detector failed with exit code $detect_rc" >&2
+            exit $detect_rc
+          fi
 
           echo "$drift_json" > /tmp/drift.json
 
           # Surface probe error count; per-variant ::error:: lines are already
-          # emitted by the script itself (escaped) and passed through via stderr below.
+          # emitted by the script itself (escaped) and passed through via stderr above.
           # Do NOT re-compose warning lines from drift_json fields here — those fields
           # are untrusted lineage data and would reintroduce GHA command injection.
           error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' || echo 0)
           if [[ "$error_count" -gt 0 ]]; then
             echo "::warning::${error_count} digest probe(s) failed — drift may be undetected for those variants (see ::error:: lines above)"
-          fi
-
-          # Pass through script's stderr unchanged — it already contains escaped
-          # ::error::probe-error: lines for each failed probe.
-          if [[ -s /tmp/drift-detect-stderr.log ]]; then
-            while IFS= read -r line; do
-              printf '%s\n' "$line"
-            done < /tmp/drift-detect-stderr.log >&2
           fi
 
           # Validate drift_json shape before downstream use.  An invalid JSON

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1118,3 +1118,191 @@ jobs:
           echo "   Updates: $UPDATE_COUNT"
           echo "   Max severity: $MAX_SEVERITY"
           echo "   Branch: update/${CONTAINER}-deps"
+
+  detect-digest-drift:
+    name: Detect base image digest drift
+    needs: [create-dependency-update-prs]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)
+    concurrency:
+      group: digest-drift-detect
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    outputs:
+      drift_containers: ${{ steps.detect.outputs.drift_containers }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Restore lineage cache
+        # Cache miss is acceptable — script handles empty dir gracefully (emits warning)
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build-lineage
+          key: build-lineage-${{ github.run_id }}
+          restore-keys: build-lineage-
+
+      - name: Detect drift
+        id: detect
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          chmod +x scripts/detect-base-digest-drift.sh
+          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/dev/null)
+
+          echo "$drift_json" > /tmp/drift.json
+
+          # Extract container names with actionable drift (drift or legacy status)
+          drift_containers=$(echo "$drift_json" | jq -c \
+            '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
+            || echo "[]")
+          echo "drift_containers=${drift_containers}" >> "$GITHUB_OUTPUT"
+
+          count=$(echo "$drift_containers" | jq 'length')
+          if [[ "$count" -gt 0 ]]; then
+            echo "::notice::Digest drift detected for ${count} container(s): ${drift_containers}"
+          else
+            echo "::notice::No base image digest drift detected"
+          fi
+
+  open-drift-prs:
+    name: Open drift PR for ${{ matrix.container }}
+    needs: [detect-digest-drift]
+    if: |
+      needs.detect-digest-drift.result == 'success' &&
+      needs.detect-digest-drift.outputs.drift_containers != '[]' &&
+      needs.detect-digest-drift.outputs.drift_containers != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        container: ${{ fromJson(needs.detect-digest-drift.outputs.drift_containers) }}
+      max-parallel: 1   # Serialize: same pattern as create-dependency-update-prs
+      fail-fast: false  # One container's transient failure must not block others
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # App token required: GITHUB_TOKEN-authored PRs do not trigger downstream
+      # workflows (auto-build smoke check) by GitHub design.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Restore lineage cache
+        # Separate restore per matrix job: detect-digest-drift ran on a different runner.
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build-lineage
+          key: build-lineage-${{ github.run_id }}
+          restore-keys: build-lineage-
+
+      - name: Re-detect drift for this container (idempotent)
+        id: drift-data
+        env:
+          CONTAINER: ${{ matrix.container }}
+        run: |
+          chmod +x scripts/detect-base-digest-drift.sh
+          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/dev/null)
+          echo "$drift_json" > /tmp/drift.json
+
+          # Check if this container actually has actionable drift
+          has_drift=$(echo "$drift_json" | jq --arg c "$CONTAINER" \
+            '[.[] | select(.container == $c) | .variants[] | select(.status == "drift" or .status == "legacy")] | length > 0')
+          echo "has_drift=${has_drift}" >> "$GITHUB_OUTPUT"
+
+      - name: Update LAST_REBUILD.md tracker
+        if: steps.drift-data.outputs.has_drift == 'true'
+        env:
+          CONTAINER: ${{ matrix.container }}
+        run: |
+          chmod +x scripts/update-last-rebuild.sh
+          < /tmp/drift.json ./scripts/update-last-rebuild.sh "$CONTAINER" "base-digest-drift"
+
+      - name: Build PR body
+        if: steps.drift-data.outputs.has_drift == 'true'
+        id: pr-body
+        env:
+          CONTAINER: ${{ matrix.container }}
+        run: |
+          drift_json=$(cat /tmp/drift.json)
+          today=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          variants=$(echo "$drift_json" | jq -c \
+            --arg c "$CONTAINER" \
+            '[.[] | select(.container == $c) | .variants[] | select(.status == "drift" or .status == "legacy")]')
+
+          variants_drifted=$(echo "$variants" | jq 'length')
+          variants_total=$(echo "$drift_json" | jq --arg c "$CONTAINER" \
+            '[.[] | select(.container == $c) | .variants[]] | length')
+
+          pr_body_file="/tmp/pr-body-${CONTAINER}.md"
+
+          # YAML frontmatter (machine-parseable for downstream tooling)
+          {
+            printf 'drift_kind: base-digest\n'
+            printf 'container: %s\n' "$CONTAINER"
+            printf 'detected_at: %s\n' "$today"
+            printf 'variants_drifted: %s\n' "$variants_drifted"
+            printf 'variants_total: %s\n' "$variants_total"
+          } > /tmp/pr-frontmatter.txt
+
+          # Build variant table (injection-safe: values come from jq --arg)
+          printf '| Variant tag | Base image ref | Old digest | New digest |\n' > /tmp/pr-table.txt
+          printf '|-------------|----------------|------------|------------|\n' >> /tmp/pr-table.txt
+          echo "$variants" | jq -r \
+            '.[] | "| \(.variant_tag) | \(.base_image_ref) | \(.recorded_digest // "unknown") | \(.current_digest // "(legacy)") |"' \
+            >> /tmp/pr-table.txt
+
+          {
+            printf -- '---\n'
+            cat /tmp/pr-frontmatter.txt
+            printf -- '---\n\n'
+            printf '# Base image digest drift — %s\n\n' "$CONTAINER"
+            cat /tmp/pr-table.txt
+            printf '\n## Action\n\n'
+            printf 'Merging this PR appends a `## base-digest-drift` section to `%s/LAST_REBUILD.md`, which triggers `auto-build.yaml` via path filter. The rebuild captures the fresh base digest in the new lineage entry. Next-day cron sees match → no further drift PR.\n' "$CONTAINER"
+            printf '\n## Chained-on-own note\n\n'
+            printf "If \`%s\`'s base image is another project-produced container with an open base-digest-drift PR, prefer merging the upstream PR first to avoid a 2-day cascade.\n" "$CONTAINER"
+          } > "$pr_body_file"
+
+          echo "pr_body_file=${pr_body_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update PR (branch-upsert)
+        if: steps.drift-data.outputs.has_drift == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # No date suffix in branch name → peter-evans upserts on re-run (idempotent dedup)
+          branch: update/base-digest-${{ matrix.container }}
+          delete-branch: true
+          commit-message: "build(${{ matrix.container }}): base image digest drift — trigger rebuild"
+          committer: Olivier ORABONA <oorabona@users.noreply.github.com>
+          title: "📦 base-digest-drift(${{ matrix.container }}): upstream base image rebase"
+          body-path: ${{ steps.pr-body.outputs.pr_body_file }}
+
+      # Labels applied separately — peter-evans/create-pull-request has a race condition
+      # where addLabels fails with "Could not resolve to a node" on fresh PRs
+      - name: Apply labels
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          CONTAINER: ${{ matrix.container }}
+        run: |
+          sleep 2
+          gh pr edit "$PR_NUMBER" --add-label "base-digest-drift,automation,container:${CONTAINER}"

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -679,7 +679,7 @@ jobs:
           source ./helpers/base-cache-utils.sh
 
           # Discover all containers and their current versions
-          containers_json=$(./make list 2>/dev/null | jq -Rc '[inputs]' || echo '[]')
+          containers_json=$(./make list 2>/dev/null | jq -Rnc '[inputs]' || echo '[]')
 
           versions_json="{}"
           for c in $(echo "$containers_json" | jq -r '.[]'); do
@@ -1315,8 +1315,11 @@ jobs:
           ./scripts/detect-base-digest-drift.sh > "$drift_file" || true
           drift_json=$(cat "$drift_file")
 
-          # Fix r7-2: check for probe errors; distinguish from "no drift"
-          error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' 2>/dev/null || echo 0)
+          # Fix r8-2: scope error_count to current matrix container only.
+          # Without the .container filter, a transient probe failure on any
+          # unrelated container blocks PR creation for every other container.
+          error_count=$(echo "$drift_json" | jq --arg c "${{ matrix.container }}" \
+            '[.[] | select(.container == $c) | .variants[] | select(.status == "error")] | length' 2>/dev/null || echo 0)
           if [[ "$error_count" -gt 0 ]]; then
             echo "::error::re-detect probe failed for $CONTAINER (${error_count} variant(s) errored) — skipping PR but not silently" >&2
             exit 1

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1201,16 +1201,17 @@ jobs:
 
           echo "$drift_json" > /tmp/drift.json
 
-          # Surface any probe errors so supply-chain monitoring failures are visible
+          # Surface probe error count; per-variant ::error:: lines are already
+          # emitted by the script itself (escaped) and passed through via stderr below.
+          # Do NOT re-compose warning lines from drift_json fields here — those fields
+          # are untrusted lineage data and would reintroduce GHA command injection.
           error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' || echo 0)
           if [[ "$error_count" -gt 0 ]]; then
-            echo "::warning::${error_count} digest probe(s) failed — drift may be undetected for those variants"
-            while IFS= read -r line; do
-              echo "::warning::probe-error: ${line}"
-            done < <(echo "$drift_json" | jq -r '[.[] | .variants[] | select(.status == "error") | "\(.variant_tag): \(.error_reason // "unknown")"][]' 2>/dev/null || true)
+            echo "::warning::${error_count} digest probe(s) failed — drift may be undetected for those variants (see ::error:: lines above)"
           fi
 
-          # Also surface any ::error:: lines from the script's stderr
+          # Pass through script's stderr unchanged — it already contains escaped
+          # ::error::probe-error: lines for each failed probe.
           if [[ -s /tmp/drift-detect-stderr.log ]]; then
             while IFS= read -r line; do
               echo "$line"
@@ -1239,13 +1240,13 @@ jobs:
       needs.detect-digest-drift.outputs.drift_containers != ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Fix 3: extend the concurrency lock that guards detect-digest-drift to
-    # cover open-drift-prs as well.  Without this a second cron/dispatch run
-    # could start open-drift-prs while the first run's open-drift-prs is still
-    # running, causing branch-name races, label conflicts, and duplicate PRs.
-    # Same group name serialises the whole detect→PR pipeline as a pair.
+    # Per-container concurrency lane: each matrix entry gets its own group so
+    # GitHub's 1-running-1-pending limit does not cancel pending drift PRs for
+    # other containers when multiple containers drift simultaneously.
+    # The broader digest-drift-detect group (on detect-digest-drift job) still
+    # serialises the detect phase across concurrent workflow runs.
     concurrency:
-      group: digest-drift-detect
+      group: digest-drift-${{ matrix.container }}
       cancel-in-progress: false
     strategy:
       matrix:

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1203,6 +1203,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - name: Install yq
         shell: bash
         run: |
@@ -1321,6 +1324,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Install yq
         shell: bash

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1125,13 +1125,15 @@ jobs:
     # GHCR mirror rather than yesterday's copy.  Without this ordering, a real
     # upstream rebase that happened since the previous sync would be invisible for
     # the current day's run.
-    needs: [create-dependency-update-prs, sync-base-images]
-    # Run when sync-base-images succeeded (probes compare fresh GHCR state) or
-    # was skipped (e.g. workflow_dispatch without sync step).  Do NOT run when
-    # sync-base-images failed: stale mirror would produce silent misreports.
-    if: |
-      needs.sync-base-images.result == 'success' ||
-      needs.sync-base-images.result == 'skipped'
+    # NOTE: create-dependency-update-prs is intentionally NOT in needs — drift
+    # detection is independent of dep-PR fanout.  Including it would silently
+    # skip drift detection whenever skip_dep_fanout (or equivalent) is set.
+    needs: [sync-base-images]
+    # Run only when sync-base-images succeeded (probes compare fresh GHCR state).
+    # 'skipped' is NOT allowed: if sync was skipped the mirror may be stale,
+    # producing silent misreports.  Scheduled cron always runs sync; for manual
+    # workflow_dispatch runs, sync must also complete before drift detection runs.
+    if: needs.sync-base-images.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1260,6 +1260,19 @@ jobs:
             exit 1
           fi
 
+          # Scope to requested container when workflow_dispatch.inputs.container is set.
+          # Older jobs in this workflow already honor this input; apply the same
+          # filter here so a manual run for one container does not fan out drift
+          # PRs across all drifting containers.
+          if [[ -n "${{ inputs.container }}" ]]; then
+            drift_json=$(echo "$drift_json" | jq --arg c "${{ inputs.container }}" '[.[] | select(.container == $c)]')
+            if [[ "$(echo "$drift_json" | jq 'length')" == "0" ]]; then
+              echo "::notice::No drift detected for requested container ${{ inputs.container }}"
+              echo "drift_containers=[]" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # Extract container names with actionable drift (drift or legacy status)
           drift_containers=$(echo "$drift_json" | jq -c \
             '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1208,8 +1208,10 @@ jobs:
         run: |
           # Install yq on PATH (mikefarah/yq action only runs yq inside the
           # action itself, it does NOT put yq on PATH for subsequent steps).
-          # Mirror the pattern used in create-update-prs.
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+          # Use checksum-verified version from create-update-prs to prevent tampering.
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
           sudo chmod +x /usr/local/bin/yq
           yq --version
 
@@ -1323,8 +1325,11 @@ jobs:
       - name: Install yq
         shell: bash
         run: |
-          # Install yq on PATH for list-builds calls.
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+          # Install yq on PATH for list-builds calls. Use checksum-verified
+          # version to prevent tampering in this write-capable workflow.
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
           sudo chmod +x /usr/local/bin/yq
           yq --version
 

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1153,13 +1153,12 @@ jobs:
     # detection is independent of dep-PR fanout.  Including it would silently
     # skip drift detection whenever skip_dep_fanout (or equivalent) is set.
     needs: [sync-base-images]
-    # Run only when sync-base-images truly succeeded (probes compare fresh GHCR
-    # state).  Checking the explicit output guards against continue-on-error
-    # swallowing real sync failures: result=='success' can be true even when the
-    # sync step exited non-zero; sync_succeeded=='true' is set only when the
-    # sync_base_images_to_ghcr call returns 0.  'skipped' is NOT allowed: if
-    # sync was skipped the mirror may be stale, producing silent misreports.
-    if: needs.sync-base-images.outputs.sync_succeeded == 'true'
+    # No `if:` gate on sync_succeeded: drift detection probes UPSTREAM via
+    # `buildx imagetools inspect` and does NOT read from the local GHCR mirror
+    # that sync-base-images populates.  The two jobs are orthogonal.  Gating on
+    # sync_succeeded caused one transient per-image 429/blip to skip drift
+    # detection for ALL containers — a silent miss repo-wide.  `needs` is kept
+    # for ordering (run after sync attempts), but outcome does not matter.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -638,6 +638,10 @@ jobs:
     # tag, and the per-image ::warning:: lines from the helper provide the
     # signal for maintainer attention.
     continue-on-error: true
+    # Fix 2: expose explicit sync status so detect-digest-drift can distinguish
+    # a real success from a continue-on-error-swallowed failure.
+    outputs:
+      sync_succeeded: ${{ steps.sync.outputs.success }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -666,6 +670,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Sync base images to GHCR (all containers)
+        id: sync
         shell: bash
         env:
           OWNER: ${{ github.repository_owner }}
@@ -684,7 +689,16 @@ jobs:
           done
 
           images=$(collect_all_cache_images "$containers_json" "$versions_json" "$OWNER")
-          sync_base_images_to_ghcr "$images"
+          # Fix 2: capture real sync exit code so the output is accurate even
+          # when the job succeeds via continue-on-error swallowing failures.
+          sync_rc=0
+          sync_base_images_to_ghcr "$images" || sync_rc=$?
+          if [[ "$sync_rc" -eq 0 ]]; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit "$sync_rc"
+          fi
 
   # Check 3rd party dependency versions (runs in parallel with base image checks)
   check-dependency-updates:
@@ -1129,11 +1143,13 @@ jobs:
     # detection is independent of dep-PR fanout.  Including it would silently
     # skip drift detection whenever skip_dep_fanout (or equivalent) is set.
     needs: [sync-base-images]
-    # Run only when sync-base-images succeeded (probes compare fresh GHCR state).
-    # 'skipped' is NOT allowed: if sync was skipped the mirror may be stale,
-    # producing silent misreports.  Scheduled cron always runs sync; for manual
-    # workflow_dispatch runs, sync must also complete before drift detection runs.
-    if: needs.sync-base-images.result == 'success'
+    # Run only when sync-base-images truly succeeded (probes compare fresh GHCR
+    # state).  Checking the explicit output guards against continue-on-error
+    # swallowing real sync failures: result=='success' can be true even when the
+    # sync step exited non-zero; sync_succeeded=='true' is set only when the
+    # sync_base_images_to_ghcr call returns 0.  'skipped' is NOT allowed: if
+    # sync was skipped the mirror may be stale, producing silent misreports.
+    if: needs.sync-base-images.outputs.sync_succeeded == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)
@@ -1223,6 +1239,14 @@ jobs:
       needs.detect-digest-drift.outputs.drift_containers != ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Fix 3: extend the concurrency lock that guards detect-digest-drift to
+    # cover open-drift-prs as well.  Without this a second cron/dispatch run
+    # could start open-drift-prs while the first run's open-drift-prs is still
+    # running, causing branch-name races, label conflicts, and duplicate PRs.
+    # Same group name serialises the whole detect→PR pipeline as a pair.
+    concurrency:
+      group: digest-drift-detect
+      cancel-in-progress: false
     strategy:
       matrix:
         container: ${{ fromJson(needs.detect-digest-drift.outputs.drift_containers) }}

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1306,29 +1306,45 @@ jobs:
           CONTAINER: ${{ matrix.container }}
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
-          drift_json=$(./scripts/detect-base-digest-drift.sh 2>/dev/null)
-          echo "$drift_json" > /tmp/drift.json
+          # Fix r7-3: unique temp paths per matrix entry — no cross-container contamination
+          # across sequential runs on the same runner.
+          drift_file="/tmp/drift-${{ github.run_id }}-${{ matrix.container }}.json"
+          # Fix r7-2: stdout → file, stderr flows to GHA log (NOT discarded).
+          # Probe errors surface as ::error:: lines in the step log AND as
+          # status:error records in the JSON — both are now visible.
+          ./scripts/detect-base-digest-drift.sh > "$drift_file" || true
+          drift_json=$(cat "$drift_file")
+
+          # Fix r7-2: check for probe errors; distinguish from "no drift"
+          error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' 2>/dev/null || echo 0)
+          if [[ "$error_count" -gt 0 ]]; then
+            echo "::error::re-detect probe failed for $CONTAINER (${error_count} variant(s) errored) — skipping PR but not silently" >&2
+            exit 1
+          fi
 
           # Check if this container actually has actionable drift
           has_drift=$(echo "$drift_json" | jq --arg c "$CONTAINER" \
             '[.[] | select(.container == $c) | .variants[] | select(.status == "drift" or .status == "legacy")] | length > 0')
           echo "has_drift=${has_drift}" >> "$GITHUB_OUTPUT"
+          echo "drift_file=${drift_file}" >> "$GITHUB_OUTPUT"
 
       - name: Update LAST_REBUILD.md tracker
         if: steps.drift-data.outputs.has_drift == 'true'
         env:
           CONTAINER: ${{ matrix.container }}
+          DRIFT_FILE: ${{ steps.drift-data.outputs.drift_file }}
         run: |
           chmod +x scripts/update-last-rebuild.sh
-          < /tmp/drift.json ./scripts/update-last-rebuild.sh "$CONTAINER" "base-digest-drift"
+          < "$DRIFT_FILE" ./scripts/update-last-rebuild.sh "$CONTAINER" "base-digest-drift"
 
       - name: Build PR body
         if: steps.drift-data.outputs.has_drift == 'true'
         id: pr-body
         env:
           CONTAINER: ${{ matrix.container }}
+          DRIFT_FILE: ${{ steps.drift-data.outputs.drift_file }}
         run: |
-          drift_json=$(cat /tmp/drift.json)
+          drift_json=$(cat "$DRIFT_FILE")
           today=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           variants=$(echo "$drift_json" | jq -c \
@@ -1339,7 +1355,10 @@ jobs:
           variants_total=$(echo "$drift_json" | jq --arg c "$CONTAINER" \
             '[.[] | select(.container == $c) | .variants[]] | length')
 
-          pr_body_file="/tmp/pr-body-${CONTAINER}.md"
+          # Fix r7-3: unique per-matrix temp paths — no cross-container contamination
+          pr_body_file="/tmp/pr-body-${{ github.run_id }}-${CONTAINER}.md"
+          pr_frontmatter_file="/tmp/pr-frontmatter-${{ github.run_id }}-${CONTAINER}.txt"
+          pr_table_file="/tmp/pr-table-${{ github.run_id }}-${CONTAINER}.txt"
 
           # YAML frontmatter (machine-parseable for downstream tooling)
           {
@@ -1348,21 +1367,21 @@ jobs:
             printf 'detected_at: %s\n' "$today"
             printf 'variants_drifted: %s\n' "$variants_drifted"
             printf 'variants_total: %s\n' "$variants_total"
-          } > /tmp/pr-frontmatter.txt
+          } > "$pr_frontmatter_file"
 
           # Build variant table (injection-safe: values come from jq --arg)
-          printf '| Variant tag | Base image ref | Old digest | New digest |\n' > /tmp/pr-table.txt
-          printf '|-------------|----------------|------------|------------|\n' >> /tmp/pr-table.txt
+          printf '| Variant tag | Base image ref | Old digest | New digest |\n' > "$pr_table_file"
+          printf '|-------------|----------------|------------|------------|\n' >> "$pr_table_file"
           echo "$variants" | jq -r \
             '.[] | "| \(.variant_tag) | \(.base_image_ref) | \(.recorded_digest // "unknown") | \(.current_digest // "(legacy)") |"' \
-            >> /tmp/pr-table.txt
+            >> "$pr_table_file"
 
           {
             printf -- '---\n'
-            cat /tmp/pr-frontmatter.txt
+            cat "$pr_frontmatter_file"
             printf -- '---\n\n'
             printf '# Base image digest drift — %s\n\n' "$CONTAINER"
-            cat /tmp/pr-table.txt
+            cat "$pr_table_file"
             printf '\n## Action\n\n'
             printf 'Merging this PR appends a `## base-digest-drift` section to `%s/LAST_REBUILD.md`, which triggers `auto-build.yaml` via path filter. The rebuild captures the fresh base digest in the new lineage entry. Next-day cron sees match → no further drift PR.\n' "$CONTAINER"
             printf '\n## Chained-on-own note\n\n'

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1204,9 +1204,14 @@ jobs:
         continue-on-error: true
 
       - name: Install yq
-        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
-        with:
-          cmd: yq --version
+        shell: bash
+        run: |
+          # Install yq on PATH (mikefarah/yq action only runs yq inside the
+          # action itself, it does NOT put yq on PATH for subsequent steps).
+          # Mirror the pattern used in create-update-prs.
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
 
       - name: Detect drift
         id: detect
@@ -1316,9 +1321,12 @@ jobs:
         continue-on-error: true
 
       - name: Install yq
-        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
-        with:
-          cmd: yq --version
+        shell: bash
+        run: |
+          # Install yq on PATH for list-builds calls.
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
 
       - name: Re-detect drift for this container (idempotent)
         id: drift-data

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1220,6 +1220,11 @@ jobs:
 
       - name: Detect drift
         id: detect
+        env:
+          # SECURITY: user-supplied workflow_dispatch input exposed via env-block
+          # to prevent GHA expression injection in the run: shell body.
+          # Never reference ${{ inputs.container }} inside run: directly.
+          REQUESTED_CONTAINER: ${{ inputs.container }}
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
           detect_rc=0
@@ -1264,10 +1269,22 @@ jobs:
           # Older jobs in this workflow already honor this input; apply the same
           # filter here so a manual run for one container does not fan out drift
           # PRs across all drifting containers.
-          if [[ -n "${{ inputs.container }}" ]]; then
-            drift_json=$(echo "$drift_json" | jq --arg c "${{ inputs.container }}" '[.[] | select(.container == $c)]')
+          #
+          # SECURITY: inputs.container is a workflow_dispatch user-supplied string.
+          # Interpolating ${{ inputs.container }} directly inside the shell body of
+          # a `run:` block allows injection — a value like `foo" ]]; then cmd; #`
+          # is substituted BEFORE bash parses the script.  Canonical GHA mitigation:
+          # expose via `env:` (set above as REQUESTED_CONTAINER) so the value is
+          # treated as data, never as code.  See OWASP / GitHub security hardening
+          # docs on "Untrusted input in workflow expressions".
+          if [[ -n "$REQUESTED_CONTAINER" ]]; then
+            drift_json=$(echo "$drift_json" | jq --arg c "$REQUESTED_CONTAINER" '[.[] | select(.container == $c)]')
             if [[ "$(echo "$drift_json" | jq 'length')" == "0" ]]; then
-              echo "::notice::No drift detected for requested container ${{ inputs.container }}"
+              # Escape for GHA ::notice:: — %0A in value would inject a new command.
+              _escaped_container="${REQUESTED_CONTAINER//%/%25}"
+              _escaped_container="${_escaped_container//$'\n'/%0A}"
+              _escaped_container="${_escaped_container//$'\r'/%0D}"
+              echo "::notice::No drift detected for requested container ${_escaped_container}"
               echo "drift_containers=[]" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1243,6 +1243,14 @@ jobs:
             done < /tmp/drift-detect-stderr.log >&2
           fi
 
+          # Validate drift_json shape before downstream use.  An invalid JSON
+          # payload (e.g. from a poisoned lineage entry) must fail loudly rather
+          # than silently masking drift as "no containers need rebuild".
+          if ! jq_err=$(jq -e . <<<"$drift_json" 2>&1 >/dev/null); then
+            echo "::error::Drift JSON is invalid; lineage may be corrupted: ${jq_err}" >&2
+            exit 1
+          fi
+
           # Extract container names with actionable drift (drift or legacy status)
           drift_containers=$(echo "$drift_json" | jq -c \
             '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -678,8 +678,19 @@ jobs:
           set -euo pipefail
           source ./helpers/base-cache-utils.sh
 
-          # Discover all containers and their current versions
-          containers_json=$(./make list 2>/dev/null | jq -Rnc '[inputs]' || echo '[]')
+          # Discover all containers and their current versions.
+          # Fix 4 (gate r9): do not mask ./make list failures with '[]'.
+          # An empty set would cause sync to run against nothing and emit "success",
+          # hiding the real failure and leaving drift comparisons against stale state.
+          make_list_out=$(./make list 2>&1) || {
+            echo "::error::./make list failed: $make_list_out" >&2
+            exit 2
+          }
+          if [[ -z "${make_list_out// /}" ]]; then
+            echo "::error::./make list returned empty container set" >&2
+            exit 2
+          fi
+          containers_json=$(echo "$make_list_out" | jq -Rnc '[inputs]')
 
           versions_json="{}"
           for c in $(echo "$containers_json" | jq -r '.[]'); do
@@ -1372,11 +1383,16 @@ jobs:
             printf 'variants_total: %s\n' "$variants_total"
           } > "$pr_frontmatter_file"
 
-          # Build variant table (injection-safe: values come from jq --arg)
+          # Build variant table.
+          # Fix 2 (gate r9): escape backticks and pipes in variant_tag and base_image_ref
+          # before embedding in the markdown table to prevent injection via poisoned lineage.
           printf '| Variant tag | Base image ref | Old digest | New digest |\n' > "$pr_table_file"
           printf '|-------------|----------------|------------|------------|\n' >> "$pr_table_file"
           echo "$variants" | jq -r \
-            '.[] | "| \(.variant_tag) | \(.base_image_ref) | \(.recorded_digest // "unknown") | \(.current_digest // "(legacy)") |"' \
+            '.[] |
+              (.variant_tag | gsub("`"; "\\`") | gsub("\\|"; "\\|")) as $safe_tag |
+              (.base_image_ref | gsub("`"; "\\`") | gsub("\\|"; "\\|")) as $safe_ref |
+              "| \($safe_tag) | \($safe_ref) | \(.recorded_digest // "unknown") | \(.current_digest // "(legacy)") |"' \
             >> "$pr_table_file"
 
           {

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1326,14 +1326,28 @@ jobs:
           CONTAINER: ${{ matrix.container }}
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
-          # Fix r7-3: unique temp paths per matrix entry — no cross-container contamination
+          # Unique temp paths per matrix entry — no cross-container contamination
           # across sequential runs on the same runner.
           drift_file="/tmp/drift-${{ github.run_id }}-${{ matrix.container }}.json"
-          # Fix r7-2: stdout → file, stderr flows to GHA log (NOT discarded).
-          # Probe errors surface as ::error:: lines in the step log AND as
-          # status:error records in the JSON — both are now visible.
-          ./scripts/detect-base-digest-drift.sh > "$drift_file" || true
+          # Detector emits ::error:: lines to stderr for visibility; capture stdout
+          # and check exit code + JSON validity before processing.
+          detect_rc=0
+          ./scripts/detect-base-digest-drift.sh > "$drift_file" || detect_rc=$?
+          if [[ $detect_rc -ne 0 ]]; then
+            echo "::error::detect-base-digest-drift.sh exited with $detect_rc — aborting PR" >&2
+            exit 1
+          fi
           drift_json=$(cat "$drift_file")
+          if [[ -z "$drift_json" || "$drift_json" == "[]" ]]; then
+            echo "::warning::detect-base-digest-drift.sh output empty — skipping (no drift)" >&2
+            echo "has_drift=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Validate JSON structure before downstream jq queries
+          if ! jq -e '.[0] | has("container")' >/dev/null 2>&1 <<<"$drift_json"; then
+            echo "::error::detect-base-digest-drift.sh output is invalid JSON — aborting PR" >&2
+            exit 1
+          fi
 
           # Fix r8-2: scope error_count to current matrix container only.
           # Without the .container filter, a transient probe failure on any

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -679,11 +679,10 @@ jobs:
           source ./helpers/base-cache-utils.sh
 
           # Discover all containers and their current versions.
-          # Fix 4 (gate r9): do not mask ./make list failures with '[]'.
-          # An empty set would cause sync to run against nothing and emit "success",
-          # hiding the real failure and leaving drift comparisons against stale state.
-          make_list_out=$(./make list 2>&1) || {
-            echo "::error::./make list failed: $make_list_out" >&2
+          # Capture stdout and stderr separately to avoid docker-compose status
+          # line on stderr being mixed with container names.
+          make_list_out=$(./make list 2>/dev/null) || {
+            echo "::error::./make list failed" >&2
             exit 2
           }
           if [[ -z "${make_list_out// /}" ]]; then
@@ -1204,6 +1203,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Install yq
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
+        with:
+          cmd: yq --version
+
       - name: Detect drift
         id: detect
         run: |
@@ -1310,6 +1314,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
+
+      - name: Install yq
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
+        with:
+          cmd: yq --version
 
       - name: Re-detect drift for this container (idempotent)
         id: drift-data

--- a/docs/adr/ADR-010-chained-on-own-and-digest-drift.md
+++ b/docs/adr/ADR-010-chained-on-own-and-digest-drift.md
@@ -1,0 +1,80 @@
+# ADR-010: Chained-on-own marker (#531) and base-image digest drift detection (#532)
+
+**Status:** Accepted
+**Date:** 2026-05-27
+**Issues:** #531, #532
+**Supersedes:** None
+**Siblings:** ADR-004 (build lineage tracking)
+
+## Context
+
+This ADR covers the final two pieces of the architectural series started in #530:
+
+- **#530** established the "truth pipeline" — `base_image_ref` and `base_image_digest` are now written to lineage files at build time with correct concrete values (no `${...}` placeholders).
+- **#531** introduced the `chained-on-own` concept: a marker file pattern for recording that a container is downstream of another project-built image.
+- **#532** closes the loop: daily cron detects when the recorded base digest diverges from the current registry digest and opens PRs to trigger rebuilds.
+
+## Problem
+
+After #530, every lineage file records the exact base image digest used at build time. However, there was no mechanism to detect when the upstream base image was updated (security patches, point releases) without the downstream container being rebuilt. This creates a window where containers run with stale base images silently.
+
+## Decision
+
+### #531 — Chained-on-own marker
+
+Containers built on top of other project-produced images (e.g., `wordpress` on `php`) write a `chained-on-own: true` flag in their lineage files. The drift detection cron uses this flag in PR bodies to document the cascade recommendation: merge upstream PR first.
+
+### #532 — Digest drift detection cron
+
+**Daily cron** (`upstream-monitor.yaml` `detect-digest-drift` job) runs after the existing dep-monitor jobs:
+
+1. Restores the GHA lineage cache (`.build-lineage/` is gitignored; cache is the authoritative store).
+2. Walks all non-sidecar `*.json` files via `is_lineage_sidecar()` helper (single source of truth in `helpers/lineage-utils.sh`).
+3. For each entry, probes current digest via `docker manifest inspect <base_image_ref>` using the same extraction as the writer (`build-container.sh:272`).
+4. Emits tri-state per variant: `drift` / `unchanged` / `error` / `legacy`.
+5. Groups by container name; matrix-fans out to `open-drift-prs` job.
+
+**One PR per drifted container** (not per variant): all drifted variants for a container appear in the same PR body. Branch name `update/base-digest-<container>` (no date suffix) → peter-evans upserts on re-run → idempotent.
+
+**`LAST_REBUILD.md` reuse**: PR writes a `## base-digest-drift (YYYY-MM-DD)` section to the existing `<container>/LAST_REBUILD.md`. `auto-build.yaml` path filter (line 89) already watches this file — no new path-filter rule needed.
+
+## Consequences
+
+### Positive
+
+- Stale base images are surfaced automatically within 24 hours of upstream publication.
+- No new infrastructure required beyond existing GHA lineage cache.
+- Loop closes correctly: drift → PR merged → rebuild → new lineage → next cron sees match → no PR.
+- `is_lineage_sidecar()` helper eliminates regex scatter; all consumers agree on which files are sidecars.
+
+### Negative / Limitations
+
+- Cache miss on first run: if the lineage cache expired or was never populated (new repo setup), the cron emits a warning and opens no PRs. Self-heals on next build.
+- 2-day cascade for chained-on-own containers: if A depends on B and both drift, two cron runs are needed to fully propagate. Mitigated by documenting in PR bodies.
+- `--baseline-only` operator action required once after #532 merge to baseline pre-#530 legacy lineage files.
+
+### Deferred
+
+- `parent_lineage_digest` field for cascade-suppression (suppress A's drift PR when B's drift PR is open).
+- Auto-merge for digest-only minor drifts (requires explicit policy).
+- Per-arch digest tracking (current: image-index manifest digest, same as writer).
+
+## Alternatives Considered
+
+**A. Poll GHCR directly (without lineage cache).** Rejected: requires registry credentials in cron, complex auth, and doesn't correlate with what was actually built.
+
+**B. Event-driven via registry webhooks.** Deferred: webhook infrastructure exceeds benefit at project scale; daily cron is sufficient for security-patch latency requirements.
+
+**C. Embed drift check in auto-build.yaml.** Rejected: drift detection is independent of build events; adding it to auto-build would conflate concerns and run drift checks on every PR.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `helpers/lineage-utils.sh` | `is_lineage_sidecar()` — canonical sidecar predicate |
+| `scripts/detect-base-digest-drift.sh` | Lineage walker, digest prober, tri-state emitter |
+| `scripts/update-last-rebuild.sh` | Appends `## base-digest-drift` section to `LAST_REBUILD.md` |
+| `.github/workflows/upstream-monitor.yaml` | `detect-digest-drift` + `open-drift-prs` jobs |
+| `tests/unit/lineage-utils.bats` | Unit tests for `is_lineage_sidecar()` |
+| `tests/unit/detect-base-digest-drift.bats` | BDD tests including mutation guards |
+| `tests/fixtures/digest-drift/` | Captured manifest inspect responses + synthetic lineage |

--- a/docs/adr/ADR-010-chained-on-own-and-digest-drift.md
+++ b/docs/adr/ADR-010-chained-on-own-and-digest-drift.md
@@ -30,7 +30,7 @@ Containers built on top of other project-produced images (e.g., `wordpress` on `
 
 1. Restores the GHA lineage cache (`.build-lineage/` is gitignored; cache is the authoritative store).
 2. Walks all non-sidecar `*.json` files via `is_lineage_sidecar()` helper (single source of truth in `helpers/lineage-utils.sh`).
-3. For each entry, probes current digest via `docker manifest inspect <base_image_ref>` using the same extraction as the writer (`build-container.sh:272`).
+3. For each entry, probes current digest via `docker buildx imagetools inspect --format '{{json .Manifest}}' <ref> | jq -r '.digest'` — canonical multi-arch image-index digest, same extraction as the writer (`build-container.sh`).
 4. Emits tri-state per variant: `drift` / `unchanged` / `error` / `legacy`.
 5. Groups by container name; matrix-fans out to `open-drift-prs` job.
 
@@ -52,6 +52,7 @@ Containers built on top of other project-produced images (e.g., `wordpress` on `
 - Cache miss on first run: if the lineage cache expired or was never populated (new repo setup), the cron emits a warning and opens no PRs. Self-heals on next build.
 - 2-day cascade for chained-on-own containers: if A depends on B and both drift, two cron runs are needed to fully propagate. Mitigated by documenting in PR bodies.
 - `--baseline-only` operator action required once after #532 merge to baseline pre-#530 legacy lineage files.
+- Probe requires `docker buildx` on the cron runner. If absent, the detector emits `status: error` for affected entries (degrades safely; no drift is reported on probe failure).
 
 ### Deferred
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -62,7 +62,7 @@ After #530 began recording `base_image_digest` in lineage files, there was no au
 
 ### Decision
 
-Daily cron (via `upstream-monitor.yaml`) compares each container/variant's `base_image_digest` from the GHA lineage cache against the current registry digest via `docker manifest inspect`. Drift opens one PR per drifted container listing all affected variants. Merging the PR updates `LAST_REBUILD.md` → `auto-build.yaml` path filter triggers rebuild → new lineage written → next-day cron sees match → no further PR.
+Daily cron (via `upstream-monitor.yaml`) compares each container/variant's `base_image_digest` from the GHA lineage cache against the current registry digest via `docker buildx imagetools inspect --format '{{json .Manifest}}' | jq -r '.digest'` (canonical multi-arch image-index digest — order-independent, single source of truth matching `scripts/build-container.sh`). Drift opens one PR per drifted container listing all affected variants. Merging the PR updates `LAST_REBUILD.md` → `auto-build.yaml` path filter triggers rebuild → new lineage written → next-day cron sees match → no further PR.
 
 ### Key design choices
 
@@ -78,7 +78,7 @@ Daily cron (via `upstream-monitor.yaml`) compares each container/variant's `base
 
 **`--baseline-only` flag**: suppresses real drift records, emits only `legacy` entries. Operator runs ONCE after #532 merge to baseline pre-#530 lineage files without flooding CI with drift PRs.
 
-**Multi-arch index digest**: the same extraction as `scripts/build-container.sh:272` — `docker manifest inspect <ref> | grep -o '"sha256:[a-f0-9]*"' | head -1`. This is the image-index manifest digest, not a per-arch digest.
+**Multi-arch index digest**: `docker buildx imagetools inspect --format '{{json .Manifest}}' <ref> | jq -r '.digest'` — same extraction as `scripts/build-container.sh`. Returns the image-index manifest digest, not a per-arch digest.
 
 ### Cascade pattern (chained-on-own)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -51,3 +51,43 @@ Affected containers (sslh, web-shell, wordpress) currently have v1 lineage files
 ### Integration smoke origin
 
 `tests/unit/dashboard-integration-smoke.bats` was added per `feedback_perf_integration_smoke_test.md`: a layer-shifting refactor (base_image written at build time, read at dashboard-regen time) requires an end-to-end mutation guard. Unit tests of each individual function are insufficient because the bug manifests at the seam between the write phase and the read phase. The smoke's SMOKE-01 and SMOKE-07 tests guard Fix A1 specifically: disabling the `_BUILD_ARGS_RESOLVED` substitution loop causes `base_image_ref` to read `${OS_IMAGE_BASE}:${OS_IMAGE_TAG}` in the written lineage file, which SMOKE-01 catches via a concrete-value assertion.
+
+## #532 — Universal base-image digest drift detection cron
+
+**Issue:** #532. Completes the 3-issue architectural series (#530 → #531 → #532).
+
+### Problem
+
+After #530 began recording `base_image_digest` in lineage files, there was no automated mechanism to detect when a container's base image had been updated upstream without the container being rebuilt. Stale base images accumulate security patches silently.
+
+### Decision
+
+Daily cron (via `upstream-monitor.yaml`) compares each container/variant's `base_image_digest` from the GHA lineage cache against the current registry digest via `docker manifest inspect`. Drift opens one PR per drifted container listing all affected variants. Merging the PR updates `LAST_REBUILD.md` → `auto-build.yaml` path filter triggers rebuild → new lineage written → next-day cron sees match → no further PR.
+
+### Key design choices
+
+**Tri-state output** (`drift` / `unchanged` / `error` / `legacy`): probe failures are not collapsed to drift to avoid false-positive rebuilds. `legacy` status handles pre-#530 lineage without `base_image_digest`.
+
+**Per-container grouping**: output is `[{container, variants[]}]` rather than one record per variant. This enables one PR per container (not one per variant), reducing PR noise.
+
+**`is_lineage_sidecar()` helper** (`helpers/lineage-utils.sh`): single source of truth for identifying `.sbom.json`, `.changelog.json`, `.history.json`, `ext-*.json` files that should not be treated as container lineage. Eliminates regex scatter across consumers.
+
+**`LAST_REBUILD.md` reuse**: the existing `<container>/LAST_REBUILD.md` pattern (written by upstream-monitor for version updates, watched by auto-build path filter) is reused with a distinct `## base-digest-drift (YYYY-MM-DD)` section header. No new marker file needed.
+
+**Branch-upsert dedup** (`update/base-digest-<container>` — no date suffix): peter-evans/create-pull-request upserts the branch on re-run. N cron firings produce 1 open PR with the latest digest delta, not N PRs.
+
+**`--baseline-only` flag**: suppresses real drift records, emits only `legacy` entries. Operator runs ONCE after #532 merge to baseline pre-#530 lineage files without flooding CI with drift PRs.
+
+**Multi-arch index digest**: the same extraction as `scripts/build-container.sh:272` — `docker manifest inspect <ref> | grep -o '"sha256:[a-f0-9]*"' | head -1`. This is the image-index manifest digest, not a per-arch digest.
+
+### Cascade pattern (chained-on-own)
+
+If container A's base is container B (also project-produced), and both drift, two PRs open. Merging B's PR first avoids a 2-day cascade. PR body documents this. The `parent_lineage_digest` field for cascade-suppression is deferred to a follow-up issue.
+
+### Rejected alternatives
+
+**(a) Per-variant PRs.** Rejected: N variants per container would open N PRs, most for minor digest-only refreshes. Per-container grouping keeps PR volume manageable.
+
+**(b) Auto-merge for digest-only drifts.** Deferred: requires explicit policy decision about risk tolerance for unreviewed base image changes.
+
+**(c) Event-driven detection (registry webhooks).** Deferred: webhook infrastructure cost exceeds benefit at current project scale; daily cron is sufficient.

--- a/helpers/build-cache-utils.sh
+++ b/helpers/build-cache-utils.sh
@@ -162,6 +162,24 @@ compute_build_digest() {
         _digest_log "  digest input: CUSTOM_BUILD_ARGS=${CUSTOM_BUILD_ARGS}"
     fi
 
+    # --- Input: LAST_REBUILD.md (if present) ---
+    # Including LAST_REBUILD.md in the digest ensures that any drift-PR merge
+    # (which appends a base-digest-drift section) invalidates the cached digest,
+    # forcing should_skip_build to return false and trigger a fresh rebuild.
+    # Without this, smart-skip would match the old digest and skip the build,
+    # leaving the base digest unchanged and causing an infinite drift-PR loop.
+    #
+    # compute_build_digest is always called with cwd = container directory
+    # (the make script does pushd <container> before invoking build_container).
+    # LAST_REBUILD.md lives at the container root, so $PWD/LAST_REBUILD.md is correct.
+    local last_rebuild_path="$PWD/LAST_REBUILD.md"
+    if [[ -f "$last_rebuild_path" ]]; then
+        local last_rebuild_hash
+        last_rebuild_hash=$(sha256sum "$last_rebuild_path" | awk '{print $1}')
+        digest_inputs+=("LAST_REBUILD.md=$last_rebuild_hash")
+        _digest_log "  digest input: LAST_REBUILD.md=$last_rebuild_hash"
+    fi
+
     # --- Compute hash ---
     local concatenated
     concatenated=$(printf '%s\n' "${digest_inputs[@]}")

--- a/helpers/lineage-utils.sh
+++ b/helpers/lineage-utils.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# lineage-utils.sh — Shared predicates and helpers for .build-lineage/*.json files.
+#
+# Single source of truth for identifying lineage sidecar files so that all
+# consumers (enrich-lineage.sh, detect-base-digest-drift.sh, etc.) agree on
+# which files to skip.
+#
+# Usage (source this file):
+#   source helpers/lineage-utils.sh
+#
+# Then use:
+#   is_lineage_sidecar "foo-1.0-alpine.sbom.json"  # returns 0 (true) for sidecars
+
+# ---------------------------------------------------------------------------
+# is_lineage_sidecar <basename>
+#
+# Returns 0 (true) if the given filename is a lineage sidecar that should be
+# skipped by consumers walking .build-lineage/*.json.
+#
+# Sidecar patterns:
+#   *.sbom.json       — SPDX SBOM data (anchore/syft output)
+#   *.changelog.json  — package delta between consecutive builds
+#   *.history.json    — monotonic build history log
+#   ext-*.json        — per-extension lineage fragments (merged into main entry)
+#
+# Usage:
+#   if is_lineage_sidecar "$basename"; then continue; fi
+# ---------------------------------------------------------------------------
+is_lineage_sidecar() {
+    local f="${1:-}"
+    case "$f" in
+        *.sbom.json|*.changelog.json|*.history.json) return 0 ;;
+        ext-*.json) return 0 ;;
+        *) return 1 ;;
+    esac
+}

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -267,9 +267,15 @@ _resolve_base_image() {
     fi
 
     # Resolve digest if we have a concrete image reference
+    # Use `docker buildx imagetools inspect --format '{{json .Manifest}}'` to obtain
+    # the IMAGE-INDEX (manifest-list) digest.  This is the same digest that
+    # detect-base-digest-drift.sh probes, so writer and probe always agree on
+    # multi-arch images.  The previous `docker manifest inspect | grep sha256 | head -1`
+    # pattern was order-dependent and could return a per-arch child digest instead
+    # of the index digest — causing a perpetual drift-PR loop.
     _BASE_DIGEST=""
     if [[ -n "$_BASE_IMAGE_REF" && ! "$_BASE_IMAGE_REF" =~ \$ ]]; then
-        _BASE_DIGEST=$(docker manifest inspect "$_BASE_IMAGE_REF" 2>/dev/null | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
+        _BASE_DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$_BASE_IMAGE_REF" 2>/dev/null | jq -r '.digest // empty' 2>/dev/null || true)
         if [[ -n "$_BASE_DIGEST" ]]; then
             # Fix D: printf -v replaces eval; no shell-metacharacter injection vector
             printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -17,6 +17,25 @@ source "$PROJECT_ROOT/helpers/extension-utils.sh"
 # shellcheck source=../helpers/extension-duration-utils.sh
 [[ -f "$PROJECT_ROOT/helpers/extension-duration-utils.sh" ]] && source "$PROJECT_ROOT/helpers/extension-duration-utils.sh"
 
+# ---------------------------------------------------------------------------
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command.  Without this, a %0A/%0D in the value could terminate
+# the command early and inject another workflow command.  Mapping per GitHub's
+# runner spec:  %→%25  \n→%0A  \r→%0D
+#
+# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command;
+# inlined here to avoid importing the full base-cache helper.
+# ---------------------------------------------------------------------------
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    printf '%s' "$s"
+}
+
 # Function to check if multi-platform builds are supported (QEMU emulation)
 check_multiplatform_support() {
     # Cache the result to avoid repeated checks
@@ -288,8 +307,9 @@ _resolve_base_image() {
                 # Fix r23: explicitly clear _BASE_DIGEST on shape-validation failure so
                 # _emit_build_lineage writes "unresolved" (treated as legacy by the
                 # detector) rather than a malformed value that poisons comparisons.
-                _safe_digest=$(printf '%s' "$_BASE_DIGEST" | tr -d '`|\n\r')
-                printf '::warning::Malformed base digest '\''%s'\'' from manifest probe; discarding\n' "$_safe_digest" >&2
+                # Fix r28: route through _escape_gha_command to prevent %0A/%0D in the
+                # malformed value from injecting additional GHA workflow commands.
+                printf '::warning::Malformed base digest '\''%s'\'' from manifest probe; discarding\n' "$(_escape_gha_command "$_BASE_DIGEST")" >&2
                 _BASE_DIGEST=""
             fi
         fi

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -285,7 +285,9 @@ _resolve_base_image() {
                 printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"
                 log_info "Base image $_BASE_IMAGE_REF pinned: ${_BASE_DIGEST:0:19}..."
             else
-                log_warning "Refusing to embed malformed _BASE_DIGEST: ${_BASE_DIGEST}" >&2
+                # Escape the malformed digest for safe logging (may contain CR/LF)
+                _safe_digest=$(printf '%s' "$_BASE_DIGEST" | tr -d '`|\n\r')
+                log_warning "Refusing to embed malformed _BASE_DIGEST: ${_safe_digest}" >&2
             fi
         fi
     fi

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -277,9 +277,16 @@ _resolve_base_image() {
     if [[ -n "$_BASE_IMAGE_REF" && ! "$_BASE_IMAGE_REF" =~ \$ ]]; then
         _BASE_DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$_BASE_IMAGE_REF" 2>/dev/null | jq -r '.digest // empty' 2>/dev/null || true)
         if [[ -n "$_BASE_DIGEST" ]]; then
-            # Fix D: printf -v replaces eval; no shell-metacharacter injection vector
-            printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"
-            log_info "Base image $_BASE_IMAGE_REF pinned: ${_BASE_DIGEST:0:19}..."
+            # Fix r7-1: validate digest shape before embedding in label_args.
+            # A malformed value (spaces, shell metacharacters, injected flags)
+            # must never reach --label or --build-arg.
+            if [[ "$_BASE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+                # Fix D: printf -v replaces eval; no shell-metacharacter injection vector
+                printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"
+                log_info "Base image $_BASE_IMAGE_REF pinned: ${_BASE_DIGEST:0:19}..."
+            else
+                log_warning "Refusing to embed malformed _BASE_DIGEST: ${_BASE_DIGEST}" >&2
+            fi
         fi
     fi
 }

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -285,9 +285,12 @@ _resolve_base_image() {
                 printf -v "$label_args_var" '%s --label org.opencontainers.image.base.digest=%s' "${!label_args_var}" "$_BASE_DIGEST"
                 log_info "Base image $_BASE_IMAGE_REF pinned: ${_BASE_DIGEST:0:19}..."
             else
-                # Escape the malformed digest for safe logging (may contain CR/LF)
+                # Fix r23: explicitly clear _BASE_DIGEST on shape-validation failure so
+                # _emit_build_lineage writes "unresolved" (treated as legacy by the
+                # detector) rather than a malformed value that poisons comparisons.
                 _safe_digest=$(printf '%s' "$_BASE_DIGEST" | tr -d '`|\n\r')
-                log_warning "Refusing to embed malformed _BASE_DIGEST: ${_safe_digest}" >&2
+                printf '::warning::Malformed base digest '\''%s'\'' from manifest probe; discarding\n' "$_safe_digest" >&2
+                _BASE_DIGEST=""
             fi
         fi
     fi

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -204,6 +204,25 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
+    # Validate container name against canonical list (Fix 1: poisoning prevention)
+    # A corrupted entry (e.g. container: "docs", container: ".github", or a path
+    # with "/") could otherwise cause the bot to act on non-container directories.
+    #
+    # _VALID_CONTAINERS_OVERRIDE: test hook — when set, use this newline-separated
+    # list instead of ./make list (avoids needing the full project context in tests).
+    if [[ -z "${_valid_containers+x}" ]]; then
+        # Cache the list on first use (avoids re-running ./make list per file)
+        if [[ -n "${_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
+            _valid_containers="$_VALID_CONTAINERS_OVERRIDE"
+        else
+            _valid_containers=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null || true)
+        fi
+    fi
+    if ! grep -qxF "$container" <<<"$_valid_containers"; then
+        echo "::warning::Skipping $basename_file: invalid container name '$container' (not in ./make list)" >&2
+        continue
+    fi
+
     variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$variant_tag" ]]; then
         echo "::warning::Skipping $basename_file: missing 'tag' field" >&2

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -69,11 +69,19 @@ done
 # ---------------------------------------------------------------------------
 # Probe function — extract IMAGE-INDEX digest from a registry manifest
 #
-# Uses the same extraction logic as scripts/build-container.sh:272:
-#   docker manifest inspect <ref> | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"'
+# Extracts the authoritative image-index digest via the top-level `.digest`
+# field of the manifest JSON returned by `docker manifest inspect`.  For a
+# manifest list (multi-arch) this is the image-index digest, NOT a per-arch
+# entry digest from `.manifests[].digest`.
 #
-# This extracts the first SHA256 that appears in the manifest JSON, which for
-# a multi-arch image index is the index digest embedded in the response body.
+# Why jq instead of grep-o head-1: grep-o relies on JSON field ordering to
+# find the index digest before the per-arch entries.  jq -r '.digest' is
+# explicit and order-independent.
+#
+# If the top-level `.digest` field is absent (e.g., single-arch manifest
+# without an explicit digest field in the JSON body), we fall back to the
+# first sha256 found via grep-o — matching the writer in build-container.sh:272
+# for backward compatibility.
 #
 # For fixture-based testing, set PROBE_CMD to a function/script that reads
 # a pre-captured manifest JSON from a file named after the image ref.
@@ -81,22 +89,50 @@ done
 _probe_digest() {
     local image_ref="$1"
     local raw
+    local probe_stderr
+    local probe_exit=0
 
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
-        raw=$("${PROBE_CMD}" "${image_ref}" 2>/dev/null || true)
+        probe_stderr=$(mktemp)
+        raw=$("${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        if [[ $probe_exit -ne 0 ]]; then
+            local err_detail
+            err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
+            rm -f "$probe_stderr"
+            [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$image_ref" "$err_detail" >&2
+            return 1
+        fi
+        rm -f "$probe_stderr"
     else
-        raw=$(docker manifest inspect "${image_ref}" 2>/dev/null || true)
+        probe_stderr=$(mktemp)
+        raw=$(docker manifest inspect "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        if [[ $probe_exit -ne 0 ]]; then
+            local err_detail
+            err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
+            rm -f "$probe_stderr"
+            printf '::error::docker manifest inspect failed for %s: %s\n' "$image_ref" "$err_detail" >&2
+            return 1
+        fi
+        rm -f "$probe_stderr"
     fi
 
     if [[ -z "$raw" ]]; then
+        printf '::error::docker manifest inspect returned empty output for %s\n' "$image_ref" >&2
         return 1
     fi
 
+    # Extract image-index digest: prefer top-level .digest (explicit, order-independent)
     local digest
-    digest=$(printf '%s' "$raw" | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
+    digest=$(printf '%s' "$raw" | jq -r '.digest // empty' 2>/dev/null || true)
+
+    # Fallback: grep-o for single-arch manifests without top-level .digest
+    if [[ -z "$digest" ]]; then
+        digest=$(printf '%s' "$raw" | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
+    fi
 
     if [[ -z "$digest" ]]; then
+        printf '::error::could not extract digest from manifest for %s\n' "$image_ref" >&2
         return 1
     fi
 
@@ -176,6 +212,7 @@ for lineage_file in "${lineage_files[@]}"; do
 
     base_image_ref=$(jq -re '.base_image_ref // empty' "$lineage_file" 2>/dev/null || true)
     recorded_digest=$(jq -re '.base_image_digest // empty' "$lineage_file" 2>/dev/null || true)
+    error_reason=""
 
     # Track container ordering
     if [[ -z "${_container_variants[$container]+x}" ]]; then
@@ -231,15 +268,18 @@ for lineage_file in "${lineage_files[@]}"; do
     fi
 
     if [[ "$probe_failed" == "true" || -z "$current_digest" ]]; then
-        echo "::warning::Probe failed for $base_image_ref (container=$container tag=$variant_tag)" >&2
+        error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
+        printf '::error::probe-error: %s\n' "$error_reason" >&2
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        safe_error=$(_sanitize_for_json "$error_reason")
         variant_json=$(jq -cn \
             --arg variant_tag       "$variant_tag" \
             --arg base_ref          "$safe_ref" \
             --arg recorded_digest   "$safe_recorded" \
             --arg status            "error" \
-            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status}')
+            --arg error_reason      "$safe_error" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
         _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# detect-base-digest-drift.sh — Compare recorded base_image_digest in .build-lineage/
+# against the current registry digest for each container/variant.
+#
+# Outputs a JSON array on stdout, grouped per container:
+#   [{"container":"foo","variants":[{"variant_tag":"1.0-alpine","status":"drift",...},...]}]
+#
+# Tri-state status per variant:
+#   drift     — recorded_digest != current_digest (real drift)
+#   unchanged — recorded_digest == current_digest (no action needed)
+#   error     — registry probe failed (timeout, 401, 404); NOT collapsed to drift
+#   legacy    — lineage lacks base_image_digest field (pre-v2); rebuild baselines it
+#
+# Usage:
+#   detect-base-digest-drift.sh [--baseline-only] [LINEAGE_DIR]
+#
+# Options:
+#   --baseline-only   Emit ONLY status:legacy records; suppress real drifts.
+#                     Use ONCE after #532 merge to baseline pre-v2 lineage.
+#   LINEAGE_DIR       Override lineage directory (default: .build-lineage/)
+#
+# Env:
+#   PROBE_CMD         Override probe command for testing. Must accept one arg
+#                     (image_ref) and output a JSON manifest on stdout.
+#                     Defaults to: docker manifest inspect <ref>
+#
+# Exit codes:
+#   0   — Success (drift/unchanged/legacy/error records emitted; drift itself is NOT an error)
+#   1   — Fatal script error (e.g., invalid digest shape passed to emit)
+#
+# Digest shape validation (injection prevention):
+#   Every digest extracted from the registry is validated against
+#   ^sha256:[a-f0-9]{64}$ before inclusion in any output record.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Source helpers
+# ---------------------------------------------------------------------------
+# shellcheck source=../helpers/lineage-utils.sh
+source "${PROJECT_ROOT}/helpers/lineage-utils.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+BASELINE_ONLY=false
+LINEAGE_DIR="${PROJECT_ROOT}/.build-lineage"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --baseline-only)
+            BASELINE_ONLY=true
+            shift
+            ;;
+        -*)
+            echo "::error::Unknown flag: $1" >&2
+            exit 1
+            ;;
+        *)
+            LINEAGE_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Probe function — extract IMAGE-INDEX digest from a registry manifest
+#
+# Uses the same extraction logic as scripts/build-container.sh:272:
+#   docker manifest inspect <ref> | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"'
+#
+# This extracts the first SHA256 that appears in the manifest JSON, which for
+# a multi-arch image index is the index digest embedded in the response body.
+#
+# For fixture-based testing, set PROBE_CMD to a function/script that reads
+# a pre-captured manifest JSON from a file named after the image ref.
+# ---------------------------------------------------------------------------
+_probe_digest() {
+    local image_ref="$1"
+    local raw
+
+    if [[ -n "${PROBE_CMD:-}" ]]; then
+        # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
+        raw=$("${PROBE_CMD}" "${image_ref}" 2>/dev/null || true)
+    else
+        raw=$(docker manifest inspect "${image_ref}" 2>/dev/null || true)
+    fi
+
+    if [[ -z "$raw" ]]; then
+        return 1
+    fi
+
+    local digest
+    digest=$(printf '%s' "$raw" | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
+
+    if [[ -z "$digest" ]]; then
+        return 1
+    fi
+
+    printf '%s' "$digest"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Digest shape validation
+# Validates ^sha256:[a-f0-9]{64}$ — refuse if invalid.
+# ---------------------------------------------------------------------------
+_validate_digest_shape() {
+    local digest="$1"
+    # Must match sha256: followed by exactly 64 lowercase hex chars
+    if [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Sanitize a string for safe embedding in JSON string values.
+# Strips/replaces: backticks, pipes, newlines, carriage returns.
+# ---------------------------------------------------------------------------
+_sanitize_for_json() {
+    local val="$1"
+    # Use printf %s to avoid escape interpretation, then sed for replacement
+    printf '%s' "$val" | tr -d '`|\n\r'
+}
+
+# ---------------------------------------------------------------------------
+# Walk lineage directory
+# ---------------------------------------------------------------------------
+if [[ ! -d "$LINEAGE_DIR" ]]; then
+    echo "::warning::Lineage directory '$LINEAGE_DIR' does not exist — nothing to check" >&2
+    printf '[]'
+    exit 0
+fi
+
+# Collect all *.json files; sort for deterministic output
+mapfile -t lineage_files < <(find "$LINEAGE_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | sort)
+
+if [[ ${#lineage_files[@]} -eq 0 ]]; then
+    echo "::warning::Lineage cache empty — no .json files in '$LINEAGE_DIR'; skipping drift check" >&2
+    printf '[]'
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Per-variant processing — build associative maps keyed by container name
+# ---------------------------------------------------------------------------
+# We accumulate variant JSON fragments per container name, then assemble.
+
+declare -A _container_variants  # container_name -> newline-separated JSON fragments
+declare -a _container_order     # ordered list of unique container names seen
+
+for lineage_file in "${lineage_files[@]}"; do
+    basename_file="$(basename "$lineage_file")"
+
+    # Skip sidecar files via single source of truth
+    if is_lineage_sidecar "$basename_file"; then
+        continue
+    fi
+
+    # Parse required fields
+    container=$(jq -re '.container // empty' "$lineage_file" 2>/dev/null || true)
+    if [[ -z "$container" ]]; then
+        echo "::warning::Skipping $basename_file: missing 'container' field" >&2
+        continue
+    fi
+
+    variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
+    if [[ -z "$variant_tag" ]]; then
+        echo "::warning::Skipping $basename_file: missing 'tag' field" >&2
+        continue
+    fi
+
+    base_image_ref=$(jq -re '.base_image_ref // empty' "$lineage_file" 2>/dev/null || true)
+    recorded_digest=$(jq -re '.base_image_digest // empty' "$lineage_file" 2>/dev/null || true)
+
+    # Track container ordering
+    if [[ -z "${_container_variants[$container]+x}" ]]; then
+        _container_order+=("$container")
+        _container_variants["$container"]=""
+    fi
+
+    # ---------------------------------------------------------------------------
+    # Determine status
+    # ---------------------------------------------------------------------------
+
+    # Legacy: lineage lacks base_image_digest field
+    if [[ -z "$recorded_digest" || "$recorded_digest" == "unresolved" ]]; then
+        safe_ref=$(_sanitize_for_json "${base_image_ref:-unknown}")
+        variant_json=$(jq -cn \
+            --arg variant_tag  "$variant_tag" \
+            --arg base_ref     "$safe_ref" \
+            --arg status       "legacy" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
+
+        if [[ "$BASELINE_ONLY" == "true" ]]; then
+            # In baseline mode, emit legacy records
+            _container_variants["$container"]+="${variant_json}"$'\n'
+        else
+            # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
+            _container_variants["$container"]+="${variant_json}"$'\n'
+        fi
+        continue
+    fi
+
+    # Skip if base_image_ref is unresolved (placeholder from pre-#530 lineage)
+    if [[ "$base_image_ref" =~ \$ ]]; then
+        echo "::warning::Skipping $basename_file: base_image_ref contains unresolved placeholder: $base_image_ref" >&2
+        continue
+    fi
+
+    # Skip if no base_image_ref
+    if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
+        echo "::warning::Skipping $basename_file: base_image_ref is unknown" >&2
+        continue
+    fi
+
+    # In baseline-only mode, suppress real drift records
+    if [[ "$BASELINE_ONLY" == "true" ]]; then
+        continue
+    fi
+
+    # Probe current digest
+    current_digest=""
+    probe_failed=false
+    if ! current_digest=$(_probe_digest "$base_image_ref"); then
+        probe_failed=true
+    fi
+
+    if [[ "$probe_failed" == "true" || -z "$current_digest" ]]; then
+        echo "::warning::Probe failed for $base_image_ref (container=$container tag=$variant_tag)" >&2
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        variant_json=$(jq -cn \
+            --arg variant_tag       "$variant_tag" \
+            --arg base_ref          "$safe_ref" \
+            --arg recorded_digest   "$safe_recorded" \
+            --arg status            "error" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
+        continue
+    fi
+
+    # Validate digest shape (injection prevention)
+    if ! _validate_digest_shape "$current_digest"; then
+        echo "::error::Registry returned malformed digest for $base_image_ref: '$current_digest' — refusing to emit record" >&2
+        exit 1
+    fi
+
+    # Compare
+    safe_ref=$(_sanitize_for_json "$base_image_ref")
+    safe_recorded=$(_sanitize_for_json "$recorded_digest")
+
+    if [[ "$current_digest" == "$recorded_digest" ]]; then
+        variant_json=$(jq -cn \
+            --arg variant_tag       "$variant_tag" \
+            --arg base_ref          "$safe_ref" \
+            --arg recorded_digest   "$safe_recorded" \
+            --arg current_digest    "$current_digest" \
+            --arg status            "unchanged" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, current_digest: $current_digest, status: $status}')
+    else
+        variant_json=$(jq -cn \
+            --arg variant_tag       "$variant_tag" \
+            --arg base_ref          "$safe_ref" \
+            --arg recorded_digest   "$safe_recorded" \
+            --arg current_digest    "$current_digest" \
+            --arg status            "drift" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, current_digest: $current_digest, status: $status}')
+    fi
+
+    _container_variants["$container"]+="${variant_json}"$'\n'
+done
+
+# ---------------------------------------------------------------------------
+# Assemble final JSON output: array of {container, variants[]}
+# ---------------------------------------------------------------------------
+output="["
+first_container=true
+
+for container in "${_container_order[@]}"; do
+    fragments="${_container_variants[$container]}"
+
+    # Skip containers with no variant records (e.g., all skipped)
+    if [[ -z "$fragments" ]]; then
+        continue
+    fi
+
+    # Build variants array from newline-separated JSON fragments
+    variants_array="["
+    first_variant=true
+    while IFS= read -r frag; do
+        [[ -z "$frag" ]] && continue
+        if [[ "$first_variant" == "true" ]]; then
+            first_variant=false
+        else
+            variants_array+=","
+        fi
+        variants_array+="$frag"
+    done <<< "$fragments"
+    variants_array+="]"
+
+    # Validate the variants array is valid JSON
+    if ! printf '%s' "$variants_array" | jq '.' >/dev/null 2>&1; then
+        echo "::warning::Skipping container '$container': could not build valid variants JSON" >&2
+        continue
+    fi
+
+    container_json=$(jq -cn \
+        --arg container "$container" \
+        --argjson variants "$variants_array" \
+        '{container: $container, variants: $variants}')
+
+    if [[ "$first_container" == "true" ]]; then
+        first_container=false
+    else
+        output+=","
+    fi
+    output+="$container_json"
+done
+
+output+="]"
+
+# Final validation — output must be valid JSON
+if ! printf '%s' "$output" | jq '.' >/dev/null 2>&1; then
+    echo "::error::Internal error: output is not valid JSON" >&2
+    exit 1
+fi
+
+printf '%s' "$output"

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -21,10 +21,11 @@
 #
 # Env:
 #   PROBE_CMD         Override probe command for testing. Must accept one arg
-#                     (image_ref) and print the image-index manifest digest to
-#                     stdout (sha256:... string).
+#                     (image_ref) and output JSON containing a `.digest` field
+#                     (the canonical multi-arch image-index digest). The script
+#                     extracts the digest via `jq -r '.digest // empty'`.
 #                     Defaults to: docker buildx imagetools inspect --format
-#                       '{{json .Manifest}}' <ref> | jq -r '.digest'
+#                       '{{json .Manifest}}' <ref>
 #                     (canonical multi-arch image-index digest via buildx
 #                     imagetools — order-independent, single source of truth,
 #                     matches scripts/build-container.sh digest extraction)

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -21,12 +21,18 @@
 #
 # Env:
 #   PROBE_CMD         Override probe command for testing. Must accept one arg
-#                     (image_ref) and output a JSON manifest on stdout.
-#                     Defaults to: docker manifest inspect <ref>
+#                     (image_ref) and print the image-index manifest digest to
+#                     stdout (sha256:... string).
+#                     Defaults to: docker buildx imagetools inspect --format
+#                       '{{json .Manifest}}' <ref> | jq -r '.digest'
+#                     (canonical multi-arch image-index digest via buildx
+#                     imagetools — order-independent, single source of truth,
+#                     matches scripts/build-container.sh digest extraction)
 #
 # Exit codes:
 #   0   — Success (drift/unchanged/legacy/error records emitted; drift itself is NOT an error)
 #   1   — Fatal script error (e.g., invalid digest shape passed to emit)
+#   2   — Tooling failure (./make list unavailable or returned empty)
 #
 # Digest shape validation (injection prevention):
 #   Every digest extracted from the registry is validated against
@@ -211,6 +217,10 @@ _sanitize_for_json() {
 # ---------------------------------------------------------------------------
 _validate_image_ref() {
     local ref="$1"
+
+    # Reject refs starting with '/' — first_segment would be empty, which
+    # falls through the OCI registry-host check with no meaningful value.
+    [[ "$ref" == /* ]] && return 1
 
     # Must be non-empty and free of whitespace/control chars
     if [[ -z "$ref" || "$ref" =~ [[:space:][:cntrl:]] ]]; then

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -272,43 +272,46 @@ for lineage_file in "${lineage_files[@]}"; do
     # Applied here so every downstream use of $variant_tag_safe is already clean.
     variant_tag_safe=$(_escape_gha_command "$variant_tag")
 
-    # Filter to active build-matrix tags only.
-    # Stale lineage files for dropped/non-retained tags persist in the cache after
-    # rotation.  Without this filter each cron run re-detects drift on them, opens a
-    # PR, the PR rebuild only updates current retained tags → stale lineage unchanged
-    # → next cron re-detects → infinite PR loop.
-    #
-    # _ACTIVE_TAGS_OVERRIDE_<container>: test hook — set to a newline-separated list
-    # of active tags for a container to bypass ./make list-builds in tests.
-    #
-    # Cache key: _active_tags_cache_<container> (associative array not available in
-    # bash <4.2 without namerefs; use indirect variable via printf '%s' trick).
-    _active_tags_var="_active_tags_cache_${container//-/_}"
-    if [[ -z "${!_active_tags_var+x}" ]]; then
-        # Check for per-container test hook first
-        _override_var="_ACTIVE_TAGS_OVERRIDE_${container//-/_}"
-        if [[ -n "${!_override_var:-}" ]]; then
-            printf -v "$_active_tags_var" '%s' "${!_override_var}"
-        else
-            # list-builds must succeed; on failure abort rather than silently skip
-            # the stale-lineage filter (which would disable drift detection).
-            if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
-                printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
-                exit 2
+    # Filter to active build-matrix tags only (NORMAL MODE ONLY).
+    # In --baseline-only mode, we intentionally emit ALL pre-v2 entries including
+    # stale ones, so the stale-lineage filter is bypassed until baseline is complete.
+    # In normal (cron) mode: stale lineage files for dropped/non-retained tags persist
+    # in the cache after rotation. Without this filter each cron run re-detects drift
+    # on them, opens a PR, the PR rebuild only updates current retained tags → stale
+    # lineage unchanged → next cron re-detects → infinite PR loop.
+    if [[ "$BASELINE_ONLY" != "true" ]]; then
+        # _ACTIVE_TAGS_OVERRIDE_<container>: test hook — set to a newline-separated list
+        # of active tags for a container to bypass ./make list-builds in tests.
+        #
+        # Cache key: _active_tags_cache_<container> (associative array not available in
+        # bash <4.2 without namerefs; use indirect variable via printf '%s' trick).
+        _active_tags_var="_active_tags_cache_${container//-/_}"
+        if [[ -z "${!_active_tags_var+x}" ]]; then
+            # Check for per-container test hook first
+            _override_var="_ACTIVE_TAGS_OVERRIDE_${container//-/_}"
+            if [[ -n "${!_override_var:-}" ]]; then
+                printf -v "$_active_tags_var" '%s' "${!_override_var}"
+            else
+                # list-builds must succeed; on failure abort rather than silently skip
+                # the stale-lineage filter (which would disable drift detection).
+                if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
+                    printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
+                    exit 2
+                fi
+                _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
+                if [[ -z "$_fetched" ]]; then
+                    printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
+                    exit 2
+                fi
+                printf -v "$_active_tags_var" '%s' "$_fetched"
             fi
-            _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
-            if [[ -z "$_fetched" ]]; then
-                printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
-                exit 2
-            fi
-            printf -v "$_active_tags_var" '%s' "$_fetched"
         fi
-    fi
-    _active_tags="${!_active_tags_var}"
-    if ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
-        printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
-            "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
-        continue
+        _active_tags="${!_active_tags_var}"
+        if ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+            printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
+                "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
+            continue
+        fi
     fi
 
     base_image_ref=$(jq -re '.base_image_ref // empty' "$lineage_file" 2>/dev/null || true)

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -44,6 +44,28 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${PROJECT_ROOT}/helpers/lineage-utils.sh"
 
 # ---------------------------------------------------------------------------
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command.  Without this, a newline/CR/`%` in the value could
+# terminate the command early and inject another (e.g. `::add-mask::`,
+# `::stop-commands::`).  Mapping per GitHub's runner spec:
+#   %  → %25
+#   \n → %0A
+#   \r → %0D
+#
+# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command;
+# inlined here to avoid importing the full base-cache helper.
+# ---------------------------------------------------------------------------
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    printf '%s' "$s"
+}
+
+# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 BASELINE_ONLY=false
@@ -69,28 +91,27 @@ done
 # ---------------------------------------------------------------------------
 # Probe function — extract IMAGE-INDEX digest from a registry manifest
 #
-# Extracts the authoritative image-index digest via the top-level `.digest`
-# field of the manifest JSON returned by `docker manifest inspect`.  For a
-# manifest list (multi-arch) this is the image-index digest, NOT a per-arch
-# entry digest from `.manifests[].digest`.
+# Uses `docker buildx imagetools inspect --format '{{json .Manifest}}'` to
+# obtain the IMAGE-INDEX (manifest-list) digest.  This is the same method
+# used by the writer in build-container.sh, so writer and probe always agree
+# on multi-arch images.
 #
-# Why jq instead of grep-o head-1: grep-o relies on JSON field ordering to
-# find the index digest before the per-arch entries.  jq -r '.digest' is
-# explicit and order-independent.
+# The previous `docker manifest inspect | jq -r '.digest'` approach was
+# unreliable: `docker manifest inspect` does NOT include a top-level `.digest`
+# field in its JSON body (the digest is only in the HTTP response Content-Digest
+# header).  imagetools inspect --format '{{json .Manifest}}' exposes the
+# authoritative OCI index descriptor including `.digest`.
 #
-# If the top-level `.digest` field is absent (e.g., single-arch manifest
-# without an explicit digest field in the JSON body), we fall back to the
-# first sha256 found via grep-o — matching the writer in build-container.sh:272
-# for backward compatibility.
-#
-# For fixture-based testing, set PROBE_CMD to a function/script that reads
-# a pre-captured manifest JSON from a file named after the image ref.
+# For fixture-based testing, set PROBE_CMD to a function/script that accepts
+# image_ref as $1 and outputs the `{{json .Manifest}}` JSON on stdout.
 # ---------------------------------------------------------------------------
 _probe_digest() {
     local image_ref="$1"
     local raw
     local probe_stderr
     local probe_exit=0
+    local safe_ref
+    safe_ref=$(_escape_gha_command "$image_ref")
 
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
@@ -100,39 +121,34 @@ _probe_digest() {
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             rm -f "$probe_stderr"
-            [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$image_ref" "$err_detail" >&2
+            [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             return 1
         fi
         rm -f "$probe_stderr"
     else
         probe_stderr=$(mktemp)
-        raw=$(docker manifest inspect "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        raw=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             rm -f "$probe_stderr"
-            printf '::error::docker manifest inspect failed for %s: %s\n' "$image_ref" "$err_detail" >&2
+            printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             return 1
         fi
         rm -f "$probe_stderr"
     fi
 
     if [[ -z "$raw" ]]; then
-        printf '::error::docker manifest inspect returned empty output for %s\n' "$image_ref" >&2
+        printf '::error::imagetools inspect returned empty output for %s\n' "$safe_ref" >&2
         return 1
     fi
 
-    # Extract image-index digest: prefer top-level .digest (explicit, order-independent)
+    # Extract image-index digest: .digest from the OCI index descriptor JSON
     local digest
     digest=$(printf '%s' "$raw" | jq -r '.digest // empty' 2>/dev/null || true)
 
-    # Fallback: grep-o for single-arch manifests without top-level .digest
     if [[ -z "$digest" ]]; then
-        digest=$(printf '%s' "$raw" | grep -o '"sha256:[a-f0-9]*"' | head -1 | tr -d '"' || true)
-    fi
-
-    if [[ -z "$digest" ]]; then
-        printf '::error::could not extract digest from manifest for %s\n' "$image_ref" >&2
+        printf '::error::could not extract digest from manifest for %s\n' "$safe_ref" >&2
         return 1
     fi
 
@@ -200,7 +216,7 @@ for lineage_file in "${lineage_files[@]}"; do
     # Parse required fields
     container=$(jq -re '.container // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$container" ]]; then
-        echo "::warning::Skipping $basename_file: missing 'container' field" >&2
+        printf '::warning::Skipping %s: missing '\''container'\'' field\n' "$(_escape_gha_command "$basename_file")" >&2
         continue
     fi
 
@@ -219,13 +235,14 @@ for lineage_file in "${lineage_files[@]}"; do
         fi
     fi
     if ! grep -qxF "$container" <<<"$_valid_containers"; then
-        echo "::warning::Skipping $basename_file: invalid container name '$container' (not in ./make list)" >&2
+        printf '::warning::Skipping %s: invalid container name '\''%s'\'' (not in ./make list)\n' \
+            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
         continue
     fi
 
     variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$variant_tag" ]]; then
-        echo "::warning::Skipping $basename_file: missing 'tag' field" >&2
+        printf '::warning::Skipping %s: missing '\''tag'\'' field\n' "$(_escape_gha_command "$basename_file")" >&2
         continue
     fi
 
@@ -243,12 +260,42 @@ for lineage_file in "${lineage_files[@]}"; do
     # Determine status
     # ---------------------------------------------------------------------------
 
-    # Skip if base_image_ref is unresolved (placeholder from pre-#530 lineage).
-    # Must precede the legacy check: a file with ${...} in base_image_ref and
-    # no recorded digest would otherwise be mis-classified as "legacy" and
-    # generate a bogus drift PR.
+    # Fix 4 (baseline-only precedence):
+    # In --baseline-only mode the goal is to baseline ALL pre-v2 entries, including
+    # ones where base_image_ref still contains a placeholder.  So legacy-emit takes
+    # precedence over the placeholder-skip in baseline mode.
+    #
+    # In normal (cron) mode the placeholder-skip MUST run first: a file with ${...}
+    # in base_image_ref and no recorded digest must not be mis-classified as legacy
+    # and trigger a bogus drift PR.
+    if [[ "$BASELINE_ONLY" == "true" ]]; then
+        # Baseline mode: emit legacy first (even for placeholder refs)
+        if [[ -z "$recorded_digest" || "$recorded_digest" == "unresolved" ]]; then
+            safe_ref=$(_sanitize_for_json "${base_image_ref:-unknown}")
+            variant_json=$(jq -cn \
+                --arg variant_tag  "$variant_tag" \
+                --arg base_ref     "$safe_ref" \
+                --arg status       "legacy" \
+                '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
+            _container_variants["$container"]+="${variant_json}"$'\n'
+            continue
+        fi
+
+        # Skip if base_image_ref is a placeholder (non-legacy entry with unresolved ref)
+        if [[ "$base_image_ref" =~ \$ ]]; then
+            printf '::warning::Skipping %s: base_image_ref contains unresolved placeholder: %s\n' \
+                "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$base_image_ref")" >&2
+            continue
+        fi
+
+        # In baseline-only mode, suppress real drift records for fully-resolved entries
+        continue
+    fi
+
+    # Normal mode: placeholder-skip runs before legacy check to prevent mis-classification
     if [[ "$base_image_ref" =~ \$ ]]; then
-        echo "::warning::Skipping $basename_file: base_image_ref contains unresolved placeholder: $base_image_ref" >&2
+        printf '::warning::Skipping %s: base_image_ref contains unresolved placeholder: %s\n' \
+            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$base_image_ref")" >&2
         continue
     fi
 
@@ -260,25 +307,14 @@ for lineage_file in "${lineage_files[@]}"; do
             --arg base_ref     "$safe_ref" \
             --arg status       "legacy" \
             '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
-
-        if [[ "$BASELINE_ONLY" == "true" ]]; then
-            # In baseline mode, emit legacy records
-            _container_variants["$container"]+="${variant_json}"$'\n'
-        else
-            # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
-            _container_variants["$container"]+="${variant_json}"$'\n'
-        fi
+        # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
+        _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi
 
     # Skip if no base_image_ref
     if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
-        echo "::warning::Skipping $basename_file: base_image_ref is unknown" >&2
-        continue
-    fi
-
-    # In baseline-only mode, suppress real drift records
-    if [[ "$BASELINE_ONLY" == "true" ]]; then
+        printf '::warning::Skipping %s: base_image_ref is unknown\n' "$(_escape_gha_command "$basename_file")" >&2
         continue
     fi
 
@@ -291,7 +327,7 @@ for lineage_file in "${lineage_files[@]}"; do
 
     if [[ "$probe_failed" == "true" || -z "$current_digest" ]]; then
         error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
-        printf '::error::probe-error: %s\n' "$error_reason" >&2
+        printf '::error::probe-error: %s\n' "$(_escape_gha_command "$error_reason")" >&2
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")
         safe_error=$(_sanitize_for_json "$error_reason")
@@ -308,7 +344,8 @@ for lineage_file in "${lineage_files[@]}"; do
 
     # Validate digest shape (injection prevention)
     if ! _validate_digest_shape "$current_digest"; then
-        echo "::error::Registry returned malformed digest for $base_image_ref: '$current_digest' — refusing to emit record" >&2
+        printf '::error::Registry returned malformed digest for %s: '\''%s'\'' — refusing to emit record\n' \
+            "$(_escape_gha_command "$base_image_ref")" "$(_escape_gha_command "$current_digest")" >&2
         exit 1
     fi
 
@@ -367,7 +404,8 @@ for container in "${_container_order[@]}"; do
 
     # Validate the variants array is valid JSON
     if ! printf '%s' "$variants_array" | jq '.' >/dev/null 2>&1; then
-        echo "::warning::Skipping container '$container': could not build valid variants JSON" >&2
+        printf '::warning::Skipping container '\''%s'\'': could not build valid variants JSON\n' \
+            "$(_escape_gha_command "$container")" >&2
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -290,25 +290,18 @@ for lineage_file in "${lineage_files[@]}"; do
         if [[ -n "${!_override_var:-}" ]]; then
             printf -v "$_active_tags_var" '%s' "${!_override_var}"
         else
-            # In test mode (when _VALID_CONTAINERS_OVERRIDE is set), generate stub
-            # active tags for the container to avoid calling real ./make list-builds.
-            # Outside tests, list-builds must succeed; on failure abort.
-            if [[ -n "${_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
-                # Test mode: construct minimal tag from container name for stale-check
-                # (tests validate container name, but don't care about tag matching)
-                printf -v "$_active_tags_var" '%s' "test-tag-for-$container"
-            else
-                if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
-                    printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
-                    exit 2
-                fi
-                _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
-                if [[ -z "$_fetched" ]]; then
-                    printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
-                    exit 2
-                fi
-                printf -v "$_active_tags_var" '%s' "$_fetched"
+            # list-builds must succeed; on failure abort rather than silently skip
+            # the stale-lineage filter (which would disable drift detection).
+            if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
+                printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
+                exit 2
             fi
+            _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
+            if [[ -z "$_fetched" ]]; then
+                printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
+                exit 2
+            fi
+            printf -v "$_active_tags_var" '%s' "$_fetched"
         fi
     fi
     _active_tags="${!_active_tags_var}"

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -230,7 +230,11 @@ for lineage_file in "${lineage_files[@]}"; do
         if [[ -n "${_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
             _valid_containers="$_VALID_CONTAINERS_OVERRIDE"
         else
-            _valid_containers=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null || true)
+            _valid_containers=$(cd "$PROJECT_ROOT" && ./make list) || _valid_containers=""
+            if [[ -z "$_valid_containers" ]]; then
+                printf '::error::./make list returned empty — canonical container list unavailable\n' >&2
+                exit 2
+            fi
         fi
     fi
     if ! grep -qxF "$container" <<<"$_valid_containers"; then

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -219,17 +219,17 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Fix 3 (gate r9): Reject container names with control characters BEFORE the
-    # grep -qxF check.  A value like $'ansible\nmalicious' contains a newline which
-    # grep -xF treats as TWO patterns, so "ansible" matches and "malicious" passes
-    # validation silently.  Explicit cntrl-char rejection closes that bypass.
+    # Control-character rejection — MUST be BEFORE any validation or caching.
+    # A value like $'ansible\nmalicious' contains a newline which grep -xF treats
+    # as TWO patterns, so "ansible" matches and "malicious" passes validation silently.
+    # Explicit cntrl-char rejection at entry point closes that bypass entirely.
     if [[ "$container" =~ [[:cntrl:]] ]]; then
         printf '::warning::Rejecting lineage entry %s: container name contains control chars: %s\n' \
             "$(_escape_gha_command "$basename_file")" "$(printf '%q' "$container")" >&2
         continue
     fi
 
-    # Validate container name against canonical list (Fix 1: poisoning prevention)
+    # Validate container name against canonical list (poisoning prevention)
     # A corrupted entry (e.g. container: "docs", container: ".github", or a path
     # with "/") could otherwise cause the bot to act on non-container directories.
     #
@@ -263,7 +263,7 @@ for lineage_file in "${lineage_files[@]}"; do
     # Applied here so every downstream use of $variant_tag_safe is already clean.
     variant_tag_safe=$(_escape_gha_command "$variant_tag")
 
-    # Fix 1 (gate r9, NON-TERMINATING BUG): filter to active build-matrix tags only.
+    # Filter to active build-matrix tags only.
     # Stale lineage files for dropped/non-retained tags persist in the cache after
     # rotation.  Without this filter each cron run re-detects drift on them, opens a
     # PR, the PR rebuild only updates current retained tags → stale lineage unchanged
@@ -281,13 +281,23 @@ for lineage_file in "${lineage_files[@]}"; do
         if [[ -n "${!_override_var:-}" ]]; then
             printf -v "$_active_tags_var" '%s' "${!_override_var}"
         else
-            _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null \
-                | jq -r '.[].tag // empty' 2>/dev/null | sort -u || true)
+            # list-builds must succeed; on failure abort rather than silently skip
+            # the stale-lineage filter (which would disable drift detection for all
+            # variants of this container).
+            if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
+                printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
+                exit 2
+            fi
+            _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
+            if [[ -z "$_fetched" ]]; then
+                printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
+                exit 2
+            fi
             printf -v "$_active_tags_var" '%s' "$_fetched"
         fi
     fi
     _active_tags="${!_active_tags_var}"
-    if [[ -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+    if ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
         printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
             "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
         continue

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -113,10 +113,12 @@ _probe_digest() {
     local safe_ref
     safe_ref=$(_escape_gha_command "$image_ref")
 
-    # Guarantee temp file cleanup on all return paths (including early returns
-    # for empty raw and missing digest below).
+    # Explicit cleanup on every return path below.  We do NOT use
+    # `trap '...' RETURN` because bash RETURN traps are GLOBAL — they fire on
+    # every subsequent function return in the same shell, not just returns from
+    # the function that set them.  Under set -u that crashes the script after
+    # the first _probe_digest call when probe_stderr is out of scope.
     probe_stderr=$(mktemp)
-    trap 'rm -f "$probe_stderr"' RETURN
 
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
@@ -125,6 +127,7 @@ _probe_digest() {
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
+            rm -f "$probe_stderr"
             return 1
         fi
     else
@@ -133,12 +136,14 @@ _probe_digest() {
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
+            rm -f "$probe_stderr"
             return 1
         fi
     fi
 
     if [[ -z "$raw" ]]; then
         printf '::error::imagetools inspect returned empty output for %s\n' "$safe_ref" >&2
+        rm -f "$probe_stderr"
         return 1
     fi
 
@@ -148,9 +153,11 @@ _probe_digest() {
 
     if [[ -z "$digest" ]]; then
         printf '::error::could not extract digest from manifest for %s\n' "$safe_ref" >&2
+        rm -f "$probe_stderr"
         return 1
     fi
 
+    rm -f "$probe_stderr"
     printf '%s' "$digest"
     return 0
 }

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -292,22 +292,28 @@ for lineage_file in "${lineage_files[@]}"; do
             if [[ -n "${!_override_var:-}" ]]; then
                 printf -v "$_active_tags_var" '%s' "${!_override_var}"
             else
-                # list-builds must succeed; on failure abort rather than silently skip
-                # the stale-lineage filter (which would disable drift detection).
+                # list-builds may fail transiently (upstream discovery, version script timeout).
+                # Skip this container's variants (stale-lineage filter disabled) rather than
+                # aborting the entire drift detector, which would suppress drift reports
+                # for all subsequent containers.
                 if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
-                    printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
-                    exit 2
+                    printf '::warning::./make list-builds %s failed — skipping stale-lineage filter for this container (drift detection still active)\n' "$container" >&2
+                    printf -v "$_active_tags_var" '%s' "__SKIPPED__"
+                else
+                    _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
+                    if [[ -z "$_fetched" ]]; then
+                        printf '::warning::./make list-builds %s returned no tags — skipping stale-lineage filter (drift detection still active)\n' "$container" >&2
+                        printf -v "$_active_tags_var" '%s' "__SKIPPED__"
+                    else
+                        printf -v "$_active_tags_var" '%s' "$_fetched"
+                    fi
                 fi
-                _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
-                if [[ -z "$_fetched" ]]; then
-                    printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
-                    exit 2
-                fi
-                printf -v "$_active_tags_var" '%s' "$_fetched"
             fi
         fi
         _active_tags="${!_active_tags_var}"
-        if ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+        # Skip filtering if: list-builds failed (__SKIPPED__), override empty string (test mode no-filter),
+        # or tag matches active set
+        if [[ "$_active_tags" != "__SKIPPED__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
             printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
                 "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
             continue

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -313,7 +313,7 @@ for lineage_file in "${lineage_files[@]}"; do
     # Explicit cntrl-char rejection at entry point closes that bypass entirely.
     if [[ "$container" =~ [[:cntrl:]] ]]; then
         printf '::warning::Rejecting lineage entry %s: container name contains control chars: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(printf '%q' "$container")" >&2
+            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
         continue
     fi
 
@@ -352,7 +352,7 @@ for lineage_file in "${lineage_files[@]}"; do
     # reach markdown with incomplete escaping. Validate early to close bypass.
     if [[ "$variant_tag" =~ [[:cntrl:]] ]]; then
         printf '::warning::Rejecting lineage entry %s: tag contains control chars: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(printf '%q' "$variant_tag")" >&2
+            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$variant_tag")" >&2
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -179,6 +179,69 @@ _sanitize_for_json() {
 }
 
 # ---------------------------------------------------------------------------
+# Validate base_image_ref shape and registry allowlist (SSRF prevention).
+#
+# A poisoned lineage cache with an attacker-controlled base_image_ref could
+# cause the workflow to probe an untrusted registry with Docker credentials,
+# potentially leaking tokens or enabling SSRF abuse.
+#
+# Accepts:
+#   - Docker Hub bare names:  alpine:3.21, postgres:17-alpine, org/image:tag
+#   - Explicit GHCR refs:     ghcr.io/owner/image:tag[@digest]
+#   - Microsoft MCR refs:     mcr.microsoft.com/windows/servercore:ltsc2022
+#
+# Rejects anything whose registry component is not in the above set.
+#
+# Registry detection (per OCI Distribution Spec):
+#   An explicit registry is present only when the ref contains a '/' AND the
+#   first path segment (before the first '/') contains a '.' (FQDN) or a ':'
+#   (host:port pattern like localhost:5000).
+#   If the ref has no '/', it is always a Docker Hub bare name (image:tag).
+#   If the ref has '/' but the first segment has no '.' and no ':', the first
+#   segment is a Docker Hub org name (e.g., hashicorp/terraform:1.14.4).
+#
+# Returns 0 if valid, 1 if rejected.
+# ---------------------------------------------------------------------------
+_validate_image_ref() {
+    local ref="$1"
+
+    # Must be non-empty and free of whitespace/control chars
+    if [[ -z "$ref" || "$ref" =~ [[:space:][:cntrl:]] ]]; then
+        return 1
+    fi
+
+    # No '/' in ref → always a Docker Hub bare name (image:tag or image:version)
+    # e.g. alpine:3.21, postgres:17-alpine, ubuntu:latest
+    if [[ "$ref" != *"/"* ]]; then
+        return 0
+    fi
+
+    # Ref has at least one '/' — check if the first segment is an explicit registry.
+    # Per OCI spec, the first segment is a registry host only if it contains '.'
+    # (FQDN) or ':' (host:port).  Otherwise it is a Docker Hub org name.
+    local first_segment="${ref%%/*}"
+
+    # Docker Hub org/image pattern (e.g. hashicorp/terraform:1.14.4)
+    if [[ "$first_segment" != *"."* && "$first_segment" != *":"* ]]; then
+        return 0
+    fi
+
+    # Explicit registry FQDN or host:port — check against allowlist
+    local registry="$first_segment"
+    case "$registry" in
+        ghcr.io | \
+        registry-1.docker.io | \
+        index.docker.io | \
+        mcr.microsoft.com)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
 # Walk lineage directory
 # ---------------------------------------------------------------------------
 if [[ ! -d "$LINEAGE_DIR" ]]; then
@@ -299,17 +362,21 @@ for lineage_file in "${lineage_files[@]}"; do
                 printf -v "$_active_tags_var" '%s' "__TEST_NO_FILTER__"
             else
                 # Production mode: list-builds may fail transiently (upstream discovery, version script timeout).
-                # Skip this container's variants (stale-lineage filter disabled) rather than
-                # aborting the entire drift detector, which would suppress drift reports
-                # for all subsequent containers.
-                if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
-                    printf '::warning::./make list-builds %s failed — skipping stale-lineage filter for this container (drift detection still active)\n' "$container" >&2
-                    printf -v "$_active_tags_var" '%s' "__SKIPPED__"
+                # FAIL CLOSED: skip ALL variants for this container (no drift detection) rather than
+                # disabling the stale-lineage filter.  Disabling the filter is worse — it allows stale
+                # lineage entries to re-trigger drift PRs on every cron run (infinite PR loop).
+                # A missed drift during a transient failure is recoverable; a runaway PR loop is not.
+                _lb_rc=0
+                _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null) || _lb_rc=$?
+                if [[ "$_lb_rc" -ne 0 ]]; then
+                    printf '::warning::./make list-builds %s failed (rc=%s) — skipping entire container (fail-closed; retry next cron run)\n' "$container" "$_lb_rc" >&2
+                    # Mark container as fully skipped so the outer loop continues to the next container
+                    printf -v "$_active_tags_var" '%s' "__CONTAINER_SKIP__"
                 else
                     _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
                     if [[ -z "$_fetched" ]]; then
-                        printf '::warning::./make list-builds %s returned no tags — skipping stale-lineage filter (drift detection still active)\n' "$container" >&2
-                        printf -v "$_active_tags_var" '%s' "__SKIPPED__"
+                        printf '::warning::./make list-builds %s returned no tags — skipping entire container (fail-closed; retry next cron run)\n' "$container" >&2
+                        printf -v "$_active_tags_var" '%s' "__CONTAINER_SKIP__"
                     else
                         printf -v "$_active_tags_var" '%s' "$_fetched"
                     fi
@@ -317,9 +384,13 @@ for lineage_file in "${lineage_files[@]}"; do
             fi
         fi
         _active_tags="${!_active_tags_var}"
-        # Skip filtering if: list-builds failed (__SKIPPED__), test-mode no-filter (__TEST_NO_FILTER__),
+        # Fail-closed: if list-builds failed for this container, skip ALL its variants
+        if [[ "$_active_tags" == "__CONTAINER_SKIP__" ]]; then
+            continue
+        fi
+        # Skip filtering if: test-mode no-filter (__TEST_NO_FILTER__),
         # empty override (backward compat), or tag matches active set
-        if [[ "$_active_tags" != "__SKIPPED__" && "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+        if [[ "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
             printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
                 "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
             continue
@@ -396,6 +467,16 @@ for lineage_file in "${lineage_files[@]}"; do
             '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
         # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
         _container_variants["$container"]+="${variant_json}"$'\n'
+        continue
+    fi
+
+    # Validate base_image_ref before probing (SSRF prevention).
+    # Poisoned lineage with an attacker-controlled ref could cause the workflow
+    # to probe an untrusted registry with Docker credentials.
+    if ! _validate_image_ref "$base_image_ref"; then
+        printf '::warning::Refusing to probe untrusted base_image_ref for %s:%s: %s\n' \
+            "$(_escape_gha_command "$container")" "$variant_tag_safe" \
+            "$(_escape_gha_command "$base_image_ref")" >&2
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -238,6 +238,13 @@ _validate_image_ref() {
     # (FQDN) or ':' (host:port).  Otherwise it is a Docker Hub org name.
     local first_segment="${ref%%/*}"
 
+    # Reject localhost-as-registry: Docker/OCI treats bare 'localhost' (and
+    # 'localhost:PORT') as an explicit registry host, not a Docker Hub namespace.
+    # Allowing it would bypass the registry allowlist on self-hosted runners.
+    if [[ "$first_segment" == "localhost" || "$first_segment" == localhost:* ]]; then
+        return 1
+    fi
+
     # Docker Hub org/image pattern (e.g. hashicorp/terraform:1.14.4)
     if [[ "$first_segment" != *"."* && "$first_segment" != *":"* ]]; then
         return 0
@@ -328,7 +335,7 @@ for lineage_file in "${lineage_files[@]}"; do
             fi
         fi
     fi
-    if ! grep -qxF "$container" <<<"$_valid_containers"; then
+    if ! grep -qxF -- "$container" <<<"$_valid_containers"; then
         printf '::warning::Skipping %s: invalid container name '\''%s'\'' (not in ./make list)\n' \
             "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
         continue
@@ -408,7 +415,7 @@ for lineage_file in "${lineage_files[@]}"; do
         fi
         # Skip filtering if: test-mode no-filter (__TEST_NO_FILTER__),
         # empty override (backward compat), or tag matches active set
-        if [[ "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+        if [[ "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF -- "$variant_tag" <<<"$_active_tags"; then
             printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
                 "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
             continue

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -430,8 +430,28 @@ for lineage_file in "${lineage_files[@]}"; do
             fi
         fi
         _active_tags="${!_active_tags_var}"
-        # Fail-closed: if list-builds failed for this container, skip ALL its variants
+        # Fail-closed: if list-builds failed for this container, emit an explicit
+        # error record per lineage entry so error_count surfaces the gap (r29 Finding 2).
+        # Before r29, this path silently dropped the entry, leaving the workflow green
+        # even when an entire container's drift detection was unavailable.
         if [[ "$_active_tags" == "__CONTAINER_SKIP__" ]]; then
+            # Ensure container is registered in the output map before emitting
+            if [[ -z "${_container_variants[$container]+x}" ]]; then
+                _container_order+=("$container")
+                _container_variants["$container"]=""
+            fi
+            _err_base_ref=$(jq -re '.base_image_ref // empty' "$lineage_file" 2>/dev/null || true)
+            _err_recorded=$(jq -re '.base_image_digest // empty' "$lineage_file" 2>/dev/null || true)
+            _err_base_safe=$(_sanitize_for_json "$_err_base_ref")
+            _err_recorded_safe=$(_sanitize_for_json "$_err_recorded")
+            variant_json=$(jq -cn \
+                --arg variant_tag     "$variant_tag" \
+                --arg base_ref        "$_err_base_safe" \
+                --arg recorded_digest "$_err_recorded_safe" \
+                --arg status          "error" \
+                --arg error_reason    "active_tags_unavailable" \
+                '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+            _container_variants["$container"]+="${variant_json}"$'\n'
             continue
         fi
         # Skip filtering if: test-mode no-filter (__TEST_NO_FILTER__),
@@ -544,6 +564,19 @@ for lineage_file in "${lineage_files[@]}"; do
         printf '::warning::Refusing to probe untrusted base_image_ref for %s:%s: %s\n' \
             "$(_escape_gha_command "$container")" "$variant_tag_safe" \
             "$(_escape_gha_command "$base_image_ref")" >&2
+        # r29 Finding 3: emit an explicit error record so error_count surfaces the
+        # rejection in workflow output.  The ::warning:: above is kept for the audit
+        # trail on stderr; the record here is the machine-readable signal.
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        variant_json=$(jq -cn \
+            --arg variant_tag     "$variant_tag" \
+            --arg base_ref        "$safe_ref" \
+            --arg recorded_digest "$safe_recorded" \
+            --arg status          "error" \
+            --arg error_reason    "untrusted_ref" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -495,6 +495,27 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
+    # Fix r23: validate recorded_digest shape before comparing.
+    # A malformed value (written by an older probe before the write-side guard)
+    # must not be treated as an authoritative baseline — comparing a corrupt
+    # hash against a valid probe result drives bogus drift PRs.
+    if [[ ! "$recorded_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        printf '::warning::Malformed recorded_digest for %s:%s ('\''%s'\''); treating as corrupt lineage\n' \
+            "$(_escape_gha_command "$container")" "$(_escape_gha_command "$variant_tag")" \
+            "$(_escape_gha_command "$recorded_digest")" >&2
+        variant_json=$(jq -cn \
+            --arg variant_tag       "$variant_tag" \
+            --arg base_ref          "$safe_ref" \
+            --arg recorded_digest   "$safe_recorded" \
+            --arg status            "error" \
+            --arg error_reason      "malformed_recorded_digest" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
+        continue
+    fi
+
     # Validate base_image_ref before probing (SSRF prevention).
     # Poisoned lineage with an attacker-controlled ref could cause the workflow
     # to probe an untrusted registry with Docker credentials.

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -229,6 +229,7 @@ _validate_image_ref() {
     # Explicit registry FQDN or host:port — check against allowlist
     local registry="$first_segment"
     case "$registry" in
+        docker.io | \
         ghcr.io | \
         registry-1.docker.io | \
         index.docker.io | \

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -113,29 +113,28 @@ _probe_digest() {
     local safe_ref
     safe_ref=$(_escape_gha_command "$image_ref")
 
+    # Guarantee temp file cleanup on all return paths (including early returns
+    # for empty raw and missing digest below).
+    probe_stderr=$(mktemp)
+    trap 'rm -f "$probe_stderr"' RETURN
+
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
-        probe_stderr=$(mktemp)
         raw=$("${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
-            rm -f "$probe_stderr"
             [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             return 1
         fi
-        rm -f "$probe_stderr"
     else
-        probe_stderr=$(mktemp)
         raw=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
-            rm -f "$probe_stderr"
             printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             return 1
         fi
-        rm -f "$probe_stderr"
     fi
 
     if [[ -z "$raw" ]]; then

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -219,6 +219,16 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
+    # Fix 3 (gate r9): Reject container names with control characters BEFORE the
+    # grep -qxF check.  A value like $'ansible\nmalicious' contains a newline which
+    # grep -xF treats as TWO patterns, so "ansible" matches and "malicious" passes
+    # validation silently.  Explicit cntrl-char rejection closes that bypass.
+    if [[ "$container" =~ [[:cntrl:]] ]]; then
+        printf '::warning::Rejecting lineage entry %s: container name contains control chars: %s\n' \
+            "$(_escape_gha_command "$basename_file")" "$(printf '%q' "$container")" >&2
+        continue
+    fi
+
     # Validate container name against canonical list (Fix 1: poisoning prevention)
     # A corrupted entry (e.g. container: "docs", container: ".github", or a path
     # with "/") could otherwise cause the bot to act on non-container directories.
@@ -246,6 +256,40 @@ for lineage_file in "${lineage_files[@]}"; do
     variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$variant_tag" ]]; then
         printf '::warning::Skipping %s: missing '\''tag'\'' field\n' "$(_escape_gha_command "$basename_file")" >&2
+        continue
+    fi
+
+    # Fix 2 (gate r9): sanitize tag for safe embedding in GHA commands / markdown.
+    # Applied here so every downstream use of $variant_tag_safe is already clean.
+    variant_tag_safe=$(_escape_gha_command "$variant_tag")
+
+    # Fix 1 (gate r9, NON-TERMINATING BUG): filter to active build-matrix tags only.
+    # Stale lineage files for dropped/non-retained tags persist in the cache after
+    # rotation.  Without this filter each cron run re-detects drift on them, opens a
+    # PR, the PR rebuild only updates current retained tags → stale lineage unchanged
+    # → next cron re-detects → infinite PR loop.
+    #
+    # _ACTIVE_TAGS_OVERRIDE_<container>: test hook — set to a newline-separated list
+    # of active tags for a container to bypass ./make list-builds in tests.
+    #
+    # Cache key: _active_tags_cache_<container> (associative array not available in
+    # bash <4.2 without namerefs; use indirect variable via printf '%s' trick).
+    _active_tags_var="_active_tags_cache_${container//-/_}"
+    if [[ -z "${!_active_tags_var+x}" ]]; then
+        # Check for per-container test hook first
+        _override_var="_ACTIVE_TAGS_OVERRIDE_${container//-/_}"
+        if [[ -n "${!_override_var:-}" ]]; then
+            printf -v "$_active_tags_var" '%s' "${!_override_var}"
+        else
+            _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null \
+                | jq -r '.[].tag // empty' 2>/dev/null | sort -u || true)
+            printf -v "$_active_tags_var" '%s' "$_fetched"
+        fi
+    fi
+    _active_tags="${!_active_tags_var}"
+    if [[ -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+        printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
+            "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -137,7 +137,9 @@ _probe_digest() {
             return 1
         fi
     else
-        raw=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        # `--` separates options from the image ref: belt-and-suspenders against
+        # dash-prefix option injection if a poisoned ref slips past _validate_image_ref.
+        raw=$(docker buildx imagetools inspect --format '{{json .Manifest}}' -- "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
@@ -217,6 +219,14 @@ _sanitize_for_json() {
 # ---------------------------------------------------------------------------
 _validate_image_ref() {
     local ref="$1"
+
+    # Reject refs starting with '-' — a dash-prefix ref would be treated as a
+    # CLI option by `docker buildx imagetools inspect` (and similar tools) even
+    # with quoted expansion, unless a `--` separator is present at the call site.
+    # Belt-and-suspenders: reject here AND use `--` at the call site (line ~140).
+    # Without this guard, `-h` triggers help output and `--config /tmp/x` swaps
+    # the Docker config — option injection via poisoned lineage entries.
+    [[ "$ref" == -* ]] && return 1
 
     # Reject refs starting with '/' — first_segment would be empty, which
     # falls through the OCI registry-host check with no meaningful value.

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -391,8 +391,18 @@ for lineage_file in "${lineage_files[@]}"; do
                 # disabling the stale-lineage filter.  Disabling the filter is worse — it allows stale
                 # lineage entries to re-trigger drift PRs on every cron run (infinite PR loop).
                 # A missed drift during a transient failure is recoverable; a runaway PR loop is not.
+                #
+                # Pass `current` (not the default `latest`) so the active-tag filter operates on the
+                # currently-published version rather than the upstream-newest version.  Without this,
+                # when an upstream-version PR is pending (upstream X.Y released but variants.yaml still
+                # at X.Y-1), list-builds returns tags from the future state while lineage files hold
+                # tags from the currently-published state — the filter rejects them as "stale" and
+                # drift on the live container is silently undetected until the version PR merges.
+                # When `current` resolves to empty (new container, never built), get_build_version
+                # returns "unknown", list_container_builds emits empty output, and the existing
+                # fail-closed path below handles it with a ::warning:: (no new code needed).
                 _lb_rc=0
-                _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null) || _lb_rc=$?
+                _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" current 2>/dev/null) || _lb_rc=$?
                 if [[ "$_lb_rc" -ne 0 ]]; then
                     printf '::warning::./make list-builds %s failed (rc=%s) — skipping entire container (fail-closed; retry next cron run)\n' "$container" "$_lb_rc" >&2
                     # Mark container as fully skipped so the outer loop continues to the next container

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -224,6 +224,15 @@ for lineage_file in "${lineage_files[@]}"; do
     # Determine status
     # ---------------------------------------------------------------------------
 
+    # Skip if base_image_ref is unresolved (placeholder from pre-#530 lineage).
+    # Must precede the legacy check: a file with ${...} in base_image_ref and
+    # no recorded digest would otherwise be mis-classified as "legacy" and
+    # generate a bogus drift PR.
+    if [[ "$base_image_ref" =~ \$ ]]; then
+        echo "::warning::Skipping $basename_file: base_image_ref contains unresolved placeholder: $base_image_ref" >&2
+        continue
+    fi
+
     # Legacy: lineage lacks base_image_digest field
     if [[ -z "$recorded_digest" || "$recorded_digest" == "unresolved" ]]; then
         safe_ref=$(_sanitize_for_json "${base_image_ref:-unknown}")
@@ -240,12 +249,6 @@ for lineage_file in "${lineage_files[@]}"; do
             # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
             _container_variants["$container"]+="${variant_json}"$'\n'
         fi
-        continue
-    fi
-
-    # Skip if base_image_ref is unresolved (placeholder from pre-#530 lineage)
-    if [[ "$base_image_ref" =~ \$ ]]; then
-        echo "::warning::Skipping $basename_file: base_image_ref contains unresolved placeholder: $base_image_ref" >&2
         continue
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -259,7 +259,16 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Fix 2 (gate r9): sanitize tag for safe embedding in GHA commands / markdown.
+    # Reject tags with control characters before any grep/markdown operations.
+    # A tag like "active\npayload" would pass grep -xF (multiple patterns) and
+    # reach markdown with incomplete escaping. Validate early to close bypass.
+    if [[ "$variant_tag" =~ [[:cntrl:]] ]]; then
+        printf '::warning::Rejecting lineage entry %s: tag contains control chars: %s\n' \
+            "$(_escape_gha_command "$basename_file")" "$(printf '%q' "$variant_tag")" >&2
+        continue
+    fi
+
+    # Sanitize tag for safe embedding in GHA commands / markdown.
     # Applied here so every downstream use of $variant_tag_safe is already clean.
     variant_tag_safe=$(_escape_gha_command "$variant_tag")
 
@@ -281,19 +290,25 @@ for lineage_file in "${lineage_files[@]}"; do
         if [[ -n "${!_override_var:-}" ]]; then
             printf -v "$_active_tags_var" '%s' "${!_override_var}"
         else
-            # list-builds must succeed; on failure abort rather than silently skip
-            # the stale-lineage filter (which would disable drift detection for all
-            # variants of this container).
-            if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
-                printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
-                exit 2
+            # In test mode (when _VALID_CONTAINERS_OVERRIDE is set), generate stub
+            # active tags for the container to avoid calling real ./make list-builds.
+            # Outside tests, list-builds must succeed; on failure abort.
+            if [[ -n "${_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
+                # Test mode: construct minimal tag from container name for stale-check
+                # (tests validate container name, but don't care about tag matching)
+                printf -v "$_active_tags_var" '%s' "test-tag-for-$container"
+            else
+                if ! _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" 2>/dev/null); then
+                    printf '::error::./make list-builds %s failed — cannot determine active tags for drift filtering, aborting\n' "$container" >&2
+                    exit 2
+                fi
+                _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
+                if [[ -z "$_fetched" ]]; then
+                    printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
+                    exit 2
+                fi
+                printf -v "$_active_tags_var" '%s' "$_fetched"
             fi
-            _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
-            if [[ -z "$_fetched" ]]; then
-                printf '::error::./make list-builds %s returned no tags — drift filter broken for %s, aborting\n' "$container" "$container" >&2
-                exit 2
-            fi
-            printf -v "$_active_tags_var" '%s' "$_fetched"
         fi
     fi
     _active_tags="${!_active_tags_var}"

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -282,6 +282,8 @@ for lineage_file in "${lineage_files[@]}"; do
     if [[ "$BASELINE_ONLY" != "true" ]]; then
         # _ACTIVE_TAGS_OVERRIDE_<container>: test hook — set to a newline-separated list
         # of active tags for a container to bypass ./make list-builds in tests.
+        # If _VALID_CONTAINERS_OVERRIDE is set (test mode) and _ACTIVE_TAGS_OVERRIDE_*
+        # is NOT set, disable filtering for that container (test-mode default).
         #
         # Cache key: _active_tags_cache_<container> (associative array not available in
         # bash <4.2 without namerefs; use indirect variable via printf '%s' trick).
@@ -290,9 +292,13 @@ for lineage_file in "${lineage_files[@]}"; do
             # Check for per-container test hook first
             _override_var="_ACTIVE_TAGS_OVERRIDE_${container//-/_}"
             if [[ -n "${!_override_var:-}" ]]; then
+                # Override is explicitly set (even if empty) — use it as-is
                 printf -v "$_active_tags_var" '%s' "${!_override_var}"
+            elif [[ -n "${_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
+                # Test mode detected but no per-container override — disable filtering
+                printf -v "$_active_tags_var" '%s' "__TEST_NO_FILTER__"
             else
-                # list-builds may fail transiently (upstream discovery, version script timeout).
+                # Production mode: list-builds may fail transiently (upstream discovery, version script timeout).
                 # Skip this container's variants (stale-lineage filter disabled) rather than
                 # aborting the entire drift detector, which would suppress drift reports
                 # for all subsequent containers.
@@ -311,9 +317,9 @@ for lineage_file in "${lineage_files[@]}"; do
             fi
         fi
         _active_tags="${!_active_tags_var}"
-        # Skip filtering if: list-builds failed (__SKIPPED__), override empty string (test mode no-filter),
-        # or tag matches active set
-        if [[ "$_active_tags" != "__SKIPPED__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
+        # Skip filtering if: list-builds failed (__SKIPPED__), test-mode no-filter (__TEST_NO_FILTER__),
+        # empty override (backward compat), or tag matches active set
+        if [[ "$_active_tags" != "__SKIPPED__" && "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF "$variant_tag" <<<"$_active_tags"; then
             printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
                 "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
             continue
@@ -373,9 +379,16 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Legacy: lineage lacks base_image_digest field
+    # Skip if base_image_ref is unknown or missing (must run BEFORE legacy check
+    # which would otherwise emit a legacy record for a corrupt/unknown entry).
+    if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
+        printf '::warning::Skipping %s: base_image_ref is unknown or missing\n' "$(_escape_gha_command "$basename_file")" >&2
+        continue
+    fi
+
+    # Legacy: lineage lacks base_image_digest field (known base_image_ref only)
     if [[ -z "$recorded_digest" || "$recorded_digest" == "unresolved" ]]; then
-        safe_ref=$(_sanitize_for_json "${base_image_ref:-unknown}")
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
         variant_json=$(jq -cn \
             --arg variant_tag  "$variant_tag" \
             --arg base_ref     "$safe_ref" \
@@ -383,12 +396,6 @@ for lineage_file in "${lineage_files[@]}"; do
             '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
         # Normal mode: legacy is treated as drift-equivalent (will trigger PR)
         _container_variants["$container"]+="${variant_json}"$'\n'
-        continue
-    fi
-
-    # Skip if no base_image_ref
-    if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
-        printf '::warning::Skipping %s: base_image_ref is unknown\n' "$(_escape_gha_command "$basename_file")" >&2
         continue
     fi
 

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -65,7 +65,7 @@ if [[ -z "$valid_containers" ]]; then
     echo "::error::./make list returned empty — canonical container list unavailable" >&2
     exit 2
 fi
-if ! grep -qxF "$CONTAINER" <<<"$valid_containers"; then
+if ! grep -qxF -- "$CONTAINER" <<<"$valid_containers"; then
     echo "::warning::container '$CONTAINER' is not a valid container name (not in ./make list) — skipping" >&2
     exit 0
 fi

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -31,6 +31,27 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command.  A %0A in the value would terminate the command line and
+# inject the remainder as a new command.  Mapping per GitHub's runner spec:
+#   %  → %25
+#   \n → %0A
+#   \r → %0D
+#
+# Inlined from helpers/base-cache-utils.sh::_escape_gha_command to avoid
+# importing the full base-cache helper.
+# ---------------------------------------------------------------------------
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    printf '%s' "$s"
+}
+
+# ---------------------------------------------------------------------------
 # Argument validation
 # ---------------------------------------------------------------------------
 if [[ $# -lt 2 ]]; then
@@ -55,18 +76,35 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-make_exit=0
-valid_containers=$(cd "$PROJECT_ROOT" && ./make list) || make_exit=$?
-if [[ "$make_exit" -ne 0 ]]; then
-    echo "::error::./make list failed with exit $make_exit" >&2
-    exit 2
+# _ULR_PROJECT_ROOT_OVERRIDE: test hook — when set, use this path as PROJECT_ROOT
+# instead of deriving it from BASH_SOURCE[0].  Avoids needing the full project
+# context in unit tests that invoke update-last-rebuild.sh via bash "$UPDATE_SCRIPT".
+# Named with _ULR_ prefix to avoid collision with similarly-named vars in the
+# detect-base-digest-drift.sh test suite.
+if [[ -n "${_ULR_PROJECT_ROOT_OVERRIDE:-}" ]]; then
+    PROJECT_ROOT="$_ULR_PROJECT_ROOT_OVERRIDE"
 fi
-if [[ -z "$valid_containers" ]]; then
-    echo "::error::./make list returned empty — canonical container list unavailable" >&2
-    exit 2
+
+make_exit=0
+# _ULR_VALID_CONTAINERS_OVERRIDE: test hook — when set, use this newline-separated
+# list instead of ./make list (avoids needing the full project context in tests).
+# Named with _ULR_ prefix to avoid collision with _VALID_CONTAINERS_OVERRIDE used
+# by detect-base-digest-drift.sh (which is exported by its bats setup()).
+if [[ -n "${_ULR_VALID_CONTAINERS_OVERRIDE:-}" ]]; then
+    valid_containers="$_ULR_VALID_CONTAINERS_OVERRIDE"
+else
+    valid_containers=$(cd "$PROJECT_ROOT" && ./make list) || make_exit=$?
+    if [[ "$make_exit" -ne 0 ]]; then
+        echo "::error::./make list failed with exit $make_exit" >&2
+        exit 2
+    fi
+    if [[ -z "$valid_containers" ]]; then
+        echo "::error::./make list returned empty — canonical container list unavailable" >&2
+        exit 2
+    fi
 fi
 if ! grep -qxF -- "$CONTAINER" <<<"$valid_containers"; then
-    echo "::warning::container '$CONTAINER' is not a valid container name (not in ./make list) — skipping" >&2
+    echo "::warning::container '$(_escape_gha_command "$CONTAINER")' is not a valid container name (not in ./make list) — skipping" >&2
     exit 0
 fi
 
@@ -136,6 +174,17 @@ target_file="${PROJECT_ROOT}/${CONTAINER}/LAST_REBUILD.md"
 # written.  A stale entry must not break the entire workflow.
 if [[ ! -d "${PROJECT_ROOT}/${CONTAINER}" ]]; then
     echo "::warning::container directory '${PROJECT_ROOT}/${CONTAINER}' missing — skipping LAST_REBUILD.md update" >&2
+    exit 0
+fi
+
+# Idempotency: skip-if-present (gate r25, Defect B).
+# compute_build_digest hashes LAST_REBUILD.md; each duplicate section would
+# change the hash and retrigger smoke CI on workflow retries.  If today's
+# heading already exists, we no-op rather than append a duplicate.
+# Strategy chosen: skip-if-present (simpler than replace-in-place; body
+# content is informational and mid-day changes are rare operator-edit cases).
+if grep -qxF -- "$section_header" "$target_file" 2>/dev/null; then
+    echo "::notice::Same-day ${KIND} section already present in $target_file, skipping append" >&2
     exit 0
 fi
 

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -104,9 +104,14 @@ fi
 today=$(date -u +"%Y-%m-%d")
 section_header="## ${KIND} (${today})"
 
-# Build variant lines using jq to safely extract field values
+# Build variant lines using jq to safely extract field values.
+# Fix 2 (gate r9): escape backticks and pipes in variant_tag and base_image_ref
+# before embedding in markdown — prevents injection via poisoned lineage entries.
 variant_lines=$(printf '%s' "$drifted_variants" | \
-    jq -r '.[] | "- Variant: \(.variant_tag), base \(.base_image_ref)\n  Old digest: \(.recorded_digest // "unknown")\n  New digest: \(.current_digest // "(legacy — no recorded digest)")"' \
+    jq -r '.[] |
+        (.variant_tag | gsub("`"; "\\`") | gsub("\\|"; "\\|")) as $safe_tag |
+        (.base_image_ref | gsub("`"; "\\`") | gsub("\\|"; "\\|")) as $safe_ref |
+        "- Variant: \($safe_tag), base \($safe_ref)\n  Old digest: \(.recorded_digest // "unknown")\n  New digest: \(.current_digest // "(legacy — no recorded digest)")"' \
     2>/dev/null || true)
 
 if [[ -z "$variant_lines" ]]; then

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -26,6 +26,7 @@
 # Exit codes:
 #   0  — Section appended (or container has no drifted variants — no-op)
 #   1  — Fatal error (invalid args, missing jq, etc.)
+#   2  — Tooling failure (./make list unavailable or returned empty)
 
 set -euo pipefail
 
@@ -54,7 +55,12 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-valid_containers=$(cd "$PROJECT_ROOT" && ./make list)
+make_exit=0
+valid_containers=$(cd "$PROJECT_ROOT" && ./make list) || make_exit=$?
+if [[ "$make_exit" -ne 0 ]]; then
+    echo "::error::./make list failed with exit $make_exit" >&2
+    exit 2
+fi
 if [[ -z "$valid_containers" ]]; then
     echo "::error::./make list returned empty — canonical container list unavailable" >&2
     exit 2

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -177,19 +177,33 @@ if [[ ! -d "${PROJECT_ROOT}/${CONTAINER}" ]]; then
     exit 0
 fi
 
-# Idempotency: skip-if-present (gate r25, Defect B).
-# compute_build_digest hashes LAST_REBUILD.md; each duplicate section would
-# change the hash and retrigger smoke CI on workflow retries.  If today's
-# heading already exists, we no-op rather than append a duplicate.
-# Strategy chosen: skip-if-present (simpler than replace-in-place; body
-# content is informational and mid-day changes are rare operator-edit cases).
-if grep -qxF -- "$section_header" "$target_file" 2>/dev/null; then
-    echo "::notice::Same-day ${KIND} section already present in $target_file, skipping append" >&2
+# Idempotency: content-hash dedupe (gate r27, Defect C — replaces r25 heading-only dedupe).
+#
+# The r25 fix deduped on the `## base-digest-drift (YYYY-MM-DD)` heading alone.
+# False negative: if drift A merges in the morning → rebuild → then drift B
+# (different variants) occurs the same UTC day → the heading is already present →
+# script skipped → no file change → no PR/rebuild trigger for drift B.
+#
+# Fix: embed a SHA-256 content-hash of the drift section body as an HTML comment
+# ABOVE the heading.  Two invocations with identical drift content (same variants,
+# same digests) share the same hash → idempotent skip preserved.  Two invocations
+# with different content (even on the same day) produce different hashes → both
+# sections are appended.
+#
+# Hash scope: variant_lines only (the stable, injected-safe content derived from
+# drift JSON).  16 hex characters is sufficient; collision probability per
+# container per day is negligible.
+drift_content_hash=$(printf '%s\n' "${variant_lines}" | sha256sum | cut -d' ' -f1 | head -c 16)
+hash_marker="<!-- drift-content-hash: ${drift_content_hash} -->"
+
+if grep -qF -- "$hash_marker" "$target_file" 2>/dev/null; then
+    echo "::notice::Same drift event already recorded (hash ${drift_content_hash}), skipping append" >&2
     exit 0
 fi
 
 {
     printf '\n'
+    printf '%s\n' "$hash_marker"
     printf '%s\n' "$section_header"
     printf '\n'
     printf '%s\n' "$variant_lines"

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# update-last-rebuild.sh — Append a `## base-digest-drift (YYYY-MM-DD)` section
+# to <container>/LAST_REBUILD.md, distinguishing from upstream-monitor's
+# existing `## version-update` sections.
+#
+# Usage:
+#   ./scripts/update-last-rebuild.sh <container> <kind> < drift.json
+#
+#   <container>  — Container directory name (e.g. "foo")
+#   <kind>       — Section identifier (e.g. "base-digest-drift")
+#
+# Input (stdin):
+#   JSON array from detect-base-digest-drift.sh output.
+#   The script filters for the given container's drifted variants.
+#
+# Output:
+#   Appends a markdown section to <container>/LAST_REBUILD.md (creates the
+#   file if it does not exist). The file already exists for most containers
+#   (written by upstream-monitor.yaml:440) — we append a new section.
+#
+# Injection safety:
+#   All values written to the file are passed through printf '%s' and
+#   sanitized — no direct interpolation of registry-sourced data in
+#   heredocs or eval contexts.
+#
+# Exit codes:
+#   0  — Section appended (or container has no drifted variants — no-op)
+#   1  — Fatal error (invalid args, missing jq, etc.)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <container> <kind>" >&2
+    echo "  Reads drift JSON from stdin." >&2
+    exit 1
+fi
+
+CONTAINER="$1"
+KIND="$2"
+
+if [[ -z "$CONTAINER" ]]; then
+    echo "::error::container argument is empty" >&2
+    exit 1
+fi
+
+if [[ -z "$KIND" ]]; then
+    echo "::error::kind argument is empty" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Read drift JSON from stdin
+# ---------------------------------------------------------------------------
+drift_json=$(cat)
+
+if [[ -z "$drift_json" ]]; then
+    echo "::warning::No drift JSON on stdin — nothing to write for $CONTAINER" >&2
+    exit 0
+fi
+
+# Validate it's parseable JSON
+if ! printf '%s' "$drift_json" | jq '.' >/dev/null 2>&1; then
+    echo "::error::Drift JSON from stdin is not valid JSON" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Extract drifted variants for this container
+# ---------------------------------------------------------------------------
+drifted_variants=$(printf '%s' "$drift_json" | \
+    jq -c --arg c "$CONTAINER" \
+    '[.[] | select(.container == $c) | .variants[] | select(.status == "drift" or .status == "legacy")]' \
+    2>/dev/null || true)
+
+if [[ -z "$drifted_variants" || "$drifted_variants" == "[]" ]]; then
+    echo "::notice::No drifted variants for container '$CONTAINER' — skipping LAST_REBUILD.md update" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build the section content (injection-safe)
+# ---------------------------------------------------------------------------
+today=$(date -u +"%Y-%m-%d")
+section_header="## ${KIND} (${today})"
+
+# Build variant lines using jq to safely extract field values
+variant_lines=$(printf '%s' "$drifted_variants" | \
+    jq -r '.[] | "- Variant: \(.variant_tag), base \(.base_image_ref)\n  Old digest: \(.recorded_digest // "unknown")\n  New digest: \(.current_digest // "(legacy — no recorded digest)")"' \
+    2>/dev/null || true)
+
+if [[ -z "$variant_lines" ]]; then
+    echo "::warning::Could not build variant lines for $CONTAINER — skipping" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Append section to LAST_REBUILD.md
+# ---------------------------------------------------------------------------
+target_file="${CONTAINER}/LAST_REBUILD.md"
+
+# Ensure container directory exists (it always should, but be safe)
+if [[ ! -d "$CONTAINER" ]]; then
+    echo "::error::Container directory '$CONTAINER' not found" >&2
+    exit 1
+fi
+
+{
+    printf '\n'
+    printf '%s\n' "$section_header"
+    printf '\n'
+    printf '%s\n' "$variant_lines"
+} >> "$target_file"
+
+echo "::notice::Appended '$section_header' section to $target_file" >&2

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -54,7 +54,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-valid_containers=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null || true)
+valid_containers=$(cd "$PROJECT_ROOT" && ./make list)
+if [[ -z "$valid_containers" ]]; then
+    echo "::error::./make list returned empty — canonical container list unavailable" >&2
+    exit 2
+fi
 if ! grep -qxF "$CONTAINER" <<<"$valid_containers"; then
     echo "::warning::container '$CONTAINER' is not a valid container name (not in ./make list) — skipping" >&2
     exit 0

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -178,26 +178,42 @@ if [[ ! -d "${PROJECT_ROOT}/${CONTAINER}" ]]; then
 fi
 
 # Idempotency: content-hash dedupe (gate r27, Defect C — replaces r25 heading-only dedupe).
+# Run-id scope added in gate r29 (Finding 1 — cross-run recoverability).
 #
 # The r25 fix deduped on the `## base-digest-drift (YYYY-MM-DD)` heading alone.
 # False negative: if drift A merges in the morning → rebuild → then drift B
 # (different variants) occurs the same UTC day → the heading is already present →
 # script skipped → no file change → no PR/rebuild trigger for drift B.
 #
-# Fix: embed a SHA-256 content-hash of the drift section body as an HTML comment
+# r27 fix: embed a SHA-256 content-hash of the drift section body as an HTML comment
 # ABOVE the heading.  Two invocations with identical drift content (same variants,
 # same digests) share the same hash → idempotent skip preserved.  Two invocations
 # with different content (even on the same day) produce different hashes → both
 # sections are appended.
 #
+# r29 fix (run-id scope): a failed rebuild followed by the same drift in the NEXT
+# workflow run would match the r27 hash marker → no new section → no PR → drift
+# unrecoverable until lineage changes.  Fix: include GITHUB_RUN_ID in the marker
+# so identical content in a different run always appends fresh.
+#
+# Dedupe semantics:
+#   - Same hash AND same run_id → in-run retry → skip (preserves r25 retry invariant)
+#   - Same hash but different run_id → new run re-detecting same drift → append
+#   - Different hash → different drift content → always append
+#
 # Hash scope: variant_lines only (the stable, injected-safe content derived from
 # drift JSON).  16 hex characters is sufficient; collision probability per
 # container per day is negligible.
+#
+# This script targets GitHub Actions.  When GITHUB_RUN_ID is unset (local
+# invocation, unit tests) the literal "local" is used — same-run deduplication
+# still applies within a local session, but cross-run recovery requires GHA.
 drift_content_hash=$(printf '%s\n' "${variant_lines}" | sha256sum | cut -d' ' -f1 | head -c 16)
-hash_marker="<!-- drift-content-hash: ${drift_content_hash} -->"
+run_id="${GITHUB_RUN_ID:-local}"
+hash_marker="<!-- drift-content-hash: ${drift_content_hash} run:${run_id} -->"
 
 if grep -qF -- "$hash_marker" "$target_file" 2>/dev/null; then
-    echo "::notice::Same drift event already recorded (hash ${drift_content_hash}), skipping append" >&2
+    echo "::notice::Same drift event already recorded (hash ${drift_content_hash} run:${run_id}), skipping append" >&2
     exit 0
 fi
 

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -46,6 +46,20 @@ if [[ -z "$CONTAINER" ]]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Fix 1: Validate CONTAINER against canonical list (poisoning prevention)
+# A corrupted lineage entry (e.g. "docs", ".github", paths with "/") must
+# not cause the script to write outside the valid container set.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+valid_containers=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null || true)
+if ! grep -qxF "$CONTAINER" <<<"$valid_containers"; then
+    echo "::warning::container '$CONTAINER' is not a valid container name (not in ./make list) — skipping" >&2
+    exit 0
+fi
+
 if [[ -z "$KIND" ]]; then
     echo "::error::kind argument is empty" >&2
     exit 1
@@ -99,12 +113,15 @@ fi
 # ---------------------------------------------------------------------------
 # Append section to LAST_REBUILD.md
 # ---------------------------------------------------------------------------
-target_file="${CONTAINER}/LAST_REBUILD.md"
+target_file="${PROJECT_ROOT}/${CONTAINER}/LAST_REBUILD.md"
 
-# Ensure container directory exists (it always should, but be safe)
-if [[ ! -d "$CONTAINER" ]]; then
-    echo "::error::Container directory '$CONTAINER' not found" >&2
-    exit 1
+# Fix 4: Gracefully skip when container directory is missing.
+# Defense-in-depth after Fix 1 validation: the container name is canonical
+# but the directory may have been deleted/renamed since the lineage cache was
+# written.  A stale entry must not break the entire workflow.
+if [[ ! -d "${PROJECT_ROOT}/${CONTAINER}" ]]; then
+    echo "::warning::container directory '${PROJECT_ROOT}/${CONTAINER}' missing — skipping LAST_REBUILD.md update" >&2
+    exit 0
 fi
 
 {

--- a/tests/fixtures/digest-drift/probe-stub-scenario1.sh
+++ b/tests/fixtures/digest-drift/probe-stub-scenario1.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fixture probe that reads pre-captured registry responses from scenario-1/responses/.
+# Maps image_ref to filename: replace : and / with - (e.g. alpine:3.21 -> alpine-3.21.json)
+image_ref="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+responses_dir="${SCRIPT_DIR}/scenario-1/responses"
+key="$(printf '%s' "$image_ref" | tr ':/' '--')"
+response_file="${responses_dir}/${key}.json"
+if [[ -f "$response_file" ]]; then
+    cat "$response_file"
+    exit 0
+else
+    echo "no fixture for '$image_ref' (expected $response_file)" >&2
+    exit 1
+fi

--- a/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-alpine.json
+++ b/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-alpine.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-alpine",
+  "flavor": "alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "foo:1.0-alpine",
+    "ghcr": "ghcr.io/oorabona/foo:1.0-alpine"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-alpine.sbom.json
+++ b/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-alpine.sbom.json
@@ -1,0 +1,5 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "name": "foo-1.0-alpine",
+  "packages": []
+}

--- a/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-debian.json
+++ b/tests/fixtures/digest-drift/scenario-1/lineage-cache/foo-1.0-debian.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-debian",
+  "flavor": "debian",
+  "base_image_ref": "debian:trixie-slim",
+  "base_image_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "foo:1.0-debian",
+    "ghcr": "ghcr.io/oorabona/foo:1.0-debian"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-1/responses/alpine-3.21.json
+++ b/tests/fixtures/digest-drift/scenario-1/responses/alpine-3.21.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-1/responses/debian-trixie-slim.json
+++ b/tests/fixtures/digest-drift/scenario-1/responses/debian-trixie-slim.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1234,
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-2/lineage-cache/bar-2.0-rocky.json
+++ b/tests/fixtures/digest-drift/scenario-2/lineage-cache/bar-2.0-rocky.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "bar",
+  "version": "2.0",
+  "tag": "2.0-rocky",
+  "flavor": "rocky",
+  "base_image_ref": "rockylinux:9",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "bar:2.0-rocky",
+    "ghcr": "ghcr.io/oorabona/bar:2.0-rocky"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-2/lineage-cache/bar-2.0-ubuntu.json
+++ b/tests/fixtures/digest-drift/scenario-2/lineage-cache/bar-2.0-ubuntu.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "bar",
+  "version": "2.0",
+  "tag": "2.0-ubuntu",
+  "flavor": "ubuntu",
+  "base_image_ref": "ubuntu:24.04",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "bar:2.0-ubuntu",
+    "ghcr": "ghcr.io/oorabona/bar:2.0-ubuntu"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-2/lineage-cache/foo-1.0-alpine.json
+++ b/tests/fixtures/digest-drift/scenario-2/lineage-cache/foo-1.0-alpine.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-alpine",
+  "flavor": "alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "foo:1.0-alpine",
+    "ghcr": "ghcr.io/oorabona/foo:1.0-alpine"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-2/lineage-cache/foo-1.0-debian.json
+++ b/tests/fixtures/digest-drift/scenario-2/lineage-cache/foo-1.0-debian.json
@@ -1,0 +1,15 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-debian",
+  "flavor": "debian",
+  "base_image_ref": "debian:trixie-slim",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false,
+  "images": {
+    "dockerhub": "foo:1.0-debian",
+    "ghcr": "ghcr.io/oorabona/foo:1.0-debian"
+  }
+}

--- a/tests/fixtures/digest-drift/scenario-2/responses/alpine-3.21.json
+++ b/tests/fixtures/digest-drift/scenario-2/responses/alpine-3.21.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-2/responses/debian-trixie-slim.json
+++ b/tests/fixtures/digest-drift/scenario-2/responses/debian-trixie-slim.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1234,
+      "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-2/responses/rockylinux-9.json
+++ b/tests/fixtures/digest-drift/scenario-2/responses/rockylinux-9.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1234,
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-2/responses/ubuntu-24.04.json
+++ b/tests/fixtures/digest-drift/scenario-2/responses/ubuntu-24.04.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1234,
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/unit/build-cache-utils.bats
+++ b/tests/unit/build-cache-utils.bats
@@ -582,3 +582,94 @@ EOF
 
     [[ "$_BASE_IMAGE_REF" == "ghcr.io/second/library/postgres:17-alpine" ]]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r10-1: LAST_REBUILD.md included in compute_build_digest
+#
+# Regression guard: modifying LAST_REBUILD.md must change the digest, so that
+# should_skip_build returns false after a drift PR modifies the file.
+# Without this fix, smart-skip would match the pre-PR digest and skip the
+# rebuild, leaving base digest unchanged → infinite drift-PR loop.
+# ---------------------------------------------------------------------------
+
+@test "r10-fix1a: LAST_REBUILD.md absent — digest is stable (baseline)" {
+    echo "FROM alpine:3.21" > Dockerfile
+
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9a-f]{12}$ ]]
+    local digest_without="$output"
+
+    # Running a second time without LAST_REBUILD.md must return same digest
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "$digest_without" ]
+}
+
+@test "r10-fix1b: LAST_REBUILD.md present changes digest vs absent" {
+    echo "FROM alpine:3.21" > Dockerfile
+
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    local digest_without="$output"
+
+    # Create LAST_REBUILD.md — digest must change
+    cat > LAST_REBUILD.md <<'EOF'
+## base-digest-drift
+
+Drift detected for alpine:3.21 on 2026-05-27.
+EOF
+
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    local digest_with="$output"
+
+    # Must differ from the no-file digest
+    [ "$digest_with" != "$digest_without" ]
+}
+
+@test "r10-fix1c: modifying LAST_REBUILD.md changes digest (invalidates cache)" {
+    echo "FROM alpine:3.21" > Dockerfile
+
+    echo "## base-digest-drift v1" > LAST_REBUILD.md
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    local digest_v1="$output"
+
+    # Append new content to LAST_REBUILD.md (simulates second drift PR)
+    echo "## base-digest-drift v2" >> LAST_REBUILD.md
+    run compute_build_digest "Dockerfile" ""
+    [ "$status" -eq 0 ]
+    local digest_v2="$output"
+
+    # Digest must change after modification
+    [ "$digest_v2" != "$digest_v1" ]
+}
+
+@test "r10-fix1d: LAST_REBUILD.md included in digest with postgres-style flavor" {
+    mkdir -p flavors extensions
+    cat > flavors/vector.yaml <<'EOF'
+name: vector
+extensions:
+  - pgvector
+EOF
+    cat > extensions/config.yaml <<'EOF'
+extensions:
+  pgvector:
+    version: "0.8.1"
+EOF
+    echo "FROM postgres:17-alpine" > Dockerfile
+
+    run compute_build_digest "Dockerfile" "vector"
+    [ "$status" -eq 0 ]
+    local digest_without="$output"
+
+    echo "## base-digest-drift" > LAST_REBUILD.md
+
+    run compute_build_digest "Dockerfile" "vector"
+    [ "$status" -eq 0 ]
+    local digest_with="$output"
+
+    # Digest must change even for postgres-style flavor
+    [ "$digest_with" != "$digest_without" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2365,3 +2365,148 @@ STUB
     result_len=$(printf '%s' "$result" | jq 'length')
     [ "$result_len" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r23: malformed recorded_digest in lineage must not be treated as a
+# valid baseline for drift comparison.  A short hex value or a non-sha256
+# string must surface as status:error with error_reason:malformed_recorded_digest
+# so the operator sees the corruption explicitly rather than a bogus drift PR.
+# ---------------------------------------------------------------------------
+
+@test "r23-fix-a: short hex recorded_digest surfaces as error, not drift" {
+    local lineage_dir="$TEST_TEMP_DIR/r23a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Malformed: short hex string (not 64 hex chars after sha256:)
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "myimage",' \
+        '  "tag": "1.0",' \
+        '  "base_image_ref": "ghcr.io/library/alpine:3.21",' \
+        '  "base_image_digest": "deadbeef"' \
+        '}' > "$lineage_dir/myimage-1.0.json"
+
+    # Probe stub that must NOT be called (malformed recorded_digest should be
+    # caught before the probe fires)
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r23a-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE WAS CALLED" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result stderr_out rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r23a-stderr.txt") || rc=$?
+
+    stderr_out=$(cat "$TEST_TEMP_DIR/r23a-stderr.txt")
+
+    # Must exit 0 — corrupt lineage is non-fatal
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called
+    run grep -c "PROBE WAS CALLED" "$TEST_TEMP_DIR/r23a-stderr.txt"
+    [ "$output" = "0" ]
+
+    # Must emit a ::warning:: about the malformed digest
+    echo "$stderr_out" | grep -q "Malformed recorded_digest"
+
+    # Result must have one container record
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 1 ]
+
+    # Variant status must be "error"
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
+    [ "$status" = "error" ]
+
+    # error_reason must be "malformed_recorded_digest"
+    local error_reason
+    error_reason=$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')
+    [ "$error_reason" = "malformed_recorded_digest" ]
+}
+
+@test "r23-fix-b: non-sha256 recorded_digest string surfaces as error, not drift" {
+    local lineage_dir="$TEST_TEMP_DIR/r23b/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Malformed: plain string (no sha256: prefix)
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "myimage",' \
+        '  "tag": "2.0",' \
+        '  "base_image_ref": "ghcr.io/library/debian:trixie-slim",' \
+        '  "base_image_digest": "sha256:short"' \
+        '}' > "$lineage_dir/myimage-2.0.json"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r23b-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE WAS CALLED" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result stderr_out rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="2.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r23b-stderr.txt") || rc=$?
+
+    stderr_out=$(cat "$TEST_TEMP_DIR/r23b-stderr.txt")
+
+    [ "$rc" -eq 0 ]
+
+    run grep -c "PROBE WAS CALLED" "$TEST_TEMP_DIR/r23b-stderr.txt"
+    [ "$output" = "0" ]
+
+    echo "$stderr_out" | grep -q "Malformed recorded_digest"
+
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
+    [ "$status" = "error" ]
+
+    local error_reason
+    error_reason=$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')
+    [ "$error_reason" = "malformed_recorded_digest" ]
+}
+
+@test "r23-fix-c: well-formed recorded_digest still reaches probe and compares normally" {
+    local lineage_dir="$TEST_TEMP_DIR/r23c/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    local valid_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "myimage",' \
+        '  "tag": "3.0",' \
+        '  "base_image_ref": "ghcr.io/library/alpine:3.21",' \
+        "  \"base_image_digest\": \"${valid_digest}\"" \
+        '}' > "$lineage_dir/myimage-3.0.json"
+
+    # Probe stub that returns the same digest → unchanged.
+    # PROBE_CMD output is parsed by _probe_digest via `jq -r '.digest // empty'`,
+    # so the stub must emit imagetools-style JSON ({"digest":"sha256:..."}).
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r23c-probe.XXXXXX")
+    cat > "$probe_stub" <<STUB
+#!/usr/bin/env bash
+printf '{"digest":"%s"}\n' "${valid_digest}"
+STUB
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="3.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    [ "$rc" -eq 0 ]
+
+    # Shape-valid recorded_digest must reach comparison and yield "unchanged"
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
+    [ "$status" = "unchanged" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2011,3 +2011,71 @@ EOF
     status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
     [ "$status" = "drift" ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r17: docker.io FQDN allowlist (gate r17 REFUSE concordant finding)
+#
+# The build pipeline resolves ARG REMOTE_CR=docker.io into lineage refs of
+# the form docker.io/library/foo:bar or docker.io/oorabona/foo:tag.  The r10
+# allowlist included registry-1.docker.io and index.docker.io but omitted
+# the bare docker.io FQDN, causing silent drift detection failure for those
+# containers.
+# ---------------------------------------------------------------------------
+
+@test "r17-fix-a: docker.io/library/* ref passes validation and is probed normally" {
+    local lineage_dir="$TEST_TEMP_DIR/r17fixa/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "docker.io/library/alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Must report drift (probe was called, not silently skipped)
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}
+
+@test "r17-fix-b: docker.io/oorabona/* ref passes validation and is probed normally" {
+    local lineage_dir="$TEST_TEMP_DIR/r17fixb/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "docker.io/oorabona/php:latest",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Must report drift (probe was called, not silently skipped)
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1788,7 +1788,7 @@ bar" \
 # infinite drift-PR loops.
 # ---------------------------------------------------------------------------
 
-@test "r10-fix2a: list-builds failure → container fully skipped (fail-closed)" {
+@test "r10-fix2a: list-builds failure → container emits error record (r29 Finding 2)" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix2a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -1802,20 +1802,31 @@ bar" \
 }
 EOF
 
-    # Run without _VALID_CONTAINERS_OVERRIDE so production path runs list-builds
-    # Since ./make list-builds won't work in the test dir, it will fail → fail-closed
+    # Simulate the __CONTAINER_SKIP__ path via test hook: set the per-container
+    # active-tags override to the sentinel value so the code exercises the
+    # error-record emission path without needing to invoke ./make list-builds.
+    # The _ACTIVE_TAGS_OVERRIDE_myimage passthrough is the existing test hook;
+    # __CONTAINER_SKIP__ is the same sentinel the production list-builds failure
+    # path sets when ./make fails (rc != 0 or returns no tags).
     local result rc=0
-    result=$(unset _VALID_CONTAINERS_OVERRIDE && \
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="__CONTAINER_SKIP__" \
         PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
 
-    # Script must exit 0 (container skip is not fatal)
+    # Script must exit 0 (container error is not fatal to the overall run)
     [ "$rc" -eq 0 ]
 
-    # Output must be empty array — container was skipped entirely
+    # r29 Finding 2: output must contain one error record for the known lineage entry
     local result_len
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+
+    local err_status err_reason
+    err_status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_status" = "error" ]
+    [ "$err_reason" = "active_tags_unavailable" ]
 }
 
 @test "r10-fix2b: script contains fail-closed warning text (code audit)" {
@@ -1917,13 +1928,19 @@ STUB
     # Probe must NOT have been called
     echo "$stderr_out" | grep -qv "PROBE WAS CALLED"
 
-    # Must emit a ::warning:: about the untrusted ref
+    # Must emit a ::warning:: about the untrusted ref (audit trail on stderr)
     echo "$stderr_out" | grep -q "Refusing to probe untrusted"
 
-    # Result must be empty array (entry skipped)
+    # r29 Finding 3: result must contain one error record (not empty array)
     local result_len
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+
+    local err_status err_reason
+    err_status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_status" = "error" ]
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 @test "r10-fix3b: valid ghcr.io ref passes validation and is probed normally" {
@@ -2182,10 +2199,12 @@ STUB
     # Probe must NOT have been called
     ! echo "$stderr_out" | grep -q "PROBE WAS CALLED"
 
-    # Entry must be skipped — result is empty array
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -2323,10 +2342,12 @@ STUB
     run grep -c "PROBE CALLED on localhost ref" "$TEST_TEMP_DIR/r21c-stderr.txt"
     [ "$output" = "0" ]
 
-    # Result must be empty array (no drift report for rejected ref)
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 @test "r21-C: localhost:5000/foo:1.0 is rejected by _validate_image_ref (host:port localhost)" {
@@ -2360,10 +2381,12 @@ STUB
     run grep -c "PROBE CALLED on localhost:PORT ref" "$TEST_TEMP_DIR/r21c2-stderr.txt"
     [ "$output" = "0" ]
 
-    # Result must be empty
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -2793,10 +2816,12 @@ _r27b_lineage_with_ref() {
     # Probe must NOT have been called (ref rejected before registry call)
     run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b1-stderr.txt"
     [ "$output" = "0" ]
-    # Result must be empty array (no drift record for rejected ref)
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 @test "r27-B2: _validate_image_ref rejects '--config' (long option injection)" {
@@ -2817,9 +2842,12 @@ _r27b_lineage_with_ref() {
     [ "$rc" -eq 0 ]
     run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b2-stderr.txt"
     [ "$output" = "0" ]
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
 }
 
 @test "r27-B3: _validate_image_ref rejects '-foo:1.0' (dash-prefix with tag)" {
@@ -2840,7 +2868,135 @@ _r27b_lineage_with_ref() {
     [ "$rc" -eq 0 ]
     run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b3-stderr.txt"
     [ "$output" = "0" ]
-    local result_len
+    # r29 Finding 3: rejected ref emits error record (not empty array)
+    local result_len err_reason
     result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ "$result_len" -eq 1 ]
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_reason" = "untrusted_ref" ]
+}
+
+# ---------------------------------------------------------------------------
+# r29-2: error records on list-builds failure (gate r29, Finding 2)
+#
+# When ./make list-builds fails or returns empty for a container, the
+# detector must emit one status:"error" record per known lineage entry
+# for that container (not silently skip them), so error_count in the
+# workflow surfaces the gap.
+# ---------------------------------------------------------------------------
+
+@test "r29-2: stub list-builds failure emits error record per lineage entry" {
+    local lineage_dir="$TEST_TEMP_DIR/r29-2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Two lineage entries for the same container (both should get error records).
+    # We use the __CONTAINER_SKIP__ test hook to simulate a list-builds failure
+    # without needing to invoke ./make: the production failure path sets the
+    # per-container cache to __CONTAINER_SKIP__; _ACTIVE_TAGS_OVERRIDE_* is a
+    # passthrough that injects exactly that sentinel value directly.
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/myimage-2.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "2.0",
+  "base_image_ref": "alpine:3.22",
+  "base_image_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}
+EOF
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="__CONTAINER_SKIP__" \
+        PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    # Script exits 0 (container error is not fatal)
+    [ "$rc" -eq 0 ]
+
+    # One container record in output
+    local container_count
+    container_count=$(printf '%s' "$result" | jq 'length')
+    [ "$container_count" -eq 1 ]
+
+    # Both lineage entries must appear as error records
+    local variant_count
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$variant_count" -eq 2 ]
+
+    # All statuses must be "error" with reason "active_tags_unavailable"
+    local err_count reason_count
+    err_count=$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error")] | length')
+    reason_count=$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.error_reason == "active_tags_unavailable")] | length')
+    [ "$err_count" -eq 2 ]
+    [ "$reason_count" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# r29-3: error record on rejected base_image_ref (gate r29, Finding 3)
+#
+# When _validate_image_ref rejects a base_image_ref (untrusted registry,
+# dash-prefix, etc.), the detector must emit a status:"error" record with
+# error_reason:"untrusted_ref" in addition to the ::warning:: on stderr.
+# Before r29, only the ::warning:: was emitted → error_count stayed at 0
+# → poisoned lineage left the workflow green.
+# ---------------------------------------------------------------------------
+
+@test "r29-3: untrusted registry base_image_ref emits error record with untrusted_ref reason" {
+    local lineage_dir="$TEST_TEMP_DIR/r29-3/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "evil.example.com/foo:1.0",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub that fails loudly if called — ref must be rejected before probe
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r29-3-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED — untrusted ref not blocked!" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result stderr_out rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/tmp/r29-3-stderr.txt) || rc=$?
+    stderr_out=$(cat /tmp/r29-3-stderr.txt)
+
+    # Must exit 0 — rejection is non-fatal
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called (SSRF prevention intact)
+    ! echo "$stderr_out" | grep -q "PROBE CALLED"
+
+    # ::warning:: must still be emitted on stderr (audit trail preserved)
+    echo "$stderr_out" | grep -q "Refusing to probe untrusted"
+
+    # One container record with one error variant
+    local container_count variant_count
+    container_count=$(printf '%s' "$result" | jq 'length')
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$container_count" -eq 1 ]
+    [ "$variant_count" -eq 1 ]
+
+    # Status and reason must be set correctly
+    local err_status err_reason
+    err_status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
+    [ "$err_status" = "error" ]
+    [ "$err_reason" = "untrusted_ref" ]
 }

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2079,3 +2079,60 @@ EOF
     status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
     [ "$status" = "drift" ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r18: global RETURN trap crash in multi-entry probe sequence
+# Regression guard: bash RETURN traps are GLOBAL — the former
+# `trap 'rm -f "$probe_stderr"' RETURN` in _probe_digest fired on every
+# subsequent function return after the first _probe_digest call, referencing
+# an out-of-scope variable and crashing under set -u.
+# This test runs the detector against 3 lineage entries so _probe_digest is
+# called 3 times in sequence; it verifies (a) the script completes without
+# "unbound variable" error and (b) all 3 entries produce drift output.
+# ---------------------------------------------------------------------------
+@test "r18-fix: multi-entry probe sequence completes without unbound-variable crash" {
+    local lineage_dir="$TEST_TEMP_DIR/r18fix/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    local recorded_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local live_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+    # Three independent containers, each with one lineage entry — forces
+    # _probe_digest to be called 3 times in sequence within the same shell.
+    for cname in alpha beta gamma; do
+        cat > "$lineage_dir/${cname}-1.0.json" <<EOF
+{
+  "lineage_schema_version": 2,
+  "container": "${cname}",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "${recorded_digest}"
+}
+EOF
+    done
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "$live_digest")
+
+    local stderr_out
+    stderr_out="$TEST_TEMP_DIR/r18fix-stderr.txt"
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="alpha
+beta
+gamma" \
+        _ACTIVE_TAGS_OVERRIDE_alpha="1.0" \
+        _ACTIVE_TAGS_OVERRIDE_beta="1.0" \
+        _ACTIVE_TAGS_OVERRIDE_gamma="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_out")
+
+    # No unbound-variable error must appear on stderr
+    run grep -c "unbound variable" "$stderr_out"
+    [ "$output" = "0" ]
+
+    # All 3 containers must appear in the output with drift status
+    local drift_count
+    drift_count=$(printf '%s' "$result" | jq -r '[.[] | .variants[].status] | map(select(. == "drift")) | length')
+    [ "$drift_count" -eq 3 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1236,3 +1236,272 @@ STUB_EOF
     leaked=$(find "$isolated_tmp" -maxdepth 1 -type f 2>/dev/null | wc -l)
     [ "$leaked" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r7-1: Digest shape validation before label_args embedding
+# Regression guard: a malformed _BASE_DIGEST value (spaces, injected flags,
+# non-hex chars) must be refused and NOT embedded in label_args.  Only
+# ^sha256:[a-f0-9]{64}$ passes.
+# ---------------------------------------------------------------------------
+@test "r7-fix1a: malformed digest (spaces/injection) is NOT added to label_args" {
+    # Exercise _resolve_base_image from build-container.sh with a docker stub that
+    # returns a malformed digest — verify label_args stays clean.
+    local test_container_dir="$TEST_TEMP_DIR/r7fix1a"
+    mkdir -p "$test_container_dir/bin"
+
+    # Docker stub: imagetools inspect returns a digest containing a space (injection vector)
+    cat > "$test_container_dir/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+    printf '{"digest":"sha256:aabbcc --label org.opencontainers.image.extra=injected"}\n'
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$test_container_dir/bin/docker"
+
+    # Run _resolve_base_image in a subshell so PATH is scoped and globals don't leak
+    local label_args_val
+    label_args_val=$(
+        export PATH="$test_container_dir/bin:$PATH"
+        cd "$test_container_dir"
+        printf 'FROM alpine:3.21\n' > Dockerfile
+        # Source logging + build-container
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/logging.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/build-args-utils.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/variant-utils.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/template-utils.sh" 2>/dev/null || true
+        pushd "${SCRIPTS_DIR}" >/dev/null 2>&1
+        # shellcheck source=/dev/null
+        source "./build-container.sh" 2>/dev/null || true
+        popd >/dev/null 2>&1
+        declare -gA _BUILD_ARGS_RESOLVED=()
+        label_args=""
+        _resolve_base_image "Dockerfile" "3.21" "label_args" 2>/dev/null || true
+        printf '%s' "$label_args"
+    )
+
+    # label_args must NOT contain the malformed digest value
+    [[ "$label_args_val" != *"aabbcc"* ]] || {
+        echo "FAIL: malformed digest fragment 'aabbcc' appeared in label_args: '$label_args_val'"
+        return 1
+    }
+    [[ "$label_args_val" != *"--label org.opencontainers.image.extra"* ]] || {
+        echo "FAIL: injected extra label appeared in label_args: '$label_args_val'"
+        return 1
+    }
+}
+
+@test "r7-fix1b: well-formed sha256 digest is embedded in label_args" {
+    # Positive case: ^sha256:[a-f0-9]{64}$ must still be accepted.
+    local test_container_dir="$TEST_TEMP_DIR/r7fix1b"
+    mkdir -p "$test_container_dir/bin"
+
+    local valid_digest="sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+    cat > "$test_container_dir/bin/docker" <<MOCK
+#!/usr/bin/env bash
+if [[ "\$1" == "buildx" && "\$2" == "imagetools" && "\$3" == "inspect" ]]; then
+    printf '{"digest":"${valid_digest}"}\n'
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$test_container_dir/bin/docker"
+
+    local label_args_val
+    label_args_val=$(
+        export PATH="$test_container_dir/bin:$PATH"
+        cd "$test_container_dir"
+        printf 'FROM alpine:3.21\n' > Dockerfile
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/logging.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/build-args-utils.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/variant-utils.sh" 2>/dev/null || true
+        # shellcheck source=/dev/null
+        source "${SCRIPTS_DIR}/../helpers/template-utils.sh" 2>/dev/null || true
+        pushd "${SCRIPTS_DIR}" >/dev/null 2>&1
+        # shellcheck source=/dev/null
+        source "./build-container.sh" 2>/dev/null || true
+        popd >/dev/null 2>&1
+        declare -gA _BUILD_ARGS_RESOLVED=()
+        label_args=""
+        _resolve_base_image "Dockerfile" "3.21" "label_args" 2>/dev/null || true
+        printf '%s' "$label_args"
+    )
+
+    [[ "$label_args_val" == *"org.opencontainers.image.base.digest=${valid_digest}"* ]] || {
+        echo "FAIL: valid digest not found in label_args: '$label_args_val'"
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Fix r7-2: Re-detect step distinguishes status:error from no-drift
+# Regression guard: when every probe returns error (PROBE_CMD=/bin/false),
+# the JSON output contains status:error records — the workflow's error_count
+# check (jq '[.[] | .variants[] | select(.status == "error")] | length') is
+# non-zero, so the step exits non-zero rather than silently skipping.
+# This test verifies the script emits status:error that a downstream
+# error_count check can detect, not that the script itself exits non-zero.
+# ---------------------------------------------------------------------------
+@test "r7-fix2: probe failure emits status:error in JSON (re-detect error_count detectable)" {
+    local lineage_dir="$TEST_TEMP_DIR/r7fix2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # /bin/false simulates a probe that always fails (registry unreachable)
+    result=$(PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Must be valid JSON
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Must contain at least one status:error record — the workflow's error_count jq
+    # expression will be > 0, so the step exits 1 (not silently treats as no-drift).
+    error_count=$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error")] | length')
+    [ "$error_count" -gt 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r7-4a: ./make list hard-fail in detect-base-digest-drift.sh
+# Regression guard: when _VALID_CONTAINERS_OVERRIDE is explicitly empty (not set
+# at all, so the script falls through to ./make list), and ./make list fails,
+# the script must exit 2 — NOT silently treat all containers as invalid and
+# return "[]" (false no-drift).
+# ---------------------------------------------------------------------------
+@test "r7-fix4a: detect script exits 2 when _VALID_CONTAINERS_OVERRIDE unset and make list fails" {
+    local fake_root="$TEST_TEMP_DIR/r7fix4a"
+    mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
+    cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
+    # The script sources PROJECT_ROOT/helpers/lineage-utils.sh — must exist in fake root
+    cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
+
+    cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # ./make list exits non-zero — simulates tooling failure
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "list" ]]; then
+    exit 1
+fi
+STUB
+    chmod +x "$fake_root/make"
+
+    local rc=0
+    # Unset the override so the script falls through to ./make list
+    cd "$fake_root" && unset _VALID_CONTAINERS_OVERRIDE && \
+        bash scripts/detect-base-digest-drift.sh ".build-lineage" >/dev/null 2>/dev/null || rc=$?
+
+    # Must exit with code 2 (tooling failure), NOT 0 (silent false no-drift)
+    [ "$rc" -eq 2 ]
+}
+
+@test "r7-fix4b: detect script exits 2 when make list returns empty string" {
+    # A make list that succeeds but prints nothing (empty output) is equally invalid.
+    local fake_root="$TEST_TEMP_DIR/r7fix4b"
+    mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
+    cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
+    cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
+
+    cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # ./make list exits 0 but prints nothing — empty canonical list
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && { printf ''; exit 0; }
+STUB
+    chmod +x "$fake_root/make"
+
+    local rc=0
+    cd "$fake_root" && unset _VALID_CONTAINERS_OVERRIDE && \
+        bash scripts/detect-base-digest-drift.sh ".build-lineage" >/dev/null 2>/dev/null || rc=$?
+
+    # Empty make list is also a hard failure (exit 2)
+    [ "$rc" -eq 2 ]
+}
+
+@test "r7-fix4c: _VALID_CONTAINERS_OVERRIDE non-empty bypasses make list check" {
+    # Test hook: _VALID_CONTAINERS_OVERRIDE set to a non-empty value must bypass
+    # the ./make list call entirely (existing pre-r7 behavior preserved for tests).
+    local lineage_dir="$TEST_TEMP_DIR/r7fix4c/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # _VALID_CONTAINERS_OVERRIDE is set (non-empty) → ./make list never called
+    local rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    # Script must exit 0 (even with probe failure the detection itself runs)
+    # and must NOT exit 2 (make list was bypassed)
+    [ "$rc" -ne 2 ]
+    # result must be valid JSON
+    printf '%s' "$result" | jq '.' >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Fix r7-4d: update-last-rebuild.sh exits 2 when ./make list is empty
+# Regression guard: ./make list returning empty must cause exit 2, not
+# silently skip with exit 0 (which would hide the tooling failure).
+# ---------------------------------------------------------------------------
+@test "r7-fix4d: update-last-rebuild exits 2 when make list returns empty" {
+    local fake_root="$TEST_TEMP_DIR/r7fix4d"
+    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
+    mkdir -p "$fake_root/scripts"
+    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+
+    # ./make list succeeds but returns nothing
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && { printf ''; exit 0; }
+STUB
+    chmod +x "$fake_root/make"
+
+    local rc=0
+    cd "$fake_root" && \
+        bash scripts/update-last-rebuild.sh "mycontainer" "base-digest-drift" \
+        <<< '[]' 2>/dev/null || rc=$?
+
+    # Must exit 2 — tooling failure, NOT silent success
+    [ "$rc" -eq 2 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2510,3 +2510,148 @@ STUB
     status=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
     [ "$status" = "unchanged" ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r24 (gate r24 — Copilot M): active-tag filter must use `current` semantics
+#
+# Regression guard: when an upstream-version PR is pending (upstream has released
+# X.Y but variants.yaml still points at X.Y-1), ./make list-builds with the
+# default `latest` would resolve to X.Y (future state) and return tags built
+# from that version.  The lineage files on disk, however, reference tags from the
+# currently-published X.Y-1 state.  The stale-lineage filter would then reject
+# the published tags as "stale" → drift on the live container silently undetected
+# until the version PR merges.
+#
+# Fix: pass `current` explicitly so the active-tag set reflects published state.
+# The _ACTIVE_TAGS_OVERRIDE_ test seam is used to inject the "current" active set
+# (simulating what `./make list-builds <container> current` returns post-fix).
+# ---------------------------------------------------------------------------
+
+@test "r24-fix1a: upstream-pending scenario — lineage tag matches current published; drift detected" {
+    # Simulate: upstream just released 2.0 (future), but currently published is 1.0.
+    # Lineage file records tag 1.0 (currently published).
+    # _ACTIVE_TAGS_OVERRIDE_ is set to "1.0" (what `list-builds current` returns).
+    # The drift probe returns a different digest → drift must be reported.
+    local lineage_dir="$TEST_TEMP_DIR/r24fix1a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe returns a DIFFERENT digest (simulating base image updated upstream)
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # Active-tag override = "1.0" (current published); mirrors what `list-builds current` returns.
+    # With the pre-fix bug (default `latest`), the caller would have used tag "2.0" here,
+    # causing 1.0 to be rejected as stale.  With the fix, 1.0 is active → drift detected.
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    [ "$rc" -eq 0 ]
+
+    # Must be valid JSON
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Drift must be detected for tag 1.0 (the currently-published tag)
+    local variant_count
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$variant_count" -eq 1 ]
+
+    local reported_tag
+    reported_tag=$(printf '%s' "$result" | jq -r '.[] | .variants[].variant_tag')
+    [ "$reported_tag" = "1.0" ]
+
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}
+
+@test "r24-fix1b: upstream-pending scenario — pre-fix simulation: tag 2.0 active rejects 1.0 as stale (no false-positive)" {
+    # Validate the opposite: if active tags were set to "2.0" (the future/upstream state,
+    # which is what the pre-fix `latest` resolution would have returned), then the 1.0
+    # lineage entry is treated as stale and skipped — this is the false-negative the fix
+    # corrects.  This test documents the bug behavior to pin the fix semantics.
+    local lineage_dir="$TEST_TEMP_DIR/r24fix1b/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # Active-tag override = "2.0" (upstream-newest, NOT currently published) — this is what
+    # the pre-fix code would have produced via `./make list-builds <container>` (default latest).
+    local stderr_output rc=0
+    stderr_output=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="2.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
+
+    [ "$rc" -eq 0 ]
+
+    # With active=2.0 and lineage=1.0, the entry is skipped as stale
+    echo "$stderr_output" | grep -q "Skipping stale lineage entry"
+}
+
+@test "r24-fix2: empty-override (backward compat) bypasses stale filter — entry reaches probe stage" {
+    # When _ACTIVE_TAGS_OVERRIDE_myimage is set to an empty string, the filter logic
+    # short-circuits (empty _active_tags → -n check fails → condition is false) and the
+    # entry is NOT skipped.  This is the backward-compat path documented in the filter code.
+    # In production the equivalent is a list-builds call that fails (rc!=0), which uses
+    # __CONTAINER_SKIP__ (a different path).  The empty-override path is retained for
+    # test-rig convenience; it must not discard lineage entries silently.
+    # Verify: entry reaches the probe, probe returns different digest → drift reported.
+    local lineage_dir="$TEST_TEMP_DIR/r24fix2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe returns different digest → drift
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    # Empty override → filter bypassed → probe runs
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    [ "$rc" -eq 0 ]
+
+    # Entry must NOT have been silently discarded — drift is reported
+    local variant_count
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$variant_count" -eq 1 ]
+
+    local reported_tag
+    reported_tag=$(printf '%s' "$result" | jq -r '.[] | .variants[].variant_tag')
+    [ "$reported_tag" = "1.0" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -113,7 +113,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     # Output must be valid JSON
     printf '%s' "$result" | jq '.' >/dev/null
@@ -163,7 +163,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     length=$(printf '%s' "$result" | jq 'length')
     [ "$length" -eq 1 ]
@@ -176,7 +176,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     debian_status=$(printf '%s' "$result" | \
         jq -r '.[0].variants[] | select(.variant_tag == "1.0-debian") | .status')
@@ -190,7 +190,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     foo_variants=$(printf '%s' "$result" | jq '.[0].variants | length')
     [ "$foo_variants" -eq 2 ]
@@ -203,7 +203,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     # Extract all digest fields and verify shape
     while IFS= read -r dgst; do
@@ -225,7 +225,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     printf '%s' "$result" | jq '.' >/dev/null
 
@@ -239,7 +239,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     foo_count=$(printf '%s' "$result" | \
         jq '[.[] | select(.container == "foo")] | .[0].variants | length')
@@ -252,7 +252,7 @@ STUB_EOF
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
 
     result=$(PROBE_CMD="$probe_stub" \
-        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
 
     bar_count=$(printf '%s' "$result" | \
         jq '[.[] | select(.container == "bar")] | .[0].variants | length')
@@ -692,5 +692,30 @@ EOF
     result=$(PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
+    [ "$result" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Precedence guard: placeholder ref + missing digest must be skipped (not
+# classified as legacy).  Before Fix 3 the legacy check ran first and would
+# emit a bogus drift PR for pre-#530 lineage files.
+# ---------------------------------------------------------------------------
+@test "unresolved-ref: placeholder ref with missing digest is skipped, not emitted as legacy" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    # Simulates a pre-#530 lineage entry: placeholder ref AND no recorded digest
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Must be empty — placeholder takes precedence over legacy classification
     [ "$result" = "[]" ]
 }

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2655,3 +2655,92 @@ EOF
     reported_tag=$(printf '%s' "$result" | jq -r '.[] | .variants[].variant_tag')
     [ "$reported_tag" = "1.0" ]
 }
+
+# ---------------------------------------------------------------------------
+# r25-A: GHA workflow-command escape — rejected container / tag values
+# Regression guard for Defect A (gate r25): the rejection-path ::warning::
+# must route poisoned values through _escape_gha_command, NOT printf '%q'.
+# A value containing a literal %0A must appear as %250A in the warning
+# (% → %25 then 0A suffix), not as a raw newline or %0A command separator.
+# A value embedding ::add-mask:: must not reintroduce that command.
+# ---------------------------------------------------------------------------
+@test "r25-A1: container name with literal %0A is not passed raw in ::warning::" {
+    # Build a lineage file where container field contains the literal string %0A
+    # (percent-zero-A — a GHA encoded newline that would inject a new command).
+    local lineage_dir="$TEST_TEMP_DIR/r25a1/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # The container value contains the literal characters %0A (not a newline).
+    # After _escape_gha_command the % becomes %25, so the output is %250A.
+    local poisoned_container
+    poisoned_container=$'foo%0Abar'
+
+    cat > "$lineage_dir/foo-1.0.json" <<EOF
+{
+  "lineage_schema_version": 2,
+  "container": "${poisoned_container}",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Container name contains control char (%0A is not a cntrl byte here, but
+    # the rejection path for invalid-container (not in ./make list) is the
+    # relevant site).  Use an empty override so the validation fast-path fires.
+    local stderr_output rc=0
+    stderr_output=$(PROBE_CMD=/bin/false \
+        _VALID_CONTAINERS_OVERRIDE="foo" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
+
+    # The ::warning:: line must NOT contain a literal %0A sequence that would
+    # inject a workflow command.  After _escape_gha_command it becomes %250A.
+    # grep -F matches fixed strings — if %0A appears verbatim the test fails.
+    if printf '%s' "$stderr_output" | grep -qF '::warning::' 2>/dev/null; then
+        # Extract only the warning line(s) and verify %0A is escaped.
+        local warning_lines
+        warning_lines=$(printf '%s' "$stderr_output" | grep -F '::warning::' || true)
+        # Must NOT contain bare %0A in the value portion
+        ! printf '%s' "$warning_lines" | grep -qF '%0Abar'
+        # Must contain the escaped form %250A (% was encoded first)
+        printf '%s' "$warning_lines" | grep -qF '%250Abar'
+    fi
+}
+
+@test "r25-A2: tag with newline cntrl char — ::warning:: must not contain raw newline after rejection" {
+    # Build a lineage file with a tag containing an embedded newline (cntrl char).
+    # The rejection path at the cntrl-char check must emit the value through
+    # _escape_gha_command so the newline becomes %0A (literal percent-zero-A),
+    # NOT a real newline that would terminate the ::warning:: command and inject
+    # the next line as a workflow command.
+    local lineage_dir="$TEST_TEMP_DIR/r25a2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # tag with embedded newline + injection payload after it
+    local poisoned_tag
+    poisoned_tag=$'1.0\n::add-mask::SECRET'
+
+    # Write file with Python to preserve literal newline in JSON value
+    python3 -c "
+import json, pathlib
+d = {
+  'lineage_schema_version': 2,
+  'container': 'foo',
+  'tag': '1.0\n::add-mask::SECRET',
+  'base_image_ref': 'alpine:3.21',
+  'base_image_digest': 'sha256:' + 'a'*64
+}
+pathlib.Path('${lineage_dir}/foo-1.0.json').write_text(json.dumps(d))
+"
+
+    local stderr_output rc=0
+    stderr_output=$(PROBE_CMD=/bin/false \
+        _VALID_CONTAINERS_OVERRIDE="foo" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
+
+    # The emitted warning must NOT contain the injection payload as a separate
+    # workflow command.  If the newline was not escaped, ::add-mask:: would
+    # appear on its own line as a parseable GHA command.
+    # We assert: no line in the output starts with ::add-mask::
+    ! printf '%s' "$stderr_output" | grep -qE '^::add-mask::'
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2187,3 +2187,181 @@ STUB
     result_len=$(printf '%s' "$result" | jq 'length')
     [ "$result_len" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Gate r21 regression tests
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# r21-A: grep option injection — variant tag '--help'
+# A lineage tag value of '--help' must NOT be treated as a grep option.
+# The stale-tag filter must reject/skip the entry (not match as active),
+# not print grep help text and exit 0 (which would accept the tag).
+# Mutation guard: if `--` is removed from `grep -qxF -- "$variant_tag"`,
+# grep treats '--help' as an option → prints help and exits 0 → probe is
+# called → this test fails.
+# ---------------------------------------------------------------------------
+@test "r21-A: variant tag '--help' is treated as literal string, not grep option" {
+    local lineage_dir="$TEST_TEMP_DIR/r21a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "foo",' \
+        '  "tag": "--help",' \
+        '  "base_image_ref": "alpine:3.21",' \
+        '  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' > "$lineage_dir/foo---help.json"
+
+    # Active tags override does NOT include '--help' → must be treated as stale
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r21a-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on option-injection tag" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r21a-stderr.txt") || rc=$?
+
+    # Must exit 0 (stale-skip is non-fatal)
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called (tag correctly filtered as stale)
+    run grep -c "PROBE CALLED on option-injection tag" "$TEST_TEMP_DIR/r21a-stderr.txt"
+    [ "$output" = "0" ]
+
+    # Result must be empty array (no drift report for poisoned tag)
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# r21-A2: grep option injection — container name '--help' in lineage JSON
+# A container field of '--help' in the lineage must be rejected as not in
+# ./make list, not accepted because grep printed help text and exited 0.
+# Mutation guard: removing `--` from `grep -qxF -- "$container"` causes
+# grep to treat '--help' as an option → exits 0 → probe would be called.
+# ---------------------------------------------------------------------------
+@test "r21-A2: container name '--help' in lineage is rejected as invalid (not a grep option)" {
+    local lineage_dir="$TEST_TEMP_DIR/r21a2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "--help",' \
+        '  "tag": "1.0",' \
+        '  "base_image_ref": "alpine:3.21",' \
+        '  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' > "$lineage_dir/---help-1.0.json"
+
+    # Valid containers override does NOT include '--help'
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r21a2-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on --help container" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r21a2-stderr.txt") || rc=$?
+
+    # Must exit 0 (invalid container is a warning, not fatal)
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called
+    run grep -c "PROBE CALLED on --help container" "$TEST_TEMP_DIR/r21a2-stderr.txt"
+    [ "$output" = "0" ]
+
+    # Result is empty
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# r21-C: localhost allowlist bypass
+# 'localhost/foo:1.0' must be rejected by _validate_image_ref: Docker/OCI
+# treats bare 'localhost' as an explicit registry host (not a Docker Hub org),
+# so it must hit the allowlist check and be denied.
+# Mutation guard: removing the localhost guard causes first_segment="localhost"
+# to fall through to the "no dot, no colon → Docker Hub org" path → return 0
+# → probe would be called.
+# ---------------------------------------------------------------------------
+@test "r21-C: localhost/foo:1.0 is rejected by _validate_image_ref (not a Docker Hub org)" {
+    local lineage_dir="$TEST_TEMP_DIR/r21c/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "foo",' \
+        '  "tag": "1.0",' \
+        '  "base_image_ref": "localhost/foo:1.0",' \
+        '  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' > "$lineage_dir/foo-1.0.json"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r21c-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on localhost ref" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r21c-stderr.txt") || rc=$?
+
+    # Must exit 0 — invalid ref is non-fatal (probe-error path)
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called (ref rejected before registry call)
+    run grep -c "PROBE CALLED on localhost ref" "$TEST_TEMP_DIR/r21c-stderr.txt"
+    [ "$output" = "0" ]
+
+    # Result must be empty array (no drift report for rejected ref)
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+@test "r21-C: localhost:5000/foo:1.0 is rejected by _validate_image_ref (host:port localhost)" {
+    local lineage_dir="$TEST_TEMP_DIR/r21c2/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "foo",' \
+        '  "tag": "1.0",' \
+        '  "base_image_ref": "localhost:5000/foo:1.0",' \
+        '  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' > "$lineage_dir/foo-1.0.json"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r21c2-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on localhost:PORT ref" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r21c2-stderr.txt") || rc=$?
+
+    # Must exit 0 — invalid ref is non-fatal
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called
+    run grep -c "PROBE CALLED on localhost:PORT ref" "$TEST_TEMP_DIR/r21c2-stderr.txt"
+    [ "$output" = "0" ]
+
+    # Result must be empty
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2136,3 +2136,54 @@ gamma" \
     drift_count=$(printf '%s' "$result" | jq -r '[.[] | .variants[].status] | map(select(. == "drift")) | length')
     [ "$drift_count" -eq 3 ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix #537-s1: leading-slash ref bypass in _validate_image_ref
+# Regression guard: a ref like /alpine:3.21 has an empty first_segment after
+# the leading '/' is split off.  The former code fell through to the
+# "Docker Hub org name" path with first_segment="", accepting the ref.
+# The fix adds an explicit leading-slash guard at function entry.
+# ---------------------------------------------------------------------------
+
+@test "s1-fix: leading-slash ref /alpine:3.21 is rejected by _validate_image_ref" {
+    local lineage_dir="$TEST_TEMP_DIR/s1fix/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "/alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub that fails loudly if called — must NOT be called
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/slash-probe.XXXXXX")
+    cat > "$probe_stub" <<'STUB'
+#!/usr/bin/env bash
+echo "PROBE WAS CALLED on leading-slash ref — validation bypass!" >&2
+exit 1
+STUB
+    chmod +x "$probe_stub"
+
+    local result stderr_out rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/tmp/s1fix-stderr.txt) || rc=$?
+    stderr_out=$(cat /tmp/s1fix-stderr.txt)
+
+    # Script must exit 0 — rejection is not fatal
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called
+    ! echo "$stderr_out" | grep -q "PROBE WAS CALLED"
+
+    # Entry must be skipped — result is empty array
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -314,6 +314,58 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Fix 1 regression: probe errors surfaced on stderr (::error::) AND error_reason
+# in JSON record — supply-chain monitoring must not silently drop probe failures.
+# ---------------------------------------------------------------------------
+@test "probe-failure: emits ::error:: to stderr when probe fails" {
+    local fail_stub
+    fail_stub=$(_make_failing_probe_stub)
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local stderr_log="$TEST_TEMP_DIR/probe-failure-stderr.log"
+    PROBE_CMD="$fail_stub" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
+
+    # stderr must contain at least one ::error:: annotation
+    grep -q '::error::' "$stderr_log"
+}
+
+@test "probe-failure: error JSON record contains error_reason field" {
+    local fail_stub
+    fail_stub=$(_make_failing_probe_stub)
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$fail_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # error_reason must be a non-empty string (not null)
+    error_reason=$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason // "null"')
+    [ "$error_reason" != "null" ]
+    [ -n "$error_reason" ]
+}
+
+# ---------------------------------------------------------------------------
 # Scenario 4 (spec §4): Legacy lineage (no base_image_digest field)
 # ---------------------------------------------------------------------------
 @test "legacy: variant without base_image_digest gets status=legacy" {
@@ -494,13 +546,16 @@ EOF
 # ---------------------------------------------------------------------------
 # Scenario 5 (spec §4): Multi-arch index digest extraction
 # The probe returns a multi-arch manifest list. The script must extract the
-# INDEX digest (from .digest field at the top level), NOT a per-arch digest.
+# INDEX digest via the top-level .digest field (jq -r '.digest'), NOT a
+# per-arch entry digest from .manifests[].digest.
+#
+# Fix 2 regression guard: using grep-o head-1 is order-dependent; jq .digest
+# is explicit.  Both the fixture and a synthetic test cover this.
 # ---------------------------------------------------------------------------
 @test "multi-arch: script extracts the image-index digest, not per-arch" {
     # Fixture: alpine-3.21.json has .digest = ccc... (index)
-    # and .manifests[0].digest = ddd... (amd64)
-    # The probe stub reads the whole JSON and the script uses grep-o to find
-    # the first sha256 — which is the .digest field in the response body.
+    # and .manifests[0].digest = ddd... (amd64), .manifests[1].digest = eee... (arm64)
+    # The script must return ccc... (index), NOT ddd.../eee...
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -525,6 +580,71 @@ EOF
 
     # The fixture alpine-3.21.json has .digest = ccc... (64 c's)
     # Per-arch digests are ddd... and eee... — must NOT be one of those
+    [ "$current_digest" = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ]
+}
+
+# Fix 2 synthetic: manifest where per-arch digest appears FIRST in the JSON body
+# (before the top-level .digest).  grep-o head-1 would return the wrong digest;
+# jq -r '.digest' must return the correct index digest regardless of field order.
+@test "multi-arch: index digest extracted even when per-arch entry precedes .digest in JSON" {
+    # Synthetic fixture: .manifests[] listed before .digest at top level.
+    # grep-o '"sha256:[a-f0-9]*"' | head -1 would return amd64 digest (ddd...).
+    # jq -r '.digest' returns the index digest (ccc...) — order-independent.
+    local synthetic_dir="$TEST_TEMP_DIR/synthetic-probe"
+    mkdir -p "$synthetic_dir/responses"
+
+    # Write manifest JSON with per-arch entries BEFORE the top-level .digest field
+    cat > "$synthetic_dir/responses/myimage-latest.json" <<'EOF'
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "platform": {"architecture": "amd64", "os": "linux"}
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "platform": {"architecture": "arm64", "os": "linux"}
+    }
+  ],
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}
+EOF
+
+    local stub_script="$synthetic_dir/probe.sh"
+    cat > "$stub_script" <<STUB_EOF
+#!/usr/bin/env bash
+image_ref="\$1"
+key="\$(printf '%s' "\$image_ref" | tr ':/' '--')"
+response_file="${synthetic_dir}/responses/\${key}.json"
+[[ -f "\$response_file" ]] && { cat "\$response_file"; exit 0; }
+exit 1
+STUB_EOF
+    chmod +x "$stub_script"
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/myimage-latest.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "latest",
+  "base_image_ref": "myimage:latest",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$stub_script" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir")
+
+    current_digest=$(printf '%s' "$result" | jq -r '.[0].variants[0].current_digest')
+
+    # Must be the INDEX digest (ccc...), NOT the first per-arch entry (ddd...)
     [ "$current_digest" = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ]
 }
 

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1778,3 +1778,236 @@ bar" \
 
     [ "$length" -eq 3 ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r10-2: active-tags filter failure is FAIL CLOSED (skip container entirely)
+#
+# When ./make list-builds fails or returns empty, the detector must NOT emit
+# drift records for that container (fail-closed).  Previous behavior disabled
+# the stale-lineage filter (__SKIPPED__), allowing stale tags to trigger
+# infinite drift-PR loops.
+# ---------------------------------------------------------------------------
+
+@test "r10-fix2a: list-builds failure → container fully skipped (fail-closed)" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix2a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-2.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "2.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Run without _VALID_CONTAINERS_OVERRIDE so production path runs list-builds
+    # Since ./make list-builds won't work in the test dir, it will fail → fail-closed
+    local result rc=0
+    result=$(unset _VALID_CONTAINERS_OVERRIDE && \
+        PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    # Script must exit 0 (container skip is not fatal)
+    [ "$rc" -eq 0 ]
+
+    # Output must be empty array — container was skipped entirely
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+@test "r10-fix2b: script contains fail-closed warning text (code audit)" {
+    # The production list-builds failure path (without _VALID_CONTAINERS_OVERRIDE)
+    # cannot be exercised in tests without a full project context (the detector derives
+    # PROJECT_ROOT from BASH_SOURCE[0] at startup, so env-var override is impossible).
+    # r10-fix2a already confirms the container is skipped when list-builds fails.
+    # This test audits that the warning text is present in the script source, ensuring
+    # the fail-closed message is not accidentally removed.
+    grep -q 'fail-closed' "${DETECTOR_SCRIPT}"
+}
+
+@test "r10-fix2c: stale tag still skipped when active-tags succeeds (no regression)" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix2c/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # One active tag (2.0), one stale tag (1.0)
+    cat > "$lineage_dir/myimage-2.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "2.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="2.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Only active tag 2.0 should appear
+    local variant_count
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$variant_count" -eq 1 ]
+
+    local reported_tag
+    reported_tag=$(printf '%s' "$result" | jq -r '.[] | .variants[].variant_tag')
+    [ "$reported_tag" = "2.0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r10-3: base_image_ref registry allowlist validation (SSRF prevention)
+#
+# Poisoned lineage with an attacker-controlled base_image_ref must be rejected
+# before the probe fires.  The detector must emit a ::warning:: and skip the
+# entry without calling the registry.
+# ---------------------------------------------------------------------------
+
+@test "r10-fix3a: poisoned base_image_ref (evil.com) is rejected without probe" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix3a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "evil.example.com/path:tag",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub that fails if called — must NOT be called
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/poison-probe.XXXXXX")
+    cat > "$probe_stub" <<'STUB'
+#!/usr/bin/env bash
+echo "PROBE WAS CALLED — SSRF not prevented!" >&2
+exit 1
+STUB
+    chmod +x "$probe_stub"
+
+    local result stderr_out rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/tmp/r10fix3a-stderr.txt) || rc=$?
+
+    stderr_out=$(cat /tmp/r10fix3a-stderr.txt)
+
+    # Must exit 0 — rejection is not a fatal error
+    [ "$rc" -eq 0 ]
+
+    # Probe must NOT have been called
+    echo "$stderr_out" | grep -qv "PROBE WAS CALLED"
+
+    # Must emit a ::warning:: about the untrusted ref
+    echo "$stderr_out" | grep -q "Refusing to probe untrusted"
+
+    # Result must be empty array (entry skipped)
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+@test "r10-fix3b: valid ghcr.io ref passes validation and is probed normally" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix3b/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "ghcr.io/oorabona/debian:trixie",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub returns a different digest (drift)
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Must report drift (probe was called and returned a different digest)
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}
+
+@test "r10-fix3c: Docker Hub bare name passes validation and is probed normally" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix3c/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}
+
+@test "r10-fix3d: mcr.microsoft.com ref passes validation" {
+    local lineage_dir="$TEST_TEMP_DIR/r10fix3d/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "mcr.microsoft.com/windows/servercore:ltsc2022",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    local status
+    status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
+    [ "$status" = "drift" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -27,19 +27,14 @@ setup() {
     FIXTURES_DIR_DRIFT="${FIXTURES_DIR}/digest-drift"
 
     # Pre-existing tests use synthetic container names (foo, bar, myimage) that
-    # are not in the real ./make list.  Expose the test-hook overrides so the
-    # validation and active-tag checks accept them without spawning ./make.
-    # New container-validation tests explicitly unset these to exercise real logic.
+    # are not in the real ./make list.  Expose _VALID_CONTAINERS_OVERRIDE so the
+    # validation check accepts them without spawning ./make. When this is set,
+    # the detector disables the stale-lineage filter by default for containers
+    # without explicit _ACTIVE_TAGS_OVERRIDE_*, allowing tests to use any tags.
+    # Specific tests can override this by unsetting _VALID_CONTAINERS_OVERRIDE.
     export _VALID_CONTAINERS_OVERRIDE="foo
 bar
 myimage"
-
-    # Active tags for each test container (fixture tags from lineage files)
-    export _ACTIVE_TAGS_OVERRIDE_foo="1.0-alpine
-1.0-debian"
-    export _ACTIVE_TAGS_OVERRIDE_bar="2.0-rocky
-2.0-ubuntu"
-    export _ACTIVE_TAGS_OVERRIDE_myimage=""
 
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1,0 +1,576 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/detect-base-digest-drift.sh
+#
+# BDD scenarios from spec §4. All registry calls are stubbed via PROBE_CMD.
+# PROBE_CMD is a function exported from setup() that reads pre-captured
+# JSON responses from tests/fixtures/digest-drift/*/responses/.
+#
+# Mutation guards documented per spec §6:
+#   MG1: Remove digest comparison → debian reports drift (false positive)
+#   MG2: Remove sidecar filter → foo's variants array has 3 entries
+#   MG3: Remove per-container grouping → result has 2 records instead of 1
+#   MG4: Remove digest shape validation → invalid digest accepted
+#
+# BDD scenario covered explicitly: "Per-container grouping (2×2 mutation guard)"
+# per spec §4 Scenario 6 — this test directly implements the 2×2 grouping assertion.
+
+load "../test_helper"
+
+DETECTOR_SCRIPT=""
+FIXTURES_DIR_DRIFT=""
+
+setup() {
+    setup_temp_dir
+
+    DETECTOR_SCRIPT="${SCRIPTS_DIR}/detect-base-digest-drift.sh"
+    FIXTURES_DIR_DRIFT="${FIXTURES_DIR}/digest-drift"
+
+    export TEST_TEMP_DIR
+    export DETECTOR_SCRIPT
+    export FIXTURES_DIR_DRIFT
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a probe stub that serves fixture responses by image ref.
+# The stub maps image refs to JSON files in the given responses/ dir.
+# Mapping table (image_ref → filename stem, : and / replaced with -):
+#   alpine:3.21         → alpine-3.21.json
+#   debian:trixie-slim  → debian-trixie-slim.json
+#   ubuntu:24.04        → ubuntu-24.04.json
+#   rockylinux:9        → rockylinux-9.json
+# ---------------------------------------------------------------------------
+_make_probe_stub() {
+    local responses_dir="$1"
+    local stub_path="$TEST_TEMP_DIR/bin/probe-stub"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<STUB_EOF
+#!/usr/bin/env bash
+# Fixture probe stub — maps image ref to a JSON file in responses/
+image_ref="\$1"
+responses_dir="${responses_dir}"
+
+# Normalize: replace : and / with - (matching fixture filename convention)
+key="\$(printf '%s' "\$image_ref" | tr ':/' '--')"
+response_file="\${responses_dir}/\${key}.json"
+
+if [[ -f "\$response_file" ]]; then
+    cat "\$response_file"
+    exit 0
+else
+    echo "stub: no fixture for '\$image_ref' (expected \$response_file)" >&2
+    exit 1
+fi
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a probe stub that always fails (simulates registry error)
+# ---------------------------------------------------------------------------
+_make_failing_probe_stub() {
+    local stub_path="$TEST_TEMP_DIR/bin/probe-fail"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<'STUB_EOF'
+#!/usr/bin/env bash
+echo "stub: simulated registry failure for '$1'" >&2
+exit 1
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a probe stub returning a specific digest for all refs
+# ---------------------------------------------------------------------------
+_make_digest_probe_stub() {
+    local digest="$1"
+    local stub_path="$TEST_TEMP_DIR/bin/probe-digest-$$"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<STUB_EOF
+#!/usr/bin/env bash
+printf '{"digest":"%s"}' "${digest}"
+exit 0
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1 (spec §4): Drift detected for a single variant (real registry shape)
+# Observable Success fixture: scenario-1
+# Alpine recorded=aaa...→current=ccc... (drift), Debian recorded==current (unchanged)
+# Sidecar foo-1.0-alpine.sbom.json must be excluded
+# ---------------------------------------------------------------------------
+@test "scenario-1: alpine reports drift, debian reports unchanged, sidecar excluded" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    # Output must be valid JSON
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Length: 1 container (foo)
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+
+    # Container name is foo
+    container=$(printf '%s' "$result" | jq -r '.[0].container')
+    [ "$container" = "foo" ]
+
+    # foo has 2 variants (alpine drift + debian unchanged)
+    foo_variants=$(printf '%s' "$result" | jq '.[0].variants | length')
+    [ "$foo_variants" -eq 2 ]
+
+    # Alpine variant: status=drift
+    alpine_status=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-alpine") | .status')
+    [ "$alpine_status" = "drift" ]
+
+    # Alpine variant: recorded_digest is the old one (aaaa...)
+    alpine_recorded=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-alpine") | .recorded_digest')
+    [[ "$alpine_recorded" =~ ^sha256:[a-f0-9]{64}$ ]]
+
+    # Alpine variant: current_digest is different (cccc...)
+    alpine_current=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-alpine") | .current_digest')
+    [[ "$alpine_current" =~ ^sha256:[a-f0-9]{64}$ ]]
+    [ "$alpine_current" != "$alpine_recorded" ]
+
+    # Debian variant: status=unchanged
+    debian_status=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-debian") | .status')
+    [ "$debian_status" = "unchanged" ]
+
+    # Sidecar excluded: no sbom reference in output
+    [[ "$result" != *"sbom"* ]]
+}
+
+# MG3: Per-container grouping — removing it would produce 2 records instead of 1
+# This test directly guards against that regression.
+@test "scenario-1: output length is 1 (per-container grouping guard MG3)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+}
+
+# MG1: Digest comparison — if comparison were removed, debian would also report drift
+@test "scenario-1: debian status is unchanged (digest comparison guard MG1)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    debian_status=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-debian") | .status')
+    [ "$debian_status" = "unchanged" ]
+}
+
+# MG2: Sidecar filter — removing it would produce 3 variants instead of 2
+@test "scenario-1: foo has exactly 2 variants (sidecar exclusion guard MG2)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    foo_variants=$(printf '%s' "$result" | jq '.[0].variants | length')
+    [ "$foo_variants" -eq 2 ]
+}
+
+# MG4: Digest shape validation — valid digests must match ^sha256:[a-f0-9]{64}$
+@test "scenario-1: all digests in output match sha256:[a-f0-9]{64} (shape guard MG4)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    # Extract all digest fields and verify shape
+    while IFS= read -r dgst; do
+        [[ -z "$dgst" ]] && continue
+        [[ "$dgst" =~ ^sha256:[a-f0-9]{64}$ ]] || \
+            { echo "FAIL: malformed digest '$dgst'"; return 1; }
+    done < <(printf '%s' "$result" | \
+        jq -r '.[].variants[] | .current_digest // empty, .recorded_digest // empty')
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 6 (spec §4): Per-container grouping (2×2 mutation guard)
+# foo: 2 variants (alpine + debian), bar: 2 variants (ubuntu + rocky) — all drifted
+# Output must have length 2 (grouped by container, NOT by variant)
+# ---------------------------------------------------------------------------
+@test "scenario-2: 2x2 grouping — output length is 2 (one per container)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 2 ]
+}
+
+@test "scenario-2: foo record contains 2 variants" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    foo_count=$(printf '%s' "$result" | \
+        jq '[.[] | select(.container == "foo")] | .[0].variants | length')
+    [ "$foo_count" -eq 2 ]
+}
+
+@test "scenario-2: bar record contains 2 variants" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/.build-lineage")
+
+    bar_count=$(printf '%s' "$result" | \
+        jq '[.[] | select(.container == "bar")] | .[0].variants | length')
+    [ "$bar_count" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3 (spec §4): Probe fails — tri-state error (NOT collapsed to drift)
+# ---------------------------------------------------------------------------
+@test "probe-failure: status is error, not drift" {
+    local fail_stub
+    fail_stub=$(_make_failing_probe_stub)
+
+    # Create a minimal lineage dir with one entry
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$fail_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    status_val=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].status')
+    [ "$status_val" = "error" ]
+}
+
+@test "probe-failure: error status does not include current_digest field" {
+    local fail_stub
+    fail_stub=$(_make_failing_probe_stub)
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$fail_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    current_digest=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].current_digest // "null"')
+    [ "$current_digest" = "null" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4 (spec §4): Legacy lineage (no base_image_digest field)
+# ---------------------------------------------------------------------------
+@test "legacy: variant without base_image_digest gets status=legacy" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    status_val=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].status')
+    [ "$status_val" = "legacy" ]
+}
+
+@test "legacy: variant with legacy flag set" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    legacy_flag=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].legacy')
+    [ "$legacy_flag" = "true" ]
+}
+
+@test "legacy: unresolved base_image_digest also treated as legacy" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "unresolved"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    status_val=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].status')
+    [ "$status_val" = "legacy" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4 (spec §4): --baseline-only flag
+# Given pre-v2 legacy entries alongside drifted v2 entries:
+# --baseline-only emits ONLY legacy records
+# ---------------------------------------------------------------------------
+@test "baseline-only: suppresses real-drift records, emits only legacy" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Real v2 entry — would drift if probed
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Legacy entry — should appear in baseline-only output
+    cat > "$lineage_dir/bar-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "bar",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" --baseline-only "$lineage_dir" 2>/dev/null)
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Only bar (legacy) should appear; foo (real drift) suppressed
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+
+    container=$(printf '%s' "$result" | jq -r '.[0].container')
+    [ "$container" = "bar" ]
+
+    status_val=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
+    [ "$status_val" = "legacy" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 9 (spec §4): Container with no lineage files at all
+# ---------------------------------------------------------------------------
+@test "empty lineage dir: emits warning and returns empty array" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage-empty"
+    mkdir -p "$lineage_dir"
+
+    result=$(bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/tmp/detect-stderr-$$.log)
+    stderr_out=$(cat /tmp/detect-stderr-$$.log 2>/dev/null || true)
+    rm -f /tmp/detect-stderr-$$.log
+
+    # Output is empty array
+    [ "$result" = "[]" ]
+
+    # stderr contains warning about empty cache
+    [[ "$stderr_out" == *"warning"* ]]
+}
+
+@test "nonexistent lineage dir: exits 0 and returns empty array" {
+    result=$(bash "${DETECTOR_SCRIPT}" "/nonexistent/lineage/dir/$$" 2>/dev/null)
+    [ "$result" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 8 (spec §4): Digest shape validation — security
+# ---------------------------------------------------------------------------
+@test "digest-shape-validation: malformed digest (short hex) causes exit 1" {
+    # The probe stub returns a manifest with a short digest (not 64 hex chars).
+    # grep -o '"sha256:[a-f0-9]*"' WILL extract it (the pattern matches any length),
+    # but _validate_digest_shape enforces ^sha256:[a-f0-9]{64}$ → refuses → exit 1.
+    local malformed_stub_dir="$TEST_TEMP_DIR/malformed-probe"
+    mkdir -p "$malformed_stub_dir/responses"
+
+    # Write the fixture response with a short digest (16 chars, not 64)
+    printf '%s' '{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:abcdef1234567890","manifests":[]}' \
+        > "$malformed_stub_dir/responses/alpine-3.21.json"
+
+    # Write a probe stub that reads from the malformed fixture dir
+    local stub_script="${malformed_stub_dir}/probe.sh"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        'image_ref="$1"' \
+        "responses_dir=\"${malformed_stub_dir}/responses\"" \
+        'key="$(printf "%s" "$image_ref" | tr ":/" "--")"' \
+        'response_file="${responses_dir}/${key}.json"' \
+        '[[ -f "$response_file" ]] && { cat "$response_file"; exit 0; }' \
+        'exit 1' \
+        > "$stub_script"
+    chmod +x "$stub_script"
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    printf '%s\n' '{' \
+        '"lineage_schema_version": 2,' \
+        '"container": "foo",' \
+        '"tag": "1.0-alpine",' \
+        '"base_image_ref": "alpine:3.21",' \
+        '"base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' \
+        > "$lineage_dir/foo-1.0-alpine.json"
+
+    # The script must exit non-zero when digest shape validation fails
+    run env PROBE_CMD="$stub_script" bash "${DETECTOR_SCRIPT}" "$lineage_dir"
+    # Exit code must be non-zero (validation refused the malformed digest)
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 5 (spec §4): Multi-arch index digest extraction
+# The probe returns a multi-arch manifest list. The script must extract the
+# INDEX digest (from .digest field at the top level), NOT a per-arch digest.
+# ---------------------------------------------------------------------------
+@test "multi-arch: script extracts the image-index digest, not per-arch" {
+    # Fixture: alpine-3.21.json has .digest = ccc... (index)
+    # and .manifests[0].digest = ddd... (amd64)
+    # The probe stub reads the whole JSON and the script uses grep-o to find
+    # the first sha256 — which is the .digest field in the response body.
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir")
+
+    current_digest=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[0].current_digest')
+
+    # The fixture alpine-3.21.json has .digest = ccc... (64 c's)
+    # Per-arch digests are ddd... and eee... — must NOT be one of those
+    [ "$current_digest" = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ]
+}
+
+# ---------------------------------------------------------------------------
+# Sidecar exclusion: explicit verification that is_lineage_sidecar() is called
+# ---------------------------------------------------------------------------
+@test "sidecar-exclusion: .sbom.json not processed even if valid JSON" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Valid-looking but is-a-sidecar file
+    cat > "$lineage_dir/foo-1.0-alpine.sbom.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine-sbom",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Should be empty — sidecar filtered
+    [ "$result" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Unresolved placeholder in base_image_ref — skip with warning
+# ---------------------------------------------------------------------------
+@test "unresolved-ref: entry with \${...} placeholder in base_image_ref is skipped" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ "$result" = "[]" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1586,3 +1586,193 @@ EOF
     # confirming the fix prevents foo from being incorrectly blocked.
     [ "$unscoped_errors" -gt "$foo_errors" ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r9-1 (NON-TERMINATING BUG): stale lineage filter via active build matrix
+#
+# Regression guard: a lineage entry whose tag is NOT in the active build matrix
+# (returned by ./make list-builds) must be silently skipped.  Only active-tag
+# entries should be reported.
+# ---------------------------------------------------------------------------
+@test "r9-fix1a: stale tag in lineage is skipped; active tag is reported" {
+    local lineage_dir="$TEST_TEMP_DIR/r9fix1a/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Two lineage files: one for an active tag, one for a stale (rotated-away) tag
+    cat > "$lineage_dir/myimage-2.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "2.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Active build matrix: only tag 2.0 is active; 1.0 was rotated away
+    # Use per-container test hook to inject the active-tags list
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="2.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Output must be valid JSON
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Only the active tag (2.0) should appear in drift output
+    local variant_count
+    variant_count=$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')
+    [ "$variant_count" -eq 1 ]
+
+    local reported_tag
+    reported_tag=$(printf '%s' "$result" | jq -r '.[] | .variants[].variant_tag')
+    [ "$reported_tag" = "2.0" ]
+}
+
+@test "r9-fix1b: stale tag skip emits ::notice:: to stderr" {
+    local lineage_dir="$TEST_TEMP_DIR/r9fix1b/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Active matrix is empty for this container (all tags rotated away)
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="2.0" \
+        PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
+
+    # Script must exit 0 (stale skip is not a fatal error)
+    [ "$rc" -eq 0 ]
+
+    # stderr must mention the stale skip notice
+    echo "$result" | grep -q "Skipping stale lineage entry"
+}
+
+# ---------------------------------------------------------------------------
+# Fix r9-2: tag sanitization — backticks and pipes in variant_tag are escaped
+# in GHA ::notice:: output (via _escape_gha_command applied at extraction).
+# ---------------------------------------------------------------------------
+@test "r9-fix2: update-last-rebuild escapes backticks and pipes in variant_tag" {
+    # Regression guard: a poisoned variant_tag containing backticks or pipes in the
+    # drift JSON must be escaped before embedding in LAST_REBUILD.md markdown.
+    local fake_root="$TEST_TEMP_DIR/r9fix2"
+    mkdir -p "$fake_root/scripts" "$fake_root/myimage"
+    cp "${SCRIPTS_DIR}/update-last-rebuild.sh" "$fake_root/scripts/update-last-rebuild.sh"
+
+    # Provide a minimal ./make list stub
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && { printf 'myimage\n'; exit 0; }
+STUB
+    chmod +x "$fake_root/make"
+
+    # Drift JSON with a poisoned variant_tag containing backtick and pipe
+    local drift_json
+    drift_json=$(jq -cn '[{
+      "container": "myimage",
+      "variants": [{
+        "variant_tag": "1.0`evil|cmd`",
+        "base_image_ref": "alpine:3.21",
+        "recorded_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "status": "drift"
+      }]
+    }]')
+
+    cd "$fake_root" && \
+        printf '%s' "$drift_json" | \
+        bash scripts/update-last-rebuild.sh "myimage" "base-digest-drift" 2>/dev/null
+
+    local content
+    content=$(cat "$fake_root/myimage/LAST_REBUILD.md")
+
+    # The backtick must be escaped as \` in markdown output (not raw `evil)
+    # Correct form: 1.0\`evil\|cmd\` — backslash before backtick and pipe.
+    # grep -F for literal backslash-backtick to verify escaping was applied.
+    echo "$content" | grep -qF '\`evil'
+    # And the pipe must also be escaped
+    echo "$content" | grep -qF '\|cmd'
+}
+
+# ---------------------------------------------------------------------------
+# Fix r9-3: container name with embedded newline is rejected before grep check
+# ---------------------------------------------------------------------------
+@test "r9-fix3: container name with embedded newline is rejected before grep validation" {
+    local lineage_dir="$TEST_TEMP_DIR/r9fix3/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Craft a lineage JSON where the container field contains a newline sequence.
+    # jq -n --arg produces the literal string with \n in it (not a real newline
+    # in the JSON value — we need the jq raw output to embed a real newline).
+    # We write it directly so the container field truly contains a newline char.
+    printf '{"lineage_schema_version":2,"container":"foo\nmalicious","tag":"1.0","base_image_ref":"alpine:3.21","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}\n' \
+        > "$lineage_dir/evil-1.0.json"
+
+    # _VALID_CONTAINERS_OVERRIDE contains "foo" and "bar" but NOT "malicious"
+    # Without Fix r9-3, grep -qxF "foo\nmalicious" <<<"foo\nbar" would match "foo"
+    # and pass "malicious" through as a valid container.
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo
+bar" \
+        PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    # Script exits 0 (a single rejected entry is not fatal)
+    [ "$rc" -eq 0 ]
+
+    # Output must be empty array (the entry was rejected, not passed through)
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r9-4: ./make list pipeline failure in upstream-monitor sync step
+# Unit-level regression: the jq pipeline on an empty/failed make list must
+# produce an empty array, and the shell-level check must detect length == 0.
+# This mirrors the fix applied in upstream-monitor.yaml.
+# ---------------------------------------------------------------------------
+@test "r9-fix4: empty make_list_out is detected before jq pipeline" {
+    # Simulate the fixed pattern: the guard checks the raw string BEFORE piping
+    # into jq -Rnc, because a here-string of "" sends a newline to jq which
+    # produces [""] (length 1) — false non-empty.
+    local make_list_out=""
+
+    # Pattern used in the workflow: trim whitespace and check empty
+    local trimmed="${make_list_out// /}"
+    [ -z "$trimmed" ]
+}
+
+@test "r9-fix4b: jq -Rnc on non-empty make list output is non-zero length" {
+    local make_list_out
+    make_list_out=$(printf 'ansible\ndebian\nphp\n')
+
+    local containers_json
+    containers_json=$(jq -Rnc '[inputs]' <<<"$make_list_out")
+
+    local length
+    length=$(echo "$containers_json" | jq 'length')
+
+    [ "$length" -eq 3 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1505,3 +1505,84 @@ STUB
     # Must exit 2 — tooling failure, NOT silent success
     [ "$rc" -eq 2 ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r8-1: jq -Rnc preserves alphabetically-first container
+# Regression guard: piping N lines through `jq -Rc '[inputs]'` drops the
+# first line because -R without -n consumes one line before [inputs] runs.
+# Adding -n makes jq use null as its initial input, so [inputs] sees all lines.
+# ---------------------------------------------------------------------------
+@test "r8-fix1: jq -Rnc collects all containers including alphabetically-first" {
+    # Simulate ./make list output: 3 containers in alphabetical order.
+    # The first one (ansible) was previously dropped by jq -Rc (no -n).
+    local make_output
+    make_output=$(printf 'ansible\nbeta\ngamma\n')
+
+    # Old broken form: jq -Rc '[inputs]' — drops first line
+    local broken
+    broken=$(echo "$make_output" | jq -Rc '[inputs]')
+    # ansible is missing from broken output
+    run bash -c "echo '$broken' | jq -r 'length'"
+    [ "$output" -eq 2 ]
+    run bash -c "echo '$broken' | jq -r '.[0]'"
+    [ "$output" = "beta" ]
+
+    # New correct form: jq -Rnc '[inputs]' — all lines present
+    local correct
+    correct=$(echo "$make_output" | jq -Rnc '[inputs]')
+    run bash -c "echo '$correct' | jq -r 'length'"
+    [ "$output" -eq 3 ]
+    run bash -c "echo '$correct' | jq -r '.[0]'"
+    [ "$output" = "ansible" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r8-2: error_count scoped to current matrix container
+# Regression guard: a transient probe error on container "bar" must NOT
+# prevent container "foo"'s matrix job from creating its drift PR.
+# The jq filter must restrict error counting to the matrix container only.
+# ---------------------------------------------------------------------------
+@test "r8-fix2: error_count scoped to matrix container — bar error does not block foo" {
+    # Synthetic drift JSON: foo has drift (clean), bar has an error variant
+    local drift_json
+    drift_json=$(cat <<'EOF'
+[
+  {
+    "container": "foo",
+    "variants": [
+      {"tag": "foo:latest", "status": "drift", "cached_digest": "sha256:aaa", "live_digest": "sha256:bbb"}
+    ]
+  },
+  {
+    "container": "bar",
+    "variants": [
+      {"tag": "bar:latest", "status": "error", "error": "registry timeout"}
+    ]
+  }
+]
+EOF
+)
+
+    # Scoped filter for "foo" — should return 0 errors even though bar has 1
+    local foo_errors
+    foo_errors=$(echo "$drift_json" | jq --arg c "foo" \
+        '[.[] | select(.container == $c) | .variants[] | select(.status == "error")] | length')
+    [ "$foo_errors" -eq 0 ]
+
+    # Scoped filter for "bar" — should return 1 error
+    local bar_errors
+    bar_errors=$(echo "$drift_json" | jq --arg c "bar" \
+        '[.[] | select(.container == $c) | .variants[] | select(.status == "error")] | length')
+    [ "$bar_errors" -eq 1 ]
+
+    # The old unscoped filter — counts errors across ALL containers:
+    # foo's job would have seen 1 error from bar and exited 1 (wrong).
+    local unscoped_errors
+    unscoped_errors=$(echo "$drift_json" | jq \
+        '[.[] | .variants[] | select(.status == "error")] | length')
+    [ "$unscoped_errors" -eq 1 ]
+
+    # Cross-check: unscoped count is > 0 but foo-scoped count is 0,
+    # confirming the fix prevents foo from being incorrectly blocked.
+    [ "$unscoped_errors" -gt "$foo_errors" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -2744,3 +2744,103 @@ pathlib.Path('${lineage_dir}/foo-1.0.json').write_text(json.dumps(d))
     # We assert: no line in the output starts with ::add-mask::
     ! printf '%s' "$stderr_output" | grep -qE '^::add-mask::'
 }
+
+# ---------------------------------------------------------------------------
+# r27-B: dash-prefix option injection in _validate_image_ref
+#
+# A base_image_ref starting with '-' must be rejected by _validate_image_ref.
+# Without the guard, refs like '-h', '--config /tmp/x', or '-foo:1.0' flow to
+# `docker buildx imagetools inspect ... "${image_ref}"` (or the PROBE_CMD stub)
+# as positional arguments that begin with '-' — option injection.
+# Belt-and-suspenders: the validation guard rejects these before the probe call;
+# the `--` separator at the call site provides the second defence layer.
+# Mutation guard: removing `[[ "$ref" == -* ]] && return 1` from
+# _validate_image_ref → probe would be called → test fails.
+# ---------------------------------------------------------------------------
+
+_r27b_lineage_with_ref() {
+    # Write a lineage file with the given base_image_ref into a scratch dir.
+    # Args: <lineage_dir> <ref_value>
+    local lineage_dir="$1"
+    local ref="$2"
+    mkdir -p "$lineage_dir"
+    printf '%s\n' \
+        '{' \
+        '  "lineage_schema_version": 2,' \
+        '  "container": "foo",' \
+        '  "tag": "1.0",' \
+        "  \"base_image_ref\": \"${ref}\"," \
+        '  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '}' > "$lineage_dir/foo-1.0.json"
+}
+
+@test "r27-B1: _validate_image_ref rejects '-h' (short option injection)" {
+    local lineage_dir="$TEST_TEMP_DIR/r27b1/.build-lineage"
+    _r27b_lineage_with_ref "$lineage_dir" "-h"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r27b1-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on dash-prefix ref" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r27b1-stderr.txt") || rc=$?
+
+    [ "$rc" -eq 0 ]
+    # Probe must NOT have been called (ref rejected before registry call)
+    run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b1-stderr.txt"
+    [ "$output" = "0" ]
+    # Result must be empty array (no drift record for rejected ref)
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+@test "r27-B2: _validate_image_ref rejects '--config' (long option injection)" {
+    local lineage_dir="$TEST_TEMP_DIR/r27b2/.build-lineage"
+    _r27b_lineage_with_ref "$lineage_dir" "--config"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r27b2-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on --config ref" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r27b2-stderr.txt") || rc=$?
+
+    [ "$rc" -eq 0 ]
+    run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b2-stderr.txt"
+    [ "$output" = "0" ]
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}
+
+@test "r27-B3: _validate_image_ref rejects '-foo:1.0' (dash-prefix with tag)" {
+    local lineage_dir="$TEST_TEMP_DIR/r27b3/.build-lineage"
+    _r27b_lineage_with_ref "$lineage_dir" "-foo:1.0"
+
+    local probe_stub
+    probe_stub=$(mktemp "$TEST_TEMP_DIR/r27b3-probe.XXXXXX")
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "PROBE CALLED on -foo:1.0 ref" >&2' 'exit 1' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result rc=0
+    result=$(_VALID_CONTAINERS_OVERRIDE="foo" \
+        _ACTIVE_TAGS_OVERRIDE_foo="1.0" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r27b3-stderr.txt") || rc=$?
+
+    [ "$rc" -eq 0 ]
+    run grep -c "PROBE CALLED" "$TEST_TEMP_DIR/r27b3-stderr.txt"
+    [ "$output" = "0" ]
+    local result_len
+    result_len=$(printf '%s' "$result" | jq 'length')
+    [ "$result_len" -eq 0 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1045,3 +1045,194 @@ EOF
 
     [ "$result" = "[]" ]
 }
+
+# ---------------------------------------------------------------------------
+# Fix r6-1: Per-container concurrency — matrix output separates containers
+# Regression guard: when two containers drift, the script emits two separate
+# container records in drift_json.  The open-drift-prs matrix uses
+# matrix.container (derived from drift_containers) to fan out.  This test
+# verifies that multi-container drift produces one record per container so
+# each matrix entry (and its own concurrency lane) is distinct.
+# ---------------------------------------------------------------------------
+@test "r6-fix1: two drifted containers produce two separate container records" {
+    export _VALID_CONTAINERS_OVERRIDE="foo
+bar"
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # foo: recorded digest differs from current → drift
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # bar: recorded digest differs from current → drift
+    cat > "$lineage_dir/bar-2.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "bar",
+  "tag": "2.0",
+  "base_image_ref": "debian:trixie-slim",
+  "base_image_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}
+EOF
+
+    # Probe stub: returns a different digest for each ref (simulating real drift)
+    local stub_script="$TEST_TEMP_DIR/probe-two-containers"
+    cat > "$stub_script" <<'STUB_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    alpine:3.21)
+        printf '{"digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}'
+        ;;
+    debian:trixie-slim)
+        printf '{"digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}'
+        ;;
+    *)
+        echo "unexpected ref: $1" >&2
+        exit 1
+        ;;
+esac
+STUB_EOF
+    chmod +x "$stub_script"
+
+    result=$(PROBE_CMD="$stub_script" bash "${DETECTOR_SCRIPT}" "$lineage_dir")
+
+    printf '%s' "$result" | jq '.' >/dev/null  # valid JSON
+
+    # Must produce exactly 2 container records — one per drifted container
+    record_count=$(printf '%s' "$result" | jq 'length')
+    [ "$record_count" -eq 2 ]
+
+    # Both containers present with status=drift
+    foo_status=$(printf '%s' "$result" | jq -r '.[] | select(.container=="foo") | .variants[0].status')
+    [ "$foo_status" = "drift" ]
+
+    bar_status=$(printf '%s' "$result" | jq -r '.[] | select(.container=="bar") | .variants[0].status')
+    [ "$bar_status" = "drift" ]
+
+    # drift_containers list (as the workflow computes it) has 2 distinct entries
+    drift_containers=$(printf '%s' "$result" | jq -c '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]')
+    foo_in_list=$(printf '%s' "$drift_containers" | jq 'index("foo")')
+    bar_in_list=$(printf '%s' "$drift_containers" | jq 'index("bar")')
+    # Both containers are in the list (non-null index)
+    [ "$foo_in_list" != "null" ]
+    [ "$bar_in_list" != "null" ]
+    # List has exactly 2 entries → each matrix job gets its own concurrency lane
+    list_len=$(printf '%s' "$drift_containers" | jq 'length')
+    [ "$list_len" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r6-2: Workflow re-emit injection prevention
+# Regression guard: a base_image_ref with a percent-encoded newline (%0A)
+# would survive _sanitize_for_json (which only strips literal control chars)
+# and land in error_reason in the JSON.  The old workflow re-emitted that
+# field unescaped via `echo "::warning::probe-error: ${line}"`, allowing the
+# GHA runner to decode %0A back to a newline and inject a second command.
+#
+# This test verifies that the script itself does NOT double-encode: it already
+# escapes the probe-error line via _escape_gha_command before writing to
+# stderr.  The workflow no longer re-emits from JSON, so the injection path
+# is gone — this test guards that the script-level emission (the surviving
+# path) is correctly escaped.
+# ---------------------------------------------------------------------------
+@test "r6-fix2: percent-encoded newline in base_image_ref is escaped in script stderr output" {
+    # A crafted base_image_ref containing %0A (percent-encoded newline).
+    # _sanitize_for_json strips literal \n/\r but NOT %0A, so %0A survives
+    # into error_reason.  The script must escape the ::error:: line via
+    # _escape_gha_command so the %0A becomes %250A (double-encoded), preventing
+    # the GHA runner from decoding it back into a newline command injection.
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    printf '{"lineage_schema_version":2,"container":"foo","tag":"1.0","base_image_ref":"alpine:3.21%%0A::add-mask::s3cr3t","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+        > "$lineage_dir/foo-1.0.json"
+
+    local stderr_log="$TEST_TEMP_DIR/r6-fix2-stderr.log"
+    PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
+
+    # The injected command must NOT appear as a standalone GHA command line
+    ! grep -q '^::add-mask::' "$stderr_log"
+
+    # The ::error:: line must be present (probe failure was emitted)
+    grep -q '::error::' "$stderr_log"
+}
+
+# ---------------------------------------------------------------------------
+# Fix r6-3: Temp file cleanup in _probe_digest (trap RETURN)
+# Regression guard: _probe_digest must not leave /tmp files behind when the
+# probe returns empty raw output or fails to extract a digest.  We verify
+# indirectly: run the script in a restricted TMPDIR with a known prefix and
+# check that no files with that prefix remain after the script exits.
+# ---------------------------------------------------------------------------
+@test "r6-fix3: no temp files left behind after empty-raw probe failure" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local isolated_tmp="$TEST_TEMP_DIR/probe-tmp"
+    mkdir -p "$lineage_dir" "$isolated_tmp"
+
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub: exits 0 but emits empty stdout → triggers the "empty raw" early return
+    local stub_script="$TEST_TEMP_DIR/probe-empty-raw"
+    cat > "$stub_script" <<'STUB_EOF'
+#!/usr/bin/env bash
+# Output nothing — simulates imagetools returning empty body
+exit 0
+STUB_EOF
+    chmod +x "$stub_script"
+
+    # Run with isolated TMPDIR so any leaked mktemp files are contained
+    TMPDIR="$isolated_tmp" PROBE_CMD="$stub_script" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" >/dev/null 2>&1 || true
+
+    # No temp files must remain in isolated_tmp after script exits
+    leaked=$(find "$isolated_tmp" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    [ "$leaked" -eq 0 ]
+}
+
+@test "r6-fix3: no temp files left behind after digest-extraction failure" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local isolated_tmp="$TEST_TEMP_DIR/probe-tmp2"
+    mkdir -p "$lineage_dir" "$isolated_tmp"
+
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Probe stub: exits 0, emits JSON with no .digest field → triggers the
+    # "could not extract digest" early return path
+    local stub_script="$TEST_TEMP_DIR/probe-no-digest"
+    cat > "$stub_script" <<'STUB_EOF'
+#!/usr/bin/env bash
+printf '{"mediaType":"application/vnd.oci.image.manifest.v1+json"}'
+exit 0
+STUB_EOF
+    chmod +x "$stub_script"
+
+    TMPDIR="$isolated_tmp" PROBE_CMD="$stub_script" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" >/dev/null 2>&1 || true
+
+    leaked=$(find "$isolated_tmp" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    [ "$leaked" -eq 0 ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -27,12 +27,19 @@ setup() {
     FIXTURES_DIR_DRIFT="${FIXTURES_DIR}/digest-drift"
 
     # Pre-existing tests use synthetic container names (foo, bar, myimage) that
-    # are not in the real ./make list.  Expose the test-hook override so the
-    # validation check accepts them without spawning ./make in the project root.
-    # New container-validation tests explicitly unset this to exercise real logic.
+    # are not in the real ./make list.  Expose the test-hook overrides so the
+    # validation and active-tag checks accept them without spawning ./make.
+    # New container-validation tests explicitly unset these to exercise real logic.
     export _VALID_CONTAINERS_OVERRIDE="foo
 bar
 myimage"
+
+    # Active tags for each test container (fixture tags from lineage files)
+    export _ACTIVE_TAGS_OVERRIDE_foo="1.0-alpine
+1.0-debian"
+    export _ACTIVE_TAGS_OVERRIDE_bar="2.0-rocky
+2.0-ubuntu"
+    export _ACTIVE_TAGS_OVERRIDE_myimage=""
 
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -905,3 +905,143 @@ STUB
     [ -f "$fake_root/mycontainer/LAST_REBUILD.md" ]
     grep -q 'base-digest-drift' "$fake_root/mycontainer/LAST_REBUILD.md"
 }
+
+# ---------------------------------------------------------------------------
+# Fix r5-1: Unified digest source (writer + probe both use imagetools format)
+# Regression guard: probe must extract .digest from imagetools-style JSON
+# (the format `docker buildx imagetools inspect --format '{{json .Manifest}}'`
+# returns).  The fixture is the imagetools Manifest descriptor — a flat object
+# with .digest, .mediaType, .size (no .manifests[] wrapper at the outer level).
+# ---------------------------------------------------------------------------
+@test "r5-fix1: probe extracts digest from imagetools Manifest descriptor format" {
+    # Fixture: imagetools --format '{{json .Manifest}}' returns a flat OCI descriptor
+    # with .digest at the top level.  This is different from the `docker manifest
+    # inspect` format which has .manifests[] and a top-level .digest only in the
+    # manifest-list body.  Both formats have .digest at top level — jq '.digest'
+    # works for both.  This test guards the imagetools-format path specifically.
+    local synthetic_dir="$TEST_TEMP_DIR/r5-fix1-probe"
+    mkdir -p "$synthetic_dir/responses"
+
+    # imagetools --format '{{json .Manifest}}' output: flat descriptor
+    cat > "$synthetic_dir/responses/alpine-3.21.json" <<'EOF'
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "size": 2048
+}
+EOF
+
+    local stub_script="$synthetic_dir/probe.sh"
+    cat > "$stub_script" <<STUB_EOF
+#!/usr/bin/env bash
+key="\$(printf '%s' "\$1" | tr ':/' '--')"
+response_file="${synthetic_dir}/responses/\${key}.json"
+[[ -f "\$response_file" ]] && { cat "\$response_file"; exit 0; }
+exit 1
+STUB_EOF
+    chmod +x "$stub_script"
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-3.21-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "3.21-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(PROBE_CMD="$stub_script" bash "${DETECTOR_SCRIPT}" "$lineage_dir")
+
+    current_digest=$(printf '%s' "$result" | jq -r '.[0].variants[0].current_digest')
+    # Probe must extract 1111... (from imagetools Manifest descriptor), NOT fall back to grep
+    [ "$current_digest" = "sha256:1111111111111111111111111111111111111111111111111111111111111111" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r5-2: GHA command injection prevention (::error:: escaping)
+# Regression guard: a newline-bearing base_image_ref in a probe-error scenario
+# must NOT inject a second GHA workflow command.  The escaped form (%0A) must
+# appear in the ::error:: line instead of a raw newline.
+# ---------------------------------------------------------------------------
+@test "r5-fix2: newline in base_image_ref is escaped in ::error:: output" {
+    # Lineage file with a base_image_ref containing an embedded newline (simulates
+    # a crafted/corrupted lineage entry).  When the registry probe fails, the error
+    # line must escape the newline as %0A to prevent GHA command injection.
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Use a JSON-escaped newline (\n) in the base_image_ref value.  jq decodes
+    # \n → literal newline when reading the field, giving _escape_gha_command
+    # a real newline to escape as %0A.
+    printf '{"lineage_schema_version":2,"container":"foo","tag":"1.0","base_image_ref":"alpine:3.21\\nmalicious::add-mask::secret","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+        > "$lineage_dir/foo-1.0.json"
+
+    local stderr_log="$TEST_TEMP_DIR/r5-fix2-stderr.log"
+    PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
+
+    # The raw newline must NOT appear in stderr (it would split the ::error:: line)
+    # Instead %0A must be present
+    if grep -qP '\n' "$stderr_log" 2>/dev/null; then
+        # grep -P may not be available everywhere; use a portable check
+        true
+    fi
+    # Primary assertion: %0A must appear in any ::error:: line containing the ref
+    grep -q '%0A' "$stderr_log"
+    # Secondary: the injected GHA command must NOT appear as a standalone command line
+    ! grep -q '^::add-mask::' "$stderr_log"
+}
+
+# ---------------------------------------------------------------------------
+# Fix r5-4: --baseline-only precedence (legacy wins over placeholder-skip)
+# Regression guard: a pre-#530 lineage entry with a placeholder base_image_ref
+# AND no recorded digest must emit status=legacy in --baseline-only mode (so the
+# baseline migration picks it up), while the same entry must be SKIPPED (result=[])
+# in normal mode (to prevent bogus drift PRs).
+# ---------------------------------------------------------------------------
+@test "r5-fix4: baseline-only mode emits legacy for placeholder-ref + missing-digest entry" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    # Pre-#530 entry: placeholder ref, no digest field at all
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim"
+}
+EOF
+
+    # --baseline-only: must emit a legacy record (not skip)
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" --baseline-only "$lineage_dir" 2>/dev/null)
+
+    printf '%s' "$result" | jq '.' >/dev/null  # valid JSON
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+
+    status_val=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
+    [ "$status_val" = "legacy" ]
+}
+
+@test "r5-fix4: normal mode still skips placeholder-ref + missing-digest entry (no regression)" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    # Same pre-#530 entry
+    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 1,
+  "container": "foo",
+  "tag": "1.0",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim"
+}
+EOF
+
+    # Normal mode (no --baseline-only): must skip — empty output
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ "$result" = "[]" ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -26,6 +26,14 @@ setup() {
     DETECTOR_SCRIPT="${SCRIPTS_DIR}/detect-base-digest-drift.sh"
     FIXTURES_DIR_DRIFT="${FIXTURES_DIR}/digest-drift"
 
+    # Pre-existing tests use synthetic container names (foo, bar, myimage) that
+    # are not in the real ./make list.  Expose the test-hook override so the
+    # validation check accepts them without spawning ./make in the project root.
+    # New container-validation tests explicitly unset this to exercise real logic.
+    export _VALID_CONTAINERS_OVERRIDE="foo
+bar
+myimage"
+
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT
     export FIXTURES_DIR_DRIFT
@@ -718,4 +726,182 @@ EOF
 
     # Must be empty — placeholder takes precedence over legacy classification
     [ "$result" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r4-1: Container name validation — poisoning prevention
+# Lineage entries whose .container field is NOT in `./make list` output must
+# be skipped with a ::warning::, never processed.
+# Regression: a corrupted entry with container: "docs" (or ".github", or a
+# path with "/") would otherwise cause the bot to act on non-container dirs.
+# ---------------------------------------------------------------------------
+@test "container-validation: entry with invalid container name 'docs' is skipped" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Corrupted entry: container field is a real directory name but NOT a container
+    cat > "$lineage_dir/docs-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "docs",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Unset override: "docs" is not in the real ./make list
+    result=$(unset _VALID_CONTAINERS_OVERRIDE && PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Invalid container must be filtered out — output must be empty
+    [ "$result" = "[]" ]
+}
+
+@test "container-validation: entry with invalid container name 'docs' emits ::warning:: to stderr" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/docs-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "docs",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local stderr_log="$TEST_TEMP_DIR/invalid-container-stderr.log"
+    # Unset override: "docs" is not in the real ./make list
+    unset _VALID_CONTAINERS_OVERRIDE
+    PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
+
+    # stderr must contain ::warning:: about invalid container
+    grep -q '::warning::' "$stderr_log"
+}
+
+@test "container-validation: entry with container name containing slash is skipped" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    # Path traversal attempt
+    cat > "$lineage_dir/traversal-1.0.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "../docs",
+  "tag": "1.0",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # Unset override: "../docs" is certainly not in ./make list
+    result=$(unset _VALID_CONTAINERS_OVERRIDE && PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    # Path-traversal container name must be filtered out
+    [ "$result" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix r4-4: update-last-rebuild.sh — missing container directory
+#
+# When the container directory does not exist (stale lineage cache entry),
+# update-last-rebuild.sh must exit 0 with a ::warning:: rather than exit 1.
+# A single stale entry must not break the entire open-drift-prs workflow.
+# ---------------------------------------------------------------------------
+
+# Helper: minimal drift JSON for a given container name
+_drift_json_for_container() {
+    local container="$1"
+    printf '%s' '[{"container":"'"$container"'","variants":[{"variant_tag":"1.0","base_image_ref":"alpine:3.21","recorded_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","current_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","status":"drift"}]}]'
+}
+
+@test "update-last-rebuild: exits 0 when container directory does not exist" {
+    local fake_root="$TEST_TEMP_DIR/fake-root-r4"
+    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
+    mkdir -p "$fake_root/scripts"
+    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+
+    # Stub ./make list — "mycontainer" is valid, but directory is never created
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && printf 'mycontainer\n'
+STUB
+    chmod +x "$fake_root/make"
+
+    local rc=0
+    cd "$fake_root" && \
+        bash scripts/update-last-rebuild.sh "mycontainer" "base-digest-drift" \
+        <<< "$(_drift_json_for_container mycontainer)" 2>/dev/null || rc=$?
+
+    # Must exit 0 — graceful skip, not failure
+    [ "$rc" -eq 0 ]
+
+    # Must NOT have created the LAST_REBUILD.md
+    [ ! -f "$fake_root/mycontainer/LAST_REBUILD.md" ]
+}
+
+@test "update-last-rebuild: emits ::warning:: when container directory missing" {
+    local fake_root="$TEST_TEMP_DIR/fake-root-r4b"
+    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
+    mkdir -p "$fake_root/scripts"
+    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && printf 'mycontainer\n'
+STUB
+    chmod +x "$fake_root/make"
+
+    local stderr_log="$TEST_TEMP_DIR/missing-dir-stderr.log"
+    cd "$fake_root" && \
+        bash scripts/update-last-rebuild.sh "mycontainer" "base-digest-drift" \
+        <<< "$(_drift_json_for_container mycontainer)" 2>"$stderr_log" >/dev/null || true
+
+    grep -q '::warning::' "$stderr_log"
+}
+
+@test "update-last-rebuild: exits 0 for invalid container name not in make list" {
+    local fake_root="$TEST_TEMP_DIR/fake-root-r4c"
+    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
+    mkdir -p "$fake_root/scripts"
+    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+
+    # ./make list returns only "ansible"; "docs" is not valid
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && printf 'ansible\n'
+STUB
+    chmod +x "$fake_root/make"
+
+    local rc=0
+    cd "$fake_root" && \
+        bash scripts/update-last-rebuild.sh "docs" "base-digest-drift" \
+        <<< "$(_drift_json_for_container docs)" 2>/dev/null || rc=$?
+
+    [ "$rc" -eq 0 ]
+}
+
+@test "update-last-rebuild: normal path appends section when container dir exists" {
+    local fake_root="$TEST_TEMP_DIR/fake-root-r4d"
+    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
+    mkdir -p "$fake_root/scripts"
+    mkdir -p "$fake_root/mycontainer"
+    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "list" ]] && printf 'mycontainer\n'
+STUB
+    chmod +x "$fake_root/make"
+
+    cd "$fake_root" && \
+        bash scripts/update-last-rebuild.sh "mycontainer" "base-digest-drift" \
+        <<< "$(_drift_json_for_container mycontainer)" >/dev/null 2>&1
+
+    # LAST_REBUILD.md must exist and contain the section header
+    [ -f "$fake_root/mycontainer/LAST_REBUILD.md" ]
+    grep -q 'base-digest-drift' "$fake_root/mycontainer/LAST_REBUILD.md"
 }

--- a/tests/unit/lineage-utils.bats
+++ b/tests/unit/lineage-utils.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/lineage-utils.sh
+# Tests is_lineage_sidecar() — single source of truth for sidecar identification.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    # shellcheck source=../../helpers/lineage-utils.sh
+    source "${HELPERS_DIR}/lineage-utils.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# is_lineage_sidecar: true (return 0) cases
+# ---------------------------------------------------------------------------
+
+@test "is_lineage_sidecar: *.sbom.json returns 0 (sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'foo-1.0-alpine.sbom.json'"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_lineage_sidecar: *.changelog.json returns 0 (sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'foo-1.0-alpine.changelog.json'"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_lineage_sidecar: *.history.json returns 0 (sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'bar-2.0-ubuntu.history.json'"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_lineage_sidecar: ext-*.json returns 0 (sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'ext-php-1.0-alpine.json'"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_lineage_sidecar: ext-anything.json returns 0 (sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'ext-whatever-here.json'"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# is_lineage_sidecar: false (return 1) cases — real lineage files
+# ---------------------------------------------------------------------------
+
+@test "is_lineage_sidecar: plain *.json returns 1 (lineage file)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'foo-1.0-alpine.json'"
+    [ "$status" -eq 1 ]
+}
+
+@test "is_lineage_sidecar: versioned plain *.json returns 1" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'postgres-17.2-alpine.json'"
+    [ "$status" -eq 1 ]
+}
+
+@test "is_lineage_sidecar: container with dots in tag returns 1" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'php-8.4-fpm-alpine.json'"
+    [ "$status" -eq 1 ]
+}
+
+@test "is_lineage_sidecar: empty string returns 1 (not a sidecar)" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar ''"
+    [ "$status" -eq 1 ]
+}
+
+@test "is_lineage_sidecar: file without .json extension returns 1" {
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'foo-1.0.sbom'"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Mutation guard: sidecar suffix must be a full compound suffix
+# A file like "foo.json" (plain) must NOT match *.sbom.json
+# ---------------------------------------------------------------------------
+
+@test "is_lineage_sidecar: file named just 'sbom.json' is NOT a sidecar (no leading dot)" {
+    # The pattern *.sbom.json requires at least one char before .sbom.json
+    # "sbom.json" does NOT match "*.sbom.json" in bash case
+    run bash -c "source '${HELPERS_DIR}/lineage-utils.sh'; is_lineage_sidecar 'sbom.json'"
+    # sbom.json does not have a dot before sbom — it's "sbom.json" not "*.sbom.json"
+    # bash case: *.sbom.json matches "anything.sbom.json", so "sbom.json" has no .sbom suffix → 1
+    [ "$status" -eq 1 ]
+}

--- a/tests/unit/update-last-rebuild.bats
+++ b/tests/unit/update-last-rebuild.bats
@@ -64,20 +64,27 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# r25-B: idempotent same-day section — skip-if-present (gate r25, Defect B)
-# Running the script twice for the same container on the same day must not
-# produce duplicate ## base-digest-drift sections in LAST_REBUILD.md, because
-# compute_build_digest hashes the file and each duplicate would retrigger CI.
+# r25-B / r27-C: idempotent same-day section — content-hash dedupe
+#
+# Gate r25, Defect B introduced skip-if-present on the section heading.
+# Gate r27, Defect C replaces heading-only dedupe with content-hash dedupe:
+# the heading alone caused a false negative when a second legitimate drift
+# event (different variants) occurred on the same UTC day after the first
+# drift PR had already been merged → script skipped → no rebuild trigger.
+#
+# Fix: embed <!-- drift-content-hash: <16-hex> --> above the heading.
+# Same content → same hash → idempotent skip preserved.
+# Different content → different hash → both sections appended.
 # ---------------------------------------------------------------------------
 
-# Helper: build a hermetic fake project directory for r25-B tests.
+# Helper: build a hermetic fake project directory for r25-B / r27-C tests.
 # Uses _ULR_PROJECT_ROOT_OVERRIDE and _ULR_VALID_CONTAINERS_OVERRIDE test hooks to
 # avoid spawning the real ./make or writing into the real project tree.
 _setup_r25b_project() {
     local base="$TEST_TEMP_DIR/r25b"
     mkdir -p "$base/mycontainer"
 
-    # Drift JSON for mycontainer with one drifted variant
+    # Drift JSON for mycontainer with one drifted variant (content-A)
     printf '%s' '[
       {
         "container": "mycontainer",
@@ -96,7 +103,27 @@ _setup_r25b_project() {
     printf '%s' "$base"
 }
 
-@test "r25-B1: running script twice same day produces exactly one section in LAST_REBUILD.md" {
+# Helper: second distinct drift JSON (content-B) for same container + same day.
+# Uses a different variant tag and digests to produce a different content-hash.
+_setup_r27c_project_b() {
+    local base="$1"
+    printf '%s' '[
+      {
+        "container": "mycontainer",
+        "variants": [
+          {
+            "variant_tag": "2.0",
+            "base_image_ref": "alpine:3.21",
+            "recorded_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "current_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "status": "drift"
+          }
+        ]
+      }
+    ]' > "$base/drift-b.json"
+}
+
+@test "r25-B1: running script twice same day with IDENTICAL drift produces exactly one section" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -111,7 +138,7 @@ _setup_r25b_project() {
         bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
         < "$fake_project/drift.json" 2>/dev/null
 
-    # Second run (simulates workflow retry)
+    # Second run (simulates workflow retry with same content)
     _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
     _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
         bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
@@ -120,13 +147,13 @@ _setup_r25b_project() {
     local target="$fake_project/mycontainer/LAST_REBUILD.md"
     [ -f "$target" ]
 
-    # Count occurrences of the heading — must be exactly 1
+    # Count occurrences of the heading — must be exactly 1 (idempotency preserved)
     local count
     count=$(grep -cxF -- "$heading" "$target")
     [ "$count" -eq 1 ]
 }
 
-@test "r25-B1-notice: second run emits ::notice:: about skipping" {
+@test "r25-B1-notice: second run with same content emits ::notice:: about skipping" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -148,7 +175,70 @@ _setup_r25b_project() {
     ) || rc=$?
 
     [ "$rc" -eq 0 ]
-    printf '%s' "$stderr_output" | grep -qF "already present"
+    # r27-C: skip message changed from "already present" to "already recorded"
+    printf '%s' "$stderr_output" | grep -qF "already recorded"
+}
+
+# ---------------------------------------------------------------------------
+# r27-C: two invocations same day with DIFFERENT drift content → 2 sections
+# Regression test for the false-negative path Copilot identified:
+# drift A merges in the morning → LAST_REBUILD.md updated → rebuild →
+# drift B (different variants) occurs same day → r25 heading-only dedupe
+# would skip → no file change → no PR trigger → silent false negative.
+# With content-hash dedupe the different-content event appends a new section.
+# ---------------------------------------------------------------------------
+@test "r27-C1: same day different drift content produces two distinct sections" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+    _setup_r27c_project_b "$fake_project"
+
+    local kind="base-digest-drift"
+    local today
+    today="$(date -u +%Y-%m-%d)"
+    local heading="## ${kind} (${today})"
+
+    # First run — drift event A (variant 1.0)
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run — drift event B (variant 2.0, different digests)
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift-b.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    # Both headings must be present (2 sections for same-day different events)
+    local count
+    count=$(grep -cxF -- "$heading" "$target")
+    [ "$count" -eq 2 ]
+
+    # Two distinct hash markers must be present
+    local hash_count
+    hash_count=$(grep -c 'drift-content-hash:' "$target")
+    [ "$hash_count" -eq 2 ]
+}
+
+@test "r27-C2: first section contains hash marker above the heading" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    # File must contain an HTML comment with the hash marker
+    grep -qF '<!-- drift-content-hash:' "$target"
 }
 
 @test "r25-B2: warning emission for invalid container escapes %0A via _escape_gha_command" {

--- a/tests/unit/update-last-rebuild.bats
+++ b/tests/unit/update-last-rebuild.bats
@@ -260,3 +260,120 @@ _setup_r27c_project_b() {
     # Must NOT contain a line that starts with ::add-mask:: or similar injected command
     ! printf '%s' "$stderr_output" | grep -qE '^::add-mask::|^::set-env::|^::set-output::'
 }
+
+# ---------------------------------------------------------------------------
+# r29-1: run-id-scoped dedupe (gate r29, Finding 1 — cross-run recoverability)
+#
+# The r27 content-hash marker without run-id made identical-content drift
+# unrecoverable across runs: failed rebuild + same drift next run → hash
+# already in file → no new section → no PR/rebuild trigger.
+#
+# Fix: marker is now `<!-- drift-content-hash: <hash> run:<run_id> -->`.
+# Same hash + same run_id → in-run retry → skip (r25 invariant preserved).
+# Same hash + different run_id → new run re-detecting same drift → append.
+# ---------------------------------------------------------------------------
+
+@test "r29-1a: same hash same GITHUB_RUN_ID invoked twice → exactly one section" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+    local today
+    today="$(date -u +%Y-%m-%d)"
+    local heading="## ${kind} (${today})"
+
+    # First run with explicit run-id
+    GITHUB_RUN_ID="stub-run-1" \
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run — same run-id, same content → must dedupe (in-run retry)
+    GITHUB_RUN_ID="stub-run-1" \
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    local count
+    count=$(grep -cxF -- "$heading" "$target")
+    [ "$count" -eq 1 ]
+}
+
+@test "r29-1b: same hash different GITHUB_RUN_ID → two sections (cross-run re-detection)" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+    local today
+    today="$(date -u +%Y-%m-%d)"
+    local heading="## ${kind} (${today})"
+
+    # First run
+    GITHUB_RUN_ID="stub-run-1" \
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run — different run-id, same content → must append (new run)
+    GITHUB_RUN_ID="stub-run-2" \
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    # Both runs must have appended → 2 headings
+    local count
+    count=$(grep -cxF -- "$heading" "$target")
+    [ "$count" -eq 2 ]
+
+    # Two distinct run-id markers must be present
+    local r1_count r2_count
+    r1_count=$(grep -cF 'run:stub-run-1' "$target")
+    r2_count=$(grep -cF 'run:stub-run-2' "$target")
+    [ "$r1_count" -eq 1 ]
+    [ "$r2_count" -eq 1 ]
+}
+
+@test "r29-1c: unset GITHUB_RUN_ID falls back to run:local and dedupes within same local session" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+    local today
+    today="$(date -u +%Y-%m-%d)"
+    local heading="## ${kind} (${today})"
+
+    # First run — no GITHUB_RUN_ID set (local invocation)
+    unset GITHUB_RUN_ID
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run — still no GITHUB_RUN_ID → same "local" run_id → dedupe
+    unset GITHUB_RUN_ID
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    # Must be exactly 1 section (local-session deduplication preserved)
+    local count
+    count=$(grep -cxF -- "$heading" "$target")
+    [ "$count" -eq 1 ]
+
+    # Marker must use "run:local" fallback
+    grep -qF 'run:local' "$target"
+}

--- a/tests/unit/update-last-rebuild.bats
+++ b/tests/unit/update-last-rebuild.bats
@@ -62,3 +62,111 @@ teardown() {
     [ "$rc" -eq 0 ]
     grep -q "not a valid container" "$TEST_TEMP_DIR/r21a3b-stderr.txt"
 }
+
+# ---------------------------------------------------------------------------
+# r25-B: idempotent same-day section — skip-if-present (gate r25, Defect B)
+# Running the script twice for the same container on the same day must not
+# produce duplicate ## base-digest-drift sections in LAST_REBUILD.md, because
+# compute_build_digest hashes the file and each duplicate would retrigger CI.
+# ---------------------------------------------------------------------------
+
+# Helper: build a hermetic fake project directory for r25-B tests.
+# Uses _ULR_PROJECT_ROOT_OVERRIDE and _ULR_VALID_CONTAINERS_OVERRIDE test hooks to
+# avoid spawning the real ./make or writing into the real project tree.
+_setup_r25b_project() {
+    local base="$TEST_TEMP_DIR/r25b"
+    mkdir -p "$base/mycontainer"
+
+    # Drift JSON for mycontainer with one drifted variant
+    printf '%s' '[
+      {
+        "container": "mycontainer",
+        "variants": [
+          {
+            "variant_tag": "1.0",
+            "base_image_ref": "alpine:3.21",
+            "recorded_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "current_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "status": "drift"
+          }
+        ]
+      }
+    ]' > "$base/drift.json"
+
+    printf '%s' "$base"
+}
+
+@test "r25-B1: running script twice same day produces exactly one section in LAST_REBUILD.md" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+    local today
+    today="$(date -u +%Y-%m-%d)"
+    local heading="## ${kind} (${today})"
+
+    # First run — uses test hooks to bypass ./make and real PROJECT_ROOT
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run (simulates workflow retry)
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    local target="$fake_project/mycontainer/LAST_REBUILD.md"
+    [ -f "$target" ]
+
+    # Count occurrences of the heading — must be exactly 1
+    local count
+    count=$(grep -cxF -- "$heading" "$target")
+    [ "$count" -eq 1 ]
+}
+
+@test "r25-B1-notice: second run emits ::notice:: about skipping" {
+    local fake_project
+    fake_project=$(_setup_r25b_project)
+
+    local kind="base-digest-drift"
+
+    # First run (creates section)
+    _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+    _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+        bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+        < "$fake_project/drift.json" 2>/dev/null
+
+    # Second run — capture stderr
+    local stderr_output rc=0
+    stderr_output=$(
+        _ULR_PROJECT_ROOT_OVERRIDE="$fake_project" \
+        _ULR_VALID_CONTAINERS_OVERRIDE="mycontainer" \
+            bash "$UPDATE_SCRIPT" "mycontainer" "$kind" \
+            < "$fake_project/drift.json" 2>&1 >/dev/null
+    ) || rc=$?
+
+    [ "$rc" -eq 0 ]
+    printf '%s' "$stderr_output" | grep -qF "already present"
+}
+
+@test "r25-B2: warning emission for invalid container escapes %0A via _escape_gha_command" {
+    # Gate r25, Defect A applied to update-last-rebuild.sh:
+    # a container name containing literal %0A must appear as %250A in the
+    # warning (% encoded to %25 first, then 0A suffix), not as a raw sequence
+    # that injects a new GHA command.
+    local stderr_output rc=0
+    stderr_output=$(
+        _ULR_VALID_CONTAINERS_OVERRIDE="goodcontainer" \
+            bash "$UPDATE_SCRIPT" "bad%0Acontainer" "base-digest-drift" \
+            < /dev/null 2>&1 >/dev/null
+    ) || rc=$?
+
+    [ "$rc" -eq 0 ]
+
+    # The warning line must contain the escaped form %250A (% encoded first)
+    printf '%s' "$stderr_output" | grep -qF '%250A'
+    # Must NOT contain a line that starts with ::add-mask:: or similar injected command
+    ! printf '%s' "$stderr_output" | grep -qE '^::add-mask::|^::set-env::|^::set-output::'
+}

--- a/tests/unit/update-last-rebuild.bats
+++ b/tests/unit/update-last-rebuild.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/update-last-rebuild.sh
+#
+# Focused on the gate r21 regression: container name option injection
+# (grep without -- separator) at line 68.
+
+load "../test_helper"
+
+UPDATE_SCRIPT=""
+
+setup() {
+    setup_temp_dir
+    UPDATE_SCRIPT="${SCRIPTS_DIR}/update-last-rebuild.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# r21-A3: grep option injection — container name '--help' as CLI arg
+# update-last-rebuild.sh calls `grep -qxF "$CONTAINER"` at line 68.
+# Without `--`, passing '--help' as $1 causes grep to print help and exit 0,
+# bypassing the container validation entirely.
+# Mutation guard: removing `--` from the grep call → grep treats '--help' as
+# option → exits 0 → script proceeds past validation with the poisoned name.
+# ---------------------------------------------------------------------------
+@test "r21-A3: container name '--help' is rejected as invalid (not a grep option)" {
+    # Create a fake ./make script that returns a valid container list
+    local fake_project="$TEST_TEMP_DIR/project"
+    mkdir -p "$fake_project"
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "foo"' 'echo "bar"' > "$fake_project/make"
+    chmod +x "$fake_project/make"
+
+    # Run the script with container='--help'; it should reject and exit 0
+    local rc=0
+    (
+        cd "$fake_project"
+        printf '[]' | bash "$UPDATE_SCRIPT" "--help" "base-digest-drift"
+    ) 2>"$TEST_TEMP_DIR/r21a3-stderr.txt" || rc=$?
+
+    # Exit 0: container not found is a warning (skip), not fatal
+    [ "$rc" -eq 0 ]
+
+    # Must emit a warning that the container is invalid
+    grep -q "not a valid container" "$TEST_TEMP_DIR/r21a3-stderr.txt"
+}
+
+@test "r21-A3b: container name '-n' is rejected as invalid (not a grep option)" {
+    local fake_project="$TEST_TEMP_DIR/project"
+    mkdir -p "$fake_project"
+    printf '%s\n' '#!/usr/bin/env bash' 'echo "foo"' > "$fake_project/make"
+    chmod +x "$fake_project/make"
+
+    local rc=0
+    (
+        cd "$fake_project"
+        printf '[]' | bash "$UPDATE_SCRIPT" "-n" "base-digest-drift"
+    ) 2>"$TEST_TEMP_DIR/r21a3b-stderr.txt" || rc=$?
+
+    [ "$rc" -eq 0 ]
+    grep -q "not a valid container" "$TEST_TEMP_DIR/r21a3b-stderr.txt"
+}


### PR DESCRIPTION
Closes #532

Final piece of the architectural series (#530 ✅ → #531 ✅ → #532). Daily cron compares each container/variant's recorded `base_image_digest` (from lineage cache) vs current registry digest of `base_image_ref`. On drift, opens 1 PR per affected container — body lists all drifted variants. Merging the PR updates `LAST_REBUILD.md` → `auto-build.yaml` path filter triggers rebuild → new lineage written → next-day cron sees match.

## Summary

- **Detector** `scripts/detect-base-digest-drift.sh`: walks `.build-lineage/*.json` (sidecar filter centralized in new `helpers/lineage-utils.sh::is_lineage_sidecar`), probes via `docker buildx imagetools inspect`, emits tri-state JSON per container (`drift` / `unchanged` / `error` / `legacy`). Registry allowlist (`docker.io`, `ghcr.io`, `registry-1.docker.io`, `index.docker.io`, `mcr.microsoft.com`) blocks SSRF; container name validation against `./make list`; active-tags filter via `./make list-builds <container>`.
- **Workflow** `.github/workflows/upstream-monitor.yaml`: new `detect-digest-drift` + `open-drift-prs` jobs (matrix-fanout, `max-parallel: 1`, per-container `concurrency:` lanes). Uses GitHub App token (`actions/create-github-app-token@bcd2ba49`) — `GITHUB_TOKEN`-authored PRs do not trigger downstream `auto-build.yaml`. `docker/login-action` + `packages: read` in both jobs.
- **Tracker** `scripts/update-last-rebuild.sh`: appends `## base-digest-drift (YYYY-MM-DD)` section to `<container>/LAST_REBUILD.md` to trigger `auto-build.yaml` path filter on PR merge.
- **Smart-skip invalidation** `helpers/build-cache-utils.sh::compute_build_digest`: includes `sha256` of `LAST_REBUILD.md` when present — backward-compatible (containers without the file get identical digests). Prevents infinite drift-PR loop when merge would otherwise be a no-op.
- **Digest extraction** `scripts/build-container.sh:184`: `docker buildx imagetools inspect --format '{{json .Manifest}}' | jq -r '.digest // empty'` (multi-arch index digest, canonical). Shape validation `^sha256:[a-f0-9]{64}$` before label_args. `printf -v` replaces `eval`.
- **ADR-010**: `docs/adr/ADR-010-chained-on-own-and-digest-drift.md` documents the architectural decision (chained-on-own + drift detection).

## Architecture trail

19 orthogonal gate rounds (codex xhigh + copilot in parallel; set-union refuse). r17 surfaced an architectural mismatch — `compute_build_digest` didn't include `LAST_REBUILD.md` → drift PR merges would be no-ops → infinite PR loop. r10 fix landed the smart-skip invalidation. r18 surfaced a bash RETURN trap leak (global scope) crashing the detector after the first probe; r12 fix replaced with explicit `rm -f` on each return path. **r19 = GATE_OK both engines** at `bf6df49`.

## Files

- `scripts/detect-base-digest-drift.sh` (NEW, 600+ LOC)
- `scripts/update-last-rebuild.sh` (NEW)
- `helpers/lineage-utils.sh` (NEW, sidecar predicate)
- `helpers/build-cache-utils.sh` (smart-skip invalidation)
- `scripts/build-container.sh` (digest extraction + shape validation)
- `.github/workflows/upstream-monitor.yaml` (2 new jobs)
- `docs/adr/ADR-010-chained-on-own-and-digest-drift.md` (NEW)
- `tests/unit/detect-base-digest-drift.bats` (60+ tests)
- `tests/unit/lineage-utils.bats` (NEW)
- `tests/unit/build-cache-utils.bats` (LAST_REBUILD.md invalidation tests)
- `tests/fixtures/digest-drift/scenario-{1,2}/` (lineage-cache fixtures, response stubs)

## Test plan

- [ ] CI passes (shellcheck + bats 523/523)
- [ ] Detector dry-run against current lineage cache produces tri-state JSON
- [ ] Verify `concurrency:` key prevents matrix lane interleaving
- [ ] Confirm GitHub App token actually triggers `auto-build.yaml` on PR merge (vs `GITHUB_TOKEN` design)
- [ ] One canary container (e.g., postgres) — observe full drift detect → PR → merge → rebuild → lineage match cycle
- [ ] No regressions on `auto-build.yaml` direct-push or upstream-monitor non-drift paths

## Follow-ups (out-of-scope, tracked)

- `scripts/enrich-lineage.sh::_is_skippable_file()` should call `helpers/lineage-utils.sh::is_lineage_sidecar()` (identical behavior, duplication only)
- `parent_lineage_digest` cascade-suppression (deferred from adversarial)
