### PR TITLE
fix(ci): ensure static issue labels exist before gh issue create (#595)

### DIFF
--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -800,11 +800,23 @@ COMMENT
         fi
         echo "commented #${existing_number}"
     else
-        # Ensure the dep:<container> label exists (create if missing — best effort)
-        gh label create "dep:${container}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --color "e4e669" \
-            --description "Dep-attributed build failures for ${container}" 2>/dev/null || true
+        # Ensure all labels used in dedup_labels exist (create if missing — best effort, idempotent).
+        # Static labels first, then the per-container label.
+        _ensure_label() {
+            local _name="$1" _color="$2" _desc="$3"
+            gh label create "$_name" \
+                --repo "$GITHUB_REPOSITORY" \
+                --color "$_color" \
+                --description "$_desc" 2>/dev/null || true
+        }
+        _ensure_label "dep-attributed" "5319e7" \
+            "Build failure attributed to a specific container/dependency"
+        _ensure_label "build-failure"  "d73a4a" \
+            "Automated build failure"
+        _ensure_label "automation"     "0e8a16" \
+            "Automated process"
+        _ensure_label "dep:${container}" "e4e669" \
+            "Dep-attributed build failures for ${container}"
 
         # Capture create output; validate non-empty numeric issue number.
         # Do NOT use `| grep ... || true` — that masks gh exit code and can

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -382,6 +382,73 @@ GHEOF
 }
 
 # ---------------------------------------------------------------------------
+# Static label ensure: create path must call gh label create for dep-attributed
+# BEFORE gh issue create, so a repo missing the static label never causes a
+# "could not add label: 'dep-attributed' not found" failure on issue create.
+# ---------------------------------------------------------------------------
+
+@test "create path: gh label create dep-attributed called before gh issue create" {
+    # Mock records every gh invocation to a call log so we can assert ordering.
+    # gh issue create only succeeds AFTER seeing a prior label create dep-attributed.
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    local call_log="$TEST_TEMP_DIR/gh_calls.log"
+    cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
+#!/bin/bash
+echo "\$*" >> "$call_log"
+case "\$*" in
+    *"issue list"*)
+        echo "[]"
+        ;;
+    *"label create"*)
+        # All label creates succeed (best-effort idempotent)
+        exit 0
+        ;;
+    *"issue create"*)
+        # Verify that dep-attributed label was created before reaching issue create.
+        if ! grep -q "label create dep-attributed" "$call_log" 2>/dev/null; then
+            echo "ERROR: gh label create dep-attributed was never called before gh issue create" >&2
+            exit 1
+        fi
+        echo "https://github.com/oorabona/docker-containers/issues/77"
+        ;;
+    *)
+        echo "unexpected gh args: \$*" >&2
+        exit 1
+        ;;
+esac
+GHEOF
+    chmod +x "$TEST_TEMP_DIR/bin/gh"
+    # Mock sleep to skip retry_with_backoff waits
+    printf '#!/bin/bash\nexit 0\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    export COMMIT_SUBJECT="deps(php): update 4 dependencies"
+    export PR_NUMBER="300"
+    export PR_TITLE="📦 deps(php): update 4 dependencies"
+    export PR_BODY="| Dependency | Old | New |
+|---|---|---|
+| LIBSSL | 1.1.1w | 3.5.6 |"
+    export DRY_RUN="false"
+
+    run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created"* ]]
+    [[ "$output" == *"#77"* ]]
+
+    # Assert gh label create was called for dep-attributed
+    grep -q "label create dep-attributed" "$call_log"
+
+    # Assert gh label create was called before gh issue create (ordering)
+    local label_line issue_line
+    label_line=$(grep -n "label create dep-attributed" "$call_log" | head -1 | cut -d: -f1)
+    issue_line=$(grep -n "issue create" "$call_log" | head -1 | cut -d: -f1)
+    [ -n "$label_line" ]
+    [ -n "$issue_line" ]
+    [ "$label_line" -lt "$issue_line" ]
+}
+
+# ---------------------------------------------------------------------------
 # open_version_drift_issue — drift table rendering
 # Guards the "jq .[] over row strings" regression: the buggy program applied
 # | .[] to the whole comma-separated output stream (header array + row strings),


### PR DESCRIPTION
find_or_create_issue created dep:<container> but not the static dep-attributed/build-failure/automation labels; gh issue create requires every --label to pre-exist, so per-container issue opens failed on a repo missing dep-attributed (live #595 slice-3 run hit this; checkpoint downgraded to generic — resilience held). Adds an idempotent _ensure_label helper creating all four labels before create. Orthogonal gate dual-CLEAN. 67 bats, shellcheck clean.