### PR TITLE
feat(ci): detect content staleness in the version-drift guard

### DIFF
--- a/.github/workflows/version-drift.yaml
+++ b/.github/workflows/version-drift.yaml
@@ -117,7 +117,7 @@ jobs:
           # to the runner so ::warning::/ ::notice:: annotations are visible.
           drift_json=$(GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY%%/*}" \
             bash scripts/check-version-drift.sh \
-            --mode sweep --grace-hours "$GRACE_HOURS" --json) || sweep_rc=$?
+            --mode sweep --grace-hours "$GRACE_HOURS" --check-content --json) || sweep_rc=$?
 
           echo "sweep_rc=${sweep_rc}" >> "$GITHUB_OUTPUT"
           printf '%s' "${drift_json:-[]}" > /tmp/drift-sweep.json

--- a/scripts/check-version-drift.sh
+++ b/scripts/check-version-drift.sh
@@ -17,24 +17,31 @@
 #   --grace-hours <N>            Grace period in hours (default: 6). Versions bumped
 #                                within the grace window are in_flight, not drift.
 #   --json                       Output JSON array instead of human table.
+#   --check-content              Enable content-staleness detection: compare the
+#                                org.opencontainers.image.build-digest label on the
+#                                published image against the locally-computed digest.
+#                                Requires an extra skopeo round-trip per tag.
+#                                Can also be enabled via CHECK_CONTENT_DRIFT=true env.
 #
 # Output rows (JSON object fields):
 #   kind        "container" | "extension"
 #   name        container or extension name (extensions: "ext-<name>:pg<major>")
 #   declared    declared version tag
 #   published   published version tag (empty if not found)
-#   status      "in_sync" | "drift" | "in_flight" | "window_ok" | "window_empty" | "error"
+#   status      "in_sync" | "content_stale" | "drift" | "in_flight" | "window_ok" | "window_empty" | "error"
 #
 # Exit codes:
 #   0 — no drift rows (all in_sync, in_flight, window_ok)
-#   1 — at least one drift row
+#   1 — at least one drift or content_stale row
 #   2 — probe error OR window_empty (resolver failed/returned [] — fail-closed)
 #
 # Test seams:
-#   _VDRIFT_BUMP_EPOCH_OVERRIDE   — override git log bump timestamp (epoch seconds)
-#   _VDRIFT_CONTAINERS_OVERRIDE   — whitespace-sep container list, bypasses ./make list
-#   _VDRIFT_GHCR_OWNER_OVERRIDE   — override GHCR owner derivation
-#   _VDRIFT_PROBE_OVERRIDE        — function/path: probe(<image> <tag>) → "present"|"absent"|"error"
+#   _VDRIFT_BUMP_EPOCH_OVERRIDE         — override git log bump timestamp (epoch seconds)
+#   _VDRIFT_CONTAINERS_OVERRIDE         — whitespace-sep container list, bypasses ./make list
+#   _VDRIFT_GHCR_OWNER_OVERRIDE         — override GHCR owner derivation
+#   _VDRIFT_PROBE_OVERRIDE              — function/path: probe(<image> <tag>) → "present"|"absent"|"error"
+#   _VDRIFT_LABEL_PROBE_OVERRIDE        — function/path: label_probe(<full_image_ref>) → "<label_value>"|""|"__error__"
+#   _VDRIFT_COMPUTE_DIGEST_OVERRIDE     — function/path: compute_digest(<container> <flavor>) → "<digest>"|""
 #
 # GHA command injection prevention:
 #   All user-derived strings emitted via ::notice::/::warning:: are escaped via
@@ -59,6 +66,8 @@ fi
 source "${_vdrift_self_dir}/../helpers/variant-utils.sh"
 # shellcheck source=../helpers/extension-utils.sh
 source "${_vdrift_self_dir}/../helpers/extension-utils.sh"
+# shellcheck source=../helpers/build-cache-utils.sh
+source "${_vdrift_self_dir}/../helpers/build-cache-utils.sh"
 
 # ---------------------------------------------------------------------------
 # _escape_gha_command <value>
@@ -82,6 +91,11 @@ MODE=""
 CONTAINER_ARG=""
 GRACE_HOURS=6
 JSON_OUTPUT=false
+# Content-staleness check: opt-in via --check-content flag or env var.
+# Default OFF to preserve existing behavior and avoid the extra skopeo round-trip.
+CHECK_CONTENT_DRIFT="${CHECK_CONTENT_DRIFT:-false}"
+# Emit the per-variant coverage notice at most once per run (avoid log spam).
+_CONTENT_VARIANT_NOTICE_EMITTED=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -93,6 +107,8 @@ while [[ $# -gt 0 ]]; do
             GRACE_HOURS="$2"; shift 2 ;;
         --json)
             JSON_OUTPUT=true; shift ;;
+        --check-content)
+            CHECK_CONTENT_DRIFT=true; shift ;;
         -h|--help)
             grep '^#' "$0" | grep -v '#!/' | sed 's/^# \?//'
             exit 0 ;;
@@ -387,6 +403,200 @@ _vdrift_probe_published() {
 }
 
 # ---------------------------------------------------------------------------
+# _vdrift_fetch_build_digest_label <owner> <image_name> <tag>
+#
+# Fetch the org.opencontainers.image.build-digest label from the published
+# amd64 child manifest of a multi-arch image in GHCR.
+#
+# Because the label lives in the per-arch config (not the index manifest),
+# this is a two-step skopeo probe:
+#   1. skopeo inspect --raw docker://ghcr.io/<owner>/<image>:<tag>
+#      → extract the amd64 child digest from .manifests[].
+#   2. skopeo inspect docker://ghcr.io/<owner>/<image>@<amd64_digest>
+#      → read .Labels["org.opencontainers.image.build-digest"].
+#
+# Outputs:
+#   ""          — label absent/empty on the image (pre-mechanism image; caller
+#                 treats this as "skip content check", NOT stale)
+#   "<digest>"  — the 12-char build-digest label value
+#   "__error__" — skopeo/transport error (caller must treat as error, fail-closed)
+#
+# Never exits non-zero.
+#
+# Test seam: _VDRIFT_LABEL_PROBE_OVERRIDE is a function/path that accepts
+#   $1=<full image ref with tag>
+# and outputs one of the three values above.
+# ---------------------------------------------------------------------------
+_vdrift_fetch_build_digest_label() {
+    local owner="$1"
+    local image_name="$2"
+    local tag="$3"
+    local full_ref="ghcr.io/${owner}/${image_name}:${tag}"
+
+    if [[ -n "${_VDRIFT_LABEL_PROBE_OVERRIDE:-}" ]]; then
+        local result
+        result=$("${_VDRIFT_LABEL_PROBE_OVERRIDE}" "$full_ref" 2>/dev/null) || true
+        # Validate result is one of the expected sentinel values or a digest
+        case "$result" in
+            __error__)
+                printf '__error__' ;;
+            *)
+                # Empty string or a digest value — pass through
+                printf '%s' "$result" ;;
+        esac
+        return 0
+    fi
+
+    if ! command -v skopeo >/dev/null 2>&1; then
+        # skopeo not available — skip content check (treat as empty label)
+        printf ''
+        return 0
+    fi
+
+    # Step 1: Fetch the raw index manifest to get the amd64 child digest.
+    local raw_stderr_tmp
+    raw_stderr_tmp=$(mktemp)
+    local raw_stdout raw_rc
+
+    raw_stdout=$(skopeo inspect --raw "docker://${full_ref}" \
+        2>"$raw_stderr_tmp") && raw_rc=0 || raw_rc=$?
+    rm -f "$raw_stderr_tmp"
+
+    if [[ "$raw_rc" -ne 0 ]]; then
+        # Transport/auth error on the raw inspect → fail-closed
+        printf '__error__'
+        return 0
+    fi
+
+    # Extract the amd64 child digest from the index manifest.
+    local amd64_digest
+    amd64_digest=$(printf '%s' "$raw_stdout" \
+        | jq -r '.manifests[]? | select(.platform.architecture=="amd64") | .digest' \
+        2>/dev/null | head -1 || true)
+
+    if [[ -z "$amd64_digest" ]]; then
+        # No amd64 child in the manifest (e.g. single-arch or Windows image)
+        # → cannot read the label, treat as empty (skip content check)
+        printf ''
+        return 0
+    fi
+
+    # Step 2: Inspect the amd64 child manifest (by digest) to get labels.
+    local cfg_tmp
+    cfg_tmp=$(mktemp)
+    local cfg_stdout cfg_rc
+
+    cfg_stdout=$(skopeo inspect \
+        "docker://ghcr.io/${owner}/${image_name}@${amd64_digest}" \
+        2>"$cfg_tmp") && cfg_rc=0 || cfg_rc=$?
+    rm -f "$cfg_tmp"
+
+    if [[ "$cfg_rc" -ne 0 ]]; then
+        # Transport/auth error on the config inspect → fail-closed
+        printf '__error__'
+        return 0
+    fi
+
+    # Extract the build-digest label.  Empty string if the label is absent.
+    local label_value
+    label_value=$(printf '%s' "$cfg_stdout" \
+        | jq -r --arg lbl "$BUILD_DIGEST_LABEL" '.Labels[$lbl] // empty' \
+        2>/dev/null || true)
+
+    printf '%s' "${label_value:-}"
+}
+
+# ---------------------------------------------------------------------------
+# _vdrift_compute_current_digest <container> <flavor>
+#
+# Compute the current expected build digest for a container/flavor pair by
+# calling compute_build_digest (from helpers/build-cache-utils.sh) with the
+# correct working directory (the container's source directory).
+#
+# Returns the 12-char hex digest on stdout, or empty string on error/skip.
+#
+# Test seam: _VDRIFT_COMPUTE_DIGEST_OVERRIDE is a function/path that accepts
+#   $1=<container> $2=<flavor>
+# and outputs the digest (or empty for error/skip).
+# ---------------------------------------------------------------------------
+_vdrift_compute_current_digest() {
+    local container="$1"
+    local flavor="${2:-}"
+
+    if [[ -n "${_VDRIFT_COMPUTE_DIGEST_OVERRIDE:-}" ]]; then
+        local result
+        result=$("${_VDRIFT_COMPUTE_DIGEST_OVERRIDE}" "$container" "$flavor" 2>/dev/null) || true
+        printf '%s' "$result"
+        return 0
+    fi
+
+    local container_dir="${PROJECT_ROOT}/${container}"
+
+    if [[ ! -d "$container_dir" ]]; then
+        # Container directory missing — skip content check
+        printf ''
+        return 0
+    fi
+
+    # Detect template/generated-Dockerfile containers.
+    #
+    # The build computes the digest over the GENERATED Dockerfile (after template
+    # expansion), not over the committed Dockerfile or template.  Since we cannot
+    # faithfully reproduce the generated Dockerfile here (that would require running
+    # the full generate-dockerfile.sh / generate_dockerfile pipeline), we SKIP
+    # the content check for these containers to avoid false content_stale positives
+    # on a freshly-built image.
+    #
+    # Template-container detection heuristics (in priority order):
+    #   1. generate-dockerfile.sh exists in the container dir — the build invokes it
+    #      to produce a per-flavour/per-distro Dockerfile at build time.
+    #      Covers: web-shell, github-runner.
+    #      Note: github-runner's base-image staleness is already covered by the
+    #      separate base-digest-drift mechanism; skipping content-check here is safe.
+    #   2. The committed Dockerfile contains @@MARKER@@ placeholders — the build
+    #      calls generate_dockerfile() to expand them before computing the digest.
+    #      Covers: postgres (@@EXTENSION_STAGES@@, @@EXTENSION_COPIES@@, @@RUNTIME_DEPS@@).
+    #
+    # Static containers (jekyll, terraform, ansible, openresty, sslh, vector, …)
+    # have a plain committed Dockerfile with no template machinery — for those the
+    # locally-computed digest faithfully matches the build-time digest, so the
+    # content check is safe and meaningful (catches the #595 class of staleness).
+    if [[ -x "${container_dir}/generate-dockerfile.sh" ]]; then
+        printf '::notice::version-drift: content-check skipped for %s: generate-dockerfile.sh present (generated Dockerfile, parity not guaranteed)\n' \
+            "$(_escape_gha_command "$container")" >&2
+        printf ''
+        return 0
+    fi
+
+    # Determine the Dockerfile path (same logic as the build: default "Dockerfile")
+    local dockerfile="Dockerfile"
+    if [[ ! -f "${container_dir}/${dockerfile}" ]]; then
+        # Missing Dockerfile — skip content check
+        printf ''
+        return 0
+    fi
+
+    # Check for @@MARKER@@ template patterns in the committed Dockerfile.
+    # grep -q exits 0 if found, 1 if not found; || true prevents set -e abort.
+    if grep -qF '@@' "${container_dir}/${dockerfile}" 2>/dev/null; then
+        printf '::notice::version-drift: content-check skipped for %s: Dockerfile contains @@MARKER@@ template placeholders (generated Dockerfile, parity not guaranteed)\n' \
+            "$(_escape_gha_command "$container")" >&2
+        printf ''
+        return 0
+    fi
+
+    # compute_build_digest must be called with cwd = container directory
+    local digest
+    digest=$(
+        pushd "$container_dir" >/dev/null
+        compute_build_digest "$dockerfile" "$flavor"
+        popd >/dev/null
+    ) || true
+
+    printf '%s' "${digest:-}"
+}
+
+# ---------------------------------------------------------------------------
 # Result accumulator
 # ---------------------------------------------------------------------------
 # Rows are accumulated as a newline-delimited JSON objects in _ROWS_BUF,
@@ -418,9 +628,10 @@ _append_row() {
     _ROWS_BUF+="$row"
 
     case "$status" in
-        drift)         _HAS_DRIFT=true ;;
-        error)         _HAS_ERROR=true ;;
-        window_empty)  _HAS_ERROR=true ;;
+        drift)          _HAS_DRIFT=true ;;
+        content_stale)  _HAS_DRIFT=true ;;
+        error)          _HAS_ERROR=true ;;
+        window_empty)   _HAS_ERROR=true ;;
     esac
 
     # GHA annotations
@@ -433,6 +644,9 @@ _append_row() {
         drift)
             printf '::warning::version-drift: %s declared=%s status=%s\n' \
                 "$safe_name" "$safe_declared" "$safe_status" >&2 ;;
+        content_stale)
+            printf '::warning::version-drift: %s declared=%s status=content_stale (rebuild needed: build-digest mismatch)\n' \
+                "$safe_name" "$safe_declared" >&2 ;;
         in_flight)
             printf '::notice::version-drift: %s declared=%s status=in_flight (within grace window)\n' \
                 "$safe_name" "$safe_declared" >&2 ;;
@@ -454,13 +668,60 @@ _check_container_tag() {
     local image_name="$3"    # e.g. "postgres"
     local version_tag="$4"   # e.g. "18-alpine" or "13.7.0-ubuntu"
     local declaring_file="$5" # relative to PROJECT_ROOT, for bump timestamp
+    local flavor="${6:-}"     # flavor/variant name for content digest computation
 
     local probe_result
     probe_result=$(_vdrift_probe_published "$owner" "$image_name" "$version_tag")
 
     case "$probe_result" in
         present)
-            _append_row "container" "$container" "$version_tag" "$version_tag" "in_sync"
+            # Tag is present and multi-arch.  Optionally check content freshness.
+            if [[ "$CHECK_CONTENT_DRIFT" == "true" ]]; then
+                # Coverage note: content-staleness is currently checked for the
+                # DEFAULT VARIANT only per version (the variant passed as $flavor).
+                # Non-default variants are not individually probed here.
+                # TODO: per-variant content drift is a follow-up improvement; skipping
+                # non-default variants now avoids scope explosion and keeps the
+                # no-false-positive rule intact (each variant needs its own generated
+                # digest path which is non-trivial to reproduce for template containers).
+                if [[ "$_CONTENT_VARIANT_NOTICE_EMITTED" == "false" ]]; then
+                    printf '::notice::version-drift: content-staleness check covers the default variant only per version; non-default variant content drift is not detected (follow-up TODO)\n' >&2
+                    _CONTENT_VARIANT_NOTICE_EMITTED=true
+                fi
+                local published_label
+                published_label=$(_vdrift_fetch_build_digest_label \
+                    "$owner" "$image_name" "$version_tag")
+
+                case "$published_label" in
+                    __error__)
+                        # Label fetch failed (transport/auth error) → fail-closed
+                        _append_row "container" "$container" "$version_tag" "$version_tag" "error"
+                        ;;
+                    "")
+                        # Label absent → pre-mechanism image; cannot compare → in_sync
+                        _append_row "container" "$container" "$version_tag" "$version_tag" "in_sync"
+                        ;;
+                    *)
+                        # Label present → compare against current expected digest
+                        local current_digest
+                        current_digest=$(_vdrift_compute_current_digest \
+                            "$container" "$flavor")
+
+                        if [[ -z "$current_digest" ]]; then
+                            # Cannot compute current digest (template container,
+                            # missing Dockerfile, etc.) → skip content check, in_sync
+                            _append_row "container" "$container" "$version_tag" "$version_tag" "in_sync"
+                        elif [[ "$published_label" != "$current_digest" ]]; then
+                            # Digest mismatch → content stale, rebuild needed
+                            _append_row "container" "$container" "$version_tag" "$version_tag" "content_stale"
+                        else
+                            _append_row "container" "$container" "$version_tag" "$version_tag" "in_sync"
+                        fi
+                        ;;
+                esac
+            else
+                _append_row "container" "$container" "$version_tag" "$version_tag" "in_sync"
+            fi
             ;;
         absent)
             # Check grace window
@@ -545,7 +806,7 @@ _process_container() {
                 fi
                 [[ -z "$published_tag" ]] && published_tag="${vtag}${bsfx}"
                 _check_container_tag "$owner" "$container" "$container" \
-                    "$published_tag" "${container}/variants.yaml"
+                    "$published_tag" "${container}/variants.yaml" "${default_var:-}"
             done <<< "$versions"
             return 0
         fi
@@ -557,7 +818,7 @@ _process_container() {
     while IFS= read -r vtag; do
         [[ -z "$vtag" ]] && continue
         _check_container_tag "$owner" "$container" "$container" \
-            "$vtag" "${container}/variants.yaml"
+            "$vtag" "${container}/variants.yaml" ""
     done <<< "$versions"
 }
 

--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -408,9 +408,10 @@ open_version_drift_issue() {
         return 1
     fi
 
-    # Count drift rows
+    # Count drift rows — include content_stale rows: they indicate a rebuild is
+    # needed and must surface as actionable issues, not be silently dropped.
     local drift_count
-    drift_count=$(printf '%s' "$drift_json" | jq '[.[] | select(.status=="drift")] | length' 2>/dev/null || echo "0")
+    drift_count=$(printf '%s' "$drift_json" | jq '[.[] | select(.status=="drift" or .status=="content_stale")] | length' 2>/dev/null || echo "0")
     if [[ "$drift_count" -eq 0 ]]; then
         return 0
     fi
@@ -444,17 +445,19 @@ open_version_drift_issue() {
     # Build issue title
     local issue_title
     if [[ -n "$validated_container" ]]; then
-        issue_title="Version drift detected — ${validated_container}: ${drift_count} declared version(s) not published"
+        issue_title="Version drift detected — ${validated_container}: ${drift_count} version(s) need attention"
     else
-        issue_title="Version drift detected — ${drift_count} declared version(s) not published"
+        issue_title="Version drift detected — ${drift_count} version(s) need attention"
     fi
 
-    # Build markdown table from drift rows
+    # Build markdown table from drift rows.
+    # content_stale rows are rendered alongside drift rows: they represent
+    # images that need a rebuild and are equally actionable.
     local drift_table
     drift_table="$(printf '%s' "$drift_json" | jq -r '
         (["| Kind | Name | Declared | Published | Status |",
           "|------|------|----------|-----------|--------|"] | .[]),
-        (.[] | select(.status=="drift") |
+        (.[] | select(.status=="drift" or .status=="content_stale") |
          "| \(.kind) | \(.name) | \(.declared) | \(.published) | \(.status) |")
     ' 2>/dev/null || echo "_(unable to render drift table)_")"
 

--- a/tests/unit/check-version-drift.bats
+++ b/tests/unit/check-version-drift.bats
@@ -2833,3 +2833,643 @@ GH_EOF
     new_message_count=$(grep -cE 'probe error|resolver failure|missing prerequisite' "$DRIFT_YAML" || true)
     [ "$new_message_count" -ge 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT tests — content-staleness detection (--check-content / #595)
+#
+# The mechanism: every published image is stamped with
+#   org.opencontainers.image.build-digest  (12-char SHA256 prefix)
+# The guard fetches that label from the amd64 child manifest and compares it
+# against the locally-computed digest from compute_build_digest.
+#
+# Test seams used:
+#   _VDRIFT_LABEL_PROBE_OVERRIDE  — stubs _vdrift_fetch_build_digest_label
+#   _VDRIFT_COMPUTE_DIGEST_OVERRIDE — stubs _vdrift_compute_current_digest
+#   _VDRIFT_PROBE_OVERRIDE        — stubs _vdrift_probe_published (tag present)
+#
+# Mutation guards:
+#   MGC1: Delete the content_stale branch → published_label != current_digest
+#         never produces content_stale, test CONTENT-DRIFT-1 fails (status=in_sync
+#         instead of content_stale, drift_count=0 instead of 1).
+#   MGC2: Invert the comparison (== instead of !=) → matching digests produce
+#         content_stale, mismatching produce in_sync; tests CONTENT-DRIFT-1 and
+#         CONTENT-DRIFT-2 both fail.
+#   MGC3: Remove the __error__ sentinel branch → label-fetch errors silently
+#         become in_sync; test CONTENT-DRIFT-4 fails (status=in_sync, exit 0).
+#   MGC4: Remove the empty-label branch → empty label produces content_stale
+#         (false-positive on pre-mechanism images); test CONTENT-DRIFT-3 fails.
+#   MGC5: Remove the CHECK_CONTENT_DRIFT guard → content check runs even without
+#         --check-content; test CONTENT-DRIFT-5 fails (probes run, status changes).
+# ---------------------------------------------------------------------------
+
+# Helper: make a label-probe stub that maps full image refs to label values.
+# Usage: _make_label_probe_stub <ref1> <label_value_1> [<ref2> <val2> ...]
+# Special values:
+#   "__error__"  → the stub outputs "__error__"
+#   ""           → the stub outputs "" (empty = label absent)
+#   "<digest>"   → the stub outputs the digest string
+# Unmatched refs default to "" (label absent).
+_make_label_probe_stub() {
+    local stub_path="${TEST_TEMP_DIR}/label-probe-stub-$$"
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+
+    local case_branches=""
+    local default_val=""
+    local -a args=("$@")
+    local i=0
+    while (( i < ${#args[@]} )); do
+        local ref="${args[$i]}"
+        local val="${args[$i+1]}"
+        (( i += 2 )) || true
+        if [[ "$ref" == "__default__" ]]; then
+            default_val="$val"
+        else
+            local escaped_ref
+            escaped_ref=$(printf '%s' "$ref" | sed 's/[\\*?[]/\\&/g')
+            case_branches+="        '${escaped_ref}') printf '%s' '${val}' ;;"$'\n'
+        fi
+    done
+
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'case "$1" in\n'
+        printf '%s' "$case_branches"
+        printf "        *) printf '%%s' '%s' ;;\n" "$default_val"
+        printf 'esac\n'
+    } > "$stub_path"
+
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# Helper: make a compute-digest stub that returns a fixed value.
+# Usage: _make_compute_digest_stub <digest_value>
+_make_compute_digest_stub() {
+    local digest="$1"
+    local stub_path="${TEST_TEMP_DIR}/compute-digest-stub-$$"
+
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf "printf '%%s' '%s'\n" "$digest"
+    } > "$stub_path"
+
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-1: tag present + published digest != current digest
+#                  → status content_stale, counted as drift, exit 1
+#
+# MGC1 guard: delete the content_stale branch → in_sync, drift_count=0, exit 0
+# MGC2 guard: invert == to != → matching digests become content_stale
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-1: published digest != current digest + --check-content → content_stale + exit 1" {
+    local root
+    root=$(_make_temp_project "myapp" "3.0.0")
+
+    # Tag is present (multi-arch)
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/myapp:3.0.0" "present")
+
+    # Published label returns a different digest than current
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/myapp:3.0.0" "aabbcc112233")
+
+    # Current digest: different from published
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "ddeeff445566")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="myapp" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # content_stale counts as drift → exit 1
+    [ "$status" -eq 1 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 1 ]
+
+    # Drift count (for issue aggregation) must include content_stale
+    # (verified by exit 1, not exit 0 or 2)
+
+    local row
+    row=$(printf '%s' "$output" | jq '.[0]')
+    [ "$(printf '%s' "$row" | jq -r '.name')" = "myapp" ]
+    [ "$(printf '%s' "$row" | jq -r '.declared')" = "3.0.0" ]
+    [ "$(printf '%s' "$row" | jq -r '.status')" = "content_stale" ]
+
+    # No in_sync rows (the tag was stale, not in_sync)
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-2: published digest == current digest + --check-content
+#                  → in_sync, exit 0
+#
+# MGC2 guard: invert == to != → this produces content_stale, test fails
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-2: published digest == current digest + --check-content → in_sync + exit 0" {
+    local root
+    root=$(_make_temp_project "myapp" "3.0.0")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/myapp:3.0.0" "present")
+
+    # Published label and current digest match
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/myapp:3.0.0" "aabbcc112233")
+
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "aabbcc112233")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="myapp" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-3: published label absent (empty) → in_sync (NOT content_stale)
+#                  Pre-mechanism images that predate the label must not false-positive.
+#
+# MGC4 guard: remove the empty-label branch → empty label falls through to
+#             comparison (produces content_stale), test fails (status=content_stale)
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-3: label absent on published image + --check-content → in_sync (not content_stale)" {
+    local root
+    root=$(_make_temp_project "myapp" "3.0.0")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/myapp:3.0.0" "present")
+
+    # Published label is absent (empty string)
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/myapp:3.0.0" "")
+
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "ddeeff445566")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="myapp" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Empty label → pre-mechanism image → in_sync, exit 0
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-4: label fetch returns __error__ → error row, exit 2 (fail-closed)
+#
+# MGC3 guard: remove __error__ branch → error falls through to empty/digest
+#             comparison, produces in_sync silently; test fails (exit 0, not 2)
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-4: label fetch error + --check-content → error row + exit 2 (fail-closed)" {
+    local root
+    root=$(_make_temp_project "myapp" "3.0.0")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/myapp:3.0.0" "present")
+
+    # Label probe simulates a transport error
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/myapp:3.0.0" "__error__")
+
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "aabbcc112233")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="myapp" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Label fetch error → fail-closed → exit 2
+    [ "$status" -eq 2 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local error_count
+    error_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="error")] | length')
+    [ "$error_count" -eq 1 ]
+
+    # Must NOT have produced in_sync or content_stale
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-5: without --check-content (default), stale digest is NOT detected
+#                  → in_sync, exit 0 (opt-in behavior preserved)
+#
+# MGC5 guard: remove the CHECK_CONTENT_DRIFT guard → content check runs always,
+#             producing content_stale even without the flag; test fails (exit 1)
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-5: without --check-content, mismatched digests → in_sync (opt-in gate works)" {
+    local root
+    root=$(_make_temp_project "myapp" "3.0.0")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/myapp:3.0.0" "present")
+
+    # Even though label and compute differ, without --check-content no comparison runs
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/myapp:3.0.0" "aabbcc112233")
+
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "ddeeff445566")
+
+    # No --check-content flag; also ensure env var is NOT set
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="myapp" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        CHECK_CONTENT_DRIFT="" \
+        bash "$DRIFT_SCRIPT" --mode sweep --json
+
+    # Without --check-content: tag is present → in_sync (unchanged behavior)
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CONTENT-DRIFT-6: structural — version-drift.yaml sweep passes --check-content
+# ---------------------------------------------------------------------------
+@test "CONTENT-DRIFT-6: version-drift.yaml sweep invocation passes --check-content" {
+    [ -f "$DRIFT_YAML" ]
+    grep -q -- '--check-content' "$DRIFT_YAML"
+}
+
+# ---------------------------------------------------------------------------
+# FINDING-2 tests — no-false-positive rule for template containers
+#
+# Template containers (those with generate-dockerfile.sh OR a Dockerfile with
+# @@MARKER@@ placeholders) must NEVER produce content_stale even when the
+# published label differs from a locally-computed raw-template digest.
+#
+# The guard cannot faithfully reproduce the generated Dockerfile without running
+# the full generation pipeline, so it skips the content check for these
+# containers and emits in_sync instead.
+#
+# Mutation guards:
+#   MGF2a: Remove generate-dockerfile.sh detection → template containers get
+#          content-checked; with a label mismatch they produce content_stale
+#          (false positive on a freshly-built image). Tests FINDING-2a/b fail.
+#   MGF2b: Remove @@MARKER@@ detection → postgres-like containers produce
+#          false content_stale. Test FINDING-2c fails.
+#   MGF2d: Remove the guard entirely → both template types produce false
+#          content_stale. Tests FINDING-2a/b/c all fail.
+# ---------------------------------------------------------------------------
+
+# Helper: create a temp project with a container that has generate-dockerfile.sh
+# (simulating web-shell / github-runner). Includes a variants.yaml so the drift
+# script can enumerate versions.
+_make_template_generate_project() {
+    local container="$1"
+    local version="$2"
+
+    local root="${TEST_TEMP_DIR}/template-gen-project-$$"
+    local cdir="${root}/${container}"
+    mkdir -p "$cdir"
+
+    # variants.yaml (simple, one version)
+    {
+        printf 'build:\n  version_retention: 3\nversions:\n'
+        printf '  - tag: %s\n' "$version"
+    } > "${cdir}/variants.yaml"
+
+    # A static Dockerfile (no @@MARKER@@) — content check would run on this
+    # if generate-dockerfile.sh were not present
+    printf 'FROM debian:bookworm-slim\nRUN echo hello\n' > "${cdir}/Dockerfile"
+
+    # generate-dockerfile.sh marks this as a template container
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'echo "FROM generated:image"\n'
+    } > "${cdir}/generate-dockerfile.sh"
+    chmod +x "${cdir}/generate-dockerfile.sh"
+
+    # Stub ./make list
+    cat > "${root}/make" <<MAKE_EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "list" ]]; then
+    echo "${container}"
+fi
+MAKE_EOF
+    chmod +x "${root}/make"
+
+    printf '%s' "$root"
+}
+
+# Helper: create a temp project with a container whose Dockerfile has @@MARKER@@
+# placeholders (simulating postgres).
+_make_template_marker_project() {
+    local container="$1"
+    local version="$2"
+
+    local root="${TEST_TEMP_DIR}/template-marker-project-$$"
+    local cdir="${root}/${container}"
+    mkdir -p "$cdir"
+
+    {
+        printf 'build:\n  version_retention: 3\nversions:\n'
+        printf '  - tag: %s\n' "$version"
+    } > "${cdir}/variants.yaml"
+
+    # Dockerfile with @@MARKER@@ placeholder (like postgres)
+    printf 'FROM postgres:16-alpine\n# @@EXTENSION_STAGES@@\nRUN echo hello\n' > "${cdir}/Dockerfile"
+
+    cat > "${root}/make" <<MAKE_EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "list" ]]; then
+    echo "${container}"
+fi
+MAKE_EOF
+    chmod +x "${root}/make"
+
+    printf '%s' "$root"
+}
+
+# ---------------------------------------------------------------------------
+# FINDING-2a: container with generate-dockerfile.sh → content check SKIPPED,
+#             status in_sync (NOT content_stale), no false positive.
+#
+# This test exercises the REAL _vdrift_compute_current_digest (no compute
+# override) so that the generate-dockerfile.sh detection inside that function
+# is exercised.  The label probe returns a non-empty value so the code reaches
+# the compute path; the real implementation returns "" (skip) for template
+# containers, which maps to the "empty current_digest → in_sync" branch.
+#
+# The mutation guard: if generate-dockerfile.sh detection is removed from
+# _vdrift_compute_current_digest, the function calls compute_build_digest on
+# the static Dockerfile present in the test fixture (FROM debian:...).
+# compute_build_digest will compute a real digest → mismatch with the label
+# → content_stale → exit 1 (test fails).
+# ---------------------------------------------------------------------------
+@test "FINDING-2a: container with generate-dockerfile.sh → content-check skipped, in_sync (no false positive)" {
+    local root
+    root=$(_make_template_generate_project "web-shell-variant" "1.0.0")
+
+    # Tag is present (image exists)
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/web-shell-variant:1.0.0" "present")
+
+    # Label returns a digest — if compute is not skipped, a mismatch would produce content_stale.
+    # The Dockerfile in the fixture is "FROM debian..." with compute returning a real hash ≠ aabbcc112233.
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/web-shell-variant:1.0.0" "aabbcc112233")
+
+    # NO _VDRIFT_COMPUTE_DIGEST_OVERRIDE — real _vdrift_compute_current_digest runs.
+    # It must detect generate-dockerfile.sh and return "" (skip), yielding in_sync.
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="web-shell-variant" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Template container: content check skipped → in_sync, exit 0
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    # Must be in_sync (NOT content_stale — no false positive)
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# FINDING-2b: generate-dockerfile.sh container, label IS present but compute
+#             returns "" (skipped) → in_sync rather than content_stale.
+#
+#             The flow: fetch label → non-empty → call compute → compute returns
+#             "" (template skip) → "empty current_digest → in_sync" branch.
+#             This confirms the "empty digest → in_sync" short-circuit is the
+#             mechanism that prevents false positives for template containers.
+# ---------------------------------------------------------------------------
+@test "FINDING-2b: generate-dockerfile.sh container, label present, compute skips → in_sync (no false positive)" {
+    local root
+    root=$(_make_template_generate_project "github-runner-sim" "2.321.0")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/github-runner-sim:2.321.0" "present")
+
+    # Label returns a real digest (non-empty, non-error)
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/github-runner-sim:2.321.0" "aabbcc112233")
+
+    # Compute stub returns EMPTY — simulates the template skip in _vdrift_compute_current_digest
+    # (the real implementation returns "" for generate-dockerfile.sh containers)
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="github-runner-sim" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Label present but compute returns "" → "cannot compute current digest → in_sync"
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# FINDING-2c: container with @@MARKER@@ Dockerfile (postgres-like) →
+#             content-check skipped, in_sync (no false positive).
+#
+# Same real-implementation pattern as FINDING-2a: no compute override, so the
+# @@MARKER@@ detection inside _vdrift_compute_current_digest is exercised.
+# The label returns a real digest; if @@MARKER@@ detection were absent,
+# compute_build_digest would hash the committed template Dockerfile →
+# mismatch → content_stale → exit 1 (test fails).
+# ---------------------------------------------------------------------------
+@test "FINDING-2c: Dockerfile with @@MARKER@@ → content-check skipped, in_sync (no false positive)" {
+    local root
+    root=$(_make_template_marker_project "mypostgres" "17-alpine")
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/mypostgres:17-alpine" "present")
+
+    # Label returns a digest that would NOT match a raw compute of the template Dockerfile.
+    # If @@MARKER@@ detection is removed, compute runs on the template → different digest
+    # → content_stale.  With the fix, compute is skipped → in_sync.
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/mypostgres:17-alpine" "aabbcc112233")
+
+    # NO _VDRIFT_COMPUTE_DIGEST_OVERRIDE — real implementation must detect @@MARKER@@.
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="mypostgres" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Template (@@MARKER@@): content check skipped → in_sync, exit 0
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local sync_count
+    sync_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="in_sync")] | length')
+    [ "$sync_count" -eq 1 ]
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# FINDING-2d: plain static Dockerfile (no generate-dockerfile.sh, no @@MARKER@@)
+#             → content check RUNS, content_stale on mismatch.
+#             This proves the no-false-positive fix does not suppress content
+#             checks on static containers (like jekyll, terraform, sslh, etc.).
+# ---------------------------------------------------------------------------
+@test "FINDING-2d: static Dockerfile (no template) → content check runs, content_stale on mismatch" {
+    # Create a container with a plain static Dockerfile (no @@MARKER@@, no generate-dockerfile.sh)
+    local root="${TEST_TEMP_DIR}/static-container-project-$$"
+    local cdir="${root}/jekyllsim"
+    mkdir -p "$cdir"
+
+    {
+        printf 'build:\n  version_retention: 3\nversions:\n'
+        printf '  - tag: 4.3.4\n'
+    } > "${cdir}/variants.yaml"
+
+    # Plain Dockerfile — no template markers, no generate-dockerfile.sh
+    printf 'FROM ruby:3.3-alpine\nRUN gem install jekyll\n' > "${cdir}/Dockerfile"
+
+    cat > "${root}/make" <<'MAKE_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    echo "jekyllsim"
+fi
+MAKE_EOF
+    chmod +x "${root}/make"
+
+    local probe
+    probe=$(_make_probe_stub "ghcr.io/testowner/jekyllsim:4.3.4" "present")
+
+    # Published label and current digest differ → content_stale
+    local label_probe
+    label_probe=$(_make_label_probe_stub \
+        "ghcr.io/testowner/jekyllsim:4.3.4" "aabbcc112233")
+
+    local compute_stub
+    compute_stub=$(_make_compute_digest_stub "ddeeff445566")
+
+    run --separate-stderr env \
+        PROJECT_ROOT="$root" \
+        _VDRIFT_CONTAINERS_OVERRIDE="jekyllsim" \
+        _VDRIFT_GHCR_OWNER_OVERRIDE="testowner" \
+        _VDRIFT_BUMP_EPOCH_OVERRIDE="1" \
+        _VDRIFT_PROBE_OVERRIDE="$probe" \
+        _VDRIFT_LABEL_PROBE_OVERRIDE="$label_probe" \
+        _VDRIFT_COMPUTE_DIGEST_OVERRIDE="$compute_stub" \
+        bash "$DRIFT_SCRIPT" --mode sweep --check-content --json
+
+    # Static Dockerfile → content check runs → content_stale detected → exit 1
+    [ "$status" -eq 1 ]
+
+    printf '%s' "$output" | jq '.' >/dev/null
+
+    local stale_count
+    stale_count=$(printf '%s' "$output" | jq '[.[] | select(.status=="content_stale")] | length')
+    [ "$stale_count" -eq 1 ]
+
+    local row_status
+    row_status=$(printf '%s' "$output" | jq -r '.[0].status')
+    [ "$row_status" = "content_stale" ]
+}

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -410,6 +410,76 @@ GHEOF
 }
 
 # ---------------------------------------------------------------------------
+# FINDING-1 — content_stale rows must be counted and rendered by
+# open_version_drift_issue (not silently dropped as a no-op).
+#
+# A run that produces ONLY content_stale rows must open/refresh an issue.
+# Before the fix the count used select(.status=="drift") exclusively, so a
+# content_stale-only JSON was counted as 0 drift rows and the function
+# returned early without creating an issue.
+# ---------------------------------------------------------------------------
+
+@test "FINDING-1: content_stale-only drift_json → issue created (not a no-op)" {
+    # drift_json has exactly one content_stale row and no drift rows.
+    local drift_json='[
+        {"status":"content_stale","kind":"container","name":"jekyll","declared":"4.3.4","published":"4.3.4"}
+    ]'
+    export DRY_RUN="true"
+
+    run open_version_drift_issue "$drift_json" "jekyll"
+    [ "$status" -eq 0 ]
+
+    # Must print dry-run output (not silent exit as if no drift)
+    [[ "$output" == *"DRY_RUN"* || "$output" == *"dry-run"* ]]
+
+    # Must render the content_stale row in the table
+    [[ "$output" == *"| jekyll |"* ]]
+
+    # The status column must show content_stale (distinguishable from drift)
+    [[ "$output" == *"content_stale"* ]]
+
+    # Must NOT fall back to the error sentinel
+    [[ "$output" != *"unable to render drift table"* ]]
+}
+
+@test "FINDING-1: mixed drift+content_stale → both rows rendered, count = 2" {
+    # drift_json has one drift row and one content_stale row.
+    local drift_json='[
+        {"status":"drift","kind":"container","name":"foo","declared":"1.0.0","published":""},
+        {"status":"content_stale","kind":"container","name":"bar","declared":"2.0.0","published":"2.0.0"}
+    ]'
+    export DRY_RUN="true"
+
+    run open_version_drift_issue "$drift_json" ""
+    [ "$status" -eq 0 ]
+
+    # Both rows must appear in the table
+    [[ "$output" == *"| foo |"* ]]
+    [[ "$output" == *"| bar |"* ]]
+
+    # The status values must both be visible
+    [[ "$output" == *"drift"* ]]
+    [[ "$output" == *"content_stale"* ]]
+
+    # in_sync must not appear
+    [[ "$output" != *"in_sync"* ]]
+}
+
+@test "FINDING-1: in_sync-only drift_json → still a no-op (content_stale fix must not break this)" {
+    # An all-in_sync JSON must remain a no-op — the fix must not break that path.
+    local drift_json='[
+        {"status":"in_sync","kind":"container","name":"foo","declared":"1.0.0","published":"1.0.0"}
+    ]'
+    export DRY_RUN="true"
+
+    run open_version_drift_issue "$drift_json" "foo"
+    [ "$status" -eq 0 ]
+
+    # No dry-run output (no issue to open)
+    [[ "$output" != *"DRY_RUN"* && "$output" != *"dry-run"* && "$output" != *"Issue"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # Dedup: mock gh issue list returns empty → "created"
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #595

## Summary

The durable fix (approach C) for #595: the version-drift guard now detects **content** staleness, not just tag presence. When a container's `config.yaml` build-arg changes (or a base-image rebase lands) but the version tag stays constant, a missed rebuild (e.g. from the supersede gap in #595) left a stale image the tag-only guard reported `in_sync`. This catches it.

- **Mechanism (already in place — no build-side change):** every published image carries `org.opencontainers.image.build-digest` (a hash over Dockerfile + `config.yaml` build-args + `LAST_REBUILD.md`), and `compute_build_digest()` computes the current expected value (the same hash the build's skip-rebuild logic uses).
- **`--check-content` / `CHECK_CONTENT_DRIFT=true`** (opt-in; wired into the daily sweep): for a present tag, read the published label (two-step skopeo: index → amd64 child → config labels) and compare to the current digest. Mismatch → new **`content_stale`** status (counts as drift, opens/refreshes the version-drift issue). Absent label (pre-mechanism image) → `in_sync` (no false positive). skopeo transport error → `error` (fail closed).
- **No false positives on template containers:** the build computes the digest over the *generated* Dockerfile, which the guard cannot faithfully reproduce. So containers with `generate-dockerfile.sh` (web-shell, github-runner) or `@@MARKER@@` placeholders (postgres) are **skipped** with a `::notice::`, not guessed. Static-Dockerfile containers (jekyll, terraform, ansible, …) are checked — covering the #595 cases. (github-runner's base-image staleness is already covered by the separate base-digest-drift mechanism, #559.)
- **Known limitation (documented + `::notice::`):** content check covers the default variant per version only — per-variant content drift is a follow-up.

## Test plan

- [x] `check-version-drift.bats` 89/89, `open-dep-failure-issue.bats` 29/29 — content_stale vs in_sync vs absent-label (no false positive) vs fetch-error (fail closed) vs flag-off (opt-in); template-container skip exercising the **real** detection (no false positive); static-container mismatch → content_stale; and `content_stale`-only `drift_json` now creates/refreshes an issue (the round-1 gate's High finding).
- [x] `shellcheck -x` clean; `actionlint` (the #567 gate) EXIT 0.
- [x] Orthogonal gate (codex xhigh + copilot) dual-CLEAN after one fix round (issue-surfacing, template false-positives, variant-coverage note).
