### PR TITLE
feat(ci): auto-close 'Auto Build Failed' issue on build recovery

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1315,7 +1315,64 @@ jobs:
           containers='${{ needs.detect-containers.outputs.containers }}'
           container_count='${{ needs.detect-containers.outputs.count }}'
 
-          if [ "$container_count" -gt 0 ]; then
+          # ---------------------------------------------------------------
+          # Step A — compute both machine signals up front, branch-free.
+          #
+          # build-and-push is SKIPPED (not failed) when build-extensions or
+          # merge-extension-manifests fail, so we must check all three jobs.
+          # create-manifest is included: it publishes the multi-arch manifest
+          # and has no job-level continue-on-error; its failure means the
+          # image was not fully published.
+          # detect-containers is included: if it fails/cancels the downstream
+          # build jobs are skipped and build_failed would never be set otherwise —
+          # a detect failure must still surface as a build-failure issue.
+          # sync-registries is EXCLUDED: it only runs in rebuild=sync mode
+          # (a dedicated GHCR→DockerHub sync, not a non-blocking by design).
+          # A 'skipped' result is NOT a failure (non-postgres builds legitimately
+          # skip the extension jobs).
+          # ---------------------------------------------------------------
+          detect_result="${{ needs.detect-containers.result }}"
+          bap_result="${{ needs.build-and-push.result }}"
+          bex_result="${{ needs.build-extensions.result }}"
+          mem_result="${{ needs.merge-extension-manifests.result }}"
+          cm_result="${{ needs.create-manifest.result }}"
+          dry_run_flag="${{ env.DRY_RUN }}"
+
+          # build_failed: any monitored pipeline job failed or cancelled.
+          build_failed=false
+          for _r in "$detect_result" "$bap_result" "$bex_result" "$mem_result" "$cm_result"; do
+            if [ "$_r" = "failure" ] || [ "$_r" = "cancelled" ]; then
+              build_failed=true
+            fi
+          done
+
+          # container_count must be a non-negative integer; anything else is
+          # indeterminate (detect failed and set no output).
+          count_valid=true
+          [[ "$container_count" =~ ^[0-9]+$ ]] || count_valid=false
+
+          # build_succeeded: a REAL successful build was published.
+          # Requires: not build_failed, a valid count > 0, build-and-push
+          # success, and NOT a dry run.
+          # count=0 is explicitly NOT a success signal — closing an issue
+          # requires evidence that something was actually built and published.
+          # DRY_RUN runs are NOT a recovery signal: docker/skopeo become echo
+          # no-ops, so build-and-push reports success without publishing anything.
+          build_succeeded=false
+          if [ "$build_failed" = "false" ] && [ "$count_valid" = "true" ] \
+             && [ "$container_count" -gt 0 ] && [ "$bap_result" = "success" ] \
+             && [ "$dry_run_flag" != "true" ]; then
+            build_succeeded=true
+          fi
+
+          # Emit BOTH signals unconditionally — never inside a conditional branch.
+          {
+            echo "build_failed=${build_failed}"
+            echo "build_succeeded=${build_succeeded}"
+          } >> "$GITHUB_OUTPUT"
+
+          # Containers Processed row — safe to emit now that count_valid is known.
+          if [ "$count_valid" = "true" ] && [ "$container_count" -gt 0 ]; then
             echo "| **Containers Processed** | $container_count |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| **Containers Processed** | 0 |" >> $GITHUB_STEP_SUMMARY
