### PR TITLE
fix(ci): version-drift issue renders an empty drift table (#577)

### DIFF
--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -452,11 +452,10 @@ open_version_drift_issue() {
     # Build markdown table from drift rows
     local drift_table
     drift_table="$(printf '%s' "$drift_json" | jq -r '
-        ["| Kind | Name | Declared | Published | Status |",
-         "|------|------|----------|-----------|--------|"],
+        (["| Kind | Name | Declared | Published | Status |",
+          "|------|------|----------|-----------|--------|"] | .[]),
         (.[] | select(.status=="drift") |
          "| \(.kind) | \(.name) | \(.declared) | \(.published) | \(.status) |")
-        | .[]
     ' 2>/dev/null || echo "_(unable to render drift table)_")"
 
     local short_sha="${GITHUB_SHA:0:8}"

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -382,6 +382,34 @@ GHEOF
 }
 
 # ---------------------------------------------------------------------------
+# open_version_drift_issue — drift table rendering
+# Guards the "jq .[] over row strings" regression: the buggy program applied
+# | .[] to the whole comma-separated output stream (header array + row strings),
+# causing jq to error on strings and fall back to "unable to render drift table".
+# ---------------------------------------------------------------------------
+
+@test "drift table: renders drift rows and omits in_sync rows" {
+    # One drift row + one in_sync row. Only the drift row must appear in the table.
+    local drift_json='[
+        {"status":"drift","kind":"extension","name":"pgvector","declared":"0.8.0","published":"0.7.4"},
+        {"status":"in_sync","kind":"extension","name":"timescaledb","declared":"2.17.2","published":"2.17.2"}
+    ]'
+    export DRY_RUN="true"
+
+    run open_version_drift_issue "$drift_json" "postgres"
+    [ "$status" -eq 0 ]
+
+    # Must contain the rendered drift row
+    [[ "$output" == *"| pgvector |"* ]]
+    # Must contain the table header (proves the header | .[] scoping is also correct)
+    [[ "$output" == *"| Kind | Name | Declared | Published | Status |"* ]]
+    # Must NOT fall back to the error sentinel (guards the jq regression)
+    [[ "$output" != *"unable to render drift table"* ]]
+    # in_sync row must NOT appear (guards the select(.status=="drift") filter)
+    [[ "$output" != *"| timescaledb |"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # Dedup: mock gh issue list returns empty → "created"
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #577

## Summary

The version-drift guard (#563) filed #577 — "postgres: 27 declared version(s) not published" — but its body showed `_(unable to render drift table)_` instead of the 27 rows, making it unactionable.

**Root cause** (`scripts/open-dep-failure-issue.sh`, `open_version_drift_issue`): the drift-table jq applied a trailing `| .[]` to the whole `[headers], (rows)` comma-stream. `.[]` over a row **string** throws `jq: error: Cannot iterate over string` (exit 5), so the `2>/dev/null || echo "_(unable to render drift table)_"` fallback fired on **any** input with ≥1 drift row. Every drift issue (per-container and sweep) rendered an empty table.

**Fix:** scope `.[]` to the header array only, stream the rows directly:

```diff
-        ["| Kind | Name | Declared | Published | Status |",
-         "|------|------|----------|-----------|--------|"],
+        (["| Kind | Name | Declared | Published | Status |",
+          "|------|------|----------|-----------|--------|"] | .[]),
         (.[] | select(.status=="drift") |
          "| \(.kind) | \(.name) | \(.declared) | \(.published) | \(.status) |")
-        | .[]
```

The fallback is kept (still correct for genuinely malformed input).

## Why it shipped

No bats test rendered the table with drift rows — the #563 suite covered issue creation/dedup/title but never a populated body. Added one.

## Test plan

- [x] `tests/unit/open-dep-failure-issue.bats`: new regression test renders a table with a `drift` row, asserts the row is present and `unable to render drift table` is absent, and that an `in_sync` row is excluded. Fails on the old jq (fallback), passes on the fix. 26/26 pass.
- [x] `tests/unit/check-version-drift.bats`: 79/79, no regression.
- [x] `shellcheck -x` clean.
- [x] Orthogonal gate (codex + copilot) dual-CLEAN.

## Follow-up (separate, not this PR)

This fix is the prerequisite to answer the still-open question: are the **27** detected drifts real, or is the sweep over-reporting? With the table now rendering, the next scheduled sweep will list them. Leading hypothesis: postgres extensions are baked into flavor images (per #564), not published standalone, so the sweep may be expecting standalone ext publication that never happens (false positive). Triage once the populated table is visible.
