### PR TITLE
fix(ci): cumulative container detection from a coverage checkpoint (#595)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -82,9 +82,124 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # Finding 2 fix: GH_TOKEN is scoped to this push-only step exclusively.
+    # The token is required only to validate the coverage checkpoint tag via the
+    # GH API (Finding 1 fix: job-level verification).  It must NOT be present in
+    # the Find-containers step that runs ./make list (branch-controlled code on
+    # PR/manual events).
+    # Scoped to master-only: the checkpoint tag (auto-build-coverage-master) is
+    # only written by the publish-coverage-checkpoint job which also gates on
+    # refs/heads/master.  A non-master push (e.g. the "main" branch listed in
+    # the on.push.branches trigger) must use the original event.before..after
+    # diff instead — applying master's checkpoint there would produce a wrong
+    # baseline and needless fail-safe expansions.
+    - name: Resolve coverage checkpoint baseline
+      id: resolve-coverage-baseline
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_SHA_CTX: ${{ github.sha }}
+        GITHUB_REPOSITORY_CTX: ${{ github.repository }}
+      run: |
+        set -e
+        baseline_sha=""
+        baseline_valid=false
+
+        # Fetch the coverage-checkpoint tag.  detect-containers callers use
+        # fetch-depth:0 so the tag is reachable without a full clone.
+        set +e
+        git fetch --no-tags origin \
+          "refs/tags/auto-build-coverage-master:refs/tags/auto-build-coverage-master" \
+          2>/dev/null
+        fetch_rc=$?
+        set -e
+
+        if [[ $fetch_rc -ne 0 ]]; then
+          echo "::warning::Coverage checkpoint tag auto-build-coverage-master not found (first run?) — failing safe: build-all with retained expansion"
+        else
+          # Resolve the tagged SHA.
+          set +e
+          baseline_sha=$(git rev-list -n1 auto-build-coverage-master 2>/dev/null)
+          resolve_rc=$?
+          set -e
+
+          if [[ $resolve_rc -ne 0 || -z "$baseline_sha" ]]; then
+            echo "::warning::Failed to resolve auto-build-coverage-master tag SHA — failing safe: build-all with retained expansion"
+            baseline_sha=""
+          else
+            # Ancestor check: tag must point to a commit on the current lineage.
+            set +e
+            git merge-base --is-ancestor "$baseline_sha" "$GITHUB_SHA_CTX" 2>/dev/null
+            ancestor_rc=$?
+            set -e
+
+            if [[ $ancestor_rc -ne 0 ]]; then
+              echo "::warning::Coverage checkpoint tag ($baseline_sha) is not an ancestor of HEAD — falling back to build-all with retained expansion"
+              baseline_sha=""
+            else
+              # Finding 1 fix: verify B was written by a successful
+              # publish-coverage-checkpoint job, not just any successful push run.
+              # A successful push run whose checkpoint job was skipped (or a run
+              # predating the mechanism) would wrongly validate via a headSha-only
+              # check, risking under-build when the tag is pointed to such a SHA.
+              #
+              # Strategy: find all push runs at B, then for each run check whether
+              # the "Publish coverage checkpoint tag" job completed with conclusion
+              # "success".  Any match → trusted.  No match / API error → fail-safe.
+              set +e
+              run_ids=$(gh run list \
+                --repo "$GITHUB_REPOSITORY_CTX" \
+                --workflow auto-build.yaml \
+                --branch master \
+                --event push \
+                --status success \
+                --limit 40 \
+                --json databaseId,headSha \
+                --jq ".[] | select(.headSha==\"$baseline_sha\") | .databaseId" \
+                2>/dev/null)
+              list_rc=$?
+              set -e
+
+              if [[ $list_rc -ne 0 || -z "$run_ids" ]]; then
+                echo "::warning::Coverage checkpoint tag ($baseline_sha) — GH API run-list failed or no matching push runs found; failing safe: build-all with retained expansion"
+              else
+                verified=no
+                while IFS= read -r rid; do
+                  [[ -z "$rid" ]] && continue
+                  set +e
+                  concl=$(gh run view "$rid" \
+                    --repo "$GITHUB_REPOSITORY_CTX" \
+                    --json jobs \
+                    --jq '.jobs[] | select(.name | test("publish coverage checkpoint tag";"i")) | .conclusion' \
+                    2>/dev/null)
+                  view_rc=$?
+                  set -e
+                  if [[ $view_rc -eq 0 && "$concl" == "success" ]]; then
+                    verified=yes
+                    break
+                  fi
+                done <<< "$run_ids"
+
+                if [[ "$verified" == "yes" ]]; then
+                  baseline_valid=true
+                  echo "Coverage checkpoint verified: run at $baseline_sha had a successful publish-coverage-checkpoint job"
+                else
+                  echo "::warning::Coverage checkpoint tag ($baseline_sha) — no run at that SHA had a successful publish-coverage-checkpoint job (tag may be mis-pointed or predate the mechanism); failing safe: build-all with retained expansion"
+                fi
+              fi
+            fi
+          fi
+        fi
+
+        echo "baseline_sha=${baseline_sha}" >> "$GITHUB_OUTPUT"
+        echo "baseline_valid=${baseline_valid}" >> "$GITHUB_OUTPUT"
+
     - name: Find containers to build
       id: find-containers
       shell: bash
+      # No GH_TOKEN here — this step runs ./make list (branch-controlled code) and
+      # must not have a write-capable token in its environment (Finding 2 fix).
       run: |
         set -e
         diff_rc=0
@@ -93,12 +208,12 @@ runs:
         # Get list of valid containers from make script (source of truth)
         echo "🔍 Getting list of valid containers from make script..."
         valid_containers=$(cd "$GITHUB_WORKSPACE" && ./make list)
-        
+
         if [[ -z "$valid_containers" ]]; then
           echo "⚠️  No valid containers found in make script"
           exit 1
         fi
-        
+
         echo "📋 Valid containers from make: $(echo "$valid_containers" | tr '\n' ' ')"
 
         # If specific container requested, validate it
@@ -113,26 +228,47 @@ runs:
           fi
         else
           echo "🔍 Detecting containers that need building based on changed files..."
-          
+
           # Determine what files changed in this push/PR
           diff_rc=0
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            # For push events, use event SHAs (handles initial commit with all-zeros before SHA gracefully)
-            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
-              # Initial commit - diff against empty tree
-              # The SHA '4b825dc642cb6eb9a060e54bf8d69288fbee4904' is Git's canonical empty tree object hash, used for initial commit diffs.
+          coverage_fallback=false
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]]; then
+            # Push to master: diff from the coverage checkpoint tag so superseded
+            # runs don't strand containers (fix for #595).
+            # Baseline resolution + GH API verification is done in the preceding
+            # resolve-coverage-baseline step (master-push-only, token-scoped).
+            # We consume its outputs here: baseline_sha and baseline_valid.
+            baseline_sha="${{ steps.resolve-coverage-baseline.outputs.baseline_sha }}"
+            baseline_valid="${{ steps.resolve-coverage-baseline.outputs.baseline_valid }}"
+
+            if [[ "$baseline_valid" == "true" ]]; then
+              echo "Coverage checkpoint baseline: $baseline_sha"
               set +e
