### PR TITLE
refactor(postgres): replace the pushed extension bundle with a consume-time collector stage

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -976,6 +976,22 @@ generate_dockerfile() {
                             # Artifact-present path: use version_digests for digest-pinned refs.
                             local _vd_field_present
                             _vd_field_present=$(echo "$_versionset_json" | jq -r 'if has("version_digests") then "yes" else "no" end' 2>/dev/null || echo "no")
+
+                            # Guard: a legacy pushed artifact carries bundle_digest but no
+                            # version_digests.  Silently falling back to mutable tag refs for
+                            # such an artifact would regress the digest-pinned guarantee.
+                            # Fail closed so the operator rebuilds under the new schema.
+                            # The tag-fallback path is valid ONLY when neither key is present
+                            # (genuine local/no-push build — producer invariant).
+                            if [[ "$_vd_field_present" == "no" ]]; then
+                                local _bd_field_present
+                                _bd_field_present=$(echo "$_versionset_json" | jq -r 'if has("bundle_digest") then "yes" else "no" end' 2>/dev/null || echo "no")
+                                if [[ "$_bd_field_present" == "yes" ]]; then
+                                    log_error "generate_dockerfile: $ext_name pg${pg_major} artifact has bundle_digest but no version_digests — this is a legacy pre-collector artifact; rebuild under the new schema to restore digest-pinned refs"
+                                    return 1
+                                fi
+                            fi
+
                             local _art_ver
                             while IFS= read -r _art_ver; do
                                 [[ -z "$_art_ver" ]] && continue
@@ -992,7 +1008,7 @@ generate_dockerfile() {
                                     # Artifact lacks version_digests (LOCAL_ONLY / no-push build path):
                                     # construct a tag-based ref using the caller's explicit registry/owner
                                     # so the ref targets the correct repo even when the caller passed
-                                    # registry/owner overrides (FIX 3: pass registry+owner to ext_image_name).
+                                    # registry/owner overrides.
                                     # This tag-fallback is correct ONLY for the not-pushed (local) case;
                                     # a pushed artifact always has version_digests (producer invariant:
                                     # version_digests absent ⟺ artifact was not pushed).

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 
+
 # Source shared logging utilities (provides log_info, log_success, log_warning, log_error)
 HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -F log_info &>/dev/null; then
@@ -572,43 +573,35 @@ get_flavor_extensions() {
     ' "$config_file"
 }
 
-# _emit_collector_stage <ext> <stages_var> <copies_var> <ref_map_var> <pg_major>
+# _emit_collector_stage <ext> <ver_ref_list>
 #
 # Emit a consume-time collector build stage for a multi-version resolver-backed
 # extension.  The collector stage absorbs all per-version COPYs; its layers are
 # NOT exported because it is an intermediate stage.  The final stage does ONE
 # COPY from the collector → exactly one exported layer regardless of version count.
 #
-# Stage emitted into <stages_var> (substituted at @@EXTENSION_STAGES@@):
-#   FROM scratch AS ext_collect_<ext>
-#   COPY --from=<ref> /output/ /<ver>/     # one COPY per version (whole /output/)
+# Output to stdout (two sections separated by the delimiter line "---ECS-COPIES---"):
+#   <stages_block>     — FROM scratch AS ext_collect_<ext> + COPY --from per version
+#   ---ECS-COPIES---
+#   <copies_block>     — COPY --from=ext_collect_<ext> / /tmp/ext/<ext>/
 #
-# Copy emitted into <copies_var> (substituted at @@EXTENSION_COPIES@@):
-#   COPY --from=ext_collect_<ext> / /tmp/ext/<ext>/
+# Caller captures stdout and splits on the delimiter to obtain stages_block and copies_block.
 #
-# Layout: /output/ already contains extension/ and lib/, so after the collector
-# COPY the layout is /<ver>/extension/ + /<ver>/lib/ inside the stage, and
-# /tmp/ext/<ext>/<ver>/{extension,lib}/ in the final image — exactly what
-# install_ext (postgres/Dockerfile:92–119, multi-version branch) expects.
+# Portable bash-4.0 pattern (no local -n namerefs, which require bash 4.3+):
+#   <ver_ref_list> is a newline-delimited list of "<version>\t<ref>" pairs.
+#   Caller serializes its version→ref map as "<ver>\t<ref>\n..." and passes it.
 #
 # Args:
-#   ext         extension name (e.g. "timescaledb")
-#   stages_var  name of the variable to append the stages block to (nameref)
-#   copies_var  name of the variable to append the copies block to (nameref)
-#   ref_map_var name of the associative array mapping version → emit ref (nameref)
-#   pg_major    PG major version (for sanitisation only; not emitted directly)
+#   $1  ext          extension name (e.g. "timescaledb")
+#   $2  ver_ref_list newline-delimited "<version>\t<ref>" pairs
 #
-# Returns 0 on success, 1 on validation failure (logged).
+# Returns 0 on success (output on stdout), 1 on validation failure (logged, no output).
 _emit_collector_stage() {
     local _ecs_ext="$1"
-    local -n _ecs_stages="$2"
-    local -n _ecs_copies="$3"
-    local -n _ecs_ref_map="$4"
-    # pg_major is unused directly in the output but kept for caller clarity
-    # local _ecs_pg_major="$5"  # unused
+    local _ecs_ver_ref_list="$2"
 
-    if [[ ${#_ecs_ref_map[@]} -eq 0 ]]; then
-        log_error "_emit_collector_stage: empty ref map for ${_ecs_ext} — fail closed"
+    if [[ -z "$_ecs_ver_ref_list" ]]; then
+        log_error "_emit_collector_stage: empty ref list for ${_ecs_ext} — fail closed"
         return 1
     fi
 
@@ -616,20 +609,24 @@ _emit_collector_stage() {
     local _ecs_stage_name="ext_collect_${_ecs_ext//[^a-zA-Z0-9_]/_}"
 
     local _ecs_stage_block="FROM scratch AS ${_ecs_stage_name}"$'\n'
-    local _ecs_ver
-    for _ecs_ver in "${!_ecs_ref_map[@]}"; do
-        local _ecs_ref="${_ecs_ref_map[$_ecs_ver]}"
-        if [[ -z "$_ecs_ref" ]]; then
-            log_error "_emit_collector_stage: empty ref for ${_ecs_ext} version ${_ecs_ver} — fail closed"
+    local _ecs_line
+    while IFS= read -r _ecs_line; do
+        [[ -z "$_ecs_line" ]] && continue
+        local _ecs_ver="${_ecs_line%%	*}"
+        local _ecs_ref="${_ecs_line#*	}"
+        if [[ -z "$_ecs_ver" ]] || [[ -z "$_ecs_ref" ]] || [[ "$_ecs_ver" == "$_ecs_ref" ]]; then
+            log_error "_emit_collector_stage: malformed or empty ref for ${_ecs_ext} — fail closed"
             return 1
         fi
         # Sanitize version for use as a path component.
         local _ecs_ver_safe="${_ecs_ver//[^a-zA-Z0-9._-]/_}"
         _ecs_stage_block+="COPY --from=${_ecs_ref} /output/ /${_ecs_ver_safe}/"$'\n'
-    done
+    done <<< "$_ecs_ver_ref_list"
 
-    _ecs_stages+="${_ecs_stage_block}"
-    _ecs_copies+="COPY --from=${_ecs_stage_name} / /tmp/ext/${_ecs_ext}/"$'\n'
+    # Print stage block, delimiter, then copy line.
+    printf '%s' "${_ecs_stage_block}"
+    printf '%s\n' "---ECS-COPIES---"
+    printf 'COPY --from=%s / /tmp/ext/%s/\n' "${_ecs_stage_name}" "${_ecs_ext}"
     return 0
 }
 
@@ -955,7 +952,14 @@ generate_dockerfile() {
 
                     if [[ -n "$raw_versions" ]]; then
                         # Build version→ref map for the emitter.
-                        local -A _emit_ref_map=()
+                        # Use the global _ECS_REF_MAP (bash-4.0 portable; no local -n namerefs
+                        # which require bash 4.3+).  Reset before population to avoid stale
+                        # entries from a previous extension in the same generate_dockerfile call.
+                        # Build a serialized version→ref list (tab-delimited "<ver>\t<ref>" lines).
+                        # Portable bash-4.0 pattern: no local -n namerefs (require bash 4.3+);
+                        # no global associative arrays (unreliable across forked subshells when
+                        # sourced inside a function scope). Serializing as a string passes cleanly.
+                        local _ecs_ver_ref_list=""
                         if [[ "$_versionset_from_selfheal" == "true" ]]; then
                             # Self-heal path: refs already resolved by ext_ref_resolve above.
                             local _sh_mv
@@ -966,7 +970,7 @@ generate_dockerfile() {
                                     log_error "generate_dockerfile: self-heal emit: no resolved ref for $ext_name $_sh_mv pg${pg_major} — fail closed"
                                     return 1
                                 fi
-                                _emit_ref_map["$_sh_mv"]="$_sh_mv_ref"
+                                _ecs_ver_ref_list+="${_sh_mv}	${_sh_mv_ref}"$'\n'
                             done <<< "$raw_versions"
                         else
                             # Artifact-present path: use version_digests for digest-pinned refs.
@@ -983,23 +987,30 @@ generate_dockerfile() {
                                         log_error "generate_dockerfile: version_digests[$_art_ver] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_art_digest:-}" | head -c 80)")') — fail closed"
                                         return 1
                                     fi
-                                    _emit_ref_map["$_art_ver"]="${registry}/${owner}/ext-${ext_name}@${_art_digest}"
+                                    _ecs_ver_ref_list+="${_art_ver}	${registry}/${owner}/ext-${ext_name}@${_art_digest}"$'\n'
                                 else
-                                    # Artifact predates version_digests (LOCAL_ONLY or old build path):
-                                    # construct a tag-based ref directly — no probing needed since
-                                    # the artifact's available[] already proves the image was present
-                                    # when the artifact was written.
+                                    # Artifact lacks version_digests (LOCAL_ONLY / no-push build path):
+                                    # construct a tag-based ref using the caller's explicit registry/owner
+                                    # so the ref targets the correct repo even when the caller passed
+                                    # registry/owner overrides (FIX 3: pass registry+owner to ext_image_name).
+                                    # This tag-fallback is correct ONLY for the not-pushed (local) case;
+                                    # a pushed artifact always has version_digests (producer invariant:
+                                    # version_digests absent ⟺ artifact was not pushed).
                                     local _art_plain_ref
-                                    _art_plain_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major")
-                                    _emit_ref_map["$_art_ver"]="$_art_plain_ref"
+                                    _art_plain_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner")
+                                    _ecs_ver_ref_list+="${_art_ver}	${_art_plain_ref}"$'\n'
                                 fi
                             done <<< "$raw_versions"
                         fi
 
                         # Emit the collector stage and single final-stage COPY.
-                        if ! _emit_collector_stage "$ext_name" stages_block copies_block _emit_ref_map "$pg_major"; then
+                        # _emit_collector_stage outputs stages and copies separated by ---ECS-COPIES---
+                        local _ecs_output
+                        if ! _ecs_output=$(_emit_collector_stage "$ext_name" "$_ecs_ver_ref_list"); then
                             return 1
                         fi
+                        stages_block+="${_ecs_output%%---ECS-COPIES---*}"
+                        copies_block+="${_ecs_output##*---ECS-COPIES---$'\n'}"
 
                         # Collect runtime_deps (if any) — unchanged from single-version path
                         local deps

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -367,10 +367,10 @@ is_strict_semver() {
 # the newline, not at the true end of the string — are safely rejected.
 #
 # This is the single shared validator used by BOTH:
-#   - The producer (assemble_and_push_bundle in build-extensions.sh) — after
-#     _capture_bundle_digest, before writing the artifact.
+#   - The producer (finalize_multiarch_manifests in build-extensions.sh) — after
+#     _capture_index_digest, before writing version_digests in the artifact.
 #   - The consumer (generate_dockerfile in extension-utils.sh) — after reading
-#     .bundle_digest from the artifact, before inserting into COPY --from=.
+#     version_digests from the artifact, before inserting into COPY --from=.
 #
 # Any value that does not satisfy the whole-string pattern is treated as
 # malformed/poisoned, regardless of whether it has the sha256: prefix.
@@ -427,8 +427,10 @@ validate_semver_set_json() {
 
 # ============================================================================
 # Flavor-aware Dockerfile generation
-# Instead of building N bundle images, we template the main Dockerfile
-# to only include FROM/COPY for extensions relevant to each flavor+PG version
+# Templates the main Dockerfile to only include FROM/COPY stages relevant
+# to each flavor+PG version. Multi-version extensions use a collector stage
+# (FROM scratch AS ext_collect_<ext>) to absorb per-version COPYs, exposing
+# exactly one final-stage COPY regardless of the retained version count.
 # ============================================================================
 
 # _scoped_ext_ref <base_ref>
@@ -570,6 +572,67 @@ get_flavor_extensions() {
     ' "$config_file"
 }
 
+# _emit_collector_stage <ext> <stages_var> <copies_var> <ref_map_var> <pg_major>
+#
+# Emit a consume-time collector build stage for a multi-version resolver-backed
+# extension.  The collector stage absorbs all per-version COPYs; its layers are
+# NOT exported because it is an intermediate stage.  The final stage does ONE
+# COPY from the collector → exactly one exported layer regardless of version count.
+#
+# Stage emitted into <stages_var> (substituted at @@EXTENSION_STAGES@@):
+#   FROM scratch AS ext_collect_<ext>
+#   COPY --from=<ref> /output/ /<ver>/     # one COPY per version (whole /output/)
+#
+# Copy emitted into <copies_var> (substituted at @@EXTENSION_COPIES@@):
+#   COPY --from=ext_collect_<ext> / /tmp/ext/<ext>/
+#
+# Layout: /output/ already contains extension/ and lib/, so after the collector
+# COPY the layout is /<ver>/extension/ + /<ver>/lib/ inside the stage, and
+# /tmp/ext/<ext>/<ver>/{extension,lib}/ in the final image — exactly what
+# install_ext (postgres/Dockerfile:92–119, multi-version branch) expects.
+#
+# Args:
+#   ext         extension name (e.g. "timescaledb")
+#   stages_var  name of the variable to append the stages block to (nameref)
+#   copies_var  name of the variable to append the copies block to (nameref)
+#   ref_map_var name of the associative array mapping version → emit ref (nameref)
+#   pg_major    PG major version (for sanitisation only; not emitted directly)
+#
+# Returns 0 on success, 1 on validation failure (logged).
+_emit_collector_stage() {
+    local _ecs_ext="$1"
+    local -n _ecs_stages="$2"
+    local -n _ecs_copies="$3"
+    local -n _ecs_ref_map="$4"
+    # pg_major is unused directly in the output but kept for caller clarity
+    # local _ecs_pg_major="$5"  # unused
+
+    if [[ ${#_ecs_ref_map[@]} -eq 0 ]]; then
+        log_error "_emit_collector_stage: empty ref map for ${_ecs_ext} — fail closed"
+        return 1
+    fi
+
+    # Sanitize extension name for the stage alias (Docker stage names: [a-zA-Z0-9_-]).
+    local _ecs_stage_name="ext_collect_${_ecs_ext//[^a-zA-Z0-9_]/_}"
+
+    local _ecs_stage_block="FROM scratch AS ${_ecs_stage_name}"$'\n'
+    local _ecs_ver
+    for _ecs_ver in "${!_ecs_ref_map[@]}"; do
+        local _ecs_ref="${_ecs_ref_map[$_ecs_ver]}"
+        if [[ -z "$_ecs_ref" ]]; then
+            log_error "_emit_collector_stage: empty ref for ${_ecs_ext} version ${_ecs_ver} — fail closed"
+            return 1
+        fi
+        # Sanitize version for use as a path component.
+        local _ecs_ver_safe="${_ecs_ver//[^a-zA-Z0-9._-]/_}"
+        _ecs_stage_block+="COPY --from=${_ecs_ref} /output/ /${_ecs_ver_safe}/"$'\n'
+    done
+
+    _ecs_stages+="${_ecs_stage_block}"
+    _ecs_copies+="COPY --from=${_ecs_stage_name} / /tmp/ext/${_ecs_ext}/"$'\n'
+    return 0
+}
+
 # Generate a Dockerfile from a template by injecting extension FROM/COPY blocks
 # Template must contain markers:
 #   # @@EXTENSION_STAGES@@   → replaced by FROM ext-* AS ext-* lines
@@ -686,9 +749,9 @@ generate_dockerfile() {
             # are created or left behind.
             # _versionset_from_selfheal tracks whether _versionset_json came from
             # the self-heal path (artifact absent/malformed) vs the on-disk artifact.
-            # Only the self-heal path needs a bundle-ref probe (AK-3): the on-disk
-            # artifact path is trusted — the producer invariant guarantees the bundle
-            # exists when the artifact was written.
+            # Both paths feed the same collector emitter; the data source controls
+            # whether digest-pinned refs (artifact with version_digests) or tag-based
+            # refs (self-heal, no digest map) are used.
             local _versionset_json=""
             local _versionset_from_selfheal=false
 
@@ -793,7 +856,7 @@ generate_dockerfile() {
                     --argjson available "$_sh_avail_json" \
                     '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:[]}')
                 # Mark that this came from the self-heal path so the downstream
-                # emission block probes the bundle ref before emitting the COPY.
+                # emission block uses tag-based refs (no digest map available).
                 _versionset_from_selfheal=true
             elif [[ -f "$versionset_file" ]] && [[ "$_artifact_valid" -eq 1 ]] && command -v jq &>/dev/null; then
                 _versionset_json=$(< "$versionset_file")
@@ -822,12 +885,10 @@ generate_dockerfile() {
                     # available == [ceiling]: single-version path is safe; fall through.
                 fi
 
-                # AL fix: use the bundle path ONLY when more than one version is
-                # available.  When available_count == 1 (the ceiling only), the
-                # producer never builds a bundle (set_size<=1 early return in
-                # _bundle_and_write_artifact), so referencing a non-existent bundle
-                # would fail the postgres build.  Fall through to the single-version
-                # path instead, which works correctly for set_size==1.
+                # Use the collector emitter when more than one version is available.
+                # When available_count == 1 (the ceiling only), no collector is needed
+                # (_bundle_and_write_artifact early-returns for set_size<=1).
+                # Fall through to the single-version path which works for set_size==1.
                 if [[ "$available_count" -gt 1 ]]; then
                     # Validate the available[] array at the JSON level BEFORE any jq -r
                     # iteration. This prevents the embedded-newline bypass where a single
@@ -875,104 +936,69 @@ generate_dockerfile() {
                         fi
                     done < <(echo "$_versionset_json" | jq -r '.available[]' 2>/dev/null || true)
 
-                    # Multi-version path: two sub-cases depending on the data source.
+                    # Multi-version path: build a {version → ref} map, then call
+                    # _emit_collector_stage to emit:
+                    #   INTO stages_block: FROM scratch AS ext_collect_<ext>
+                    #                      COPY --from=<ref> /output/ /<ver>/   (one per version)
+                    #   INTO copies_block: COPY --from=ext_collect_<ext> / /tmp/ext/<ext>/
                     #
-                    # ARTIFACT-PRESENT path (AM/AN): emit a SINGLE digest-pinned bundle COPY.
-                    # The bundle image (<registry>/<owner>/ext-<ext>:pg<major>-bundle) was
-                    # assembled by the producer (build-extensions.sh) from all available
-                    # per-version images.  Its internal layout is /<ver>/{extension,lib}/
-                    # so COPY / /tmp/ext/<ext>/ lands each version at
-                    # /tmp/ext/<ext>/<ver>/{extension,lib}/ — exactly the layout
-                    # that install_ext iterates.  The bundle is guaranteed by the producer
-                    # invariant (written atomically with the artifact) so no probe is needed.
-                    #
-                    # SELF-HEAL path (AP): artifact absent/malformed — the mutable bundle
-                    # tag (:pg<major>-bundle) can drift from the set we proved available.
-                    # Instead, emit one COPY --from=<per-version-ref> pair per version in
-                    # _sh_available (the proved-present set).  Per-version tags are
-                    # version-specific and cannot drift to a different retained set.
-                    # Source paths match the per-version image layout: /output/extension/
-                    # and /output/lib/.  Destinations mirror the bundle layout that
-                    # install_ext iterates: /tmp/ext/<ext>/<ver>/extension/ and
-                    # /tmp/ext/<ext>/<ver>/lib/.  NO bundle reference on the self-heal path.
-                    local _bundle_copy_written=false
+                    # Two data sources feed the same emitter:
+                    #   Artifact-present: use <registry>/<owner>/ext-<ext>@<version_digests[ver]>
+                    #     (fail-closed if any version in available[] is missing from version_digests
+                    #     or its digest is malformed).
+                    #   Self-heal (artifact absent): use _sh_emit_ref_map[ver] from ext_ref_resolve
+                    #     (the degraded path — no digest map without the artifact; tag resolution
+                    #     is the accepted fallback).
+
                     local raw_versions
                     raw_versions=$(echo "$_versionset_json" | jq -r '.available[]' 2>/dev/null || true)
 
                     if [[ -n "$raw_versions" ]]; then
+                        # Build version→ref map for the emitter.
+                        local -A _emit_ref_map=()
                         if [[ "$_versionset_from_selfheal" == "true" ]]; then
-                            # AP: self-heal path — emit per-version COPYs from proved-present refs.
-                            # _sh_emit_ref_map[ver] was populated by ext_ref_resolve in the probe
-                            # loop above (canonical-first, PR-scoped fallback, FORCE-aware).
-                            local _pv_ver
-                            while IFS= read -r _pv_ver; do
-                                [[ -z "$_pv_ver" ]] && continue
-                                local _pv_ref="${_sh_emit_ref_map[$_pv_ver]:-}"
-                                if [[ -z "$_pv_ref" ]]; then
-                                    # Should not happen: every version in available[] was resolved by ext_ref_resolve.
-                                    log_error "generate_dockerfile: AP self-heal emit: no resolved ref for $ext_name $_pv_ver pg${pg_major} — fail closed"
+                            # Self-heal path: refs already resolved by ext_ref_resolve above.
+                            local _sh_mv
+                            while IFS= read -r _sh_mv; do
+                                [[ -z "$_sh_mv" ]] && continue
+                                local _sh_mv_ref="${_sh_emit_ref_map[$_sh_mv]:-}"
+                                if [[ -z "$_sh_mv_ref" ]]; then
+                                    log_error "generate_dockerfile: self-heal emit: no resolved ref for $ext_name $_sh_mv pg${pg_major} — fail closed"
                                     return 1
                                 fi
-                                copies_block+="COPY --from=${_pv_ref} /output/extension/ /tmp/ext/${ext_name}/${_pv_ver}/extension/"$'\n'
-                                copies_block+="COPY --from=${_pv_ref} /output/lib/ /tmp/ext/${ext_name}/${_pv_ver}/lib/"$'\n'
+                                _emit_ref_map["$_sh_mv"]="$_sh_mv_ref"
                             done <<< "$raw_versions"
-                            _bundle_copy_written=true
                         else
-                            # Artifact-present path (AM/AN): single digest-pinned bundle COPY.
-                            local _bundle_ref="${registry}/${owner}/ext-${ext_name}:pg${pg_major}-bundle"
-
-                            # AM fix: use a digest-pinned COPY ref when the artifact has a
-                            # bundle_digest (publish path).  The digest is immutable and
-                            # consistent with the atomic invariant (written by the producer
-                            # only after a successful push).  LOCAL_ONLY artifacts omit
-                            # bundle_digest, so the tag-based fallback is correct there.
-                            #
-                            # AN fix: validate the digest with is_valid_oci_digest (strict
-                            # whole-string: sha256: + exactly 64 lowercase hex, no extra
-                            # content) before using it in the COPY line.  A present-but-
-                            # invalid digest signals a poisoned or corrupted artifact:
-                            # fail closed (log error, return 1) — do NOT emit a COPY with
-                            # an unvalidated digest, and do NOT silently fall back to the
-                            # tag (that would mask the corruption).  An absent bundle_digest
-                            # (LOCAL_ONLY case) → tag-based COPY, unchanged.
-                            #
-                            # BB-1 Part 3: when bundle_digest is present, reference the
-                            # bundle by REPO + DIGEST only (no tag segment).  A digest
-                            # reference is addressable in the repo regardless of which tag
-                            # (pr-scoped or canonical) points to it, so the SAME artifact
-                            # works whether produced by a PR or a push/dispatch run.
-                            # Format: <registry>/<owner>/ext-<name>@sha256:<64hex>
-                            # The tag-based fallback (no bundle_digest) is unchanged —
-                            # LOCAL_ONLY artifacts use the un-suffixed bundle tag directly.
-                            # BC-3: distinguish FIELD-ABSENT from FIELD-PRESENT-BUT-EMPTY.
-                            # jq '.bundle_digest // empty' maps both absent and "" to empty
-                            # string — that would allow present-but-empty to fall through to
-                            # the mutable tag fallback, defeating atomic pinning.
-                            # Use has("bundle_digest") to detect field presence explicitly:
-                            #   - Field ABSENT   → LOCAL_ONLY case → tag-based fallback (allowed).
-                            #   - Field PRESENT  → value must be a valid OCI digest; empty or
-                            #                      non-conforming value → FAIL CLOSED.
-                            local _bundle_digest_field_present
-                            _bundle_digest_field_present=$(echo "$_versionset_json" | jq -r 'if has("bundle_digest") then "yes" else "no" end' 2>/dev/null || echo "no")
-                            local _bundle_digest
-                            _bundle_digest=$(echo "$_versionset_json" | jq -r '.bundle_digest // empty' 2>/dev/null || true)
-                            local _bundle_copy_ref
-                            if [[ "$_bundle_digest_field_present" == "yes" ]]; then
-                                # Field present: value must be a valid OCI digest.
-                                if ! is_valid_oci_digest "$_bundle_digest"; then
-                                    log_error "generate_dockerfile: bundle_digest for $ext_name pg${pg_major} is present but malformed or contains invalid content ('$(_sanitize_for_log "$(printf '%s' "$_bundle_digest" | head -c 80)")') — fail closed (possible artifact corruption or poisoning)"
-                                    return 1
+                            # Artifact-present path: use version_digests for digest-pinned refs.
+                            local _vd_field_present
+                            _vd_field_present=$(echo "$_versionset_json" | jq -r 'if has("version_digests") then "yes" else "no" end' 2>/dev/null || echo "no")
+                            local _art_ver
+                            while IFS= read -r _art_ver; do
+                                [[ -z "$_art_ver" ]] && continue
+                                if [[ "$_vd_field_present" == "yes" ]]; then
+                                    # Artifact has version_digests: require a valid digest per version.
+                                    local _art_digest
+                                    _art_digest=$(echo "$_versionset_json" | jq -r --arg v "$_art_ver" '.version_digests[$v] // empty' 2>/dev/null || true)
+                                    if ! is_valid_oci_digest "$_art_digest"; then
+                                        log_error "generate_dockerfile: version_digests[$_art_ver] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_art_digest:-}" | head -c 80)")') — fail closed"
+                                        return 1
+                                    fi
+                                    _emit_ref_map["$_art_ver"]="${registry}/${owner}/ext-${ext_name}@${_art_digest}"
+                                else
+                                    # Artifact predates version_digests (LOCAL_ONLY or old build path):
+                                    # construct a tag-based ref directly — no probing needed since
+                                    # the artifact's available[] already proves the image was present
+                                    # when the artifact was written.
+                                    local _art_plain_ref
+                                    _art_plain_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major")
+                                    _emit_ref_map["$_art_ver"]="$_art_plain_ref"
                                 fi
-                                # Repo-only digest ref (no tag segment) — valid for both
-                                # PR-scoped and canonical bundles sharing the same digest.
-                                _bundle_copy_ref="${registry}/${owner}/ext-${ext_name}@${_bundle_digest}"
-                            else
-                                # Field absent (LOCAL_ONLY case) → tag-based fallback.
-                                _bundle_copy_ref="${_bundle_ref}"
-                            fi
+                            done <<< "$raw_versions"
+                        fi
 
-                            copies_block+="COPY --from=${_bundle_copy_ref} / /tmp/ext/${ext_name}/"$'\n'
-                            _bundle_copy_written=true
+                        # Emit the collector stage and single final-stage COPY.
+                        if ! _emit_collector_stage "$ext_name" stages_block copies_block _emit_ref_map "$pg_major"; then
+                            return 1
                         fi
 
                         # Collect runtime_deps (if any) — unchanged from single-version path

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -1010,7 +1010,10 @@ generate_dockerfile() {
                             return 1
                         fi
                         stages_block+="${_ecs_output%%---ECS-COPIES---*}"
-                        copies_block+="${_ecs_output##*---ECS-COPIES---$'\n'}"
+                        # Command substitution strips the trailing newline, so the copies
+                        # part would be appended without a newline terminator, causing the
+                        # next extension's COPY to concatenate onto the same line.
+                        copies_block+="${_ecs_output##*---ECS-COPIES---$'\n'}"$'\n'
 
                         # Collect runtime_deps (if any) — unchanged from single-version path
                         local deps

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -763,8 +763,44 @@ _bundle_and_write_artifact() {
         return 0
     fi
 
-    # Write the artifact without version_digests (multi-arch index digests are only
-    # available after finalize_multiarch_manifests merges both arch legs).
+    # Invariant: version_digests is present IFF do_push=true (non-ARCH_SUFFIX path).
+    # A pushed artifact MUST carry version_digests so the consumer can emit digest-
+    # pinned COPY --from= refs.  Omitting version_digests is correct ONLY when the
+    # artifact was not pushed (LOCAL_ONLY / PULL_ONLY / do_push=false).
+    # The consumer's tag-fallback for a no-version_digests artifact relies on this
+    # invariant: it is safe ONLY for local/no-push artifacts; a pushed artifact that
+    # lacks version_digests would cause the consumer to emit mutable-tag refs,
+    # silently regressing the digest-pinned ref guarantee.
+    local _version_digests_json="null"
+    if [[ "$do_push" == "true" ]]; then
+        # Capture the pushed digest for each confirmed-available version.
+        # Fail-closed: if any digest is missing or malformed, abort — a partial
+        # version_digests map would leave some versions tag-pinned, which violates
+        # the invariant.
+        local _vd_entries=()
+        local _vd_ver
+        for _vd_ver in "${_confirmed_available[@]+"${_confirmed_available[@]}"}"; do
+            local _vd_image
+            _vd_image=$(ext_image_name "$ext" "$_vd_ver" "$major_ver")
+            local _vd_digest
+            _vd_digest=$(_capture_index_digest "$_vd_image") || true
+            if ! is_valid_oci_digest "${_vd_digest:-}"; then
+                log_error "$ext: digest capture failed for $_vd_ver ($major_ver) — cannot write pushed artifact without valid digest; fail-closed"
+                _delete_stale_versionset_artifact "$ext" "$major_ver"
+                return 1
+            fi
+            _vd_entries+=("$(printf '%s' "$_vd_ver" | jq -Rr @json):$(printf '%s' "$_vd_digest" | jq -Rr @json)")
+        done
+        # Build the version_digests JSON object from collected entries.
+        _version_digests_json="{$(IFS=,; printf '%s' "${_vd_entries[*]+"${_vd_entries[*]}"}") }"
+        # Validate that jq can parse the constructed object.
+        if ! echo "$_version_digests_json" | jq -e 'type == "object"' > /dev/null 2>&1; then
+            log_error "$ext: constructed version_digests JSON is invalid — fail-closed"
+            _delete_stale_versionset_artifact "$ext" "$major_ver"
+            return 1
+        fi
+    fi
+
     local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
     mkdir -p "${ROOT_DIR}/.build-lineage"
 
@@ -773,16 +809,32 @@ _bundle_and_write_artifact() {
     _excluded_json="[$(IFS=,; echo "${_excluded_entries[*]+"${_excluded_entries[*]}"}")]"
     _resolved_json=$(echo "$version_set_json" | jq '.')
 
-    jq -nc \
-        --arg ext "$ext" \
-        --arg pg_major "$major_ver" \
-        --arg ceiling "$ceiling" \
-        --argjson resolved "$_resolved_json" \
-        --argjson available "$_available_json" \
-        --argjson excluded "$_excluded_json" \
-        '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
-        > "$_vs_lineage_file"
-    log_info "Version-set lineage (build path, no version_digests yet): $_vs_lineage_file"
+    if [[ "$_version_digests_json" == "null" ]]; then
+        # No-push path: omit version_digests (local/no-push artifact).
+        jq -nc \
+            --arg ext "$ext" \
+            --arg pg_major "$major_ver" \
+            --arg ceiling "$ceiling" \
+            --argjson resolved "$_resolved_json" \
+            --argjson available "$_available_json" \
+            --argjson excluded "$_excluded_json" \
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
+            > "$_vs_lineage_file"
+        log_info "Version-set lineage (build path, no-push — no version_digests): $_vs_lineage_file"
+    else
+        # Pushed path: include version_digests so consumer emits digest-pinned refs.
+        jq -nc \
+            --arg ext "$ext" \
+            --arg pg_major "$major_ver" \
+            --arg ceiling "$ceiling" \
+            --argjson resolved "$_resolved_json" \
+            --argjson available "$_available_json" \
+            --argjson excluded "$_excluded_json" \
+            --argjson version_digests "$_version_digests_json" \
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests}' \
+            > "$_vs_lineage_file"
+        log_info "Version-set lineage (build path, pushed — with version_digests): $_vs_lineage_file"
+    fi
     return 0
 }
 
@@ -1024,7 +1076,10 @@ build_tag_push_extensions() {
         # Artifact write (atomic): for resolver-backed multi-version extensions,
         # _bundle_and_write_artifact computes confirmed_available ONCE (3-state probe
         # + built-this-run union) and writes the versionset artifact from that set.
-        # version_digests (multi-arch index digests) are added by finalize_multiarch_manifests.
+        # When do_push=true (non-ARCH_SUFFIX path): version_digests is captured and
+        # written here so the consumer can emit digest-pinned COPY --from= refs.
+        # When ARCH_SUFFIX is set (CI per-arch leg): artifact is deferred to
+        # finalize_multiarch_manifests which captures multi-arch index digests.
         #
         # Under DRY_RUN: skip (no mutation).
         # Fatal failure guard (AK-1): if ANY version for this ext failed in this run,

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -686,7 +686,13 @@ _bundle_and_write_artifact() {
 
     # Single 3-state pass: compute confirmed_available from resolved set.
     # BI-2: canonical-first, PR-aware availability probe.
+    # _confirmed_refs maps each confirmed version to the EXACT ref that was
+    # confirmed available (canonical or PR-scoped).  The digest-capture step
+    # MUST use this ref, not an independently-reconstructed canonical ref,
+    # so that on a PR where only -prNN tags exist the digest is captured from
+    # the ref that is actually present.
     local _confirmed_available=()
+    local -A _confirmed_refs=()
     local _excluded_entries=()
     local _probe_error=false
     local _cv
@@ -696,12 +702,16 @@ _bundle_and_write_artifact() {
 
         if [[ -n "${_btr_set[$_cv]:-}" ]]; then
             _confirmed_available+=("$_cv")
+            # Built this run: image was pushed as the scoped ref (PR-scoped on PR,
+            # canonical on push/dispatch).  The multi-arch tag has no arch suffix.
+            _confirmed_refs["$_cv"]=$(_scoped_tag "$_cv_image")
         else
             local _probe_rc=0
             _image_present_3state "$_cv_image" || _probe_rc=$?
             case "$_probe_rc" in
                 0)
                     _confirmed_available+=("$_cv")
+                    _confirmed_refs["$_cv"]="$_cv_image"
                     ;;
                 1)
                     # Canonical absent: on a PR, also check the PR-scoped ref.
@@ -713,6 +723,7 @@ _bundle_and_write_artifact() {
                         case "$_pr_probe_rc" in
                             0)
                                 _confirmed_available+=("$_cv")
+                                _confirmed_refs["$_cv"]="$_cv_pr_image"
                                 ;;
                             1)
                                 _excluded_entries+=("{\"version\":\"${_cv}\",\"reason\":\"not available\"}")
@@ -774,18 +785,27 @@ _bundle_and_write_artifact() {
     local _version_digests_json="null"
     if [[ "$do_push" == "true" ]]; then
         # Capture the pushed digest for each confirmed-available version.
+        # Use _confirmed_refs["ver"] — the exact ref that was confirmed available
+        # during the probe loop — rather than reconstructing the canonical ref.
+        # This ensures digest capture succeeds on PRs where only the PR-scoped
+        # ref exists and the canonical tag is absent.
         # Fail-closed: if any digest is missing or malformed, abort — a partial
         # version_digests map would leave some versions tag-pinned, which violates
         # the invariant.
         local _vd_entries=()
         local _vd_ver
         for _vd_ver in "${_confirmed_available[@]+"${_confirmed_available[@]}"}"; do
-            local _vd_image
-            _vd_image=$(ext_image_name "$ext" "$_vd_ver" "$major_ver")
+            local _vd_confirmed_ref
+            _vd_confirmed_ref="${_confirmed_refs[$_vd_ver]:-}"
+            if [[ -z "$_vd_confirmed_ref" ]]; then
+                log_error "$ext: no confirmed ref stored for $_vd_ver ($major_ver) — internal error; fail-closed"
+                _delete_stale_versionset_artifact "$ext" "$major_ver"
+                return 1
+            fi
             local _vd_digest
-            _vd_digest=$(_capture_index_digest "$_vd_image") || true
+            _vd_digest=$(_capture_index_digest "$_vd_confirmed_ref") || true
             if ! is_valid_oci_digest "${_vd_digest:-}"; then
-                log_error "$ext: digest capture failed for $_vd_ver ($major_ver) — cannot write pushed artifact without valid digest; fail-closed"
+                log_error "$ext: digest capture failed for $_vd_ver ($major_ver) ref=$_vd_confirmed_ref — cannot write pushed artifact without valid digest; fail-closed"
                 _delete_stale_versionset_artifact "$ext" "$major_ver"
                 return 1
             fi

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -2000,7 +2000,7 @@ finalize_multiarch_manifests() {
                 fi
 
                 if [[ "$_ma_rc" -eq 0 ]]; then
-                    # Multi-arch manifest present → reuse (canonical or PR-scoped).
+                    # Multi-arch manifest present → attempt reuse (canonical or PR-scoped).
                     # Capture its index digest for the version_digests artifact map.
                     log_info "$ext $ver pg${major_ver}: manifest present — reused (unchanged)"
                     local _reuse_digest _reuse_digest_rc=0
@@ -2010,18 +2010,20 @@ finalize_multiarch_manifests() {
                         _ext_failed=true
                         break
                     fi
-                    # Verify manifest covers both target platforms.
+                    # Verify the reused manifest covers both target platforms.
+                    # If it is single-arch (legacy / pre-multi-arch), fall through to the
+                    # CREATE path to rebuild it from this run's per-arch legs instead of
+                    # blindly accepting a stale single-arch manifest.
                     local _reuse_inspect_out
                     _reuse_inspect_out=$($DOCKER buildx imagetools inspect "$_ma_ref" 2>/dev/null) || true
-                    if ! echo "$_reuse_inspect_out" | grep -q "linux/amd64" || \
-                       ! echo "$_reuse_inspect_out" | grep -q "linux/arm64"; then
-                        log_error "$ext $ver pg${major_ver}: reused manifest does not cover both linux/amd64 and linux/arm64 — fail closed"
-                        _ext_failed=true
-                        break
+                    if echo "$_reuse_inspect_out" | grep -q "linux/amd64" && \
+                       echo "$_reuse_inspect_out" | grep -q "linux/arm64"; then
+                        _confirmed_available+=("$ver")
+                        _ver_index_digests["$ver"]="$_reuse_digest"
+                        continue
                     fi
-                    _confirmed_available+=("$ver")
-                    _ver_index_digests["$ver"]="$_reuse_digest"
-                    continue
+                    log_warning "$ext $ver pg${major_ver}: reused manifest is not multi-arch — re-creating from per-arch legs"
+                    # Fall through to the CREATE path below.
                 fi
             fi
 
@@ -2098,9 +2100,15 @@ finalize_multiarch_manifests() {
             _inspect_out=$($DOCKER buildx imagetools inspect "$ver_multiarch" 2>/dev/null) || true
             if ! echo "$_inspect_out" | grep -q "linux/amd64" || \
                ! echo "$_inspect_out" | grep -q "linux/arm64"; then
-                log_error "$ext $ver pg${major_ver}: created manifest does not cover both linux/amd64 and linux/arm64 — fail closed"
-                _ext_failed=true
-                break
+                if [[ "$ver" == "$ceiling" ]]; then
+                    log_error "$ext $ver pg${major_ver} (ceiling): created manifest does not cover both linux/amd64 and linux/arm64 — fatal"
+                    _ext_failed=true
+                    break
+                else
+                    log_warning "$ext $ver pg${major_ver}: created manifest does not cover both arches (intersection) — excluded"
+                    _excluded_entries+=("{\"version\":\"${ver}\",\"reason\":\"created manifest missing one or more arches (intersection)\"}")
+                    continue
+                fi
             fi
             log_info "$ext $ver pg${major_ver}: index digest: $_ver_digest"
 

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -2034,8 +2034,13 @@ finalize_multiarch_manifests() {
                     # If it is single-arch (legacy / pre-multi-arch), fall through to the
                     # CREATE path to rebuild it from this run's per-arch legs instead of
                     # blindly accepting a stale single-arch manifest.
-                    local _reuse_inspect_out
-                    _reuse_inspect_out=$($DOCKER buildx imagetools inspect "$_ma_ref" 2>/dev/null) || true
+                    local _reuse_inspect_out _reuse_inspect_rc=0
+                    _reuse_inspect_out=$($DOCKER buildx imagetools inspect "$_ma_ref" 2>&1) || _reuse_inspect_rc=$?
+                    if [[ "$_reuse_inspect_rc" -ne 0 ]]; then
+                        log_error "$ext $ver pg${major_ver}: imagetools inspect failed on reused manifest ref (rc=$_reuse_inspect_rc) — transient infra error — fail closed"
+                        _ext_failed=true
+                        break
+                    fi
                     if echo "$_reuse_inspect_out" | grep -q "linux/amd64" && \
                        echo "$_reuse_inspect_out" | grep -q "linux/arm64"; then
                         _confirmed_available+=("$ver")
@@ -2116,8 +2121,13 @@ finalize_multiarch_manifests() {
                 break
             fi
             # Verify the created manifest covers both target platforms.
-            local _inspect_out
-            _inspect_out=$($DOCKER buildx imagetools inspect "$ver_multiarch" 2>/dev/null) || true
+            local _inspect_out _inspect_rc=0
+            _inspect_out=$($DOCKER buildx imagetools inspect "$ver_multiarch" 2>&1) || _inspect_rc=$?
+            if [[ "$_inspect_rc" -ne 0 ]]; then
+                log_error "$ext $ver pg${major_ver}: imagetools inspect failed after manifest create (rc=$_inspect_rc) — transient infra error — fail closed"
+                _ext_failed=true
+                break
+            fi
             if ! echo "$_inspect_out" | grep -q "linux/amd64" || \
                ! echo "$_inspect_out" | grep -q "linux/arm64"; then
                 if [[ "$ver" == "$ceiling" ]]; then

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -617,19 +617,21 @@ handle_pull_only_mode() {
     LOCAL_ONLY=true build_tag_push_extensions "$config_file" "$major_ver" "$container_dir" "false" "${unique_exts_to_build[@]}"
 }
 
-# Compute the confirmed_available set for (ext, major_ver) from version_set_json,
-# push the bundle with that set, then write the versionset artifact from that SAME
-# set. This is the single-assembly, atomic-ordering contract:
+# Compute the confirmed_available set for (ext, major_ver) from version_set_json
+# and write the versionset artifact (without version_digests — multi-arch index
+# digests are not available on the per-arch build path; finalize_multiarch_manifests
+# writes the canonical artifact with version_digests after merging both arches).
+#
+# Contract:
 #   confirmed = { v in resolved : 3state(v)=PRESENT } UNION { v in built-this-run }
 #   fail-closed: 3state ERROR, empty confirmed, or ceiling absent → fatal
-#   bundle push THEN artifact write (never artifact without bundle)
 #
 # Args: ext config_file major_ver version_set_json ceiling do_push
-#   do_push: "true" = push to registry; "false" = local-only build.
+#   do_push: "true" = push to registry; "false" = local-only / CI smoke.
 # Returns: 0 on success; 1 on any failure.
 # Does nothing (returns 0) under DRY_RUN — callers handle DRY_RUN logging.
 # When set_size <= 1: deletes any stale versionset artifact and returns 0
-#   (no bundle needed for single-version; consumer self-heals to single-version path).
+#   (single-version; consumer uses single-version path).
 _bundle_and_write_artifact() {
     local ext="$1" config_file="$2" major_ver="$3" version_set_json="$4" ceiling="$5" do_push="$6"
 
@@ -644,31 +646,36 @@ _bundle_and_write_artifact() {
 
     # CI no-push guard: when do_push=false AND this is not a LOCAL_ONLY or PULL_ONLY
     # recovery path, we are in a fork PR / CI smoke context where the package registry
-    # is read-only.  Neither a bundle push nor an artifact write is safe here — the
-    # bundle was never pushed so any artifact would reference an unpushed (local-only)
-    # bundle image, causing the downstream postgres build to fail.
-    # Delete any stale artifact so the downstream consumer self-heals to per-version COPYs.
-    # LOCAL_ONLY and PULL_ONLY callers pass do_push=false but still need a local bundle
-    # and artifact for local consumption — they are NOT affected by this guard.
+    # is read-only.  Delete any stale artifact so the downstream consumer self-heals.
+    # LOCAL_ONLY and PULL_ONLY callers pass do_push=false but still need an artifact
+    # for local consumption — they are NOT affected by this guard.
     if [[ "$do_push" != "true" ]] && \
        [[ "${LOCAL_ONLY:-false}" != "true" ]] && \
        [[ "${PULL_ONLY:-false}" != "true" ]]; then
-        log_info "$ext: skipping bundle+artifact (CI no-push context — do_push=false)"
+        log_info "$ext: skipping artifact (CI no-push context — do_push=false)"
         _delete_stale_versionset_artifact "$ext" "$major_ver"
         return 0
     fi
 
-    # AV-2 double-bundle guard: record that this (ext, major_ver) bundle was assembled
-    # on the BUILD PATH so _emit_final_versionset_pass can skip it (preventing the same
-    # bundle from being assembled twice in a single run).
+    # AV-2 double-write guard: record that this (ext, major_ver) artifact was written
+    # on the BUILD PATH so _emit_final_versionset_pass can skip it (preventing a
+    # second write in the same run).
     # Sentinel file: ${_BUILT_THIS_RUN_DIR}/bundle-<ext>-<major_ver>
-    # Written BEFORE the bundle assembly so the final pass never re-enters here for
-    # the same key even if _bundle_and_write_artifact is called from the build path.
     local _bundle_sentinel="${_BUILT_THIS_RUN_DIR}/bundle-${ext}-${major_ver}"
     printf '1' > "$_bundle_sentinel"
 
+    # ARCH_SUFFIX defer: on a CI per-arch leg the multi-arch index digests are not
+    # yet available.  The manifest-merge step (finalize_multiarch_manifests) writes
+    # the canonical artifact with version_digests after merging both arches.
+    # Defer here — delete any stale artifact so the consumer does not use old data.
+    if [[ -n "${ARCH_SUFFIX:-}" ]]; then
+        log_info "$ext pg${major_ver}: ARCH_SUFFIX=${ARCH_SUFFIX} — deferring versionset artifact to manifest-merge step"
+        _delete_stale_versionset_artifact "$ext" "$major_ver"
+        return 0
+    fi
+
     # Load built-this-run set so a version pushed this run is counted PRESENT
-    # regardless of propagation lag (identical to _emit_versionset_artifact's guard).
+    # regardless of propagation lag.
     local _built_this_run_file="${_BUILT_THIS_RUN_DIR:-/dev/null}/${ext}-${major_ver}"
     local -A _btr_set=()
     if [[ -f "$_built_this_run_file" ]]; then
@@ -678,25 +685,7 @@ _bundle_and_write_artifact() {
     fi
 
     # Single 3-state pass: compute confirmed_available from resolved set.
-    #
-    # BI-2 fix: canonical-first, PR-aware availability probe.
-    # On a same-repo PR (PR_TAG_SUFFIX non-empty), a version may have been built in
-    # an EARLIER run of this PR and exists ONLY under the PR-scoped tag.  The
-    # canonical probe alone returns ABSENT, incorrectly excluding the version and
-    # causing the artifact to be deleted — breaking PR rerun idempotency.
-    # Fix: if the canonical probe returns ABSENT AND PR_TAG_SUFFIX is non-empty,
-    # also probe the PR-scoped ref; if PRESENT there, version is confirmed-available.
-    # On push/dispatch (PR_TAG_SUFFIX empty), only the canonical probe runs (unchanged).
-    # Single 3-state pass: compute confirmed_available from resolved set.
-    #
-    # BI-2 fix: canonical-first, PR-aware availability probe.
-    # On a same-repo PR (PR_TAG_SUFFIX non-empty), a version may have been built in
-    # an EARLIER run of this PR and exists ONLY under the PR-scoped tag.  The
-    # canonical probe alone returns ABSENT, incorrectly excluding the version and
-    # causing the artifact to be deleted — breaking PR rerun idempotency.
-    # Fix: if the canonical probe returns ABSENT AND PR_TAG_SUFFIX is non-empty,
-    # also probe the PR-scoped ref; if PRESENT there, version is confirmed-available.
-    # On push/dispatch (PR_TAG_SUFFIX empty), only the canonical probe runs (unchanged).
+    # BI-2: canonical-first, PR-aware availability probe.
     local _confirmed_available=()
     local _excluded_entries=()
     local _probe_error=false
@@ -723,7 +712,6 @@ _bundle_and_write_artifact() {
                         _image_present_3state "$_cv_pr_image" || _pr_probe_rc=$?
                         case "$_pr_probe_rc" in
                             0)
-                                # PR-scoped ref present (built in an earlier run of this PR).
                                 _confirmed_available+=("$_cv")
                                 ;;
                             1)
@@ -763,47 +751,20 @@ _bundle_and_write_artifact() {
     done
 
     if [[ ${#_confirmed_available[@]} -eq 0 ]] || [[ "$_ceiling_in_confirmed" == "false" ]]; then
-        log_info "$ext: confirmed_available is empty or ceiling ($ceiling) absent — deleting stale artifact, skipping bundle"
+        log_info "$ext: confirmed_available is empty or ceiling ($ceiling) absent — deleting stale artifact"
         _delete_stale_versionset_artifact "$ext" "$major_ver"
         return 0
     fi
 
-    # AO-1: if only one version is confirmed available (the ceiling only, non-ceiling
-    # versions were musl-failed or absent), do NOT assemble a bundle — a 1-version
-    # bundle is unused by the consumer (available_count <= 1 falls through to the
-    # single-version path in generate_dockerfile).  A bundle push or digest-capture
-    # failure on a 1-version bundle would fail CI for no benefit.
-    # Delete any stale artifact so the consumer self-heals cleanly; return 0 (not fatal).
+    # AO-1: only one version confirmed available — consumer uses single-version path.
     if [[ ${#_confirmed_available[@]} -le 1 ]]; then
-        log_info "$ext: only ${#_confirmed_available[@]} version(s) confirmed available — skipping bundle (consumer uses single-version path), deleting stale artifact"
+        log_info "$ext: only ${#_confirmed_available[@]} version(s) confirmed available — deleting stale artifact (consumer uses single-version path)"
         _delete_stale_versionset_artifact "$ext" "$major_ver"
         return 0
     fi
 
-    # Push the bundle from EXACTLY confirmed_available.
-    local _ba_rc=0
-    assemble_and_push_bundle "$ext" "$major_ver" "$do_push" "${_confirmed_available[@]}" || _ba_rc=$?
-    if [[ "$_ba_rc" -ne 0 ]]; then
-        log_error "$ext pg${major_ver}: bundle assembly/push failed — deleting stale artifact"
-        _delete_stale_versionset_artifact "$ext" "$major_ver"
-        return 1
-    fi
-
-    # ARCH_SUFFIX defer: on a CI per-arch leg (ARCH_SUFFIX non-empty) the bundle was
-    # pushed with a platform-suffixed tag (e.g. :pg18-bundle-amd64).  The multi-arch
-    # manifest-merge step (stage B, NOT this change) will create the unsuffixed
-    # :pg18-bundle index and write the final versionset artifact with the index digest.
-    # Defer the artifact write here so stage B has a clean slate — no artifact from a
-    # single-arch leg should pre-empt the multi-arch one.
-    # We still delete any stale artifact so the consumer does not silently use old data.
-    if [[ -n "${ARCH_SUFFIX:-}" ]]; then
-        log_info "$ext pg${major_ver}: ARCH_SUFFIX=${ARCH_SUFFIX} — bundle pushed as suffixed ref; deferring versionset artifact to manifest-merge step"
-        _delete_stale_versionset_artifact "$ext" "$major_ver"
-        unset _BUNDLE_DIGEST
-        return 0
-    fi
-
-    # Bundle pushed successfully — NOW write the artifact from the SAME confirmed set.
+    # Write the artifact without version_digests (multi-arch index digests are only
+    # available after finalize_multiarch_manifests merges both arch legs).
     local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
     mkdir -p "${ROOT_DIR}/.build-lineage"
 
@@ -812,172 +773,31 @@ _bundle_and_write_artifact() {
     _excluded_json="[$(IFS=,; echo "${_excluded_entries[*]+"${_excluded_entries[*]}"}")]"
     _resolved_json=$(echo "$version_set_json" | jq '.')
 
-    # AM fix: include bundle_digest in the artifact when available (publish path).
-    # _BUNDLE_DIGEST is set by assemble_and_push_bundle after a successful push.
-    # On LOCAL_ONLY/no-push paths, _BUNDLE_DIGEST is unset or empty — omit the field.
-    local _artifact_digest="${_BUNDLE_DIGEST:-}"
-    unset _BUNDLE_DIGEST
-
-    if [[ -n "$_artifact_digest" ]]; then
-        jq -nc \
-            --arg ext "$ext" \
-            --arg pg_major "$major_ver" \
-            --arg ceiling "$ceiling" \
-            --argjson resolved "$_resolved_json" \
-            --argjson available "$_available_json" \
-            --argjson excluded "$_excluded_json" \
-            --arg bundle_digest "$_artifact_digest" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, bundle_digest:$bundle_digest}' \
-            > "$_vs_lineage_file"
-    else
-        jq -nc \
-            --arg ext "$ext" \
-            --arg pg_major "$major_ver" \
-            --arg ceiling "$ceiling" \
-            --argjson resolved "$_resolved_json" \
-            --argjson available "$_available_json" \
-            --argjson excluded "$_excluded_json" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
-            > "$_vs_lineage_file"
-    fi
-    log_info "Version-set lineage (atomic): $_vs_lineage_file"
+    jq -nc \
+        --arg ext "$ext" \
+        --arg pg_major "$major_ver" \
+        --arg ceiling "$ceiling" \
+        --argjson resolved "$_resolved_json" \
+        --argjson available "$_available_json" \
+        --argjson excluded "$_excluded_json" \
+        '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
+        > "$_vs_lineage_file"
+    log_info "Version-set lineage (build path, no version_digests yet): $_vs_lineage_file"
     return 0
 }
 
-# Assemble (and optionally push) a bundle image for a resolver-backed extension.
-#
-# The bundle is a FROM-scratch image that COPYs each available per-version image's
-# /output/extension/ and /output/lib/ layers under /<ver>/ so the consumer can do
-# a single COPY --from=ext-<ext>:pg<major>-bundle to land all versions.
-#
-# This is intentionally cheap: no compilation occurs — only COPY layers from the
-# per-version refs that already exist in the registry (or local store on LOCAL_ONLY).
-# Idempotent: rebuilding with the same available set produces the same content.
-#
-# Called from TWO sites:
-#   1. build_tag_push_extensions — after the per-version inner loop (build path).
-#   2. main() — on the all-cached path where build_tag_push_extensions is not called
-#      but the bundle must still be refreshed to match the current available set.
-#
-# Args: ext major_ver do_push avail_ver1 [avail_ver2 ...]
-#   do_push: "true" → push to registry after build; "false" → build locally only.
-#   avail_ver*: the versions to include in the bundle (must be non-empty).
-#
-# Returns: 0 on success, 1 on build or push failure (caller adds to failed[]).
-# Does NOT call exit directly; callers propagate the failure.
-# Under DRY_RUN=true, logs what would happen and returns 0 (callers handle DRY_RUN
-# before calling this function on the real path — this guard is defense-in-depth).
-assemble_and_push_bundle() {
-    local ext="$1" major_ver="$2" do_push="$3"
-    shift 3
-    local avail_versions=("$@")
-
-    if [[ "$DRY_RUN" == "true" ]]; then
-        local _bundle_image_base_d
-        _bundle_image_base_d=$(ext_image_name "$ext" "dummy" "$major_ver")
-        local _bundle_base_tag_d="${_bundle_image_base_d%:*}:pg${major_ver}-bundle"
-        local _bundle_ref_d
-        _bundle_ref_d=$(_arch_suffix_tag "$_bundle_base_tag_d" "${ARCH_SUFFIX:-}")
-        log_info "[DRY-RUN] Would build bundle $ext pg${major_ver}: $_bundle_ref_d (versions: ${avail_versions[*]})"
-        [[ "$do_push" == "true" ]] && log_info "[DRY-RUN] Would push bundle $_bundle_ref_d"
-        return 0
-    fi
-
-    local _bundle_image_base
-    _bundle_image_base=$(ext_image_name "$ext" "dummy" "$major_ver")
-    local _bundle_base_tag="${_bundle_image_base%:*}:pg${major_ver}-bundle"
-    local _bundle_ref
-    _bundle_ref=$(_arch_suffix_tag "$_bundle_base_tag" "${ARCH_SUFFIX:-}")
-
-    local _bundle_df
-    # CI per-arch leg (ARCH_SUFFIX set): the bundle is built by stage B
-    # (finalize_multiarch_manifests) from the merged per-version multi-arch manifests,
-    # not here. Skip the bundle build/push on a per-arch leg; only the local/single-arch
-    # path (ARCH_SUFFIX empty) builds the bundle directly.
-    if [[ -n "${ARCH_SUFFIX:-}" ]]; then
-        log_info "$ext pg${major_ver}: per-arch leg — bundle deferred to stage-B finalize step"
-        return 0
-    fi
-
-    _bundle_df=$(mktemp)
-
-    {
-        printf 'FROM scratch\n'
-        local _bver
-        for _bver in "${avail_versions[@]}"; do
-            # Local/single-arch path (ARCH_SUFFIX empty): reference the plain un-suffixed
-            # per-version image built on this host.
-            local _per_ver_ref
-            _per_ver_ref=$(ext_image_name "$ext" "$_bver" "$major_ver")
-            printf 'COPY --from=%s /output/extension/ /%s/extension/\n' "$_per_ver_ref" "$_bver"
-            printf 'COPY --from=%s /output/lib/ /%s/lib/\n' "$_per_ver_ref" "$_bver"
-        done
-    } > "$_bundle_df"
-
-    log_info "Building bundle $ext pg${major_ver}: $_bundle_ref"
-
-    local _bundle_ctx
-    _bundle_ctx=$(mktemp -d)
-
-    local _bundle_build_ok=true
-    if ! $DOCKER build -t "$_bundle_ref" -f "$_bundle_df" "$_bundle_ctx"; then
-        _bundle_build_ok=false
-    fi
-
-    rm -f "$_bundle_df"
-    rm -rf "$_bundle_ctx"
-
-    if [[ "$_bundle_build_ok" == "false" ]]; then
-        log_error "$ext pg${major_ver} bundle build failed"
-        return 1
-    fi
-
-    log_success "Bundle built: $_bundle_ref"
-
-    local _pushed=false
-    if [[ "$do_push" == "true" ]]; then
-        if ! $DOCKER push "$_bundle_ref"; then
-            log_error "$ext pg${major_ver} bundle push failed"
-            return 1
-        fi
-        log_success "Bundle pushed: $_bundle_ref"
-        _pushed=true
-    fi
-
-    if [[ "$_pushed" == "true" ]]; then
-        # Capture the digest of the pushed bundle image. The consumer emits a
-        # digest-pinned COPY --from=<ref>@<digest> for reproducibility.
-        # Digest capture failure after a successful push is fatal: the caller cannot
-        # construct an immutable reference without the digest.  Fail closed here;
-        # the caller (_bundle_and_write_artifact) propagates the non-zero return.
-        local _captured_digest
-        _captured_digest=$(_capture_bundle_digest "$_bundle_ref") || true
-        if ! is_valid_oci_digest "$_captured_digest"; then
-            log_error "$ext pg${major_ver}: bundle pushed but digest capture failed or is malformed (got: '$(_sanitize_for_log "${_captured_digest}")') — cannot write immutable artifact ref; fail closed"
-            return 2
-        fi
-        log_info "Bundle digest: $_captured_digest"
-
-        # Export so _bundle_and_write_artifact can read it without a subshell.
-        _BUNDLE_DIGEST="$_captured_digest"
-        export _BUNDLE_DIGEST
-    fi
-
-    return 0
-}
-
-# _capture_bundle_digest <bundle_ref>
-# Captures the content digest of a pushed bundle image using the raw-manifest
-# hashing pattern (the same proven approach used by the build-container action).
-# Returns the sha256:... digest string on stdout on success; returns empty string
-# and a non-zero exit when the raw manifest cannot be retrieved.
-# Separated from assemble_and_push_bundle so tests can override it independently
-# without needing to replicate the full docker() mock for buildx.
+# _capture_index_digest <image_ref>
+# Captures the content digest of a pushed multi-arch index manifest using the
+# raw-manifest hashing pattern (the same proven approach used by the
+# build-container action).
+# Returns the sha256:... digest string on stdout on success; returns non-zero
+# when the raw manifest cannot be retrieved.
+# Separated so tests can override it independently.
 #
 # The --format '{{.Manifest.Digest}}' template field is intentionally NOT used:
 # it is empty for some image types and version-dependent in CI, making it
 # unreliable as the primary capture method.
-_capture_bundle_digest() {
+_capture_index_digest() {
     local _ref="$1"
     local _raw_manifest
     _raw_manifest=$($DOCKER buildx imagetools inspect "$_ref" --raw 2>/dev/null) || true
@@ -1060,10 +880,6 @@ build_tag_push_extensions() {
         # _cleanup_stale_duration_files is a no-op under DRY_RUN.
         _cleanup_stale_duration_files "$ext" "$major_ver"
 
-        # Track versions that are available (built this loop OR pre-existing) for
-        # the bundle assembly step below.  Populated inside the inner loop.
-        local _available_for_bundle=()
-
         # Inner loop over each version oldest→newest.
         local version
         while IFS= read -r version; do
@@ -1081,7 +897,6 @@ build_tag_push_extensions() {
             if [[ "$LOCAL_ONLY" == "true" ]]; then
                 if ! _image_needs_build "$_check_image"; then
                     log_success "$ext $version already exists locally"
-                    _available_for_bundle+=("$version")
                     continue
                 fi
             elif [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
@@ -1090,20 +905,17 @@ build_tag_push_extensions() {
                 _canonical_arch_ref=$(_arch_suffix_tag "$ver_image" "${ARCH_SUFFIX:-}")
                 if [[ "$FORCE" != "true" ]] && image_exists_in_registry "$_canonical_arch_ref" 2>/dev/null; then
                     log_success "$ext $version already exists in registry (canonical)"
-                    _available_for_bundle+=("$version")
                     continue
                 fi
                 # Canonical absent: check PR-scoped tag (built this PR).
                 if [[ "$FORCE" != "true" ]] && image_exists_in_registry "$_check_image" 2>/dev/null; then
                     log_success "$ext $version already exists in registry (pr-scoped)"
-                    _available_for_bundle+=("$version")
                     continue
                 fi
             else
                 # Push/dispatch (PR_TAG_SUFFIX empty): canonical probe only.
                 if ! _image_needs_build "$_check_image"; then
                     log_success "$ext $version already exists in registry"
-                    _available_for_bundle+=("$version")
                     continue
                 fi
             fi
@@ -1170,9 +982,6 @@ build_tag_push_extensions() {
 
             log_success "$ext $version completed successfully"
 
-            # Mark available for bundle assembly.
-            _available_for_bundle+=("$version")
-
             # Record this version as built-this-run so _emit_versionset_artifact
             # can union it with the registry probe (guards against GHCR lag).
             if [[ "$DRY_RUN" != "true" ]]; then
@@ -1212,25 +1021,16 @@ build_tag_push_extensions() {
             fi
         done < <(echo "$version_set_json" | jq -r '.[]')
 
-        # Bundle + artifact (atomic): for resolver-backed multi-version extensions,
+        # Artifact write (atomic): for resolver-backed multi-version extensions,
         # _bundle_and_write_artifact computes confirmed_available ONCE (3-state probe
-        # + built-this-run union), pushes the bundle from that set, then writes the
-        # artifact from the SAME set. Artifact is written only after a successful push.
+        # + built-this-run union) and writes the versionset artifact from that set.
+        # version_digests (multi-arch index digests) are added by finalize_multiarch_manifests.
         #
-        # Under DRY_RUN: log intent and continue (no mutation).
+        # Under DRY_RUN: skip (no mutation).
         # Fatal failure guard (AK-1): if ANY version for this ext failed in this run,
-        # skip bundle+artifact — ceiling may be absent, confirmed set is incomplete.
+        # skip artifact — ceiling may be absent, confirmed set is incomplete.
         if [[ -n "$_resolver_path" ]] && [[ "$set_size" -gt 1 ]]; then
-            if [[ "$DRY_RUN" == "true" ]]; then
-                local _bundle_image_base_dry
-                _bundle_image_base_dry=$(ext_image_name "$ext" "dummy" "$major_ver")
-                local _bundle_ref_dry="${_bundle_image_base_dry%:*}:pg${major_ver}-bundle"
-                local _dry_all_versions
-                _dry_all_versions=$(echo "$version_set_json" | jq -r '.[]' | tr '\n' ' ')
-                log_info "[DRY-RUN] Would build bundle $ext pg${major_ver}: $_bundle_ref_dry (versions: ${_dry_all_versions})"
-                log_info "[DRY-RUN] Would push bundle $_bundle_ref_dry"
-                continue
-            fi
+            [[ "$DRY_RUN" == "true" ]] && continue
 
             # AK-1: skip if any fatal failure for this extension.
             local _ext_fatal=false
@@ -1243,13 +1043,13 @@ build_tag_push_extensions() {
             done
 
             if [[ "$_ext_fatal" == "true" ]]; then
-                log_warning "$ext pg${major_ver}: skipping bundle+artifact — fatal failure in this run"
+                log_warning "$ext pg${major_ver}: skipping artifact — fatal failure in this run"
                 _delete_stale_versionset_artifact "$ext" "$major_ver"
             else
                 local _ba_rc=0
                 _bundle_and_write_artifact "$ext" "$config_file" "$major_ver" "$version_set_json" "$ceiling" "$do_push" || _ba_rc=$?
                 if [[ "$_ba_rc" -ne 0 ]]; then
-                    failed+=("$ext@bundle")
+                    failed+=("$ext@artifact")
                     continue
                 fi
             fi
@@ -1673,11 +1473,9 @@ _cleanup_stale_duration_files() {
 # Args: config_file major_ver container_dir [_ignored_single_ext] [do_push]
 #   Arg 4 (_ignored_single_ext): accepted for backward compatibility but unused —
 #     scoping is driven exclusively by the global $EXTENSION variable.
-#   Arg 5 (do_push): "true" = push bundle to registry; "false" = no push.
-#     When do_push="false" AND not LOCAL_ONLY AND not PULL_ONLY (CI PR smoke),
-#     the bundle assembly and artifact write are SKIPPED entirely — the all-cached
-#     CI PR path must exit cleanly without any GHCR write attempt.
-#     When do_push="false" AND (LOCAL_ONLY OR PULL_ONLY): assemble locally, no push.
+#   Arg 5 (do_push): "true" = write artifact; "false" + not LOCAL_ONLY/PULL_ONLY →
+#     CI PR smoke: skip artifact entirely (registry read-only, no artifact write).
+#     do_push="false" + LOCAL_ONLY or PULL_ONLY → write artifact (local recovery).
 #     Defaults to re-deriving from LOCAL_ONLY/PULL_ONLY when arg 5 is absent
 #     (backward compatibility with callers that do not pass do_push).
 # Does nothing under DRY_RUN.
@@ -1743,10 +1541,6 @@ _emit_final_versionset_pass() {
         # Determine the effective do_push for this final pass.
         # Use arg 5 when provided (threaded from main()); otherwise re-derive from
         # LOCAL_ONLY/PULL_ONLY for backward compatibility with direct callers.
-        # Three-way contract:
-        #   do_push=true                         → assemble + push bundle + write artifact.
-        #   do_push=false + LOCAL_ONLY/PULL_ONLY → assemble locally, no push (recovery).
-        #   do_push=false + not LOCAL_ONLY/PULL_ONLY → CI PR smoke: skip bundle entirely.
         local _do_push_fp
         if [[ -n "${5:-}" ]]; then
             _do_push_fp="$5"
@@ -1755,21 +1549,21 @@ _emit_final_versionset_pass() {
             [[ "${LOCAL_ONLY:-false}" == "true" || "${PULL_ONLY:-false}" == "true" ]] && _do_push_fp="false"
         fi
 
-        # AV-2 single-bundle guard: if _bundle_and_write_artifact was already called for
+        # AV-2 single-write guard: if _bundle_and_write_artifact was already called for
         # this (ext, major_ver) on the BUILD PATH (in build_tag_push_extensions), a
         # sentinel file was written to ${_BUILT_THIS_RUN_DIR}/bundle-<ext>-<major_ver>.
-        # Skip the final pass for this (ext, major_ver) to prevent assembling the bundle
-        # a second time in the same run.  The all-cached path (no build) writes no
-        # sentinel, so those always go through the final pass as before.
+        # Skip the final pass for this (ext, major_ver) to prevent a second write
+        # in the same run.  The all-cached path (no build) writes no sentinel, so
+        # those always go through the final pass as before.
         local _bundle_sentinel_fp="${_BUILT_THIS_RUN_DIR}/bundle-${ext}-${major_ver}"
         if [[ -f "$_bundle_sentinel_fp" ]]; then
-            log_info "$ext pg${major_ver}: bundle already assembled on build path — skipping final pass for this extension (AV-2 guard)"
+            log_info "$ext pg${major_ver}: artifact already written on build path — skipping final pass for this extension (AV-2 guard)"
             continue
         fi
 
-        # Atomic: push bundle from confirmed_available, then write artifact from the
-        # SAME set. _bundle_and_write_artifact handles the 3-state probe, fail-closed
-        # gates, stale artifact deletion, ordering invariant, and the CI no-push guard.
+        # Write the versionset artifact. _bundle_and_write_artifact handles the
+        # 3-state probe, fail-closed gates, stale artifact deletion, and the
+        # CI no-push guard.
         local _bwa_rc=0
         _bundle_and_write_artifact "$ext" "$config_file" "$major_ver" "$version_set_json" "$ceiling" "$_do_push_fp" || _bwa_rc=$?
         if [[ "$_bwa_rc" -ne 0 ]]; then
@@ -1959,7 +1753,7 @@ _consolidate_version_duration_file() {
 #
 #   Non-resolver extensions (single configured version):
 #     Creates the un-suffixed multi-arch manifest from stable suffixed tags
-#     (-amd64 / -arm64). No bundle, no versionset artifact.
+#     (-amd64 / -arm64). No collector stage, no versionset artifact.
 #
 #   Resolver-backed extensions:
 #     1. Re-resolves the version set (deterministic via resolver + retain_count).
@@ -1970,16 +1764,17 @@ _consolidate_version_duration_file() {
 #     3. Creates per-version multi-arch manifests from the stable suffixed tags
 #        for all AVAILABLE versions (including cached versions not rebuilt this
 #        run — their suffixed tags persist in the registry from prior runs).
-#     4. For set_size == 1 (single-version resolver result): still creates the
+#     4. Immediately after each per-version manifest creation: captures the
+#        index digest via _capture_index_digest and verifies both linux/amd64 and
+#        linux/arm64 are covered; fail-closed on capture/validation/platform miss.
+#     5. For set_size == 1 (single-version resolver result): still creates the
 #        un-suffixed per-version manifest so the consumer's single-version path
-#        finds it. No bundle needed.
-#     5. For available count >= 2: builds the multi-arch bundle image via
-#        buildx build --platform linux/amd64,linux/arm64 from the AVAILABLE
-#        per-version multi-arch manifests (un-suffixed, just created).
-#        Each platform's bundle layer gets that platform's .so from the
-#        per-version manifest — no QEMU/compilation needed, file-copy only.
-#     6. Captures the INDEX digest of the bundle manifest.
-#     7. Writes the versionset artifact with bundle_digest = that index digest.
+#        finds it. No collector needed.
+#     6. For available count >= 2: writes the versionset artifact with a
+#        version_digests map {"<ver>":"sha256:..."} covering all available versions.
+#        The consumer (generate_dockerfile) uses these digests to emit a collector
+#        stage (FROM scratch AS ext_collect_<ext>) with one digest-pinned COPY per
+#        version, and exactly ONE COPY --from=ext_collect_<ext> in the final stage.
 #
 # Stable-tag merge rationale: digest-pinned merge (reverted AX-1/AY-1 approach)
 # was dropped because it excluded cached versions (not rebuilt this run, so no
@@ -2002,7 +1797,7 @@ _consolidate_version_duration_file() {
 # race probability is near zero. This trade-off is explicit and documented here.
 #
 # Fail-closed: ceiling missing on either arch, imagetools create failure for
-# ceiling, bundle build/push failure, or digest capture failure → fatal.
+# ceiling, index digest capture/platform-check failure → fatal.
 # Non-ceiling failures are tolerated (musl-compat contract from stage A).
 #
 # Called from main() when FINALIZE_MULTIARCH=true.
@@ -2132,9 +1927,9 @@ finalize_multiarch_manifests() {
         #   Any rc 2 → fail closed.
         #   Either rc 1 → absent on that arch → exclude non-ceiling; fatal for ceiling.
         local _confirmed_available=()
-        local _confirmed_sources=()   # parallel array: ref to use in bundle COPY per available version
         local _excluded_entries=()
         local _ext_failed=false
+        local -A _ver_index_digests=()  # version → multi-arch index digest
         local ver
         while IFS= read -r ver; do
             # When FORCE=true: skip reuse check, always create fresh manifest from arch tags.
@@ -2151,9 +1946,26 @@ finalize_multiarch_manifests() {
 
                 if [[ "$_ma_rc" -eq 0 ]]; then
                     # Multi-arch manifest present → reuse (canonical or PR-scoped).
+                    # Capture its index digest for the version_digests artifact map.
                     log_info "$ext $ver pg${major_ver}: manifest present — reused (unchanged)"
+                    local _reuse_digest _reuse_digest_rc=0
+                    _reuse_digest=$(_capture_index_digest "$_ma_ref") || _reuse_digest_rc=$?
+                    if [[ "$_reuse_digest_rc" -ne 0 ]] || ! is_valid_oci_digest "$_reuse_digest"; then
+                        log_error "$ext $ver pg${major_ver}: reused manifest digest capture failed (got: '$(_sanitize_for_log "${_reuse_digest:-<empty>}")') — fail closed"
+                        _ext_failed=true
+                        break
+                    fi
+                    # Verify manifest covers both target platforms.
+                    local _reuse_inspect_out
+                    _reuse_inspect_out=$($DOCKER buildx imagetools inspect "$_ma_ref" 2>/dev/null) || true
+                    if ! echo "$_reuse_inspect_out" | grep -q "linux/amd64" || \
+                       ! echo "$_reuse_inspect_out" | grep -q "linux/arm64"; then
+                        log_error "$ext $ver pg${major_ver}: reused manifest does not cover both linux/amd64 and linux/arm64 — fail closed"
+                        _ext_failed=true
+                        break
+                    fi
                     _confirmed_available+=("$ver")
-                    _confirmed_sources+=("$_ma_ref")
+                    _ver_index_digests["$ver"]="$_reuse_digest"
                     continue
                 fi
             fi
@@ -2218,8 +2030,27 @@ finalize_multiarch_manifests() {
                 break
             fi
 
+            # Capture the multi-arch index digest immediately after creation.
+            local _ver_digest _ver_digest_rc=0
+            _ver_digest=$(_capture_index_digest "$ver_multiarch") || _ver_digest_rc=$?
+            if [[ "$_ver_digest_rc" -ne 0 ]] || ! is_valid_oci_digest "$_ver_digest"; then
+                log_error "$ext $ver pg${major_ver}: index digest capture failed after imagetools create (got: '$(_sanitize_for_log "${_ver_digest:-<empty>}")') — fail closed"
+                _ext_failed=true
+                break
+            fi
+            # Verify the created manifest covers both target platforms.
+            local _inspect_out
+            _inspect_out=$($DOCKER buildx imagetools inspect "$ver_multiarch" 2>/dev/null) || true
+            if ! echo "$_inspect_out" | grep -q "linux/amd64" || \
+               ! echo "$_inspect_out" | grep -q "linux/arm64"; then
+                log_error "$ext $ver pg${major_ver}: created manifest does not cover both linux/amd64 and linux/arm64 — fail closed"
+                _ext_failed=true
+                break
+            fi
+            log_info "$ext $ver pg${major_ver}: index digest: $_ver_digest"
+
             _confirmed_available+=("$ver")
-            _confirmed_sources+=("$ver_multiarch")
+            _ver_index_digests["$ver"]="$_ver_digest"
         done < <(echo "$version_set_json" | jq -r '.[]')
 
         # Ceiling merge failed → fatal for this extension.
@@ -2239,106 +2070,69 @@ finalize_multiarch_manifests() {
             fi
         done
         if [[ "$_ceiling_ok" == "false" ]] || [[ ${#_confirmed_available[@]} -eq 0 ]]; then
-            log_info "$ext pg${major_ver}: confirmed_available is empty or ceiling ($ceiling) absent after per-version merges — skipping bundle+artifact"
+            log_info "$ext pg${major_ver}: confirmed_available is empty or ceiling ($ceiling) absent after per-version merges — skipping artifact"
             _delete_stale_versionset_artifact "$ext" "$major_ver"
             continue
         fi
 
         # For set_size == 1 (single-version resolver): the per-version multi-arch manifest
-        # was already created above (ceiling). No bundle needed; consumer uses single-version
-        # path. Delete any stale versionset artifact. (AZ-4 fix: manifest IS created above.)
+        # was already created above (ceiling). Consumer uses single-version path.
+        # Delete any stale versionset artifact. (AZ-4 fix: manifest IS created above.)
         if [[ "$set_size" -le 1 ]]; then
-            log_info "$ext pg${major_ver}: single-version resolver result — per-version manifest created, no bundle needed"
+            log_info "$ext pg${major_ver}: single-version resolver result — per-version manifest created, no collector needed"
             _delete_stale_versionset_artifact "$ext" "$major_ver"
             continue
         fi
 
-        # Only one version confirmed available — no bundle (consumer uses single-version path).
+        # Only one version confirmed available — consumer uses single-version path.
         if [[ ${#_confirmed_available[@]} -le 1 ]]; then
-            log_info "$ext pg${major_ver}: only ${#_confirmed_available[@]} version(s) available — skipping bundle (consumer uses single-version path)"
+            log_info "$ext pg${major_ver}: only ${#_confirmed_available[@]} version(s) available — consumer uses single-version path"
             _delete_stale_versionset_artifact "$ext" "$major_ver"
             continue
         fi
 
-        # Step 2: build the multi-arch bundle from the AVAILABLE per-version multi-arch
-        # manifests (scoped, just created above). Each platform's bundle layer gets
-        # that platform's .so via the per-version manifest's platform selection.
-        # This is file-copy only (no compilation), so buildx multi-platform on the amd64
-        # merge runner works without QEMU. The bundle contains EXACTLY the available set.
-        local _bundle_image_base
-        _bundle_image_base=$(ext_image_name "$ext" "dummy" "$major_ver")
-        local _bundle_base_tag_canonical="${_bundle_image_base%:*}:pg${major_ver}-bundle"
-        # Apply PR_TAG_SUFFIX to the bundle tag so PR runs publish a scoped bundle ref
-        # and never overwrite the canonical :pg<major>-bundle tag.
-        local _bundle_base_tag
-        _bundle_base_tag=$(_scoped_tag "$_bundle_base_tag_canonical")
-
-        local _bundle_df
-        _bundle_df=$(mktemp)
-        {
-            printf 'FROM scratch\n'
-            local _bv_idx=0 _bv
-            for _bv in "${_confirmed_available[@]}"; do
-                local _bv_ref
-                # BF: use the resolved source ref for each version from _confirmed_sources.
-                # - unchanged versions: canonical multi-arch ref (e.g. :pg18-2.23.0)
-                # - new/changed version: PR-scoped multi-arch ref (e.g. :pg18-2.27.1-pr42)
-                # On push (PR_TAG_SUFFIX empty): all refs are canonical (no change).
-                if [[ "${#_confirmed_sources[@]}" -gt "$_bv_idx" ]]; then
-                    _bv_ref="${_confirmed_sources[$_bv_idx]}"
-                else
-                    # Fallback (should not happen): use scoped ref.
-                    _bv_ref=$(_scoped_tag "$(ext_image_name "$ext" "$_bv" "$major_ver")")
-                fi
-                _bv_idx=$(( _bv_idx + 1 ))
-                printf 'COPY --from=%s /output/extension/ /%s/extension/\n' "$_bv_ref" "$_bv"
-                printf 'COPY --from=%s /output/lib/ /%s/lib/\n' "$_bv_ref" "$_bv"
-            done
-        } > "$_bundle_df"
-
-        local _bundle_ctx
-        _bundle_ctx=$(mktemp -d)
-
-        log_info "$ext pg${major_ver}: buildx build --platform linux/amd64,linux/arm64 -t $_bundle_base_tag (bundle from available: ${_confirmed_available[*]})"
-        local _bundle_build_rc=0
-        $DOCKER buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t "$_bundle_base_tag" \
-            -f "$_bundle_df" \
-            --push \
-            "$_bundle_ctx" 2>&1 \
-            || _bundle_build_rc=$?
-        if [[ "$_bundle_build_rc" -ne 0 ]]; then
-            log_error "$ext pg${major_ver}: bundle buildx build failed (rc=$_bundle_build_rc) — fail-closed"
-            rm -f "$_bundle_df"
-            rm -rf "$_bundle_ctx"
+        # Validate: every version in confirmed_available must have a valid index digest.
+        local _digest_ok=true
+        local _dv
+        for _dv in "${_confirmed_available[@]}"; do
+            if ! is_valid_oci_digest "${_ver_index_digests[$_dv]:-}"; then
+                log_error "$ext pg${major_ver}: version $(_sanitize_for_log "$_dv") missing valid index digest — fail closed"
+                _digest_ok=false
+            fi
+        done
+        if [[ "$_digest_ok" == "false" ]]; then
             _delete_stale_versionset_artifact "$ext" "$major_ver"
             _failed=true
             continue
         fi
-        rm -f "$_bundle_df"
-        rm -rf "$_bundle_ctx"
-        log_success "Bundle multi-arch image built+pushed: $_bundle_base_tag"
 
-        # Step 3: capture INDEX digest of the bundle manifest.
-        local _index_digest
-        _index_digest=$(_capture_bundle_digest "$_bundle_base_tag") || true
-        if ! is_valid_oci_digest "$_index_digest"; then
-            log_error "$ext pg${major_ver}: bundle index digest capture failed or malformed (got: '$(_sanitize_for_log "${_index_digest}")') — fail-closed"
-            _delete_stale_versionset_artifact "$ext" "$major_ver"
-            _failed=true
-            continue
-        fi
-        log_info "$ext pg${major_ver}: bundle index digest: $_index_digest"
-
-        # Step 4: write versionset artifact with bundle_digest = index digest.
+        # Write versionset artifact with version_digests map (version → index digest).
+        # The consumer (generate_dockerfile) uses these digests to emit
+        # digest-pinned COPY --from= lines in the collector stage.
         local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
         mkdir -p "${ROOT_DIR}/.build-lineage"
 
-        local _available_json _excluded_json _resolved_json
+        local _available_json _excluded_json _resolved_json _version_digests_json
         _available_json=$(printf '%s\n' "${_confirmed_available[@]+"${_confirmed_available[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
         _excluded_json="[$(IFS=,; echo "${_excluded_entries[*]+"${_excluded_entries[*]}"}")]"
         _resolved_json=$(echo "$version_set_json" | jq '.')
+
+        # Build version_digests JSON object: {"<ver>":"sha256:..."}
+        local _vd_args=()
+        local _vd_obj='{'
+        local _vd_first=true
+        for _dv in "${_confirmed_available[@]}"; do
+            local _vd_digest="${_ver_index_digests[$_dv]}"
+            _vd_args+=(--arg "vd_ver_${#_vd_args[@]}" "$_dv" --arg "vd_dig_${#_vd_args[@]}" "$_vd_digest")
+            if [[ "$_vd_first" == "true" ]]; then
+                _vd_obj+="\"${_dv}\":\"${_vd_digest}\""
+                _vd_first=false
+            else
+                _vd_obj+=",\"${_dv}\":\"${_vd_digest}\""
+            fi
+        done
+        _vd_obj+='}'
+        _version_digests_json="$_vd_obj"
 
         jq -nc \
             --arg ext "$ext" \
@@ -2347,8 +2141,8 @@ finalize_multiarch_manifests() {
             --argjson resolved "$_resolved_json" \
             --argjson available "$_available_json" \
             --argjson excluded "$_excluded_json" \
-            --arg bundle_digest "$_index_digest" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, bundle_digest:$bundle_digest}' \
+            --argjson version_digests "$_version_digests_json" \
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests}' \
             > "$_vs_lineage_file"
         log_success "Versionset artifact written: $_vs_lineage_file"
 
@@ -2400,8 +2194,8 @@ main() {
     # LOCAL_ONLY=true → local-only build, no push (recovery path).
     # PULL_ONLY=true  → pull-only build, no push (final pass writes local artifact).
     # NO_PUSH=true    → explicit no-push context (e.g. CI fork PR with read-only
-    #                   package permissions); bundle and artifact are skipped.
-    # do_push=false + not LOCAL_ONLY/PULL_ONLY → CI PR smoke: skip bundle + artifact.
+    #                   package permissions); artifact write is skipped.
+    # do_push=false + not LOCAL_ONLY/PULL_ONLY → CI PR smoke: skip artifact write.
     local do_push="true"
     [[ "$LOCAL_ONLY" == "true" ]] && do_push="false"
     [[ "$PULL_ONLY" == "true" ]] && do_push="false"
@@ -2473,12 +2267,10 @@ main() {
             done < <(list_extensions_by_priority "$config_file" "$major_ver")
         fi
 
-        # Atomic pass: for each in-scope resolver-backed extension, compute
-        # confirmed_available once, push the bundle from that set, then write the
-        # artifact from the SAME set. Bundle and artifact are always in sync.
+        # Write versionset artifacts for all in-scope resolver-backed extensions.
         # This covers both the "all-cached" and "all-DRY_RUN" sub-paths.
         # Pass do_push so the final pass honors the same push decision as the
-        # rest of main() — prevents the all-cached path from pushing on CI PR smoke.
+        # rest of main() — prevents the all-cached path from writing on CI PR smoke.
         local _fp_rc=0
         _emit_final_versionset_pass "$config_file" "$major_ver" "$container_dir" "${EXTENSION:-}" "$do_push" || _fp_rc=$?
 

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -413,6 +413,92 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
+# FIX1: pushed artifact (do_push=true, no ARCH_SUFFIX) must include version_digests
+# for every available version.
+#
+# Invariant: version_digests absent ⟺ artifact was NOT pushed.
+# A pushed artifact without version_digests would cause the consumer to emit
+# mutable-tag refs, silently regressing the digest-pinned ref guarantee.
+#
+# Before fix: _bundle_and_write_artifact omits version_digests on the non-ARCH_SUFFIX
+# push path → consumer falls back to tag-based refs (wrong for a pushed artifact).
+# After fix: version_digests is captured and included for every available version.
+# ---------------------------------------------------------------------------
+
+@test "FIX1-push-has-digests: do_push=true artifact includes version_digests for every available version" {
+    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
+    export -f resolve_version_set
+
+    ext_config() {
+        case "$2" in
+            version) echo "2.27.1" ;;
+            repo)    echo "https://github.com/timescale/timescaledb" ;;
+            *)       echo "" ;;
+        esac
+    }
+    export -f ext_config
+
+    # _capture_index_digest already mocked in _setup_default_mocks to return a valid
+    # fixed digest (sha256:000...0).  All versions available — no build failures.
+
+    run build_tag_push_extensions \
+        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
+
+    [ "$status" -eq 0 ]
+
+    # Artifact must exist (written by _bundle_and_write_artifact on the push path).
+    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
+
+    # version_digests must be present (pushed artifact invariant: absent ⟺ not pushed).
+    local vd_present
+    vd_present=$(jq -r 'if has("version_digests") then "yes" else "no" end' "$artifact")
+    [ "$vd_present" = "yes" ]
+
+    # version_digests must contain an entry for EVERY available version.
+    local available_count vd_count
+    available_count=$(jq '.available | length' "$artifact")
+    vd_count=$(jq '.version_digests | length' "$artifact")
+    [ "$available_count" -eq "$vd_count" ]
+
+    # Every version in available[] must have a valid sha256 digest.
+    local all_valid
+    all_valid=$(jq -r '.available[] as $v | .version_digests[$v] // "MISSING" | test("^sha256:[0-9a-f]{64}$")' "$artifact" \
+        | sort -u)
+    [ "$all_valid" = "true" ]
+}
+
+@test "FIX1-no-push-no-digests: do_push=false artifact omits version_digests (local/no-push invariant)" {
+    export LOCAL_ONLY=true
+
+    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
+    export -f resolve_version_set
+
+    ext_config() {
+        case "$2" in
+            version) echo "2.27.1" ;;
+            repo)    echo "https://github.com/timescale/timescaledb" ;;
+            *)       echo "" ;;
+        esac
+    }
+    export -f ext_config
+
+    run build_tag_push_extensions \
+        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "false" "timescaledb"
+
+    [ "$status" -eq 0 ]
+
+    # Artifact must exist (LOCAL_ONLY allows artifact write on the no-push path).
+    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
+
+    # version_digests must be ABSENT (no-push path; consumer uses tag-based refs).
+    local vd_present
+    vd_present=$(jq -r 'if has("version_digests") then "yes" else "no" end' "$artifact")
+    [ "$vd_present" = "no" ]
+}
+
+# ---------------------------------------------------------------------------
 # M1: resolver call-count — resolve_version_set called AT MOST ONCE per
 # (ext, pg_major) even though both _should_build_extension and
 # build_tag_push_extensions consume the result.

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -136,14 +136,14 @@ _setup_default_mocks() {
     }
     export -f ext_local_image_name
 
-    # _capture_bundle_digest: returns a stable digest on success (production-faithful:
+    # _capture_index_digest: returns a stable digest on success (production-faithful:
     # a successful push always has a retrievable digest; tests that need failure
     # override this function directly).
-    _capture_bundle_digest() {
+    _capture_index_digest() {
         echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
         return 0
     }
-    export -f _capture_bundle_digest
+    export -f _capture_index_digest
 
     # resolve_version_set: default → single-version (overridden per-test)
     resolve_version_set() {
@@ -516,8 +516,8 @@ _count_log_lines() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image()      { echo \"BUILD ext=\$1 ver=\$2\" >> '${build_log}'; return 0; }
         export -f build_ext_image
         tag_ext_image()        { return 0; }
@@ -609,8 +609,8 @@ _count_log_lines() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image() { return 0; }
         export -f build_ext_image
         tag_ext_image() { return 0; }
@@ -1009,8 +1009,8 @@ _count_log_lines() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -1412,8 +1412,8 @@ _count_log_lines() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo 'BUILD_CALLED' >> \"$tmpd/cached1_build.log\"
@@ -1524,8 +1524,8 @@ _count_log_lines() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         skopeo() {
             echo 'manifest unknown: manifest unknown' >&2
@@ -1686,8 +1686,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"$build_log\"
@@ -1789,8 +1789,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"$build_log\"
@@ -1889,8 +1889,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         # All versions pulled successfully → no fallback builds needed
         pull_ext_image() { return 0; }
@@ -1904,8 +1904,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         image_exists_in_registry() { return 1; }
         export -f image_exists_in_registry
@@ -2014,8 +2014,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -2098,8 +2098,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo 'BUILD_CALLED' >> \"$tmpd/staleness_build.log\"
@@ -2212,8 +2212,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -2348,8 +2348,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -2459,8 +2459,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -2584,8 +2584,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         skopeo() { echo 'manifest unknown: manifest unknown' >&2; return 1; }
         export -f skopeo
@@ -2695,8 +2695,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         skopeo() { echo 'manifest unknown: manifest unknown' >&2; return 1; }
         export -f skopeo
@@ -2846,8 +2846,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -2949,8 +2949,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         image_exists_in_registry() { return 1; }
         export -f image_exists_in_registry
 
@@ -3038,8 +3038,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo 'BUILD_CALLED' >> \"$tmpd/ff1_build.log\"
@@ -3169,8 +3169,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -3265,8 +3265,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         image_exists_in_registry() { return 1; }
         export -f image_exists_in_registry
 
@@ -3356,8 +3356,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -3457,8 +3457,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo 'SHOULD_NOT_BUILD' >> \"$tmpd/hh2_build.log\"
@@ -3738,8 +3738,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -3904,11 +3904,11 @@ EOF
     export DOCKER
 
     # Production-faithful: a successful push always has a retrievable digest.
-    _capture_bundle_digest() {
+    _capture_index_digest() {
         echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
         return 0
     }
-    export -f _capture_bundle_digest
+    export -f _capture_index_digest
 
     # tag_ext_image / push_ext_image must record calls for the ceiling version
     tag_ext_image() {
@@ -4152,8 +4152,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"\$pgv_build_log\"
@@ -4235,8 +4235,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"\$build_log\"
             return 0
@@ -4315,8 +4315,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"\$build_log\"
             return 0
@@ -4418,8 +4418,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image() { return 0; }
         export -f build_ext_image
         tag_ext_image()  { return 0; }
@@ -4513,8 +4513,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image() { return 0; }
         export -f build_ext_image
         tag_ext_image()  { return 0; }
@@ -4594,8 +4594,8 @@ _run_3state_probe() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         # skopeo mock: mirrors the tightened classification.
         skopeo() {
             local _not_found_pat='manifest unknown|name unknown|repository name not known|no such manifest'
@@ -4816,8 +4816,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"$build_log\"
@@ -4965,8 +4965,8 @@ _run_emit_versionset() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         skopeo() { printf "manifest unknown: manifest unknown\n" >&2; return 1; }
         export -f skopeo
     '
@@ -5005,8 +5005,8 @@ _run_emit_versionset() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         skopeo() { printf "manifest unknown: manifest unknown\n" >&2; return 1; }
         export -f skopeo
     '
@@ -5042,8 +5042,8 @@ _run_emit_versionset() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         skopeo() { printf "toomanyrequests: pull rate limit\n" >&2; return 1; }
         export -f skopeo
     '
@@ -5072,8 +5072,8 @@ _run_emit_versionset() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
     '
 
     run _run_emit_versionset "$mocks" '["2.25.0","2.26.0","2.27.1"]' "2.27.1" "true"
@@ -5101,8 +5101,8 @@ _run_emit_versionset() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
     '
 
     run _run_emit_versionset "$mocks" '["2.25.0","2.26.0","2.27.1"]' "2.27.1"
@@ -5499,8 +5499,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo \"BUILD ext=\${1} ver=\${2}\" >> \"$build_log\"
@@ -5582,8 +5582,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         pull_ext_image() { return 0; }
         export -f pull_ext_image
@@ -5660,8 +5660,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -5733,8 +5733,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -6023,8 +6023,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         build_ext_image()  { return 0; }
         export -f build_ext_image
         tag_ext_image()    { return 0; }
@@ -6086,171 +6086,6 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-1: resolver-backed ext with 3 available versions → after the
-# per-version build/tag/push loop, a bundle image is built AND pushed.
-# Bundle ref: ghcr.io/test/ext-timescaledb:pg18-bundle
-# Bundle build uses $DOCKER (DRY_RUN-aware).
-# ---------------------------------------------------------------------------
-
-@test "BUNDLE-1: 3 available versions → bundle built and pushed after per-version loop" {
-    local docker_log="$TEST_TEMP_DIR/bundle1_docker.log"
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    # Use $DOCKER="docker" (default from logging.sh) so the docker() function is called.
-    # The docker() mock records all calls including bundle build/push.
-    docker() {
-        echo "DOCKER_CMD=$1 ARGS=${*:2}" >> "$docker_log"
-        return 0
-    }
-    export -f docker
-    export docker_log
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
-
-    [ "$status" -eq 0 ]
-
-    # $DOCKER build must have been called with the bundle ref
-    [ -f "$docker_log" ]
-    grep -q "DOCKER_CMD=build" "$docker_log"
-    grep -q "pg18-bundle" "$docker_log"
-
-    # $DOCKER push must have been called with the bundle ref
-    grep -q "DOCKER_CMD=push" "$docker_log"
-}
-
-# ---------------------------------------------------------------------------
-# BUNDLE-2: DRY_RUN=true → bundle docker build/push command is echoed,
-# no real docker invocation.
-# ---------------------------------------------------------------------------
-
-@test "BUNDLE-2: DRY_RUN=true → bundle build+push commands echoed, not executed" {
-    export DRY_RUN=true
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    # Under DRY_RUN, $DOCKER is "echo docker" — capture that output
-    local real_build_log="$TEST_TEMP_DIR/bundle2_real_build.log"
-    build_ext_image() {
-        echo "REAL_BUILD ext=${1} ver=${2}" >> "$real_build_log"
-        return 0
-    }
-    export -f build_ext_image
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
-
-    [ "$status" -eq 0 ]
-
-    # Under DRY_RUN no real build occurred (build_ext_image not called)
-    local real_count
-    real_count=$(_count_log_lines "$real_build_log")
-    [ "$real_count" -eq 0 ]
-
-    # Output must mention the bundle ref (echoed, not executed)
-    [[ "$output" == *"pg18-bundle"* ]]
-}
-
-# ---------------------------------------------------------------------------
-# BUNDLE-3: LOCAL_ONLY=true → bundle is built locally, NOT pushed.
-# ---------------------------------------------------------------------------
-
-@test "BUNDLE-3: LOCAL_ONLY=true → bundle built locally, push NOT called" {
-    export LOCAL_ONLY=true
-
-    local docker_log="$TEST_TEMP_DIR/bundle3_docker.log"
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    docker() {
-        echo "DOCKER $*" >> "$docker_log"
-        return 0
-    }
-    export -f docker
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "false" "timescaledb"
-
-    [ "$status" -eq 0 ]
-
-    # Bundle build must have been called
-    [ -f "$docker_log" ]
-    grep -q "build.*pg18-bundle" "$docker_log"
-
-    # Bundle push must NOT have been called
-    ! grep -q "push.*pg18-bundle" "$docker_log"
-}
-
-# ---------------------------------------------------------------------------
-# BUNDLE-4: bundle build failure is fatal on the publish path (do_push=true).
-# ---------------------------------------------------------------------------
-
-@test "BUNDLE-4: bundle build failure → exit non-zero (fatal on publish path)" {
-    local docker_call_count=0
-    local docker_log="$TEST_TEMP_DIR/bundle4_docker.log"
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    # Per-version build/tag/push succeed; bundle docker build fails
-    docker() {
-        local cmd="$1"
-        echo "DOCKER $*" >> "$docker_log"
-        if [[ "$cmd" == "build" ]] && grep -q "bundle" <(echo "$*"); then
-            return 1
-        fi
-        return 0
-    }
-    export -f docker
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
-
-    # Bundle build failure must be fatal (non-zero exit)
-    [ "$status" -ne 0 ]
-}
-
-# ---------------------------------------------------------------------------
 # BUNDLE-5: empty available set → NO bundle is built.
 # If all per-version builds fail (e.g. ceiling fatal), available is empty
 # and build_tag_push_extensions should exit non-zero without building a bundle.
@@ -6294,435 +6129,6 @@ EOCFG
     if [ -f "$docker_log" ]; then
         ! grep -q "bundle" "$docker_log"
     fi
-}
-
-# ---------------------------------------------------------------------------
-# BUNDLE-6: bundle Dockerfile content — FROM scratch + per-version COPYs.
-# Verify the producer writes a bundle Dockerfile with the correct structure:
-#   FROM scratch
-#   COPY --from=<per-version-ref> /output/extension/ /<ver>/extension/
-#   COPY --from=<per-version-ref> /output/lib/ /<ver>/lib/
-# for each available version.
-# ---------------------------------------------------------------------------
-
-@test "BUNDLE-6: bundle Dockerfile has FROM scratch + per-version layout COPYs" {
-    local docker_log="$TEST_TEMP_DIR/bundle6_docker.log"
-    local bundle_df_capture="$TEST_TEMP_DIR/bundle6_df.txt"
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    # Capture the -f <dockerfile> path from the bundle docker build call,
-    # then copy its contents for assertion.
-    docker() {
-        echo "DOCKER $*" >> "$docker_log"
-        # When this is the bundle build call, capture the Dockerfile content.
-        if [[ "$1" == "build" ]]; then
-            local i
-            for (( i=1; i<=$#; i++ )); do
-                if [[ "${!i}" == "-f" ]]; then
-                    local next=$(( i + 1 ))
-                    local df_path="${!next}"
-                    if [[ -f "$df_path" ]]; then
-                        cp "$df_path" "$bundle_df_capture"
-                    fi
-                fi
-            done
-        fi
-        return 0
-    }
-    export -f docker
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
-
-    [ "$status" -eq 0 ]
-
-    # Bundle Dockerfile must exist and have been captured
-    [ -f "$bundle_df_capture" ]
-
-    # First line must be FROM scratch
-    local first_line
-    first_line=$(head -1 "$bundle_df_capture")
-    [ "$first_line" = "FROM scratch" ]
-
-    # Must contain per-version COPY lines: /output/extension/ -> /<ver>/extension/
-    grep -q "COPY --from=.*pg18-2.25.0.*/output/extension/ /2.25.0/extension/" "$bundle_df_capture"
-    grep -q "COPY --from=.*pg18-2.26.0.*/output/lib/ /2.26.0/lib/" "$bundle_df_capture"
-    grep -q "COPY --from=.*pg18-2.27.1.*/output/extension/ /2.27.1/extension/" "$bundle_df_capture"
-
-    # Must NOT use FROM scratch as anything other than the first line
-    local scratch_count
-    scratch_count=$(grep -c "FROM scratch" "$bundle_df_capture")
-    [ "$scratch_count" -eq 1 ]
-}
-
-# ---------------------------------------------------------------------------
-# AJ-1: all-cached path still assembles and pushes the bundle.
-# When ALL per-version images already exist in the registry, _should_build_extension
-# returns 1 (skip) and build_tag_push_extensions is never called. Before the fix,
-# the bundle is never (re)assembled on this path. After the fix, assemble_and_push_bundle
-# is called from main() after the all-cached early-exit, so the bundle always exists
-# and always reflects the current available[].
-#
-# RED before fix:  bundle docker build/push NOT called on all-cached path.
-# GREEN after fix: bundle docker build/push IS called even when no per-version build runs.
-# ---------------------------------------------------------------------------
-
-@test "AJ-all-cached-still-builds-bundle: all-cached path assembles and pushes the bundle" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-    local docker_log="$tmpd/aj1_docker.log"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    export docker_log
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        export docker_log=\"$docker_log\"
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All per-version images already in registry — per-version build loop is skipped.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-
-        # Record docker calls.
-        docker() {
-            echo \"DOCKER_CMD=\$1 ARGS=\${*:2}\" >> \"\$docker_log\"
-            return 0
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        build_ext_image() {
-            echo 'BUILD_CALLED' >> \"$tmpd/aj1_build.log\"
-            return 0
-        }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    [ "$status" -eq 0 ]
-
-    # No per-version build must have occurred (all-cached).
-    local build_count
-    build_count=$(_count_log_lines "$tmpd/aj1_build.log")
-    [ "$build_count" -eq 0 ]
-
-    # Bundle docker build MUST have been called (AJ fix assertion).
-    # Before fix: docker_log absent or has no bundle entry → RED.
-    # After fix:  docker build pg18-bundle present → GREEN.
-    [ -f "$docker_log" ]
-    grep -q "DOCKER_CMD=build" "$docker_log"
-    grep -q "pg18-bundle" "$docker_log"
-
-    # Bundle docker push MUST have been called on the publish path.
-    grep -q "DOCKER_CMD=push" "$docker_log"
-}
-
-# ---------------------------------------------------------------------------
-# AJ-2: bundle assembled from the AVAILABLE set (not a stale or larger set).
-# The bundle Dockerfile must COPY exactly the versions that are currently
-# available in the registry — no more, no fewer.
-#
-# Scenario: resolved set = [2.25.0, 2.26.0, 2.27.1]; 2.25.0 is absent
-# from the registry (musl-failed previously); 2.26.0 and 2.27.1 are present.
-# The all-cached path (2.26.0 and 2.27.1 are cached, 2.25.0 never built) runs
-# because _should_build_extension sees 2.25.0 absent — wait, 2.25.0 is absent
-# so _should_build_extension returns 0 (needs build). Adjust: available = those
-# currently present; we use the build path but confirm the bundle only copies
-# from available versions (not from 2.25.0 which fails to build).
-#
-# Strategy: 3-version resolver; 2.25.0 build fails (musl); 2.26.0 and 2.27.1
-# succeed. Bundle Dockerfile must only contain COPYs for 2.26.0 and 2.27.1.
-# ---------------------------------------------------------------------------
-
-@test "AJ-bundle-matches-available: bundle Dockerfile copies only available versions" {
-    local docker_log="$TEST_TEMP_DIR/aj2_docker.log"
-    local bundle_df_capture="$TEST_TEMP_DIR/aj2_df.txt"
-
-    resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
-    export -f resolve_version_set
-
-    ext_config() {
-        case "$2" in
-            version) echo "2.27.1" ;;
-            repo)    echo "https://github.com/timescale/timescaledb" ;;
-            *)       echo "" ;;
-        esac
-    }
-    export -f ext_config
-
-    # 2.25.0 fails to build (musl incompatibility)
-    build_ext_image() {
-        if [[ "$2" == "2.25.0" ]]; then
-            return 1
-        fi
-        echo "BUILD_CALLED ext=${1} ver=${2}" >> "$TEST_TEMP_DIR/build_calls.log"
-        return 0
-    }
-    export -f build_ext_image
-
-    # Capture the bundle Dockerfile content.
-    # Production-faithful: build/push succeed; manifest inspect returns "manifest unknown"
-    # (2.25.0 was never pushed — this is the definitive-absent signal from the registry).
-    # 2.26.0 and 2.27.1 are in _built_this_run_set so _image_present_3state skips the
-    # probe for them; only 2.25.0 reaches the probe, and "manifest unknown" correctly
-    # classifies it as ABSENT (rc=1), keeping it out of confirmed_available.
-    docker() {
-        local _dcmd="${1:-}"
-        echo "DOCKER $*" >> "$docker_log"
-        if [[ "$_dcmd" == "build" ]]; then
-            local i
-            for (( i=1; i<=$#; i++ )); do
-                if [[ "${!i}" == "-f" ]]; then
-                    local next=$(( i + 1 ))
-                    local df_path="${!next}"
-                    if [[ -f "$df_path" ]]; then
-                        cp "$df_path" "$bundle_df_capture"
-                    fi
-                fi
-            done
-            return 0
-        fi
-        if [[ "$_dcmd" == "push" ]]; then
-            return 0
-        fi
-        if [[ "$*" == *"manifest inspect"* ]]; then
-            printf 'manifest unknown: manifest unknown\n' >&2
-        fi
-        return 1
-    }
-    export -f docker
-
-    run build_tag_push_extensions \
-        "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" "true" "timescaledb"
-
-    [ "$status" -eq 0 ]
-
-    # Bundle Dockerfile must have been captured.
-    [ -f "$bundle_df_capture" ]
-
-    # Must contain COPY lines for the available versions (2.26.0 and 2.27.1).
-    grep -q "2.26.0" "$bundle_df_capture"
-    grep -q "2.27.1" "$bundle_df_capture"
-
-    # Must NOT contain a COPY for the failed (unavailable) version 2.25.0.
-    ! grep -q "2.25.0" "$bundle_df_capture"
-}
-
-# ---------------------------------------------------------------------------
-# AJ-3: all-cached + LOCAL_ONLY=true → bundle is built, NOT pushed.
-# On the all-cached path with LOCAL_ONLY, the bundle must be assembled from
-# the available per-version images (already in local store from prior pulls/builds),
-# but must not be pushed to the registry.
-# ---------------------------------------------------------------------------
-
-@test "AJ-local-only-no-push: all-cached + LOCAL_ONLY=true → bundle built, not pushed" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-    local docker_log="$tmpd/aj3_docker.log"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    export docker_log
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=true DRY_RUN=false CONTAINER=postgres
-        export docker_log=\"$docker_log\"
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # LOCAL_ONLY: all versions present locally (docker image inspect returns 0).
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            echo \"DOCKER_CMD=\$_dcmd ARGS=\${*:2}\" >> \"\$docker_log\"
-            if [[ \"\$_dcmd\" == \"image\" ]]; then
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == \"build\" || \"\$_dcmd\" == \"push\" ]]; then
-                return 0
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        # image_exists_in_registry not consulted in LOCAL_ONLY mode for per-version skip check
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        build_ext_image() {
-            echo 'BUILD_CALLED' >> \"$tmpd/aj3_build.log\"
-            return 0
-        }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18 --local-only
-    "
-
-    [ "$status" -eq 0 ]
-
-    # Bundle docker build MUST have been called.
-    [ -f "$docker_log" ]
-    grep -q "DOCKER_CMD=build" "$docker_log"
-    grep -q "pg18-bundle" "$docker_log"
-
-    # Bundle docker push must NOT have been called (LOCAL_ONLY=true).
-    ! grep -qE "DOCKER_CMD=push.*pg18-bundle|DOCKER_CMD=push.+bundle" "$docker_log"
-}
-
-# ---------------------------------------------------------------------------
-# AJ-4: bundle push failure on the publish path is fatal (exit non-zero).
-# After the all-cached path assembles the bundle, if the push fails the run
-# must exit non-zero so CI does not silently succeed with a missing bundle tag.
-# ---------------------------------------------------------------------------
-
-@test "AJ-publish-bundle-failure-fatal: bundle push failure on publish path exits non-zero" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All per-version images already in registry.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-
-        # Bundle build succeeds; bundle push FAILS (registry error).
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            if [[ \"\$_dcmd\" == \"build\" ]]; then
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == \"push\" ]]; then
-                return 1
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()   { return 0; }
-        export -f tag_ext_image
-        push_ext_image()  { return 0; }
-        export -f push_ext_image
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Bundle push failure must be fatal on the publish path.
-    [ "$status" -ne 0 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -6825,8 +6231,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
@@ -6957,8 +6363,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -7072,464 +6478,6 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AK-atomic: artifact is written ONLY AFTER a successful bundle push.
-# Simulating a bundle push failure: artifact must NOT be written, exit non-zero.
-#
-# RED before fix: _emit_final_versionset_pass runs after build_tag_push_extensions
-#   (which called assemble_and_push_bundle and returned non-zero on push failure),
-#   but build_tag_push_extensions exits 1 before returning to main(), so main()
-#   already propagates the non-zero. The artifact writing happens in _emit_final_-
-#   versionset_pass which is called AFTER build_tag_push_extensions → the question
-#   is: does main() still call _emit_final_versionset_pass after build_tag_push_-
-#   extensions exits 1?
-# In the current code: build_tag_push_extensions calls exit 1 (not return 1) when
-#   failed[] is non-empty, so main() never reaches _emit_final_versionset_pass.
-#   This test verifies that specific path: bundle push fails → build_tag_push_extensions
-#   exits non-zero → main() propagates exit code → no artifact written.
-# ---------------------------------------------------------------------------
-@test "AK-atomic: bundle push failure → no versionset artifact written, exit non-zero" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All per-version images absent from registry → all need to be built.
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        # Per-version build, tag, push: all succeed.
-        # Bundle docker: build succeeds, push FAILS (simulates registry error on bundle push).
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            if [[ \"\$_dcmd\" == \"build\" ]]; then
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == \"push\" ]]; then
-                # Bundle push failure.
-                if [[ \"\$*\" == *'bundle'* ]]; then
-                    return 1
-                fi
-                return 0
-            fi
-            if [[ \"\$*\" == *'manifest inspect'* ]]; then
-                echo 'manifest unknown: manifest unknown' >&2
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Bundle push failure → exit non-zero.
-    [ "$status" -ne 0 ]
-
-    # No versionset artifact must have been written (atomic: artifact only after bundle push).
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
-# INV-bundle-eq-artifact: confirmed_available is computed ONCE and drives BOTH
-# the bundle COPYs and the artifact available[].
-#
-# Scenario: all per-version builds succeed; confirmed_available = {2.26.0, 2.27.1}
-# (2.25.0 fails to build → never pushed → absent from registry; 2.26.0 and 2.27.1
-# are pushed). The bundle Dockerfile COPY lines and the artifact available[] must
-# be EXACTLY {2.26.0, 2.27.1} — same set, same source.
-#
-# RED before fix: bundle is built from _available_for_bundle (inner-loop tracking),
-#   while the artifact re-probes independently via _image_present_3state. With a
-#   stateful mock they stay in sync, but the divergence is visible if the probe is
-#   overridden to disagree with the inner loop. After the fix, both come from the
-#   same confirmed_available variable, so equality is structural.
-# GREEN after fix: artifact.available[] set == bundle COPY versions == confirmed set.
-# ---------------------------------------------------------------------------
-@test "INV-bundle-eq-artifact: confirmed_available drives both bundle COPYs and artifact available[]" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-    local bundle_df_cap="$tmpd/inv_beqa_bundle_df.txt"
-    local docker_log="$tmpd/inv_beqa_docker.log"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    export bundle_df_cap docker_log
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        export bundle_df_cap=\"$bundle_df_cap\" docker_log=\"$docker_log\"
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # 2.25.0 absent from registry (never built/pushed); 2.26.0 and 2.27.1 absent
-        # initially — they are built and pushed in this run (stateful mock).
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        # 2.25.0 fails to build; 2.26.0 and 2.27.1 succeed.
-        build_ext_image() {
-            [[ \"\$2\" == '2.25.0' ]] && return 1
-            return 0
-        }
-        export -f build_ext_image
-        tag_ext_image() { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        # Bundle docker mock: capture the Dockerfile content at build time.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            if [[ \"\$_dcmd\" == 'build' ]]; then
-                echo \"DOCKER_CMD=build args=\$*\" >> \"\$docker_log\"
-                local _found_f=false _df_arg
-                for _a in \"\$@\"; do
-                    [[ \"\$_found_f\" == 'true' ]] && { _df_arg=\"\$_a\"; _found_f=false; }
-                    [[ \"\$_a\" == '-f' ]] && _found_f=true
-                done
-                [[ -n \"\$_df_arg\" && -f \"\$_df_arg\" ]] && cp \"\$_df_arg\" \"\$bundle_df_cap\"
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == 'push' ]]; then
-                return 0
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        # 3-state probe used by _emit_versionset_artifact and the all-cached refresh loop.
-        # 2.25.0 ABSENT (build failed, never pushed); 2.26.0 and 2.27.1 PRESENT
-        # (pushed this run — guarded by _built_this_run_set in _emit_versionset_artifact).
-        _image_present_3state() {
-            case \"\$1\" in
-                *pg18-2.25.0*) return 1 ;;
-                *pg18-2.26.0*) return 0 ;;
-                *pg18-2.27.1*) return 0 ;;
-                *)             return 1 ;;
-            esac
-        }
-        export -f _image_present_3state
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Non-ceiling musl failure → exit 0.
-    [ "$status" -eq 0 ]
-
-    # The artifact must exist.
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    [ -f "$artifact" ]
-
-    # artifact.available[] must be exactly {2.26.0, 2.27.1} (2 entries, ceiling present).
-    local art_avail_count
-    art_avail_count=$(jq '.available | length' "$artifact")
-    [ "$art_avail_count" -eq 2 ]
-
-    local art_avail
-    art_avail=$(jq -r '.available[]' "$artifact")
-    [[ "$art_avail" == *'2.26.0'* ]]
-    [[ "$art_avail" == *'2.27.1'* ]]
-    [[ "$art_avail" != *'2.25.0'* ]]
-
-    # The bundle Dockerfile must have been produced.
-    [ -f "$bundle_df_cap" ]
-
-    # Bundle Dockerfile must COPY exactly 2.26.0 and 2.27.1 — same set as artifact.
-    grep -q "2.26.0" "$bundle_df_cap"
-    grep -q "2.27.1" "$bundle_df_cap"
-    ! grep -q "2.25.0" "$bundle_df_cap"
-
-    # Equality invariant: bundle COPY version count must equal artifact available[] count.
-    local bundle_copy_count
-    bundle_copy_count=$(grep -c "^COPY " "$bundle_df_cap" || true)
-    # Each version contributes 2 COPY lines (/output/extension/ and /output/lib/).
-    local expected_copy_lines=$(( art_avail_count * 2 ))
-    [ "$bundle_copy_count" -eq "$expected_copy_lines" ]
-}
-
-# ---------------------------------------------------------------------------
-# INV-bundle-push-fail-no-artifact: all per-version builds succeed but
-# $DOCKER push of the BUNDLE fails → NO versionset artifact is written (and a
-# pre-existing stale one is deleted) AND exit non-zero.
-#
-# RED before fix: on the build path, build_tag_push_extensions adds $ext@bundle
-#   to failed[] and exits 1, so _emit_final_versionset_pass never runs and no
-#   NEW artifact is written. But a PRE-EXISTING stale artifact survives — this
-#   test seeds a stale artifact and asserts it is DELETED on bundle push failure.
-# GREEN after fix: bundle push failure → stale artifact deleted → exit non-zero.
-# ---------------------------------------------------------------------------
-@test "INV-bundle-push-fail-no-artifact: bundle push fails → stale artifact deleted, exit non-zero" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    local lineage_dir="$tmpd/.build-lineage"
-    mkdir -p "$lineage_dir"
-
-    # Pre-seed a stale artifact from a prior run.
-    local artifact="$lineage_dir/ext-timescaledb-pg18-versionset.json"
-    printf '{"ext":"timescaledb","pg_major":"18","ceiling":"2.26.0","resolved":["2.26.0"],"available":["2.26.0"],"excluded":[]}\n' \
-        > "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All per-version images absent → all are built in this run.
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        # All per-version builds, tags, pushes succeed.
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        # docker build succeeds; docker push FAILS for the bundle.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            if [[ \"\$_dcmd\" == 'build' ]]; then
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == 'push' ]]; then
-                if [[ \"\$*\" == *'bundle'* ]]; then
-                    return 1
-                fi
-                return 0
-            fi
-            if [[ \"\$*\" == *'manifest inspect'* ]]; then
-                echo 'manifest unknown: manifest unknown' >&2
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Bundle push failure → exit non-zero.
-    [ "$status" -ne 0 ]
-
-    # The stale artifact MUST have been deleted (not silently left for the consumer).
-    # RED before fix: artifact is never touched because build_tag_push_extensions exits 1
-    #   before _emit_final_versionset_pass runs, leaving the stale artifact in place.
-    # GREEN after fix: bundle failure triggers stale artifact deletion.
-    [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
-# INV-allcached-bundle-fail-fatal: all-cached path, bundle refresh push fails
-# → exit non-zero AND no artifact written (the _fp_rc clobber is fixed).
-#
-# RED before fix: _fp_rc is declared (=0) before _emit_final_versionset_pass,
-#   but the bundle refresh failure accumulates into _fp_rc AFTER the emit pass.
-#   If the emit pass succeeds (writes artifact), then the bundle refresh fails
-#   (_fp_rc becomes 1), the exit is non-zero — that part works. But the artifact
-#   was already written by the emit pass BEFORE the bundle push — so the artifact
-#   exists even though the bundle push failed. The invariant "artifact present ⟺
-#   bundle pushed OK" is violated.
-# GREEN after fix: on the all-cached path, the confirmed_available set drives
-#   BOTH the bundle push AND the artifact write; the artifact is written ONLY
-#   AFTER a successful bundle push.
-# ---------------------------------------------------------------------------
-@test "INV-allcached-bundle-fail-fatal: all-cached path, bundle push fails → exit non-zero, no artifact" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    # No pre-existing artifact.
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All per-version images already in registry (all-cached path).
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        # All versions probed as PRESENT (all-cached scenario).
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        # Bundle build succeeds; bundle push FAILS (network error).
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            if [[ \"\$_dcmd\" == 'build' ]]; then
-                return 0
-            fi
-            if [[ \"\$_dcmd\" == 'push' ]]; then
-                return 1
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # All-cached path with bundle push failure → exit non-zero.
-    [ "$status" -ne 0 ]
-
-    # No artifact must be written (bundle push failed — atomic invariant).
-    # RED before fix: _emit_final_versionset_pass runs first and writes the artifact,
-    #   then the bundle refresh fails — artifact is present but bundle is missing.
-    # GREEN after fix: artifact is written only after a successful bundle push.
-    [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
 # INV-transient-failclosed: 3-state ERROR on one resolved version on the
 # publish path → no bundle assembled, no artifact written, exit non-zero.
 #
@@ -7606,8 +6554,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -7627,167 +6575,6 @@ EOCFG
 
     # No artifact must be written.
     [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
-# INV-artifact-after-bundle: ordering invariant — the artifact does NOT exist
-# until AFTER a successful bundle push; a mock that fails the push leaves no
-# artifact; a mock that succeeds leaves both.
-#
-# This test verifies the ordering with two sub-cases in sequence:
-#   (a) bundle push fails → no artifact → exit non-zero
-#   (b) bundle push succeeds → artifact present → exit zero
-# ---------------------------------------------------------------------------
-@test "INV-artifact-after-bundle: artifact written only after successful bundle push (ordering)" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    # --- Sub-case (a): bundle push fails → no artifact ---
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All cached: skip-build path.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-
-        # All versions PRESENT via 3-state.
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        # Bundle push FAILS.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            [[ \"\$_dcmd\" == 'build' ]] && return 0
-            [[ \"\$_dcmd\" == 'push' ]] && return 1
-            return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Sub-case (a): push failed → exit non-zero, no artifact.
-    [ "$status" -ne 0 ]
-    [ ! -f "$artifact" ]
-
-    # --- Sub-case (b): bundle push succeeds → artifact present ---
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All cached.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-
-        # All versions PRESENT via 3-state.
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()  { return 0; }
-        export -f tag_ext_image
-        push_ext_image() { return 0; }
-        export -f push_ext_image
-
-        # Bundle push SUCCEEDS.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            [[ \"\$_dcmd\" == 'build' || \"\$_dcmd\" == 'push' ]] && return 0 || return 1
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        validate_prerequisites()  { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()     { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Sub-case (b): push succeeded → exit zero, artifact present.
-    [ "$status" -eq 0 ]
-    [ -f "$artifact" ]
-
-    # Artifact must have ceiling and available[].
-    local ceiling
-    ceiling=$(jq -r '.ceiling' "$artifact")
-    [ "$ceiling" = "2.27.1" ]
-
-    local avail_count
-    avail_count=$(jq '.available | length' "$artifact")
-    [ "$avail_count" -gt 0 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -7855,8 +6642,8 @@ EOCFG
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()      { return 0; }
         export -f validate_prerequisites
@@ -7883,361 +6670,6 @@ EOCFG
     # from the bundle assembly path.  The per-version build goes through build_ext_image()
     # (overridden separately), NOT through docker() directly, so bundle_call_log is clean.
     [ ! -f "$bundle_call_log" ]
-}
-
-# ---------------------------------------------------------------------------
-# AM-artifact-records-digest: resolver-backed ext, set>1, bundle push succeeds
-# → the written versionset artifact contains a non-empty bundle_digest field.
-# RED before fix: artifact has no bundle_digest field.
-# GREEN after fix: artifact.bundle_digest matches the sha256 returned by the
-# digest-capture mock.
-# ---------------------------------------------------------------------------
-@test "AM-artifact-records-digest: bundle push succeeds → artifact contains non-empty bundle_digest" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All images present so no build is needed; triggered via all-cached path.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()   { return 0; }
-        export -f tag_ext_image
-        push_ext_image()  { return 0; }
-        export -f push_ext_image
-
-        # Bundle build+push succeed; digest capture succeeds.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            case \"\$_dcmd\" in
-                build) return 0 ;;
-                push)  return 0 ;;
-                buildx)
-                    # imagetools inspect --format '{{.Manifest.Digest}}' → emit a digest
-                    if [[ \"\$*\" == *'imagetools'* && \"\$*\" == *'inspect'* ]]; then
-                        echo 'sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
-                        return 0
-                    fi
-                    return 1
-                    ;;
-                *)     return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
-
-        validate_prerequisites()      { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()         { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    [ "$status" -eq 0 ]
-
-    # Artifact must be present.
-    [ -f "$artifact" ]
-
-    # Must contain a non-empty bundle_digest field.
-    # RED before fix: .bundle_digest is null/absent.
-    # GREEN after fix: .bundle_digest == 'sha256:abcdef...'
-    local digest
-    digest=$(jq -r '.bundle_digest // empty' "$artifact")
-    [[ -n "$digest" ]]
-    [[ "$digest" == sha256:* ]]
-}
-
-# ---------------------------------------------------------------------------
-# AM-digest-capture-fail-fatal: bundle push succeeds but digest capture fails
-# → fail closed: no artifact written, exit non-zero.
-# RED before fix: artifact is written (no digest capture, no digest field).
-# GREEN after fix: digest capture failure after push is fatal — no artifact.
-# ---------------------------------------------------------------------------
-@test "AM-digest-capture-fail-fatal: bundle push OK but digest capture fails → no artifact, exit non-zero" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()   { return 0; }
-        export -f tag_ext_image
-        push_ext_image()  { return 0; }
-        export -f push_ext_image
-
-        # Bundle build+push succeed; digest capture FAILS.
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            case \"\$_dcmd\" in
-                build) return 0 ;;
-                push)  return 0 ;;
-                buildx)
-                    # imagetools inspect → simulate failure (e.g. transient registry error)
-                    if [[ \"\$*\" == *'imagetools'* && \"\$*\" == *'inspect'* ]]; then
-                        echo 'error: manifest unknown' >&2
-                        return 1
-                    fi
-                    return 1
-                    ;;
-                *)     return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-
-        validate_prerequisites()      { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()         { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # RED before fix: exits 0 (artifact written without digest).
-    # GREEN after fix: exits non-zero (fail closed — cannot guarantee immutable ref).
-    [ "$status" -ne 0 ]
-
-    # No artifact must be written (digest capture failed → fail-closed, no partial artifact).
-    [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
-# AN-producer: strict OCI digest validation at the producer boundary.
-#
-# _capture_bundle_digest output flows directly into the artifact bundle_digest
-# field and from there into the generated Dockerfile COPY line.  A poisoned
-# or malformed value (uppercase hex, short hash, embedded whitespace/newline,
-# extra tokens after the hash) must be rejected BEFORE the artifact is written.
-#
-# Fix: `is_valid_oci_digest` validates the whole captured string:
-#   - MUST match exactly: sha256: followed by exactly 64 lowercase hex chars
-#   - Embedded newlines MUST be rejected (bash $= in =~ can match before \n)
-#   - Zero trailing content allowed
-#
-# AN-producer-rejects-malformed-digest: each malformed form → FATAL, no artifact.
-# AN-producer-accepts-valid: proper sha256:<64hex> → artifact written (regression).
-# ---------------------------------------------------------------------------
-
-# Helper: drive _bundle_and_write_artifact in a subprocess via main() so the
-# artifact write gate is exercised. All versions present in registry (no build
-# needed), digest injected via _capture_bundle_digest mock.
-_run_an_producer() {
-    # Args: <digest_to_return>
-    local digest_value="$1"
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    # version.sh so detect_major_version can run
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        # All versions in registry — no builds needed, just bundle + artifact.
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-        _image_present_3state() { return 0; }
-        export -f _image_present_3state
-
-        build_ext_image() { return 0; }
-        export -f build_ext_image
-        tag_ext_image()   { return 0; }
-        export -f tag_ext_image
-        push_ext_image()  { return 0; }
-        export -f push_ext_image
-
-        # Bundle build+push succeed; digest is what we control.
-        docker() {
-            local _dc=\"\${1:-}\"
-            case \"\$_dc\" in
-                build) return 0 ;;
-                push)  return 0 ;;
-                *) return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-
-        # _capture_bundle_digest returns the digest under test.
-        _capture_bundle_digest() {
-            printf '%s' '$digest_value'
-            return 0
-        }
-        export -f _capture_bundle_digest
-
-        validate_prerequisites()      { return 0; }
-        export -f validate_prerequisites
-        check_registry_auth()         { return 0; }
-        export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-}
-
-@test "AN-producer-rejects-uppercase-hex: sha256:DEADBEEF... uppercase → FATAL, no artifact" {
-    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    # Uppercase hex — should be rejected (valid OCI digest is lowercase only)
-    local bad_digest="sha256:DEADBEEF00000000000000000000000000000000000000000000000000000000"
-    _run_an_producer "$bad_digest"
-
-    # RED before fix: exits 0, artifact written with uppercase digest.
-    # GREEN after fix: exits non-zero (strict validator rejects uppercase hex).
-    [ "$status" -ne 0 ]
-    # Artifact must NOT be written.
-    [ ! -f "$artifact" ]
-}
-
-@test "AN-producer-rejects-short-hash: sha256:<63hex> too short → FATAL, no artifact" {
-    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    # 63 hex chars — one short of a valid sha256 digest
-    local bad_digest="sha256:000000000000000000000000000000000000000000000000000000000000000"
-    _run_an_producer "$bad_digest"
-
-    [ "$status" -ne 0 ]
-    [ ! -f "$artifact" ]
-}
-
-@test "AN-producer-rejects-extra-tokens: sha256:<64hex> extra trailing content → FATAL, no artifact" {
-    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    # Valid digest followed by extra content (e.g. injected Dockerfile directive)
-    local bad_digest="sha256:0000000000000000000000000000000000000000000000000000000000000000 extra"
-    _run_an_producer "$bad_digest"
-
-    [ "$status" -ne 0 ]
-    [ ! -f "$artifact" ]
-}
-
-@test "AN-producer-rejects-embedded-newline: sha256:<64hex>\\nRUN evil → FATAL, no artifact" {
-    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    # Digest with embedded newline followed by a Dockerfile injection attempt.
-    # This is the canonical newline bypass: bash "=~" matches $ before \n.
-    local bad_digest
-    bad_digest=$(printf 'sha256:0000000000000000000000000000000000000000000000000000000000000000\nRUN evil')
-    _run_an_producer "$bad_digest"
-
-    [ "$status" -ne 0 ]
-    [ ! -f "$artifact" ]
-}
-
-@test "AN-producer-accepts-valid: proper sha256:<64lowercase-hex> → artifact written" {
-    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    local good_digest="sha256:abcdef0000000000000000000000000000000000000000000000000000000000"
-    _run_an_producer "$good_digest"
-
-    # Regression: a valid digest must succeed.
-    [ "$status" -eq 0 ]
-    # Artifact must be written.
-    [ -f "$artifact" ]
-    # The artifact must contain the exact valid digest.
-    local recorded
-    recorded=$(jq -r '.bundle_digest' "$artifact")
-    [ "$recorded" = "$good_digest" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -8333,8 +6765,8 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()      { return 0; }
         export -f validate_prerequisites
@@ -8427,10 +6859,10 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo 'manifest unknown' >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
         build_ext_image() { return 0; }; export -f build_ext_image
         tag_ext_image()  { return 0; };  export -f tag_ext_image
         push_ext_image() { return 0; };  export -f push_ext_image
@@ -8456,176 +6888,6 @@ _run_an_producer() {
     [ ! -f "$artifact" ]
 }
 
-@test "AQ1-master-allcached-pushes: all-cached + do_push=true (master) → bundle pushed + artifact written" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    local push_call_log="${tmpd}/aq1master_push.log"
-    local artifact="${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false PULL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        # NO NO_PUSH — master/publish path, do_push=true by default.
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-        docker() {
-            local _cmd=\"\${1:-}\"
-            if [[ \"\$_cmd\" == 'push' || \"\$_cmd\" == 'build' ]]; then
-                echo \"DOCKER_\${_cmd^^}\" >> \"$push_call_log\"
-                return 0
-            fi
-            if [[ \"\$*\" == *'buildx'* ]]; then
-                echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
-                return 0
-            fi
-            if [[ \"\$*\" == *'manifest inspect'* ]]; then
-                echo 'manifest unknown: manifest unknown' >&2
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo 'manifest unknown' >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() {
-            echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
-        }
-        export -f _capture_bundle_digest
-        build_ext_image() { return 0; }; export -f build_ext_image
-        tag_ext_image()  { return 0; };  export -f tag_ext_image
-        push_ext_image() { return 0; };  export -f push_ext_image
-        validate_prerequisites()  { return 0; }; export -f validate_prerequisites
-        check_registry_auth()     { return 0; }; export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-        main postgres --major-version 18
-    "
-
-    [ "$status" -eq 0 ]
-
-    # Publish path: docker push MUST have been called for the bundle.
-    local push_count
-    push_count=$(_count_log_lines "$push_call_log")
-    [ "$push_count" -gt 0 ]
-
-    # Artifact MUST be written.
-    [ -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
-# AX4: same-repo PR / push — NO_PUSH unset → do_push=true → build+push.
-#
-# Context: the workflow previously set NO_PUSH=true for ALL pull_request events,
-# which prevented pushing on same-repo PRs even though they have packages:write.
-# AX-4 reverts that: fork PRs are excluded by the job if: clause, so
-# build-extensions only runs for push/dispatch and same-repo PRs.  On those
-# events NO_PUSH is not set → do_push=true → build+push happens normally.
-#
-# This test is a regression guard confirming the revert: with NO_PUSH unset
-# (same-repo PR or push context) the script pushes the bundle and writes the
-# versionset artifact — the full end-to-end smoke path.
-# ---------------------------------------------------------------------------
-@test "AX4-samerepo-pr-pushes: NO_PUSH unset (same-repo PR / push) → do_push=true → bundle pushed + artifact written" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    local push_call_log="${tmpd}/ax4_samerepo_push.log"
-    local artifact="${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    rm -f "$artifact"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false PULL_ONLY=false DRY_RUN=false CONTAINER=postgres
-        # NO_PUSH is intentionally NOT set — simulates same-repo PR or push context
-        # where the workflow no longer sets NO_PUSH (AX-4 revert).
-        unset NO_PUSH
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-        image_exists_in_registry() { return 0; }
-        export -f image_exists_in_registry
-        docker() {
-            local _cmd=\"\${1:-}\"
-            if [[ \"\$_cmd\" == 'push' || \"\$_cmd\" == 'build' ]]; then
-                echo \"DOCKER_\${_cmd^^}\" >> \"$push_call_log\"
-                return 0
-            fi
-            if [[ \"\$*\" == *'buildx'* ]]; then
-                echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
-                return 0
-            fi
-            if [[ \"\$*\" == *'manifest inspect'* ]]; then
-                echo 'manifest unknown: manifest unknown' >&2
-            fi
-            return 1
-        }
-        export -f docker
-        skopeo() { echo 'manifest unknown' >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() {
-            echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
-        }
-        export -f _capture_bundle_digest
-        build_ext_image() { return 0; }; export -f build_ext_image
-        tag_ext_image()  { return 0; };  export -f tag_ext_image
-        push_ext_image() { return 0; };  export -f push_ext_image
-        validate_prerequisites()  { return 0; }; export -f validate_prerequisites
-        check_registry_auth()     { return 0; }; export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-        main postgres --major-version 18
-    "
-
-    # Must exit cleanly.
-    [ "$status" -eq 0 ]
-
-    # AX4 regression: docker push MUST have been called (do_push=true path).
-    # Before revert: NO_PUSH=true would suppress push. After revert: push fires.
-    local push_count
-    push_count=$(_count_log_lines "$push_call_log")
-    [ "$push_count" -gt 0 ]
-
-    # Artifact MUST be written (versionset consumed by postgres build-and-push).
-    [ -f "$artifact" ]
-}
 
 # ---------------------------------------------------------------------------
 # AX4 defensive: NO_PUSH=true still suppresses push (script honors it even
@@ -8680,10 +6942,10 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo 'manifest unknown' >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
         build_ext_image() { return 0; }; export -f build_ext_image
         tag_ext_image()  { return 0; };  export -f tag_ext_image
         push_ext_image() { return 0; };  export -f push_ext_image
@@ -8749,10 +7011,10 @@ _run_an_producer() {
         export -f skopeo
         image_exists_in_registry() { return 1; }
         export -f image_exists_in_registry
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
         build_ext_image() { return 0; }; export -f build_ext_image
         tag_ext_image()  { return 0; };  export -f tag_ext_image
         push_ext_image() { return 0; };  export -f push_ext_image
@@ -8839,10 +7101,10 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
         skopeo() { printf 'manifest unknown\n' >&2; return 1; }
         export -f skopeo
 
@@ -8907,9 +7169,9 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        # LOCAL_ONLY: _capture_bundle_digest not called (no push) → unset is fine.
-        _capture_bundle_digest() { echo ''; return 0; }
-        export -f _capture_bundle_digest
+        # LOCAL_ONLY: _capture_index_digest not called (no push) → unset is fine.
+        _capture_index_digest() { echo ''; return 0; }
+        export -f _capture_index_digest
         image_exists_in_registry() { return 1; }
         export -f image_exists_in_registry
         skopeo() { printf 'manifest unknown\n' >&2; return 1; }
@@ -8936,87 +7198,6 @@ _run_an_producer() {
     local digest_field
     digest_field=$(jq -r '.bundle_digest // "absent"' "$artifact")
     [ "$digest_field" = "absent" ]
-}
-
-# ---------------------------------------------------------------------------
-# AR-1 regression: do_push=true (normal publish path) — bundle pushed,
-# artifact written with digest.
-# ---------------------------------------------------------------------------
-@test "AR1-push-true-unchanged: do_push=true — bundle pushed, artifact with digest" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false PULL_ONLY=false DRY_RUN=false NO_PUSH=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        build_ext_image() { return 0; }; export -f build_ext_image
-        tag_ext_image()  { return 0; };  export -f tag_ext_image
-        push_ext_image() { return 0; };  export -f push_ext_image
-
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            case \"\$_dcmd\" in
-                build|push) return 0 ;;
-                manifest) printf 'manifest unknown\n' >&2; return 1 ;;
-                *) return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { echo manifest unknown >&2; return 1; }
-        export -f skopeo
-        _capture_bundle_digest() {
-            echo 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-            return 0
-        }
-        export -f _capture_bundle_digest
-        skopeo() { printf 'manifest unknown\n' >&2; return 1; }
-        export -f skopeo
-
-        validate_prerequisites() { return 0; }; export -f validate_prerequisites
-        check_registry_auth()     { return 0; }; export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    [ "$status" -eq 0 ]
-
-    # Publish path: artifact MUST be written.
-    local artifact="${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    [ -f "$artifact" ]
-
-    # Digest MUST be present on the publish path.
-    local digest_field
-    digest_field=$(jq -r '.bundle_digest // "absent"' "$artifact")
-    [ "$digest_field" != "absent" ]
-    [[ "$digest_field" == sha256:* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -9081,172 +7262,6 @@ _run_an_producer() {
 }
 
 # ---------------------------------------------------------------------------
-# AS-1: _capture_bundle_digest uses raw-manifest + sha256sum, not the
-#        unreliable --format '{{.Manifest.Digest}}' template field.
-#
-# AS1-digest-via-raw-manifest: when --raw returns a manifest, the produced
-# digest is sha256:<64 lowercase hex> and is recorded in the artifact.
-# RED before fix: the mock only stubs --raw; the old template-field path
-# returns empty → is_valid_oci_digest rejects → fatal even after a good push.
-# GREEN after fix: --raw output is hashed → valid sha256:<64hex> digest.
-# ---------------------------------------------------------------------------
-@test "AS1-digest-via-raw-manifest: --raw returns manifest → valid sha256 digest in artifact" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false PULL_ONLY=false DRY_RUN=false NO_PUSH=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        build_ext_image() { return 0; }; export -f build_ext_image
-        tag_ext_image()  { return 0; };  export -f tag_ext_image
-        push_ext_image() { return 0; };  export -f push_ext_image
-
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            case \"\$_dcmd\" in
-                build|push) return 0 ;;
-                buildx)
-                    # imagetools inspect: only --raw is stubbed; --format must NOT be called
-                    if [[ \"\$*\" == *'--raw'* ]]; then
-                        printf '{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"}'
-                        return 0
-                    fi
-                    # If old --format path is exercised, return empty to make test RED
-                    return 0
-                    ;;
-                manifest) printf 'manifest unknown\n' >&2; return 1 ;;
-                *) return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { printf 'manifest unknown\n' >&2; return 1; }
-        export -f skopeo
-
-        validate_prerequisites() { return 0; }; export -f validate_prerequisites
-        check_registry_auth()     { return 0; }; export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    [ "$status" -eq 0 ]
-
-    local artifact="${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    [ -f "$artifact" ]
-
-    local digest_field
-    digest_field=$(jq -r '.bundle_digest // "absent"' "$artifact")
-
-    # Must be a valid OCI digest (sha256: + 64 lowercase hex).
-    [[ "$digest_field" =~ ^sha256:[0-9a-f]{64}$ ]]
-}
-
-# ---------------------------------------------------------------------------
-# AS1-empty-raw-manifest-fatal: when --raw returns empty, digest capture
-# produces an empty string → is_valid_oci_digest rejects → fail closed
-# (assemble_and_push_bundle returns non-zero, no artifact written).
-# ---------------------------------------------------------------------------
-@test "AS1-empty-raw-manifest-fatal: --raw returns empty → digest empty → fail closed (exit non-zero, no artifact)" {
-    local tmpd="$TEST_TEMP_DIR"
-    local sd="$SCRIPTS_DIR"
-
-    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
-    chmod +x "${tmpd}/postgres/version.sh"
-
-    run bash -c "
-        export FORCE=false LOCAL_ONLY=false PULL_ONLY=false DRY_RUN=false NO_PUSH=false CONTAINER=postgres
-        cd \"$sd\"
-        source ./build-extensions.sh
-        export ROOT_DIR=\"$tmpd\"
-
-        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
-        export -f resolve_version_set
-
-        ext_config() {
-            case \"\$2\" in
-                version) echo '2.27.1' ;;
-                repo)    echo 'https://github.com/timescale/timescaledb' ;;
-                *)       echo '' ;;
-            esac
-        }
-        export -f ext_config
-
-        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
-        export -f ext_image_name
-        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
-        export -f ext_local_image_name
-
-        image_exists_in_registry() { return 1; }
-        export -f image_exists_in_registry
-
-        build_ext_image() { return 0; }; export -f build_ext_image
-        tag_ext_image()  { return 0; };  export -f tag_ext_image
-        push_ext_image() { return 0; };  export -f push_ext_image
-
-        docker() {
-            local _dcmd=\"\${1:-}\"
-            case \"\$_dcmd\" in
-                build|push) return 0 ;;
-                buildx)
-                    # imagetools inspect --raw returns empty (simulates CI failure case)
-                    if [[ \"\$*\" == *'--raw'* ]]; then
-                        printf ''
-                        return 1
-                    fi
-                    return 0
-                    ;;
-                manifest) printf 'manifest unknown\n' >&2; return 1 ;;
-                *) return 1 ;;
-            esac
-        }
-        export -f docker
-        skopeo() { printf 'manifest unknown\n' >&2; return 1; }
-        export -f skopeo
-
-        validate_prerequisites() { return 0; }; export -f validate_prerequisites
-        check_registry_auth()     { return 0; }; export -f check_registry_auth
-        list_extensions_by_priority() { echo 'timescaledb'; }
-        export -f list_extensions_by_priority
-
-        main postgres --major-version 18
-    "
-
-    # Empty raw-manifest → empty digest → fail closed.
-    [ "$status" -ne 0 ]
-
-    # No artifact must have been written (fail closed).
-    local artifact="${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json"
-    [ ! -f "$artifact" ]
-}
-
-# ---------------------------------------------------------------------------
 # AS-2: the failure-log site in assemble_and_push_bundle that logs the
 # captured digest must sanitize the value before logging.
 #
@@ -9307,13 +7322,13 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        # _capture_bundle_digest returns a malformed multi-line value with
+        # _capture_index_digest returns a malformed multi-line value with
         # an embedded GHA workflow command injection attempt.
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             printf 'sha256:abc\n::add-mask::x'
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         skopeo() { printf 'manifest unknown\n' >&2; return 1; }
         export -f skopeo
@@ -9538,8 +7553,8 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -9624,8 +7639,8 @@ _run_an_producer() {
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -9701,11 +7716,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo "BUILD_EXT_CALLED $*" >> "'"$docker_calls"'"
@@ -9797,11 +7812,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         build_ext_image() {
             echo "BUILD_EXT_CALLED $*" >> "'"$docker_calls"'"
@@ -9893,11 +7908,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -10013,11 +8028,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         build_ext_image() { return 0; }
         export -f build_ext_image
@@ -10050,24 +8065,27 @@ _run_an_producer() {
 
     [ "$status" -eq 0 ]
 
-    # Bundle assembled EXACTLY ONCE (AV-2 fix).
-    # Before fix: build_tag_push_extensions + _emit_final_versionset_pass both assemble => count=2 (RED).
-    # After fix:  final pass skips ext already bundled on the build path => count=1 (GREEN).
+    # AV-2 double-write guard: artifact written EXACTLY ONCE on the build path.
+    # build_tag_push_extensions writes it; _emit_final_versionset_pass is skipped
+    # for that ext via the sentinel file.
+    # No bundle is built — collector approach eliminates the bundle image entirely.
     local bundle_count
     bundle_count=$(_count_log_lines "$bundle_build_log")
-    [ "$bundle_count" -eq 1 ]
+    [ "$bundle_count" -eq 0 ]
+
+    # Artifact must exist (written by _bundle_and_write_artifact on the build path)
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
 }
 
 # ---------------------------------------------------------------------------
 # B-merge-creates-multiarch: finalize --finalize-multiarch for an ext with
-# versions [a,b,ceiling] invokes imagetools create for each version AND the
-# bundle, merging -amd64 + -arm64 suffixed refs into un-suffixed targets.
+# versions [a,b,ceiling] invokes imagetools create for each version, captures
+# per-version index digests (via imagetools inspect) + validates both platforms,
+# and writes the versionset artifact with version_digests. NO bundle build.
 # ---------------------------------------------------------------------------
 
-@test "B-merge-creates-multiarch: finalize-multiarch calls imagetools create for each version and builds bundle via buildx" {
-    # SIMP-merge-from-stable-tags: imagetools create uses stable SUFFIXED TAG refs
-    # (ext:pg18-2.25.0-amd64, ext:pg18-2.25.0-arm64), not @digest refs.
-    # Bundle is built via buildx build --platform, not imagetools create.
+@test "B-merge-creates-multiarch: finalize-multiarch calls imagetools create for each version, captures index digests, no bundle build" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -10105,18 +8123,25 @@ _run_an_producer() {
         # multi-arch manifests are absent (stage B creates them).
         image_exists_in_registry() {
             local ref="$1"
-            # Per-arch tags (ending in -amd64 or -arm64): PRESENT
             [[ "$ref" =~ -amd64$ ]] || [[ "$ref" =~ -arm64$ ]]
         }
         export -f image_exists_in_registry
 
-        # Mock docker to record all calls; succeed for all.
-        # manifest inspect returns manifest-unknown for absent un-suffixed refs.
+        # Mock docker:
+        # - manifest: returns not-found (un-suffixed manifests absent; stage B creates them)
+        # - buildx imagetools create: succeeds (merges per-arch into multi-arch)
+        # - buildx imagetools inspect: returns output containing both platforms
+        #   (needed by the platform-coverage check)
         docker() {
             echo "DOCKER $*" >> "$docker_calls"
             if [[ "$1" == "manifest" ]]; then
                 echo "manifest unknown: manifest unknown" >&2
                 return 1
+            fi
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                # Return fake inspect output with both platforms (platform-coverage check)
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
             fi
             return 0
         }
@@ -10124,11 +8149,12 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        # Stable mock: valid index digest returned by _capture_index_digest
+        _capture_index_digest() {
             echo "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10146,9 +8172,7 @@ _run_an_producer() {
     local calls
     calls=$(cat "$docker_calls")
 
-    # SIMP-merge-from-stable-tags: imagetools create for per-version merges MUST use
-    # stable suffixed TAG refs (not @digest refs). Verify the -amd64 and -arm64
-    # suffixed tag refs appear in the imagetools create calls.
+    # imagetools create for per-version merges MUST use stable suffixed TAG refs.
     [[ "$calls" == *"pg18-2.25.0-amd64"* ]]
     [[ "$calls" == *"pg18-2.25.0-arm64"* ]]
     [[ "$calls" == *"pg18-2.26.0-amd64"* ]]
@@ -10159,31 +8183,29 @@ _run_an_producer() {
     digest_lines=$(grep 'imagetools.*create' "$docker_calls" | grep '@sha256:' || true)
     [ -z "$digest_lines" ]
 
-    # Bundle must be built via buildx build --platform, NOT imagetools create.
-    # SIMP-bundle-from-available: bundle build uses --platform and --push.
-    grep -q 'buildx build.*--platform' "$docker_calls"
-    grep -q '\-\-push' "$docker_calls"
+    # NO bundle build via buildx build --platform (bundle approach removed).
+    local bundle_build_lines
+    bundle_build_lines=$(grep 'buildx build' "$docker_calls" || true)
+    [ -z "$bundle_build_lines" ]
 
-    # The bundle must NOT be assembled via imagetools create (old per-arch approach).
-    # pg18-bundle-amd64 and pg18-bundle-arm64 are not referenced in any imagetools create.
-    local bundle_imagetools_lines
-    bundle_imagetools_lines=$(grep 'imagetools.*create' "$docker_calls" | grep 'pg18-bundle' || true)
-    [ -z "$bundle_imagetools_lines" ]
+    # The pg18-bundle tag must NOT appear anywhere in the calls (bundle approach removed).
+    local bundle_ref_lines
+    bundle_ref_lines=$(grep 'pg18-bundle' "$docker_calls" || true)
+    [ -z "$bundle_ref_lines" ]
 
-    # Un-suffixed multi-arch targets must be in the imagetools create calls (the -t flag).
-    [[ "$calls" == *"-t "* ]]
-    # pg18-bundle (un-suffixed) must appear in the buildx build call.
-    grep -qE 'pg18-bundle' "$docker_calls"
+    # imagetools inspect must have been called (for digest capture + platform check)
+    local inspect_lines
+    inspect_lines=$(grep 'imagetools inspect' "$docker_calls" || true)
+    [ -n "$inspect_lines" ]
 }
 
 # ---------------------------------------------------------------------------
-# B-merge-captures-index-digest-and-writes-artifact: after bundle manifest
-# create, the index digest is captured (mock imagetools inspect --raw →
-# manifest) and the versionset artifact is written with
-# bundle_digest = sha256:<64hex>. Assert artifact content.
+# B-merge-captures-index-digest-and-writes-artifact: finalize-multiarch captures
+# per-version index digests and writes the versionset artifact with
+# version_digests = {"<ver>":"sha256:<64hex>", ...}. Assert artifact content.
 # ---------------------------------------------------------------------------
 
-@test "B-merge-captures-index-digest-and-writes-artifact: artifact written with bundle_digest" {
+@test "B-merge-captures-index-digest-and-writes-artifact: artifact written with version_digests map" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -10217,17 +8239,24 @@ _run_an_producer() {
         image_exists_in_registry() { return 0; }
         export -f image_exists_in_registry
 
-        docker() { return 0; }
+        # Mock docker: imagetools inspect returns platform output; everything else succeeds.
+        docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
+            return 0
+        }
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
         # Stable mock digest (64 hex chars).
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:cafebabe00000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10235,8 +8264,6 @@ _run_an_producer() {
         export -f check_registry_auth
         list_extensions_by_priority() { echo "timescaledb"; }
         export -f list_extensions_by_priority
-        skopeo() { echo "manifest unknown" >&2; return 1; }
-        export -f skopeo
 
         main postgres --major-version 18 --finalize-multiarch
     '
@@ -10246,10 +8273,20 @@ _run_an_producer() {
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
     [ -f "$artifact" ]
 
-    # bundle_digest must be the SHA256 returned by the mock.
-    local bd
-    bd=$(jq -r '.bundle_digest' "$artifact")
-    [ "$bd" = "sha256:cafebabe00000000000000000000000000000000000000000000000000000000" ]
+    # version_digests must be present (object with per-version digests).
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$artifact" 2>/dev/null || echo 0)
+    [ "$vd_count" -eq 3 ]
+
+    # Each version must have the mock digest value.
+    local vd_2251
+    vd_2251=$(jq -r '.version_digests["2.25.0"]' "$artifact" 2>/dev/null || echo "")
+    [ "$vd_2251" = "sha256:cafebabe00000000000000000000000000000000000000000000000000000000" ]
+
+    # bundle_digest must NOT be present (replaced by version_digests).
+    local has_bundle_digest
+    has_bundle_digest=$(jq 'has("bundle_digest")' "$artifact" 2>/dev/null || echo "false")
+    [ "$has_bundle_digest" = "false" ]
 
     # available must contain ceiling.
     local av_ceiling
@@ -10326,11 +8363,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10390,11 +8427,11 @@ _run_an_producer() {
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "not-a-valid-digest"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10498,8 +8535,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10598,6 +8635,11 @@ EOF
                 echo \"IMAGETOOLS_CREATE \${*}\" >> \"$imagetools_log\"
                 return 0
             fi
+            if [[ \"\$2\" == 'imagetools' && \"\$3\" == 'inspect' ]]; then
+                # Platform check: return both platforms so the check passes
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
             if [[ \"\$1\" == 'manifest' ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -10608,8 +8650,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -10633,9 +8675,9 @@ EOF
     [[ "$create_content" == *"pg18-2.25.0-amd64"* ]]
     [[ "$create_content" == *"pg18-2.26.0-amd64"* ]]
     [[ "$create_content" == *"pg18-2.27.1-amd64"* ]]
-    # bundle is built via buildx build, NOT imagetools create
-    [[ "$create_content" != *"pg18-bundle-amd64"* ]] || {
-        echo "FAIL: bundle was assembled via imagetools create instead of buildx build"
+    # no bundle via imagetools create (bundle approach removed)
+    [[ "$create_content" != *"pg18-bundle"* ]] || {
+        echo "FAIL: bundle ref appeared in imagetools create calls"
         false
     }
 
@@ -10895,6 +8937,11 @@ EOF
             if [[ \"\$2\" == 'imagetools' && \"\$3\" == 'create' ]]; then
                 return 0
             fi
+            # imagetools inspect: return both platforms (platform-coverage check)
+            if [[ \"\$2\" == 'imagetools' && \"\$3\" == 'inspect' ]]; then
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
             if [[ \"\$1\" == 'manifest' ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -10905,8 +8952,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11004,6 +9051,11 @@ EOF
                 fi
                 return 0
             fi
+            # imagetools inspect: return both platforms (platform-coverage check)
+            if [[ \"\$2\" == 'imagetools' && \"\$3\" == 'inspect' ]]; then
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
             if [[ \"\$1\" == 'manifest' ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -11014,8 +9066,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11085,6 +9137,10 @@ EOF
                 echo "IMAGETOOLS_CREATE $*" >> "'"$imagetools_calls_log"'"
                 return 0
             fi
+            if [[ "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             if [[ "$1" == "manifest" ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -11095,8 +9151,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11201,6 +9257,10 @@ EOF
                 echo "IMAGETOOLS_CREATE $*" >> "'"$imagetools_calls_log"'"
                 return 0
             fi
+            if [[ "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             if [[ "$1" == "manifest" ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -11211,8 +9271,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11318,8 +9378,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11391,13 +9451,19 @@ EOF
         image_exists_in_registry() { return 0; }
         export -f image_exists_in_registry
 
-        docker() { return 0; }
+        docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
+            return 0
+        }
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11492,6 +9558,10 @@ EOF
                 echo \"IMAGETOOLS_CALLED: \$*\" >> \"$imagetools_log\"
                 return 0
             fi
+            if [[ \"\$_dcmd\" == 'buildx' && \"\${2:-}\" == 'imagetools' && \"\${3:-}\" == 'inspect' ]]; then
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
             if [[ \"\$_dcmd\" == 'manifest' ]]; then
                 echo \"manifest unknown: manifest unknown\" >&2
                 return 1
@@ -11501,8 +9571,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         list_extensions_by_priority() { echo 'pgvector'; }
         export -f list_extensions_by_priority
@@ -11580,8 +9650,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         list_extensions_by_priority() { echo 'pgvector'; }
         export -f list_extensions_by_priority
@@ -11631,18 +9701,18 @@ EOF
             return 0
         fi
         if [[ "$_dcmd" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
-            # Return raw manifest JSON so _capture_bundle_digest can hash it
+            # Return raw manifest JSON so _capture_index_digest can hash it
             printf '{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}\n'
             return 0
         fi
         return 0
     }
     export -f docker
-    _capture_bundle_digest() {
+    _capture_index_digest() {
         echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
         return 0
     }
-    export -f _capture_bundle_digest
+    export -f _capture_index_digest
 
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     rm -rf "$lineage_dir"
@@ -11782,7 +9852,7 @@ EOF
                     return 0
                 fi
                 if [[ \"\${3:-}\" == 'inspect' ]]; then
-                    printf '{\"schemaVersion\":2}\n'
+                    printf 'linux/amd64\nlinux/arm64\n'
                     return 0
                 fi
             fi
@@ -11791,8 +9861,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
 
         list_extensions_by_priority() { echo 'timescaledb'; }
         export -f list_extensions_by_priority
@@ -11877,16 +9947,22 @@ EOF
         image_exists_in_registry() { return 0; }
         export -f image_exists_in_registry
 
-        docker() { return 0; }
+        docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
+            return 0
+        }
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:cafecafe00000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -11928,10 +10004,14 @@ EOF
         false
     }
 
-    # bundle_digest must be set (bundle was built).
-    local bd
-    bd=$(jq -r '.bundle_digest // empty' "$artifact")
-    [ -n "$bd" ]
+    # version_digests must be set (per-version index digests written by finalize).
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$artifact" 2>/dev/null || echo 0)
+    [ "$vd_count" -ge 2 ] || {
+        echo "FAIL: version_digests has fewer than 2 entries (expected 2.25.0 + 2.27.1)"
+        jq '.' "$artifact"
+        false
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -11939,9 +10019,10 @@ EOF
 # amd64,arm64) from AVAILABLE per-version multi-arch manifests. An excluded
 # version is NOT in the bundle COPY list. (AZ-1 regression guard)
 # ---------------------------------------------------------------------------
-@test "SIMP-bundle-from-available: stage-B bundle uses buildx build from available manifests, excluded version absent" {
+@test "SIMP-bundle-from-available: stage-B uses only available versions in version_digests; excluded version absent" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
+    local imagetools_log="$tmpd/simp_available_imagetools.log"
     local buildx_log="$tmpd/buildx_build.log"
 
     printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
@@ -11990,11 +10071,15 @@ EOF
         _image_present_3state() { _image_registry_probe_3state "$@"; }
         export -f _image_present_3state
 
-        # Record buildx build calls to a log file for inspection.
+        # Record imagetools create calls; return both platforms for inspect.
         docker() {
             local _dcmd="${1:-}"
-            if [[ "$_dcmd" == "buildx" && "${2:-}" == "build" ]]; then
-                echo "BUILDX_BUILD $*" >> "'"$buildx_log"'"
+            if [[ "$_dcmd" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "create" ]]; then
+                echo "IMAGETOOLS_CREATE $*" >> "'"$imagetools_log"'"
+                return 0
+            fi
+            if [[ "$_dcmd" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
                 return 0
             fi
             if [[ "$_dcmd" == "manifest" ]]; then
@@ -12007,11 +10092,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:dddddddd00000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12027,13 +10112,18 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # A buildx build call must exist (bundle is built via buildx, not imagetools create).
-    [ -f "$buildx_log" ]
-    grep -q 'BUILDX_BUILD' "$buildx_log"
+    # imagetools create must have been called for available versions (2.26.0 + 2.27.1).
+    [ -f "$imagetools_log" ]
+    grep -q 'pg18-2.26.0' "$imagetools_log"
+    grep -q 'pg18-2.27.1' "$imagetools_log"
 
-    # The buildx build call must use --platform linux/amd64,linux/arm64 and --push.
-    grep -q '\-\-platform' "$buildx_log"
-    grep -q '\-\-push' "$buildx_log"
+    # 2.25.0 (excluded: arm64 absent) must NOT appear in imagetools create calls.
+    local excl_imagetools
+    excl_imagetools=$(grep '2.25.0' "$imagetools_log" || true)
+    [ -z "$excl_imagetools" ]
+
+    # No bundle build via buildx build --platform (bundle approach removed).
+    [ ! -f "$buildx_log" ] || ! grep -q 'BUILDX_BUILD' "$buildx_log"
 
     # The versionset artifact must list only available versions (not excluded 2.25.0).
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -12059,6 +10149,11 @@ EOF
     local excl_count
     excl_count=$(jq -r '[.excluded[] | select(.version == "2.25.0")] | length' "$artifact")
     [ "$excl_count" -eq 1 ]
+
+    # version_digests must be present and contain only available versions.
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$artifact" 2>/dev/null || echo 0)
+    [ "$vd_count" -eq 2 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -12115,6 +10210,10 @@ EOF
                 echo "IMAGETOOLS_CREATE $*" >> "'"$imagetools_log"'"
                 return 0
             fi
+            if [[ "$_dcmd" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             if [[ "$_dcmd" == "manifest" ]]; then
                 echo manifest unknown >&2
                 return 1
@@ -12125,8 +10224,8 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"; return 0; }
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12508,11 +10607,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12599,6 +10698,10 @@ EOF
         export -f _image_present_3state
 
         docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             if [[ "$1" == "buildx" && "$2" == "imagetools" ]]; then return 0; fi
             if [[ "$1" == "buildx" && "$2" == "build" ]]; then return 0; fi
             if [[ "$*" == *"manifest inspect"* ]]; then
@@ -12611,11 +10714,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12734,11 +10837,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12802,10 +10905,19 @@ EOF
         ext_local_image_name() { echo "localhost/ext-builder-${1}:pg${2}"; }
         export -f ext_local_image_name
 
-        image_exists_in_registry() { return 0; }
+        # Faithful: per-arch suffixed tags present (both canonical and PR-scoped);
+        # un-suffixed multi-arch manifests ABSENT (canonical never existed, stage B creates PR-scoped).
+        image_exists_in_registry() {
+            local ref="$1"
+            [[ "$ref" =~ -amd64$ ]] || [[ "$ref" =~ -arm64$ ]] || [[ "$ref" == *-pr42 ]]
+        }
         export -f image_exists_in_registry
 
         docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             echo "DOCKER $*" >> "$docker_calls"
             return 0
         }
@@ -12813,11 +10925,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12850,23 +10962,23 @@ EOF
         [[ "$target_ref" == *"-pr42" ]]
     done <<< "$target_lines"
 
-    # Bundle: the buildx build -t ref must carry -pr42.
-    local bundle_ref_in_calls
-    bundle_ref_in_calls=$(grep 'buildx build' "$docker_calls" | grep 'pg18-bundle' || true)
-    [[ "$bundle_ref_in_calls" == *"-pr42"* ]]
+    # No bundle build calls (bundle approach removed — collector is consume-time).
+    local bundle_calls
+    bundle_calls=$(grep 'pg18-bundle' "$docker_calls" || true)
+    [ -z "$bundle_calls" ]
 
-    # Canonical refs (no -pr suffix) must NEVER appear in imagetools create -t lines.
-    # The canonical tags are :pg18-2.27.1 and :pg18-bundle (no suffix).
-    # They must not appear as -t targets — only the suffixed versions are targets.
+    # Canonical refs (no -pr suffix) must NEVER appear as -t targets in imagetools create.
     local canon_target_lines
     canon_target_lines=$(grep 'imagetools.*create.*-t ' "$docker_calls" \
         | grep -v '\-pr42' | grep 'pg18-2' || true)
     [ -z "$canon_target_lines" ]
 
-    local canon_bundle_target
-    canon_bundle_target=$(grep 'buildx build.*-t ' "$docker_calls" \
-        | grep 'pg18-bundle' | grep -v '\-pr42' || true)
-    [ -z "$canon_bundle_target" ]
+    # versionset artifact must be written with version_digests.
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$artifact" 2>/dev/null || echo 0)
+    [ "$vd_count" -ge 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -12917,6 +11029,10 @@ EOF
         export -f image_exists_in_registry
 
         docker() {
+            if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+                printf "linux/amd64\nlinux/arm64\n"
+                return 0
+            fi
             echo "DOCKER $*" >> "$docker_calls"
             if [[ "$1" == "manifest" ]]; then
                 echo manifest unknown >&2
@@ -12928,11 +11044,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -12952,12 +11068,21 @@ EOF
 
     # Canonical per-version target refs must appear (no -pr suffix).
     [[ "$calls" == *"pg18-2.27.1"* ]]
-    # Bundle must appear without a -pr suffix.
-    grep -q 'pg18-bundle' "$docker_calls"
+    # No bundle ref (bundle approach removed — collector is consume-time).
+    local bundle_calls
+    bundle_calls=$(grep 'pg18-bundle' "$docker_calls" || true)
+    [ -z "$bundle_calls" ]
     # No -pr suffix refs should appear at all.
     local pr_refs
     pr_refs=$(grep '\-pr[0-9]' "$docker_calls" || true)
     [ -z "$pr_refs" ]
+
+    # Artifact must be written with version_digests.
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$artifact" 2>/dev/null || echo 0)
+    [ "$vd_count" -ge 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -13016,11 +11141,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -13370,11 +11495,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -13551,11 +11676,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -13637,11 +11762,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         validate_prerequisites()  { return 0; }
         export -f validate_prerequisites
@@ -13801,11 +11926,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
@@ -13900,13 +12025,17 @@ EOF
         }
         export -f image_exists_in_registry
 
-        # docker mock: log all calls; for manifest inspect, return PRESENT/ABSENT
-        # based on image_exists_in_registry so _image_present_3state is faithful.
+        # docker mock: log all calls; for imagetools inspect, return both platforms.
+        # For manifest inspect, mirror image_exists_in_registry for faithful 3-state.
         docker() {
-            echo \"DOCKER \$*\" >> \"\$docker_calls\"
             local _dc=\"\${1:-}\" _d2=\"\${2:-}\" _d3=\"\${3:-}\"
+            # imagetools inspect: return both platforms (platform-coverage check)
+            if [[ \"\$_dc\" == 'buildx' && \"\$_d2\" == 'imagetools' && \"\$_d3\" == 'inspect' ]]; then
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
+            echo \"DOCKER \$*\" >> \"\$docker_calls\"
             if [[ \"\$_dc\" == 'manifest' && \"\$_d2\" == 'inspect' ]]; then
-                # Mirror image_exists_in_registry: absent refs emit 'manifest unknown'
                 local _ref=\"\$_d3\"
                 case \"\$_ref\" in
                     *'pg18-2.23.0-amd64' | *'pg18-2.23.0-arm64') return 0 ;;
@@ -13925,11 +12054,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
@@ -13947,19 +12076,13 @@ EOF
     [ "$status" -eq 0 ]
     [ -f "${docker_calls}" ]
 
-    # The PR-scoped bundle must be created (pg18-bundle-pr42).
+    # No bundle build (bundle approach removed — collector is consume-time).
     local bundle_written
-    bundle_written=$(grep 'buildx build' "${docker_calls}" | grep 'pg18-bundle-pr42' || true)
-    [ -n "$bundle_written" ]
-
-    # The canonical bundle (pg18-bundle without -pr42) must NEVER be written from a PR.
-    local canonical_bundle
-    canonical_bundle=$(grep 'buildx build.*-t.*pg18-bundle' "${docker_calls}" \
-        | grep -v '\-pr42' || true)
-    [ -z "$canonical_bundle" ]
+    bundle_written=$(grep 'buildx build' "${docker_calls}" | grep 'pg18-bundle' || true)
+    [ -z "$bundle_written" ]
 
     # For unchanged versions (2.23.0, 2.25.0): imagetools create must NOT be called
-    # because their canonical multi-arch manifests already exist.
+    # because their canonical multi-arch manifests already exist (REUSE path).
     local create_for_23
     create_for_23=$(grep 'imagetools.*create.*2\.23\.0' "${docker_calls}" || true)
     [ -z "$create_for_23" ]
@@ -13981,6 +12104,11 @@ EOF
     local avail_count
     avail_count=$(jq '.available | length' "$vs_file")
     [ "$avail_count" -eq 3 ]
+
+    # version_digests must have all 3 entries.
+    local vd_count
+    vd_count=$(jq '.version_digests | length' "$vs_file" 2>/dev/null || echo 0)
+    [ "$vd_count" -eq 3 ]
 
     unset PR_TAG_SUFFIX
 }
@@ -14464,7 +12592,8 @@ EOF
                 return 0
             fi
             if [[ \"\$_dc\" == 'buildx' && \"\$_d2\" == 'imagetools' && \"\$_d3\" == 'inspect' ]]; then
-                echo '{\"schemaVersion\":2}' && return 0
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
             fi
             if [[ \"\$_dc\" == 'buildx' && \"\$_d2\" == 'build' ]]; then
                 return 0
@@ -14476,11 +12605,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         list_extensions_by_priority() { echo 'timescaledb'; }
         export -f list_extensions_by_priority
@@ -14575,6 +12704,10 @@ EOF
                 echo \"IMAGETOOLS_CALLED: \$*\" >> \"\$imagetools_log\"
                 return 0
             fi
+            if [[ \"\$_dc\" == 'buildx' && \"\$_d2\" == 'imagetools' && \"\$_d3\" == 'inspect' ]]; then
+                printf 'linux/amd64\nlinux/arm64\n'
+                return 0
+            fi
             return 0
         }
         export -f docker
@@ -14582,11 +12715,11 @@ EOF
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
 
-        _capture_bundle_digest() {
+        _capture_index_digest() {
             echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
             return 0
         }
-        export -f _capture_bundle_digest
+        export -f _capture_index_digest
 
         list_extensions_by_priority() { echo 'timescaledb'; }
         export -f list_extensions_by_priority
@@ -14698,8 +12831,8 @@ EOF
         export -f docker
         skopeo() { echo manifest unknown >&2; return 1; }
         export -f skopeo
-        _capture_bundle_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
-        export -f _capture_bundle_digest
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
         skopeo() { echo 'manifest unknown: manifest unknown' >&2; return 1; }
         export -f skopeo
 

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -13716,3 +13716,236 @@ _mock_probe_outcomes() {
     [ "$rc" -eq 1 ]
     unset PR_TAG_SUFFIX FORCE
 }
+
+# ---------------------------------------------------------------------------
+# INSPECT-FAIL: imagetools inspect failure is treated as a transient infra
+# error and causes finalize_multiarch_manifests to fail closed (exit non-zero).
+#
+# Before fix: both inspect sites used `|| true`, swallowing the exit code.
+# An inspect failure yielded empty output → the arch-coverage grep saw no
+# linux/amd64 or linux/arm64 → the version was silently excluded (non-ceiling)
+# or treated as genuinely single-arch, writing a REDUCED versionset artifact.
+#
+# After fix: inspect failure → _ext_failed=true → abort → no reduced artifact.
+#
+# This test drives the CREATE path (multi-arch manifest absent → per-arch tags
+# confirmed PRESENT → imagetools create SUCCEEDS → imagetools inspect FAILS).
+# Non-ceiling version: the old code would have silently excluded it and
+# continued; the fixed code must fail closed (exit non-zero, no artifact).
+# ---------------------------------------------------------------------------
+@test "INSPECT-FAIL: imagetools inspect failure on CREATE path → fail closed (no reduced artifact)" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+
+    run bash -c "
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export FINALIZE_MULTIARCH=true
+        cd \"$sd\"
+        source ./build-extensions.sh
+        export ROOT_DIR=\"$tmpd\"
+
+        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case \"\$2\" in
+                version) echo '2.27.1' ;;
+                repo)    echo 'https://github.com/timescale/timescaledb' ;;
+                *)       echo '' ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve:
+        #   arch=\"\"    → rc 1 (multi-arch manifest absent → trigger CREATE path)
+        #   arch=\"amd64\" / arch=\"arm64\" → rc 0 with a stable arch-suffixed ref
+        # This drives the CREATE path in finalize_multiarch_manifests.
+        ext_ref_resolve() {
+            local _ext=\"\$1\" _ver=\"\$2\" _maj=\"\$3\" _arch=\"\${4:-}\"
+            if [[ -z \"\$_arch\" ]]; then
+                return 1  # multi-arch absent → proceed to CREATE
+            fi
+            printf 'ghcr.io/test/ext-%s:pg%s-%s-%s' \"\$_ext\" \"\$_maj\" \"\$_ver\" \"\$_arch\"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        # _capture_index_digest: returns a valid digest (create succeeded)
+        _capture_index_digest() {
+            echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+            return 0
+        }
+        export -f _capture_index_digest
+
+        # docker:
+        #   buildx imagetools create  → succeeds (per-arch tags confirmed PRESENT)
+        #   buildx imagetools inspect → FAILS (transient infra error — the bug site)
+        #   everything else           → fail (not needed)
+        docker() {
+            local _cmd=\"\${1:-}\" _sub=\"\${2:-}\" _subsub=\"\${3:-}\"
+            if [[ \"\$_cmd\" == 'buildx' && \"\$_sub\" == 'imagetools' ]]; then
+                if [[ \"\$_subsub\" == 'create' ]]; then
+                    return 0
+                fi
+                if [[ \"\$_subsub\" == 'inspect' ]]; then
+                    printf 'error: transient registry failure\\n' >&2
+                    return 1
+                fi
+            fi
+            return 1
+        }
+        export -f docker
+
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+        image_exists_in_registry() { return 1; }
+        export -f image_exists_in_registry
+        validate_prerequisites()  { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()     { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo 'timescaledb'; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18
+    "
+
+    # CORE ASSERTION: inspect failure on any version must cause fail-closed (exit non-zero).
+    # Before fix: exit 0, version silently excluded, reduced artifact written.
+    # After fix:  exit non-zero, no reduced artifact.
+    [ "$status" -ne 0 ]
+
+    # The versionset artifact must NOT exist: inspect failure must not produce a
+    # reduced artifact (writing available=[2.26.0,2.27.1] while silently dropping
+    # 2.25.0 is the exact pre-fix data-loss scenario this test guards against).
+    [ ! -f "$artifact" ]
+}
+
+# ---------------------------------------------------------------------------
+# INSPECT-FAIL REUSE PATH: imagetools inspect failure on the REUSE path
+# (multi-arch manifest already present → reuse attempted → inspect FAILS).
+#
+# Before fix: both inspect sites used `|| true`, swallowing the exit code.
+# An inspect failure yielded empty output → arch-coverage grep saw nothing →
+# the version fell through to the CREATE path (or was silently excluded).
+# Either way a transient infra error produced a different artifact than the
+# correct, fully-available set.
+#
+# After fix: inspect failure → _ext_failed=true → abort → no artifact.
+#
+# This test drives the REUSE path:
+#   ext_ref_resolve(arch="") → rc 0 (manifest present)
+#   _capture_index_digest    → succeeds
+#   imagetools inspect       → rc 1 (transient infra error — the bug site)
+# Non-ceiling version: the old code would fall through to CREATE; the fixed
+# code must fail closed (exit non-zero, no artifact).
+# ---------------------------------------------------------------------------
+@test "INSPECT-FAIL: imagetools inspect failure on REUSE path → fail closed (no reduced artifact)" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+
+    run bash -c "
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export FINALIZE_MULTIARCH=true
+        cd \"$sd\"
+        source ./build-extensions.sh
+        export ROOT_DIR=\"$tmpd\"
+
+        resolve_version_set() { echo '[\"2.25.0\",\"2.26.0\",\"2.27.1\"]'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case \"\$2\" in
+                version) echo '2.27.1' ;;
+                repo)    echo 'https://github.com/timescale/timescaledb' ;;
+                *)       echo '' ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name()       { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve:
+        #   arch=\"\"    → rc 0 with a ref (multi-arch manifest PRESENT → trigger REUSE path)
+        #   arch=*      → rc 0 with arch-suffixed ref (per-arch tags also present)
+        # This drives the REUSE path in finalize_multiarch_manifests.
+        ext_ref_resolve() {
+            local _ext=\"\$1\" _ver=\"\$2\" _maj=\"\$3\" _arch=\"\${4:-}\"
+            if [[ -z \"\$_arch\" ]]; then
+                printf 'ghcr.io/test/ext-%s:pg%s-%s' \"\$_ext\" \"\$_maj\" \"\$_ver\"
+                return 0  # manifest PRESENT → enter reuse path
+            fi
+            printf 'ghcr.io/test/ext-%s:pg%s-%s-%s' \"\$_ext\" \"\$_maj\" \"\$_ver\" \"\$_arch\"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        # _capture_index_digest: succeeds (reuse digest captured without issue)
+        _capture_index_digest() {
+            echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+            return 0
+        }
+        export -f _capture_index_digest
+
+        # docker:
+        #   buildx imagetools inspect → FAILS (transient infra error — the bug site)
+        #   buildx imagetools create  → not expected to be called (reuse path fails first)
+        #   everything else           → fail (not needed)
+        docker() {
+            local _cmd=\"\${1:-}\" _sub=\"\${2:-}\" _subsub=\"\${3:-}\"
+            if [[ \"\$_cmd\" == 'buildx' && \"\$_sub\" == 'imagetools' ]]; then
+                if [[ \"\$_subsub\" == 'inspect' ]]; then
+                    printf 'error: transient registry failure\\n' >&2
+                    return 1
+                fi
+                if [[ \"\$_subsub\" == 'create' ]]; then
+                    return 0
+                fi
+            fi
+            return 1
+        }
+        export -f docker
+
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+        image_exists_in_registry() { return 1; }
+        export -f image_exists_in_registry
+        validate_prerequisites()  { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()     { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo 'timescaledb'; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18
+    "
+
+    # CORE ASSERTION: inspect failure on the REUSE path must cause fail-closed (exit non-zero).
+    # Before fix: inspect rc was swallowed by || true, empty output fell through to CREATE
+    # path (or silently excluded the version), producing a reduced or incorrect artifact.
+    # After fix: non-zero inspect rc → _ext_failed=true → no artifact written.
+    [ "$status" -ne 0 ]
+
+    # The versionset artifact must NOT exist: a transient inspect failure must never
+    # produce any artifact (reduced or full), as the set of confirmed-available versions
+    # is unknown.
+    [ ! -f "$artifact" ]
+}

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -13328,6 +13328,151 @@ EOF
     unset PR_TAG_SUFFIX ARCH_SUFFIX
 }
 
+# ---------------------------------------------------------------------------
+# PR-scoped digest capture: when canonical is absent and only the PR-scoped
+# ref exists, _bundle_and_write_artifact must capture the digest from the
+# PR-scoped ref (not the absent canonical ref).
+#
+# Scenario: PR_TAG_SUFFIX=-pr42, ARCH_SUFFIX empty (final local path).
+# Version set: [2.25.0, 2.27.1]. Canonical refs absent; PR-scoped refs present.
+# do_push=true → version_digests must be captured.
+#
+# Pre-fix: digest capture reconstructed the canonical ref → skopeo/docker on
+#   canonical (absent) → digest empty → fail-closed → artifact write fails.
+# Post-fix: digest capture uses _confirmed_refs[ver] (PR-scoped ref) →
+#   digest captured from pr42 ref → artifact written with valid version_digests.
+# ---------------------------------------------------------------------------
+@test "PR-scoped-digest-capture: canonical absent, pr42 only → digest from pr42 ref, artifact has version_digests" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    # Record which refs _capture_index_digest was called with.
+    local digest_log="${tmpd}/digest_calls.log"
+
+    run bash -c "
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export PR_TAG_SUFFIX='-pr42'
+        export ARCH_SUFFIX=''
+
+        cd \"$sd\"
+        source ./build-extensions.sh
+        export ROOT_DIR=\"$tmpd\"
+
+        resolve_version_set() { echo '[\"2.25.0\",\"2.27.1\"]'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case \"\$2\" in
+                version) echo '2.27.1' ;;
+                repo)    echo 'https://github.com/timescale/timescaledb' ;;
+                *)       echo '' ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name() { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
+        export -f ext_local_image_name
+
+        # Canonical refs absent; PR-scoped refs present.
+        image_exists_in_registry() {
+            local ref=\"\$1\"
+            case \"\$ref\" in
+                *pg18-2.25.0-pr42) return 0 ;;
+                *pg18-2.27.1-pr42) return 0 ;;
+                *)                 return 1 ;;
+            esac
+        }
+        export -f image_exists_in_registry
+
+        _image_present_3state() {
+            local ref=\"\$1\"
+            case \"\$ref\" in
+                *pg18-2.25.0-pr42) return 0 ;;
+                *pg18-2.27.1-pr42) return 0 ;;
+                *)                 return 1 ;;
+            esac
+        }
+        export -f _image_present_3state
+
+        # Capture which ref is probed; return a deterministic digest based on the ref.
+        _capture_index_digest() {
+            local ref=\"\$1\"
+            printf 'DIGEST_CALLED %s\n' \"\$ref\" >> \"$digest_log\"
+            if [[ \"\$ref\" == *-pr42 ]]; then
+                echo 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                return 0
+            fi
+            # Canonical ref (absent) — must not be reached after fix.
+            printf '' >&2
+            return 1
+        }
+        export -f _capture_index_digest
+
+        docker() { local _dk=\"\$1\"; case \"\$_dk\" in build|push) return 0;; manifest|buildx) echo 'manifest unknown' >&2; return 1;; *) return 1;; esac; }
+        export -f docker
+        skopeo() { echo 'manifest unknown: manifest unknown' >&2; return 1; }
+        export -f skopeo
+        build_ext_image()   { return 0; }
+        export -f build_ext_image
+        tag_ext_image()     { return 0; }
+        export -f tag_ext_image
+        push_ext_image()    { return 0; }
+        export -f push_ext_image
+        validate_prerequisites() { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()    { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo 'timescaledb'; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18
+    "
+
+    [ "$status" -eq 0 ]
+
+    # Artifact must exist with version_digests.
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ] || {
+        echo "FAIL: artifact must be written. status=$status output=$output"
+        false
+    }
+
+    local vd_present
+    vd_present=$(jq -r 'if has("version_digests") then "yes" else "no" end' "$artifact")
+    [ "$vd_present" = "yes" ] || {
+        echo "FAIL: artifact must have version_digests. content=$(cat "$artifact")"
+        false
+    }
+
+    # All digests must be the pr42 value (not empty / not from absent canonical).
+    local all_valid
+    all_valid=$(jq -r '.available[] as $v | .version_digests[$v] // "MISSING" | test("^sha256:[0-9a-f]{64}$")' "$artifact" | sort -u)
+    [ "$all_valid" = "true" ] || {
+        echo "FAIL: every version_digests entry must be a valid sha256. content=$(cat "$artifact")"
+        false
+    }
+
+    # _capture_index_digest must have been called ONLY with pr42-scoped refs.
+    [ -f "$digest_log" ] || {
+        echo "FAIL: digest_calls.log not written — _capture_index_digest was never called"
+        false
+    }
+    local non_pr42_calls
+    non_pr42_calls=$(grep -cv -- '-pr42' "$digest_log" || true)
+    [ "$non_pr42_calls" -eq 0 ] || {
+        echo "FAIL: _capture_index_digest called with non-pr42 ref. digest_calls.log:"
+        cat "$digest_log"
+        false
+    }
+
+    unset PR_TAG_SUFFIX ARCH_SUFFIX
+}
+
 # ===========================================================================
 # ext_ref_resolve exhaustive unit matrix
 #

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -9488,6 +9488,351 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# SIMP-reuse-single-arch-falls-through: REUSE path finds a single-arch canonical
+# manifest → falls through to CREATE (re-creates from per-arch legs), exit 0.
+# The reused manifest covers only linux/amd64; per-arch legs exist for both arches.
+# ---------------------------------------------------------------------------
+@test "SIMP-reuse-single-arch-falls-through: single-arch reused manifest triggers re-create from per-arch legs" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+    local docker_calls="$tmpd/docker_calls.log"
+    export docker_calls
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    run bash -c '
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export docker_calls="'"$docker_calls"'"
+        cd "'"$sd"'"
+        source ./build-extensions.sh
+        export ROOT_DIR="'"$tmpd"'"
+
+        # 2.27.1 is the only version (ceiling = only version)
+        resolve_version_set() { echo '"'"'["2.27.1"]'"'"'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case "$2" in
+                version) echo "2.27.1" ;;
+                repo)    echo "https://github.com/timescale/timescaledb" ;;
+                *)       echo "" ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name()       { echo "ghcr.io/test/ext-${1}:pg${3}-${2}"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo "localhost/ext-builder-${1}:pg${2}"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve: un-suffixed manifest is PRESENT (so reuse path is entered);
+        # per-arch suffixed tags are also PRESENT (so CREATE succeeds after fall-through).
+        ext_ref_resolve() {
+            local _ext="$1" _ver="$2" _pg="$3" _arch="${4:-}"
+            if [[ -z "$_arch" ]]; then
+                # Un-suffixed multi-arch ref → PRESENT (triggers reuse attempt)
+                echo "ghcr.io/test/ext-${_ext}:pg${_pg}-${_ver}"
+                return 0
+            fi
+            echo "ghcr.io/test/ext-${_ext}:pg${_pg}-${_ver}-${_arch}"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        image_exists_in_registry() { return 0; }
+        export -f image_exists_in_registry
+
+        _capture_index_digest() {
+            echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            return 0
+        }
+        export -f _capture_index_digest
+
+        # docker mock:
+        # - imagetools inspect: first call returns amd64-ONLY (reuse check);
+        #                       subsequent calls return both arches (create-path check).
+        #   Call count tracked via counter file: inspect runs inside a subshell so
+        #   in-memory variables do not persist between calls.
+        # - imagetools create: succeeds, recorded
+        # - manifest: absent
+        _inspect_count_file="'"$tmpd"'/inspect_count.txt"
+        echo 0 > "$_inspect_count_file"
+        docker() {
+            echo "DOCKER $*" >> "$docker_calls"
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+                local _cnt
+                _cnt=$(cat "$_inspect_count_file" 2>/dev/null || echo 0)
+                _cnt=$(( _cnt + 1 ))
+                echo "$_cnt" > "$_inspect_count_file"
+                if [[ "$_cnt" -eq 1 ]]; then
+                    # First inspect = reuse check: single-arch (amd64 only)
+                    printf "linux/amd64\n"
+                else
+                    # Subsequent inspects = create-path check: both arches
+                    printf "linux/amd64\nlinux/arm64\n"
+                fi
+                return 0
+            fi
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "create" ]]; then
+                return 0
+            fi
+            if [[ "${1:-}" == "manifest" ]]; then
+                echo "manifest unknown" >&2
+                return 1
+            fi
+            return 0
+        }
+        export -f docker
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+
+        validate_prerequisites()  { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()     { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo "timescaledb"; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18 --finalize-multiarch
+    '
+
+    # Build must succeed (ceiling re-created from per-arch legs after reuse fell through).
+    [ "$status" -eq 0 ]
+
+    # imagetools create must have been called (not blindly reused the single-arch manifest).
+    [ -f "$docker_calls" ]
+    local create_calls
+    create_calls=$(grep 'imagetools create' "$docker_calls" || true)
+    [ -n "$create_calls" ]
+
+    # inspect must have been called at least twice (reuse check + create-path check).
+    local inspect_count
+    inspect_count=$(grep -c 'imagetools inspect' "$docker_calls" || true)
+    [ "$inspect_count" -ge 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# SIMP-nonceil-single-arch-create-excluded: non-ceiling version whose
+# imagetools create produces a single-arch manifest → EXCLUDED (exit 0).
+# Ceiling (both arches) → merged; artifact omits excluded version.
+# ---------------------------------------------------------------------------
+@test "SIMP-nonceil-single-arch-create-excluded: non-ceiling single-arch create is excluded, ceiling merged, exit 0" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+    local docker_calls="$tmpd/docker_calls.log"
+    export docker_calls
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    run bash -c '
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export docker_calls="'"$docker_calls"'"
+        cd "'"$sd"'"
+        source ./build-extensions.sh
+        export ROOT_DIR="'"$tmpd"'"
+
+        # 2.23.1 = non-ceiling (will be excluded); 2.26.0 + 2.27.1 = remaining two versions
+        resolve_version_set() { echo '"'"'["2.23.1","2.26.0","2.27.1"]'"'"'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case "$2" in
+                version) echo "2.27.1" ;;
+                repo)    echo "https://github.com/timescale/timescaledb" ;;
+                *)       echo "" ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name()       { echo "ghcr.io/test/ext-${1}:pg${3}-${2}"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo "localhost/ext-builder-${1}:pg${2}"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve:
+        #  - un-suffixed manifest: ABSENT for all (force CREATE path)
+        #  - per-arch suffixed tags: PRESENT for both versions on both arches
+        ext_ref_resolve() {
+            local _ext="$1" _ver="$2" _pg="$3" _arch="${4:-}"
+            if [[ -z "$_arch" ]]; then
+                return 1  # un-suffixed absent → enter CREATE path
+            fi
+            echo "ghcr.io/test/ext-${_ext}:pg${_pg}-${_ver}-${_arch}"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        image_exists_in_registry() { return 0; }
+        export -f image_exists_in_registry
+
+        _capture_index_digest() {
+            echo "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            return 0
+        }
+        export -f _capture_index_digest
+
+        # docker mock:
+        # - imagetools inspect for 2.23.1: returns only linux/amd64 (single-arch result)
+        # - imagetools inspect for 2.27.1: returns both arches
+        # - imagetools create: succeeds
+        # - manifest: absent
+        docker() {
+            echo "DOCKER $*" >> "$docker_calls"
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+                local _ref="${*: -1}"
+                if [[ "$_ref" == *"2.23.1"* ]]; then
+                    # Non-ceiling: inspect shows only amd64 after create
+                    printf "linux/amd64\n"
+                else
+                    printf "linux/amd64\nlinux/arm64\n"
+                fi
+                return 0
+            fi
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "create" ]]; then
+                return 0
+            fi
+            if [[ "${1:-}" == "manifest" ]]; then
+                echo "manifest unknown" >&2
+                return 1
+            fi
+            return 0
+        }
+        export -f docker
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+
+        validate_prerequisites()  { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()     { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo "timescaledb"; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18 --finalize-multiarch
+    '
+
+    # Non-ceiling single-arch → excluded; ceiling merged → exit 0.
+    [ "$status" -eq 0 ]
+
+    # Versionset artifact must exist (ceiling merged).
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ -f "$artifact" ]
+
+    # 2.23.1 must be in excluded[].
+    local excluded_versions
+    excluded_versions=$(jq -r '.excluded[].version' "$artifact")
+    [[ "$excluded_versions" == *"2.23.1"* ]]
+
+    # 2.27.1 (ceiling) must be in available[].
+    local available_versions
+    available_versions=$(jq -r '.available[]' "$artifact")
+    [[ "$available_versions" == *"2.27.1"* ]]
+    [[ "$available_versions" != *"2.23.1"* ]]
+
+    # version_digests must contain 2.27.1 but NOT 2.23.1.
+    local vd_keys
+    vd_keys=$(jq -r '.version_digests | keys[]' "$artifact")
+    [[ "$vd_keys" == *"2.27.1"* ]]
+    [[ "$vd_keys" != *"2.23.1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# SIMP-ceiling-single-arch-create-fatal: ceiling version whose imagetools create
+# produces a single-arch manifest → fatal (exit non-zero). No artifact written.
+# ---------------------------------------------------------------------------
+@test "SIMP-ceiling-single-arch-create-fatal: ceiling single-arch create is fatal" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+
+    printf '#!/bin/bash\necho "18.0"\n' > "${tmpd}/postgres/version.sh"
+    chmod +x "${tmpd}/postgres/version.sh"
+
+    run bash -c '
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        cd "'"$sd"'"
+        source ./build-extensions.sh
+        export ROOT_DIR="'"$tmpd"'"
+
+        # Single version = ceiling only
+        resolve_version_set() { echo '"'"'["2.27.1"]'"'"'; }
+        export -f resolve_version_set
+
+        ext_config() {
+            case "$2" in
+                version) echo "2.27.1" ;;
+                repo)    echo "https://github.com/timescale/timescaledb" ;;
+                *)       echo "" ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name()       { echo "ghcr.io/test/ext-${1}:pg${3}-${2}"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo "localhost/ext-builder-${1}:pg${2}"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve:
+        #  - un-suffixed: ABSENT → CREATE path entered
+        #  - per-arch: PRESENT for both arches
+        ext_ref_resolve() {
+            local _ext="$1" _ver="$2" _pg="$3" _arch="${4:-}"
+            if [[ -z "$_arch" ]]; then
+                return 1
+            fi
+            echo "ghcr.io/test/ext-${_ext}:pg${_pg}-${_ver}-${_arch}"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        image_exists_in_registry() { return 0; }
+        export -f image_exists_in_registry
+
+        _capture_index_digest() {
+            echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            return 0
+        }
+        export -f _capture_index_digest
+
+        # docker mock: imagetools inspect returns only linux/amd64 (ceiling single-arch)
+        docker() {
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+                printf "linux/amd64\n"
+                return 0
+            fi
+            if [[ "${2:-}" == "imagetools" && "${3:-}" == "create" ]]; then
+                return 0
+            fi
+            if [[ "${1:-}" == "manifest" ]]; then
+                echo "manifest unknown" >&2
+                return 1
+            fi
+            return 0
+        }
+        export -f docker
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+
+        validate_prerequisites()  { return 0; }
+        export -f validate_prerequisites
+        check_registry_auth()     { return 0; }
+        export -f check_registry_auth
+        list_extensions_by_priority() { echo "timescaledb"; }
+        export -f list_extensions_by_priority
+
+        main postgres --major-version 18 --finalize-multiarch
+    '
+
+    # Ceiling single-arch after create → fatal.
+    [ "$status" -ne 0 ]
+
+    # No versionset artifact must be written.
+    local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    [ ! -f "$artifact" ]
+}
+
+# ---------------------------------------------------------------------------
 # AX3-duration-consolidated: per-arch duration files for a version
 # (amd64=100s, arm64=140s) → canonical artifact gets one duration file with
 # MAX policy (140s); the consolidated duration_seconds is 140.

--- a/tests/unit/collector-emitter.bats
+++ b/tests/unit/collector-emitter.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+
+# Unit tests for the _emit_collector_stage helper and the two call sites
+# (artifact-present with version_digests, self-heal) in generate_dockerfile.
+#
+# Tests:
+#   (a) artifact-present digest-pinned emission
+#   (b) self-heal tag-resolved emission
+#   (c) single-version unchanged (no collector)
+#   (d) empty/ceiling-absent → fail-closed
+#   (e) version in available but missing from version_digests → fail-closed
+#   (f) depth: a synthetic 30-version set yields exactly ONE final-stage COPY
+
+bats_require_minimum_version 1.5.0
+
+load "../test_helper"
+
+_source_extension_utils() {
+    # shellcheck disable=SC1091
+    source "$HELPERS_DIR/extension-utils.sh"
+}
+
+setup() {
+    setup_temp_dir
+    export ROOT_DIR="$TEST_TEMP_DIR"
+    mkdir -p "$TEST_TEMP_DIR/.build-lineage"
+
+    # Config: timescaledb (resolver-backed) + pgvector (single-version)
+    mkdir -p "$TEST_TEMP_DIR/extensions"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  timescaledb:
+    version: "2.27.1"
+    repo: "timescale/timescaledb"
+    priority: 1
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    priority: 2
+
+flavors:
+  timeseries:
+    - timescaledb
+  multi_mixed:
+    - timescaledb
+    - pgvector
+  vector:
+    - pgvector
+EOF
+
+    # Minimal Dockerfile template
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@EXTENSION_COPIES@@
+# @@RUNTIME_DEPS@@
+EOF
+
+    _source_extension_utils
+
+    get_registry()   { echo "ghcr.io"; }
+    get_repo_owner() { echo "testowner"; }
+    export -f get_registry get_repo_owner
+}
+
+teardown() {
+    teardown_temp_dir
+    unset ROOT_DIR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: write versionset WITH version_digests (CI/publish path)
+# ---------------------------------------------------------------------------
+_write_versionset_with_digests() {
+    local ext="$1" pg_major="$2"
+    shift 2
+    local -a available_arr=("$@")
+
+    local arr_json="["
+    local first=1
+    for v in "${available_arr[@]}"; do
+        [[ "$first" -eq 0 ]] && arr_json+=","
+        arr_json+="\"$v\""
+        first=0
+    done
+    arr_json+="]"
+
+    local vd_json="{"
+    local idx=1
+    local vd_first=1
+    for v in "${available_arr[@]}"; do
+        [[ "$vd_first" -eq 0 ]] && vd_json+=","
+        local hex_idx
+        hex_idx=$(printf '%064x' "$idx")
+        vd_json+="\"${v}\":\"sha256:${hex_idx}\""
+        vd_first=0
+        idx=$((idx + 1))
+    done
+    vd_json+="}"
+
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-${ext}-pg${pg_major}-versionset.json" <<EOF
+{"ext":"${ext}","pg_major":"${pg_major}","ceiling":"${available_arr[-1]}","resolved":${arr_json},"available":${arr_json},"excluded":[],"version_digests":${vd_json}}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# (a) Artifact-present digest-pinned emission
+# ---------------------------------------------------------------------------
+@test "(a) artifact with version_digests → collector stage with digest-pinned per-version COPYs" {
+    _write_versionset_with_digests "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # Collector stage must be declared
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+
+    # Per-version COPYs inside collector must use repo@digest format
+    local pinned_count
+    pinned_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:" || true)
+    [ "$pinned_count" -eq 3 ]
+
+    # Each per-version COPY must land at /<ver>/ inside the collector
+    echo "$output" | grep -qE "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:.* /output/ /2\.23\.0/"
+    echo "$output" | grep -qE "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:.* /output/ /2\.27\.1/"
+
+    # Exactly ONE final-stage COPY from the collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# (b) Self-heal tag-resolved emission
+# ---------------------------------------------------------------------------
+@test "(b) self-heal (no artifact) → collector stage with tag-based per-version COPYs" {
+    # No artifact on disk → self-heal triggers
+
+    resolve_version_set() {
+        echo '["2.23.0","2.25.0","2.27.1"]'
+    }
+    export -f resolve_version_set
+
+    image_exists_in_registry() { return 0; }
+    export -f image_exists_in_registry
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # Collector stage present
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+
+    # Per-version COPYs inside collector use tag-based refs (no @digest)
+    local per_ver_count
+    per_ver_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    [ "$per_ver_count" -eq 3 ]
+
+    # Exactly ONE final-stage COPY
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# (c) Single-version unchanged — no collector emitted
+# ---------------------------------------------------------------------------
+@test "(c) single available version → single-version FROM path, no collector" {
+    # Artifact with exactly one version (ceiling only)
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.27.1"],"available":["2.27.1"],"excluded":[]}
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # No collector stage
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 0 ]
+
+    # Single-version FROM stage present
+    local from_count
+    from_count=$(echo "$output" | grep -c "FROM ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 AS ext-timescaledb" || true)
+    [ "$from_count" -eq 1 ]
+
+    # Flat COPY paths (no /<ver>/ subdirectory)
+    echo "$output" | grep -q "COPY --from=ext-timescaledb /output/extension/ /tmp/ext/timescaledb/extension/"
+}
+
+# ---------------------------------------------------------------------------
+# (d) Empty available → fail-closed
+# ---------------------------------------------------------------------------
+@test "(d) empty available[] → generate_dockerfile fails closed" {
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.27.1"],"available":[],"excluded":[]}
+EOF
+
+    resolve_version_set() {
+        echo "::error::simulated resolver failure" >&2
+        return 1
+    }
+    export -f resolve_version_set
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    # Fail closed: empty available + resolver fails → non-zero
+    [ "$status" -ne 0 ]
+}
+
+# (d-2) ceiling absent from available → fail-closed
+@test "(d-2) ceiling absent from non-empty available[] → fail-closed" {
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.25.0","2.27.1"],"available":["2.23.0","2.25.0"],"excluded":[{"version":"2.27.1","reason":"not available"}]}
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (e) Version in available but missing from version_digests → fail-closed
+# ---------------------------------------------------------------------------
+@test "(e) version in available[] absent from version_digests → fail-closed" {
+    # Artifact: 3 versions in available but version_digests only has 2
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.25.0","2.27.1"],"available":["2.23.0","2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"sha256:0000000000000000000000000000000000000000000000000000000000000001","2.27.1":"sha256:0000000000000000000000000000000000000000000000000000000000000002"}}
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    # 2.23.0 is in available but absent from version_digests → fail closed
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (f) Depth: 30 synthetic versions → exactly ONE final-stage COPY
+# ---------------------------------------------------------------------------
+@test "(f) 30-version set → exactly ONE final-stage COPY (count-independent)" {
+    # Generate artifact with 30 versions
+    local arr_json="["
+    local vd_json="{"
+    local ceiling_ver=""
+    local first=1
+    for i in $(seq 1 30); do
+        local v="2.${i}.0"
+        [[ "$first" -eq 0 ]] && arr_json+="," && vd_json+=","
+        arr_json+="\"$v\""
+        local hex_idx
+        hex_idx=$(printf '%064x' "$i")
+        vd_json+="\"${v}\":\"sha256:${hex_idx}\""
+        ceiling_ver="$v"
+        first=0
+    done
+    arr_json+="]"
+    vd_json+="}"
+
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<EOF
+{"ext":"timescaledb","pg_major":"18","ceiling":"${ceiling_ver}","resolved":${arr_json},"available":${arr_json},"excluded":[],"version_digests":${vd_json}}
+EOF
+
+    # Update config to have ceiling matching our last version
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<EOF
+extensions:
+  timescaledb:
+    version: "${ceiling_ver}"
+    repo: "timescale/timescaledb"
+    priority: 1
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+
+flavors:
+  timeseries:
+    - timescaledb
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # Collector stage declared exactly once
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # 30 per-version COPYs inside the collector
+    local per_ver_count
+    per_ver_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256: /output/ /" || true)
+    # They may appear with hex digest refs; count by /output/ / pattern
+    per_ver_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:" || true)
+    [ "$per_ver_count" -eq 30 ]
+
+    # Exactly ONE final-stage COPY — count-independent regardless of version count
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
+}

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -3352,6 +3352,65 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# BD-1: legacy artifact with bundle_digest but no version_digests must fail
+# closed — the consumer must not silently downgrade to mutable tag refs.
+#
+# A pre-collector pushed artifact carries bundle_digest (the old single-image
+# schema) but no version_digests.  The tag-fallback path in generate_dockerfile
+# is valid ONLY for artifacts that have NEITHER key (genuine local/no-push).
+# When bundle_digest is present but version_digests is absent, the artifact was
+# produced by an old push path and must be rejected so the operator rebuilds.
+#
+# BD1-legacy-bundle-digest-failclosed:
+#   artifact has bundle_digest key but no version_digests → generate_dockerfile
+#   exits non-zero (fail-closed); no Dockerfile emitted.
+#
+# BD1-neither-key-tag-fallback:
+#   artifact has neither bundle_digest nor version_digests → tag-based refs,
+#   exit 0 (LOCAL_ONLY regression guard — must stay green).
+# ---------------------------------------------------------------------------
+@test "BD1-legacy-bundle-digest-failclosed: bundle_digest present, no version_digests → fail closed, no Dockerfile" {
+    # Legacy artifact: has bundle_digest (old schema) but no version_digests.
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    # Must fail closed — legacy artifact must not silently downgrade to tag refs.
+    [ "$status" -ne 0 ]
+
+    # No @sha256: in output (should be empty / no Dockerfile emitted).
+    local digest_pin_count
+    digest_pin_count=$(echo "$output" | grep -c "@sha256:" || true)
+    [ "$digest_pin_count" -eq 0 ]
+}
+
+@test "BD1-neither-key-tag-fallback: no bundle_digest, no version_digests → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
+    # LOCAL_ONLY artifact: neither key present → tag-based fallback, exit 0.
+    _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # Collector stage present with tag-based refs (no digest pin).
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
+
+    local pinned_count
+    pinned_count=$(echo "$output" | grep -c "@sha256:" || true)
+    [ "$pinned_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # BE-2: self-heal availability probe must use the PR-scoped ref it emits.
 #
 # Defect: in the self-heal loop, _sh_image is built with ext_image_name (no

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -456,6 +456,44 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# FIX3: tag-based fallback (no-version_digests artifact) must use the caller's
+#       explicit registry/owner, not the default get_registry()/get_repo_owner().
+#
+# Before fix: ext_image_name called without registry/owner → uses get_registry()
+#   and get_repo_owner() → wrong repo when caller passed explicit overrides.
+# After fix:  ext_image_name called with "$registry" "$owner" → honors caller args.
+#
+# Test strategy: generate_dockerfile with explicit registry="custom.io" and
+#   owner="customowner" against a no-version_digests artifact (LOCAL_ONLY/old path).
+#   All per-version COPY --from= refs inside the collector must use custom.io/customowner.
+# ---------------------------------------------------------------------------
+@test "FIX3-tag-fallback-uses-explicit-registry-owner: no-digests artifact refs use caller registry/owner" {
+    # No-version_digests artifact (LOCAL_ONLY / old build path).
+    _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "custom.io" "customowner"
+
+    [ "$status" -eq 0 ]
+
+    # Collector stage must be present (3 versions → multi-version path).
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+
+    # Every per-version COPY inside the collector must use custom.io/customowner.
+    local copy_count
+    copy_count=$(echo "$output" | grep -cE "COPY --from=custom\.io/customowner/ext-timescaledb:pg18-[0-9]" || true)
+    [ "$copy_count" -eq 3 ]
+
+    # Must NOT use the default get_registry() value (ghcr.io) set up in setup().
+    local wrong_count
+    wrong_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]" || true)
+    [ "$wrong_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # Test Y: production cwd/PROJECT_ROOT path — artifact found via PROJECT_ROOT
 #         even when ROOT_DIR is unset and cwd is a container subdirectory.
 #

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -166,17 +166,17 @@ EOF
 
     # One collector stage declared (FROM scratch AS ext_collect_timescaledb)
     local collector_from_count
-    collector_from_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_from_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_from_count" -eq 1 ]
 
     # Exactly ONE final-stage COPY from the collector (single exported layer)
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 
     # Three per-version COPYs inside the collector (one per available version)
     local collector_ver_count
-    collector_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-.* /output/ /" || true)
+    collector_ver_count=$(echo "$output" | grep -cxE "COPY --from=.*ext-timescaledb.*pg18-.* /output/ /.+" || true)
     [ "$collector_ver_count" -eq 3 ]
 }
 
@@ -216,7 +216,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # Final-stage COPY lands at /tmp/ext/timescaledb/
-    echo "$output" | grep -q "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
+    echo "$output" | grep -qx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
 }
 
 @test "multi-version: ceiling version 2.27.1 — collector stage succeeds, single final COPY" {
@@ -233,11 +233,11 @@ EOF
     [ "$status" -eq 0 ]
 
     # Collector stage present
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # Exactly ONE final-stage COPY
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -303,17 +303,17 @@ EOF
 
     # timescaledb: collector stage present
     local ts_collector_count
-    ts_collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    ts_collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$ts_collector_count" -eq 1 ]
 
     # timescaledb: exactly ONE final-stage COPY from collector
     local ts_bundle_count
-    ts_bundle_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    ts_bundle_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$ts_bundle_count" -eq 1 ]
 
     # timescaledb: per-version COPYs are INSIDE the collector (3 versions in stages_block)
     local ts_per_ver_count
-    ts_per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    ts_per_ver_count=$(echo "$output" | grep -cxE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$ts_per_ver_count" -eq 3 ]
 
     # pgvector: exactly 1 FROM stage (single-version, non-resolver path unchanged)
@@ -326,6 +326,73 @@ EOF
 
     # pgvector must NOT have version-subdirectory paths
     ! echo "$output" | grep -q "/tmp/ext/pgvector/0\."
+}
+
+# ---------------------------------------------------------------------------
+# NL-1: trailing-newline stripping by command substitution must not concatenate
+#        the collector final COPY with the next extension's COPY line.
+#
+# Mutation caught: removing the `$'\n'` appended to copies_block after the
+# command-substitution `${_ecs_output##*---ECS-COPIES---$'\n'}` in
+# generate_dockerfile. Without that `$'\n'`, bash command-substitution strips the
+# trailing newline from _emit_collector_stage's output, causing the final
+# collector COPY to be concatenated with the immediately following extension's
+# first line:
+#   COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/COPY --from=...
+#
+# The flavor under test (multi_mixed) places timescaledb (multi-version,
+# collector path) before pgvector (single-version, flat-copy path). The
+# timescaledb final COPY and the pgvector FROM must each appear on their own
+# line — a concatenated line is the exact bug signature.
+#
+# RED (before fix): the final COPY line contains "timescaledb/COPY" and the
+#   whole-line match for the clean COPY fails → test fails.
+# GREEN (after fix): each COPY/FROM is on its own whole line.
+# ---------------------------------------------------------------------------
+@test "NL-1: collector final COPY is on its own line, not concatenated with the next extension (trailing-newline bug)" {
+    # Mutation caught: removing `$'\n'` after copies_block+= in generate_dockerfile
+    # causes command-substitution to strip the trailing newline, concatenating
+    # COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/ with the
+    # next extension's COPY line.
+    _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "multi_mixed" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # BUG SIGNATURE: the collector final COPY must NOT appear merged with the next
+    # extension's COPY on the same line. This is the exact string the bug produces.
+    local bug_line_count
+    bug_line_count=$(echo "$output" | grep -cF "timescaledb/COPY" || true)
+    [ "$bug_line_count" -eq 0 ] || {
+        echo "FAIL: collector COPY concatenated with next line (trailing-newline bug). Output:"
+        echo "$output"
+        false
+    }
+
+    # PRIMARY ORACLE: the collector final COPY must be on its OWN exact line.
+    # grep -x requires the ENTIRE line to match — a concatenated line fails.
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ] || {
+        echo "FAIL: expected exactly 1 whole-line match for collector final COPY. Got: $final_copy_count. Output:"
+        echo "$output"
+        false
+    }
+
+    # SECONDARY ORACLE: the pgvector FROM stage must also be on its own exact line.
+    # A non-zero count here proves it was not absorbed into the preceding COPY line.
+    local pv_from_count
+    pv_from_count=$(echo "$output" | grep -cx "FROM ghcr.io/testowner/ext-pgvector:pg18-0.8.2 AS ext-pgvector" || true)
+    [ "$pv_from_count" -eq 1 ] || {
+        echo "FAIL: pgvector FROM must be on its own line. Got: $pv_from_count. Output:"
+        echo "$output"
+        false
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -375,18 +442,18 @@ EOF
 
     # Collector stage present (FROM scratch AS ext_collect_timescaledb)
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Self-heal path emits per-version COPYs INSIDE the collector stage.
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector (no bundle tag in output)
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -480,16 +547,16 @@ EOF
     [ "$status" -eq 0 ]
 
     # Collector stage must be present (3 versions → multi-version path).
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # Every per-version COPY inside the collector must use custom.io/customowner.
     local copy_count
-    copy_count=$(echo "$output" | grep -cE "COPY --from=custom\.io/customowner/ext-timescaledb:pg18-[0-9]" || true)
+    copy_count=$(echo "$output" | grep -cxE "COPY --from=custom\.io/customowner/ext-timescaledb:pg18-[0-9].* /output/ /.+" || true)
     [ "$copy_count" -eq 3 ]
 
     # Must NOT use the default get_registry() value (ghcr.io) set up in setup().
     local wrong_count
-    wrong_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]" || true)
+    wrong_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9].* /output/ /.+" || true)
     [ "$wrong_count" -eq 0 ]
 }
 
@@ -557,11 +624,11 @@ EOF
     # RED before fix: 1 FROM stage (single-version fallback because artifact not found).
     # GREEN after fix: collector stage + 1 final COPY (multi-version from artifact via PROJECT_ROOT).
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -606,11 +673,11 @@ EOF
 
     # Collector stage present + single final COPY
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -722,18 +789,18 @@ EOF
 
     # Collector stage present (self-heal funnels into same emitter)
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Self-heal emits per-version COPYs INSIDE the collector stage (/output/ → /<ver>/).
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector (no pg18-bundle in output)
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -852,12 +919,12 @@ EOF
     # Self-heal emits per-version COPYs INSIDE the collector stage.
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -883,12 +950,12 @@ EOF
 
     # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -914,12 +981,12 @@ EOF
 
     # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -960,11 +1027,11 @@ EOF
 
     # All 3 valid versions → collector stage + single final COPY.
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -1024,11 +1091,11 @@ EOF
 
     # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -1077,11 +1144,11 @@ EOF
 
     # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -1186,17 +1253,17 @@ EOF
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Self-heal emits per-version COPYs for the proved-present set (2.25.0, 2.27.1).
     # 2.23.0 is definitively absent and must NOT appear.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /2.27.1/"
 
     # 2.23.0 must NOT appear in the collector (definitively absent).
     local absent_count
@@ -1205,7 +1272,7 @@ EOF
 
     # Exactly ONE final-stage COPY from collector
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -1427,11 +1494,11 @@ _run_registry_probe_3state() {
     # Self-heal emits per-version COPYs inside the collector stage.
     # Three versions proved present locally: 2.25.0, 2.26.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -1473,11 +1540,11 @@ _run_registry_probe_3state() {
 
     # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 }
 
@@ -1654,11 +1721,11 @@ _run_registry_probe_3state() {
 
     # Must produce collector stage + single final COPY (non-vacuous: proves artifact was consumed).
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -1764,17 +1831,17 @@ _run_registry_probe_3state() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Single final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 
     # Three per-version COPYs inside the collector
     local per_ver_count
-    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_count=$(echo "$output" | grep -cxE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_count" -eq 3 ]
 }
 
@@ -1844,17 +1911,17 @@ _run_registry_probe_3state() {
 
     # One collector stage declared
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Exactly ONE final-stage COPY from the collector
     local final_copy_count
-    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_copy_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_copy_count" -eq 1 ]
 
     # Three per-version COPYs inside the collector (one per available version)
     local per_ver_copy_count
-    per_ver_copy_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_copy_count=$(echo "$output" | grep -cxE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_copy_count" -eq 3 ]
 }
 
@@ -1876,7 +1943,7 @@ _run_registry_probe_3state() {
     [ "$status" -eq 0 ]
 
     # The final-stage COPY lands at /tmp/ext/timescaledb/
-    echo "$output" | grep -q "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
+    echo "$output" | grep -qx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
 }
 
 # ---------------------------------------------------------------------------
@@ -1946,11 +2013,11 @@ _run_registry_probe_3state() {
 
     # timescaledb: collector stage + single final COPY
     local ts_collector_count
-    ts_collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    ts_collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$ts_collector_count" -eq 1 ]
 
     local ts_final_count
-    ts_final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    ts_final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$ts_final_count" -eq 1 ]
 
     # pgvector: exactly one FROM stage (single-version path unchanged)
@@ -1989,17 +2056,17 @@ _run_registry_probe_3state() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Three per-version COPYs inside the collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -2040,17 +2107,17 @@ _run_registry_probe_3state() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # 3 per-version COPYs inside collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -2090,16 +2157,16 @@ _run_registry_probe_3state() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Only the 2 proved-present versions must appear inside the collector.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /2.27.1/"
 
     # 2.23.0 must NOT appear inside the collector.
     local absent_count
@@ -2108,7 +2175,7 @@ _run_registry_probe_3state() {
 
     # Exactly ONE final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -2209,7 +2276,7 @@ EOF
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Per-version COPYs must use repo@digest format inside the collector.
@@ -2219,7 +2286,7 @@ EOF
 
     # Final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -2241,7 +2308,7 @@ EOF
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Tag-based refs (no @sha256: in the per-version COPYs inside the collector).
@@ -2251,7 +2318,7 @@ EOF
 
     # Still has 2 per-version COPYs inside collector
     local per_ver_count
-    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_count=$(echo "$output" | grep -cxE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_count" -eq 2 ]
 }
 
@@ -2383,7 +2450,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$status" -eq 0 ]
 
     # Collector stage present
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # Digest-pinned COPYs inside the collector
     local pinned_count
@@ -2404,7 +2471,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$status" -eq 0 ]
 
     # Collector stage still present (tag-based fallback)
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # No @sha256: in output (tag-based refs, no pinning when version_digests absent).
     local pinned_count
@@ -2567,17 +2634,17 @@ _write_versionset_with_malformed_ver_digest() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # 3 per-version COPYs inside the collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
     # Exactly ONE final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -2608,12 +2675,12 @@ _write_versionset_with_malformed_ver_digest() {
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Only proved-present versions inside collector (2.25.0 and 2.27.1).
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
     # 2.23.0 must NOT appear.
@@ -2636,7 +2703,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$status" -eq 0 ]
 
     # Collector stage present
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # Digest-pinned per-version COPYs inside the collector (2 versions)
     local pinned_count
@@ -2645,7 +2712,7 @@ _write_versionset_with_malformed_ver_digest() {
 
     # Exactly ONE final-stage COPY from collector
     local final_count
-    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    final_count=$(echo "$output" | grep -cx "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$final_count" -eq 1 ]
 }
 
@@ -3026,7 +3093,7 @@ ARTIFACT_EOF
 
     # Self-heal emits per-version COPYs for the 2 proved-present versions inside collector.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
     # A reduction warning must have been emitted.
@@ -3220,12 +3287,12 @@ ARTIFACT_EOF
     # Self-heal emits per-version COPYs inside collector with -pr42 suffix.
     # Canonical absent + PR-scoped present → each per-version ref must carry -pr42.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /.+" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
     # Both expected pr42 refs present inside collector.
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0-pr42 /output/ /"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1-pr42 /output/ /"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0-pr42 /output/ /2.25.0/"
+    echo "$output" | grep -qx "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1-pr42 /output/ /2.27.1/"
 }
 
 # ---------------------------------------------------------------------------
@@ -3276,7 +3343,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # Collector stage present with tag-based refs
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -qx "FROM scratch AS ext_collect_timescaledb"
 
     # No @sha256: anywhere (tag-based fallback, no digest pin).
     local pinned_count
@@ -3353,17 +3420,17 @@ EOF
 
     # Collector stage present
     local collector_count
-    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    collector_count=$(echo "$output" | grep -cx "FROM scratch AS ext_collect_timescaledb" || true)
     [ "$collector_count" -eq 1 ]
 
     # Self-heal emits per-version COPYs inside collector with -pr42 suffix.
     local pr_copy_count
-    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /" || true)
+    pr_copy_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /.+" || true)
     [ "$pr_copy_count" -eq 2 ]
 
     # No canonical (un-suffixed) per-version COPYs (canonical was absent for all versions).
     local canonical_copy_count
-    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+[^-] /output/ /" || true)
+    canonical_copy_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+[^-].* /output/ /.+" || true)
     [ "$canonical_copy_count" -eq 0 ]
 }
 
@@ -3406,12 +3473,12 @@ EOF
 
     # Self-heal emits per-version COPYs inside collector with NO pr suffix.
     local canonical_copy_count
-    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    canonical_copy_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /.+" || true)
     [ "$canonical_copy_count" -eq 2 ]
 
     # No -pr<N> suffixed COPY lines inside collector.
     local pr_copy_count
-    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=.*-pr[0-9]+ /output/ /" || true)
+    pr_copy_count=$(echo "$output" | grep -cxE "COPY --from=.*-pr[0-9]+ /output/ /.+" || true)
     [ "$pr_copy_count" -eq 0 ]
 }
 

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -85,8 +85,12 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: write a versionset fixture under .build-lineage/
+# Helpers: write versionset fixtures under .build-lineage/
 # ---------------------------------------------------------------------------
+
+# _write_versionset: write a versionset artifact WITHOUT version_digests.
+# Used for tests where version_digests is absent (LOCAL_ONLY / pre-finalize path).
+# The consumer falls back to tag-based refs (ext_image_name) without probing.
 _write_versionset() {
     local ext="$1"
     local pg_major="$2"
@@ -108,37 +112,48 @@ _write_versionset() {
 EOF
 }
 
-# ---------------------------------------------------------------------------
-# Test 1: multi-version — 3 available → ONE bundle COPY, NO per-version FROM stages
-# ---------------------------------------------------------------------------
-@test "multi-version: 3 available versions produce 3 direct COPY --from= lines, NO per-version FROM stages" {
-    _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
+# _write_versionset_with_digests: write a versionset artifact WITH version_digests.
+# Used for tests that exercise the digest-pinned collector stage (CI/publish path).
+# Assigns a deterministic fake digest per version (sha256:00..00<ver-index>0..0).
+_write_versionset_with_digests() {
+    local ext="$1"
+    local pg_major="$2"
+    shift 2
+    local -a available_arr=("$@")
 
-    run generate_dockerfile \
-        "$TEST_TEMP_DIR/extensions/config.yaml" \
-        "$TEST_TEMP_DIR/Dockerfile.template" \
-        "timeseries" "18" \
-        "ghcr.io" "testowner"
+    local arr_json="["
+    local first=1
+    for v in "${available_arr[@]}"; do
+        [[ "$first" -eq 0 ]] && arr_json+=","
+        arr_json+="\"$v\""
+        first=0
+    done
+    arr_json+="]"
 
-    [ "$status" -eq 0 ]
+    # Build version_digests: assign fake-but-valid sha256 per version (64 lowercase hex chars)
+    local vd_json="{"
+    local idx=1
+    local vd_first=1
+    for v in "${available_arr[@]}"; do
+        [[ "$vd_first" -eq 0 ]] && vd_json+=","
+        # Deterministic valid digest: sha256:000...0<idx as 2-digit hex padded to 64>
+        local hex_idx
+        hex_idx=$(printf '%064x' "$idx")
+        vd_json+="\"${v}\":\"sha256:${hex_idx}\""
+        vd_first=0
+        idx=$((idx + 1))
+    done
+    vd_json+="}"
 
-    # No per-version FROM ... AS stage lines for the resolver-backed extension
-    local per_ver_from_count
-    per_ver_from_count=$(echo "$output" | grep -c "^FROM ghcr.io/testowner/ext-timescaledb:pg18-" || true)
-    [ "$per_ver_from_count" -eq 0 ]
-
-    # Exactly ONE bundle COPY covers all available versions (single layer)
-    local bundle_copy_count
-    bundle_copy_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_copy_count" -eq 1 ]
-
-    # Zero per-version COPY lines for individual version tags
-    local per_ver_copy_count
-    per_ver_copy_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$per_ver_copy_count" -eq 0 ]
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-${ext}-pg${pg_major}-versionset.json" <<EOF
+{"ext":"${ext}","pg_major":"${pg_major}","ceiling":"${available_arr[-1]}","resolved":${arr_json},"available":${arr_json},"excluded":[],"version_digests":${vd_json}}
+EOF
 }
 
-@test "multi-version: COPY --from= refs are full image refs (host/path:tag), NOT bareword stage names" {
+# ---------------------------------------------------------------------------
+# Test 1: multi-version — 3 available → collector stage + ONE final-stage COPY
+# ---------------------------------------------------------------------------
+@test "multi-version: 3 available versions → FROM scratch AS ext_collect_timescaledb + 1 final COPY" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -149,22 +164,47 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # Every COPY --from= for timescaledb must use a full image ref (host/path:tag pattern)
-    # A bareword like "ext-timescaledb-2_23_0" would NOT match this pattern.
+    # One collector stage declared (FROM scratch AS ext_collect_timescaledb)
+    local collector_from_count
+    collector_from_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_from_count" -eq 1 ]
+
+    # Exactly ONE final-stage COPY from the collector (single exported layer)
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
+
+    # Three per-version COPYs inside the collector (one per available version)
+    local collector_ver_count
+    collector_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-.* /output/ /" || true)
+    [ "$collector_ver_count" -eq 3 ]
+}
+
+@test "multi-version: COPY --from= refs inside collector are full image refs (host/path:tag)" {
+    _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+
+    # Every COPY --from= inside the collector stage must use a full image ref.
+    # A bareword stage alias would NOT match the ghcr.io/...:.+ pattern.
     while IFS= read -r copy_line; do
         [[ -z "$copy_line" ]] && continue
-        # Extract the --from= value
         local from_ref
         from_ref=$(echo "$copy_line" | sed -n 's/.*--from=\([^ ]*\).*/\1/p')
-        # Must contain a registry host (has a slash before the first colon), a colon, and a tag
         [[ "$from_ref" =~ ghcr\.io/.+:.+ ]]
-    done < <(echo "$output" | grep "COPY --from=.*ext-timescaledb" || true)
+    done < <(echo "$output" | grep "COPY --from=.*ext-timescaledb.*pg18-" || true)
 }
 
-@test "multi-version: COPYs go into per-version subdirs /tmp/ext/timescaledb/<ver>/" {
-    # The bundle COPY lands at /tmp/ext/timescaledb/ so the bundle's internal
-    # /<ver>/{extension,lib}/ structure arrives at /tmp/ext/timescaledb/<ver>/
-    # which is exactly the layout install_ext iterates.
+@test "multi-version: final-stage COPY lands at /tmp/ext/timescaledb/ preserving per-version layout" {
+    # The collector COPY --from=ext_collect_timescaledb / /tmp/ext/<ext>/
+    # combined with the collector's internal /<ver>/ dirs produces
+    # /tmp/ext/<ext>/<ver>/{extension,lib}/ which install_ext iterates.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -175,17 +215,13 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # The single bundle COPY lands at /tmp/ext/timescaledb/ — version coverage
-    # is preserved because the bundle contains /<ver>/{extension,lib}/ for every
-    # available version.
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/"
+    # Final-stage COPY lands at /tmp/ext/timescaledb/
+    echo "$output" | grep -q "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
 }
 
-@test "multi-version: ceiling version 2.27.1 appears LAST (ascending order, COPY lines)" {
-    # With the bundle approach, ordering is handled by the producer (bundle Dockerfile
-    # lists versions ascending). The consumer emits exactly ONE COPY; version ordering
-    # is no longer observable in the consumer output.
-    # This test verifies the consumer still succeeds and emits the bundle COPY.
+@test "multi-version: ceiling version 2.27.1 — collector stage succeeds, single final COPY" {
+    # Collector approach makes version ordering inside the final stage irrelevant:
+    # the collector's layers are not exported. Test that consumer still succeeds.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -196,13 +232,13 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # Single bundle COPY present
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/"
+    # Collector stage present
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
 
-    # Zero per-version COPY lines (order no longer needs asserting in the consumer)
-    local per_ver_copy_count
-    per_ver_copy_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$per_ver_copy_count" -eq 0 ]
+    # Exactly ONE final-stage COPY
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -265,20 +301,20 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # timescaledb: NO per-version FROM ... AS stages
-    local ts_from_count
-    ts_from_count=$(echo "$output" | grep -c "^FROM ghcr.io/testowner/ext-timescaledb:pg18-" || true)
-    [ "$ts_from_count" -eq 0 ]
+    # timescaledb: collector stage present
+    local ts_collector_count
+    ts_collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$ts_collector_count" -eq 1 ]
 
-    # timescaledb: exactly ONE bundle COPY covering all available versions
+    # timescaledb: exactly ONE final-stage COPY from collector
     local ts_bundle_count
-    ts_bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
+    ts_bundle_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
     [ "$ts_bundle_count" -eq 1 ]
 
-    # timescaledb: zero per-version COPY lines
+    # timescaledb: per-version COPYs are INSIDE the collector (3 versions in stages_block)
     local ts_per_ver_count
-    ts_per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$ts_per_ver_count" -eq 0 ]
+    ts_per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    [ "$ts_per_ver_count" -eq 3 ]
 
     # pgvector: exactly 1 FROM stage (single-version, non-resolver path unchanged)
     local pv_count
@@ -337,21 +373,21 @@ EOF
     # Must self-heal to multi-version (NOT single-version ceiling fallback).
     [ "$status" -eq 0 ]
 
-    # No per-version FROM ... AS stages (single-version path bypassed)
-    local per_ver_from_count
-    per_ver_from_count=$(echo "$output" | grep -c "^FROM ghcr.io/testowner/ext-timescaledb:pg18-" || true)
-    [ "$per_ver_from_count" -eq 0 ]
+    # Collector stage present (FROM scratch AS ext_collect_timescaledb)
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY) — one pair per proved version.
+    # Self-heal path emits per-version COPYs INSIDE the collector stage.
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path (AP: mutable bundle tag not used)
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector (no bundle tag in output)
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "empty-available: artifact with available=[] + resolver fails → fail closed" {
@@ -479,12 +515,16 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # Must find artifact via PROJECT_ROOT → bundle COPY path (single COPY, not single-version FROM).
+    # Must find artifact via PROJECT_ROOT → collector stage path (not single-version FROM).
     # RED before fix: 1 FROM stage (single-version fallback because artifact not found).
-    # GREEN after fix: 1 bundle COPY (multi-version from artifact found via PROJECT_ROOT).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_count" -eq 1 ]
+    # GREEN after fix: collector stage + 1 final COPY (multi-version from artifact via PROJECT_ROOT).
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -514,8 +554,8 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "Z-ceiling-present: ceiling in available[] → multi-version path succeeds" {
-    # Sanity: ceiling IS present → normal multi-version success with bundle COPY.
+@test "Z-ceiling-present: ceiling in available[] → collector stage + single final COPY" {
+    # Sanity: ceiling IS present → normal multi-version success with collector stage.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -526,10 +566,14 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # Single bundle COPY (all 3 versions are in the bundle)
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_count" -eq 1 ]
+    # Collector stage present + single final COPY
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -638,21 +682,21 @@ EOF
     # Self-heal succeeds: must exit 0.
     [ "$status" -eq 0 ]
 
-    # No per-version FROM ... AS stages (single-version path bypassed).
-    local per_ver_from_count
-    per_ver_from_count=$(echo "$output" | grep -c "^FROM ghcr.io/testowner/ext-timescaledb:pg18-" || true)
-    [ "$per_ver_from_count" -eq 0 ]
+    # Collector stage present (self-heal funnels into same emitter)
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY).
+    # Self-heal emits per-version COPYs INSIDE the collector stage (/output/ → /<ver>/).
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector (no pg18-bundle in output)
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "EE-a-2-resolver-fails: resolver-backed ext + no artifact + resolver fails → fail closed" {
@@ -767,16 +811,16 @@ EOF
     # Must exit 0 (self-heal succeeded).
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs, NOT a bundle COPY.
+    # Self-heal emits per-version COPYs INSIDE the collector stage.
     # Three versions proved present: 2.23.0, 2.25.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "JJ-2-malformed-garbage: non-JSON garbage artifact + resolver succeeds → self-heals to multi-version" {
@@ -799,15 +843,15 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs, NOT a bundle COPY.
+    # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "JJ-3-malformed-no-available: JSON missing .available key + resolver succeeds → self-heals" {
@@ -830,15 +874,15 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs, NOT a bundle COPY.
+    # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "JJ-4-malformed-resolver-fails: malformed artifact + resolver FAILS → fail closed (non-zero)" {
@@ -876,10 +920,14 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # All 3 valid versions → single bundle COPY (no per-version FROM stages or individual COPYs).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_count" -eq 1 ]
+    # All 3 valid versions → collector stage + single final COPY.
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -936,14 +984,14 @@ EOF
     rm -rf "$controlled_tmp"
     [ "$leftover_count" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY).
+    # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -989,14 +1037,14 @@ EOF
     rm -rf "$controlled_tmp"
     [ "$leftover_count" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY).
+    # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1098,24 +1146,29 @@ EOF
     # _sh_available == [2.25.0, 2.27.1] — ceiling present, count > 1.
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs for the proved-present set (2.25.0, 2.27.1).
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # Self-heal emits per-version COPYs for the proved-present set (2.25.0, 2.27.1).
     # 2.23.0 is definitively absent and must NOT appear.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/extension/"
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /"
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /"
 
-    # 2.23.0 must NOT appear (definitively absent).
+    # 2.23.0 must NOT appear in the collector (definitively absent).
     local absent_count
     absent_count=$(echo "$output" | grep -c "ext-timescaledb:pg18-2.23.0" || true)
     [ "$absent_count" -eq 0 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1333,16 +1386,15 @@ _run_registry_probe_3state() {
     # Exits 0 (local daemon probe finds images, self-heals).
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY).
+    # Self-heal emits per-version COPYs inside the collector stage.
     # Three versions proved present locally: 2.25.0, 2.26.0, 2.27.1.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "PP-pull-only-self-heal: PULL_ONLY=true + images present locally → generate_dockerfile self-heals" {
@@ -1381,15 +1433,14 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs (not bundle COPY).
+    # Self-heal emits per-version COPYs inside the collector stage.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
 }
 
 @test "PP-local-only-image-absent-locally: LOCAL_ONLY=true + image NOT in local daemon → generate_dockerfile fails closed" {
@@ -1563,15 +1614,14 @@ _run_registry_probe_3state() {
     # Must succeed — valid artifact requires no skopeo.
     [ "$status" -eq 0 ]
 
-    # Must produce single bundle COPY (non-vacuous: proves artifact was consumed).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_count" -eq 1 ]
+    # Must produce collector stage + single final COPY (non-vacuous: proves artifact was consumed).
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # No per-version COPY lines (version coverage is in the bundle, not individual COPYs).
-    local per_ver_count
-    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$per_ver_count" -eq 0 ]
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1660,10 +1710,10 @@ _run_registry_probe_3state() {
 
 # ---------------------------------------------------------------------------
 # AG-5: regression guard — valid versionset artifact with 3 clean elements
-# still produces exactly 3 FROM stages (chokepoint must not break happy path).
+# still produces collector stage + single final COPY (chokepoint must not break happy path).
 # ---------------------------------------------------------------------------
 
-@test "AG-5-valid-artifact-still-works: clean available[] with 3 valid elements -> 3 direct COPY --from= lines" {
+@test "AG-5-valid-artifact-still-works: clean available[] with 3 valid elements -> collector stage + 1 final COPY" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1674,20 +1724,20 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # No per-version FROM ... AS stages
-    local per_ver_from_count
-    per_ver_from_count=$(echo "$output" | grep -c "^FROM ghcr.io/testowner/ext-timescaledb:pg18-" || true)
-    [ "$per_ver_from_count" -eq 0 ]
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # Single bundle COPY (chokepoint must not break happy path; version coverage in bundle).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_count" -eq 1 ]
+    # Single final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 
-    # Zero per-version COPY lines
+    # Three per-version COPYs inside the collector
     local per_ver_count
-    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$per_ver_count" -eq 0 ]
+    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    [ "$per_ver_count" -eq 3 ]
 }
 
 @test "SS-jq-absent: jq not on PATH + resolver-backed ext + valid artifact → fail-fast with 'jq' in error message" {
@@ -1736,14 +1786,14 @@ _run_registry_probe_3state() {
 
 # ---------------------------------------------------------------------------
 # BUNDLE-CON-1: resolver-backed ext with 3 available versions →
-# generated Dockerfile has EXACTLY ONE COPY --from=<bundle-ref> / /tmp/ext/<ext>/
-# and ZERO per-version COPY/FROM lines.
+# generated Dockerfile has a collector stage (FROM scratch AS ext_collect_<ext>)
+# with 3 per-version COPYs inside, and EXACTLY ONE final-stage COPY from the collector.
 #
-# RED before: N per-version COPY pairs (2N lines)
-# GREEN after: 1 bundle COPY line
+# The per-version COPYs are inside the collector stage (not exported layers).
+# The final stage sees exactly 1 COPY from the collector (1 exported layer).
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-1: 3 available versions → exactly 1 bundle COPY, 0 per-version refs" {
+@test "BUNDLE-CON-1: 3 available versions → collector stage + exactly 1 final COPY" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1754,29 +1804,29 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # Exactly ONE COPY --from=<bundle-ref> landing at /tmp/ext/timescaledb/
-    local bundle_copy_count
-    bundle_copy_count=$(echo "$output" | grep -c "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$bundle_copy_count" -eq 1 ]
+    # One collector stage declared
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # ZERO per-version COPY lines referencing individual version tags (pg18-2.X.Y)
+    # Exactly ONE final-stage COPY from the collector
+    local final_copy_count
+    final_copy_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_copy_count" -eq 1 ]
+
+    # Three per-version COPYs inside the collector (one per available version)
     local per_ver_copy_count
-    per_ver_copy_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$per_ver_copy_count" -eq 0 ]
-
-    # ZERO per-version FROM ... AS stages for timescaledb
-    local per_ver_from_count
-    per_ver_from_count=$(echo "$output" | grep -cE "^FROM .*ext-timescaledb:pg18-[0-9]" || true)
-    [ "$per_ver_from_count" -eq 0 ]
+    per_ver_copy_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    [ "$per_ver_copy_count" -eq 3 ]
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-2: the bundle COPY places files at /tmp/ext/<ext>/
-# so that /<ver>/... in the bundle lands at /tmp/ext/<ext>/<ver>/...
-# which is the layout install_ext iterates.
+# BUNDLE-CON-2: the final-stage COPY places the collector's content at
+# /tmp/ext/<ext>/ so that /<ver>/ dirs inside the collector land at
+# /tmp/ext/<ext>/<ver>/ which is the layout install_ext iterates.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-2: bundle COPY destination is /tmp/ext/timescaledb/ (installs at correct path)" {
+@test "BUNDLE-CON-2: collector COPY destination is /tmp/ext/timescaledb/ (installs at correct path)" {
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1787,18 +1837,16 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # The single COPY must land at /tmp/ext/timescaledb/ so bundle's
-    # /<ver>/{extension,lib}/ becomes /tmp/ext/timescaledb/<ver>/{extension,lib}/
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/"
+    # The final-stage COPY lands at /tmp/ext/timescaledb/
+    echo "$output" | grep -q "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/"
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-3: bundle ref is derived identically by producer and consumer.
-# Consumer must use ext_image_name base + :pg<major>-bundle suffix.
-# The ref in the generated COPY must match the producer's naming scheme.
+# BUNDLE-CON-3: the collector stage name is derived from the extension name.
+# Consumer emits "FROM scratch AS ext_collect_<ext>".
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-3: bundle ref in generated COPY uses correct scheme ghcr.io/<owner>/ext-<ext>:pg<major>-bundle" {
+@test "BUNDLE-CON-3: collector stage name is ext_collect_timescaledb" {
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1809,8 +1857,8 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # Full bundle ref must appear in the output
-    echo "$output" | grep -q "ghcr.io/testowner/ext-timescaledb:pg18-bundle"
+    # Collector stage name must appear
+    echo "$output" | grep -q "FROM scratch AS ext_collect_timescaledb"
 }
 
 # ---------------------------------------------------------------------------
@@ -1847,7 +1895,7 @@ _run_registry_probe_3state() {
 # timescaledb COPYs, one pgvector FROM.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-5: mixed flavor — timescaledb bundle COPY + pgvector single-version unchanged" {
+@test "BUNDLE-CON-5: mixed flavor — timescaledb collector + pgvector single-version unchanged" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1858,20 +1906,14 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # timescaledb: exactly one bundle COPY
-    local ts_bundle_count
-    ts_bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/")
-    [ "$ts_bundle_count" -eq 1 ]
+    # timescaledb: collector stage + single final COPY
+    local ts_collector_count
+    ts_collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$ts_collector_count" -eq 1 ]
 
-    # timescaledb: zero per-version FROM stages
-    local ts_from_count
-    ts_from_count=$(echo "$output" | grep -cE "^FROM .*ext-timescaledb:pg18-[0-9]" || true)
-    [ "$ts_from_count" -eq 0 ]
-
-    # timescaledb: zero per-version COPY lines
-    local ts_per_ver_count
-    ts_per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+" || true)
-    [ "$ts_per_ver_count" -eq 0 ]
+    local ts_final_count
+    ts_final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$ts_final_count" -eq 1 ]
 
     # pgvector: exactly one FROM stage (single-version path unchanged)
     local pv_from_count
@@ -1880,19 +1922,15 @@ _run_registry_probe_3state() {
 
     # pgvector: flat COPY paths
     echo "$output" | grep -q "COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/"
-
-    # pgvector: no bundle COPY
-    ! echo "$output" | grep -q "ext-pgvector:pg18-bundle"
 }
 
 # ---------------------------------------------------------------------------
 # BUNDLE-CON-6: self-heal path (no artifact) for resolver-backed ext
-# also emits a single bundle COPY (not per-version COPYs).
+# also emits a collector stage + 1 final COPY (not a mutable bundle tag).
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-6: self-heal (no artifact) emits per-version COPYs, not bundle COPY" {
-    # AP: self-heal path no longer uses the mutable bundle tag — it emits per-version
-    # COPYs from the proved-present per-version image refs instead.
+@test "BUNDLE-CON-6: self-heal (no artifact) emits collector stage + 1 final COPY" {
+    # Self-heal uses the same collector emitter as the artifact-present path.
     # No versionset file — self-heal must kick in.
 
     resolve_version_set() {
@@ -1911,19 +1949,20 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # AP: three per-version COPY --from= pairs (one /output/extension/ + one /output/lib/ each).
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # Three per-version COPYs inside the collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    local per_ver_lib_count
-    per_ver_lib_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/lib/" || true)
-    [ "$per_ver_lib_count" -eq 3 ]
-
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1961,20 +2000,20 @@ _run_registry_probe_3state() {
     # Self-heal succeeds.
     [ "$status" -eq 0 ]
 
-    # AP: must emit exactly 3 per-version /output/extension/ COPYs.
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # 3 per-version COPYs inside collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # AP: must emit exactly 3 per-version /output/lib/ COPYs.
-    local per_ver_lib_count
-    per_ver_lib_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/lib/" || true)
-    [ "$per_ver_lib_count" -eq 3 ]
-
-    # NO bundle ref anywhere in the output (AP: mutable bundle tag not used on self-heal).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -2011,23 +2050,28 @@ _run_registry_probe_3state() {
 
     [ "$status" -eq 0 ]
 
-    # Only the 2 proved-present versions must appear (2.25.0 and 2.27.1).
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # Only the 2 proved-present versions must appear inside the collector.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/extension/"
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /"
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/ /"
 
-    # 2.23.0 must NOT appear.
+    # 2.23.0 must NOT appear inside the collector.
     local absent_count
     absent_count=$(echo "$output" | grep -c "ext-timescaledb:pg18-2.23.0" || true)
     [ "$absent_count" -eq 0 ]
 
-    # No bundle COPY on self-heal path.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 @test "AK-selfheal-error-version-failclosed: transient ERROR probe in self-heal → fail closed, no output" {
@@ -2107,17 +2151,15 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AM-consumer-digest-pin: artifact present with bundle_digest → generated
-# Dockerfile COPYs from <bundle-ref>@<digest> (immutable, pinned reference).
+# AM-consumer-digest-pin: artifact present with version_digests → generated
+# Dockerfile collector stage COPYs from <repo>@<digest> (immutable, pinned).
 #
-# RED before fix: COPY uses only the mutable tag <bundle-ref>, no @sha256:...
-# GREEN after fix: COPY uses <bundle-ref>@sha256:... (digest-pinned).
+# version_digests: {"2.25.0":"sha256:<64hex>", "2.27.1":"sha256:<64hex>"}
+# Each per-version COPY inside the collector uses the digest-pinned ref.
 # ---------------------------------------------------------------------------
-@test "AM-consumer-digest-pin: artifact with bundle_digest → COPY from repo@digest (no tag segment)" {
-    # Artifact: multi-version with bundle_digest.
-    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
-{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":"sha256:deadbeef00000000000000000000000000000000000000000000000000000000"}
-EOF
+@test "AM-consumer-digest-pin: artifact with version_digests → collector COPYs use repo@digest refs" {
+    # Artifact: multi-version with version_digests.
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -2127,31 +2169,29 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # BB-1 Part 3: COPY uses repo@digest (no tag segment) — addressable regardless
-    # of whether the bundle was produced by a PR (pr-scoped tag) or push (canonical tag).
-    # Must NOT contain ":pg18-bundle@" (old tag-ref@digest format).
-    local old_format_count
-    old_format_count=$(echo "$output" | grep -c "ext-timescaledb:pg18-bundle@sha256:" || true)
-    [ "$old_format_count" -eq 0 ]
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # Must contain the repo@digest format (no tag between image name and @digest).
+    # Per-version COPYs must use repo@digest format inside the collector.
     local pinned_count
-    pinned_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:" || true)
-    [ "$pinned_count" -eq 1 ]
+    pinned_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:" || true)
+    [ "$pinned_count" -eq 2 ]
 
-    # The full repo@digest ref must contain the exact digest from the artifact.
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:deadbeef"
+    # Final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
-# AM-consumer-no-digest-tag-fallback: artifact present WITHOUT bundle_digest
-# (local/LOCAL_ONLY-produced artifact) → COPY uses tag-based reference only
-# (no @sha256:, no failure).
+# AM-consumer-no-digest-tag-fallback: artifact present WITHOUT version_digests
+# (LOCAL_ONLY-produced artifact) → collector COPYs use tag-based references.
 # ---------------------------------------------------------------------------
-@test "AM-consumer-no-digest-tag-fallback: artifact without bundle_digest → tag-based COPY, no @ pin" {
-    # Artifact: multi-version, no bundle_digest (LOCAL_ONLY-produced case).
+@test "AM-consumer-no-digest-tag-fallback: artifact without version_digests → tag-based refs in collector" {
+    # Artifact: multi-version, no version_digests (LOCAL_ONLY-produced case).
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
-    # _write_versionset does not include bundle_digest — the artifact is a plain object.
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -2161,44 +2201,42 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # Must emit exactly ONE bundle COPY (tag-based, no digest pin).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/" || true)
-    [ "$bundle_count" -eq 1 ]
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
 
-    # Must NOT contain any @sha256: (no digest pinning when digest absent).
+    # Tag-based refs (no @sha256: in the per-version COPYs inside the collector).
     local pinned_count
     pinned_count=$(echo "$output" | grep -c "@sha256:" || true)
     [ "$pinned_count" -eq 0 ]
+
+    # Still has 2 per-version COPYs inside collector
+    local per_ver_count
+    per_ver_count=$(echo "$output" | grep -cE "COPY --from=.*ext-timescaledb.*pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
+    [ "$per_ver_count" -eq 2 ]
 }
 
 # ---------------------------------------------------------------------------
 # AN-consumer: strict OCI digest validation at the consumer boundary.
 #
-# bundle_digest flows from the artifact into COPY --from=<ref>@<digest>.
-# A poisoned artifact can put whitespace/newlines/extra tokens in bundle_digest
-# and inject arbitrary Dockerfile instructions.
+# version_digests[ver] flows from the artifact into COPY --from=<repo>@<digest>
+# inside the collector stage. A poisoned artifact can inject arbitrary content.
 #
-# Fix: `is_valid_oci_digest` validates the whole-string before use:
+# Fix: `is_valid_oci_digest` validates whole-string before use:
 #   EXACTLY sha256: followed by EXACTLY 64 lowercase hex chars, nothing else.
 #
-# AN-consumer-rejects-malformed-digest: poisoned bundle_digest (embedded
-#   newline + RUN evil, wrong length, uppercase, extra chars) → generate_dockerfile
-#   FAILS CLOSED (non-zero, no injected text in any emitted line).
-#   RED before (injected into COPY), GREEN after.
-#
-# AN-consumer-accepts-valid-digest: valid digest → COPY --from=<ref>@sha256:<64hex>
-#   (regression — AM digest-pin still works).
-#
-# AN-consumer-absent-digest-tag: no bundle_digest in artifact → tag-based COPY
-#   (LOCAL_ONLY case, unchanged).
+# AN tests verify that malformed per-version digests cause fail-closed,
+# valid digests produce digest-pinned collector COPYs, and absent version_digests
+# falls back to tag-based refs.
 # ---------------------------------------------------------------------------
 
-# Helper: write a versionset artifact that contains bundle_digest.
-_write_versionset_with_digest() {
+# Helper: write a versionset artifact with a specific (potentially malformed)
+# digest for the FIRST version in the available list.  Used by AN injection tests.
+_write_versionset_with_malformed_ver_digest() {
     local ext="$1"
     local pg_major="$2"
-    local digest="$3"
+    local bad_digest="$3"
     shift 3
     local -a available_arr=("$@")
 
@@ -2211,78 +2249,79 @@ _write_versionset_with_digest() {
     done
     arr_json+="]"
 
+    # Write with a valid digest for the last version and the bad_digest for the first.
+    local first_ver="${available_arr[0]}"
+    local last_ver="${available_arr[-1]}"
+    local good_digest="sha256:abcdef0000000000000000000000000000000000000000000000000000000000"
+
     # Use printf to write the digest value literally (handles embedded newlines).
     local tmp_digest_file
     tmp_digest_file=$(mktemp)
-    printf '%s' "$digest" > "$tmp_digest_file"
+    printf '%s' "$bad_digest" > "$tmp_digest_file"
+
+    local bad_val
+    bad_val=$(cat "$tmp_digest_file")
+    rm -f "$tmp_digest_file"
+
+    # Build version_digests JSON with bad_val for first_ver
+    local vd_json="{\"${first_ver}\":$(jq -n --arg d "$bad_val" '$d')}"
+    # If there is a second version, add a valid digest for it
+    if [[ "${#available_arr[@]}" -ge 2 ]]; then
+        vd_json="{\"${first_ver}\":$(jq -n --arg d "$bad_val" '$d'),\"${last_ver}\":\"${good_digest}\"}"
+    fi
 
     jq -nc \
         --arg ext "$ext" \
         --arg pg_major "$pg_major" \
-        --arg ceiling "${available_arr[-1]}" \
+        --arg ceiling "$last_ver" \
         --argjson resolved "$arr_json" \
         --argjson available "$arr_json" \
-        --rawfile bundle_digest "$tmp_digest_file" \
-        '{ext:$ext,pg_major:$pg_major,ceiling:$ceiling,resolved:$resolved,available:$available,excluded:[],bundle_digest:($bundle_digest|rtrimstr("\n"))}' \
+        --argjson version_digests "$vd_json" \
+        '{ext:$ext,pg_major:$pg_major,ceiling:$ceiling,resolved:$resolved,available:$available,excluded:[],version_digests:$version_digests}' \
         > "$TEST_TEMP_DIR/.build-lineage/ext-${ext}-pg${pg_major}-versionset.json"
-    rm -f "$tmp_digest_file"
 }
 
-@test "AN-consumer-rejects-embedded-newline-injection: bundle_digest with newline+RUN evil → fail closed, injected text absent" {
-    # Poisoned digest: valid-looking sha256 prefix + embedded newline + injected directive.
-    # An attacker who controls the artifact can put this in bundle_digest to inject
-    # a RUN instruction into the generated Dockerfile.
+@test "AN-consumer-rejects-embedded-newline-injection: version_digests with newline+RUN evil → fail closed" {
+    # Poisoned digest for one version: valid-looking sha256 prefix + embedded newline + injected directive.
     local evil_digest
     evil_digest=$(printf 'sha256:0000000000000000000000000000000000000000000000000000000000000000\nRUN evil')
-    _write_versionset_with_digest "timescaledb" "18" "$evil_digest" "2.25.0" "2.27.1"
+    _write_versionset_with_malformed_ver_digest "timescaledb" "18" "$evil_digest" "2.25.0" "2.27.1"
 
-    # Use --separate-stderr so $output contains only stdout (Dockerfile content)
-    # and $stderr contains error messages. This prevents the log_error message
-    # (which quotes the malformed digest for diagnostics) from being mistaken
-    # for injected Dockerfile content in the evil_count assertion.
     run --separate-stderr generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
         "$TEST_TEMP_DIR/Dockerfile.template" \
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # RED before fix: exits 0, "RUN evil" appears in stdout (injected into Dockerfile).
-    # GREEN after fix: exits non-zero (fail closed — malformed digest rejected).
+    # Must fail closed — malformed digest rejected.
     [ "$status" -ne 0 ]
 
-    # The injected token must NEVER appear in the Dockerfile stdout (primary oracle).
-    # $output is stdout-only with --separate-stderr; error messages go to $stderr.
+    # Injected text must NOT appear in stdout.
     local evil_count
     evil_count=$(printf '%s' "$output" | grep -c "RUN evil" || true)
     [ "$evil_count" -eq 0 ]
 }
 
-@test "AN-consumer-rejects-uppercase-hex: uppercase digest → fail closed" {
-    # sha256: followed by 64 uppercase hex chars — fails strict validator (must be lowercase).
+@test "AN-consumer-rejects-uppercase-hex: uppercase digest in version_digests → fail closed" {
     local bad_digest="sha256:DEADBEEF00000000000000000000000000000000000000000000000000000000"
-    _write_versionset_with_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
+    _write_versionset_with_malformed_ver_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
 
-    # Use --separate-stderr so $output contains Dockerfile stdout only.
     run --separate-stderr generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
         "$TEST_TEMP_DIR/Dockerfile.template" \
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # RED before fix: exits 0, emits COPY with uppercase digest (unvalidated).
-    # GREEN after fix: exits non-zero.
     [ "$status" -ne 0 ]
 
-    # The uppercase hex must not appear in any COPY line in the Dockerfile stdout.
     local upper_count
     upper_count=$(printf '%s' "$output" | grep -c "DEADBEEF" || true)
     [ "$upper_count" -eq 0 ]
 }
 
-@test "AN-consumer-rejects-short-hash: sha256:<63hex> too-short → fail closed" {
-    # 63 hex chars — one char short of a valid sha256 digest.
+@test "AN-consumer-rejects-short-hash: sha256:<63hex> in version_digests → fail closed" {
     local bad_digest="sha256:000000000000000000000000000000000000000000000000000000000000000"
-    _write_versionset_with_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
+    _write_versionset_with_malformed_ver_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -2293,10 +2332,9 @@ _write_versionset_with_digest() {
     [ "$status" -ne 0 ]
 }
 
-@test "AN-consumer-accepts-valid-digest: valid sha256:<64lowercase-hex> → repo@digest COPY emitted" {
-    # Proper OCI digest — must produce a pinned COPY --from=<repo>@sha256:<64hex> (no tag).
-    local good_digest="sha256:abcdef0000000000000000000000000000000000000000000000000000000000"
-    _write_versionset_with_digest "timescaledb" "18" "$good_digest" "2.25.0" "2.27.1"
+@test "AN-consumer-accepts-valid-digest: valid version_digests → per-version repo@digest COPYs inside collector" {
+    # Proper OCI digest — must produce collector stage with digest-pinned per-version COPYs.
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -2304,15 +2342,19 @@ _write_versionset_with_digest() {
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # Regression: valid digest must succeed.
     [ "$status" -eq 0 ]
 
-    # BB-1 Part 3: COPY must use repo@digest format (no tag segment).
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb@${good_digest} / /tmp/ext/timescaledb/"
+    # Collector stage present
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+
+    # Digest-pinned COPYs inside the collector
+    local pinned_count
+    pinned_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:" || true)
+    [ "$pinned_count" -eq 2 ]
 }
 
-@test "AN-consumer-absent-digest-tag: no bundle_digest in artifact → tag-based COPY, no @ pin" {
-    # LOCAL_ONLY-produced artifact: no bundle_digest field.
+@test "AN-consumer-absent-digest-tag: no version_digests in artifact → tag-based refs in collector" {
+    # LOCAL_ONLY-produced artifact: no version_digests field.
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -2323,12 +2365,10 @@ _write_versionset_with_digest() {
 
     [ "$status" -eq 0 ]
 
-    # Tag-based COPY (no digest pin).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/" || true)
-    [ "$bundle_count" -eq 1 ]
+    # Collector stage still present (tag-based fallback)
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
 
-    # No @sha256: in output.
+    # No @sha256: in output (tag-based refs, no pinning when version_digests absent).
     local pinned_count
     pinned_count=$(echo "$output" | grep -c "@sha256:" || true)
     [ "$pinned_count" -eq 0 ]
@@ -2467,7 +2507,7 @@ _write_versionset_with_digest() {
 #   self-heal, ceiling absent from _sh_available → fail closed (AO-4 still enforced).
 # ---------------------------------------------------------------------------
 
-@test "AP-selfheal-per-version-not-bundle: self-heal >1 proved-present versions → per-version COPYs, NO bundle tag" {
+@test "AP-selfheal-per-version-not-bundle: self-heal >1 proved-present versions → collector stage, no bundle tag" {
     # No versionset artifact → forces self-heal path.
     # _sh_available = [2.23.0, 2.25.0, 2.27.1] (all present, ceiling present, count > 1).
 
@@ -2485,30 +2525,22 @@ _write_versionset_with_digest() {
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # Must succeed.
     [ "$status" -eq 0 ]
 
-    # Per-version COPYs: one /output/extension/ line per proved version.
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # 3 per-version COPYs inside the collector (/output/ → /<ver>/)
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 3 ]
 
-    # Per-version COPYs: one /output/lib/ line per proved version.
-    local per_ver_lib_count
-    per_ver_lib_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/lib/" || true)
-    [ "$per_ver_lib_count" -eq 3 ]
-
-    # Destinations are version-subdirectoried: /tmp/ext/<ext>/<ver>/extension/ and /tmp/ext/<ext>/<ver>/lib/
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.23.0 /output/extension/ /tmp/ext/timescaledb/2.23.0/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/extension/ /tmp/ext/timescaledb/2.25.0/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/extension/ /tmp/ext/timescaledb/2.27.1/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.23.0 /output/lib/ /tmp/ext/timescaledb/2.23.0/lib/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1 /output/lib/ /tmp/ext/timescaledb/2.27.1/lib/"
-
-    # NO :pg18-bundle reference anywhere in the generated Dockerfile.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 @test "AP-selfheal-only-proved-versions: absent version not emitted; transient ERROR fails closed" {
@@ -2534,32 +2566,28 @@ _write_versionset_with_digest() {
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # Ceiling (2.27.1) is present, count=2 → multi-version per-version path.
     [ "$status" -eq 0 ]
 
-    # Only proved-present versions must appear (2.25.0 and 2.27.1).
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # Only proved-present versions inside collector (2.25.0 and 2.27.1).
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
     # 2.23.0 must NOT appear.
     local absent_count
     absent_count=$(echo "$output" | grep -c "ext-timescaledb:pg18-2.23.0" || true)
     [ "$absent_count" -eq 0 ]
-
-    # No bundle ref.
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c ":pg18-bundle" || true)
-    [ "$bundle_count" -eq 0 ]
 }
 
-@test "AP-artifact-path-still-bundle-digest: artifact present with bundle_digest → repo@digest COPY (no tag segment)" {
-    # AM regression: artifact-present path must still emit a digest-pinned COPY.
-    # BB-1 Part 3: the ref is repo@digest (no tag segment) — tag-agnostic.
-    # Self-heal is NOT triggered (valid artifact on disk).
-    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
-{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":"sha256:cafebabe00000000000000000000000000000000000000000000000000000000"}
-EOF
+@test "AP-artifact-path-still-version-digests: artifact with version_digests → digest-pinned collector COPYs" {
+    # AM regression: artifact-present path must still emit digest-pinned refs inside the collector.
+    # Self-heal is NOT triggered (valid artifact on disk with version_digests).
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -2569,20 +2597,18 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # BB-1 Part 3: exactly ONE repo@digest COPY (no tag segment before @sha256:).
+    # Collector stage present
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+
+    # Digest-pinned per-version COPYs inside the collector (2 versions)
     local pinned_count
-    pinned_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:cafebabe" || true)
-    [ "$pinned_count" -eq 1 ]
+    pinned_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:" || true)
+    [ "$pinned_count" -eq 2 ]
 
-    # Must NOT contain the old tag-ref format (:pg18-bundle@sha256:).
-    local old_format_count
-    old_format_count=$(echo "$output" | grep -c ":pg18-bundle@sha256:" || true)
-    [ "$old_format_count" -eq 0 ]
-
-    # NO per-version individual COPY lines (artifact path uses bundle, not per-version).
-    local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
-    [ "$per_ver_ext_count" -eq 0 ]
+    # Exactly ONE final-stage COPY from collector
+    local final_count
+    final_count=$(echo "$output" | grep -c "COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/" || true)
+    [ "$final_count" -eq 1 ]
 }
 
 @test "AP-selfheal-ceiling-present-enforced: self-heal ceiling absent from proved set → fail closed" {
@@ -2689,18 +2715,16 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AR-2: a malformed bundle_digest containing GHA workflow-command injection
+# AR-2: a malformed version_digests entry containing GHA workflow-command injection
 # bytes must be defanged in the log diagnostic and the function must fail closed.
 #
-# A poisoned artifact has bundle_digest = "sha256:abc\n::add-mask::secret".
-# is_valid_oci_digest rejects this (not valid sha256:<64 hex>), so generate_dockerfile
-# must fail closed (exit non-zero). The log_error message must NOT contain a raw
-# newline immediately followed by ::add-mask:: (the injection form GHA interprets).
+# A poisoned artifact has version_digests["2.23.0"] = "sha256:abc\n::add-mask::secret".
+# is_valid_oci_digest rejects this, so generate_dockerfile must fail closed (exit
+# non-zero). The log_error message must NOT contain a raw newline immediately followed
+# by ::add-mask:: (the injection form GHA interprets).
 # ---------------------------------------------------------------------------
-@test "AR2-digest-diagnostic-sanitized: malformed bundle_digest with injection bytes — fail closed, diagnostic defanged" {
-    # Artifact with 3 available versions (triggers bundle path) and a poisoned digest.
-    # The digest contains an embedded newline + GHA workflow command.
-    # We write it with a literal newline embedded in the JSON string value.
+@test "AR2-digest-diagnostic-sanitized: malformed version_digests entry with injection bytes — fail closed, diagnostic defanged" {
+    # Artifact with 3 available versions and a poisoned digest for one version.
     python3 -c "
 import json, os
 artifact = {
@@ -2710,15 +2734,17 @@ artifact = {
     'resolved': ['2.23.0', '2.25.0', '2.27.1'],
     'available': ['2.23.0', '2.25.0', '2.27.1'],
     'excluded': [],
-    'bundle_digest': 'sha256:abc\n::add-mask::secret'
+    'version_digests': {
+        '2.23.0': 'sha256:abc\n::add-mask::secret',
+        '2.25.0': 'sha256:' + 'a' * 64,
+        '2.27.1': 'sha256:' + 'b' * 64
+    }
 }
 path = os.path.join('$TEST_TEMP_DIR', '.build-lineage', 'ext-timescaledb-pg18-versionset.json')
 with open(path, 'w') as f:
     json.dump(artifact, f)
 "
 
-    # Capture stderr by running generate_dockerfile in a subprocess that redirects
-    # stderr to a file — the inner redirect ensures we capture the log_error bytes.
     local ar2_stderr="/tmp/ar2_digest_stderr_$$.txt"
     local ar2_rc=0
     bash -c "
@@ -2741,12 +2767,10 @@ with open(path, 'w') as f:
     local stderr_content
     stderr_content=$(cat "$ar2_stderr" 2>/dev/null || true)
 
-    # The log diagnostic must have been emitted (error message mentions bundle_digest).
-    [[ "$stderr_content" == *"bundle_digest"* ]]
+    # The log diagnostic must have been emitted (error message mentions version_digests).
+    [[ "$stderr_content" == *"version_digests"* ]]
 
     # The injection sequence must NOT appear as a line starting with :: in the output.
-    # GHA interprets any line whose first two characters are '::' as a workflow command.
-    # After sanitization no line in the diagnostic may begin with '::'.
     if printf '%s\n' "$stderr_content" | grep -qE '^::'; then
         echo "FAIL: log output contains a line starting with '::' — GHA injection not neutralized"
         echo "--- stderr_content ---"
@@ -2962,9 +2986,9 @@ ARTIFACT_EOF
     # Must succeed — reduced set with ceiling present is not a fatal error.
     [ "$status" -eq 0 ]
 
-    # AP: per-version COPYs for the 2 proved-present versions (2.25.0 and 2.27.1).
+    # Self-heal emits per-version COPYs for the 2 proved-present versions inside collector.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
     # A reduction warning must have been emitted.
@@ -3006,24 +3030,13 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB1-consumer-repo-digest: artifact with bundle_digest → consumer COPY uses
-# <registry>/<owner>/ext-<ext>@<digest> (repo + digest, NO tag segment).
-# This is addressable in the repo regardless of which tag (pr-scoped or
-# canonical) points to it — the SAME artifact works from both PR and master.
-#
-# RED before fix: COPY uses <bundle-ref>@<digest> where <bundle-ref> includes
-#   the tag segment (:pg18-bundle). A digest ref with a tag is still
-#   tag-dependent notation — Docker resolves by digest but pulls tag namespace.
-#   More importantly: if the tag was -pr42-scoped, a later canonical master run
-#   would need the artifact regenerated.
-# GREEN after fix: COPY uses <registry>/<owner>/ext-<ext>@<digest> (no tag),
-#   which is a pure-digest reference valid across any tag scope.
+# BB1-consumer-repo-digest: artifact with version_digests → each per-version
+# COPY inside the collector uses <registry>/<owner>/ext-<ext>@<digest>
+# (repo + digest, NO tag segment). Pure-digest references are valid across
+# any tag scope (PR-scoped or canonical).
 # ---------------------------------------------------------------------------
-@test "BB1-consumer-repo-digest: bundle_digest in artifact → COPY ref is repo@digest (no tag segment)" {
-    # Artifact: multi-version with bundle_digest.
-    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
-{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":"sha256:deadbeef00000000000000000000000000000000000000000000000000000000"}
-EOF
+@test "BB1-consumer-repo-digest: version_digests in artifact → per-version COPYs are repo@digest (no tag segment)" {
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
         "$TEST_TEMP_DIR/extensions/config.yaml" \
@@ -3033,23 +3046,20 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # GREEN: COPY ref must be repo@digest format (no tag segment like :pg18-bundle).
-    # The ref must be ghcr.io/testowner/ext-timescaledb@sha256:deadbeef...
-    # with NO colon-delimited tag between the image name and the @digest.
-    local copy_line
-    copy_line=$(echo "$output" | grep "COPY --from=.*timescaledb.*deadbeef" || true)
-    [ -n "$copy_line" ]
+    # All per-version COPYs must use repo@digest format (no tag segment).
+    local copy_lines
+    copy_lines=$(echo "$output" | grep "COPY --from=.*timescaledb@sha256:" || true)
+    [ -n "$copy_lines" ]
 
-    # Must NOT contain ":pg18-bundle" before the @digest.
-    [[ "$copy_line" != *":pg18-bundle@"* ]]
+    # No ":pg" before @sha256: (no tag segment in the ref).
+    local tagged_digest_count
+    tagged_digest_count=$(echo "$output" | grep -c ":pg.*@sha256:" || true)
+    [ "$tagged_digest_count" -eq 0 ]
 
-    # Must contain the bare repo path + @digest.
-    [[ "$copy_line" == *"ghcr.io/testowner/ext-timescaledb@sha256:deadbeef"* ]]
-
-    # Exactly one such COPY line.
+    # 2 such digest-pinned COPYs (one per version in the collector stage)
     local copy_count
     copy_count=$(echo "$output" | grep -c "ghcr.io/testowner/ext-timescaledb@sha256:" || true)
-    [ "$copy_count" -eq 1 ]
+    [ "$copy_count" -eq 2 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -3169,15 +3179,15 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # AP path: per-version COPY lines for each proved version.
+    # Self-heal emits per-version COPYs inside collector with -pr42 suffix.
     # Canonical absent + PR-scoped present → each per-version ref must carry -pr42.
     local per_ver_ext_count
-    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/extension/" || true)
+    per_ver_ext_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /" || true)
     [ "$per_ver_ext_count" -eq 2 ]
 
-    # Both expected pr42 refs present.
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0-pr42 /output/extension/"
-    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1-pr42 /output/extension/"
+    # Both expected pr42 refs present inside collector.
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0-pr42 /output/ /"
+    echo "$output" | grep -q "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.27.1-pr42 /output/ /"
 }
 
 # ---------------------------------------------------------------------------
@@ -3187,23 +3197,21 @@ EOF
 # ABSENT and PRESENT-EMPTY to the empty string — falling back to the mutable
 # bundle tag.  BC-3 requires distinguishing:
 #   - FIELD ABSENT    → allowed LOCAL_ONLY tag fallback (exit 0)
-#   - FIELD PRESENT but empty string → FAIL CLOSED (exit non-zero)
+#   - FIELD PRESENT but empty digest string → FAIL CLOSED (exit non-zero)
 #   - FIELD PRESENT but not valid OCI digest → FAIL CLOSED (already AN-covered)
 #
 # BC3-empty-digest-failclosed:
-#   artifact has {"bundle_digest":""} (present, empty string) →
+#   artifact has version_digests["2.25.0"]="" (present, empty string) →
 #   generate_dockerfile FAILS CLOSED (non-zero).
-#   RED before fix: falls back to mutable tag (exits 0).
-#   GREEN after: exits non-zero (field present but invalid → fail closed).
 #
 # BC3-absent-digest-tag-fallback:
-#   artifact has NO bundle_digest key → tag-based COPY, exit 0 (LOCAL_ONLY case).
+#   artifact has NO version_digests key → tag-based refs, exit 0 (LOCAL_ONLY case).
 #   Must remain GREEN (regression guard).
 # ---------------------------------------------------------------------------
-@test "BC3-empty-digest-failclosed: bundle_digest present-but-empty string → fail closed (no mutable-tag fallback)" {
-    # Artifact with bundle_digest field present but set to empty string.
+@test "BC3-empty-digest-failclosed: version_digests entry present-but-empty → fail closed" {
+    # Artifact with version_digests having one empty-string value.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
-{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":""}
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"","2.27.1":"sha256:abcdef0000000000000000000000000000000000000000000000000000000000"}}
 EOF
 
     run generate_dockerfile \
@@ -3212,18 +3220,12 @@ EOF
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # RED before fix: exits 0 (falls through to mutable bundle tag).
-    # GREEN after fix: exits non-zero (field present, value invalid → fail closed).
+    # Field present with empty value → fail closed.
     [ "$status" -ne 0 ]
-
-    # The mutable bundle tag must NOT appear in any COPY line (no fallback).
-    local bundle_tag_count
-    bundle_tag_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle" || true)
-    [ "$bundle_tag_count" -eq 0 ]
 }
 
-@test "BC3-absent-digest-tag-fallback: NO bundle_digest key in artifact → tag-based COPY, exit 0 (LOCAL_ONLY regression)" {
-    # LOCAL_ONLY-produced artifact: bundle_digest key is completely absent.
+@test "BC3-absent-digest-tag-fallback: NO version_digests key in artifact → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
+    # LOCAL_ONLY-produced artifact: version_digests key is completely absent.
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -3232,15 +3234,13 @@ EOF
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # Must succeed (LOCAL_ONLY case — key absent is allowed).
+    # Must succeed (LOCAL_ONLY case — key absent → tag-based refs in collector).
     [ "$status" -eq 0 ]
 
-    # Must emit exactly ONE mutable bundle tag COPY (no digest pin).
-    local bundle_count
-    bundle_count=$(echo "$output" | grep -c "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-bundle / /tmp/ext/timescaledb/" || true)
-    [ "$bundle_count" -eq 1 ]
+    # Collector stage present with tag-based refs
+    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
 
-    # No @sha256: anywhere.
+    # No @sha256: anywhere (tag-based fallback, no digest pin).
     local pinned_count
     pinned_count=$(echo "$output" | grep -c "@sha256:" || true)
     [ "$pinned_count" -eq 0 ]
@@ -3313,14 +3313,19 @@ EOF
     # Canonical absent → fall back to PR-scoped → PRESENT → self-heal succeeds → exit 0.
     [ "$status" -eq 0 ]
 
-    # Self-heal emits per-version COPYs with -pr42 suffix (AP path, canonical absent → PR-scoped).
+    # Collector stage present
+    local collector_count
+    collector_count=$(echo "$output" | grep -c "^FROM scratch AS ext_collect_timescaledb" || true)
+    [ "$collector_count" -eq 1 ]
+
+    # Self-heal emits per-version COPYs inside collector with -pr42 suffix.
     local pr_copy_count
-    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/extension/" || true)
+    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+-pr42 /output/ /" || true)
     [ "$pr_copy_count" -eq 2 ]
 
-    # No canonical (un-suffixed) COPY lines for timescaledb (canonical was absent for all versions).
+    # No canonical (un-suffixed) per-version COPYs (canonical was absent for all versions).
     local canonical_copy_count
-    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+[^-] /output/extension/" || true)
+    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+[^-] /output/ /" || true)
     [ "$canonical_copy_count" -eq 0 ]
 }
 
@@ -3361,14 +3366,14 @@ EOF
     # Push path must succeed: canonical probe → PRESENT → self-heal succeeds.
     [ "$status" -eq 0 ]
 
-    # AP: self-heal emits per-version COPYs with NO pr suffix.
+    # Self-heal emits per-version COPYs inside collector with NO pr suffix.
     local canonical_copy_count
-    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/extension/" || true)
+    canonical_copy_count=$(echo "$output" | grep -cE "COPY --from=ghcr\.io/testowner/ext-timescaledb:pg18-[0-9]+\.[0-9]+\.[0-9]+ /output/ /" || true)
     [ "$canonical_copy_count" -eq 2 ]
 
-    # No -pr<N> suffixed COPY lines.
+    # No -pr<N> suffixed COPY lines inside collector.
     local pr_copy_count
-    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=.*-pr[0-9]+ /output/extension/" || true)
+    pr_copy_count=$(echo "$output" | grep -cE "COPY --from=.*-pr[0-9]+ /output/ /" || true)
     [ "$pr_copy_count" -eq 0 ]
 }
 
@@ -3549,16 +3554,16 @@ EOF
     # Self-heal must succeed.
     [ "$status" -eq 0 ]
 
-    # 2.23.0 must be emitted as the CANONICAL ref (no -pr42 suffix).
+    # 2.23.0 must be emitted as the CANONICAL ref (no -pr42 suffix) inside the collector.
     local canonical_copy_count
-    canonical_copy_count=$(echo "$output" | grep -c 'ghcr.io/testowner/ext-timescaledb:pg18-2.23.0 /output/extension/' || true)
+    canonical_copy_count=$(echo "$output" | grep -c 'ghcr.io/testowner/ext-timescaledb:pg18-2.23.0 /output/ /' || true)
     [ "$canonical_copy_count" -eq 1 ] || {
-        echo "FAIL: 2.23.0 must appear as canonical ref in COPY line. Output was:"
+        echo "FAIL: 2.23.0 must appear as canonical ref in collector COPY. Output was:"
         echo "$output"
         false
     }
 
-    # 2.23.0 must NOT appear with -pr42 suffix in any COPY line.
+    # 2.23.0 must NOT appear with -pr42 suffix.
     local pr_copy_count
     pr_copy_count=$(echo "$output" | grep -c 'pg18-2.23.0-pr42' || true)
     [ "$pr_copy_count" -eq 0 ] || {
@@ -3567,9 +3572,9 @@ EOF
         false
     }
 
-    # 2.27.1 (bumped, built this PR) must appear as PR-scoped ref.
+    # 2.27.1 (bumped, built this PR) must appear as PR-scoped ref inside the collector.
     local pr42_count
-    pr42_count=$(echo "$output" | grep -c 'pg18-2.27.1-pr42 /output/extension/' || true)
+    pr42_count=$(echo "$output" | grep -c 'pg18-2.27.1-pr42 /output/ /' || true)
     [ "$pr42_count" -eq 1 ] || {
         echo "FAIL: 2.27.1 must appear as pr42-scoped ref. Output was:"
         echo "$output"


### PR DESCRIPTION
## What

Replace the pushed `ext-<ext>:pg<major>-bundle` image with a **consume-time collector build stage**, unifying the two ways retained TimescaleDB versions reached the postgres image.

Before, `generate_dockerfile` had two paths:
- **artifact-present**: one `COPY --from=<bundle@digest>` of a pushed multi-arch bundle, behind a build/push/digest-capture/validate machinery (the BB-1 path);
- **self-heal** (artifact absent: `skip_extensions`, local builds, transient artifact-download failure): N per-version `COPY --from=…` straight into the **final** stage → 2×N exported layers. Safe at `retain_count=12` (~76 layers) but re-hits BuildKit "max depth exceeded" (overlay2 ~128-layer export cap) as the window grows.

Now both go through one mechanism — an intermediate throwaway stage whose layers are **not exported**:
```dockerfile
FROM scratch AS ext_collect_<ext>
COPY --from=<ref-ver> /output/ /<ver>/     # one COPY per version, in the collector
...
# in the final stage:
COPY --from=ext_collect_<ext> / /tmp/ext/<ext>/   # ONE exported layer, any version count
```
The final image gains **one layer for the whole retained window regardless of version count**, and there is **no pushed bundle**. This deletes the bundle build/push + the BB-1 digest machinery, collapses the consumer to a single `_emit_collector_stage` path, and makes the retained window count-independent (so `retain_count` can grow without re-hitting max-depth). `install_ext`'s layout is unchanged.

## Design review
codex + copilot were consulted on the design before implementation; both returned **PROCEED-WITH-CHANGES**. Their required changes are incorporated: one COPY per version (not split — halves collector depth); pin the per-version **multi-arch index** digest (not an arch manifest) and validate it covers both platforms; carry a `{version → index digest}` map in the artifact (no mutable-tag fallback on the publish path); keep the producer-side existence preflight. Sharded collectors (only needed for "all upstream") are out of scope.

## Producer (`scripts/build-extensions.sh`)
- Delete `assemble_and_push_bundle` and the bundle build/push/digest block in `finalize_multiarch_manifests`.
- Capture each per-version multi-arch **index** digest after `imagetools create`, validating it is an index covering `linux/amd64` + `linux/arm64`; fail-closed otherwise.
- Replace the single `bundle_digest` artifact field with a `version_digests: {ver: sha256:…}` map. **Invariant: `version_digests` is absent only when the build did not push** — every push path (including the non-arch publish path) now pins each published version, fail-closed if any can't be pinned.

## Consumer (`helpers/extension-utils.sh`)
- One `_emit_collector_stage` helper fed a `version → ref` map: digest-pinned (`repo@<index-digest>`) when the artifact carries `version_digests` (fail-closed if a declared version lacks a digest), tag-resolved via `ext_ref_resolve` on the self-heal path. No bash 4.3+ namerefs (keeps the documented 4.0+ floor). The fallback honors explicit `registry`/`owner` overrides.

## Tests
- Migrated `build-extensions-versionset.bats` + `generate-dockerfile-versionset.bats` to the `version_digests` schema and collector-stage shape; deleted the tests that only exercised the removed bundle machinery.
- New `collector-emitter.bats`: digest-pinned, self-heal tag-resolved, single-version unchanged, empty/ceiling-absent fail-closed, version-in-available-but-no-digest fail-closed, and a 30-version set yielding exactly ONE final-stage COPY (count-independent).
- Net diff ≈ −1500 LOC (mostly deleted bundle code + bundle tests). shellcheck clean. Orthogonal gate (codex + copilot) clean on the cumulative diff.

## Follow-up (not in this PR)
- A CI stress build of `postgres:full` at an elevated `retain_count` to prove the collector depth holds well beyond 12.
- Sharded collectors if "all upstream" retention is ever wanted.

Refs #558.
