### PR TITLE
fix(ci): verify multi-arch on extension manifest reuse (both paths, DRY)

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -880,6 +880,29 @@ _capture_index_digest() {
     fi
 }
 
+# _reuse_ref_is_multiarch <image_ref>
+# Inspects an existing manifest and checks whether it covers both linux/amd64
+# and linux/arm64.
+#
+# Returns:
+#   0 — ref is a multi-arch index covering amd64 + arm64 (safe to reuse)
+#   1 — ref exists but is NOT multi-arch (single-arch / partial — must re-create)
+#   2 — imagetools inspect failed (transient/infra) — caller should fail closed
+#
+# Does NOT decide control flow; the caller maps rc to reuse / re-create / fail.
+_reuse_ref_is_multiarch() {
+    local _ref="$1"
+    local _out _rc=0
+    _out=$($DOCKER buildx imagetools inspect "$_ref" 2>&1) || _rc=$?
+    if [[ "$_rc" -ne 0 ]]; then
+        return 2
+    fi
+    if echo "$_out" | grep -q "linux/amd64" && echo "$_out" | grep -q "linux/arm64"; then
+        return 0
+    fi
+    return 1
+}
+
 # Build, tag, and optionally push a list of extensions. Exits 1 if any fail.
 # Args: config_file major_ver container_dir push ext1 [ext2 ...]
 build_tag_push_extensions() {
@@ -1909,13 +1932,29 @@ finalize_multiarch_manifests() {
             # When FORCE=true: always create fresh manifest (skip reuse check).
             # Otherwise: use ext_ref_resolve to probe for existing manifest (canonical-first, PR-scoped fallback).
             if [[ "${FORCE:-false}" != "true" ]]; then
-                local _nr_multiarch_rc=0
-                ext_ref_resolve "$ext" "$ceiling" "$major_ver" "" > /dev/null || _nr_multiarch_rc=$?
+                local _nr_multiarch_rc=0 _nr_resolved_ref
+                _nr_resolved_ref=$(ext_ref_resolve "$ext" "$ceiling" "$major_ver" "") || _nr_multiarch_rc=$?
 
                 case "$_nr_multiarch_rc" in
                     0)
-                        log_info "$ext $ceiling pg${major_ver}: manifest present — reused (unchanged, non-resolver)"
-                        continue
+                        # Manifest present — verify it covers both target platforms before reusing.
+                        local _nr_ma_rc=0
+                        _reuse_ref_is_multiarch "$_nr_resolved_ref" || _nr_ma_rc=$?
+                        case "$_nr_ma_rc" in
+                            0)
+                                log_info "$ext $ceiling pg${major_ver}: manifest present — reused (unchanged, non-resolver)"
+                                continue
+                                ;;
+                            1)
+                                log_warning "$ext $ceiling pg${major_ver}: reused manifest is not multi-arch — re-creating from per-arch legs"
+                                # Fall through to the CREATE path below.
+                                ;;
+                            *)
+                                log_error "$ext $ceiling pg${major_ver}: imagetools inspect failed on reused non-resolver manifest — fail closed"
+                                _failed=true
+                                continue
+                                ;;
+                        esac
                         ;;
                     2)
                         log_error "$ext $ceiling pg${major_ver}: transient registry probe error on non-resolver ref — fail closed"