-              changed_files=$(git diff --name-only 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.event.after }}" 2>/dev/null)
+              changed_files=$(git diff --name-only --no-renames "$baseline_sha" "${{ github.sha }}" 2>/dev/null)
               diff_rc=$?
               set -e
-              [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (initial commit)"; changed_files=""; }
+              [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (push/checkpoint)"; changed_files=""; }
             else
-              set +e
-              changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" 2>/dev/null)
-              diff_rc=$?
-              set -e
-              [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (push event)"; changed_files=""; }
+              # Fail-safe: build ALL containers + force retained expansion.
+              # Reason is already ::warning::-logged by resolve-coverage-baseline.
+              coverage_fallback=true
+              diff_rc=0
+              changed_files=""
             fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # Push to a non-master branch (e.g. "main"): use the original per-push
+            # diff window — no checkpoint involvement here, the tag belongs to master.
+            set +e
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+              # Initial / branch-creation push (all-zero before): diff against the
+              # empty tree so detection works instead of failing on a bogus base.
+              changed_files=$(git diff --name-only --no-renames 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.sha }}" 2>/dev/null)
+            else
+              changed_files=$(git diff --name-only --no-renames "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null)
+            fi
+            diff_rc=$?
+            set -e
+            [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (push/non-master event.before..after)"; changed_files=""; }
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # For PRs, compare with base and head SHAs from the event (robust, does not require fetch)
             set +e
@@ -157,10 +293,50 @@ runs:
             fi
           fi
 
+          # Coverage checkpoint fail-safe: build ALL containers + signal retained expansion
+          if [[ "$coverage_fallback" == "true" ]]; then
+            echo "🔄 Coverage checkpoint fail-safe — building all containers with retained version expansion"
+            while IFS= read -r container; do
+              [[ -n "$container" ]] && containers_to_build+=("$container")
+            done <<< "$valid_containers"
+          fi
+
           if [[ -n "$changed_files" ]]; then
             echo "📝 Changed files:"
             echo "$changed_files"
-            
+
+            # Root-level shared build files: a change to 'make' (or other root-level
+            # orchestrators) affects every container — fan out to all.
+            # This closes the detection hole where root-level files have no slash,
+            # causing the path-prefix loop below to skip them entirely.
+            build_all_from_root=false
+            while IFS= read -r file; do
+              [[ -z "$file" ]] && continue
+              case "$file" in
+                make)
+                  build_all_from_root=true
+                  break
+                  ;;
+              esac
+            done <<< "$changed_files"
+
+            if [[ "$build_all_from_root" == "true" ]]; then
+              echo "🔧 Root build orchestrator (make) changed — building all containers with retained version expansion"
+              while IFS= read -r container; do
+                [[ -n "$container" ]] && containers_to_build+=("$container")
+              done <<< "$valid_containers"
+              changed_files=""  # Skip per-container detection; all already queued
+              # A root build-logic change means ALL retained versions must rebuild,
+              # not just the latest. Reuse the same full-rebuild signal as the
+              # coverage-checkpoint fail-safe so compute_expand_retained_map
+              # returns all-true for every container.
+              coverage_fallback=true
+            fi
+            # TODO: Shared-helper fanout (helpers/*.sh change affecting all images)
+            # is a broader policy; tracked as follow-up to avoid over-engineering here.
+          fi
+
+          if [[ -n "$changed_files" ]]; then
             # Extract container names from changed file paths
             while IFS= read -r file; do
               # Skip root-level files (no slash in path)
@@ -233,6 +409,8 @@ runs:
           touch "${RUNNER_TEMP}/changed_files.txt.diff_failed"
         fi
         echo "changed_files_file=${RUNNER_TEMP}/changed_files.txt" >> "$GITHUB_OUTPUT"
+        # Propagate the coverage-checkpoint fail-safe flag to the compute-expand-map step.
+        echo "coverage_fallback=${coverage_fallback}" >> "$GITHUB_OUTPUT"
 
     - name: Compute expand_retained map
       id: compute-expand-map
@@ -242,6 +420,7 @@ runs:
         BUILD_ALL_RETAINED: ${{ inputs.build_all_retained }}
         CHANGED_FILES_FILE: ${{ steps.find-containers.outputs.changed_files_file }}
         CONTAINERS_JSON: ${{ steps.find-containers.outputs.containers }}
+        COVERAGE_FALLBACK: ${{ steps.find-containers.outputs.coverage_fallback }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC1091
@@ -265,7 +444,8 @@ runs:
           "$EVENT_NAME" \
           "$BUILD_ALL_RETAINED" \
           "$CHANGED_FILES_FILE" \
-          "$CONTAINERS_JSON")
+          "$CONTAINERS_JSON" \
+          "$COVERAGE_FALLBACK")
 
         echo "map=$map" >> "$GITHUB_OUTPUT"
         echo "::notice::Expand-retained map: $map"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1289,6 +1289,53 @@ jobs:
           sbom-path: ${{ steps.sbom-windows.outputs.sbom_file }}
         continue-on-error: true
 
+  # Advance the coverage checkpoint git tag to HEAD when a push to master fully
+  # succeeded (or had nothing to build — docs-only push is still globally covered).
+  #
+  # The tag `auto-build-coverage-master` is the ONLY safe baseline for cumulative
+  # container detection (fix for #595 / supersede-stranding).  Invariants:
+  #   - Only this job writes the tag, so tag-exists ↔ valid-coverage-checkpoint.
+  #   - Targeted workflow_dispatch, workflow_call (upstream-monitor), and PR runs
+  #     NEVER write it, so they can never poison the baseline.
+  #   - A failed/cancelled run (any build job failed) never advances the tag, so the
+  #     next run re-diffs from the old baseline and rebuilds the stranded containers.
+  #   - A "nothing to build" docs-only push still advances the tag (no containers were
+  #     newly changed, so the prior checkpoint remains valid coverage for them).
+  publish-coverage-checkpoint:
+    name: Publish coverage checkpoint tag
+    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest]
+    # Only on push to master; only when no monitored build job failed or was cancelled.
+    # !failure() && !cancelled() catches all terminal states: success and skipped both pass.
+    # The individual result checks below are belt-and-suspenders for the core jobs.
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      !failure() &&
+      !cancelled() &&
+      needs.detect-containers.result != 'failure' &&
+      needs.detect-containers.result != 'cancelled' &&
+      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped') &&
+      (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
+      (needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped') &&
+      (needs.create-manifest.result == 'success' || needs.create-manifest.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write  # Required to push the coverage checkpoint tag
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Force-update coverage checkpoint tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git tag -f auto-build-coverage-master "$GITHUB_SHA"
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}" \
+            "refs/tags/auto-build-coverage-master"
+          echo "::notice::Coverage checkpoint advanced to $GITHUB_SHA"
+
   summary:
     needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries]
     if: always()

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -537,7 +537,7 @@ list_variant_tags() {
 # Compute per-container expand-retained signals from a git-diff-derived changed-files list.
 # This is the signal-computation layer for "matrix default to latest-only, expand on dep change".
 #
-# Usage: compute_expand_retained_map <event_name> <build_all_retained> <changed_files_file> <containers_json>
+# Usage: compute_expand_retained_map <event_name> <build_all_retained> <changed_files_file> <containers_json> [fallback_all]
 #
 # Args:
 #   event_name           - GitHub event name (e.g. "push", "pull_request", "workflow_dispatch"). May be empty.
@@ -545,10 +545,13 @@ list_variant_tags() {
 #   changed_files_file   - Path to a file with one changed path per line (output of `git diff --name-only`).
 #                          If file <changed_files_file>.diff_failed exists alongside, treat as diff failure.
 #   containers_json      - JSON array of detected container names, e.g. ["openresty","postgres"].
+#   fallback_all         - Optional. String "true" forces all containers to true regardless of other signals.
+#                          Used by the detect-containers fail-safe path (coverage checkpoint missing/invalid).
 #
 # Output (stdout):
 #   JSON object mapping container name -> boolean. true = expand retained versions, false = latest only.
 #   Priority chain (first match wins) for each container c:
+#     0. fallback_all == "true"                                 → c: true  (coverage-checkpoint fail-safe)
 #     1. <changed_files_file>.diff_failed sentinel exists       → c: true  (ERR-01a defensive expand)
 #     2. event_name empty or unrecognized                       → c: true  (ERR-06 backward-compat)
 #     3. event_name == "pull_request"                           → c: true  (PR smoke matrix)
@@ -564,6 +567,7 @@ compute_expand_retained_map() {
     local build_all_retained="$2"
     local changed_files_file="$3"
     local containers_json="$4"
+    local fallback_all="${5:-false}"
 
     # Validate containers_json is a valid JSON array
     if ! echo "$containers_json" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
@@ -591,6 +595,12 @@ compute_expand_retained_map() {
     local container
     while IFS= read -r container; do
         [[ -z "$container" ]] && continue
+
+        # Priority 0: coverage-checkpoint fail-safe — override everything
+        if [[ "$fallback_all" == "true" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
 
         # Priority 1: diff_failed sentinel
         if [[ "$diff_failed" == "true" ]]; then

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -826,3 +826,227 @@ EOF
     stderr_out=$(list_build_matrix "threevers" "" "false" 2>&1 >/dev/null)
     [[ "$stderr_out" == *"::notice::Container threevers: latest-only (skipped retained versions:"* ]]
 }
+
+# --- compute_expand_retained_map fallback_all (coverage checkpoint fail-safe, #595) ---
+
+setup_fallback_test() {
+    # Shared setup for fallback tests: temp changed_files with no content
+    printf '' > "${TEST_DIR}/changed.txt"
+}
+
+@test "compute_expand_retained_map: fallback_all=true forces all containers to true" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    setup_fallback_test
+    containers='["openresty","terraform","postgres"]'
+
+    # fallback_all=true — every container must expand, regardless of event/diff
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+}
+
+@test "compute_expand_retained_map: fallback_all=true overrides per-container diff signal" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # changed_files contains ONLY openresty — without fallback, terraform/postgres stay false
+    printf 'openresty/Dockerfile\n' > "${TEST_DIR}/changed.txt"
+    containers='["openresty","terraform","postgres"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    # fallback_all wins even for containers not in changed_files
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+}
+
+@test "compute_expand_retained_map: fallback_all=false preserves normal per-container logic" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Only openresty changed; push event; fallback_all=false (normal path)
+    printf 'openresty/Dockerfile\n' > "${TEST_DIR}/changed.txt"
+    containers='["openresty","terraform"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false"
+    [ "$status" -eq 0 ]
+    # openresty: changed → true; terraform: not changed → false
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "false" ]
+}
+
+@test "compute_expand_retained_map: fallback_all omitted (backward compat) — normal logic applies" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    printf 'openresty/Dockerfile\n' > "${TEST_DIR}/changed.txt"
+    containers='["openresty","terraform"]'
+
+    # 4-arg call (no fallback_all) — must behave as fallback_all=false
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "false" ]
+}
+
+@test "compute_expand_retained_map: fallback_all=true with single container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    setup_fallback_test
+    containers='["ansible"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.ansible')" = "true" ]
+}
+
+# --- Finding 1: make fan-out shares the full-rebuild signal with coverage-checkpoint fail-safe ---
+# The make root-file fan-out sets coverage_fallback=true (same signal as the fail-safe),
+# which is passed as fallback_all=true to compute_expand_retained_map.
+# This test verifies that the shared signal forces all containers to expand retained versions,
+# even when changed_files is empty (which is what the make fan-out does — it clears
+# changed_files after queuing all containers).
+
+@test "compute_expand_retained_map: make-fanout full-rebuild signal (fallback_all=true, empty diff) forces all containers to expand retained" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Simulate the make fan-out state: changed_files is empty (cleared after queuing all),
+    # but coverage_fallback=true (new signal added to make fan-out).
+    printf '' > "${TEST_DIR}/changed.txt"
+    containers='["postgres","terraform","openresty","ansible"]'
+
+    # fallback_all=true mirrors what the make fan-out now sets.
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    # Every container must expand retained versions — NOT just latest.
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.ansible')" = "true" ]
+}
+
+@test "compute_expand_retained_map: WITHOUT full-rebuild signal, empty diff produces latest-only for push event" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Contrast test: same setup but fallback_all=false (old behaviour before fix).
+    # With an empty diff and a push event, all containers should be latest-only.
+    printf '' > "${TEST_DIR}/changed.txt"
+    containers='["terraform","openresty"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "false" ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "false" ]
+}
+
+# --- Finding 2: forged/unverified checkpoint tag → fail-safe build-all with retained expansion ---
+# When the checkpoint tag cannot be verified against a successful push run (e.g. tag was
+# manually advanced or the GH API query fails), the code sets coverage_fallback=true,
+# which is the same full-rebuild signal. This test verifies the shared signal path.
+
+@test "compute_expand_retained_map: unverified-tag fail-safe (fallback_all=true) forces retained expansion on all containers" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Simulate: tag present + ancestor check passed, but GH API verification failed
+    # (or returned 'no'). Code falls through to coverage_fallback=true → same signal.
+    printf '' > "${TEST_DIR}/changed.txt"
+    containers='["postgres","openresty","terraform"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
+}
+
+@test "compute_expand_retained_map: verified checkpoint tag with partial diff expands only changed containers" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Simulate: tag verified (fallback_all=false), only openresty changed.
+    # Only openresty should expand retained; terraform stays latest-only.
+    printf 'openresty/Dockerfile\n' > "${TEST_DIR}/changed.txt"
+    containers='["openresty","terraform","postgres"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "false" ]
+    [ "$(echo "$output" | jq -r '.postgres')" = "false" ]
+}
+
+# --- Finding 1 checkpoint-job binding traces ---
+# Trace (a): resolve-coverage-baseline finds a run at B whose
+#   publish-coverage-checkpoint job succeeded → baseline_valid=true →
+#   find-containers uses the partial diff → compute_expand_retained_map
+#   receives fallback_all=false and the partial diff → only changed containers expand.
+#
+# Trace (b): resolve-coverage-baseline finds a run at B (successful push run)
+#   but NO publish-coverage-checkpoint job success → baseline_valid=false →
+#   find-containers sets coverage_fallback=true → compute_expand_retained_map
+#   receives fallback_all=true → ALL containers expand (fail-safe).
+#
+# The compute_expand_retained_map function is the downstream consumer of
+# baseline_valid; it receives fallback_all from the action step.  The two
+# bats tests below exercise the contract of the downstream consumer for each
+# upstream trace, ensuring that changing fallback_all between the two traces
+# produces the correct per-container result.
+
+@test "compute_expand_retained_map: trace-a (checkpoint job verified, baseline_valid=true) — partial diff, only changed container expands" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Trace (a): baseline_valid=true passed as fallback_all=false.
+    # changed_files contains only postgres; other containers must stay latest-only.
+    printf 'postgres/variants.yaml\n' > "${TEST_DIR}/changed.txt"
+    containers='["postgres","ansible","terraform"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false"
+    [ "$status" -eq 0 ]
+    # The changed container expands all retained versions.
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+    # Unchanged containers stay at latest-only.
+    [ "$(echo "$output" | jq -r '.ansible')" = "false" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "false" ]
+}
+
+@test "compute_expand_retained_map: trace-b (push run succeeded but checkpoint job not present/skipped) — fail-safe: all containers expand" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Trace (b): a successful push run existed at B, but the
+    # publish-coverage-checkpoint job was skipped or not present (e.g. a run
+    # predating the mechanism, or a partial success where only checkpoint was
+    # skipped).  resolve-coverage-baseline leaves baseline_valid=false →
+    # find-containers sets coverage_fallback=true → fallback_all=true here.
+    # Even though only postgres changed, ALL containers must expand.
+    printf 'postgres/variants.yaml\n' > "${TEST_DIR}/changed.txt"
+    containers='["postgres","ansible","terraform"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "true"
+    [ "$status" -eq 0 ]
+    # Fail-safe: every container expands retained versions regardless of diff.
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+    [ "$(echo "$output" | jq -r '.ansible')" = "true" ]
+    [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
+}


