### PR TITLE
feat(ci): attribute checkpoint failures via per-matrix build-result artifacts (#595)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -356,6 +356,7 @@ jobs:
           scripts/list-extension-versions.sh
 
       - name: Build and push extension images
+        id: build-extensions-step
         if: steps.ext-versions.outputs.containers != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -473,6 +474,37 @@ jobs:
           # silently skips files inside hidden directories unless this is set.
           include-hidden-files: true
 
+      - name: Emit build-result artifact (postgres extensions, ${{ matrix.arch }})
+        if: always()
+        env:
+          # job.status: success only when all prior steps (checkout, login, build)
+          # completed without error. An upstream step failure (e.g. login 403) sets
+          # job.status=failure even though the build step itself was skipped.
+          # Whole-run artifact absence is handled by the checkpoint's find/mapfile guard.
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          result="failure"
+          [[ "$JOB_STATUS" == "success" ]] && result="success"
+          mkdir -p .build-lineage
+          jq -cn \
+            --arg c "postgres" \
+            --arg v "extensions" \
+            --arg t "" \
+            --arg a "${{ matrix.arch }}" \
+            --arg r "$result" \
+            '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+            > ".build-lineage/build-result-postgres-ext-${{ matrix.arch }}.json" || true
+
+      - name: Upload build-result artifact (postgres extensions, ${{ matrix.arch }})
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-postgres-ext-${{ matrix.arch }}
+          path: .build-lineage/build-result-postgres-ext-${{ matrix.arch }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
   # Stage B: merge per-arch extension manifests into multi-arch manifests and
   # write the versionset artifact with the multi-arch bundle INDEX digest.
   # Runs on ubuntu-latest (manifest operations are registry API calls — no native
@@ -557,6 +589,7 @@ jobs:
           scripts/list-extension-versions.sh
 
       - name: Merge per-arch manifests and write versionset artifacts
+        id: merge-manifests-step
         if: steps.ext-versions.outputs.containers != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -637,6 +670,36 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
           include-hidden-files: true
+
+      - name: Emit build-result artifact (postgres extmerge)
+        if: always()
+        env:
+          # job.status: success only when checkout, login, version-discovery, and
+          # the merge step all completed without error. Upstream failure → fail-closed.
+          # Whole-run artifact absence is handled by the checkpoint's find/mapfile guard.
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          result="failure"
+          [[ "$JOB_STATUS" == "success" ]] && result="success"
+          mkdir -p .build-lineage
+          jq -cn \
+            --arg c "postgres" \
+            --arg v "extmerge" \
+            --arg t "" \
+            --arg a "multiarch" \
+            --arg r "$result" \
+            '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+            > ".build-lineage/build-result-postgres-extmerge.json" || true
+
+      - name: Upload build-result artifact (postgres extmerge)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-postgres-extmerge
+          path: .build-lineage/build-result-postgres-extmerge.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
 
   # Sync base images: blind-copy detected containers' base images from Docker Hub
   # to GHCR on every push. Consolidated with the daily upstream-monitor sync via
@@ -942,6 +1005,38 @@ jobs:
           echo "**Tag:** \`$tag\`" >> $GITHUB_STEP_SUMMARY
           echo "**Attempt:** $attempt" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ✅ Success" >> $GITHUB_STEP_SUMMARY
+
+      - name: Emit build-result artifact
+        if: always()
+        shell: bash
+        env:
+          # job.status reflects the whole job outcome: success only when the job's
+          # work completed without error (build||retry succeeded, "Handle build failure"
+          # did not exit 1). failure/cancelled → fail-closed "failure" record.
+          # Whole-run artifact absence is handled by the checkpoint's find/mapfile guard.
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          result="failure"
+          [[ "$JOB_STATUS" == "success" ]] && result="success"
+          mkdir -p .build-lineage
+          jq -cn \
+            --arg c "${{ matrix.build.container }}" \
+            --arg v "${{ matrix.build.variant }}" \
+            --arg t "${{ matrix.build.tag }}" \
+            --arg a "${{ matrix.arch }}" \
+            --arg r "$result" \
+            '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+            > ".build-lineage/build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}.json" || true
+
+      - name: Upload build-result artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
+          path: .build-lineage/build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
 
       - name: Run Pester tests (Windows)
         if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.build.os == 'windows' && matrix.build.build_flavor == 'base' && inputs.run_tests == true
@@ -1289,6 +1384,36 @@ jobs:
           sbom-path: ${{ steps.sbom-windows.outputs.sbom_file }}
         continue-on-error: true
 
+      - name: Emit build-result artifact (manifest)
+        if: always()
+        env:
+          # job.status: success only when checkout, login, and the GHCR manifest step
+          # all completed without error. Upstream failure → fail-closed "failure" record.
+          # Whole-run artifact absence is handled by the checkpoint's find/mapfile guard.
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          result="failure"
+          [[ "$JOB_STATUS" == "success" ]] && result="success"
+          mkdir -p .build-lineage
+          jq -cn \
+            --arg c "${{ matrix.build.container }}" \
+            --arg v "${{ matrix.build.variant }}" \
+            --arg t "${{ matrix.build.tag }}" \
+            --arg a "manifest" \
+            --arg r "$result" \
+            '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+            > ".build-lineage/build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}.json" || true
+
+      - name: Upload build-result artifact (manifest)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}
+          path: .build-lineage/build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
   # Advance the coverage checkpoint tag on every master push run that completes
   # (even when individual build jobs failed).  The tag carries a JSON state record
   # of which containers failed so the next run can retry them while other containers
@@ -1339,9 +1464,10 @@ jobs:
           # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
           source "${GITHUB_WORKSPACE}/helpers/coverage-checkpoint-utils.sh"
 
-          # Step 1: Fetch this run's job conclusions. On gh failure we cannot determine
-          # per-container outcomes, so we fail closed (force unmapped) rather than
-          # advancing the baseline while silently dropping this run's real failures.
+          # Step 1: Fetch this run's job conclusions (kept for fallback path).
+          # On gh failure we cannot determine per-container outcomes via the fallback,
+          # so we fail closed (force unmapped) rather than advancing the baseline while
+          # silently dropping this run's real failures.
           set +e
           jobs_json=$(gh run view "$GITHUB_RUN_ID" --json jobs --jq '{jobs: [.jobs[] | {name, conclusion}]}' 2>/dev/null)
           gh_rc=$?
@@ -1361,7 +1487,24 @@ jobs:
           fi
 
           # Step 3: Classify jobs against the matrix.
-          er=$(extract_failed_recovered "$jobs_json" "$matrix_json")
+          # PRIMARY: machine-readable build-result artifacts (exact container field, no
+          # token-collision, infra jobs emit nothing so they can't pollute unmapped_failure).
+          # FALLBACK: job-name matching (extract_failed_recovered) when no artifacts found.
+          # Guard: use find+mapfile (not a glob) to count files — an empty download dir
+          # leaves the glob un-expanded (nullglob off), which would feed the literal path
+          # string to jq and produce a malformed payload instead of falling back.
+          gh run download "$GITHUB_RUN_ID" --pattern 'build-result-*' -D "$RUNNER_TEMP/bres" 2>/dev/null || true
+          mapfile -t _bres_files < <(find "$RUNNER_TEMP/bres" -type f -name '*.json' 2>/dev/null)
+          if [[ ${#_bres_files[@]} -gt 0 ]]; then
+            results_json=$(jq -s -c '.' "${_bres_files[@]}")
+            echo "::notice::checkpoint attribution via build-result artifacts ($(echo "$results_json" | jq 'length') records)"
+            # Pass jobs_json as 3rd arg so the recovery gate can catch missing failure
+            # records from crashed multi-arch legs (codex finding: multi-arch false recovery).
+            er=$(aggregate_build_results "$results_json" "$matrix_json" "$jobs_json")
+          else
+            echo "::warning::no build-result artifacts found — falling back to job-name matching"
+            er=$(extract_failed_recovered "$jobs_json" "$matrix_json")
+          fi
           ftr=$(echo "$er" | jq -c '.failed_this_run')
           rec=$(echo "$er" | jq -c '.recovered_candidates')
           unmapped=$(echo "$er" | jq -r '.unmapped_failure')

--- a/helpers/coverage-checkpoint-utils.sh
+++ b/helpers/coverage-checkpoint-utils.sh
@@ -10,7 +10,8 @@
 #
 # Functions (all pure — read args/stdin, write stdout only):
 #   checkpoint_failed_containers  <state_str>
-#   extract_failed_recovered      <jobs_json> <matrix_json>
+#   aggregate_build_results       <results_json> <matrix_json> [jobs_json]  ← PRIMARY attribution (slice 2)
+#   extract_failed_recovered      <jobs_json> <matrix_json>      ← FALLBACK (name-matching)
 #   merge_failed_set              <prior_json> <failed_this_json> <recovered_cand_json> <matrix_json> <unmapped_failure>
 #   compute_carry_forward         <queued_json> <baseline_failed_json> <valid_json>
 
@@ -163,6 +164,165 @@ compute_carry_forward() {
         (($q + $carried) | sort | unique) as $queued_out |
 
         { queued: $queued_out, carried: $carried }
+        '
+}
+
+# aggregate_build_results <results_json> <matrix_json> [jobs_json]
+#
+# Classify per-matrix containers as failed, recovered, or neither using
+# machine-readable build-result artifact records.  jobs_json is used to
+# detect completeness gaps via a COUNT-based invariant.
+#
+# This is the PRIMARY attribution path (slice 2).  It eliminates three bugs:
+#   1. Token-collision false positives (e.g. "debian" job matching "web-shell:debian").
+#   2. Infra job failures (e.g. "Sync base images") triggering carry-all via
+#      unmapped_failure because the job name matched no container token.
+#   3. Multi-arch / extension-pipeline stranding: a crashed leg or postgres extension
+#      job produces no record; a success record from another leg/job alone would
+#      falsely recover a prior failure → crashed leg/pipeline never retried.
+#
+# Arguments:
+#   results_json  – JSON array of objects, each with at least {container, result}
+#                   where result ∈ "success" | "failure".  Other fields are ignored.
+#                   Invalid / non-array input is treated as [] (fail-safe).
+#   matrix_json   – JSON array of container name strings (same format as
+#                   extract_failed_recovered's second argument).
+#   jobs_json     – (optional) slimmed gh run view output: {jobs:[{name,conclusion}]}
+#                   or a bare array.  Used only for the COUNT completeness invariant:
+#                   bad_build_job_count vs failure_record_count.  Infra jobs (matching
+#                   no matrix container) are NOT counted — no all-13 regression.
+#                   If omitted/empty → counts are both 0 → unmapped stays false
+#                   (backward-compat for 2-arg callers).
+#
+# Core algorithm (COUNT-based completeness invariant):
+#   fail_rec              = matrix containers with ≥1 record where .result=="failure"
+#   succ_rec              = matrix containers with ≥1 record where .result=="success"
+#   failure_record_count  = number of records with .result=="failure" AND .container ∈ matrix
+#   bad_jobs              = jobs_json jobs with terminal conclusion (not null/""/success/skipped)
+#   bad_build_job_count   = number of bad_jobs that map to ≥1 matrix container via
+#                           maps_to_container (token-match OR postgres ext/merge alias)
+#                           (counted once per job; infra jobs matching nothing → not counted)
+#   unmapped_failure      = (bad_build_job_count > failure_record_count)  — gap detected
+#                           OR (out-of-matrix failure record exists)       — always fail-closed
+#   failed_this_run       = fail_rec  (artifact-precise)
+#   recovered_candidates  = succ_rec \ fail_rec
+#
+# When unmapped_failure=true, merge_failed_set carries (prior ∪ matrix) so no
+# container is silently dropped despite incomplete artifact data.
+#
+# Output compact JSON (same shape as extract_failed_recovered):
+#   {
+#     "failed_this_run":      [...],   # containers with ≥1 failure record
+#     "recovered_candidates": [...],   # success-only containers
+#     "unmapped_failure":     bool     # true → gap or out-of-matrix record detected
+#   }
+# All arrays are sorted and unique.  A container with no records appears in neither list.
+#
+# Note: results_json and jobs_json are passed via --arg + fromjson? (not --argjson)
+# so that malformed JSON is silently treated as [] rather than causing a jq parse error.
+# Records are slim (one per build job, ~158 max, <128 KB total) — no ARG_MAX risk.
+aggregate_build_results() {
+    local results_json="${1:-}"
+    local matrix_json="${2:-[]}"
+    local jobs_json="${3:-}"
+    [[ -z "$results_json" ]] && results_json='[]'
+    [[ -z "$jobs_json" ]]    && jobs_json='{"jobs":[]}'
+
+    jq -cn \
+        --arg results_str "$results_json" \
+        --argjson matrix "$matrix_json" \
+        --arg jobs_str "$jobs_json" \
+        '
+        # Parse results_str; treat any non-array (or parse failure) as [] (fail-safe).
+        # fromjson? silently becomes empty on invalid JSON; // [] recovers to empty array.
+        (($results_str | fromjson?) // []) as $raw_results |
+        (if ($raw_results | type) == "array" then $raw_results else [] end) as $rs |
+        (if ($matrix  | type) == "array" then $matrix  else [] end) as $m  |
+
+        # Parse jobs_str; normalise to a flat array of job objects.
+        # Accept both {"jobs":[...]} and a bare array.  Invalid JSON → [] (fail-open:
+        # if we cannot read jobs we do not inflate the failed set).
+        (($jobs_str | fromjson?) // []) as $raw_jobs |
+        ($raw_jobs | if type == "object" then .jobs // [] else . end) as $job_list |
+
+        # Terminal-failed jobs: conclusion is set, non-success, non-skipped.
+        ($job_list | map(select(
+            .conclusion != null and .conclusion != "" and
+            .conclusion != "success" and .conclusion != "skipped"
+        ))) as $bad_jobs |
+
+        # Token-boundary regex helper (same definition as extract_failed_recovered).
+        # Container names are [a-z0-9-]+ so safe to interpolate directly.
+        def token_re(name):
+            "(^|[^A-Za-z0-9_-])" + name + "([^A-Za-z0-9_-]|$)";
+
+        # maps_to_container: true iff a job display name maps to a matrix container.
+        # Used ONLY for the COUNT completeness gate (bad_build_job_count) — NOT for
+        # failure attribution (failed_this_run stays artifact-record-based).
+        #
+        # The postgres extension pipeline jobs ("Build PostgreSQL Extensions (arm64)",
+        # "Merge Extension Manifests (multi-arch)") emit records attributed to the
+        # "postgres" container, but their display names contain no lowercase "postgres"
+        # token. Without the alias, a crashed ext/merge job (no record produced) would
+        # go unnoticed by the count gate → bad_build_job_count stays 0 → no gap →
+        # postgres is falsely recovered. The alias fixes this: when the matrix contains
+        # "postgres", extension/merge job names also count toward the gate.
+        def maps_to_container($jobname; $c):
+            ($jobname | test(token_re($c)))
+            or ($c == "postgres" and ($jobname | test("PostgreSQL Extensions|Extension Manifests")));
+
+        # fail_rec: matrix containers that have >=1 failure RECORD (artifact-precise).
+        [ $m[] | . as $c |
+          if ([ $rs[] | select(.container == $c and .result == "failure") ] | length) > 0
+          then $c else empty end
+        ] | sort | unique as $fail_rec |
+
+        # succ_rec: matrix containers that have >=1 success record.
+        [ $m[] | . as $c |
+          if ([ $rs[] | select(.container == $c and .result == "success") ] | length) > 0
+          then $c else empty end
+        ] | sort | unique as $succ_rec |
+
+        # failure_record_count: number of failure records whose container is in matrix.
+        # (Excludes out-of-matrix failures — those are caught by the unmapped check below.)
+        ([ $rs[] | . as $rec | select($rec.result == "failure" and ($m | index($rec.container)) != null) ] | length)
+        as $failure_record_count |
+
+        # bad_build_job_count: number of terminal-failed jobs that map to >=1 matrix
+        # container via maps_to_container.  Each job counted at most once; infra jobs
+        # (matching nothing) contribute 0 — this preserves the Sync-base-images all-13
+        # fix.  The postgres extension/merge alias ensures a crashed ext/merge job is
+        # counted even though its display name contains no "postgres" token.
+        ($bad_jobs | map(
+            . as $job |
+            if ([ $m[] | . as $c | select(maps_to_container($job.name; $c)) ] | length) > 0
+            then 1 else 0 end
+        ) | add // 0) as $bad_build_job_count |
+
+        # out_of_matrix: any failure record whose .container is not in matrix.
+        ([ $rs[] | select(.result == "failure") ] |
+         map(.container) |
+         map(. as $cn | ($m | index($cn)) == null) |
+         any) as $out_of_matrix |
+
+        # unmapped_failure: gap detected (more failed build jobs than failure records)
+        # OR an out-of-matrix failure record exists.
+        (($bad_build_job_count > $failure_record_count) or $out_of_matrix) as $unmapped |
+
+        # failed_this_run: artifact-precise (fail_rec only).
+        $fail_rec as $failed |
+
+        # recovered_candidates: success-only containers (no failure record).
+        [ $succ_rec[] | . as $c |
+          if ($fail_rec | index($c)) == null
+          then $c else empty end
+        ] | sort | unique as $recovered |
+
+        {
+            failed_this_run:      $failed,
+            recovered_candidates: $recovered,
+            unmapped_failure:     $unmapped
+        }
         '
 }
 

--- a/tests/unit/coverage-checkpoint-utils.bats
+++ b/tests/unit/coverage-checkpoint-utils.bats
@@ -402,6 +402,552 @@ make_jobs_json() {
     json_eq "$recovered" '["jekyll"]'
 }
 
+# ---------------------------------------------------------------------------
+# aggregate_build_results — machine-readable artifact attribution (slice 2)
+# ---------------------------------------------------------------------------
+
+# Build a minimal results JSON array from pairs of "container:result".
+make_results_json() {
+    local pairs=("$@")
+    local arr="["
+    local first=1
+    for pair in "${pairs[@]}"; do
+        local container="${pair%%:*}"
+        local result="${pair##*:}"
+        [[ "$first" -eq 0 ]] && arr+=","
+        arr+="{\"container\":$(echo -n "$container" | jq -Rs .),\"result\":\"$result\"}"
+        first=0
+    done
+    arr+="]"
+    echo "$arr"
+}
+
+@test "aggregate_build_results: Proof A — web-shell failure does NOT collide with debian success" {
+    # Mutation locked: if attribution used token matching (extract_failed_recovered
+    # path), "Build web-shell:debian" failure would falsely attribute to "debian"
+    # because "debian" is a token in the job name. With exact container field
+    # matching, only the record whose .container=="web-shell" is a failure.
+    results=$(make_results_json \
+        "web-shell:failure" \
+        "debian:success" \
+        "postgres:success")
+    matrix='["web-shell","debian","postgres"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates | sort')
+    json_eq "$failed" '["web-shell"]'
+    # "debian" must NOT be in failed_this_run
+    [ "$(echo "$failed" | jq 'index("debian")')" = "null" ]
+    # "debian" must be in recovered_candidates
+    [ "$(echo "$recovered" | jq 'index("debian") != null')" = "true" ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: Proof B — infra job absence keeps unmapped_failure false" {
+    # Mutation locked: if infra jobs emitted records, a failed "Sync base images"
+    # record with no matching matrix container would set unmapped_failure=true,
+    # triggering carry-all of all 13 containers. This test verifies that when
+    # NO infra record is present (only container records), unmapped_failure stays
+    # false even when github-runner fails.
+    results=$(make_results_json \
+        "github-runner:failure" \
+        "ansible:success" \
+        "debian:success" \
+        "jekyll:success" \
+        "openresty:success" \
+        "openvpn:success" \
+        "php:success" \
+        "postgres:success" \
+        "sslh:success" \
+        "vector:success" \
+        "web-shell:success" \
+        "web-shell-debian:success" \
+        "wordpress:success")
+    matrix='["github-runner","ansible","debian","jekyll","openresty","openvpn","php","postgres","sslh","vector","web-shell","web-shell-debian","wordpress"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    json_eq "$failed" '["github-runner"]'
+    # Must NOT carry all 13 — only github-runner is in failed_this_run
+    [ "$(echo "$failed" | jq 'length')" = "1" ]
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: Proof C — postgres extension record attributes failure to postgres" {
+    # Mutation locked: build-extensions and merge-extension-manifests emit records
+    # with container:"postgres". A failure must land postgres in failed_this_run
+    # with unmapped_failure=false (it IS in the matrix).
+    results=$(make_results_json \
+        "postgres:failure" \
+        "debian:success")
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    json_eq "$failed" '["postgres"]'
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: multi-record same container — any failure means failed" {
+    # Two records for postgres (amd64 and arm64); one failure → postgres in failed.
+    results='[{"container":"postgres","arch":"amd64","result":"failure"},{"container":"postgres","arch":"arm64","result":"success"}]'
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    json_eq "$failed" '["postgres"]'
+    # debian has no records — must be in neither list
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    [ "$(echo "$recovered" | jq 'index("debian")')" = "null" ]
+}
+
+@test "aggregate_build_results: all-success container goes to recovered_candidates" {
+    results=$(make_results_json "ansible:success" "jekyll:success")
+    matrix='["ansible","jekyll","postgres"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    [ "$failed" = "[]" ]
+    # ansible and jekyll are recovered; postgres had no records → neither list
+    json_eq "$recovered" '["ansible","jekyll"]'
+    [ "$(echo "$recovered" | jq 'index("postgres")')" = "null" ]
+}
+
+@test "aggregate_build_results: container with zero records is in neither list" {
+    # postgres appears in matrix but has no artifact records (skipped build).
+    # It must not appear in failed_this_run or recovered_candidates.
+    results=$(make_results_json "ansible:success")
+    matrix='["ansible","postgres"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    [ "$failed" = "[]" ]
+    json_eq "$recovered" '["ansible"]'
+    [ "$(echo "$recovered" | jq 'index("postgres")')" = "null" ]
+}
+
+@test "aggregate_build_results: out-of-matrix failure sets unmapped_failure true" {
+    # A failure record for a container NOT in the matrix (defensive fail-closed).
+    results='[{"container":"ghost-container","result":"failure"}]'
+    matrix='["ansible","debian"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$unmapped" = "true" ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    [ "$failed" = "[]" ]
+}
+
+@test "aggregate_build_results: invalid results_json treated as empty (fail-safe)" {
+    run aggregate_build_results "not-json" '["ansible"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$failed" = "[]" ]
+    [ "$recovered" = "[]" ]
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: empty results_json returns all-empty (no records = nothing attempted)" {
+    run aggregate_build_results '[]' '["ansible","debian","postgres"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$failed" = "[]" ]
+    [ "$recovered" = "[]" ]
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: multi-arch missing-record false-recovery lock (COUNT invariant)" {
+    # Mutation locked: the arm64 leg crashes before the always() emit step — no failure
+    # record is written; only the amd64 success record exists.
+    # COUNT invariant: bad_build_job_count=1 ("Build postgres:full (arm64)" matches
+    # {postgres}), failure_record_count=0 (no failure records in matrix) →
+    # 1 > 0 → unmapped_failure=true. merge_failed_set carries (prior ∪ matrix).
+    # failed_this_run is artifact-precise: postgres has no failure record → [] .
+    # postgres is NOT in recovered_candidates because it also has unmapped=true
+    # (merge_failed_set carry-all prevents it from being dropped from prior).
+    # Mutation that this locks: if COUNT gap were ignored, postgres would appear in
+    # recovered_candidates (success record only) → merge yields [] → arm64 stranded.
+    results='[{"container":"postgres","arch":"amd64","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build postgres:full (arm64)","conclusion":"failure"}]}'
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # unmapped=true: bad_build_job_count(1) > failure_record_count(0)
+    [ "$unmapped" = "true" ]
+    # failed_this_run is artifact-precise: no failure records → empty
+    [ "$failed" = "[]" ]
+    # postgres is in recovered_candidates (has a success record, no failure record)
+    # but merge_failed_set's carry-all path (unmapped=true) will carry postgres anyway
+    [ "$(echo "$recovered" | jq 'index("postgres") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: legit multi-arch recovery passes when no failed jobs" {
+    # Complement of the false-recovery test: when both arch legs succeed (no
+    # terminal-failed job in jobs_json), the success record should still promote
+    # the container to recovered_candidates.
+    # COUNT invariant: bad_build_job_count=0 (no bad jobs), failure_record_count=0
+    # → 0 > 0 = false, out_of_matrix=false → unmapped=false. Recovery passes.
+    results='[{"container":"postgres","arch":"amd64","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build postgres:full (amd64)","conclusion":"success"},{"name":"Build postgres:full (arm64)","conclusion":"success"}]}'
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # postgres should be in recovered_candidates (success record, no failed job)
+    [ "$(echo "$recovered" | jq 'index("postgres") != null')" = "true" ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    [ "$(echo "$failed" | jq 'index("postgres")')" = "null" ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: 2-arg backward-compat — no jobs_json means no recovery gate" {
+    # Existing tests call aggregate_build_results with 2 args. Without jobs_json,
+    # the recovery gate must be a no-op (no bad jobs → gate passes every candidate).
+    # This test explicitly verifies the 2-arg form still recovers a success record.
+    results=$(make_results_json "ansible:success")
+    matrix='["ansible","postgres"]'
+    run aggregate_build_results "$results" "$matrix"
+    [ "$status" -eq 0 ]
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    json_eq "$recovered" '["ansible"]'
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    [ "$failed" = "[]" ]
+}
+
+@test "aggregate_build_results: collision prevented — web-shell:debian job does NOT add debian to failed" {
+    # The "Build web-shell:debian (alpine)" job token-matches both {web-shell, debian}.
+    # COUNT invariant: bad_build_job_count=1 (the job matches ≥1 matrix container),
+    # failure_record_count=1 (web-shell has a failure record) → 1 > 1 = false →
+    # unmapped=false. failed_this_run is artifact-precise: only web-shell.
+    # debian has a success record and no failure record → recovered_candidates.
+    # Mutation locked: if COUNT comparison were bad_build_job_count > failure_record_count
+    # replaced by e.g. "> 0 regardless", unmapped=true → carry-all → debian not recovered.
+    results=$(make_results_json "web-shell:failure" "debian:success")
+    jobs='{"jobs":[{"name":"Build web-shell:debian (alpine)","conclusion":"failure"}]}'
+    matrix='["web-shell","debian","postgres"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # Only web-shell has a failure RECORD → artifact-precise
+    json_eq "$failed" '["web-shell"]'
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # bad_build_job_count(1) == failure_record_count(1) → unmapped=false
+    [ "$unmapped" = "false" ]
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # debian has a success record, no failure record → IS in recovered_candidates
+    [ "$(echo "$recovered" | jq 'index("debian") != null')" = "true" ]
+    # postgres has no records at all — neither failed nor recovered
+    [ "$(echo "$recovered" | jq 'index("postgres")')" = "null" ]
+    [ "$(echo "$failed" | jq 'index("postgres")')" = "null" ]
+}
+
+@test "aggregate_build_results: stranding lock — COUNT gap reaches merge_failed_set carry-all" {
+    # Locks the full stranding scenario end-to-end: postgres amd64 success record,
+    # arm64 terminal-failed (no record). prior=["postgres"].
+    # COUNT invariant: bad_build_job_count=1, failure_record_count=0 → unmapped=true.
+    # merge_failed_set with unmapped=true carries (prior ∪ matrix) = ["debian","postgres"].
+    # Mutation: if COUNT gap were not detected → unmapped=false → merge could drop postgres.
+    results='[{"container":"postgres","arch":"amd64","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build postgres:full (arm64)","conclusion":"failure"}]}'
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    ftr=$(echo "$output" | jq -c '.failed_this_run')
+    rec=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq -r '.unmapped_failure')
+    # unmapped=true: gap detected (1 bad build job, 0 failure records)
+    [ "$unmapped" = "true" ]
+    # merge_failed_set with prior=["postgres"] and unmapped=true must carry all
+    run merge_failed_set '["postgres"]' "$ftr" "$rec" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    # carry-all: prior(["postgres"]) ∪ matrix(["postgres","debian"]) = ["debian","postgres"]
+    json_eq "$output" '["debian","postgres"]'
+}
+
+@test "aggregate_build_results: infra job ignored — unmapped stays false, no spurious container added" {
+    # A failed "Sync base images (push scope)" job matches no matrix container.
+    # COUNT invariant: bad_build_job_count=0 (infra job matches nothing → not counted),
+    # failure_record_count=0 → 0 > 0 = false → unmapped=false. All-13 regression fixed.
+    # Mutation locked: if infra jobs were counted in bad_build_job_count (even when
+    # matching nothing), count would be 1 > 0 → unmapped=true → all-13 regression.
+    results=$(make_results_json "ansible:success" "debian:success" "postgres:success")
+    jobs='{"jobs":[{"name":"Sync base images (push scope)","conclusion":"failure"},
+                   {"name":"Build ansible (amd64)","conclusion":"success"},
+                   {"name":"Build debian (amd64)","conclusion":"success"},
+                   {"name":"Build postgres (amd64)","conclusion":"success"}]}'
+    matrix='["ansible","debian","postgres"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # No container should be in failed_this_run (infra job matched nothing)
+    [ "$failed" = "[]" ]
+    [ "$unmapped" = "false" ]
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # All 3 containers have success records and are not unrepresented → all recovered
+    json_eq "$recovered" '["ansible","debian","postgres"]'
+}
+
+@test "aggregate_build_results: collision stays dead + debian recovers (COUNT path)" {
+    # Reproduction of the codex collision scenario: web-shell has a failure record;
+    # debian has a success record; a "Build web-shell:debian (arm64)" job is terminal-
+    # failed. Token-match: {web-shell, debian}.
+    # COUNT invariant: bad_build_job_count=1 (job matches ≥1 matrix container),
+    # failure_record_count=1 (web-shell failure record) → 1 > 1 = false → unmapped=false.
+    # failed_this_run is artifact-precise: only web-shell. debian recovers normally.
+    # Mutation locked: if bad_build_job_count were counted per matched container (2 for
+    # this job) instead of per job (1), count would be 2 > 1 → unmapped=true →
+    # debian never recovered.
+    results=$(make_results_json "web-shell:failure" "debian:success")
+    jobs='{"jobs":[{"name":"Build web-shell:debian (arm64)","conclusion":"failure"}]}'
+    matrix='["web-shell","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # web-shell failed via artifact; debian must NOT be in failed_this_run
+    json_eq "$failed" '["web-shell"]'
+    # debian has a success record and no failure record → IS recovered
+    json_eq "$recovered" '["debian"]'
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # bad_build_job_count(1) == failure_record_count(1) → unmapped=false
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: COUNT-normal — two failures, two bad jobs, unmapped=false" {
+    # Complete normal run: github-runner and web-shell each have a failure record;
+    # debian has a success record. Two bad build jobs, each matching one container.
+    # COUNT invariant: bad_build_job_count=2, failure_record_count=2 → 2 > 2 = false
+    # → unmapped=false. failed_this_run is artifact-precise.
+    # Mutation locked: off-by-one (> vs >=) would set unmapped=true → carry-all →
+    # debian never recovered.
+    results=$(make_results_json \
+        "github-runner:failure" \
+        "web-shell:failure" \
+        "debian:success")
+    jobs=$(make_jobs_json \
+        "Build and push github-runner (ubuntu-2404):failure" \
+        "Build and push web-shell (alpine):failure" \
+        "Build and push debian (amd64):success")
+    matrix='["github-runner","web-shell","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run | sort')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # Two failure records → two entries in failed_this_run
+    json_eq "$failed" '["github-runner","web-shell"]'
+    # debian has a success record and no failure record → recovered
+    [ "$(echo "$recovered" | jq 'index("debian") != null')" = "true" ]
+    # COUNT balanced → unmapped=false
+    [ "$unmapped" = "false" ]
+}
+
+@test "aggregate_build_results: COUNT-multiarch-crash — amd64 success + arm64 terminal → unmapped=true" {
+    # Multi-arch stranding via COUNT: postgres amd64 emits a success record; arm64
+    # crashes before emit (no record). Terminal-failed job matches {postgres}.
+    # bad_build_job_count=1, failure_record_count=0 → 1 > 0 → unmapped=true.
+    # merge_failed_set carry-all: prior(["postgres"]) ∪ matrix(["postgres"]) = ["postgres"].
+    # Mutation locked: if COUNT gap not detected → unmapped=false → postgres in
+    # recovered_candidates → merge yields [] → arm64 stranded forever.
+    results='[{"container":"postgres","arch":"amd64","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build postgres:full (arm64)","conclusion":"failure"}]}'
+    matrix='["postgres"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # COUNT gap → unmapped=true
+    [ "$unmapped" = "true" ]
+    # failed_this_run artifact-precise: no failure record → empty
+    [ "$failed" = "[]" ]
+    # merge_failed_set carry-all carries prior ∪ matrix
+    run merge_failed_set '["postgres"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["postgres"]'
+}
+
+@test "aggregate_build_results: COUNT-collision-crash — codex adversarial edge → unmapped=true" {
+    # Codex adversarial edge: debian has a failure record; web-shell has a success
+    # record; "Build web-shell:debian (arm64)" is terminal-failed, matching {web-shell,debian}.
+    # A SECOND unrelated bad job "Build web-shell (amd64)" also matches {web-shell}.
+    # bad_build_job_count=2 (two jobs each match ≥1 matrix container),
+    # failure_record_count=1 (only debian failure record) → 2 > 1 → unmapped=true.
+    # web-shell is NOT in recovered_candidates even though it has a success record,
+    # because merge_failed_set carry-all overrides everything.
+    # Mutation locked: if COUNT gap were ignored → unmapped=false → web-shell appears
+    # in recovered_candidates → a crashed web-shell build is silently dropped.
+    results=$(make_results_json "debian:failure" "web-shell:success")
+    jobs='{"jobs":[
+        {"name":"Build web-shell:debian (arm64)","conclusion":"failure"},
+        {"name":"Build web-shell (amd64)","conclusion":"failure"}
+    ]}'
+    matrix='["web-shell","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # COUNT gap: 2 bad build jobs > 1 failure record → unmapped=true
+    [ "$unmapped" = "true" ]
+    # failed_this_run is artifact-precise: only debian has a failure record
+    json_eq "$failed" '["debian"]'
+    # merge_failed_set carry-all: prior ∪ matrix carries everything
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    run merge_failed_set '["web-shell","debian"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    json_eq "$output" '["debian","web-shell"]'
+}
+
+@test "aggregate_build_results: COUNT-infra-ignored — infra failure + all-success records → unmapped=false" {
+    # Infrastructure failure with all containers succeeding:
+    # "Sync base images" fails but matches no matrix container → bad_build_job_count=0.
+    # All containers have success records → failure_record_count=0.
+    # 0 > 0 = false, out_of_matrix=false → unmapped=false.
+    # All containers recover normally — the all-13 regression is definitively blocked.
+    # Mutation locked: if infra jobs were included in bad_build_job_count regardless of
+    # matrix match, count=1 > 0 → unmapped=true → all containers carried forward forever.
+    results=$(make_results_json \
+        "ansible:success" \
+        "debian:success" \
+        "postgres:success" \
+        "web-shell:success")
+    jobs='{"jobs":[
+        {"name":"Sync base images (push scope)","conclusion":"failure"},
+        {"name":"Build ansible (amd64)","conclusion":"success"},
+        {"name":"Build debian (amd64)","conclusion":"success"},
+        {"name":"Build postgres (amd64)","conclusion":"success"},
+        {"name":"Build web-shell (alpine)","conclusion":"success"}
+    ]}'
+    matrix='["ansible","debian","postgres","web-shell"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates | sort')
+    # infra job not counted → unmapped=false
+    [ "$unmapped" = "false" ]
+    [ "$failed" = "[]" ]
+    # all 4 containers recover
+    json_eq "$recovered" '["ansible","debian","postgres","web-shell"]'
+}
+
+@test "aggregate_build_results: crashed PostgreSQL Extensions job triggers unmapped (alias lock)" {
+    # Locks the postgres extension-pipeline alias in maps_to_container.
+    # Scenario: build-and-push succeeded (record: postgres success); "Build PostgreSQL
+    # Extensions (arm64)" crashed before its always() emit → no extension failure record.
+    # The job name contains no lowercase "postgres" token, so without the alias it would
+    # NOT be counted → bad_build_job_count=0, failure_record_count=0 → 0>0=false →
+    # unmapped=false → postgres falsely recovered → arm64 extension retried never.
+    # With alias: maps_to_container("Build PostgreSQL Extensions (arm64)"; "postgres")=true
+    # → bad_build_job_count=1, failure_record_count=0 → 1>0=true → unmapped=true →
+    # merge_failed_set carries postgres forward.
+    # Mutation locked: removing the alias from maps_to_container → bad_build_job_count=0
+    # → unmapped=false → postgres wrongly recovered.
+    results='[{"container":"postgres","variant":"vector","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build PostgreSQL Extensions (arm64)","conclusion":"failure"}]}'
+    matrix='["postgres","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # alias counts the crashed ext job → 1 bad build job > 0 failure records → unmapped=true
+    [ "$unmapped" = "true" ]
+    # failed_this_run is artifact-precise: no failure records → empty
+    [ "$failed" = "[]" ]
+    # postgres is in recovered (success record, no failure record) but merge will carry-all
+    [ "$(echo "$recovered" | jq 'index("postgres") != null')" = "true" ]
+    # merge_failed_set carry-all: prior ∪ matrix keeps postgres in the retry set
+    run merge_failed_set '["postgres"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'index("postgres") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: crashed Merge Extension Manifests job triggers unmapped (alias lock)" {
+    # Same shape as the Extension job test but with "Merge Extension Manifests (multi-arch)".
+    # Both display names must be covered by the alias regex "PostgreSQL Extensions|Extension Manifests".
+    # Mutation locked: if the alias regex omitted "Extension Manifests", this job would go
+    # uncounted → bad_build_job_count=0 → unmapped=false → postgres falsely recovered.
+    results='[{"container":"postgres","variant":"full","result":"success"}]'
+    jobs='{"jobs":[{"name":"Merge Extension Manifests (multi-arch)","conclusion":"timed_out"}]}'
+    matrix='["postgres","web-shell"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # alias counts the merge job → 1 bad build job > 0 failure records → unmapped=true
+    [ "$unmapped" = "true" ]
+    [ "$failed" = "[]" ]
+    # carry-all keeps postgres in retry set
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    run merge_failed_set '["postgres"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'index("postgres") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: succeeded PostgreSQL Extensions job is NOT counted — no spurious unmapped" {
+    # Negative: when the extension job SUCCEEDS it must not increment bad_build_job_count.
+    # All jobs success, all records success → bad_build_job_count=0, failure_record_count=0
+    # → unmapped=false → postgres recovers normally.
+    # Mutation locked: if successful extension jobs were included in bad_build_job_count
+    # (e.g. by counting all extension jobs regardless of conclusion), count=1 > 0 →
+    # unmapped=true → postgres carried forward on every green run → never cleared.
+    results='[{"container":"postgres","variant":"full","result":"success"}]'
+    jobs='{"jobs":[
+        {"name":"Build PostgreSQL Extensions (amd64)","conclusion":"success"},
+        {"name":"Build PostgreSQL Extensions (arm64)","conclusion":"success"},
+        {"name":"Merge Extension Manifests (multi-arch)","conclusion":"success"}
+    ]}'
+    matrix='["postgres"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # No bad jobs → unmapped=false
+    [ "$unmapped" = "false" ]
+    [ "$failed" = "[]" ]
+    # postgres has a success record → recovered normally
+    [ "$(echo "$recovered" | jq 'index("postgres") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: zero-artifact glob payload degrades safely (FIX-1 regression lock)" {
+    # Mutation locked: before FIX-1, a failed gh run download left the bres/ dir
+    # empty; the glob "$RUNNER_TEMP/bres/*/*.json" did NOT expand (nullglob off) so
+    # jq received the literal un-expanded path string, producing the two-document
+    # stream "[]\n[]" (one [] per path segment parsed as empty). That string is
+    # non-empty and != "[]", so the PRIMARY branch was taken with effectively empty
+    # data — all failures silently dropped. This test feeds the exact malformed
+    # string to aggregate_build_results and asserts safe degradation: the helper
+    # must return exit 0 with all-empty classification (fromjson? handles it).
+    # In production FIX-1 prevents this string from ever reaching the helper by
+    # using find+mapfile to count files before calling jq.
+    malformed=$'[]\n[]'
+    run aggregate_build_results "$malformed" '["postgres","web-shell"]'
+    [ "$status" -eq 0 ]
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    [ "$failed" = "[]" ]
+    [ "$recovered" = "[]" ]
+    [ "$unmapped" = "false" ]
+}
+
 @test "extract_failed_recovered: bare-array form of large payload (>128KB) succeeds — stdin normalisation" {
     # Same as the previous test but the payload is a bare JSON array [...] rather than
     # {"jobs":[...]}.  Verifies that the stdin-path normalisation


### PR DESCRIPTION
## #595 slice 2 — robust failure attribution via per-matrix build-result artifacts

### Problem (proven live in the slice-1 bootstrap)
Slice 1 attributed coverage-checkpoint failures by token-matching `gh run view --json jobs`
names — fragile in production:
- a `Build web-shell:debian` failure falsely blamed the **`debian`** container (token collision);
- an infra job (`Sync base images`) mapped to no container → `unmapped_failure=true` → fail-closed
  **carry-all of every container** (the tag's `failed_containers` was all 13).

### Change
Each build job (`build-and-push`, `create-manifest`, `build-extensions`, `merge-extension-manifests`)
emits a machine-readable `.build-lineage/build-result-<key>.json` =
`{container, variant, tag, arch, result}` under a **unique** artifact name (`if: always()`,
`result` derived from `${{ job.status }}` so an upstream-step failure can't masquerade as success).
The `publish-coverage-checkpoint` job downloads them (`--pattern 'build-result-*'`, deterministic
`find`/`mapfile` guard) and aggregates per container via the new pure helper `aggregate_build_results`:
- **failure attribution** is artifact-record-based and exact (`matrix.build.container`) → no token
  collision; infra jobs emit nothing → can't pollute;
- **completeness gate**: `unmapped_failure=true` iff the number of terminal-failed jobs that map to a
  matrix container (token-match, plus an explicit alias for the postgres `PostgreSQL Extensions` /
  `Extension Manifests` pipeline jobs) **exceeds** the number of failure records — i.e. a build-job
  failure lacking a record (crash/timeout before the `always()` emit) fails closed (carry-all),
  never drops a real failure;
- falls back to slice-1 job-name matching when no artifacts are present.
`merge_failed_set` is unchanged.

### Result
Replay on the real build-all run (26921499440): `failed_containers` narrows from **all-13** to
**`{github-runner, web-shell}`**; `debian` correctly recovers (no false-positive); the
`Sync base images` infra failure no longer forces carry-all.

### Tests / gates
- `tests/unit/coverage-checkpoint-utils.bats`: **54** unit tests, each regression-lock naming its
  mutation (collision, infra-ignored, multi-arch missing-record stranding, count off-by-one,
  crashed ext/merge jobs, succeeded-ext negative). shellcheck clean; actionlint no new findings.
- Pre-push senior review (opus) + orthogonal gate (codex xhigh + copilot) — **dual-CLEAN** after a
  6-round convergence on failure-attribution-under-partial-observability (each round closed a real
  fail-closed gap: zero-artifact routing, `job.status` emit, recovery gate, count invariant,
  collision+crash, postgres ext/merge job-name alias).

### Live validation (post-merge, expected)
The next master run carries the current all-13 tag state forward (one last broad run; most legs
skip via `should_skip_build`), and its checkpoint reads the new artifacts → rewrites the tag's
`failed_containers` to `{github-runner, web-shell}`. Subsequent runs build only those + the diff.

### Follow-up (slices 3-4)
- Slice 3: per-container build-failure issue lifecycle (open/close container-scoped).
- Slice 4: command-scoped 3× build/push retries.
- Known narrow residual: a crashed ext/merge job is covered by the count alias; the slice-1
  name-matching fallback covers whole-run artifact absence.
