### PR TITLE
feat(ci): per-container build-failure issue lifecycle from checkpoint state (#595)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1445,6 +1445,20 @@ jobs:
     permissions:
       contents: write  # Required to push the coverage checkpoint tag
       actions: read    # Required to read job conclusions via gh run view
+      issues: write    # Required to open/close per-container build-failure issues
+    outputs:
+      # 3-state routing signal for the summary job's generic-issue gate:
+      #   per-container — real-push, ftr is precise; summary must NOT open generic issue
+      #   generic       — real-push but unmapped=true; precise ftr subset opened, unattributed remainder needs generic
+      #   deferred      — guard-break; newer run owns issues; summary must NOT open generic
+      #   uncovered     — CAS-exhaust; tag not advanced; summary MUST open generic issue
+      #   ''            — job skipped or failed before emit; summary MUST open generic issue
+      issue_mode: ${{ steps.publish.outputs.issue_mode }}
+      # Precise failure set for THIS run (artifact-attributed).  Used by summary Path 1
+      # as FAILED_ALLOWLIST to prevent spurious dep:<c> issues when the commit names a
+      # container that did not actually fail.  Empty string when checkpoint was skipped/
+      # crashed or when guard-break fired (summary must treat '' as "no allowlist").
+      failed_this_run: ${{ steps.publish.outputs.failed_this_run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1452,6 +1466,7 @@ jobs:
           fetch-depth: 0
 
       - name: Compute and publish coverage checkpoint tag
+        id: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1459,6 +1474,10 @@ jobs:
           MATRIX_CONTAINERS: ${{ needs.detect-containers.outputs.containers }}
           # github.repository is owner/repo format (trusted context, no user content).
           GH_REPOSITORY: ${{ github.repository }}
+          # Required by open-dep-failure-issue.sh source-time :? guards (per-container issue loops).
+          # GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_SERVER_URL, GITHUB_SHA,
+          # GITHUB_EVENT_NAME, GITHUB_REF_NAME are auto-set by the GHA runner.
+          COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
@@ -1528,6 +1547,16 @@ jobs:
           # already advanced beyond this run (forward-only guard).
           TAG="auto-build-coverage-master"
           pushed=false
+          # published tracks ONLY the real-push branch (not guard-break).
+          # Guard-break: a newer run already owns the baseline and manages issues.
+          # CAS-exhaust: tag not advanced → summary opens generic issue.
+          published=false
+          prior_failed='[]'
+          new_failed='[]'
+          # ftr_safe: safe default for the failed_this_run output on guard-break/CAS-exhaust.
+          # ftr is set by classify (Step 3) above; this ensures failed_this_run is always
+          # a valid JSON array even if the loop exits early via guard-break.
+          ftr_safe="${ftr:-[]}"
           for attempt in 1 2 3 4 5; do
             # Re-fetch the current remote tag (force, so our local ref tracks remote exactly).
             git fetch --force --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
@@ -1539,6 +1568,11 @@ jobs:
             if [[ -n "$remote_sha" ]] && ! git merge-base --is-ancestor "$remote_sha" "$GITHUB_SHA" 2>/dev/null; then
               echo "::notice::Coverage checkpoint already advanced beyond this run (remote=$remote_sha) — skipping; a newer run owns the baseline"
               pushed=true   # treat as success: a newer run's state supersedes ours
+              # published stays false: the newer run manages per-container issues, not us.
+              # F1 — guard-break invariant: `deferred` is reachable only because remote_sha is
+              # strictly ahead of this run's SHA — a newer run already published the tag and
+              # its own CAS close loop (re-reading fresh prior_failed) will close any recovered
+              # containers.  No orphaned open issue can result from this path.
               break
             fi
 
@@ -1565,16 +1599,84 @@ jobs:
                  "refs/tags/${TAG}" 2>/dev/null; then
               echo "::notice::Coverage checkpoint advanced to $GITHUB_SHA — failed_containers=${new_failed} (attempt $attempt)"
               pushed=true
+              published=true   # real-push: this run owns the baseline and manages issues
               break
             fi
             echo "::warning::Coverage checkpoint CAS lost (attempt $attempt) — a concurrent run updated the tag; retrying"
           done
           if [[ "$pushed" != "true" ]]; then
             echo "::warning::Coverage checkpoint not advanced after retries (heavy concurrency) — next run will re-diff from the existing baseline"
+            # F2 — CAS-exhaust deferred-close: published=false → the per-container close loop
+            # is intentionally skipped below.  A recovered container's issue lingers until the
+            # next real-push run closes it (fail-safe: the generic backstop still alerts via
+            # issue_mode=uncovered → summary opens "Auto Build Failed", so no alert is missed).
           fi
 
+          # Compute base issue_mode (NOT emitted yet — may be downgraded after open loop).
+          #   per-container — real-push, precise attribution; summary suppresses generic open
+          #   generic       — real-push + unmapped; ftr subset opened, unattributed failure remains
+          #                   OR downgraded from per-container when open loop fails
+          #   deferred      — guard-break; newer run owns issues; summary suppresses generic open
+          #   uncovered     — CAS-exhaust; summary must open generic issue
+          if [[ "$published" == "true" ]]; then
+            if [[ "$unmapped" == "true" ]]; then
+              base="generic"
+            else
+              base="per-container"
+            fi
+          elif [[ "$pushed" == "true" ]]; then
+            base="deferred"
+          else
+            base="uncovered"
+          fi
+
+          # Per-container issue management — only when this run published the tag (real-push).
+          # Open loop iterates ftr (precise artifact-attributed failures for THIS run only).
+          # new_failed (carry-forward set) is intentionally NOT used here: carried-from-prior
+          # containers already have an open issue from when they first failed.
+          # On unmapped=true, ftr is the attributed subset; the unattributed remainder surfaces
+          # via base=generic → summary opens the generic "Auto Build Failed" issue.
+          # issue_open_failed: tracks whether any per-container open failed so we can
+          # downgrade base=per-container → generic (summary then opens the generic backstop).
+          issue_open_failed=false
+          if [[ "$published" == "true" ]]; then
+            recovered=$(jq -cn --argjson p "$prior_failed" --argjson n "$new_failed" \
+              '[ $p[] | select( . as $x | ($n | index($x)) | not ) ]')
+
+            # Open/comment a per-container issue for each container that failed THIS run (ftr).
+            chmod +x scripts/open-dep-failure-issue.sh
+            while IFS= read -r c; do
+              [[ -z "$c" ]] && continue
+              ./scripts/open-dep-failure-issue.sh --mode failure --container "$c" || issue_open_failed=true
+            done < <(echo "$ftr" | jq -r '.[]' 2>/dev/null || true)
+
+            # Close the per-container issue for each recovered container (prior − new_failed).
+            # Close is best-effort: a failure here does not affect issue_mode routing.
+            while IFS= read -r c; do
+              [[ -z "$c" ]] && continue
+              ./scripts/open-dep-failure-issue.sh --mode recovery --container "$c" || true
+            done < <(echo "$recovered" | jq -r '.[]' 2>/dev/null || true)
+          fi
+
+          # Downgrade per-container → generic when any open failed.
+          # The summary's checkpoint_covers becomes false → it opens the generic "Auto Build
+          # Failed" backstop so no failed build is left without an alert.
+          if [[ "$base" == "per-container" && "$issue_open_failed" == "true" ]]; then
+            echo "::warning::one or more per-container issue opens failed — downgrading issue_mode to generic"
+            base="generic"
+          fi
+
+          # Emit issue_mode exactly once, after all loops and potential downgrade.
+          echo "issue_mode=${base}" >> "$GITHUB_OUTPUT"
+
+          # Emit failed_this_run: the precise artifact-attributed failure set for THIS run.
+          # ftr_safe is initialized from ftr (Step 3) before the CAS loop; it is '[]' on
+          # guard-break (published=false, pushed=true) and on CAS-exhaust (pushed=false).
+          # The summary job reads this as FAILED_ALLOWLIST; '' means "no allowlist".
+          echo "failed_this_run=${ftr_safe}" >> "$GITHUB_OUTPUT"
+
   summary:
-    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries]
+    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries, publish-coverage-checkpoint]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1768,6 +1870,25 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Open dep-attributed or generic build-failure issue
+        # Two independent paths run in sequence:
+        #
+        # 1. Dep-attributed open (best-effort, rich context):
+        #    ./open-dep-failure-issue.sh (no --container) reads commit/PR signals.
+        #    rc=0 → dep-bump issue opened/commented.
+        #    rc=1 → no dep-bump context (info only — does NOT gate the generic).
+        #    rc=3 → gh API/create failure (warning only — does NOT gate the generic).
+        #    rc=2 → missing required env var (fatal).
+        #    The dep-attributed open is decoupled from the generic gate; it enriches
+        #    the issue log but does not control whether a generic backstop is opened.
+        #
+        # 2. Generic "Auto Build Failed" gate (authoritative, driven by issue_mode):
+        #    issue_mode is the checkpoint job output — it encodes what the checkpoint
+        #    already handled. Gate logic:
+        #      per-container → checkpoint opened precise issues; NO generic needed
+        #      deferred      → guard-break; newer run owns issues; NO generic needed
+        #      generic       → checkpoint opened attributed subset OR downgraded; OPEN generic
+        #      uncovered     → CAS-exhaust; tag not advanced; OPEN generic
+        #      ''            → checkpoint skipped/failed/crashed; OPEN generic
         if: steps.summary.outputs.build_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1783,59 +1904,84 @@ jobs:
           PR_BODY: ${{ steps.ctx.outputs.pr_body }}
           PR_LABELS: ${{ steps.ctx.outputs.pr_labels }}
           FAILED_JOBS_JSON: ${{ steps.ctx.outputs.failed_jobs_json }}
+          # Allowlist for Path 1: only open a dep-attributed issue when the commit-attributed
+          # container actually failed this run.  '' (checkpoint skipped/guard-break/CAS-exhaust)
+          # means no cross-check — original behaviour for non-checkpoint runs preserved.
+          FAILED_ALLOWLIST: ${{ needs.publish-coverage-checkpoint.outputs.failed_this_run }}
         run: |
           chmod +x scripts/open-dep-failure-issue.sh
-          if ./scripts/open-dep-failure-issue.sh; then
-            echo "Dep-attributed issue opened/updated"
+
+          # --- Path 1: dep-attributed open (best-effort, decoupled from generic gate) ---
+          # Path-1 gating matrix (issue_mode from checkpoint job output):
+          #   per-container  — real-push, current run owns issues; Path 1 runs (cross-checked via FAILED_ALLOWLIST)
+          #   generic        — real-push + unmapped or downgraded; Path 1 runs (same)
+          #   uncovered      — CAS-exhaust, current run; Path 1 runs (generic also fires; FAILED_ALLOWLIST='[]')
+          #   ''             — non-checkpoint run (workflow_dispatch/call/skipped): Path 1 runs (#514 original behaviour)
+          #   deferred       — guard-break: this run SUPERSEDED by a newer run that owns issue management;
+          #                    Path 1 SKIPPED to prevent a stale older run from resurrecting an issue
+          #                    the newer run already closed (FAILED_ALLOWLIST is this run's ftr, non-empty).
+          issue_mode="${{ needs.publish-coverage-checkpoint.outputs.issue_mode }}"
+          if [[ "$issue_mode" == "deferred" ]]; then
+            echo "issue_mode=deferred: this run was superseded by a newer run — skipping dep-attributed open (Path 1)"
           else
-            rc=$?
-            if [ "$rc" -eq 1 ]; then
-              echo "No dep-bump context detected, falling back to generic issue"
-              # Generic "Auto Build Failed" issue is a master-health tracker.
-              # Open/comment it on any master build that is not a PR smoke run.
-              # This covers push, workflow_call (upstream-monitor), and
-              # workflow_dispatch — all real master builds.
-              # PR smoke failures surface via their own check status and must not
-              # create a persistent master-health issue (cross-event symmetry:
-              # generic-open ↔ generic-close both exclude pull_request).
-              if [ "$GITHUB_EVENT_NAME" != "pull_request" ] && [ "$GITHUB_REF_NAME" = "master" ]; then
-                existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-                  --label "build-failure" --state open --limit 5 --json title,number \
-                  | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
-                run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-                if [[ -n "$existing" ]]; then
-                  echo "Adding comment to existing issue #$existing"
-                  comment_body="$(printf '## Another build failure detected\n\n**Run:** [%s](%s)\n**Trigger:** `%s`\n**Ref:** `%s`\n**Time:** %s' \
-                    "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
-                    "$(date -u +'%Y-%m-%d %H:%M UTC')")"
-                  gh issue comment --repo "$GITHUB_REPOSITORY" "$existing" --body "$comment_body"
-                else
-                  echo "Creating new build failure issue"
-                  issue_body="$(printf '## Build Failure Alert\n\nOne or more container builds failed in the auto-build workflow.\n\n| Property | Value |\n|----------|-------|\n| **Run** | [%s](%s) |\n| **Trigger** | `%s` |\n| **Ref** | `%s` |\n| **Commit** | `%s` |\n\n## Next Steps\n\n1. Check the [workflow run](%s) for details\n2. Identify which container(s) failed\n3. Test locally: `./make build <container>`\n4. Fix and push to trigger rebuild\n\n---\n_Auto-generated by CI workflow_' \
-                    "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
-                    "$GITHUB_SHA" "$run_url")"
-                  gh issue create --repo "$GITHUB_REPOSITORY" \
-                    --title "Auto Build Failed - $(date -u +%Y-%m-%d)" \
-                    --label "build-failure,automation" \
-                    --body "$issue_body"
-                fi
-              else
-                echo "Skipping generic issue: pull_request event or non-master ref (event=$GITHUB_EVENT_NAME ref=$GITHUB_REF_NAME)"
-              fi
+            dep_rc=0
+            ./scripts/open-dep-failure-issue.sh || dep_rc=$?
+            if [ "$dep_rc" -eq 0 ]; then
+              echo "Dep-attributed issue opened/updated"
+            elif [ "$dep_rc" -eq 1 ]; then
+              echo "No dep-bump context detected — dep-attributed open skipped (info only)"
+            elif [ "$dep_rc" -eq 3 ]; then
+              echo "::warning::open-dep-failure-issue.sh: gh issue operation failed (rc=3) — dep-attributed issue may be missing"
+            elif [ "$dep_rc" -eq 2 ]; then
+              echo "open-dep-failure-issue.sh: missing required env var (rc=2)"
+              exit 2
             else
