### PR TITLE
perf(ci): cut base-image drift probe cost (dedup + per-container scope)

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1215,9 +1215,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - name: Install yq
         shell: bash
         run: |
@@ -1430,9 +1427,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - name: Install yq
         shell: bash
         run: |
@@ -1459,7 +1453,7 @@ jobs:
           # Detector emits ::error:: lines to stderr for visibility; capture stdout
           # and check exit code + JSON validity before processing.
           detect_rc=0
-          ./scripts/detect-base-digest-drift.sh > "$drift_file" || detect_rc=$?
+          ./scripts/detect-base-digest-drift.sh --container "$CONTAINER" > "$drift_file" || detect_rc=$?
           if [[ $detect_rc -ne 0 ]]; then
             echo "::error::detect-base-digest-drift.sh exited with $detect_rc — aborting PR" >&2
             exit 1
@@ -1728,9 +1722,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - name: Install yq
         shell: bash
         run: |
@@ -1757,7 +1748,7 @@ jobs:
           # Detector emits ::error:: lines to stderr for visibility; capture stdout
           # and check exit code + JSON validity before processing.
           detect_rc=0
-          ./scripts/detect-base-digest-drift.sh > "$drift_file" || detect_rc=$?
+          ./scripts/detect-base-digest-drift.sh --container "$CONTAINER" > "$drift_file" || detect_rc=$?
           if [[ $detect_rc -ne 0 ]]; then
             echo "::error::detect-base-digest-drift.sh exited with $detect_rc — aborting PR" >&2
             exit 1

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -78,6 +78,7 @@ _escape_gha_command() {
 # Argument parsing
 # ---------------------------------------------------------------------------
 BASELINE_ONLY=false
+CONTAINER_FILTER=""
 LINEAGE_DIR="${PROJECT_ROOT}/.build-lineage"
 
 while [[ $# -gt 0 ]]; do
@@ -85,6 +86,14 @@ while [[ $# -gt 0 ]]; do
         --baseline-only)
             BASELINE_ONLY=true
             shift
+            ;;
+        --container)
+            if [[ -z "${2:-}" ]]; then
+                echo "::error::--container requires a value" >&2
+                exit 1
+            fi
+            CONTAINER_FILTER="$2"
+            shift 2
             ;;
         -*)
             echo "::error::Unknown flag: $1" >&2
@@ -171,6 +180,39 @@ _probe_digest() {
     rm -f "$probe_stderr"
     printf '%s' "$digest"
     return 0
+}
+
+# ---------------------------------------------------------------------------
+# _probe_digest_cached — memoizing wrapper around _probe_digest
+#
+# IMPORTANT: this function must NOT be called via $(...) command substitution
+# because bash command substitution runs in a subshell and writes to the
+# child's copy of _DIGEST_CACHE only — the parent never sees the update.
+# Instead, callers use the output variable pattern:
+#
+#   _probe_digest_cached_out=""
+#   if _probe_digest_cached "$ref"; then
+#       use "$_probe_digest_cached_out"
+#   fi
+#
+# Cache key = verbatim base_image_ref string (no normalization).
+# Successes are cached immediately; failures are left uncached so a transient
+# registry error does not permanently suppress drift detection for a ref.
+# ---------------------------------------------------------------------------
+_probe_digest_cached_out=""   # output variable — set on success
+_probe_digest_cached() {
+    local image_ref="$1"
+    if [[ -v _DIGEST_CACHE[$image_ref] ]]; then
+        _probe_digest_cached_out="${_DIGEST_CACHE[$image_ref]}"
+        return 0
+    fi
+    local digest
+    if digest=$(_probe_digest "$image_ref"); then
+        _DIGEST_CACHE[$image_ref]="$digest"
+        _probe_digest_cached_out="$digest"
+        return 0
+    fi
+    return 1   # failures left UNCACHED (smallest semantic change)
 }
 
 # ---------------------------------------------------------------------------
@@ -304,6 +346,7 @@ fi
 
 declare -A _container_variants  # container_name -> newline-separated JSON fragments
 declare -a _container_order     # ordered list of unique container names seen
+declare -A _DIGEST_CACHE        # verbatim base_image_ref -> probed digest (successes only)
 
 for lineage_file in "${lineage_files[@]}"; do
     basename_file="$(basename "$lineage_file")"
@@ -338,6 +381,13 @@ for lineage_file in "${lineage_files[@]}"; do
     if ! [[ "$container" =~ ^[a-z0-9_-]+$ ]]; then
         printf '::warning::Rejecting lineage entry %s: container name contains invalid characters: %s\n' \
             "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
+        continue
+    fi
+
+    # Per-container scope: skip lineage entries for other containers (filter on the
+    # validated .container JSON field, NOT the filename). Placed before the probe so
+    # non-matching containers cost zero registry probes.
+    if [[ -n "$CONTAINER_FILTER" && "$container" != "$CONTAINER_FILTER" ]]; then
         continue
     fi
 
@@ -593,10 +643,16 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Probe current digest
+    # Probe current digest (memoized: same ref probed at most once per run).
+    # Use the output-variable pattern — NOT $(...) — so _DIGEST_CACHE writes
+    # propagate to the parent shell (command substitution creates a subshell
+    # whose variable writes are lost on exit).
     current_digest=""
     probe_failed=false
-    if ! current_digest=$(_probe_digest "$base_image_ref"); then
+    _probe_digest_cached_out=""
+    if _probe_digest_cached "$base_image_ref"; then
+        current_digest="$_probe_digest_cached_out"
+    else
         probe_failed=true
     fi
 

--- a/tests/fixtures/digest-drift/scenario-3/lineage-cache/foo-1.0-alpine.json
+++ b/tests/fixtures/digest-drift/scenario-3/lineage-cache/foo-1.0-alpine.json
@@ -1,0 +1,11 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-alpine",
+  "flavor": "alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false
+}

--- a/tests/fixtures/digest-drift/scenario-3/lineage-cache/foo-1.0-alpine2.json
+++ b/tests/fixtures/digest-drift/scenario-3/lineage-cache/foo-1.0-alpine2.json
@@ -1,0 +1,11 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-alpine2",
+  "flavor": "alpine2",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false
+}

