### PR TITLE
fix(ci): pipe checkpoint jobs JSON via stdin to avoid ARG_MAX (#595)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1343,7 +1343,7 @@ jobs:
           # per-container outcomes, so we fail closed (force unmapped) rather than
           # advancing the baseline while silently dropping this run's real failures.
           set +e
-          jobs_json=$(gh run view "$GITHUB_RUN_ID" --json jobs 2>/dev/null)
+          jobs_json=$(gh run view "$GITHUB_RUN_ID" --json jobs --jq '{jobs: [.jobs[] | {name, conclusion}]}' 2>/dev/null)
           gh_rc=$?
           set -e
           gh_failed=false

--- a/helpers/coverage-checkpoint-utils.sh
+++ b/helpers/coverage-checkpoint-utils.sh
@@ -67,12 +67,13 @@ extract_failed_recovered() {
     [[ -z "$jobs_json" ]] && jobs_json='{"jobs":[]}'
     [[ -z "$matrix_json" ]] && matrix_json='[]'
 
-    jq -cn \
-        --argjson jobs "$jobs_json" \
+    printf '%s' "$jobs_json" | jq -c \
         --argjson matrix "$matrix_json" \
         '
-        # Normalise: accept both {"jobs":[...]} and a bare array.
-        ($jobs | if type == "object" then .jobs // [] else . end) as $job_list |
+        # Normalise: accept both {"jobs":[...]} and a bare array. Jobs JSON arrives
+        # on stdin (NOT --argjson) because a build-all run produces a jobs payload
+        # larger than the kernel per-arg limit (MAX_ARG_STRLEN, 128 KB) → E2BIG.
+        (. | if type == "object" then .jobs // [] else . end) as $job_list |
 
         # Identify bad jobs: terminal conclusion that is not success or skipped.
         # null/"" conclusions mean in-progress — excluded so meta-jobs running

--- a/tests/unit/coverage-checkpoint-utils.bats
+++ b/tests/unit/coverage-checkpoint-utils.bats
@@ -342,3 +342,98 @@ make_jobs_json() {
     [ "$queued" = '["a","b","c"]' ]
     [ "$carried" = '["a","c"]' ]
 }
+
+# ---------------------------------------------------------------------------
+# ARG_MAX regression tests — large jobs payload (>128 KB) must NOT E2BIG
+# ---------------------------------------------------------------------------
+#
+# Production bug (exit 126): on a build-all run (~237 jobs), gh run view returns
+# full job objects with steps/URLs/timestamps.  Passing that JSON via
+# `jq --argjson jobs "$jobs_json"` exceeds the kernel per-arg limit
+# (MAX_ARG_STRLEN, 128 KB) → E2BIG → bash reports exit 126.
+# The fix routes jobs_json via stdin (printf '%s' ... | jq -c) instead.
+# These tests verify the fix by constructing a payload that genuinely exceeds
+# 128 KB and asserting that extract_failed_recovered succeeds AND returns the
+# correct classification — making the test vacuous if the payload is too small.
+
+@test "extract_failed_recovered: large jobs payload (>128KB) succeeds without E2BIG — ARG_MAX regression lock" {
+    # Mutation locked: if jobs were passed via `jq --argjson jobs` instead of stdin,
+    # this >128KB single argument would trigger E2BIG → exit 126 (the production bug);
+    # the test would report status=126 instead of 0 and the classification assertions
+    # would never be reached.
+
+    # Build one job object ~400 bytes via name padding so 600 copies exceed 128 KB.
+    # Two specific jobs carry meaningful conclusions for the assertion:
+    #   - "Build github-runner (ubuntu-2404)" → failure  (maps to github-runner)
+    #   - "Build jekyll:4.3.4 (amd64)"       → success  (maps to jekyll)
+    # The remaining 598 are synthetic padding jobs with success conclusions and
+    # names that do not match any matrix container.
+    local pad_job
+    pad_job=$(jq -cn '
+        {
+            name: ("padding-job-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+            conclusion: "success"
+        }
+    ')
+    local big
+    big=$(jq -cn \
+        --argjson real_fail '{"name":"Build github-runner (ubuntu-2404)","conclusion":"failure"}' \
+        --argjson real_ok   '{"name":"Build jekyll:4.3.4 (amd64)","conclusion":"success"}' \
+        --argjson pad "$pad_job" \
+        '{jobs: ([$real_fail, $real_ok] + [range(598) | $pad])}')
+
+    # Guard: verify the fixture actually exceeds 128 KB; if it does not, the test is
+    # vacuous (it would pass even with the buggy --argjson path because the payload
+    # would fit in the kernel per-arg limit and E2BIG would never fire).
+    local big_len="${#big}"
+    [ "$big_len" -gt 131072 ] || {
+        echo "FIXTURE TOO SMALL: ${big_len} bytes — padding insufficient, fix the test" >&2
+        return 1
+    }
+
+    local matrix='["github-runner","jekyll"]'
+    run extract_failed_recovered "$big" "$matrix"
+    [ "$status" -eq 0 ]
+
+    local failed recovered
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    json_eq "$failed"    '["github-runner"]'
+    json_eq "$recovered" '["jekyll"]'
+}
+
+@test "extract_failed_recovered: bare-array form of large payload (>128KB) succeeds — stdin normalisation" {
+    # Same as the previous test but the payload is a bare JSON array [...] rather than
+    # {"jobs":[...]}.  Verifies that the stdin-path normalisation
+    # (`. | if type == "object" then .jobs // [] else . end`) handles both forms
+    # even at scale.
+    local pad_job
+    pad_job=$(jq -cn '
+        {
+            name: ("padding-job-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+            conclusion: "success"
+        }
+    ')
+    local big_bare
+    big_bare=$(jq -cn \
+        --argjson real_fail '{"name":"Build github-runner (ubuntu-2404)","conclusion":"failure"}' \
+        --argjson real_ok   '{"name":"Build jekyll:4.3.4 (amd64)","conclusion":"success"}' \
+        --argjson pad "$pad_job" \
+        '[$real_fail, $real_ok] + [range(598) | $pad]')
+
+    local big_len="${#big_bare}"
+    [ "$big_len" -gt 131072 ] || {
+        echo "FIXTURE TOO SMALL: ${big_len} bytes — padding insufficient, fix the test" >&2
+        return 1
+    }
+
+    local matrix='["github-runner","jekyll"]'
+    run extract_failed_recovered "$big_bare" "$matrix"
+    [ "$status" -eq 0 ]
+
+    local failed recovered
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    json_eq "$failed"    '["github-runner"]'
+    json_eq "$recovered" '["jekyll"]'
+}


### PR DESCRIPTION
## Hotfix for #595 slice 1 — coverage checkpoint crashed with ARG_MAX on bootstrap

### Problem (caught by the live bootstrap run)
After #603 merged, the first master push (a build-all bootstrap, ~237 jobs) ran the
`publish-coverage-checkpoint` job — the `if:` change worked, the job executed despite
build failures — but it crashed:

```
helpers/coverage-checkpoint-utils.sh: line 70: /usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126
```

Root cause: `extract_failed_recovered` passed the `gh run view --json jobs` payload to jq
via `--argjson jobs "$jobs_json"`. On a build-all run the payload (full job objects incl.
every job's `steps` array) is **789 KB** — a single argv element far over the kernel
per-arg limit `MAX_ARG_STRLEN` (128 KB) → `E2BIG`. The annotated tag was never created, so
the checkpoint could not bootstrap. (This is the documented gotcha: "pipe large JSON via
stdin, not --argjson". Slice 1's unit tests used small fixtures and missed it; the missing
piece was a real-scale smoke test.)

### Fix
- `extract_failed_recovered`: pipe `jobs_json` into jq via **stdin** instead of `--argjson`
  (robust at any size). `matrix_json` stays `--argjson` (tiny). Output unchanged.
- Workflow Step 1: slim the query to `--jq '{jobs:[.jobs[]|{name,conclusion}]}'`
  (~10× smaller payload) as defense-in-depth.
- Two bats regression tests with **>128 KB** fixtures (195 KB, 600 jobs) that would E2BIG
  under the old `--argjson` invocation — asserts both `{"jobs":[...]}` and bare-array forms.

### Validation (against the real failed run's payload, no CI wait)
Replaying the FIXED helper on the actual 789 KB / 237-job payload from the failed run:
- `extract_failed_recovered` → **exit 0** (no E2BIG).
- Live-simulated (checkpoint job in_progress → excluded): `unmapped_failure=false`,
  bootstrap `failed_containers = ["debian","github-runner","web-shell"]` — sensible
  (`github-runner` = the chronic #598 failure, `web-shell` = web-shell:debian arm64;
  `debian` is a harmless false-positive from a job-name token collision, fixed in slice 2).
- 30 bats pass, shellcheck clean, orthogonal gate (codex + copilot) dual-CLEAN.

### Follow-up
- **Slice 2** (machine-readable per-matrix result artifacts) replaces job-name token
  matching entirely — fixes the `web-shell:debian` → `debian` false-positive and the
  extension/manifest unmapped over-build. Now clearly necessary (the live data shows
  name-matching is fragile in two ways), tracked as the next PR.
