### PR TITLE
fix(terraform): sync base_image_cache tags to retained variant versions

### DIFF
--- a/terraform/config.yaml
+++ b/terraform/config.yaml
@@ -5,13 +5,13 @@
 base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
 base_image_cache:
   # Cache must include ALL retained upstream versions, not just the latest.
-  # Each retained variant build (1.15.4, 1.15.3, 1.15.2) does
+  # Each retained variant build (1.15.5, 1.15.4, 1.15.3) does
   # `FROM ${REMOTE_CR}/hashicorp/terraform:<that-version>`; if the cache only
   # has the latest tag, retained builds 404 on the new GHCR path. List the
   # tags explicitly until rotate-versions.sh learns to update this array
   # alongside variants.yaml — see #515 follow-up.
   - source: hashicorp/terraform
-    tags: ["1.15.4", "1.15.3", "1.15.2"]
+    tags: ["1.15.5", "1.15.4", "1.15.3"]
   - source: library/alpine
     tags: ["latest"]
   - source: library/python


### PR DESCRIPTION
## Summary

Aligns `terraform/config.yaml::base_image_cache.tags` with the current retained variant versions in `terraform/variants.yaml`. Single-line array mutation, no code change.

## Root cause

PR #539 bumped terraform to `1.15.5-alpine` via `rotate-versions.sh`. The script updated `variants.yaml` (new version → 1.15.5, dropped 1.15.2) but did NOT update `config.yaml::base_image_cache.tags` which was still pinned to `[1.15.4, 1.15.3, 1.15.2]`.

Effect: the sync-base-images job mirrors only the cached list, so `ghcr.io/oorabona/hashicorp/terraform:1.15.5` was never created. Every retained variant build then did `FROM ghcr.io/oorabona/hashicorp/terraform:1.15.5` → 404 → fail.

Master auto-build for #539 and #541 both failed at 07:20Z with:
```
ERROR: ghcr.io/***/hashicorp/terraform:1.15.5: not found
ERROR: failed to solve: failed to resolve source metadata
```

Drift PRs opened by the cron at 07:30+ inherit the breakage (terraform jobs in their CI matrix fail).

## Fix

```diff
- tags: ["1.15.4", "1.15.3", "1.15.2"]
+ tags: ["1.15.5", "1.15.4", "1.15.3"]
```

Comment in the same block already documents the gap: *"tags explicitly until rotate-versions.sh learns to update this array alongside variants.yaml — see #515 follow-up."*

## Post-merge expectation

1. Master auto-build for this PR triggers sync-base-images → mirrors `hashicorp/terraform:1.15.5` to GHCR (subject to Docker Hub 429; retryable)
2. Master terraform builds go green again
3. The 3 drift PRs currently failing on terraform (#542 debian, #545 php, #548 web-shell) can be re-run and will pass via smart-skip on the now-valid GHCR cache

## Structural follow-up

The durable fix — `rotate-versions.sh` must update `config.yaml::base_image_cache.tags` atomically with `variants.yaml` for any container declaring tag-list pinning — is opened separately.

## Test plan

- [ ] CI passes
- [ ] Sync-base-images job (post-merge) mirrors `hashicorp/terraform:1.15.5`
- [ ] Master terraform builds green
- [ ] Re-run failing terraform checks on #542/#545/#548 → pass