@@ -1323,7 +1380,22 @@ jobs:
 
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "$container_count" -eq 0 ]; then
+          # ---------------------------------------------------------------
+          # Step B — human-readable summary text.
+          # Uses already-computed variables; must NOT re-emit or alter
+          # build_failed / build_succeeded.
+          # ---------------------------------------------------------------
+          if [ "$count_valid" = "false" ]; then
+            # detect-containers failed and emitted no usable count.
+            echo "::warning::container_count is non-numeric ('${container_count}') — detect-containers likely failed or was cancelled" >&2
+            echo "### ⚠️ Indeterminate state — detect-containers did not emit a valid count" >> $GITHUB_STEP_SUMMARY
+            echo "Check the detect-containers job logs for details." >> $GITHUB_STEP_SUMMARY
+          elif [ "$build_failed" = "true" ]; then
+            echo "### ❌ Some builds failed or were cancelled" >> $GITHUB_STEP_SUMMARY
+            echo "Check the individual job logs above for details." >> $GITHUB_STEP_SUMMARY
+          elif [ "$dry_run_flag" = "true" ]; then
+            echo "### ℹ️ Dry-run — no images were actually built or pushed" >> $GITHUB_STEP_SUMMARY
+          elif [ "$container_count" -eq 0 ]; then
             echo "### ℹ️ No containers needed building" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**🎯 Smart Detection Results:**" >> $GITHUB_STEP_SUMMARY
@@ -1335,7 +1407,7 @@ jobs:
               echo "- ✅ All container images are up to date in registries" >> $GITHUB_STEP_SUMMARY
               echo "- 🔍 No new upstream versions detected" >> $GITHUB_STEP_SUMMARY
             fi
-          elif [ "${{ needs.build-and-push.result }}" = "success" ]; then
+          elif [ "$bap_result" = "success" ]; then
             echo "### ✅ All builds completed successfully!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**🎯 Smart Detection Features:**" >> $GITHUB_STEP_SUMMARY
@@ -1345,13 +1417,11 @@ jobs:
             echo "- ✅ **Native multi-platform** builds (amd64 + arm64 on native runners)" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ **Multi-registry** publishing (GHCR + Docker Hub)" >> $GITHUB_STEP_SUMMARY
             echo "- ⏸️ **Security scanning** (temporarily disabled)" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.build-and-push.result }}" = "skipped" ]; then
+          elif [ "$bap_result" = "skipped" ]; then
             echo "### ⏭️ Builds were skipped" >> $GITHUB_STEP_SUMMARY
             echo "All target images already exist and are up to date." >> $GITHUB_STEP_SUMMARY
           else
-            echo "### ❌ Some builds failed or were cancelled" >> $GITHUB_STEP_SUMMARY
-            echo "Check the individual job logs above for details." >> $GITHUB_STEP_SUMMARY
-            echo "build_failed=true" >> $GITHUB_OUTPUT
+            echo "### ℹ️ Workflow completed in an unclassified state" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -1437,31 +1507,70 @@ jobs:
             rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "No dep-bump context detected, falling back to generic issue"
-              existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-                --label "build-failure" --state open --limit 5 --json title,number \
-                | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
-              run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-              if [[ -n "$existing" ]]; then
-                echo "Adding comment to existing issue #$existing"
-                comment_body="$(printf '## Another build failure detected\n\n**Run:** [%s](%s)\n**Trigger:** `%s`\n**Ref:** `%s`\n**Time:** %s' \
-                  "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
-                  "$(date -u +'%Y-%m-%d %H:%M UTC')")"
-                gh issue comment --repo "$GITHUB_REPOSITORY" "$existing" --body "$comment_body"
+              # Generic "Auto Build Failed" issue is a master-health tracker.
+              # Open/comment it on any master build that is not a PR smoke run.
+              # This covers push, workflow_call (upstream-monitor), and
+              # workflow_dispatch — all real master builds.
+              # PR smoke failures surface via their own check status and must not
+              # create a persistent master-health issue (cross-event symmetry:
+              # generic-open ↔ generic-close both exclude pull_request).
+              if [ "$GITHUB_EVENT_NAME" != "pull_request" ] && [ "$GITHUB_REF_NAME" = "master" ]; then
+                existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+                  --label "build-failure" --state open --limit 5 --json title,number \
+                  | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
+                run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                if [[ -n "$existing" ]]; then
+                  echo "Adding comment to existing issue #$existing"
+                  comment_body="$(printf '## Another build failure detected\n\n**Run:** [%s](%s)\n**Trigger:** `%s`\n**Ref:** `%s`\n**Time:** %s' \
+                    "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                    "$(date -u +'%Y-%m-%d %H:%M UTC')")"
+                  gh issue comment --repo "$GITHUB_REPOSITORY" "$existing" --body "$comment_body"
+                else
+                  echo "Creating new build failure issue"
+                  issue_body="$(printf '## Build Failure Alert\n\nOne or more container builds failed in the auto-build workflow.\n\n| Property | Value |\n|----------|-------|\n| **Run** | [%s](%s) |\n| **Trigger** | `%s` |\n| **Ref** | `%s` |\n| **Commit** | `%s` |\n\n## Next Steps\n\n1. Check the [workflow run](%s) for details\n2. Identify which container(s) failed\n3. Test locally: `./make build <container>`\n4. Fix and push to trigger rebuild\n\n---\n_Auto-generated by CI workflow_' \
+                    "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                    "$GITHUB_SHA" "$run_url")"
+                  gh issue create --repo "$GITHUB_REPOSITORY" \
+                    --title "Auto Build Failed - $(date -u +%Y-%m-%d)" \
+                    --label "build-failure,automation" \
+                    --body "$issue_body"
+                fi
               else
