### PR TITLE
ci: add actionlint workflow-compile gate

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,67 @@
+# .githooks
+
+Local Git hooks committed to the repository.
+
+## `pre-commit` — actionlint workflow gate
+
+Runs [`actionlint`](https://github.com/rhysd/actionlint) on any staged
+`.github/workflows/*.{yaml,yml}` files before a commit is recorded. Gives
+instant (~1 s) feedback on workflow grammar errors — the same class of bugs
+that cause GitHub Actions "startup_failure" at parse time.
+
+Behavior:
+
+| Situation | Outcome |
+|-----------|---------|
+| No workflow files staged | Exits silently (0 ms overhead) |
+| `actionlint` not on PATH | Prints a yellow warning, exits 0 — commit proceeds |
+| `actionlint` finds errors | Prints findings, exits 1 — commit blocked |
+| `actionlint` reports clean | Prints one success line, exits 0 |
+
+**This hook is a complement, not a replacement, for the `Actionlint` CI job.**
+Because hooks are opt-in per clone, bypassable with `--no-verify`, and never
+run for bot PRs, the CI job remains the authoritative enforcement gate.
+
+---
+
+## Activation
+
+Hooks committed to `.githooks/` require a one-time opt-in per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This redirects Git to look in `.githooks/` instead of `.git/hooks/`.
+Only `pre-commit` exists here, so no other hooks are affected.
+
+---
+
+## Installing actionlint
+
+See the official install guide:
+<https://github.com/rhysd/actionlint/blob/main/docs/install.md>
+
+Quick options:
+
+```bash
+# Homebrew (macOS / Linux)
+brew install actionlint
+
+# Go install
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+# Script (Linux/macOS, installs to current directory)
+bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+```
+
+---
+
+## Emergency bypass
+
+```bash
+git commit --no-verify
+```
+
+The CI `Actionlint` job will still run on the PR or push and will block
+merge if workflows contain errors.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — local actionlint gate for workflow changes
+#
+# Runs actionlint on every staged workflow file before a commit is recorded.
+# Mirrors the CI "Actionlint" job exactly: SHELLCHECK_OPTS=--severity=error +
+# bare `actionlint -no-color` (auto-discovery, covers both *.yaml and *.yml,
+# excludes composite actions under .github/actions/ by location).
+#
+# Degradation contract:
+#   • No workflow files staged  → exit 0 silently (fast path, no delay).
+#   • actionlint not on PATH    → warn + exit 0 (CI is the guarantee).
+#   • actionlint finds issues   → exit 1 (commit blocked with bypass hint).
+#
+# LIMITATION: actionlint lints on-disk files, not the git index.  In the
+# common workflow (edit → stage → commit) staged == on-disk, so this is fine.
+# Unstaged hunks to workflow files could theoretically be linted here but
+# aren't — reconstructing the index tree would add complexity; the CI job
+# catches any residual divergence.
+
+set -euo pipefail
+
+# Git already runs hooks from the worktree root, but make it explicit so a
+# manual invocation from a subdirectory still lints the whole repo (actionlint
+# auto-discovery is cwd-relative).
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# ── Step 1: check for staged workflow files ──────────────────────────────────
+staged_workflows="$(git diff --cached --name-only --diff-filter=ACM \
+  | grep -E '^\.github/workflows/.*\.ya?ml$' || true)"
+
+if [ -z "${staged_workflows}" ]; then
+  exit 0
+fi
+
+# ── Step 2: graceful skip if actionlint is not installed ─────────────────────
+if ! command -v actionlint > /dev/null 2>&1; then
+  printf '\033[33mactionlint not found — skipping local workflow lint (CI will still check).\033[0m\n' >&2
+  printf 'Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md\n' >&2
+  exit 0
+fi
+
+# ── Step 3: run actionlint exactly as CI does ────────────────────────────────
+# No path args: auto-discovery lints all .github/workflows/*.{yaml,yml} and
+# excludes .github/actions/ composite files (see actionlint.yaml header note 3).
+# -config-file /dev/null: ignore any in-repo .github/actionlint.yaml so a branch
+# can't add `ignore:` patterns that silently weaken the gate (matches CI).
+export SHELLCHECK_OPTS="--severity=error"
+if actionlint -no-color -config-file /dev/null; then
+  printf 'actionlint: workflows compile clean.\n'
+  exit 0
+else
+  printf '\nHint: to bypass in an emergency use `git commit --no-verify`.\n' >&2
+  printf 'Note: the CI Actionlint job will still enforce this gate on the PR/push.\n' >&2
+  exit 1
+fi

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -73,5 +73,9 @@ jobs:
           set -euo pipefail
           # No path args: actionlint auto-discovers all .github/workflows/*.{yaml,yml}
           # and excludes composite actions by location. See header note (3).
-          ./actionlint -no-color
+          # -config-file /dev/null: ignore any in-repo .github/actionlint.yaml so a
+          # branch can't add `ignore:` patterns that silently weaken this gate
+          # (a config-only change wouldn't even re-trigger this job). Wanting an
+          # actionlint config later is a deliberate edit to THIS line, reviewed.
+          ./actionlint -no-color -config-file /dev/null
           echo "✅ actionlint: workflows compile clean" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,77 @@
+# Actionlint — workflow compile-error gate
+#
+# (1) WHY THIS EXISTS
+#     Workflow YAML that passes YAML-lint and diff review can still fail at
+#     GitHub Actions parse time with a "startup_failure" — the #558 incident
+#     class (e.g. `context "env" is not allowed here` in an `if:` expression).
+#     bats, CodeQL, and the codex/copilot orthogonal gate all miss this class
+#     because they never interpret the workflow grammar.  actionlint does.
+#
+# (2) WHY SHELLCHECK_OPTS=--severity=error
+#     actionlint bundles shellcheck and runs it on every embedded `run:` block.
+#     At the default severity the repo has ~193 SC2086 (info) findings —
+#     intentional in GHA-controlled `run:` blocks where word-splitting is
+#     harmless.  At --severity=error those drop to 0 while the gate still
+#     catches genuinely broken embedded shell (error-level SC findings) and
+#     all workflow-grammar errors.  Verified: current repo → EXIT 0.
+#
+# (3) WHY AUTO-DISCOVERY (bare `actionlint`, no path args)
+#     Run from the repo root with no file arguments, actionlint discovers and
+#     lints every workflow under `.github/workflows/` — BOTH `*.yaml` and
+#     `*.yml` (GitHub loads both; an explicit `*.yaml` glob would silently skip
+#     a malformed `.yml` workflow and defeat the gate).  Auto-discovery scans
+#     only `.github/workflows/`, so composite action files under
+#     `.github/actions/*/action.yaml` are excluded by location — actionlint
+#     would otherwise parse them as workflows and emit false
+#     `"jobs"/"on" section is missing` errors.  No config file needed.
+
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # This job runs a downloaded third-party binary and never needs
+          # authenticated git after checkout — don't persist the token in
+          # local git config where that binary could read it.
+          persist-credentials: false
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 --retry-delay 2 "$url" -o actionlint.tar.gz
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          chmod +x ./actionlint
+          ./actionlint --version
+
+      - name: Run actionlint on workflows
+        env:
+          SHELLCHECK_OPTS: "--severity=error"
+        run: |
+          set -euo pipefail
+          # No path args: actionlint auto-discovers all .github/workflows/*.{yaml,yml}
+          # and excludes composite actions by location. See header note (3).
+          ./actionlint -no-color
+          echo "✅ actionlint: workflows compile clean" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #567

## Summary

Adds `actionlint` as a CI gate so a workflow that won't **compile** can't reach `master` silently — the #558 incident class (`context "env" is not allowed here` in an `if:`) produced a GitHub `startup_failure` with no failing job to point at, and bats / CodeQL / the codex+copilot diff-review gate all passed because none interpret the workflow grammar.

### CI gate — `.github/workflows/actionlint.yaml`
Mirrors `shellcheck.yaml` conventions:
- `permissions: contents: read`, `persist-credentials: false` on checkout (the job runs a downloaded third-party binary and never needs authenticated git).
- actionlint pinned to **1.7.12**, installed from the release tarball with an explicit **sha256** check (no `curl | bash`), `curl --retry`, `chmod +x`.
- **`SHELLCHECK_OPTS=--severity=error`**: actionlint runs shellcheck on every embedded `run:` block; at default severity the repo has ~193 `SC2086` (info) nits that are safe in GHA-controlled blocks. At error severity those drop to 0 while the gate still fails on broken embedded shell and **every** workflow-grammar error.
- **Auto-discovery** (bare `actionlint`, no path args): lints all `.github/workflows/*.{yaml,yml}` — both extensions, since GitHub loads both — and excludes composite `action.yaml` files by location.
- **`-config-file /dev/null`**: ignore any in-repo `.github/actionlint.yaml` so a branch can't add `ignore:` patterns that silently weaken the gate (verified: a config with `ignore: ['.*']` lets a broken workflow pass under default actionlint; `/dev/null` keeps the gate holding).

### Local complement — `.githooks/pre-commit`
Fast (~1s) pre-commit feedback that runs the **same** lint, but only when `.github/workflows/*.{yaml,yml}` are staged. Skips gracefully if actionlint isn't installed (CI is the guarantee). Activate per clone: `git config core.hooksPath .githooks`. Bypass with `--no-verify`. A hook is a complement, not a replacement — hooks are opt-in, bypassable, and never run for bot PRs, so the CI job remains authoritative.

## Test plan

- [x] Current repo lints clean: `SHELLCHECK_OPTS=--severity=error actionlint -no-color -config-file /dev/null` → EXIT 0 (includes the new workflow, which self-lints).
- [x] Gate has teeth: synthetic workflows with `if: ${{ env.X }}`, undefined `needs`, and a broken `.yml` are all rejected (EXIT 1) — proving the #558 class and `.yml` coverage. A branch-supplied ignore-all config is neutralised by `-config-file /dev/null`.
- [x] Orthogonal pre-PR gate (codex xhigh + copilot) — dual-CLEAN after 5 rounds: 3 real fixes (`.yml` coverage → auto-discovery; token persistence → `persist-credentials: false`; config-based self-bypass → `-config-file /dev/null`) + 1 defensive (`cd` to worktree root in the hook). One documented FP: copilot flagged the `actions/checkout` SHA as "unverified" — it's the repo-wide pin (`de0fac2e… # v6`, used 27× across `.github/`); copilot's network probe was sandboxed so it speculated.
- [x] Hook: `shellcheck -S warning` clean, executable, exits 0 silently when no workflow is staged.
- [ ] CI green on this PR (the `Actionlint` job runs against `.github/workflows/**` and self-lints).