@@ -1924,7 +1963,7 @@ finalize_multiarch_manifests() {
                         ;;
                 esac
             fi
-            # rc 1 → absent, or FORCE=true → fall through to create.
+            # rc 1 → absent, or FORCE=true, or single-arch reuse → fall through to create.
 
             # Resolve per-arch source refs via ext_ref_resolve.
             local _nr_src_amd64 _nr_src_arm64
@@ -2034,15 +2073,14 @@ finalize_multiarch_manifests() {
                     # If it is single-arch (legacy / pre-multi-arch), fall through to the
                     # CREATE path to rebuild it from this run's per-arch legs instead of
                     # blindly accepting a stale single-arch manifest.
-                    local _reuse_inspect_out _reuse_inspect_rc=0
-                    _reuse_inspect_out=$($DOCKER buildx imagetools inspect "$_ma_ref" 2>&1) || _reuse_inspect_rc=$?
-                    if [[ "$_reuse_inspect_rc" -ne 0 ]]; then
-                        log_error "$ext $ver pg${major_ver}: imagetools inspect failed on reused manifest ref (rc=$_reuse_inspect_rc) — transient infra error — fail closed"
+                    local _reuse_ma_rc=0
+                    _reuse_ref_is_multiarch "$_ma_ref" || _reuse_ma_rc=$?
+                    if [[ "$_reuse_ma_rc" -eq 2 ]]; then
+                        log_error "$ext $ver pg${major_ver}: imagetools inspect failed on reused manifest ref — transient infra error — fail closed"
                         _ext_failed=true
                         break
                     fi
-                    if echo "$_reuse_inspect_out" | grep -q "linux/amd64" && \
-                       echo "$_reuse_inspect_out" | grep -q "linux/arm64"; then
+                    if [[ "$_reuse_ma_rc" -eq 0 ]]; then
                         _confirmed_available+=("$ver")
                         _ver_index_digests["$ver"]="$_reuse_digest"
                         continue

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -12644,6 +12644,16 @@ EOF
                 # and the create would fail in production.
                 return 1
             fi
+            if [[ \"\$_dc\" == 'buildx' && \"\$_d2\" == 'imagetools' && \"\$_d3\" == 'inspect' ]]; then
+                local _ref=\"\${4:-}\"
+                # Canonical multi-arch ref reports both platforms (faithful: it IS multi-arch).
+                if [[ \"\$_ref\" == *':pg18-0.8.0' && \"\$_ref\" != *'-amd64'* && \"\$_ref\" != *'-arm64'* && \"\$_ref\" != *'-pr42'* ]]; then
+                    printf 'linux/amd64\nlinux/arm64\n'
+                    return 0
+                fi
+                printf 'error: manifest not found\n' >&2
+                return 1
+            fi
             if [[ \"\$_dc\" == 'manifest' && \"\$_d2\" == 'inspect' ]]; then
                 local _ref=\"\$_d3\"
                 # Canonical multi-arch ref present (no arch suffix, no PR suffix).
@@ -12877,6 +12887,172 @@ EOF
     }
 
     unset PR_TAG_SUFFIX
+}
+
+# ---------------------------------------------------------------------------
+# MG: non-resolver ext whose plain ref EXISTS but imagetools inspect reports
+# single-arch (only linux/amd64) — the path must NOT silently reuse; it must
+# log the "not multi-arch" warning and reach the CREATE path.
+#
+# RED against old code: the old `0) ... continue` blindly reused any present
+# manifest without inspecting it, so a single-arch legacy tag was never
+# re-created and the 27 ext tags remained stuck.
+#
+# GREEN after fix: `_reuse_ref_is_multiarch` returns 1 → fall-through to
+# imagetools create.
+# ---------------------------------------------------------------------------
+@test "MG-nonresolver-singlearch-recreate: non-resolver ext with single-arch existing manifest → re-creates from per-arch legs" {
+    local tmpd="$TEST_TEMP_DIR"
+    local sd="$SCRIPTS_DIR"
+    local imagetools_log="$tmpd/mg_imagetools.log"
+
+    # Config: pgvector is NON-resolver.
+    cat > "$CONTAINER_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  pgvector:
+    version: "0.8.0"
+    repo: "https://github.com/pgvector/pgvector"
+    priority: 1
+EOF
+    touch "$EXT_BUILD_DIR/pgvector.Dockerfile"
+
+    run bash -c "
+        export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
+        export imagetools_log='${imagetools_log}'
+        cd '${sd}'
+        source ./build-extensions.sh
+        export ROOT_DIR='${tmpd}'
+
+        ext_config() {
+            local ext=\"\$1\" key=\"\$2\"
+            case \"\$ext:\$key\" in
+                pgvector:version) echo '0.8.0' ;;
+                pgvector:repo)    echo 'https://github.com/pgvector/pgvector' ;;
+                *)                echo '' ;;
+            esac
+        }
+        export -f ext_config
+
+        ext_image_name() { echo \"ghcr.io/test/ext-\${1}:pg\${3}-\${2}\"; }
+        export -f ext_image_name
+        ext_local_image_name() { echo \"localhost/ext-builder-\${1}:pg\${2}\"; }
+        export -f ext_local_image_name
+
+        # ext_ref_resolve: the plain (un-suffixed) ref EXISTS; arch-suffixed refs also exist.
+        ext_ref_resolve() {
+            local _ext=\"\$1\" _ver=\"\$2\" _maj=\"\$3\" _arch=\"\${4:-}\"
+            if [[ -z \"\$_arch\" ]]; then
+                # Plain ref present — this triggers the reuse check path.
+                printf 'ghcr.io/test/ext-%s:pg%s-%s' \"\$_ext\" \"\$_maj\" \"\$_ver\"
+                return 0
+            fi
+            # Per-arch refs present (so CREATE succeeds).
+            printf 'ghcr.io/test/ext-%s:pg%s-%s-%s' \"\$_ext\" \"\$_maj\" \"\$_ver\" \"\$_arch\"
+            return 0
+        }
+        export -f ext_ref_resolve
+
+        # docker: imagetools inspect returns only linux/amd64 (single-arch manifest).
+        #         imagetools create succeeds.
+        docker() {
+            local _cmd=\"\${1:-}\" _sub=\"\${2:-}\" _subsub=\"\${3:-}\"
+            if [[ \"\$_cmd\" == 'buildx' && \"\$_sub\" == 'imagetools' && \"\$_subsub\" == 'inspect' ]]; then
+                # Single-arch: only amd64 reported.
+                printf 'linux/amd64\n'
+                return 0
+            fi
+            if [[ \"\$_cmd\" == 'buildx' && \"\$_sub\" == 'imagetools' && \"\$_subsub\" == 'create' ]]; then
+                echo \"IMAGETOOLS_CREATE \${*}\" >> \"\$imagetools_log\"
+                return 0
+            fi
+            return 0
+        }
+        export -f docker
+
+        skopeo() { echo manifest unknown >&2; return 1; }
+        export -f skopeo
+        _capture_index_digest() { echo 'sha256:0000000000000000000000000000000000000000000000000000000000000000'; return 0; }
+        export -f _capture_index_digest
+
+        list_extensions_by_priority() { echo 'pgvector'; }
+        export -f list_extensions_by_priority
+
+        finalize_multiarch_manifests \"$CONTAINER_DIR/extensions/config.yaml\" 18 \"$CONTAINER_DIR\"
+    "
+
+    # Must succeed (re-create from per-arch legs is valid).
+    [ "$status" -eq 0 ]
+
+    # imagetools create MUST have been called: single-arch manifest must not be reused.
+    # RED against old code (blind continue) — this file would not exist.
+    [ -f "$imagetools_log" ] || {
+        echo 'FAIL: imagetools_log not created — imagetools create was never called (single-arch manifest was blindly reused)'
+        false
+    }
+    local create_count
+    create_count=$(wc -l < "$imagetools_log")
+    [ "$create_count" -ge 1 ] || {
+        echo "FAIL: imagetools create was not called (expected >= 1 call, got $create_count)"
+        false
+    }
+
+    # The create call must use both arch-suffixed source tags.
+    local call
+    call=$(cat "$imagetools_log")
+    [[ "$call" == *':pg18-0.8.0-amd64'* ]] || {
+        echo "FAIL: imagetools create call does not reference -amd64 source. Got: $call"
+        false
+    }
+    [[ "$call" == *':pg18-0.8.0-arm64'* ]] || {
+        echo "FAIL: imagetools create call does not reference -arm64 source. Got: $call"
+        false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# MG helper unit tests: _reuse_ref_is_multiarch return codes.
+# ---------------------------------------------------------------------------
+
+@test "MG-helper-multiarch: _reuse_ref_is_multiarch returns 0 when both arches reported" {
+    docker() {
+        if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
+            printf 'linux/amd64\nlinux/arm64\n'
+            return 0
+        fi
+        return 1
+    }
+    export -f docker
+
+    run _reuse_ref_is_multiarch 'ghcr.io/test/ext-pgvector:pg18-0.8.0'
+    [ "$status" -eq 0 ]
+}
+
+@test "MG-helper-singlearch: _reuse_ref_is_multiarch returns 1 when only amd64 reported" {
+    docker() {
+        if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
+            printf 'linux/amd64\n'
+            return 0
+        fi
+        return 1
+    }
+    export -f docker
+
+    run _reuse_ref_is_multiarch 'ghcr.io/test/ext-pgvector:pg18-0.8.0'
+    [ "$status" -eq 1 ]
+}
+
+@test "MG-helper-inspect-error: _reuse_ref_is_multiarch returns 2 when inspect fails" {
+    docker() {
+        if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
+            printf 'error: transient failure\n' >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+
+    run _reuse_ref_is_multiarch 'ghcr.io/test/ext-pgvector:pg18-0.8.0'
+    [ "$status" -eq 2 ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #592

## Summary

`finalize_multiarch_manifests` (`scripts/build-extensions.sh`) had **two manifest-reuse paths with asymmetric multi-arch verification**:

- **resolver** (timescaledb): on a present plain tag, ran `imagetools inspect` and re-created the manifest if it wasn't multi-arch (amd64+arm64). ✅
- **non-resolver** (the other 9 extensions): checked existence only → blindly reused. ❌

So legacy single-arch amd64 ext tags (from before the arm64 matrix landed in #558) were perpetuated — 27 `ext-<name>:pg{16,17,18}` tags stuck single-arch where a multi-arch index is required. The version-drift guard correctly flagged this (#591), once its own table-render bug was fixed (#586).

**Fix (DRY):** extracted a shared `_reuse_ref_is_multiarch <ref>` helper (`0`=multi-arch, `1`=single-arch, `2`=inspect-failed) and call it from **both** reuse paths — no more duplicated `imagetools inspect` + grep block. The non-resolver path now falls through to re-create on a single-arch reuse; the resolver path keeps identical behavior (digest capture + fail-closed-on-inspect-error preserved).

## Test plan

- [x] `build-extensions-versionset.bats` 203/203 (incl. 4 new: `MG-nonresolver-singlearch-recreate` regression — RED on old code, GREEN after — + 3 helper unit tests covering rc 0/1/2). `build-extensions.bats` 8/8.
- [x] `shellcheck -x` no new warnings; `bash -n` OK.
- [x] Orthogonal gate (codex + copilot) dual-CLEAN.

## Follow-up (separate — remediation, NOT this PR)

This stops new single-arch tags and makes the next Stage B run **self-heal** the 27 (the per-arch `-amd64`/`-arm64` legs exist for the 9 non-resolver exts). To remediate now, a postgres extension rebuild is needed; timescaledb's pg{16,17,18} entries additionally need their `2.27.2` canonical per-arch legs pushed (the #575 push run was cancelled). Latent risk to verify: arm64 postgres flavor builds pull these plain ext tags, so a single-arch tag could break an arm64 flavor build.