-                echo "Creating new build failure issue"
-                issue_body="$(printf '## Build Failure Alert\n\nOne or more container builds failed in the auto-build workflow.\n\n| Property | Value |\n|----------|-------|\n| **Run** | [%s](%s) |\n| **Trigger** | `%s` |\n| **Ref** | `%s` |\n| **Commit** | `%s` |\n\n## Next Steps\n\n1. Check the [workflow run](%s) for details\n2. Identify which container(s) failed\n3. Test locally: `./make build <container>`\n4. Fix and push to trigger rebuild\n\n---\n_Auto-generated by CI workflow_' \
-                  "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
-                  "$GITHUB_SHA" "$run_url")"
-                gh issue create --repo "$GITHUB_REPOSITORY" \
-                  --title "Auto Build Failed - $(date -u +%Y-%m-%d)" \
-                  --label "build-failure,automation" \
-                  --body "$issue_body"
+                echo "Skipping generic issue: pull_request event or non-master ref (event=$GITHUB_EVENT_NAME ref=$GITHUB_REF_NAME)"
               fi
             else
               echo "open-dep-failure-issue.sh failed with exit $rc"
               exit "$rc"
             fi
           fi
+
+      - name: Close build-failure issue on recovery
+        # Close the open "Auto Build Failed" generic issue when a real build
+        # completes successfully on master (any non-PR trigger: push, workflow_call,
+        # workflow_dispatch).  Requires a POSITIVE success signal (build_succeeded)
+        # so a count=0 no-op run cannot mark a past failure as recovered.
+        # Only runs on master to avoid closing on PR smoke runs or other branches.
+        # continue-on-error: closing a stale issue is non-critical; a transient
+        # gh API error must never fail an otherwise-green master run.
+        continue-on-error: true
+        if: >-
+          github.event_name != 'pull_request' &&
+          github.ref_name == 'master' &&
+          steps.summary.outputs.build_succeeded == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          # COMMIT_SUBJECT is required by the script's source-time :? guard even
+          # in recovery mode (it runs before main() parses --mode).
+          COMMIT_SUBJECT: "recovery-check"
+        run: |
+          chmod +x scripts/open-dep-failure-issue.sh
+          ./scripts/open-dep-failure-issue.sh --mode recovery
 
       - name: Log in to GHCR (summary job)
         # Required so skopeo can read private GHCR packages during the advisory

--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -582,6 +582,144 @@ VDRIFT_COMMENT
 }
 
 # ---------------------------------------------------------------------------
