### PR TITLE
docs(registry): document _ghcr_validate_cachedir as Linux-only (GNU stat)

### DIFF
--- a/helpers/registry-utils.sh
+++ b/helpers/registry-utils.sh
@@ -64,6 +64,12 @@ _ghcr_cache_enabled() {
 # Returns:
 #   0 — safe (exists as a real dir, owned by us, mode 0700)
 #   1 — symlink, wrong owner, or loose mode — caller MUST switch to fresh mktemp
+#
+# Portability: uses GNU coreutils `stat -c FORMAT` syntax. Linux-only.
+# This codebase targets Linux CI runners exclusively (see CI matrix in
+# .github/workflows); macOS local dev is not a supported runtime.  If
+# macOS support is ever needed, probe via `stat --version 2>/dev/null`
+# and fall back to `stat -f` (BSD syntax: '%u' for owner, '%Lp' for mode).
 _ghcr_validate_cachedir() {
     local d="$1"
     # Must exist as a directory.


### PR DESCRIPTION
Follow-up from #454/#538 (senior review S3).

Adds a 4-line portability note above `_ghcr_validate_cachedir` documenting that `stat -c '%u'` / `'%a'` is GNU coreutils syntax — Linux-only — and that the codebase targets Linux CI runners exclusively.

Includes BSD-stat fallback hint (`stat -f` with `'%u'` / `'%Lp'`) as a one-line note for any future macOS-local-dev support, so a future contributor doesn't have to re-derive it.

## Test plan

- [x] Pure comment change; shellcheck clean
- [x] No behavior change; bats 541/541 untouched

Closes the S3 follow-up from #454.