--- a/tests/fixtures/digest-drift/scenario-3/responses/alpine-3.21.json
+++ b/tests/fixtures/digest-drift/scenario-3/responses/alpine-3.21.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/digest-drift/scenario-4/lineage-cache/wrongname-1.0-alpine.json
+++ b/tests/fixtures/digest-drift/scenario-4/lineage-cache/wrongname-1.0-alpine.json
@@ -1,0 +1,11 @@
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "version": "1.0",
+  "tag": "1.0-alpine",
+  "flavor": "alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "built_at": "2026-05-01T00:00:00Z",
+  "github_actions": false
+}

--- a/tests/fixtures/digest-drift/scenario-4/responses/alpine-3.21.json
+++ b/tests/fixtures/digest-drift/scenario-4/responses/alpine-3.21.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1642,
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -3768,3 +3768,208 @@ php" \
     php_present=$(printf '%s' "$internal_deps_json" | jq -r 'index("php") != null')
     [ "$php_present" = "true" ]
 }
+
+# ---------------------------------------------------------------------------
+# Helper: create a counting probe stub that serves fixture responses AND
+# records one invocation per ref under a counter directory.
+#
+# Usage: _make_counting_probe_stub <responses_dir> <counter_dir>
+#
+# Each invocation appends a line to <counter_dir>/<ref_key> so callers can
+# assert `wc -l` to verify dedup.  The counter file name uses the same
+# key normalization as _make_probe_stub (':' and '/' → '-').
+# ---------------------------------------------------------------------------
+_make_counting_probe_stub() {
+    local responses_dir="$1"
+    local counter_dir="$2"
+    local stub_path="$TEST_TEMP_DIR/bin/probe-counting-stub"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<STUB_EOF
+#!/usr/bin/env bash
+image_ref="\$1"
+responses_dir="${responses_dir}"
+counter_dir="${counter_dir}"
+
+key="\$(printf '%s' "\$image_ref" | tr ':/' '--')"
+response_file="\${responses_dir}/\${key}.json"
+
+# Bump the per-ref counter (one line per invocation)
+mkdir -p "\${counter_dir}"
+printf '%s\n' "\${image_ref}" >> "\${counter_dir}/\${key}"
+
+if [[ -f "\$response_file" ]]; then
+    cat "\$response_file"
+    exit 0
+else
+    echo "stub: no fixture for '\$image_ref' (expected \$response_file)" >&2
+    exit 1
+fi
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# MG5: Probe dedup — same base_image_ref probed at most once per run
+#
+# Scenario-3 has two foo variants (1.0-alpine and 1.0-alpine2) that both use
+# base_image_ref = "alpine:3.21".  With memoization, the real probe runs
+# exactly once for that ref.  Both variants must still receive the correct
+# status (drift, since recorded=aaa... but current=ccc...).
+# Mutation guard: deleting the _DIGEST_CACHE lookup would make the counter
+# reach 2 (one per variant), failing the [ "$count" -eq 1 ] assertion.
+# ---------------------------------------------------------------------------
+@test "scenario-3: probe dedup — shared base_image_ref probed exactly once (guard MG5)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-3"
+    local counter_dir="$TEST_TEMP_DIR/probe-counters"
+    local probe_stub
+    probe_stub=$(_make_counting_probe_stub "${fixture_dir}/responses" "$counter_dir")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Counter file for alpine:3.21 must exist and have exactly 1 line
+    counter_file="${counter_dir}/alpine-3.21"
+    [ -f "$counter_file" ]
+    count=$(wc -l < "$counter_file")
+    [ "$count" -eq 1 ]
+}
+
+@test "scenario-3: probe dedup — both variants still receive correct drift status (guard MG5)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-3"
+    local counter_dir="$TEST_TEMP_DIR/probe-counters-b"
+    local probe_stub
+    probe_stub=$(_make_counting_probe_stub "${fixture_dir}/responses" "$counter_dir")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "${fixture_dir}/lineage-cache")
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Both variants share alpine:3.21; recorded=aaa... but current=ccc... -> drift
+    v1_status=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-alpine") | .status')
+    [ "$v1_status" = "drift" ]
+
+    v2_status=$(printf '%s' "$result" | \
+        jq -r '.[0].variants[] | select(.variant_tag == "1.0-alpine2") | .status')
+    [ "$v2_status" = "drift" ]
+}
+
+# ---------------------------------------------------------------------------
+# MG6: --container scope filter
+#
+# Scenario-2 has two containers: foo (alpine + debian) and bar (ubuntu + rocky).
+# Running with --container foo must:
+#   1. Emit exactly one container record (foo)
+#   2. bar must be absent from output
+#   3. The counting stub must show ZERO invocations for refs that belong ONLY
+#      to bar (ubuntu:24.04, rockylinux:9) -- the skip happens before the probe
+# Mutation guard: deleting the `continue` skip would cause bar to appear in
+# output and the ubuntu/rocky counters to be non-zero.
+# ---------------------------------------------------------------------------
+@test "scenario-2: --container foo — output contains only foo (guard MG6)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local counter_dir="$TEST_TEMP_DIR/mg6-counters"
+    local probe_stub
+    probe_stub=$(_make_counting_probe_stub "${fixture_dir}/responses" "$counter_dir")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" --container foo "${fixture_dir}/lineage-cache")
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Exactly one container record
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+
+    # The record is for foo
+    container_name=$(printf '%s' "$result" | jq -r '.[0].container')
+    [ "$container_name" = "foo" ]
+}
+
+@test "scenario-2: --container foo — bar is absent from output (guard MG6)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" --container foo "${fixture_dir}/lineage-cache")
+
+    # bar must not appear anywhere in output
+    bar_count=$(printf '%s' "$result" | jq '[.[] | select(.container == "bar")] | length')
+    [ "$bar_count" -eq 0 ]
+}
+
+@test "scenario-2: --container foo — bar's refs are NOT probed (skip before probe, guard MG6)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local counter_dir="$TEST_TEMP_DIR/mg6-skip-counters"
+    local probe_stub
+    probe_stub=$(_make_counting_probe_stub "${fixture_dir}/responses" "$counter_dir")
+
+    PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" --container foo "${fixture_dir}/lineage-cache" >/dev/null
+
+    # Refs used only by bar: ubuntu:24.04 and rockylinux:9
+    # Their counter files must NOT exist (zero invocations)
+    [ ! -f "${counter_dir}/ubuntu-24.04" ]
+    [ ! -f "${counter_dir}/rockylinux-9" ]
+}
+
+@test "scenario-2: --container nonexistent — empty output (fail-safe)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" --container nonexistent "${fixture_dir}/lineage-cache")
+
+    # Non-matching filter -> no entries -> empty array
+    [ "$result" = "[]" ]
+}
+
+# MG6 field-vs-filename: filtering uses the .container JSON field, NOT the
+# filename stem.  Scenario-4 has a file named "wrongname-1.0-alpine.json"
+# whose .container field is "foo".  A filename-based filter would miss it;
+# a field-based filter finds it.
+@test "scenario-4: --container foo finds entry whose filename stem is 'wrongname' (field-not-filename, guard MG6)" {
+    local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-4"
+    local probe_stub
+    probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
+
+    # "wrongname" is not in _VALID_CONTAINERS_OVERRIDE; "foo" is.
+    # The file is wrongname-1.0-alpine.json but .container = "foo".
+    result=$(PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" --container foo "${fixture_dir}/lineage-cache")
+
+    printf '%s' "$result" | jq '.' >/dev/null
+
+    # Must find the entry via the .container field, not filename
+    length=$(printf '%s' "$result" | jq 'length')
+    [ "$length" -eq 1 ]
+
+    container_name=$(printf '%s' "$result" | jq -r '.[0].container')
+    [ "$container_name" = "foo" ]
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing: --container edge cases
+# ---------------------------------------------------------------------------
+@test "arg-parsing: --container with no following value exits 1" {
+    run bash "${DETECTOR_SCRIPT}" --container 2>/dev/null
+    [ "$status" -eq 1 ]
+}
+
+@test "arg-parsing: --container with no following value emits ::error:: to stderr" {
+    local stderr_log="$TEST_TEMP_DIR/container-noarg-stderr.log"
+    bash "${DETECTOR_SCRIPT}" --container 2>"$stderr_log" >/dev/null || true
+
+    grep -q '::error::' "$stderr_log"
+}
+
+@test "arg-parsing: unknown flag -x still exits 1" {
+    run bash "${DETECTOR_SCRIPT}" -x 2>/dev/null
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Part of #578 (umbrella) — tasks **1–3 only**. Tasks 4 (skopeo), 5 (probe parallelism), 6 (concurrency hygiene) remain open on the umbrella; this PR intentionally does **not** close it.

## Summary

The daily base-image drift pipeline (`upstream-monitor.yaml`: `detect-digest-drift` → `open-drift-prs-{leaves,consumers}`, landed in #559) re-probed every variant's base image independently and re-scanned the whole repo on each per-container PR-open job. This collapses the redundant GHCR-probe work.

1. **Memoize the digest probe by verbatim `base_image_ref`** (`scripts/detect-base-digest-drift.sh`). ~45 → ~11 probes per repo-wide run (`alpine:latest` was probed 11×). `_probe_digest` stays pure; a `_probe_digest_cached` wrapper holds the cache. Callers read an **output variable**, not `$(...)`, so cache writes survive — command substitution runs in a subshell whose `_DIGEST_CACHE` writes would otherwise be lost. Successes cached immediately; failures left uncached so a transient registry error can't suppress drift detection.
2. **`--container <name>` flag** filtering on the validated `.container` JSON field (not the filename), placed before the probe so non-matching containers cost zero probes. Wired into the **two PR-open re-detect steps only** (~45 → ~1–2 probes per per-container job). The first `detect-digest-drift` job stays **repo-wide** — cascade gating consumes its repo-wide CSV outputs. The downstream `jq` output-filter is left intact as defense-in-depth.
3. **Drop `setup-buildx` from the three detect-only jobs.** `docker buildx imagetools inspect` is a registry call that uses the pre-installed buildx CLI plugin, not a builder instance. Saves a ~30–60 s cold-start per detect job. The build/`sync-base-images` job keeps its `setup-buildx`.

No change to digest semantics or drift verdicts.

## Test plan

- [x] `tests/unit/detect-base-digest-drift.bats`: 99 → **109** (MG5 probe-dedup count guard, MG6 per-container scope incl. field-not-filename + zero-match fail-safe, `--container` arg-parsing). EXIT 0.
- [x] `shellcheck scripts/detect-base-digest-drift.sh` clean (only pre-existing SC1091 source-follow info on unchanged `source` lines).
- [x] Orthogonal pre-PR gate (codex xhigh + copilot, parallel) — **dual-CLEAN**.
- [ ] **Task 3 hosted-runner proof** (no local coverage): confirm `detect-digest-drift` runs `imagetools inspect` green **without** `setup-buildx` on a hosted runner (CI / `workflow_dispatch`). If it fails, revert only the three step removals — tasks 1–2 stand alone.