-              echo "open-dep-failure-issue.sh failed with exit $rc"
-              exit "$rc"
+              echo "::warning::open-dep-failure-issue.sh: unexpected exit code $dep_rc"
             fi
           fi
 
-      - name: Close build-failure issue on recovery
-        # Close the open "Auto Build Failed" generic issue when a real build
-        # completes successfully on master (any non-PR trigger: push, workflow_call,
-        # workflow_dispatch).  Requires a POSITIVE success signal (build_succeeded)
-        # so a count=0 no-op run cannot mark a past failure as recovered.
-        # Only runs on master to avoid closing on PR smoke runs or other branches.
-        # continue-on-error: closing a stale issue is non-critical; a transient
-        # gh API error must never fail an otherwise-green master run.
+          # --- Path 2: generic "Auto Build Failed" gate (driven by issue_mode) ---
+          # issue_mode already set above (Path 1 gate); re-used here.
+          # This gate is the sole control for whether a generic backstop is opened.
+          if [[ "$issue_mode" == "per-container" || "$issue_mode" == "deferred" ]]; then
+            echo "issue_mode=${issue_mode}: checkpoint handled per-container issues — skipping generic issue"
+          elif [ "$GITHUB_EVENT_NAME" != "pull_request" ] && [ "$GITHUB_REF_NAME" = "master" ]; then
+            # issue_mode is generic, uncovered, or '' → open the generic backstop.
+            echo "issue_mode=${issue_mode:-''}: opening generic 'Auto Build Failed' backstop"
+            existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+              --label "build-failure" --state open --limit 5 --json title,number \
+              | jq -r '.[] | select(.title | contains("Auto Build Failed")) | .number' | head -1)
+            run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            if [[ -n "$existing" ]]; then
+              echo "Adding comment to existing generic issue #$existing"
+              # shellcheck disable=SC2016  # \n in single-quoted printf format — interpreted by printf, not shell
+              comment_body="$(printf '## Another build failure detected\n\n**Run:** [%s](%s)\n**Trigger:** `%s`\n**Ref:** `%s`\n**Time:** %s' \
+                "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                "$(date -u +'%Y-%m-%d %H:%M UTC')")"
+              gh issue comment --repo "$GITHUB_REPOSITORY" "$existing" --body "$comment_body"
+            else
+              echo "Creating generic build failure issue"
+              # shellcheck disable=SC2016  # \n in single-quoted printf format — interpreted by printf, not shell
+              issue_body="$(printf '## Build Failure Alert\n\nOne or more container builds failed in the auto-build workflow.\n\n| Property | Value |\n|----------|-------|\n| **Run** | [%s](%s) |\n| **Trigger** | `%s` |\n| **Ref** | `%s` |\n| **Commit** | `%s` |\n\n## Next Steps\n\n1. Check the [workflow run](%s) for details\n2. Identify which container(s) failed\n3. Test locally: `./make build <container>`\n4. Fix and push to trigger rebuild\n\n---\n_Auto-generated by CI workflow_' \
+                "$GITHUB_RUN_ID" "$run_url" "$GITHUB_EVENT_NAME" "$GITHUB_REF_NAME" \
+                "$GITHUB_SHA" "$run_url")"
+              gh issue create --repo "$GITHUB_REPOSITORY" \
+                --title "Auto Build Failed - $(date -u +%Y-%m-%d)" \
+                --label "build-failure,automation" \
+                --body "$issue_body"
+            fi
+          else
+            echo "Skipping generic issue: pull_request event or non-master ref (event=$GITHUB_EVENT_NAME ref=$GITHUB_REF_NAME)"
+          fi
+
+      - name: Close generic build-failure issue on recovery
+        # Closes the generic "Auto Build Failed" issue (labels build-failure,automation,
+        # title "Auto Build Failed") when a real build succeeds on master.
+        # This ONLY ever matches the generic title issue — it cannot close per-container
+        # dep:<c> issues (different labels/title).  Therefore it is safe to run on ANY
+        # all-green master run: if a checkpoint-covered run had an open generic issue
+        # (opened by a prior dispatch/detect-fail run), this step cleans it up correctly.
+        # continue-on-error: closing a stale issue is non-critical.
         continue-on-error: true
         if: >-
           github.event_name != 'pull_request' &&