+# find_open_generic_build_failure_issue
+#
+# Finds the open generic "Auto Build Failed" issue (labels: build-failure,
+# automation, title contains "Auto Build Failed").
+# Only matches bot-managed issues (requires BOTH build-failure AND automation
+# labels) to avoid closing manually-tracked issues.
+# Prints the issue number on stdout, or empty string if none found.
+# Returns 0 on success (including "not found"), 1 on gh CLI error.
+# ---------------------------------------------------------------------------
+find_open_generic_build_failure_issue() {
+    local search_stdout search_rc
+    # Capture stdout and stderr separately so gh warnings cannot corrupt the
+    # JSON that jq will parse.  Finding 4: do NOT merge stderr into stdout.
+    local stderr_tmp
+    stderr_tmp="$(mktemp)"
+    search_stdout=$(run_gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "build-failure" \
+            --label "automation" \
+            --state open \
+            --limit 5 \
+            --json title,number 2>"$stderr_tmp"); search_rc=$?
+    if [[ $search_rc -ne 0 ]]; then
+        # Log the captured stderr for diagnostics
+        if [[ -s "$stderr_tmp" ]]; then
+            printf '::warning::find_open_generic_build_failure_issue: gh issue list failed: %s\n' \
+                "$(cat "$stderr_tmp")" >&2
+        else
+            printf '::warning::find_open_generic_build_failure_issue: gh issue list failed (rc=%d)\n' \
+                "$search_rc" >&2
+        fi
+        rm -f "$stderr_tmp"
+        return 1
+    fi
+    rm -f "$stderr_tmp"
+
+    printf '%s' "$search_stdout" \
+        | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' \
+        | head -1 \
+        || true
+}
+
+# ---------------------------------------------------------------------------
+# close_build_failure_on_recovery
+#
+# Called when a master push succeeds with no failed build jobs.
+# Finds the open generic "Auto Build Failed" issue (if any) and closes it
+# with a recovery comment referencing the recovering run.
+# Exit codes:
+#   0 — closed successfully, or no open issue found (no-op)
+#   3 — gh CLI error
+# ---------------------------------------------------------------------------
+close_build_failure_on_recovery() {
+    # Validate interpolated values — run id and ref name may come from GHA env.
+    # GITHUB_RUN_ID must be numeric.
+    local safe_run_id
+    if [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]; then
+        safe_run_id="$GITHUB_RUN_ID"
+    else
+        printf '::warning::close_build_failure_on_recovery: GITHUB_RUN_ID failed numeric validation; using empty\n' >&2
+        safe_run_id=""
+    fi
+
+    # GITHUB_REF_NAME must match safe branch name chars.
+    local safe_ref_name
+    if [[ "$GITHUB_REF_NAME" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+        safe_ref_name="$GITHUB_REF_NAME"
+    else
+        printf '::warning::close_build_failure_on_recovery: GITHUB_REF_NAME failed validation; using empty\n' >&2
+        safe_ref_name=""
+    fi
+
+    # GITHUB_SHA: 40 hex chars
+    local safe_sha="${GITHUB_SHA:0:8}"
+    if ! [[ "$safe_sha" =~ ^[0-9a-fA-F]+$ ]]; then
+        safe_sha=""
+    fi
+
+    local run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${safe_run_id}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY_RUN] Recovery close: would search for open 'Auto Build Failed' issue"
+        log_info "[DRY_RUN] Would close with recovery comment referencing run ${safe_run_id} (${safe_ref_name})"
+        return 0
+    fi
+
+    local issue_number
+    # Best-effort: find_open_generic_build_failure_issue returns 1 on gh CLI
+    # error.  Under set -e the bare subshell would abort before the warning
+    # path below — use || true so a transient API error is handled gracefully.
+    issue_number=$(find_open_generic_build_failure_issue || true)
+
+    if [[ -z "$issue_number" ]]; then
+        log_info "Recovery: no open 'Auto Build Failed' issue found — nothing to close."
+        return 0
+    fi
+
+    log_info "Recovery: closing issue #${issue_number} (run ${safe_run_id} succeeded on ${safe_ref_name})"
+
+    local comment_body
+    comment_body="$(cat <<RECOVERY_COMMENT
+## Build recovered
+
+The auto-build workflow completed successfully — no failed build jobs.
+
+| Property | Value |
+|----------|-------|
+| **Recovering run** | [${safe_run_id}](${run_url}) |
+| **Ref** | \`${safe_ref_name}\` |
+| **Commit** | \`${safe_sha}\` |
+| **Time** | $(date -u +'%Y-%m-%d %H:%M UTC') |
+
+_Auto-closed by \`scripts/open-dep-failure-issue.sh --mode recovery\`_
+RECOVERY_COMMENT
+)"
+
+    # Recovery close is best-effort: a transient gh API/auth error must never
+    # fail an otherwise-green master run.  Log a warning and return 0.
+    if ! run_gh issue comment \
+            --repo "$GITHUB_REPOSITORY" \
+            "$issue_number" \
+            --body "$comment_body" >&2; then
+        printf '::warning::close_build_failure_on_recovery: gh issue comment failed (non-critical, continuing)\n' >&2
+        return 0
+    fi
+
+    if ! run_gh issue close \
+            --repo "$GITHUB_REPOSITORY" \
+            "$issue_number" >&2; then
+        printf '::warning::close_build_failure_on_recovery: gh issue close failed (non-critical, continuing)\n' >&2
+        return 0
+    fi
+
+    log_success "Recovery: closed issue #${issue_number}"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # find_or_create_issue <container> <issue_title> <issue_body>
 #
 # Searches for an existing open issue with labels build-failure,automation,
@@ -674,6 +812,30 @@ COMMENT
 # main
 # ---------------------------------------------------------------------------
 main() {
+    # Parse optional --mode flag
+    local mode="failure"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --mode)
+                mode="$2"
+                shift 2
+                ;;
+            --mode=*)
+                mode="${1#--mode=}"
+                shift
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    if [[ "$mode" == "recovery" ]]; then
+        log_step "Recovery mode: closing open build-failure issue if any..."
+        close_build_failure_on_recovery
+        exit $?
+    fi
+
     log_step "Detecting dep bump from commit/PR signals..."
 
     if ! detect_dep_bump; then

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -413,6 +413,123 @@ GHEOF
 # Dedup: mock gh issue list returns empty → "created"
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# recovery mode: --mode recovery
+# ---------------------------------------------------------------------------
+
+@test "recovery: open 'Auto Build Failed' issue found → gh issue close called" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    # Track calls via a log file so we can assert what was called
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo '[{"number":42,"title":"Auto Build Failed - 2026-06-01"}]'
+        ;;
+    *"issue comment"*)
+        echo "comment posted" >&2
+        ;;
+    *"issue close"*)
+        echo "issue closed" >&2
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+
+    # gh issue close must have been called with the issue number
+    grep -q "issue close" "$call_log"
+    grep -q "42" "$call_log"
+    # gh issue comment must have been called first (recovery comment)
+    grep -q "issue comment" "$call_log"
+}
+
+@test "recovery: no open issue → exit 0, gh issue close NOT called" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *"issue close"*)
+        echo "ERROR: close should not be called when no issue open" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "recovery: non-matching title ('Build Warning') → not closed" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        # Title does NOT contain "Auto Build Failed"
+        echo '[{"number":7,"title":"Build Warning - some other issue"}]'
+        ;;
+    *"issue close"*)
+        echo "ERROR: should not close a non-matching issue" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called (title didn't match)
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Dedup: mock gh issue list returns empty → "created"
+# ---------------------------------------------------------------------------
+
 @test "dedup: no existing issue → result contains 'created'" {
     # Override gh mock: issue list returns empty; issue create returns URL
     mkdir -p "$TEST_TEMP_DIR/bin"
@@ -449,4 +566,325 @@ GHEOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"created"* ]]
     [[ "$output" == *"#42"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Finding 2: find_open_generic_build_failure_issue must require BOTH labels
+# ---------------------------------------------------------------------------
+
+@test "recovery: issue with build-failure but WITHOUT automation label is NOT closed" {
+    # The mock returns an issue that only has the build-failure label
+    # (no automation label).  The query now requires --label automation so
+    # gh issue list returns [] (the mock below models the label-AND behaviour).
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        # Simulates gh returning no results when automation label is required
+        # but absent on the candidate issue.
+        echo "[]"
+        ;;
+    *"issue close"*)
+        echo "ERROR: must not close an issue without automation label" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+
+    # Verify that gh issue list was called with the automation label
+    grep -q "\-\-label.*automation\|automation.*\-\-label" "$call_log"
+
+    # gh issue close must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Finding 3: recovery mode is best-effort — gh errors must not propagate
+# ---------------------------------------------------------------------------
+
+@test "recovery: gh issue comment failure → exit 0 (best-effort, non-critical)" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+case "\$*" in
+    *"issue list"*)
+        echo '[{"number":55,"title":"Auto Build Failed - 2026-06-01"}]'
+        ;;
+    *"issue comment"*)
+        # Simulate a transient API failure
+        echo "gh: error: HTTP 503 Service Unavailable" >&2
+        exit 1
+        ;;
+    *"issue close"*)
+        echo "ERROR: close should not be called after comment failure" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    # Must exit 0 regardless of gh failure — recovery is non-critical
+    [ "$status" -eq 0 ]
+}
+
+@test "recovery: gh issue list failure → exit 0, not aborted by set -e (Finding 3)" {
+    # find_open_generic_build_failure_issue returns 1 when gh issue list fails.
+    # Under set -e the bare subshell assignment would abort before the best-effort
+    # warning path.  The fix (|| true) must keep recovery at exit 0.
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo "gh: error: HTTP 503 Service Unavailable" >&2
+        exit 1
+        ;;
+    *"issue close"*)
+        echo "ERROR: close must not be called when list failed" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    # Must exit 0 — set -e must not abort on find_open_generic_build_failure_issue
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "recovery: gh issue close failure → exit 0 (best-effort, non-critical)" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+case "\$*" in
+    *"issue list"*)
+        echo '[{"number":55,"title":"Auto Build Failed - 2026-06-01"}]'
+        ;;
+    *"issue comment"*)
+        echo "comment posted" >&2
+        ;;
+    *"issue close"*)
+        # Simulate a transient API failure on close
+        echo "gh: error: HTTP 503 Service Unavailable" >&2
+        exit 1
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    # Must exit 0 regardless of gh failure — recovery is non-critical
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Finding 1: DRY_RUN master build must NOT trigger recovery close
+#
+# These tests exercise the summary job's build_succeeded / build_failed signal
+# computation in isolation.  The logic is mirrored verbatim from the YAML
+# summary step's Step A block and run in a subshell.
+#
+# Fidelity requirement: both signals are written to $GITHUB_OUTPUT (an
+# append-only file), not echoed to stdout.  The helper sets up a real temp
+# file for GITHUB_OUTPUT and cats it to stdout after the subshell, so bats
+# captures the actual emitted lines in $output.  This matches production:
+# GitHub Actions reads the file, not stdout.
+# ---------------------------------------------------------------------------
+
+# Helper: runs the summary job's signal-computation logic with given inputs.
+# Writes build_failed=... and build_succeeded=... to a temp GITHUB_OUTPUT file,
+# then cats that file to stdout so bats $output contains the real emitted lines.
+# Args: dry_run_flag container_count detect_result bap_result bex_result mem_result cm_result
+_run_build_succeeded_logic() {
+    local dry_run_flag="$1"
+    local container_count="$2"
+    local detect_result="${3:-success}"
+    local bap_result="${4:-success}"
+    local bex_result="${5:-skipped}"
+    local mem_result="${6:-skipped}"
+    local cm_result="${7:-success}"
+
+    local output_file
+    output_file="$(mktemp)"
+
+    bash <<LOGIC
+set -euo pipefail
+GITHUB_OUTPUT="${output_file}"
+dry_run_flag="${dry_run_flag}"
+container_count="${container_count}"
+detect_result="${detect_result}"
+bap_result="${bap_result}"
+bex_result="${bex_result}"
+mem_result="${mem_result}"
+cm_result="${cm_result}"
+
+# build_failed: any monitored pipeline job failed or cancelled.
+build_failed=false
+for _r in "\$detect_result" "\$bap_result" "\$bex_result" "\$mem_result" "\$cm_result"; do
+  if [ "\$_r" = "failure" ] || [ "\$_r" = "cancelled" ]; then
+    build_failed=true
+  fi
+done
+
+# container_count must be a non-negative integer.
+count_valid=true
+[[ "\$container_count" =~ ^[0-9]+\$ ]] || count_valid=false
+
+# build_succeeded: a REAL successful build was published.
+build_succeeded=false
+if [ "\$build_failed" = "false" ] && [ "\$count_valid" = "true" ] \
+   && [ "\$container_count" -gt 0 ] && [ "\$bap_result" = "success" ] \
+   && [ "\$dry_run_flag" != "true" ]; then
+  build_succeeded=true
+fi
+
+# Emit BOTH signals unconditionally to GITHUB_OUTPUT.
+{
+  echo "build_failed=\${build_failed}"
+  echo "build_succeeded=\${build_succeeded}"
+} >> "\$GITHUB_OUTPUT"
+LOGIC
+
+    # Cat the real GITHUB_OUTPUT content to stdout so bats captures it.
+    cat "${output_file}"
+    rm -f "${output_file}"
+}
+
+@test "summary logic: DRY_RUN=true with bap_result=success → build_succeeded=false (no recovery)" {
+    # A dry-run workflow_dispatch on master: build-and-push reports success but
+    # nothing was actually published.  build_succeeded must stay false so the
+    # recovery step is never triggered.
+    run _run_build_succeeded_logic "true" "3" "success" "success" "skipped" "skipped" "success"
+    [ "$status" -eq 0 ]
+    # Verify the real GITHUB_OUTPUT content (not a local echo).
+    [[ "$output" == *"build_succeeded=false"* ]]
+    [[ "$output" == *"build_failed=false"* ]]
+}
+
+@test "summary logic: DRY_RUN=false with bap_result=success → build_succeeded=true (real recovery)" {
+    # A genuine successful master build (not dry-run) must produce build_succeeded=true.
+    run _run_build_succeeded_logic "false" "3" "success" "success" "skipped" "skipped" "success"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_succeeded=true"* ]]
+    [[ "$output" == *"build_failed=false"* ]]
+}
+
+@test "summary logic: detect-containers failure → build_failed=true AND build_succeeded=false both in GITHUB_OUTPUT" {
+    # When detect-containers fails, downstream build jobs are skipped and
+    # container_count is empty.  build_failed must be true (issue-open path
+    # reachable) AND must be PRESENT in GITHUB_OUTPUT — the previous tangled
+    # if/elif only emitted build_succeeded=false in this branch, silently
+    # dropping the build_failed signal.
+    run _run_build_succeeded_logic "false" "" "failure" "skipped" "skipped" "skipped" "skipped"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_failed=true"* ]]
+    [[ "$output" == *"build_succeeded=false"* ]]
+}
+
+@test "summary logic: detect-containers cancelled → build_failed=true AND build_succeeded=false both in GITHUB_OUTPUT" {
+    run _run_build_succeeded_logic "false" "" "cancelled" "skipped" "skipped" "skipped" "skipped"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_failed=true"* ]]
+    [[ "$output" == *"build_succeeded=false"* ]]
+}
+
+@test "summary logic: count=0 → build_failed=false, build_succeeded=false (no issue, no recovery)" {
+    # count=0 means no containers needed building — not a failure, not a success.
+    run _run_build_succeeded_logic "false" "0" "success" "skipped" "skipped" "skipped" "skipped"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_failed=false"* ]]
+    [[ "$output" == *"build_succeeded=false"* ]]
+}
+
+@test "summary logic: empty container_count (detect skipped output) → build_succeeded=false in GITHUB_OUTPUT" {
+    # An empty container_count (detect-containers output not set) must not reach
+    # the [ -gt 0 ] arithmetic and must not produce build_succeeded=true.
+    run _run_build_succeeded_logic "false" "" "success" "success" "skipped" "skipped" "success"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_succeeded=false"* ]]
+}
+
+@test "summary logic: non-numeric container_count (e.g. 'abc') → build_succeeded=false in GITHUB_OUTPUT" {
+    run _run_build_succeeded_logic "false" "abc" "success" "success" "skipped" "skipped" "success"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"build_succeeded=false"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Recovery: event transparency
+#
+# The YAML recovery step if: uses event_name != 'pull_request' so that
+# workflow_call (upstream-monitor) and workflow_dispatch master builds reach
+# the script, not only direct push events.  The script itself does not
+# inspect GITHUB_EVENT_NAME in recovery mode — that filtering belongs to the
+# YAML gate.  The tests below document script-level event transparency.
+# ---------------------------------------------------------------------------
+
+@test "recovery: DRY_RUN mode with workflow_call event → exits 0 (script is event-transparent)" {
+    # workflow_call master builds (upstream-monitor) now reach the recovery
+    # step via the event_name != 'pull_request' gate.  The script must handle
+    # any event value without error.
+    export GITHUB_EVENT_NAME="workflow_call"
+    export GITHUB_REF_NAME="master"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+}
+
+@test "recovery: pull_request event → script exits 0 (YAML gate prevents invocation)" {
+    # On pull_request the YAML if: excludes the recovery step entirely.
+    # If somehow invoked in that context, the script must still exit 0 —
+    # recovery is best-effort and wrong-caller is not a script-level error.
+    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="refs/pull/99/merge"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Closes #573

## Summary

The auto-build summary job opened an "Auto Build Failed" issue on failure (since #514) but never closed it on recovery, so transient heavy-build flakes (e.g. #570) left stale "failed" issues open while master was green.

Adds a **recovery-close** path: on a real, successful master build, the open generic "Auto Build Failed" issue is closed with a recovery comment referencing the recovering run.

- `scripts/open-dep-failure-issue.sh`: `--mode recovery` / `close_build_failure_on_recovery`, reusing a shared `find_open_generic_build_failure_issue` helper (DRY). Best-effort — `gh` errors warn and `return 0`, routed through the `run_gh` retry wrapper; stdout/stderr separated so warnings can't corrupt the JSON.
- `.github/workflows/auto-build.yaml`: the summary job now computes `build_failed` and `build_succeeded` **unconditionally** from all monitored job results (`detect-containers`, `build-and-push`, `build-extensions`, `merge-extension-manifests`, `create-manifest`) + a validated `container_count` + the `DRY_RUN` flag, and emits both to `$GITHUB_OUTPUT` on every path. A new step runs `--mode recovery` gated on `event != pull_request && ref == master && build_succeeded == 'true'` — so it only fires after a genuine published build, never on PR smoke, `count==0`, dry-run, or any failed/indeterminate run. The generic-issue **open** path is symmetrically scoped to `ref == master && event != pull_request` (preserving `workflow_call`/upstream-monitor alerting while preventing PR failures from opening — then a master success closing — a shared issue).

Flake-tolerance (open only after N consecutive failures) is intentionally out of scope (belongs with the heavy-build flake work, #572).

## Test plan

- [x] `tests/unit/open-dep-failure-issue.bats` 42/42 — recovery close/no-op/best-effort-on-error, label scoping (`build-failure`+`automation`), and the signal computation asserted against the **actual `$GITHUB_OUTPUT`** (detect-fail → `build_failed=true`+`build_succeeded=false`; count=0 → both false; dry-run → not succeeded; real success → succeeded).
- [x] `shellcheck -x` clean; `actionlint` (the new #567 gate) EXIT 0.
- [x] Orthogonal gate (codex xhigh + copilot) dual-CLEAN after a 6-round convergence that hardened the generic-issue lifecycle: PR-cross-close, missing `create-manifest`/`detect-containers` in the failure signal, dry-run/no-op false recovery, `count==0` false recovery, `workflow_call` alerting loss, and best-effort error handling — then a clean rewrite of the signal computation (compute once, emit always) to untangle the accumulated branching.
