### PR TITLE
ci(upstream-monitor): tolerate missing labels on PR edit steps

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -538,7 +538,9 @@ jobs:
           assignees: ${{ steps.classify.outputs.change_type == 'major' && github.repository_owner || '' }}
 
       # Labels applied separately — peter-evans/create-pull-request has a race condition
-      # where addLabels fails with "Could not resolve to a node" (issue #4321)
+      # where addLabels fails with "Could not resolve to a node" (issue #4321).
+      # Failure tolerance: if any label is missing from the repo (or transient gh
+      # error), emit a ::warning:: and continue — PR is the authoritative signal.
       - name: Apply labels
         if: steps.create_pr.outputs.pull-request-number
         env:
@@ -546,7 +548,9 @@ jobs:
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: |
           sleep 2
-          gh pr edit "$PR_NUMBER" --add-label "automation,${{ steps.resolve.outputs.container_name }},${{ steps.classify.outputs.change_type }}-update"
+          if ! gh pr edit "$PR_NUMBER" --add-label "automation,${{ steps.resolve.outputs.container_name }},${{ steps.classify.outputs.change_type }}-update" 2>&1; then
+            echo "::warning::Failed to apply version-update labels to PR #${PR_NUMBER}; PR created successfully — continuing"
+          fi
 
       - name: Auto-merge minor updates
         id: merge_pr
@@ -1062,7 +1066,9 @@ jobs:
           assignees: ${{ steps.prepare.outputs.max_severity == 'major' && github.repository_owner || '' }}
 
       # Labels applied separately — peter-evans/create-pull-request has a race condition
-      # where addLabels fails with "Could not resolve to a node" (issue #4321)
+      # where addLabels fails with "Could not resolve to a node" (issue #4321).
+      # Failure tolerance: if any label is missing from the repo (or transient gh
+      # error), emit a ::warning:: and continue — PR is the authoritative signal.
       - name: Apply labels
         if: steps.create_pr.outputs.pull-request-number
         env:
@@ -1070,7 +1076,9 @@ jobs:
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: |
           sleep 2
-          gh pr edit "$PR_NUMBER" --add-label "automation,dependencies,${{ matrix.container }},${{ steps.prepare.outputs.max_severity }}-update"
+          if ! gh pr edit "$PR_NUMBER" --add-label "automation,dependencies,${{ matrix.container }},${{ steps.prepare.outputs.max_severity }}-update" 2>&1; then
+            echo "::warning::Failed to apply deps labels to PR #${PR_NUMBER}; PR created successfully — continuing"
+          fi
 
       - name: Auto-merge minor/patch updates
         id: merge_dep_pr
@@ -1526,7 +1534,10 @@ jobs:
           body-path: ${{ steps.pr-body.outputs.pr_body_file }}
 
       # Labels applied separately — peter-evans/create-pull-request has a race condition
-      # where addLabels fails with "Could not resolve to a node" on fresh PRs
+      # where addLabels fails with "Could not resolve to a node" on fresh PRs.
+      # Failure tolerance: if any label is missing from the repo (or transient gh
+      # error), emit a ::warning:: and continue.  The PR is the authoritative
+      # signal of drift; labels are nice-to-have triage metadata, not gating.
       - name: Apply labels
         if: steps.create-pr.outputs.pull-request-number
         env:
@@ -1535,4 +1546,6 @@ jobs:
           CONTAINER: ${{ matrix.container }}
         run: |
           sleep 2
-          gh pr edit "$PR_NUMBER" --add-label "base-digest-drift,automation,container:${CONTAINER}"
+          if ! gh pr edit "$PR_NUMBER" --add-label "base-digest-drift,automation,container:${CONTAINER}" 2>&1; then
+            echo "::warning::Failed to apply labels to PR #${PR_NUMBER} (container=${CONTAINER}); PR created successfully — continuing"
+          fi


### PR DESCRIPTION
## Summary

`upstream-monitor.yaml` has 3 `Apply labels` steps that call `gh pr edit --add-label` after PR creation. Each was hard-failing the job when a referenced label didn't exist in the repo, even though the PR itself was successfully created.

Surfaced by the first scheduled run of #532's drift cron (2026-05-28T07:17 UTC): 6 base-digest-drift PRs (#542/#543/#545/#547/#548/#549) all created OK but their 6 jobs all failed at `Apply labels` with `'base-digest-drift' not found`.

## Changes

3 sites uniformly switched from `gh pr edit ...` to:

```bash
if ! gh pr edit ... 2>&1; then
    echo "::warning::Failed to apply labels to PR #${PR_NUMBER}; PR created successfully — continuing"
fi
```

- Line 538-549: version-update PRs
- Line 1062-1076: dependency-update PRs
- Line 1526-1546: base-digest-drift PRs (added by #532)

Updated each comment to document the rationale.

## Out-of-band label backfill (already done)

The missing labels were created in the repo via `gh label create`:

- `base-digest-drift` (1 new)
- `container:<name>` for all 13 containers (13 new)

Plus retroactive `gh pr edit --add-label` applied to the 6 open drift PRs to fix the missing triage metadata.

## Test plan

- [x] yq YAML validation: 0 errors
- [x] No behavior change for PR creation itself (only the label step)
- [ ] Next scheduled cron run (2026-05-29T07:17 UTC) should report `success` instead of `failure`

Follow-up from #532/#537.