@@ -1849,8 +1995,6 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-          # COMMIT_SUBJECT is required by the script's source-time :? guard even
-          # in recovery mode (it runs before main() parses --mode).
           COMMIT_SUBJECT: "recovery-check"
         run: |
           chmod +x scripts/open-dep-failure-issue.sh

--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -10,9 +10,11 @@
 #
 # Exit codes:
 #   0  — issue created or commented successfully (or DRY_RUN printed)
-#   1  — no dep-bump detected (caller should fall back to generic issue logic)
+#   1  — no dep-bump detected (caller must fall back to generic issue logic; NOT a gh error)
 #   2  — missing required env var
-#   3  — gh CLI error after retries
+#   3  — gh CLI / issue-operation failure (create failed, comment failed, number unparseable)
+#        Callers: rc=1 → "no dep-bump" (info); rc=3 → "gh op failed" (warning); neither
+#        gates the generic issue — that is decided solely by issue_mode from the checkpoint job.
 
 set -euo pipefail
 
@@ -595,26 +597,26 @@ VDRIFT_COMMENT
 # Returns 0 on success (including "not found"), 1 on gh CLI error.
 # ---------------------------------------------------------------------------
 find_open_generic_build_failure_issue() {
-    local search_stdout search_rc
+    local search_stdout
     # Capture stdout and stderr separately so gh warnings cannot corrupt the
     # JSON that jq will parse.  Finding 4: do NOT merge stderr into stdout.
+    # Use if-! pattern: under set -euo pipefail, bare `x=$(cmd); rc=$?` aborts
+    # on gh failure before the rc check is ever reached (dead code).
     local stderr_tmp
     stderr_tmp="$(mktemp)"
-    search_stdout=$(run_gh issue list \
+    if ! search_stdout=$(run_gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --label "build-failure" \
             --label "automation" \
             --state open \
             --limit 5 \
-            --json title,number 2>"$stderr_tmp"); search_rc=$?
-    if [[ $search_rc -ne 0 ]]; then
+            --json title,number 2>"$stderr_tmp"); then
         # Log the captured stderr for diagnostics
         if [[ -s "$stderr_tmp" ]]; then
             printf '::warning::find_open_generic_build_failure_issue: gh issue list failed: %s\n' \
                 "$(cat "$stderr_tmp")" >&2
         else
-            printf '::warning::find_open_generic_build_failure_issue: gh issue list failed (rc=%d)\n' \
-                "$search_rc" >&2
+            printf '::warning::find_open_generic_build_failure_issue: gh issue list failed\n' >&2
         fi
         rm -f "$stderr_tmp"
         return 1
@@ -788,10 +790,14 @@ find_or_create_issue() {
 | **Time** | $(date -u +'%Y-%m-%d %H:%M UTC') |
 COMMENT
 )"
-        retry_with_backoff 3 5 gh issue comment \
-            --repo "$GITHUB_REPOSITORY" \
-            "$existing_number" \
-            --body "$comment_body" >&2
+        if ! retry_with_backoff 3 5 gh issue comment \
+                --repo "$GITHUB_REPOSITORY" \
+                "$existing_number" \
+                --body "$comment_body" >&2; then
+            printf '::warning::find_or_create_issue: gh issue comment failed for [%s] on issue #%s\n' \
+                "$container" "$existing_number" >&2
+            return 3
+        fi
         echo "commented #${existing_number}"
     else
         # Ensure the dep:<container> label exists (create if missing — best effort)
@@ -800,31 +806,183 @@ COMMENT
             --color "e4e669" \
             --description "Dep-attributed build failures for ${container}" 2>/dev/null || true
 
+        # Capture create output; validate non-empty numeric issue number.
+        # Do NOT use `| grep ... || true` — that masks gh exit code and can
+        # produce an empty number while still printing "created #".
+        local create_out
+        if ! create_out=$(retry_with_backoff 3 5 gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$issue_title" \
+                --label "$dedup_labels" \
+                --body "$issue_body"); then
+            printf '::warning::find_or_create_issue: gh issue create failed for [%s]\n' \
+                "$container" >&2
+            return 3
+        fi
         local new_number
-        new_number=$(retry_with_backoff 3 5 gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$issue_title" \
-            --label "$dedup_labels" \
-            --body "$issue_body" \
-            | grep -o '[0-9]*$' || true)
+        new_number=$(printf '%s' "$create_out" | grep -o '[0-9]*$' || true)
+        if [[ -z "$new_number" ]] || ! [[ "$new_number" =~ ^[0-9]+$ ]]; then
+            printf '::warning::find_or_create_issue: gh issue create succeeded but returned no issue number for [%s] (output: %s)\n' \
+                "$container" "$create_out" >&2
+            return 3
+        fi
         echo "created #${new_number}"
     fi
+}
+
+# ---------------------------------------------------------------------------
+# close_container_build_failure_on_recovery <container>
+#
+# Container-scoped recovery: finds an open issue with labels
+# build-failure,automation,dep:<container> and closes it with a recovery
+# comment.  No open issue → no-op exit 0.
+# Exit codes:
+#   0 — closed successfully, or no open issue found (no-op)
+#   3 — gh CLI error
+# ---------------------------------------------------------------------------
+close_container_build_failure_on_recovery() {
+    local container="$1"
+
+    # Validate container name — must match safe label chars.
+    if ! [[ "$container" =~ ^[a-z0-9_-]+$ ]]; then
+        printf '::warning::close_container_build_failure_on_recovery: container name failed validation; skipping\n' >&2
+        return 0
+    fi
+
+    local safe_run_id
+    if [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]; then
+        safe_run_id="$GITHUB_RUN_ID"
+    else
+        safe_run_id=""
+    fi
+
+    local safe_ref_name
+    if [[ "$GITHUB_REF_NAME" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+        safe_ref_name="$GITHUB_REF_NAME"
+    else
+        safe_ref_name=""
+    fi
+
+    local safe_sha="${GITHUB_SHA:0:8}"
+    if ! [[ "$safe_sha" =~ ^[0-9a-fA-F]+$ ]]; then
+        safe_sha=""
+    fi
+
+    local run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${safe_run_id}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY_RUN] Container recovery close: would search for open issue with labels build-failure,automation,dep:${container}"
+        log_info "[DRY_RUN] Would close with recovery comment referencing run ${safe_run_id}"
+        return 0
+    fi
+
+    # Search for open issue scoped to this container.
+    # Use if-! pattern: under set -euo pipefail, bare `x=$(cmd); rc=$?` aborts
+    # on gh failure before the rc check is ever reached (dead code).
+    local search_stdout
+    local stderr_tmp
+    stderr_tmp="$(mktemp)"
+    if ! search_stdout=$(run_gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "build-failure" \
+            --label "automation" \
+            --label "dep:${container}" \
+            --state open \
+            --limit 5 \
+            --json number,title 2>"$stderr_tmp"); then
+        if [[ -s "$stderr_tmp" ]]; then
+            printf '::warning::close_container_build_failure_on_recovery: gh issue list failed: %s\n' \
+                "$(cat "$stderr_tmp")" >&2
+        else
+            printf '::warning::close_container_build_failure_on_recovery: gh issue list failed\n' >&2
+        fi
+        rm -f "$stderr_tmp"
+        return 0
+    fi
+    rm -f "$stderr_tmp"
+
+    local issue_number
+    issue_number=$(printf '%s' "$search_stdout" \
+        | jq -r 'if type=="array" then .[0].number // empty else empty end' \
+        | head -1 || true)
+
+    if [[ -z "$issue_number" ]]; then
+        log_info "Container recovery (${container}): no open issue found — nothing to close."
+        return 0
+    fi
+
+    log_info "Container recovery (${container}): closing issue #${issue_number} (run ${safe_run_id})"
+
+    local comment_body
+    comment_body="$(cat <<RECOVERY_COMMENT
+## Build recovered
+
+The container \`${container}\` built successfully — this failure has been resolved.
+
+| Property | Value |
+|----------|-------|
+| **Recovering run** | [${safe_run_id}](${run_url}) |
+| **Ref** | \`${safe_ref_name}\` |
+| **Commit** | \`${safe_sha}\` |
+| **Time** | $(date -u +'%Y-%m-%d %H:%M UTC') |
+
+_Auto-closed by \`scripts/open-dep-failure-issue.sh --mode recovery --container ${container}\`_
+RECOVERY_COMMENT
+)"
+
+    if ! run_gh issue comment \
+            --repo "$GITHUB_REPOSITORY" \
+            "$issue_number" \
+            --body "$comment_body" >&2; then
+        printf '::warning::close_container_build_failure_on_recovery: gh issue comment failed (non-critical, continuing)\n' >&2
+        return 0
+    fi
+
+    if ! run_gh issue close \
+            --repo "$GITHUB_REPOSITORY" \
+            "$issue_number" >&2; then
+        printf '::warning::close_container_build_failure_on_recovery: gh issue close failed (non-critical, continuing)\n' >&2
+        return 0
+    fi
+
+    log_success "Container recovery (${container}): closed issue #${issue_number}"
+    return 0
 }
 
 # ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------
 main() {
-    # Parse optional --mode flag
+    # Parse optional --mode and --container flags
     local mode="failure"
+    local OVERRIDE_CONTAINER=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --mode)
-                mode="$2"
+                # Guard: --mode requires a following value; ${2:-} avoids unbound-var abort under set -u.
+                mode="${2:-}"
+                if [[ -z "$mode" ]]; then
+                    printf '::warning::open-dep-failure-issue: --mode requires a value\n' >&2
+                    return 2
+                fi
                 shift 2
                 ;;
             --mode=*)
                 mode="${1#--mode=}"
+                shift
+                ;;
+            --container)
+                # Guard: --container with no following value would hit $2: unbound variable under set -u
+                # (exit 1, misread as no-dep-bump).  Use ${2:-} and validate explicitly.
+                OVERRIDE_CONTAINER="${2:-}"
+                if [[ -z "$OVERRIDE_CONTAINER" ]]; then
+                    printf '::warning::open-dep-failure-issue: --container requires a value\n' >&2
+                    return 2
+                fi
+                shift 2
+                ;;
+            --container=*)
+                OVERRIDE_CONTAINER="${1#--container=}"
                 shift
                 ;;
             *)
@@ -834,9 +992,56 @@ main() {
     done
 
     if [[ "$mode" == "recovery" ]]; then
+        if [[ -n "$OVERRIDE_CONTAINER" ]]; then
+            log_step "Recovery mode (container-scoped): closing issue for ${OVERRIDE_CONTAINER} if any..."
+            close_container_build_failure_on_recovery "$OVERRIDE_CONTAINER"
+            exit $?
+        fi
         log_step "Recovery mode: closing open build-failure issue if any..."
         close_build_failure_on_recovery
         exit $?
+    fi
+
+    # When --container is set, bypass auto-detection and use the override directly.
+    if [[ -n "$OVERRIDE_CONTAINER" ]]; then
+        # Validate container name — must match safe label chars (mirrors recovery-close guard).
+        if ! [[ "$OVERRIDE_CONTAINER" =~ ^[a-z0-9_-]+$ ]]; then
+            printf '::warning::open-dep-failure-issue: --container value failed ^[a-z0-9_-]+$ validation; returning 3\n' >&2
+            # Return 3 (gh/op failure class), NOT 0.  The checkpoint loop's
+            # `|| issue_open_failed=true` catches any non-zero → issue_mode downgrades
+            # per-container→generic → the generic backstop alerts.  Returning 0 here
+            # would hide the failure and silently drop the alert for this container.
+            # (Recovery/close invalid-name keeps best-effort return 0 — close has no
+            # alert obligation; this fail-closed behaviour is for the OPEN path only.)
+            return 3
+        fi
+        log_step "Container override mode: opening issue for ${OVERRIDE_CONTAINER}..."
+        local container="$OVERRIDE_CONTAINER"
+        local kind="version-bump"  # safe default when called from checkpoint (no dep-bump context)
+
+        # Build issue title
+        local short_sha="${GITHUB_SHA:0:8}"
+        local issue_title="🚨 [${container}] Build failed (commit ${short_sha})"
+
+        # Build a minimal deps table (no PR context in checkpoint mode)
+        local deps_json
+        deps_json="$(extract_dep_details "$container" "$kind")"
+        local deps_table
+        deps_table="$(build_deps_table "$deps_json")"
+
+        local issue_body
+        issue_body="$(build_issue_body "$container" "$deps_table" "")"
+
+        local result find_rc
+        find_rc=0
+        result="$(find_or_create_issue "$container" "$issue_title" "$issue_body")" || find_rc=$?
+        if [[ "$find_rc" -ne 0 ]]; then
+            log_info "find_or_create_issue failed for [${container}] (rc=${find_rc}) — propagating to caller"
+            return "$find_rc"
+        fi
+        log_success "Issue action: ${result}"
+        echo "$result"
+        return 0
     fi
 
     log_step "Detecting dep bump from commit/PR signals..."
@@ -849,6 +1054,29 @@ main() {
     local container="$DETECTED_CONTAINER"
     local kind="$DETECTED_KIND"
     log_info "Detected: container=${container} kind=${kind}"
+
+    # F3 — allowlist cross-check: if the checkpoint published a precise failure set
+    # (FAILED_ALLOWLIST env, a JSON array of container names that failed THIS run),
+    # skip opening a dep-attributed issue when the detected container is NOT in that set.
+    # This prevents spurious dep:<c> issues when a dep-bump commit names a container
+    # that actually built fine (another job caused build_failed=true).
+    #
+    # Behaviour matrix:
+    #   FAILED_ALLOWLIST unset/empty → no cross-check (non-checkpoint runs: workflow_dispatch/call,
+    #                                   skipped checkpoint) — original #514 behaviour preserved.
+    #   FAILED_ALLOWLIST set, valid JSON array, container present → proceed normally.
+    #   FAILED_ALLOWLIST set, valid JSON array, container absent  → return 1 (no-op, same as no-dep-bump).
+    #   FAILED_ALLOWLIST set, invalid JSON                        → treat as empty (no cross-check; safe).
+    if [[ -n "${FAILED_ALLOWLIST:-}" ]]; then
+        local in_allowlist
+        in_allowlist=$(printf '%s' "$FAILED_ALLOWLIST" \
+            | jq -e --arg c "$container" 'if type=="array" then (index($c) != null) else false end' \
+            2>/dev/null || true)
+        if [[ "$in_allowlist" == "false" ]]; then
+            log_info "::notice::detected container [${container}] is not in the checkpoint failure set (${FAILED_ALLOWLIST}) — skipping dep-attributed open (no spurious issue)"
+            exit 1
+        fi
+    fi
 
     # Build issue title
     local short_sha="${GITHUB_SHA:0:8}"
@@ -886,8 +1114,13 @@ main() {
     issue_body="$(build_issue_body "$container" "$deps_table" "$log_excerpt")"
 
     # Find or create issue
-    local result
-    result="$(find_or_create_issue "$container" "$issue_title" "$issue_body")"
+    local result find_rc
+    find_rc=0
+    result="$(find_or_create_issue "$container" "$issue_title" "$issue_body")" || find_rc=$?
+    if [[ "$find_rc" -ne 0 ]]; then
+        log_info "find_or_create_issue failed for [${container}] (rc=${find_rc}) — propagating to caller"
+        return "$find_rc"
+    fi
     log_success "Issue action: ${result}"
     echo "$result"
 }

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -958,3 +958,527 @@ LOGIC
     run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
     [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Proof A — container-scoped open: --mode failure --container <c>
+#
+# With --container set, the script opens/comments the dep:<c> issue WITHOUT
+# relying on commit/PR/branch auto-detection.  Even when no dep-bump signal
+# is present in the environment, it must still open the issue (exit 0).
+# ---------------------------------------------------------------------------
+
+@test "Proof A: --container postgres in DRY_RUN opens dep:postgres issue (no auto-detection required)" {
+    # Clear all dep-bump signals — auto-detection would return 1 without the override.
+    export COMMIT_SUBJECT="chore: unrelated commit"
+    export GITHUB_REF_NAME="master"
+    unset PR_TITLE PR_NUMBER PR_BODY PR_LABELS
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container postgres
+    # Must succeed (not exit 1 like the no-override path would)
+    [ "$status" -eq 0 ]
+
+    # DRY_RUN output must reference the dep:postgres dedup label set
+    [[ "$output" == *"dep:postgres"* ]]
+}
+
+@test "Proof A: --container postgres DRY_RUN shows issue title containing [postgres]" {
+    export COMMIT_SUBJECT="chore: unrelated"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container postgres
+    [ "$status" -eq 0 ]
+
+    # Issue title must reference the container name
+    [[ "$output" == *"[postgres]"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Proof B — container-scoped close: --mode recovery --container <c>
+#
+# Mutation locked: close_container_build_failure_on_recovery searches by
+# labels build-failure,automation,dep:<container> — NOT by title substring
+# "Auto Build Failed".  If you change the label query to a title-based search
+# (the global close bug), Proof B breaks because the mock returns an issue
+# with "Auto Build Failed" title but WITHOUT the dep:postgres label filter.
+#
+# Critically: a different container's issue (dep:nginx) must NOT be closed.
+# ---------------------------------------------------------------------------
+
+@test "Proof B: --mode recovery --container postgres closes dep:postgres issue, not dep:nginx" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+
+    # Mock: --label dep:postgres → return postgres issue.
+    #       --label dep:nginx   → return nginx issue (must NOT be closed).
+    #       Close must only target #77 (postgres).
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"--label dep:postgres"*)
+        echo '[{"number":77,"title":"Build failed postgres"}]'
+        ;;
+    *"--label dep:nginx"*)
+        echo '[{"number":88,"title":"Build failed nginx"}]'
+        ;;
+    *"issue comment"*"77"*)
+        echo "comment posted" >&2
+        ;;
+    *"issue close"*"77"*)
+        echo "closed postgres issue" >&2
+        ;;
+    *"issue close"*"88"*)
+        echo "ERROR: must not close nginx issue during postgres recovery" >&2
+        exit 99
+        ;;
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container postgres
+    [ "$status" -eq 0 ]
+
+    # gh issue close must have been called with #77 (postgres)
+    grep -q "issue close" "$call_log"
+    grep -q "77" "$call_log"
+
+    # The close call must have used dep:postgres label (not title-based search)
+    grep -q "\-\-label dep:postgres" "$call_log"
+
+    # gh issue close for #88 (nginx) must NOT appear
+    if grep -q "issue close" "$call_log"; then
+        ! grep "issue close" "$call_log" | grep -q "88"
+    fi
+}
+
+@test "Proof B: --mode recovery --container postgres DRY_RUN shows dep:postgres in output (not title search)" {
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container postgres
+    [ "$status" -eq 0 ]
+
+    # DRY_RUN output must reference the container-scoped label
+    [[ "$output" == *"dep:postgres"* ]]
+    # Must NOT reference the generic title-based search
+    [[ "$output" != *"Auto Build Failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Proof C — recovery no-op: no open issue for the container → exit 0
+# ---------------------------------------------------------------------------
+
+@test "Proof C: --mode recovery --container nonexistent, no open issue → exit 0, no close" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *"issue close"*)
+        echo "ERROR: close must not be called when no issue exists" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container nonexistent
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Proof D — backward compatibility: without --container, all existing
+# auto-detection and generic fallback paths work unchanged.
+# ---------------------------------------------------------------------------
+
+@test "Proof D: without --container, deps(php) commit → auto-detects php, exit 0 (DRY_RUN)" {
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[php]"* ]]
+}
+
+@test "Proof D: without --container, no dep-bump → exit 1 (generic fallback)" {
+    export COMMIT_SUBJECT="fix(ci): something unrelated"
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "Proof D: without --container, --mode recovery uses global title-based close (unscoped, unchanged)" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo '[{"number":42,"title":"Auto Build Failed - 2026-06-01"}]'
+        ;;
+    *"issue comment"*)
+        echo "comment posted" >&2
+        ;;
+    *"issue close"*)
+        echo "closed" >&2
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery
+    [ "$status" -eq 0 ]
+
+    # Must have closed issue #42 via global title-based search (unscoped recovery unchanged)
+    grep -q "issue close" "$call_log"
+    grep -q "42" "$call_log"
+}
+
+# ---------------------------------------------------------------------------
+# Finding 5 — malformed/injection-shaped container names are rejected
+#
+# Both the override-open and recovery-close paths validate container names
+# against ^[a-z0-9_-]+$. A name containing shell metacharacters or spaces
+# must be rejected with a warning and exit 0 (no gh issue create/close
+# attempted). Prevents label injection via a crafted OVERRIDE_CONTAINER.
+# ---------------------------------------------------------------------------
+
+@test "FIX5+F2: --mode failure --container 'foo;bar' (invalid) → exit 3, no gh calls (fail-closed)" {
+    # Invalid container name in failure mode must return 3 (gh/op failure class) so that
+    # the checkpoint loop's `|| issue_open_failed=true` fires → issue_mode downgrades
+    # per-container→generic → generic backstop alerts (fail-closed, not silent drop).
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue create"* | *"issue comment"* | *"issue close"*)
+        echo "ERROR: gh must not be called for an invalid container name" >&2
+        exit 99
+        ;;
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container "foo;bar"
+    # exit 3 (gh/op failure class) — triggers issue_open_failed=true in checkpoint loop
+    [ "$status" -eq 3 ]
+
+    # gh issue create/comment must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep -E "issue (create|comment|close)" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "FIX5: --mode recovery --container 'a b' is rejected, exit 0, no gh close (DRY_RUN)" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue close"*)
+        echo "ERROR: gh close must not be called for an invalid container name" >&2
+        exit 99
+        ;;
+    *"issue list"*)
+        echo '[{"number":99,"title":"some build failure"}]'
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export call_log
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container "a b"
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called
+    if [ -f "$call_log" ]; then
+        run grep "issue close" "$call_log"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# FIX 2 — gh issue list failure in close_container_build_failure_on_recovery
+# must exit 0 (best-effort) with a warning, not abort under set -euo pipefail.
+# ---------------------------------------------------------------------------
+
+@test "FIX2: --mode recovery --container postgres, gh issue list fails → exit 0, no gh close (set -e safe)" {
+    # close_container_build_failure_on_recovery uses `if ! x=$(cmd); then` pattern.
+    # Under set -euo pipefail, the old `x=$(cmd); rc=$?; if rc -ne 0` was dead code:
+    # set -e aborted before the rc check.  The fix must keep exit 0 (best-effort).
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        # Simulate gh CLI failure (network error, auth error, etc.)
+        echo "gh: failed to list issues: context deadline exceeded" >&2
+        exit 1
+        ;;
+    *"issue close"*)
+        echo "ERROR: gh close must not be called when list failed" >&2
+        exit 99
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export GITHUB_REPOSITORY="owner/repo"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abcdef1234567890abcdef1234567890abcdef12"
+    export GITHUB_SERVER_URL="https://github.com"
+
+    # Recovery with a failing gh issue list must exit 0 (best-effort, not abort under set -e)
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container postgres
+    [ "$status" -eq 0 ]
+
+    # gh issue close must NOT have been called
+    run grep "issue close" "$call_log"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# FIX A+2 — find_or_create_issue must fail with exit 3 (gh op failure) on
+# create/comment failure, distinct from exit 1 (no-dep-bump-detected).
+# ---------------------------------------------------------------------------
+
+@test "FIX A+2: find_or_create_issue gh issue create failure → script exits 3 (gh op), not 1 (no-dep-bump)" {
+    # Exit code 3 = gh/issue-operation failure (distinct from 1 = no dep-bump).
+    # The auto-build.yaml summary step interprets rc=3 as a warning, NOT as
+    # "no-dep-bump" → no false suppression of the generic issue backstop.
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        # No existing open issue for this container
+        echo '[]'
+        ;;
+    *"label create"*)
+        # Best-effort label creation — succeed
+        exit 0
+        ;;
+    *"issue create"*)
+        # Simulate gh CLI failure (e.g. auth error, rate limit)
+        echo "gh: error: HTTP 401 Unauthorized" >&2
+        exit 1
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    # Mock sleep to avoid retry_with_backoff delays (3 attempts × 5+10s = 15s wall time)
+    printf '#!/bin/bash\nexit 0\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export DRY_RUN="false"    # Override setup default (setup sets DRY_RUN=true)
+    export GITHUB_REPOSITORY="owner/repo"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abcdef1234567890abcdef1234567890abcdef12"
+    export GITHUB_SERVER_URL="https://github.com"
+
+    # Script must exit 3 (gh op failure), NOT 1 (no-dep-bump)
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container postgres
+    [ "$status" -eq 3 ]
+
+    # Must NOT print a bogus "created #<empty>" or "created #0"
+    [[ "$output" != *"created #"$'\n'* ]] || [[ "$output" != *"created #0"* ]]
+}
+
+@test "FIX A+2: find_or_create_issue gh issue create returns empty number → exits 3 (not 1)" {
+    # When gh issue create succeeds (exit 0) but outputs no parseable issue number,
+    # the script must exit 3 (gh/parse failure) rather than 1 (no-dep-bump) or 0.
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo '[]'
+        ;;
+    *"label create"*)
+        exit 0
+        ;;
+    *"issue create"*)
+        # Succeed but output no numeric issue number (unexpected API response)
+        echo "https://github.com/owner/repo/issues/"
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    # No sleep mock needed: gh issue create succeeds (exit 0), no retries
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    export DRY_RUN="false"    # Override setup default (setup sets DRY_RUN=true)
+    export GITHUB_REPOSITORY="owner/repo"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abcdef1234567890abcdef1234567890abcdef12"
+    export GITHUB_SERVER_URL="https://github.com"
+
+    # Script must exit 3 (gh parse failure), NOT 1 (no-dep-bump)
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container postgres
+    [ "$status" -eq 3 ]
+}
+
+@test "FIX 2: no-dep-bump auto-detect path exits 1 (not 3) — exit codes are distinct" {
+    # Confirm the contract: rc=1 means "no dep-bump detected" (not a gh failure).
+    # This is the --mode failure path WITHOUT --container, where detect_dep_bump fails.
+    # setup() provides COMMIT_SUBJECT="chore: update readme" — no dep-bump pattern.
+    export DRY_RUN="false"    # Override setup default
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure
+    # exit 1 = no dep-bump detected (caller should fall back to generic issue logic)
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# F3 — FAILED_ALLOWLIST cross-check in auto-detect path
+# ---------------------------------------------------------------------------
+
+@test "F3: FAILED_ALLOWLIST set, detected container absent → exits 1 (skip, no spurious issue)" {
+    # deps(php) commit detected, but FAILED_ALLOWLIST=['other'] — php is not in the failure set.
+    # Script must exit 1 (no-op, same as no-dep-bump) without opening a gh issue.
+    export COMMIT_SUBJECT="deps(php): bump to 8.3"
+    export FAILED_ALLOWLIST='["other"]'
+    export DRY_RUN="true"   # DRY_RUN; would exit 0 if it reached find_or_create_issue
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure
+    # Must exit 1 (skip) — not 0 (would mean spurious issue opened)
+    [ "$status" -eq 1 ]
+}
+
+@test "F3: FAILED_ALLOWLIST set, detected container present → proceeds (exits 0 in DRY_RUN)" {
+    # deps(php) commit detected, FAILED_ALLOWLIST=['php'] — php IS in the failure set.
+    # Script must proceed to open the issue (DRY_RUN → exit 0 with dry-run output).
+    export COMMIT_SUBJECT="deps(php): bump to 8.3"
+    export FAILED_ALLOWLIST='["php"]'
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure
+    # Must exit 0 (DRY_RUN path reached → issue would be opened)
+    [ "$status" -eq 0 ]
+}
+
+@test "F3: FAILED_ALLOWLIST unset → no cross-check, original behaviour (exits 0 in DRY_RUN)" {
+    # No FAILED_ALLOWLIST → non-checkpoint run; original #514 behaviour preserved.
+    # deps(php) commit detected, no allowlist → proceeds unconditionally.
+    export COMMIT_SUBJECT="deps(php): bump to 8.3"
+    unset FAILED_ALLOWLIST
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure
+    [ "$status" -eq 0 ]
+}
+
+@test "F3: FAILED_ALLOWLIST='' (empty string) → no cross-check, original behaviour" {
+    # Empty string (checkpoint skipped/guard-break) → same as unset → no allowlist check.
+    export COMMIT_SUBJECT="deps(php): bump to 8.3"
+    export FAILED_ALLOWLIST=""
+    export DRY_RUN="true"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# F4 — --container with no value exits 2 (usage error, distinct from 1)
+# ---------------------------------------------------------------------------
+
+@test "F4: --container with no value → exit 2 + warning (not exit 1 no-dep-bump)" {
+    # Under set -u, bare --container with no $2 would crash with "unbound variable".
+    # With ${2:-} guard it must exit 2 (usage error) with a warning, not exit 1.
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--container requires a value"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# F2 — invalid --container name in failure mode → exit 3 (downgrade, not 0)
+# ---------------------------------------------------------------------------
+
+@test "F2: --mode failure --container 'Bad.Name' (invalid chars) → exit 3, not 0" {
+    # An invalid container name must return 3 (gh/op failure class) so that
+    # the checkpoint loop's `|| issue_open_failed=true` fires → issue_mode
+    # downgrades per-container→generic → generic backstop alerts.
+    # Previously returned 0, which silently suppressed the alert.
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container "Bad.Name"
+    [ "$status" -eq 3 ]
+}
+
+@test "F2: --mode recovery --container 'Bad.Name' (invalid chars) → exit 0 (best-effort close, unchanged)" {
+    # Recovery path keeps best-effort return 0 for invalid names — close has no alert
+    # obligation, so fail-open is correct there.  This test confirms the asymmetry.
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container "Bad.Name"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## #595 slice 3 — per-container build-failure issue lifecycle

### Problem
Build-failure visibility was global: the summary job opened ONE generic "Auto Build Failed"
issue and closed it only when every container was green (`build_succeeded`). One chronically
broken container kept it open without saying which, and recovery was all-or-nothing.

### Change
Drive per-container GitHub issues from the coverage-checkpoint's authoritative failed/recovered
sets. `scripts/open-dep-failure-issue.sh` gains a `--container <name>` flag (overrides
commit/PR auto-detection) for both failure (open/comment) and recovery (container-scoped close).
The `publish-coverage-checkpoint` job, after the tag CAS, opens an issue per container in `ftr`
(precise this-run failures) and closes the issue of each `recovered = prior − new_failed`
container — only on a real-push that actually published the tag.

A single `issue_mode` job output (`per-container | generic | deferred | uncovered | ''`) routes
the summary job's generic backstop: it opens the generic issue **iff** the checkpoint did not
precisely attribute (`generic`/`uncovered`/`''`), and suppresses it on `per-container`/`deferred`.
The dep-attributed open (rich dep-bump version table, #514) is cross-checked against the
checkpoint's `failed_this_run` allowlist so it never opens a spurious issue for a container that
didn't fail, and is skipped on `deferred` (superseded runs). Exit codes are distinct
(`0` ok, `1` no-dep-bump, `2` usage/env, `3` gh-op failure); an open failure or invalid
container name downgrades `per-container → generic` so no failure goes unalerted.

Issues are a UI mirror, never the carry-forward source of truth (the tag).

### Routing matrix (complete)
| issue_mode | origin | per-container open/close | summary generic |
|---|---|---|---|
| per-container | real-push, precise | open ftr / close recovered | suppressed |
| generic | real-push, unmapped or open-failure downgrade | open ftr subset | OPENED (remainder) |
| deferred | guard-break (superseded) | none; Path 1 skipped | suppressed (newer run owns) |
| uncovered | CAS-exhaust | none | OPENED |
| '' | checkpoint skipped/failed / non-checkpoint event | none | OPENED (or #514 dep-attributed) |

Every genuinely-failed container yields exactly one issue (per-container OR generic);
no superseded run mutates issues; no orphan; no silent drop.

### Tests / gates
- `tests/unit/open-dep-failure-issue.bats`: 66 tests (25 pre-existing + 41 new across `--container`,
  allowlist cross-check, exit-code scheme, downgrade-on-failure, container-scoped close, negative
  cases), each regression-lock naming its mutation. `coverage-checkpoint-utils.bats`: 54 (unchanged).
- shellcheck `-x -S warning` clean; actionlint no new findings.
- Pre-push senior review (opus) + a dedicated HOLISTIC truth-table audit of the whole routing
  state machine + orthogonal gate (codex + copilot) — **dual-CLEAN**. Convergence took several
  rounds on failure-attribution-under-partial-observability; the holistic audit (truth-table all
  signals × paths) closed the remaining edges in consolidated passes rather than reactive patches.

### Live validation (post-merge, expected)
On the next master run: per-container `dep:<c>` issues for `{github-runner, web-shell}`; when one
recovers (e.g. web-shell:debian fixed) its issue auto-closes while the other stays open.
Verify via `gh issue list --label dep:<c>`.

### Follow-up
- The bug classes this PR's review surfaced (partial-observability, signal conflation, secondary-
  path independence, ARG_MAX, set -e + cmd-subst, nullglob, concurrency CAS, outcome-step-vs-job,
  side-effect lifecycle) will be captured in `docs/GOTCHAS.md` (separate docs PR) so reviews search
  them per-stack.
- Slice 4: command-scoped 3× build/push retries.