### PR DESCRIPTION
Closes #595

## Summary

The durable fix for the supersede-stranding gap (#595), **co-designed with an adversarial codex review** after two earlier approaches were rejected (content-staleness detection = infeasible; per-SHA concurrency = reintroduces the extension Stage-A→Stage-B tag race).

**Problem:** rapid master merges supersede pending auto-builds (cancel-in-progress: false cancels pending runs), and `detect-containers` diffed only `event.before..event.after`, so a superseded push's container was silently never built (jekyll/terraform/github-runner were stranded with stale images while their version tags stayed `in_sync`).

**Fix — cumulative detection anchored to a global coverage checkpoint:**

- **Keep the per-ref top-level lock** (runs stay serial → the ext Stage-A→Stage-B tag window stays protected). No concurrency change.
- **New `publish-coverage-checkpoint` job** force-updates the `auto-build-coverage-master` git tag to HEAD — only on push-to-master and only when the build set was fully published (`!failure() && !cancelled()`). Only this job writes the tag.
- **`detect-containers` (master push)** diffs `--no-renames` from that checkpoint instead of `event.before`. Every superseded commit is in range → nothing stranded.
- **Tag is self-validating:** the baseline is trusted only after confirming (via `gh`) that a run at that exact SHA had a **successful `publish-coverage-checkpoint` job** — a forged/mis-pointed tag is ignored. Token scoped to a push-only `resolve-coverage-baseline` step (kept out of the `./make list` step).
- **Fail-safe (tag missing / non-ancestor / unverified / git error):** build **all** containers **and force retained-version expansion** — never fewer.
- Root-`make` (shared build-logic) changes fan out to all containers + retained. Non-master pushes keep the original `event.before..after` diff (incl. all-zero initial-push handling). `--no-renames` everywhere.

"Last successful run SHA" was explicitly rejected as a baseline (a targeted/latest-only green run ≠ all images current at its SHA → would under-build).

## Test plan

- [x] `tests/unit/variant-utils.bats` 57/57 — fail-safe / `make`-fanout force retained expansion; verified-checkpoint vs unverified → build-all.
- [x] `shellcheck -x` clean; `actionlint` (the #567 gate) EXIT 0; YAML valid.
- [x] Orthogonal gate (codex xhigh + copilot) **dual-CLEAN after a 5-round convergence** hardening: make→retained, tag-binding-to-checkpoint-job, token scoping, master-only scope, non-master initial-push regression.

## Operator note

External tag protection on `auto-build-coverage-master` (restrict writes to the bot/checkpoint job) is recommended as defense-in-depth, but is no longer required for correctness — the baseline is validated against a successful checkpoint job, and any doubt fails safe to a full rebuild.
