### PR TITLE
fix(ci): advance coverage checkpoint despite container failures (#595)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -78,6 +78,14 @@ outputs:
       versions, false = latest version only. Computed by compute_expand_retained_map
       helper. Consumed downstream by the Expand variants step.
     value: ${{ steps.compute-expand-map.outputs.map }}
+  carried_forward:
+    description: |
+      JSON array of container names that were newly appended to the build list
+      via the carry-forward mechanism (failed in the prior run and not already
+      queued by diff detection). Empty array [] when none. Exposed for
+      observability and consumed by compute-expand-map to force full retained-
+      version expansion (Finding A fix).
+    value: ${{ steps.find-containers.outputs.carried_forward }}
 
 runs:
   using: 'composite'
@@ -138,22 +146,23 @@ runs:
               echo "::warning::Coverage checkpoint tag ($baseline_sha) is not an ancestor of HEAD — falling back to build-all with retained expansion"
               baseline_sha=""
             else
-              # Finding 1 fix: verify B was written by a successful
-              # publish-coverage-checkpoint job, not just any successful push run.
-              # A successful push run whose checkpoint job was skipped (or a run
-              # predating the mechanism) would wrongly validate via a headSha-only
-              # check, risking under-build when the tag is pointed to such a SHA.
+              # Finding 1 fix: verify the tag was written by a successful
+              # publish-coverage-checkpoint job, not just any push run.
+              # A push run whose checkpoint job was skipped (or a run predating the
+              # mechanism) would wrongly validate via a headSha-only check, risking
+              # under-build when the tag is pointed to such a SHA.
               #
-              # Strategy: find all push runs at B, then for each run check whether
-              # the "Publish coverage checkpoint tag" job completed with conclusion
-              # "success".  Any match → trusted.  No match / API error → fail-safe.
+              # The checkpoint now advances even when build jobs fail (the run
+              # conclusion may be "failure"), so --status success is intentionally
+              # omitted here.  The per-run job-conclusion check below (gh run view)
+              # is the authority — it verifies the publish-coverage-checkpoint job
+              # itself completed with conclusion "success".
               set +e
               run_ids=$(gh run list \
                 --repo "$GITHUB_REPOSITORY_CTX" \
                 --workflow auto-build.yaml \
                 --branch master \
                 --event push \
-                --status success \
                 --limit 40 \
                 --json databaseId,headSha \
                 --jq ".[] | select(.headSha==\"$baseline_sha\") | .databaseId" \
@@ -195,13 +204,33 @@ runs:
         echo "baseline_sha=${baseline_sha}" >> "$GITHUB_OUTPUT"
         echo "baseline_valid=${baseline_valid}" >> "$GITHUB_OUTPUT"
 
+        # Read the failed-container carry-forward list from the annotated tag message.
+        # The message is a JSON state record written by publish-coverage-checkpoint.
+        # Falls back to [] for any parse/validation failure (e.g. first run, old tag format).
+        baseline_failed="[]"
+        if [[ "$baseline_valid" == "true" ]]; then
+          # shellcheck disable=SC1091  # path resolved at runtime in the action dir
+          source "${GITHUB_ACTION_PATH}/../../../helpers/coverage-checkpoint-utils.sh"
+          tag_msg=$(git for-each-ref \
+            --format='%(contents)' refs/tags/auto-build-coverage-master 2>/dev/null || true)
+          baseline_failed=$(checkpoint_failed_containers "$tag_msg")
+        fi
+        echo "baseline_failed_containers=${baseline_failed}" >> "$GITHUB_OUTPUT"
+
     - name: Find containers to build
       id: find-containers
       shell: bash
       # No GH_TOKEN here — this step runs ./make list (branch-controlled code) and
       # must not have a write-capable token in its environment (Finding 2 fix).
+      env:
+        # Failed containers carried forward from the prior checkpoint tag.
+        # Passed via env (not inline ${{ }}) to avoid injection through JSON content.
+        BASELINE_FAILED: ${{ steps.resolve-coverage-baseline.outputs.baseline_failed_containers }}
+        BASELINE_VALID: ${{ steps.resolve-coverage-baseline.outputs.baseline_valid }}
       run: |
         set -e
+        # shellcheck disable=SC1091  # path resolved at runtime in the action dir
+        source "${GITHUB_ACTION_PATH}/../../../helpers/coverage-checkpoint-utils.sh"
         diff_rc=0
         containers_to_build=()
 
@@ -386,11 +415,41 @@ runs:
           fi
         fi
 
+        # Carry forward containers that failed in the prior run.
+        # Only applies on master-push with a valid baseline (coverage_fallback already
+        # builds all, so carry-forward is redundant and skipped in that path).
+        # compute_carry_forward ensures a prior-failed container is added to the
+        # carried set even when it was already queued by another path (diff, or the
+        # shared-infra canary) — the old inline loop skipped carried recording in
+        # that case, causing a latest-only retry to falsely recover a failed retained
+        # version (Finding A, second instance: extract untested inline logic).
+        #
+        # carried = baseline_failed ∩ valid  (all valid prior-failed containers)
+        # queued' = queued ∪ carried         (full build list, deduped)
+        carried_forward_json='[]'
+        if [[ "$BASELINE_VALID" == "true" && "$coverage_fallback" != "true" \
+              && -n "$BASELINE_FAILED" && "$BASELINE_FAILED" != "[]" ]]; then
+          if [ ${#containers_to_build[@]} -eq 0 ]; then
+            queued_json='[]'
+          else
+            queued_json=$(printf '%s\n' "${containers_to_build[@]}" | jq -R . | jq -s -c .)
+          fi
+          valid_json=$(printf '%s\n' "$valid_containers" | jq -R 'select(length>0)' | jq -s -c .)
+          cf=$(compute_carry_forward "$queued_json" "$BASELINE_FAILED" "$valid_json")
+          # Rebuild the build list from the merged queue (includes carried containers).
+          mapfile -t containers_to_build < <(echo "$cf" | jq -r '.queued[]')
+          carried_forward_json=$(echo "$cf" | jq -c '.carried')
+          if [[ "$carried_forward_json" != "[]" ]]; then
+            echo "🔁 Carrying forward (retained-expand forced): $(echo "$carried_forward_json" | jq -r 'join(" ")')"
+          fi
+        fi
+
         # Create outputs (CSV first, then JSON for matrix compatibility)
         if [ ${#containers_to_build[@]} -eq 0 ]; then
           echo "containers_list=" >> $GITHUB_OUTPUT
           echo "containers=[]" >> $GITHUB_OUTPUT
           echo "count=0" >> $GITHUB_OUTPUT
+          echo "carried_forward=[]" >> $GITHUB_OUTPUT
           echo "📋 No containers need building"
         else
           containers_csv=$(IFS=','; echo "${containers_to_build[*]}")
@@ -398,6 +457,7 @@ runs:
           echo "containers_list=$containers_csv" >> $GITHUB_OUTPUT
           echo "containers=$container_json" >> $GITHUB_OUTPUT
           echo "count=${#containers_to_build[@]}" >> $GITHUB_OUTPUT
+          echo "carried_forward=${carried_forward_json}" >> $GITHUB_OUTPUT
           echo "📋 Found containers to build: ${containers_to_build[*]}"
         fi
 
@@ -421,6 +481,7 @@ runs:
         CHANGED_FILES_FILE: ${{ steps.find-containers.outputs.changed_files_file }}
         CONTAINERS_JSON: ${{ steps.find-containers.outputs.containers }}
         COVERAGE_FALLBACK: ${{ steps.find-containers.outputs.coverage_fallback }}
+        CARRIED_FORWARD: ${{ steps.find-containers.outputs.carried_forward }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC1091
@@ -440,12 +501,18 @@ runs:
           exit 0
         fi
 
+        # Guard against empty/missing CARRIED_FORWARD (e.g. non-master-push events
+        # where the output is not set by find-containers).
+        carried_forward_arg="${CARRIED_FORWARD:-[]}"
+        [[ -z "$carried_forward_arg" ]] && carried_forward_arg="[]"
+
         map=$(compute_expand_retained_map \
           "$EVENT_NAME" \
           "$BUILD_ALL_RETAINED" \
           "$CHANGED_FILES_FILE" \
           "$CONTAINERS_JSON" \
-          "$COVERAGE_FALLBACK")
+          "$COVERAGE_FALLBACK" \
+          "$carried_forward_arg")
 
         echo "map=$map" >> "$GITHUB_OUTPUT"
         echo "::notice::Expand-retained map: $map"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1289,52 +1289,146 @@ jobs:
           sbom-path: ${{ steps.sbom-windows.outputs.sbom_file }}
         continue-on-error: true
 
-  # Advance the coverage checkpoint git tag to HEAD when a push to master fully
-  # succeeded (or had nothing to build — docs-only push is still globally covered).
+  # Advance the coverage checkpoint tag on every master push run that completes
+  # (even when individual build jobs failed).  The tag carries a JSON state record
+  # of which containers failed so the next run can retry them while other containers
+  # follow the normal diff path.
   #
   # The tag `auto-build-coverage-master` is the ONLY safe baseline for cumulative
   # container detection (fix for #595 / supersede-stranding).  Invariants:
   #   - Only this job writes the tag, so tag-exists ↔ valid-coverage-checkpoint.
   #   - Targeted workflow_dispatch, workflow_call (upstream-monitor), and PR runs
   #     NEVER write it, so they can never poison the baseline.
-  #   - A failed/cancelled run (any build job failed) never advances the tag, so the
-  #     next run re-diffs from the old baseline and rebuilds the stranded containers.
+  #   - A cancelled run or a failed detect-containers job blocks advancement
+  #     (we have no reliable baseline to diff from or no container list to record).
   #   - A "nothing to build" docs-only push still advances the tag (no containers were
   #     newly changed, so the prior checkpoint remains valid coverage for them).
+  #   - Failed build jobs are recorded in the tag's JSON state and retried on the
+  #     next run via the carry-forward logic in detect-containers.
   publish-coverage-checkpoint:
     name: Publish coverage checkpoint tag
     needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest]
-    # Only on push to master; only when no monitored build job failed or was cancelled.
-    # !failure() && !cancelled() catches all terminal states: success and skipped both pass.
-    # The individual result checks below are belt-and-suspenders for the core jobs.
+    # Advance on every completed master push, even when build jobs failed.
+    # A cancelled run or a failed detect-containers job blocks advancement.
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
-      !failure() &&
       !cancelled() &&
-      needs.detect-containers.result != 'failure' &&
-      needs.detect-containers.result != 'cancelled' &&
-      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped') &&
-      (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
-      (needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped') &&
-      (needs.create-manifest.result == 'success' || needs.create-manifest.result == 'skipped')
+      needs.detect-containers.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: write  # Required to push the coverage checkpoint tag
+      actions: read    # Required to read job conclusions via gh run view
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
-      - name: Force-update coverage checkpoint tag
+      - name: Compute and publish coverage checkpoint tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Containers output is a JSON array — pass via env to avoid inline injection.
+          MATRIX_CONTAINERS: ${{ needs.detect-containers.outputs.containers }}
+          # github.repository is owner/repo format (trusted context, no user content).
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          git tag -f auto-build-coverage-master "$GITHUB_SHA"
-          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}" \
-            "refs/tags/auto-build-coverage-master"
-          echo "::notice::Coverage checkpoint advanced to $GITHUB_SHA"
+          # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
+          source "${GITHUB_WORKSPACE}/helpers/coverage-checkpoint-utils.sh"
+
+          # Step 1: Fetch this run's job conclusions. On gh failure we cannot determine
+          # per-container outcomes, so we fail closed (force unmapped) rather than
+          # advancing the baseline while silently dropping this run's real failures.
+          set +e
+          jobs_json=$(gh run view "$GITHUB_RUN_ID" --json jobs 2>/dev/null)
+          gh_rc=$?
+          set -e
+          gh_failed=false
+          if [[ $gh_rc -ne 0 || -z "$jobs_json" ]]; then
+            echo "::warning::gh run view failed (rc=$gh_rc) — failing closed: carrying forward all attempted containers"
+            jobs_json='{"jobs":[]}'
+            gh_failed=true
+          fi
+
+          # Step 2: Resolve the matrix of containers that were attempted this run.
+          if [[ -z "$MATRIX_CONTAINERS" || "$MATRIX_CONTAINERS" == "null" ]]; then
+            matrix_json="[]"
+          else
+            matrix_json="$MATRIX_CONTAINERS"
+          fi
+
+          # Step 3: Classify jobs against the matrix.
+          er=$(extract_failed_recovered "$jobs_json" "$matrix_json")
+          ftr=$(echo "$er" | jq -c '.failed_this_run')
+          rec=$(echo "$er" | jq -c '.recovered_candidates')
+          unmapped=$(echo "$er" | jq -r '.unmapped_failure')
+          # Fail closed if job outcomes were unreadable.
+          if [[ "$gh_failed" == "true" ]]; then
+            unmapped=true
+          fi
+
+          # Finding B fix: configure bot identity required for annotated tags.
+          # GitHub-hosted runners have no committer identity by default; without this
+          # `git tag -a` fails with "Committer identity unknown".
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Finding C fix: compare-and-swap the checkpoint tag.
+          # master push runs are NOT cancelled by concurrency (cancel-in-progress:false),
+          # so two runs can reach here simultaneously.  A naive force-push lets the slower
+          # OLDER run overwrite a newer run's state and move the baseline backward.
+          # The loop re-reads the remote prior on each attempt (fresh merge), uses
+          # --force-with-lease for atomic compare-and-swap, and skips when the remote has
+          # already advanced beyond this run (forward-only guard).
+          TAG="auto-build-coverage-master"
+          pushed=false
+          for attempt in 1 2 3 4 5; do
+            # Re-fetch the current remote tag (force, so our local ref tracks remote exactly).
+            git fetch --force --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
+            remote_oid=$(git rev-parse --verify -q "refs/tags/${TAG}" 2>/dev/null || true)   # tag OBJECT id (empty if absent)
+            remote_sha=$(git rev-list -n1 "${TAG}" 2>/dev/null || true)                       # peeled commit
+
+            # Forward-only guard: if the remote tag points to a commit that is NOT an ancestor
+            # of our HEAD, a newer run already owns the baseline — do not move it backward.
+            if [[ -n "$remote_sha" ]] && ! git merge-base --is-ancestor "$remote_sha" "$GITHUB_SHA" 2>/dev/null; then
+              echo "::notice::Coverage checkpoint already advanced beyond this run (remote=$remote_sha) — skipping; a newer run owns the baseline"
+              pushed=true   # treat as success: a newer run's state supersedes ours
+              break
+            fi
+
+            # Re-read the latest remote failed set and re-merge with THIS run's results.
+            # This ensures concurrent runs always merge their data rather than clobbering.
+            remote_msg=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" 2>/dev/null || true)
+            prior_failed=$(checkpoint_failed_containers "$remote_msg")
+            new_failed=$(merge_failed_set "$prior_failed" "$ftr" "$rec" "$matrix_json" "$unmapped")
+            state=$(jq -cn --arg sha "$GITHUB_SHA" --arg run "$GITHUB_RUN_ID" --argjson failed "$new_failed" \
+              '{sha:$sha, run_id:$run, failed_containers:$failed}')
+
+            # Create the annotated tag locally (overwrites our local ref).
+            git tag -f -a "${TAG}" -m "$state" "$GITHUB_SHA"
+
+            # Push with compare-and-swap against the remote oid we just observed.
+            if [[ -n "$remote_oid" ]]; then
+              lease="--force-with-lease=refs/tags/${TAG}:${remote_oid}"
+            else
+              # Tag absent remotely (bootstrap): require it to still be absent.
+              lease="--force-with-lease=refs/tags/${TAG}:"
+            fi
+            if git push "$lease" \
+                 "https://x-access-token:${GITHUB_TOKEN}@github.com/${GH_REPOSITORY}" \
+                 "refs/tags/${TAG}" 2>/dev/null; then
+              echo "::notice::Coverage checkpoint advanced to $GITHUB_SHA — failed_containers=${new_failed} (attempt $attempt)"
+              pushed=true
+              break
+            fi
+            echo "::warning::Coverage checkpoint CAS lost (attempt $attempt) — a concurrent run updated the tag; retrying"
+          done
+          if [[ "$pushed" != "true" ]]; then
+            echo "::warning::Coverage checkpoint not advanced after retries (heavy concurrency) — next run will re-diff from the existing baseline"
+          fi
 
   summary:
     needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries]

--- a/helpers/coverage-checkpoint-utils.sh
+++ b/helpers/coverage-checkpoint-utils.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Coverage checkpoint utilities for docker-containers CI
+#
+# Provides state management for the annotated coverage-checkpoint tag
+# (auto-build-coverage-master).  The tag carries a JSON record of which
+# containers failed in the last master push so the next run can retry them
+# even when other containers did not change.
+#
+# Requires: jq
+#
+# Functions (all pure — read args/stdin, write stdout only):
+#   checkpoint_failed_containers  <state_str>
+#   extract_failed_recovered      <jobs_json> <matrix_json>
+#   merge_failed_set              <prior_json> <failed_this_json> <recovered_cand_json> <matrix_json> <unmapped_failure>
+#   compute_carry_forward         <queued_json> <baseline_failed_json> <valid_json>
+
+# checkpoint_failed_containers <state_str>
+#
+# Parse the annotated tag message (which is a JSON state record) and return
+# the .failed_containers array.  Returns [] on any parse/validation failure
+# so the caller can always treat the result as a JSON array of strings.
+#
+# Output: compact JSON array of container names (may be empty: [])
+checkpoint_failed_containers() {
+    local state_str="${1:-}"
+
+    # Use fromjson? so non-JSON input silently becomes null → falls to [].
+    # The // null guard converts empty-stream (parse failure) to null before
+    # the as-binding, ensuring the if-else always has a value to test.
+    # Validate: must be an object whose .failed_containers is an array of strings.
+    jq -cn --arg s "$state_str" \
+        '(($s | fromjson?) // null) as $o |
+         if ($o | type) == "object"
+            and ($o.failed_containers | type) == "array"
+            and ([$o.failed_containers[] | type] | all(. == "string"))
+         then $o.failed_containers
+         else []
+         end'
+}
+
+# extract_failed_recovered <jobs_json> <matrix_json>
+#
+# Given the JSON from `gh run view --json jobs` and the JSON array of container
+# names attempted this run, classify each matrix container as failed, recovered,
+# or neither (never attempted).
+#
+# Job-to-container matching: job name contains container name as a full token
+# bounded by non-identifier characters so that "web-shell" does NOT match
+# "web-shell-debian", and "github-runner" does NOT match "github-runner-debian-trixie".
+# Token boundary regex: (^|[^A-Za-z0-9_-]) + name + ([^A-Za-z0-9_-]|$)
+#
+# A job is "bad" iff it has a TERMINAL non-success conclusion.
+# In-progress jobs (conclusion null or "") are ignored — at checkpoint runtime
+# the checkpoint job itself and the summary job are still running, so their
+# null conclusion must not trigger unmapped_failure and poison every run.
+# Container build jobs are all terminal by the time the checkpoint job runs
+# (they are declared as `needs`), so null-exclusion never hides a real failure.
+# Terminal non-success set: failure, cancelled, timed_out, neutral, action_required, stale.
+#
+# Output compact JSON:
+#   { "failed_this_run": [...], "recovered_candidates": [...], "unmapped_failure": bool }
+extract_failed_recovered() {
+    # Avoid ${var:-{...}} default syntax: bash appends a spurious } to non-empty
+    # args that contain } themselves (brace-expansion edge case in param expansion).
+    local jobs_json="${1}"
+    local matrix_json="${2}"
+    [[ -z "$jobs_json" ]] && jobs_json='{"jobs":[]}'
+    [[ -z "$matrix_json" ]] && matrix_json='[]'
+
+    jq -cn \
+        --argjson jobs "$jobs_json" \
+        --argjson matrix "$matrix_json" \
+        '
+        # Normalise: accept both {"jobs":[...]} and a bare array.
+        ($jobs | if type == "object" then .jobs // [] else . end) as $job_list |
+
+        # Identify bad jobs: terminal conclusion that is not success or skipped.
+        # null/"" conclusions mean in-progress — excluded so meta-jobs running
+        # alongside the checkpoint (e.g. summary) never trigger unmapped_failure.
+        ($job_list | map(select(
+            .conclusion != null and .conclusion != "" and
+            .conclusion != "success" and .conclusion != "skipped"
+        ))) as $bad_jobs |
+
+        # Build token-boundary regex for a container name.
+        # Container names are [a-z0-9-]+ so safe to interpolate directly.
+        def token_re(name):
+            "(^|[^A-Za-z0-9_-])" + name + "([^A-Za-z0-9_-]|$)";
+
+        # For each matrix container, collect matching jobs from the full list.
+        def matching_jobs(c):
+            $job_list | map(select(.name | test(token_re(c))));
+
+        # For each matrix container, collect bad matching jobs.
+        def bad_matching_jobs(c):
+            $bad_jobs | map(select(.name | test(token_re(c))));
+
+        # failed_this_run: matrix containers with >=1 bad matching job.
+        [ $matrix[] | . as $c |
+          if (bad_matching_jobs($c) | length) > 0 then $c else empty end
+        ] | sort | unique as $failed |
+
+        # recovered_candidates: matrix containers with >=1 matching job AND 0 bad.
+        [ $matrix[] | . as $c |
+          if (matching_jobs($c) | length) > 0
+             and (bad_matching_jobs($c) | length) == 0
+          then $c else empty end
+        ] | sort | unique as $recovered |
+
+        # unmapped_failure: any bad job that matches no matrix container.
+        ($bad_jobs | map(.name) | map(. as $jname |
+            if ($matrix | map(. as $c | $jname | test(token_re($c))) | any) | not
+            then true else false end
+        ) | any) as $unmapped |
+
+        {
+            failed_this_run: $failed,
+            recovered_candidates: $recovered,
+            unmapped_failure: $unmapped
+        }
+        '
+}
+
+# compute_carry_forward <queued_json> <baseline_failed_json> <valid_json>
+#
+# Merge prior-failed containers into the build queue AND compute the carried-forward
+# set that must force retained-version expansion. A prior-failed container must be
+# carried (expand=true) even if it was already queued by another path (diff, or the
+# shared-infra canary), otherwise a latest-only retry can falsely "recover" a failed
+# retained version.
+#
+#   carried = baseline_failed ∩ valid          (every valid prior-failed container)
+#   queued' = queued ∪ carried                 (full build list, deduped)
+#
+# All inputs/outputs are JSON arrays of strings; output is compact JSON:
+#   {"queued":[...sorted unique...], "carried":[...sorted unique...]}
+#
+# Invalid (non-array) inputs are silently treated as [] so the caller never
+# needs to guard against parse errors.
+compute_carry_forward() {
+    local queued_json="${1:-[]}"
+    local baseline_failed_json="${2:-[]}"
+    local valid_json="${3:-[]}"
+
+    jq -cn \
+        --argjson queued "$queued_json" \
+        --argjson baseline_failed "$baseline_failed_json" \
+        --argjson valid "$valid_json" \
+        '
+        # Treat any non-array input as [] so the function never hard-fails on
+        # malformed data — mirrors the fail-safe style of the other helpers.
+        (if ($queued | type) == "array" then $queued else [] end) as $q |
+        (if ($baseline_failed | type) == "array" then $baseline_failed else [] end) as $bf |
+        (if ($valid | type) == "array" then $valid else [] end) as $v |
+
+        # carried = baseline_failed ∩ valid (all valid prior-failed containers,
+        # regardless of whether they are already in the queued list).
+        [ $bf[] | . as $x | if ($v | index($x)) != null then $x else empty end ]
+        | sort | unique as $carried |
+
+        # queued_out = queued ∪ carried (deduped, sorted)
+        (($q + $carried) | sort | unique) as $queued_out |
+
+        { queued: $queued_out, carried: $carried }
+        '
+}
+
+# merge_failed_set <prior_json> <failed_this_json> <recovered_cand_json> <matrix_json> <unmapped_failure>
+#
+# Compute the new failed-container set to store in the next checkpoint tag.
+#
+# Semantics:
+#   - If unmapped_failure == "true": output sorted-unique (matrix ∪ prior).
+#     Rationale: an unattributed failure means we can't safely say anything
+#     was fully covered; expand the retry set conservatively.
+#   - Otherwise:
+#       recovered  = recovered_candidates ∩ prior   (was failing, now explicitly green)
+#       new_failed = (prior ∪ failed_this_run) − recovered
+#
+# A container in prior that was NOT in this run's matrix is NOT recovered
+# (it was never attempted), so it stays in the set.
+#
+# Output: compact JSON array, sorted and unique.
+merge_failed_set() {
+    local prior_json="${1:-[]}"
+    local failed_this_json="${2:-[]}"
+    local recovered_cand_json="${3:-[]}"
+    local matrix_json="${4:-[]}"
+    local unmapped_failure="${5:-false}"
+
+    jq -cn \
+        --argjson prior "$prior_json" \
+        --argjson failed "$failed_this_json" \
+        --argjson recovered_cand "$recovered_cand_json" \
+        --argjson matrix "$matrix_json" \
+        --arg unmapped "$unmapped_failure" \
+        '
+        if $unmapped == "true" then
+            # Fail-closed: carry everything — prior + matrix (any unattributed failure
+            # means we cannot confirm any subset was safely covered).
+            ($prior + $matrix | unique | sort)
+        else
+            # recovered = recovered_candidates ∩ prior
+            # (only drop a container from the failed set if it was previously
+            #  failing AND this run completed it successfully)
+            [ $recovered_cand[] | . as $x |
+              if ($prior | index($x)) != null then $x else empty end
+            ] as $recovered |
+
+            # new_failed = (prior ∪ failed_this_run) − recovered
+            (($prior + $failed | unique) |
+             map(. as $x |
+               if ($recovered | index($x)) != null then empty else . end
+             ) | sort | unique)
+        end
+        '
+}

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -537,29 +537,36 @@ list_variant_tags() {
 # Compute per-container expand-retained signals from a git-diff-derived changed-files list.
 # This is the signal-computation layer for "matrix default to latest-only, expand on dep change".
 #
-# Usage: compute_expand_retained_map <event_name> <build_all_retained> <changed_files_file> <containers_json> [fallback_all]
+# Usage: compute_expand_retained_map <event_name> <build_all_retained> <changed_files_file> <containers_json> [fallback_all] [carried_forward_json]
 #
 # Args:
-#   event_name           - GitHub event name (e.g. "push", "pull_request", "workflow_dispatch"). May be empty.
-#   build_all_retained   - String "true" or "false" (workflow input). MUST be compared as string, not bool.
-#   changed_files_file   - Path to a file with one changed path per line (output of `git diff --name-only`).
-#                          If file <changed_files_file>.diff_failed exists alongside, treat as diff failure.
-#   containers_json      - JSON array of detected container names, e.g. ["openresty","postgres"].
-#   fallback_all         - Optional. String "true" forces all containers to true regardless of other signals.
-#                          Used by the detect-containers fail-safe path (coverage checkpoint missing/invalid).
+#   event_name            - GitHub event name (e.g. "push", "pull_request", "workflow_dispatch"). May be empty.
+#   build_all_retained    - String "true" or "false" (workflow input). MUST be compared as string, not bool.
+#   changed_files_file    - Path to a file with one changed path per line (output of `git diff --name-only`).
+#                           If file <changed_files_file>.diff_failed exists alongside, treat as diff failure.
+#   containers_json       - JSON array of detected container names, e.g. ["openresty","postgres"].
+#   fallback_all          - Optional. String "true" forces all containers to true regardless of other signals.
+#                           Used by the detect-containers fail-safe path (coverage checkpoint missing/invalid).
+#   carried_forward_json  - Optional. JSON array of container names carried forward from a prior failed run.
+#                           Defaults to []. Invalid JSON is treated as [] (no hard-fail).
+#                           A carried-forward container must rebuild ALL retained versions because we do not
+#                           know which retained version originally failed — a latest-only retry would green
+#                           the latest build and cause extract_failed_recovered to mark it "recovered",
+#                           silently dropping the failed retained version from the carry-forward set.
 #
 # Output (stdout):
 #   JSON object mapping container name -> boolean. true = expand retained versions, false = latest only.
 #   Priority chain (first match wins) for each container c:
-#     0. fallback_all == "true"                                 → c: true  (coverage-checkpoint fail-safe)
-#     1. <changed_files_file>.diff_failed sentinel exists       → c: true  (ERR-01a defensive expand)
-#     2. event_name empty or unrecognized                       → c: true  (ERR-06 backward-compat)
-#     3. event_name == "pull_request"                           → c: true  (PR smoke matrix)
-#     4. build_all_retained == "true" (explicit string compare) → c: true  (operator override)
-#     5. changed_files contains any path with prefix "$c/"
+#     0. fallback_all == "true"                                   → c: true  (coverage-checkpoint fail-safe)
+#     1. <changed_files_file>.diff_failed sentinel exists         → c: true  (ERR-01a defensive expand)
+#     2. event_name empty or unrecognized                         → c: true  (ERR-06 backward-compat)
+#     3. event_name == "pull_request"                             → c: true  (PR smoke matrix)
+#     4. build_all_retained == "true" (explicit string compare)   → c: true  (operator override)
+#     5. c is a member of carried_forward_json                    → c: true  (carry-forward retained expand)
+#     6. changed_files contains any path with prefix "$c/"
 #        (case-glob anchored prefix match, sibling-collision safe:
-#         "php-fpm/foo" does NOT match prefix "php/")            → c: true  (dep-driven trigger)
-#     6. otherwise                                              → c: false (default: latest only)
+#         "php-fpm/foo" does NOT match prefix "php/")             → c: true  (dep-driven trigger)
+#     7. otherwise                                                → c: false (default: latest only)
 #
 # Exit code: 0 on success, 1 on malformed containers_json.
 compute_expand_retained_map() {
@@ -568,6 +575,21 @@ compute_expand_retained_map() {
     local changed_files_file="$3"
     local containers_json="$4"
     local fallback_all="${5:-false}"
+    local carried_forward_json="${6:-[]}"
+
+    # Validate carried_forward_json: must be a JSON array; treat invalid as [] (no hard-fail).
+    if ! echo "$carried_forward_json" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
+        echo "compute_expand_retained_map: carried_forward_json is not a valid JSON array — treating as []" >&2
+        carried_forward_json="[]"
+    fi
+
+    # Build a bash set from the carried-forward list for O(1) membership checks.
+    declare -A _carried_set
+    local _cf_container
+    while IFS= read -r _cf_container; do
+        [[ -z "$_cf_container" ]] && continue
+        _carried_set["$_cf_container"]=1
+    done < <(echo "$carried_forward_json" | jq -r '.[]')
 
     # Validate containers_json is a valid JSON array
     if ! echo "$containers_json" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
@@ -626,7 +648,18 @@ compute_expand_retained_map() {
             continue
         fi
 
-        # Rule 5: dep-driven trigger — any file inside the container directory.
+        # Priority 5: carry-forward retained expand — the container was carried forward
+        # from a prior failed run.  We do NOT know which retained version failed, so a
+        # latest-only retry would rebuild only the latest, mark it green, and cause
+        # extract_failed_recovered to drop the container from failed_containers even
+        # though the failing retained version was never rebuilt.  Force all retained
+        # versions so the retry is comprehensive and the recovery signal is accurate.
+        if [[ -n "${_carried_set[$container]+_}" ]]; then
+            expand_map["$container"]="true"
+            continue
+        fi
+
+        # Rule 6: dep-driven trigger — any file inside the container directory.
         # A file `<c>/anything` (Dockerfile, build, variants.yaml, version.sh,
         # config.yaml, LAST_REBUILD.md, custom helper, generated assets, etc.)
         # implies the container's build inputs changed and ALL retained versions
@@ -650,7 +683,7 @@ compute_expand_retained_map() {
             continue
         fi
 
-        # Priority 6: default — latest only
+        # Priority 7: default — latest only
         expand_map["$container"]="false"
 
     done < <(echo "$containers_json" | jq -r '.[]')

--- a/tests/unit/coverage-checkpoint-utils.bats
+++ b/tests/unit/coverage-checkpoint-utils.bats
@@ -1,0 +1,344 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/coverage-checkpoint-utils.sh
+# Tests the state-machine functions used by the publish-coverage-checkpoint job
+# and the detect-containers action.
+
+setup() {
+    ORIG_DIR="$PWD"
+    source "$ORIG_DIR/helpers/coverage-checkpoint-utils.sh"
+}
+
+teardown() {
+    :
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Compare two compact JSON arrays for equality (whitespace/order-insensitive)
+json_eq() {
+    local a="$1" b="$2"
+    [[ "$(echo "$a" | jq -c 'sort')" == "$(echo "$b" | jq -c 'sort')" ]]
+}
+
+# ---------------------------------------------------------------------------
+# checkpoint_failed_containers — parse annotated tag message
+# ---------------------------------------------------------------------------
+
+@test "checkpoint_failed_containers: valid state JSON returns failed_containers array" {
+    state='{"sha":"abc","run_id":"1","failed_containers":["github-runner","web-shell"]}'
+    run checkpoint_failed_containers "$state"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["github-runner","web-shell"]'
+}
+
+@test "checkpoint_failed_containers: empty failed_containers array returns []" {
+    state='{"sha":"abc","run_id":"2","failed_containers":[]}'
+    run checkpoint_failed_containers "$state"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "checkpoint_failed_containers: arbitrary commit message (non-JSON) returns []" {
+    # A lightweight tag stores a bare commit message, not our JSON.
+    run checkpoint_failed_containers "chore: bump versions"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "checkpoint_failed_containers: JSON object without failed_containers returns []" {
+    run checkpoint_failed_containers '{"sha":"abc","run_id":"3"}'
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "checkpoint_failed_containers: failed_containers not an array returns []" {
+    run checkpoint_failed_containers '{"sha":"abc","failed_containers":"github-runner"}'
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "checkpoint_failed_containers: empty string returns []" {
+    run checkpoint_failed_containers ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "checkpoint_failed_containers: failed_containers with non-string elements returns []" {
+    run checkpoint_failed_containers '{"sha":"abc","failed_containers":[1,2]}'
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# extract_failed_recovered — classify jobs against matrix
+# ---------------------------------------------------------------------------
+
+# Build a minimal jobs JSON as the gh run view --json jobs output would look.
+# Args: pairs of "name:conclusion" where conclusion may be a string value or the
+# special token "null" (emitted as JSON null, matching the real GH API for in-progress jobs).
+make_jobs_json() {
+    local pairs=("$@")
+    local jobs_arr="["
+    local first=1
+    for pair in "${pairs[@]}"; do
+        local name="${pair%%:*}"
+        local concl="${pair##*:}"
+        [[ "$first" -eq 0 ]] && jobs_arr+=","
+        # Emit real JSON null for in-progress jobs — the GH API sends null, not the string "null".
+        if [[ "$concl" == "null" ]]; then
+            jobs_arr+="{\"name\":$(echo -n "$name" | jq -Rs .),\"conclusion\":null}"
+        else
+            jobs_arr+="{\"name\":$(echo -n "$name" | jq -Rs .),\"conclusion\":\"$concl\"}"
+        fi
+        first=0
+    done
+    jobs_arr+="]"
+    echo "{\"jobs\":${jobs_arr}}"
+}
+
+@test "extract_failed_recovered: failed job lands in failed_this_run" {
+    jobs=$(make_jobs_json \
+        "Build and push github-runner (ubuntu-2404):failure" \
+        "Build and push postgres (alpine):success")
+    run extract_failed_recovered "$jobs" '["github-runner","postgres"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    json_eq "$failed" '["github-runner"]'
+    json_eq "$recovered" '["postgres"]'
+}
+
+@test "extract_failed_recovered: all green gives empty failed_this_run and all in recovered" {
+    jobs=$(make_jobs_json \
+        "Build and push github-runner (ubuntu-2404):success" \
+        "Build and push postgres (alpine):success")
+    run extract_failed_recovered "$jobs" '["github-runner","postgres"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    [ "$failed" = "[]" ]
+    json_eq "$recovered" '["github-runner","postgres"]'
+}
+
+@test "extract_failed_recovered: cancelled counts as failure (fail-closed)" {
+    jobs=$(make_jobs_json \
+        "Build and push postgres (alpine):cancelled")
+    run extract_failed_recovered "$jobs" '["postgres"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    json_eq "$failed" '["postgres"]'
+}
+
+@test "extract_failed_recovered: timed_out counts as failure (fail-closed)" {
+    jobs=$(make_jobs_json \
+        "Build and push postgres (alpine):timed_out")
+    run extract_failed_recovered "$jobs" '["postgres"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    json_eq "$failed" '["postgres"]'
+}
+
+@test "extract_failed_recovered: token-boundary web-shell does NOT match web-shell-debian" {
+    # The key correctness property: web-shell-debian job must NOT attribute to web-shell.
+    jobs=$(make_jobs_json \
+        "Build and push web-shell-debian (alpine):failure" \
+        "Build and push web-shell (alpine):success")
+    run extract_failed_recovered "$jobs" '["web-shell","web-shell-debian"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # web-shell should be recovered (its own job succeeded), not failed
+    json_eq "$failed" '["web-shell-debian"]'
+    json_eq "$recovered" '["web-shell"]'
+}
+
+@test "extract_failed_recovered: token-boundary github-runner does NOT match github-runner-debian-trixie" {
+    jobs=$(make_jobs_json \
+        "Build and push github-runner-debian-trixie (amd64):failure" \
+        "Build and push github-runner (ubuntu-2404):success")
+    run extract_failed_recovered "$jobs" '["github-runner","github-runner-debian-trixie"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    json_eq "$failed" '["github-runner-debian-trixie"]'
+    json_eq "$recovered" '["github-runner"]'
+}
+
+@test "extract_failed_recovered: unmapped_failure true when bad job matches no matrix container" {
+    # A failed job whose container is not in the matrix
+    jobs=$(make_jobs_json \
+        "Build extension timescaledb (pg17):failure")
+    run extract_failed_recovered "$jobs" '["postgres","web-shell"]'
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$unmapped" = "true" ]
+}
+
+@test "extract_failed_recovered: unmapped_failure false when all bad jobs map to matrix" {
+    jobs=$(make_jobs_json \
+        "Build and push postgres (alpine):failure")
+    run extract_failed_recovered "$jobs" '["postgres"]'
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$unmapped" = "false" ]
+}
+
+@test "extract_failed_recovered: null-conclusion meta jobs are ignored — no unmapped_failure" {
+    # The checkpoint job and summary job are still running (conclusion null) when
+    # gh run view is called from inside the checkpoint step.  They must not count
+    # as bad jobs; unmapped_failure must remain false even though they match no
+    # container token.
+    # Mutation locked: before the fix (.conclusion != "success" and != "skipped"
+    # treated null as bad), this test returns unmapped_failure=true.
+    jobs=$(make_jobs_json \
+        "Build and push github-runner (ubuntu-2404):success" \
+        "Publish coverage checkpoint tag:null" \
+        "Summary:null")
+    run extract_failed_recovered "$jobs" '["github-runner"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$failed" = "[]" ]
+    json_eq "$recovered" '["github-runner"]'
+    [ "$unmapped" = "false" ]
+}
+
+@test "extract_failed_recovered: terminal failure detected alongside null-conclusion meta job" {
+    # A real container failure must still be captured even when the jobs list
+    # also contains in-progress meta jobs with null conclusion.
+    # Mutation locked: if null exclusion accidentally excluded ALL non-success jobs
+    # (including real failures), failed_this_run would be empty — test goes RED.
+    jobs=$(make_jobs_json \
+        "Build and push github-runner (ubuntu-2404):failure" \
+        "Publish coverage checkpoint tag:null")
+    run extract_failed_recovered "$jobs" '["github-runner"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    json_eq "$failed" '["github-runner"]'
+    # The only bad job (github-runner failure) maps to a container — no unmapped.
+    [ "$unmapped" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# merge_failed_set — carry-forward state machine
+# ---------------------------------------------------------------------------
+
+@test "merge_failed_set: accumulate never drop — prior a carried when not in matrix" {
+    # a NOT in matrix (never attempted), b newly failed, c recovered
+    # Result must contain BOTH a (carried) AND b (newly failed)
+    run merge_failed_set '["a"]' '["b"]' '["c"]' '["b","c"]' "false"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["a","b"]'
+    # Mutation guard: if difference used recovered_candidates directly (not intersected
+    # with prior), "a" would be dropped because c∈recovered_cand but a∉prior is fine —
+    # what matters is: if we forgot the ∩ prior step, "a" would still survive (a∉recovered_cand).
+    # The real regression this catches: if we did (prior ∪ failed) − recovered_cand instead
+    # of − (recovered_cand ∩ prior), then when a=prior-only container, it would be
+    # dropped if a ever appeared in recovered_cand by coincidence. Anchored by this test.
+}
+
+@test "merge_failed_set: recover on real success — attempted and green clears the set" {
+    run merge_failed_set '["github-runner"]' '[]' '["github-runner"]' '["github-runner"]' "false"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+    # Mutation guard: if recovered = recovered_candidates (no ∩ prior), containers
+    # that appear in recovered_cand but are NOT in prior would also be "recovered",
+    # meaning they'd be removed from the output even if they were never failing.
+    # This test passes in both correct and wrong implementations, but the partner
+    # test "accumulate never drop" catches the wrong case.
+}
+
+@test "merge_failed_set: partial success does NOT recover — stays in failed set" {
+    run merge_failed_set '["github-runner"]' '["github-runner"]' '[]' '["github-runner"]' "false"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["github-runner"]'
+}
+
+@test "merge_failed_set: fail-closed on unmapped failure — matrix union prior" {
+    # unmapped_failure=true: we don't know what failed, so carry all.
+    run merge_failed_set '["a"]' '[]' '[]' '["b","c"]' "true"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["a","b","c"]'
+    # Mutation guard: if unmapped_failure check was skipped (treated as false),
+    # result would be ["a"] (only prior). This test goes RED in that case.
+}
+
+@test "merge_failed_set: stable when no containers failed or in prior" {
+    run merge_failed_set '[]' '[]' '["postgres"]' '["postgres"]' "false"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "merge_failed_set: multiple containers, some recovered some not" {
+    # prior: a, b, c. This run: a failed, b recovered, c not in matrix (not attempted).
+    run merge_failed_set '["a","b","c"]' '["a"]' '["b"]' '["a","b"]' "false"
+    [ "$status" -eq 0 ]
+    # recovered = ["b"] ∩ ["a","b","c"] = ["b"]
+    # new_failed = (["a","b","c"] ∪ ["a"]) − ["b"] = ["a","c"]
+    json_eq "$output" '["a","c"]'
+}
+
+# ---------------------------------------------------------------------------
+# compute_carry_forward — union logic for carry-forward queue + carried set
+# ---------------------------------------------------------------------------
+
+@test "compute_carry_forward: codex-bug-lock — already-queued container still lands in carried" {
+    # Locks the mutation: old inline loop skipped 'continue' branch recording,
+    # so postgres (already queued by the shared-infra canary) was NEVER added to
+    # carried_forward → compute_expand_retained_map returned postgres:false →
+    # latest-only retry → failed retained version falsely marked recovered.
+    run compute_carry_forward '["postgres"]' '["postgres"]' '["postgres","jekyll"]'
+    [ "$status" -eq 0 ]
+    carried=$(echo "$output" | jq -c '.carried')
+    queued=$(echo "$output" | jq -c '.queued')
+    # carried must include postgres even though it was already in the queue
+    [ "$(echo "$carried" | jq -c 'sort')" = '["postgres"]' ]
+    # queued must contain postgres exactly once (no dup)
+    [ "$(echo "$queued" | jq -c 'sort')" = '["postgres"]' ]
+}
+
+@test "compute_carry_forward: not-yet-queued container is added to both queued and carried" {
+    # github-runner was not queued by diff; it was in baseline_failed and is valid.
+    run compute_carry_forward '["jekyll"]' '["github-runner"]' '["github-runner","jekyll"]'
+    [ "$status" -eq 0 ]
+    carried=$(echo "$output" | jq -c '.carried')
+    queued=$(echo "$output" | jq -c '.queued | sort')
+    [ "$(echo "$carried" | jq -c 'sort')" = '["github-runner"]' ]
+    [ "$queued" = '["github-runner","jekyll"]' ]
+}
+
+@test "compute_carry_forward: invalid container filtered out (not in valid list)" {
+    # 'ghost' is in baseline_failed but not in valid → must NOT appear in carried or queued.
+    run compute_carry_forward '["jekyll"]' '["ghost"]' '["jekyll","postgres"]'
+    [ "$status" -eq 0 ]
+    carried=$(echo "$output" | jq -c '.carried')
+    queued=$(echo "$output" | jq -c '.queued | sort')
+    [ "$carried" = '[]' ]
+    [ "$queued" = '["jekyll"]' ]
+}
+
+@test "compute_carry_forward: empty baseline_failed produces empty carried, queued unchanged" {
+    run compute_carry_forward '["ansible","jekyll"]' '[]' '["ansible","jekyll","postgres"]'
+    [ "$status" -eq 0 ]
+    carried=$(echo "$output" | jq -c '.carried')
+    queued=$(echo "$output" | jq -c '.queued | sort')
+    [ "$carried" = '[]' ]
+    [ "$queued" = '["ansible","jekyll"]' ]
+}
+
+@test "compute_carry_forward: dedup and sort — queued and baseline_failed overlap multiple containers" {
+    # queued=["b","a"], baseline_failed=["a","c"], valid=["a","b","c"]
+    # carried = ["a","c"]  (both valid prior-failed)
+    # queued_out = ["a","b"] ∪ ["a","c"] = ["a","b","c"]
+    run compute_carry_forward '["b","a"]' '["a","c"]' '["a","b","c"]'
+    [ "$status" -eq 0 ]
+    queued=$(echo "$output" | jq -c '.queued')
+    carried=$(echo "$output" | jq -c '.carried')
+    [ "$queued" = '["a","b","c"]' ]
+    [ "$carried" = '["a","c"]' ]
+}

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -1050,3 +1050,78 @@ setup_fallback_test() {
     [ "$(echo "$output" | jq -r '.ansible')" = "true" ]
     [ "$(echo "$output" | jq -r '.terraform')" = "true" ]
 }
+
+# --- Finding A: carried-forward containers must force retained-version expansion ---
+# Mutation locked: if the new Rule 5 (carried-forward check) is removed, the first
+# test goes RED — a carried-forward container with no changed-file entry would fall
+# through to Priority 7 (default: false), rebuilding latest-only and producing a
+# false recovery signal.
+
+@test "compute_expand_retained_map: carried-forward container with NO changed-file prefix expands to true" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # No files changed for github-runner — it has no entry in changed_files.
+    # It is carried forward from a prior failed run.
+    # Without Rule 5, it would fall through to default=false → latest-only →
+    # extract_failed_recovered would see latest green → false recovery.
+    printf 'postgres/variants.yaml\n' > "${TEST_DIR}/changed.txt"
+    containers='["github-runner","postgres"]'
+    carried='["github-runner"]'
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false" "$carried"
+    [ "$status" -eq 0 ]
+    # Carried-forward container must expand all retained versions.
+    [ "$(echo "$output" | jq -r '."github-runner"')" = "true" ]
+    # postgres changed via diff — also true (unrelated to carry-forward).
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+}
+
+@test "compute_expand_retained_map: container NOT carried and NOT changed stays false (6-arg call)" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # ansible is neither in carried_forward nor in changed_files.
+    # Behavior must match the pre-Finding-A default (false).
+    printf 'postgres/variants.yaml\n' > "${TEST_DIR}/changed.txt"
+    containers='["ansible","postgres"]'
+    carried='["github-runner"]'   # github-runner not in containers — irrelevant
+
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false" "$carried"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.ansible')" = "false" ]
+    [ "$(echo "$output" | jq -r '.postgres')" = "true" ]
+}
+
+@test "compute_expand_retained_map: 5-arg call (no carried_forward) behaves as carried=[] — backward compat" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    # Three existing callers (make:524, recreate-manifests.yaml, validate-version-scripts.yaml)
+    # pass only 5 args.  This call must produce identical results to passing carried_forward=[].
+    printf 'openresty/Dockerfile\n' > "${TEST_DIR}/changed.txt"
+    containers='["openresty","terraform"]'
+
+    # 5-arg call — carried_forward defaults to []
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false"
+    [ "$status" -eq 0 ]
+    local result_5arg
+    result_5arg="$output"
+
+    # 6-arg call with explicit []
+    run compute_expand_retained_map "push" "false" "${TEST_DIR}/changed.txt" "$containers" "false" "[]"
+    [ "$status" -eq 0 ]
+    local result_6arg
+    result_6arg="$output"
+
+    # Both must produce the same map (openresty=true, terraform=false).
+    [ "$(echo "$result_5arg" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$result_5arg" | jq -r '.terraform')" = "false" ]
+    [ "$(echo "$result_6arg" | jq -r '.openresty')" = "true" ]
+    [ "$(echo "$result_6arg" | jq -r '.terraform')" = "false" ]
+    # Maps must be equal.
+    [ "$(echo "$result_5arg" | jq -c 'to_entries | sort_by(.key)')" = "$(echo "$result_6arg" | jq -c 'to_entries | sort_by(.key)')" ]
+}


### PR DESCRIPTION
## Part of #595 (slice 1 of 4) — bootstrap the coverage checkpoint

### Problem
#601 introduced cumulative container detection from the `auto-build-coverage-master`
tag, but the checkpoint **could never bootstrap**: `publish-coverage-checkpoint` only
advanced the tag when every build job was green (`!failure()`). One chronically-failing
container (`github-runner` — Windows `yq` #598 + a debian-trixie arm64 failure) made
every master run conclude `failure`, so the tag was never created and detection stayed
in permanent build-all fail-safe. **One broken container blocked the whole fleet's
checkpoint.**

### Change (slice 1 — minimal unblock)
Advance the checkpoint on run **completion** (even when build jobs fail), carrying durable
per-container failure state in the **annotated** tag's JSON message
`{sha, run_id, failed_containers}`. The next run retries `failed_containers` (carry-forward)
while other containers follow the normal diff.

State machine (pure, in `helpers/coverage-checkpoint-utils.sh`):
- `next_matrix = changed_since(baseline) ∪ failed_containers`
- `failed' = (failed ∪ failed_this_run) − recovered_this_run`
- never drops a container that wasn't attempted this run; **fail-closed** (carry
  `matrix ∪ prior`) on an unmappable failure or unreadable job outcomes.

Wiring:
- `if:` gate simplified to `push && master && !cancelled() && detect-containers==success`;
  `permissions: actions: read` added (job-conclusion read via `gh run view`).
- Verifier in `detect-containers` no longer filters on run conclusion (the checkpoint now
  publishes inside otherwise-failed runs); the per-job `publish-coverage-checkpoint`
  conclusion check remains authoritative.
- Carry-forward forces **retained-version expansion** for carried containers (via an
  explicit signal into `compute_expand_retained_map`) so a latest-only retry can't falsely
  "recover" a failed retained version.
- Checkpoint tag write is a **forward-only + compare-and-swap** loop (`--force-with-lease`)
  so concurrent master runs (`cancel-in-progress: false`) can't clobber each other's state
  or move the baseline backward.
- Annotated-tag committer identity (`github-actions[bot]`) configured before `git tag -a`.

### Tests / gates
- `tests/unit/coverage-checkpoint-utils.bats` — 28 unit tests (parse / classify / merge /
  carry-forward union), each regression-lock naming its mutation.
- `tests/unit/variant-utils.bats` — +3 for the carried-forward expansion param (60 total).
- shellcheck clean on both helpers.
- Pre-push senior review (opus) + orthogonal gate (codex xhigh + copilot) — **dual-CLEAN**
  after a 3-round convergence (5 findings, all fixed at the root; the untested inline
  carry-forward loop was extracted into the tested `compute_carry_forward` helper rather
  than re-patched).

### Live verification (post-merge)
`github-runner` is the live test: after merge, a master push should (a) advance the tag
**despite** github-runner failing, (b) record `github-runner` in `failed_containers`,
(c) the next push should carry it forward (retry, retained-expanded) while other containers
use the diff. Verify the tag JSON + a `detect-containers` log showing `diff ∪ {github-runner}`.

> Note: if a postgres **extension/manifest** job fails this run, attribution falls through
> to the fail-closed `unmapped_failure` path and the run carries all attempted containers
> forward (safe over-build, never strands) — see deferred follow-up below.

### Deferred (follow-up — out of slice 1 scope, by design)
- **Slice 2** — robust failure extraction via machine-readable per-matrix result artifacts,
  replacing job-name token-matching. Removes the "extension/manifest job failure → fail-closed
  build-all" over-build (senior review M-finding; fail-closed, never strands).
- **Slice 3** — per-container build-failure issue lifecycle (container-scoped open/close).
- **Slice 4** — command-scoped 3× build/push retries (ext Stage A already has `EXT_BUILD_RETRIES=3`).
- Cleanup: remove dormant content-staleness code from the abandoned approach C.

Operator note: external tag-protection on `auto-build-coverage-master` is recommended
(defense-in-depth; not required — the baseline is checkpoint-job-validated).
