### PR TITLE
fix(ci): command-scoped build/push/manifest retries replace job-level retry (#595)

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -442,9 +442,15 @@ runs:
         [[ -n "$build_flavor" ]] && make_args+=("--build-flavor" "$build_flavor")
         [[ -n "$dockerfile" && "$dockerfile" != "Dockerfile" ]] && make_args+=("--dockerfile" "$dockerfile")
 
+        # shellcheck source=helpers/retry.sh
+        source ./helpers/retry.sh
+
         log_info "Calling: ./make ${make_args[*]}"
-        if ! ./make "${make_args[@]}"; then
-          echo "::error::Build failed for $container:$current_tag"
+        # retry_with_backoff 3 10: retry transient build failures (network blips
+        # on FROM pulls, apk add timeouts) BEFORE any registry push occurs.
+        # A build that fails all 3 attempts aborts before touching the registry.
+        if ! retry_with_backoff 3 10 ./make "${make_args[@]}"; then
+          echo "::error::Build failed for $container:$current_tag after 3 attempts"
           exit 1
         fi
 
@@ -584,6 +590,8 @@ runs:
       shell: bash
       run: |
         set -e
+        # shellcheck disable=SC1091
+        source ./helpers/retry.sh
         image_name="${{ steps.check-build.outputs.image_name }}"
         current_tag="${{ steps.check-build.outputs.current_tag }}"
         platform_suffix="${{ steps.check-build.outputs.platform_suffix }}"
@@ -599,7 +607,8 @@ runs:
         # Tag with platform suffix
         docker tag "$ghcr_image" "$ghcr_image_platform"
 
-        if docker push "$ghcr_image_platform"; then
+        # retry_with_backoff 3 10: docker push of the same digest is idempotent.
+        if retry_with_backoff 3 10 docker push "$ghcr_image_platform"; then
           echo "success=true" >> $GITHUB_OUTPUT
           echo "::notice::GHCR push successful for $ghcr_image_platform"
         else
@@ -617,6 +626,8 @@ runs:
       id: push-dockerhub
       shell: bash
       run: |
+        # shellcheck disable=SC1091
+        source ./helpers/retry.sh
         image_name="${{ steps.check-build.outputs.image_name }}"
         current_tag="${{ steps.check-build.outputs.current_tag }}"
         platform_suffix="${{ steps.check-build.outputs.platform_suffix }}"
@@ -629,7 +640,9 @@ runs:
         # Tag the GHCR image for Docker Hub with platform suffix
         docker tag "$ghcr_image" "$dockerhub_image"
 
-        if docker push "$dockerhub_image"; then
+        # retry_with_backoff 5 30: docker push of the same digest is idempotent;
+        # longer backoff for Docker Hub rate limits (continue-on-error shields the job).
+        if retry_with_backoff 5 30 docker push "$dockerhub_image"; then
           echo "success=true" >> $GITHUB_OUTPUT
           echo "::notice::Docker Hub push successful for $dockerhub_image"
         else

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -933,29 +933,8 @@ jobs:
           use_base_cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
 
-      - name: Retry build on failure
-        if: steps.build.outcome == 'failure'
-        id: retry
-        uses: ./.github/actions/build-container
-        with:
-          container: ${{ matrix.build.container }}
-          version: ${{ matrix.build.version }}
-          tag: ${{ matrix.build.tag }}
-          flavor: ${{ matrix.build.flavor }}
-          build_flavor: ${{ matrix.build.build_flavor }}
-          variant: ${{ matrix.build.variant }}
-          dockerfile: ${{ matrix.build.dockerfile }}
-          platform: ${{ matrix.platform }}
-          rebuild_mode: all  # Always ignore digest on retry
-          docker_no_cache: 'false'
-          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          use_base_cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        continue-on-error: true
-
       - name: Handle build failure
-        if: steps.build.outcome == 'failure' && steps.retry.outcome == 'failure'
+        if: steps.build.outcome == 'failure'
         shell: bash
         run: |
           container="${{ matrix.build.container }}"
@@ -963,13 +942,12 @@ jobs:
           tag="${{ matrix.build.tag }}"
           display_name="$container${variant:+:$variant}"
 
-          echo "❌ Build failed for $display_name after retry"
+          echo "❌ Build failed for $display_name"
           echo "## 🚨 Build Failed: $display_name" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Container:** \`$container\`" >> $GITHUB_STEP_SUMMARY
           [[ -n "$variant" ]] && echo "**Variant:** \`$variant\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** \`$tag\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Attempt:** Initial build + 1 retry" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ❌ Failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Possible causes:**" >> $GITHUB_STEP_SUMMARY
@@ -985,7 +963,7 @@ jobs:
           exit 1
 
       - name: Report successful build
-        if: steps.build.outcome == 'success' || steps.retry.outcome == 'success'
+        if: steps.build.outcome == 'success'
         shell: bash
         run: |
           container="${{ matrix.build.container }}"
@@ -993,17 +971,12 @@ jobs:
           tag="${{ matrix.build.tag }}"
           display_name="$container${variant:+:$variant}"
 
-          attempt="first attempt"
-          if [ "${{ steps.build.outcome }}" = "failure" ]; then
-            attempt="retry attempt"
-          fi
-          echo "✅ Build succeeded for $display_name on $attempt"
+          echo "✅ Build succeeded for $display_name"
           echo "## ✅ Build Successful: $display_name" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Container:** \`$container\`" >> $GITHUB_STEP_SUMMARY
           [[ -n "$variant" ]] && echo "**Variant:** \`$variant\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** \`$tag\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Attempt:** $attempt" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ✅ Success" >> $GITHUB_STEP_SUMMARY
 
       - name: Emit build-result artifact
@@ -1011,7 +984,7 @@ jobs:
         shell: bash
         env:
           # job.status reflects the whole job outcome: success only when the job's
-          # work completed without error (build||retry succeeded, "Handle build failure"
+          # work completed without error (build succeeded, "Handle build failure"
           # did not exit 1). failure/cancelled → fail-closed "failure" record.
           # Whole-run artifact absence is handled by the checkpoint's find/mapfile guard.
           JOB_STATUS: ${{ job.status }}
@@ -1039,7 +1012,7 @@ jobs:
           retention-days: 1
 
       - name: Run Pester tests (Windows)
-        if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.build.os == 'windows' && matrix.build.build_flavor == 'base' && inputs.run_tests == true
+        if: steps.build.outcome == 'success' && matrix.build.os == 'windows' && matrix.build.build_flavor == 'base' && inputs.run_tests == true
         continue-on-error: true
         shell: pwsh
         run: |
@@ -1056,7 +1029,7 @@ jobs:
           }
 
       - name: Run bats tests (Linux)
-        if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.build.os != 'windows' && matrix.build.build_flavor == 'base' && matrix.arch == 'amd64' && inputs.run_tests == true
+        if: steps.build.outcome == 'success' && matrix.build.os != 'windows' && matrix.build.build_flavor == 'base' && matrix.arch == 'amd64' && inputs.run_tests == true
         timeout-minutes: 5
         continue-on-error: true
         shell: bash
@@ -1126,7 +1099,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload build lineage
-        if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.arch == 'amd64'
+        if: steps.build.outcome == 'success' && matrix.arch == 'amd64'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-lineage-${{ matrix.build.container }}-${{ matrix.build.tag }}
@@ -1136,7 +1109,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Trivy scan history
-        if: (steps.build.outcome == 'success' || steps.retry.outcome == 'success') && matrix.build.os != 'windows'
+        if: steps.build.outcome == 'success' && matrix.build.os != 'windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: trivy-scan-history-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
@@ -1148,7 +1121,7 @@ jobs:
       # SBOM generation (amd64 only — packages are identical across arches)
       - name: Install syft
         id: install-syft
-        if: matrix.build.os != 'windows' && (steps.build.outputs.image_loaded == 'true' || steps.retry.outputs.image_loaded == 'true') && matrix.arch == 'amd64' && github.event_name != 'pull_request'
+        if: matrix.build.os != 'windows' && steps.build.outputs.image_loaded == 'true' && matrix.arch == 'amd64' && github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Generate SBOM

--- a/helpers/create-manifest.sh
+++ b/helpers/create-manifest.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/logging.sh"
+# shellcheck source=retry.sh
+source "$SCRIPT_DIR/retry.sh"
 
 # Compute tag arguments for manifest creation
 # Reads from env: TAG, VERSION, FULL_VERSION, VARIANT, IS_DEFAULT, IS_LATEST_VERSION
@@ -127,9 +129,10 @@ create_registry_manifest() {
     tag_args=$(_compute_tag_args "$target_image")
     version_specific_tag_args=$(_compute_version_specific_tag_args "$target_image" 2>/dev/null) || true
 
-    # Try multi-arch manifest first (amd64 + arm64)
+    # Try multi-arch manifest first (amd64 + arm64).
+    # retry_with_backoff 3 5: imagetools create is idempotent (same manifest list on retry).
     local err_output
-    if err_output=$($DOCKER buildx imagetools create $tag_args \
+    if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $tag_args \
         "$source_image:$TAG-amd64" \
         "$source_image:$TAG-arm64" 2>&1); then
         echo "::notice::Multi-arch manifest created successfully for $target_image:$TAG"
@@ -139,7 +142,8 @@ create_registry_manifest() {
 
     # Fallback amd64-only — skip if no safe version-specific anchor (P2 fix)
     if [[ -n "$version_specific_tag_args" ]]; then
-        if err_output=$($DOCKER buildx imagetools create $version_specific_tag_args \
+        # retry_with_backoff 3 5: idempotent — recreates the same single-arch manifest.
+        if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $version_specific_tag_args \
             "$source_image:$TAG-amd64" 2>&1); then
             echo "::warning::Manifest created with amd64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
             return 0
@@ -151,7 +155,8 @@ create_registry_manifest() {
 
     # Fallback arm64-only — skip if no safe version-specific anchor (P2 fix)
     if [[ -n "$version_specific_tag_args" ]]; then
-        if err_output=$($DOCKER buildx imagetools create $version_specific_tag_args \
+        # retry_with_backoff 3 5: idempotent — recreates the same single-arch manifest.
+        if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $version_specific_tag_args \
             "$source_image:$TAG-arm64" 2>&1); then
             echo "::warning::Manifest created with arm64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
             return 0

--- a/make
+++ b/make
@@ -438,6 +438,7 @@ make() {
 
   pushd ${target}
 
+  local _op_rc=0
   for version in $versions; do
     # Use explicit tag if provided, otherwise derive from version
     local effective_tag="${wantedTag:-$version}"
@@ -447,9 +448,10 @@ make() {
     else
       log_success "$op ${target} $WANTED (version: ${VERSION} tag: $TAG) | nproc: ${NPROC}"
     fi
-    do_it $op "$registry"
+    do_it $op "$registry" || _op_rc=$?
   done
   popd
+  return $_op_rc
 }
 
 check_updates() {

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -22,6 +22,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$ROOT_DIR/helpers/extension-utils.sh"
 # shellcheck source=../helpers/version-set-resolver.sh
 source "$ROOT_DIR/helpers/version-set-resolver.sh"
+# shellcheck source=../helpers/retry.sh
+source "$ROOT_DIR/helpers/retry.sh"
 
 # Registry override: default to docker.io (raw builds); CI passes ghcr.io/oorabona.
 # Must NOT appear in config.yaml build_args (schema guard R7 rejects it).
@@ -1985,7 +1987,8 @@ finalize_multiarch_manifests() {
 
             log_info "$ext $ceiling pg${major_ver}: imagetools create $_nr_target from $_nr_src_amd64 + $_nr_src_arm64 (non-resolver, stable suffixed tags)"
             local _nr_create_rc=0
-            $DOCKER buildx imagetools create \
+            # retry_with_backoff 3 5: imagetools create is idempotent (same manifest list on retry).
+            retry_with_backoff 3 5 $DOCKER buildx imagetools create \
                 -t "$_nr_target" \
                 "$_nr_src_amd64" "$_nr_src_arm64" 2>&1 \
                 || _nr_create_rc=$?
@@ -2140,7 +2143,8 @@ finalize_multiarch_manifests() {
 
             log_info "$ext $ver pg${major_ver}: imagetools create $ver_multiarch from $_ver_tag_amd64 + $_ver_tag_arm64"
             local _create_rc=0
-            $DOCKER buildx imagetools create \
+            # retry_with_backoff 3 5: imagetools create is idempotent (same manifest list on retry).
+            retry_with_backoff 3 5 $DOCKER buildx imagetools create \
                 -t "$ver_multiarch" \
                 "$_ver_tag_amd64" "$_ver_tag_arm64" 2>&1 \
                 || _create_rc=$?

--- a/tests/unit/build-retry.bats
+++ b/tests/unit/build-retry.bats
@@ -1,0 +1,253 @@
+#!/usr/bin/env bats
+
+# Unit tests for command-scoped retry wiring (slice 4 of #595)
+#
+# Verifies:
+#   1. retry_with_backoff retries a failing command N times then fails
+#   2. retry_with_backoff succeeds on first try
+#   3. retry_with_backoff succeeds on a mid-sequence attempt
+#   4. create_registry_manifest wraps each imagetools create with retry
+#   5. build-extensions.sh sources retry.sh (retry_with_backoff available)
+#
+# YAML-level wiring (retry step gone, docker push retry in action) is
+# verified by the grep gate: `grep steps.retry auto-build.yaml` returns 1.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    source "$HELPERS_DIR/logging.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# 1. retry_with_backoff primitives (sourced directly from helpers/retry.sh)
+# ---------------------------------------------------------------------------
+
+@test "retry_with_backoff: succeeds on first attempt" {
+    source "$HELPERS_DIR/retry.sh"
+
+    run retry_with_backoff 3 1 true
+    [ "$status" -eq 0 ]
+}
+
+@test "retry_with_backoff: retries a failing command N times then fails" {
+    source "$HELPERS_DIR/retry.sh"
+
+    local counter_file="$TEST_TEMP_DIR/counter"
+    echo "0" > "$counter_file"
+
+    always_fail() {
+        local count
+        count=$(cat "$counter_file")
+        echo $((count + 1)) > "$counter_file"
+        return 1
+    }
+
+    run retry_with_backoff 3 0 always_fail
+    [ "$status" -eq 1 ]
+
+    local count
+    count=$(cat "$counter_file")
+    [ "$count" -eq 3 ]
+}
+
+@test "retry_with_backoff: succeeds on second attempt" {
+    source "$HELPERS_DIR/retry.sh"
+
+    local counter_file="$TEST_TEMP_DIR/counter"
+    echo "0" > "$counter_file"
+
+    fail_once() {
+        local count
+        count=$(cat "$counter_file")
+        echo $((count + 1)) > "$counter_file"
+        [ "$count" -ge 1 ]
+    }
+
+    run retry_with_backoff 3 0 fail_once
+    [ "$status" -eq 0 ]
+
+    local count
+    count=$(cat "$counter_file")
+    [ "$count" -eq 2 ]
+}
+
+@test "retry_with_backoff: delay=0 still retries (smoke, no real sleep)" {
+    source "$HELPERS_DIR/retry.sh"
+
+    local counter_file="$TEST_TEMP_DIR/counter"
+    echo "0" > "$counter_file"
+
+    fail_twice() {
+        local count
+        count=$(cat "$counter_file")
+        echo $((count + 1)) > "$counter_file"
+        [ "$count" -ge 2 ]
+    }
+
+    run retry_with_backoff 5 0 fail_twice
+    [ "$status" -eq 0 ]
+
+    local count
+    count=$(cat "$counter_file")
+    [ "$count" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# 2. create_registry_manifest wraps imagetools create with retry
+#
+# Strategy: stub $DOCKER to a counting script; assert it is called more
+# than once when the first attempt fails (retry fired), and that
+# create_registry_manifest ultimately returns 1 after all retries exhausted.
+# ---------------------------------------------------------------------------
+
+@test "create_registry_manifest: retries imagetools create on transient failure" {
+    # Build a stub docker binary that fails the first two calls then succeeds
+    local stub_dir="$TEST_TEMP_DIR/stub"
+    mkdir -p "$stub_dir"
+    local counter_file="$TEST_TEMP_DIR/docker_calls"
+    echo "0" > "$counter_file"
+
+    cat > "$stub_dir/docker_stub" << 'STUB'
+#!/usr/bin/env bash
+count=$(cat "$COUNTER_FILE")
+echo $((count + 1)) > "$COUNTER_FILE"
+# Fail first 2 calls, succeed from 3rd onwards
+if [ "$count" -lt 2 ]; then
+    echo "transient error" >&2
+    exit 1
+fi
+exit 0
+STUB
+    chmod +x "$stub_dir/docker_stub"
+
+    export COUNTER_FILE="$counter_file"
+    export DOCKER="$stub_dir/docker_stub"
+
+    # Minimal env that create-manifest.sh requires
+    export TAG="18-alpine"
+    export VERSION="18"
+    export FULL_VERSION="18.3-alpine"
+    export VARIANT=""
+    export IS_DEFAULT="true"
+    export IS_LATEST_VERSION="true"
+
+    # Override sleep so tests don't actually wait
+    sleep() { :; }
+    export -f sleep
+
+    source "$HELPERS_DIR/retry.sh"
+    source "$HELPERS_DIR/create-manifest.sh"
+
+    create_registry_manifest "ghcr.io/owner/postgres" "ghcr.io/owner/postgres" "false"
+    local rc=$?
+
+    [ "$rc" -eq 0 ]
+    local calls
+    calls=$(cat "$counter_file")
+    # Must have been called more than once (retry fired at least once)
+    [ "$calls" -gt 1 ]
+}
+
+@test "create_registry_manifest: returns failure after all retries exhausted" {
+    local stub_dir="$TEST_TEMP_DIR/stub"
+    mkdir -p "$stub_dir"
+    local counter_file="$TEST_TEMP_DIR/docker_calls"
+    echo "0" > "$counter_file"
+
+    cat > "$stub_dir/docker_stub" << 'STUB'
+#!/usr/bin/env bash
+count=$(cat "$COUNTER_FILE")
+echo $((count + 1)) > "$COUNTER_FILE"
+echo "persistent error" >&2
+exit 1
+STUB
+    chmod +x "$stub_dir/docker_stub"
+
+    export COUNTER_FILE="$counter_file"
+    export DOCKER="$stub_dir/docker_stub"
+
+    export TAG="18-alpine"
+    export VERSION="18"
+    export FULL_VERSION="18.3-alpine"
+    export VARIANT=""
+    export IS_DEFAULT="false"
+    export IS_LATEST_VERSION="false"
+
+    sleep() { :; }
+    export -f sleep
+
+    source "$HELPERS_DIR/retry.sh"
+    source "$HELPERS_DIR/create-manifest.sh"
+
+    # fail_on_error=false: function returns 0 even on failure (swallows error)
+    create_registry_manifest "ghcr.io/owner/postgres" "ghcr.io/owner/postgres" "false"
+    local rc=$?
+    [ "$rc" -eq 0 ]
+
+    # All three paths (multi-arch, amd64-only, arm64-only) each retry 3x → 9 calls total
+    local calls
+    calls=$(cat "$counter_file")
+    [ "$calls" -gt 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# 3. build-extensions.sh sources retry.sh (retry_with_backoff available)
+#
+# We can't source the full 2400-line script in a unit test context because it
+# requires postgres/extensions/ config and registry access. Instead, verify
+# that the source line for retry.sh is present and retry_with_backoff is
+# defined after sourcing the helpers explicitly.
+# ---------------------------------------------------------------------------
+
+@test "build-extensions.sh includes retry.sh source directive" {
+    grep -q 'source.*helpers/retry\.sh' "$PROJECT_ROOT/scripts/build-extensions.sh"
+}
+
+@test "retry_with_backoff is available after sourcing retry.sh" {
+    source "$HELPERS_DIR/retry.sh"
+    declare -f retry_with_backoff > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# 4. auto-build.yaml: job-level retry step is fully removed
+# ---------------------------------------------------------------------------
+
+@test "auto-build.yaml: no steps.retry references remain" {
+    local yaml="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    run grep -c 'steps\.retry' "$yaml"
+    # grep -c returns 0 matches → status 1 (no match), output "0"
+    [ "$status" -eq 1 ] || [ "$output" -eq 0 ]
+}
+
+@test "auto-build.yaml: Retry build on failure step is gone" {
+    local yaml="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    run grep -c 'Retry build on failure' "$yaml"
+    [ "$status" -eq 1 ] || [ "$output" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# 5. action.yaml: docker push is wrapped with retry_with_backoff
+# ---------------------------------------------------------------------------
+
+@test "build-container action.yaml: GHCR push uses retry_with_backoff" {
+    local action="$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+    grep -q 'retry_with_backoff.*docker push' "$action"
+}
+
+@test "build-container action.yaml: DockerHub push uses retry_with_backoff" {
+    local action="$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+    # Two separate retry-wrapped pushes: GHCR (3 10) and DockerHub (5 30)
+    local count
+    count=$(grep -c 'retry_with_backoff.*docker push' "$action")
+    [ "$count" -ge 2 ]
+}
+
+@test "build-container action.yaml: make build uses retry_with_backoff" {
+    local action="$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+    grep -q 'retry_with_backoff.*make' "$action"
+}

--- a/tests/unit/make-dispatcher-rc.bats
+++ b/tests/unit/make-dispatcher-rc.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+
+# Unit tests for make() dispatcher rc-propagation fix (issue #595 slice 4)
+#
+# Problem: the make() dispatcher called `do_it $op "$registry"` without
+# capturing its exit code. After the loop, `popd` returned 0, so the function
+# returned 0 even when do_it failed. This masked docker build failures and made
+# retry_with_backoff in action.yaml ineffective.
+#
+# Fix: `do_it ... || _op_rc=$?` accumulates failures; `return $_op_rc` after
+# popd propagates the non-zero rc to the caller.
+#
+# Tests 1-4: isolate the dispatcher loop logic using inline stubs.
+# Sourcing `make` directly is impractical: it has top-level execution code
+# (docker-compose check + case statement) requiring a live docker environment.
+# The inline approach tests the exact behaviour of the fixed loop body without
+# environment dependencies.
+#
+# Tests 5-7: structural grep gates confirming the fix is present in ./make.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    # Create a minimal fake container directory so pushd/popd work
+    mkdir -p "$TEST_TEMP_DIR/fakecontainer"
+    export _FAKE_CONTAINER="$TEST_TEMP_DIR/fakecontainer"
+    export NPROC=1
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Export all stubs needed by the dispatcher running in a bats subshell.
+# DO_IT_RC is an exported env var so do_it() can read it across the subshell
+# boundary (bash exported functions cannot close over local variables).
+_export_stubs() {
+    local do_it_rc="${1:-0}"
+    export DO_IT_RC="$do_it_rc"
+
+    log_success() { :; };  export -f log_success
+    log_error()   { :; };  export -f log_error
+
+    # pushd/popd: redirect to the fake container dir (no pwd-change side-effects)
+    pushd() { builtin pushd "$_FAKE_CONTAINER" > /dev/null; }; export -f pushd
+    popd()  { builtin popd  > /dev/null; };                    export -f popd
+
+    validate_target()   { return 0; };            export -f validate_target
+    get_build_version() { echo "1.0.0"; return 0; }; export -f get_build_version
+    do_it()             { return "$DO_IT_RC"; };  export -f do_it
+
+    # The dispatcher under test — mirrors make() in ./make verbatim (fixed body).
+    # Re-defined here rather than sourced so the test doesn't depend on the
+    # top-level execution code in ./make (docker-compose check, case statement).
+    dispatcher() {
+        local op=$1; shift
+        local registry=""
+
+        local positional_args=()
+        while [[ $# -gt 0 ]]; do
+            positional_args+=("$1"); shift
+        done
+        [[ ${#positional_args[@]} -gt 0 ]] && set -- "${positional_args[@]}" || set --
+
+        validate_target "$1" || return 1
+        local target=$1
+        local wantedVersion=${2:-latest}
+        local wantedTag=${3:-""}
+
+        local versions
+        versions=$(get_build_version "$target" "$wantedVersion")
+        [ $? -ne 0 ] && return 1
+
+        pushd "$target"
+
+        local _op_rc=0
+        for version in $versions; do
+            local effective_tag="${wantedTag:-$version}"
+            export WANTED=$wantedVersion VERSION=$version TAG=$effective_tag
+            log_success "$op ${target} $WANTED (version: ${VERSION} tag: $TAG) | nproc: ${NPROC}"
+            do_it "$op" "$registry" || _op_rc=$?
+        done
+        popd
+        return $_op_rc
+    }
+    export -f dispatcher
+}
+
+# ---------------------------------------------------------------------------
+# 1. When do_it succeeds, dispatcher returns 0
+# ---------------------------------------------------------------------------
+
+@test "make dispatcher: returns 0 when do_it succeeds" {
+    _export_stubs 0
+    run dispatcher build fakecontainer latest
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# 2. When do_it fails, dispatcher returns non-zero
+# ---------------------------------------------------------------------------
+
+@test "make dispatcher: returns non-zero when do_it fails" {
+    _export_stubs 1
+    run dispatcher build fakecontainer latest
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# 3. Multi-version: ALL versions are attempted even when the first fails
+#    (no early-return; _op_rc accumulates the last failing rc)
+# ---------------------------------------------------------------------------
+
+@test "make dispatcher: iterates ALL versions even when first do_it fails" {
+    local counter_file="$TEST_TEMP_DIR/do_it_calls"
+    echo "0" > "$counter_file"
+    export _DO_IT_COUNTER="$counter_file"
+
+    log_success() { :; };  export -f log_success
+    log_error()   { :; };  export -f log_error
+
+    pushd() { builtin pushd "$_FAKE_CONTAINER" > /dev/null; }; export -f pushd
+    popd()  { builtin popd  > /dev/null; };                    export -f popd
+
+    validate_target()    { return 0; };                      export -f validate_target
+    # Return two versions so the loop runs twice
+    get_build_version()  { printf "1.0.0\n2.0.0"; return 0; }; export -f get_build_version
+
+    do_it() {
+        local count; count=$(cat "$_DO_IT_COUNTER")
+        echo $((count + 1)) > "$_DO_IT_COUNTER"
+        return 1   # always fail
+    }
+    export -f do_it
+
+    dispatcher() {
+        local op=$1; shift
+        local registry=""
+        local positional_args=()
+        while [[ $# -gt 0 ]]; do positional_args+=("$1"); shift; done
+        [[ ${#positional_args[@]} -gt 0 ]] && set -- "${positional_args[@]}" || set --
+        validate_target "$1" || return 1
+        local target=$1; local wantedVersion=${2:-latest}; local wantedTag=${3:-""}
+        local versions; versions=$(get_build_version "$target" "$wantedVersion")
+        [ $? -ne 0 ] && return 1
+        pushd "$target"
+        local _op_rc=0
+        for version in $versions; do
+            local effective_tag="${wantedTag:-$version}"
+            export WANTED=$wantedVersion VERSION=$version TAG=$effective_tag
+            do_it "$op" "$registry" || _op_rc=$?
+        done
+        popd
+        return $_op_rc
+    }
+    export -f dispatcher
+
+    run dispatcher build fakecontainer latest
+    # Function must fail (both do_it calls failed)
+    [ "$status" -ne 0 ]
+
+    # Both versions must have been attempted
+    local calls; calls=$(cat "$counter_file")
+    [ "$calls" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# 4. Multi-version: second version fails; dispatcher still returns non-zero
+# ---------------------------------------------------------------------------
+
+@test "make dispatcher: returns non-zero when second of two versions fails" {
+    local counter_file="$TEST_TEMP_DIR/do_it_calls"
+    echo "0" > "$counter_file"
+    export _DO_IT_COUNTER="$counter_file"
+
+    log_success() { :; };  export -f log_success
+    log_error()   { :; };  export -f log_error
+
+    pushd() { builtin pushd "$_FAKE_CONTAINER" > /dev/null; }; export -f pushd
+    popd()  { builtin popd  > /dev/null; };                    export -f popd
+
+    validate_target()   { return 0; };                       export -f validate_target
+    get_build_version() { printf "1.0.0\n2.0.0"; return 0; }; export -f get_build_version
+
+    do_it() {
+        local count; count=$(cat "$_DO_IT_COUNTER")
+        echo $((count + 1)) > "$_DO_IT_COUNTER"
+        # Succeed on first call, fail on second
+        [ "$count" -ge 1 ] && return 1
+        return 0
+    }
+    export -f do_it
+
+    dispatcher() {
+        local op=$1; shift
+        local registry=""
+        local positional_args=()
+        while [[ $# -gt 0 ]]; do positional_args+=("$1"); shift; done
+        [[ ${#positional_args[@]} -gt 0 ]] && set -- "${positional_args[@]}" || set --
+        validate_target "$1" || return 1
+        local target=$1; local wantedVersion=${2:-latest}; local wantedTag=${3:-""}
+        local versions; versions=$(get_build_version "$target" "$wantedVersion")
+        [ $? -ne 0 ] && return 1
+        pushd "$target"
+        local _op_rc=0
+        for version in $versions; do
+            local effective_tag="${wantedTag:-$version}"
+            export WANTED=$wantedVersion VERSION=$version TAG=$effective_tag
+            do_it "$op" "$registry" || _op_rc=$?
+        done
+        popd
+        return $_op_rc
+    }
+    export -f dispatcher
+
+    run dispatcher build fakecontainer latest
+    [ "$status" -ne 0 ]
+
+    local calls; calls=$(cat "$counter_file")
+    [ "$calls" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# 5-7. Structural grep gates: confirm the fix is present in ./make
+# ---------------------------------------------------------------------------
+
+@test "make script: _op_rc variable is declared before the version loop" {
+    grep -q 'local _op_rc=0' "$PROJECT_ROOT/make"
+}
+
+@test "make script: do_it call captures rc with || _op_rc=\$?" {
+    grep -q 'do_it.*|| _op_rc=\$?' "$PROJECT_ROOT/make"
+}
+
+@test "make script: dispatcher returns _op_rc after popd" {
+    # Extract make() function body and verify 'return $_op_rc' comes after 'popd'
+    local make_fn
+    make_fn=$(awk '/^make\(\)/{found=1} found{print} found && /^}$/{exit}' "$PROJECT_ROOT/make")
+    local popd_line
+    popd_line=$(echo "$make_fn" | grep -n 'popd' | tail -1 | cut -d: -f1)
+    local return_line
+    return_line=$(echo "$make_fn" | grep -n 'return \$_op_rc' | head -1 | cut -d: -f1)
+    [ -n "$popd_line" ]
+    [ -n "$return_line" ]
+    [ "$return_line" -gt "$popd_line" ]
+}


### PR DESCRIPTION
## #595 slice 4 — command-scoped retries (+ make exit-code propagation)

### Problem
The job-level "Retry build on failure" step re-ran the **whole** `build-container` action on any
failure. After a partial success (e.g. GHCR push ok, Docker Hub push fails) it repeated
build + push + flatten + `imagetools create` — wasteful, 429-prone, and a risky rewrite of
mutable tags. Separately, `docker push` was not retried at all (failed hard on a transient).

### Change
Retry **per command** instead:
- `retry_with_backoff 3 10 ./make build` — build, before any registry mutation (a build that fails
  3× aborts before pushing, so no partial artifact is ever pushed).
- `retry_with_backoff 3 10 docker push` (GHCR), `retry_with_backoff 5 30 docker push` (Docker Hub,
  continue-on-error) — idempotent (same digest).
- `retry_with_backoff 3 5 docker buildx imagetools create` in `create-manifest.sh` (3 sites) and
  `build-extensions.sh` (2 sites) — idempotent (same manifest list).
- **Removed** the job-level retry step; simplified `Handle build failure` / `Report successful build`
  / `Run Pester tests` `if:` to drop all `steps.retry.*` (0 references remain). The build step keeps
  `continue-on-error: true` so the slice-2 build-result emit (`job.status`-based) still runs.
- ext Stage A `EXT_BUILD_RETRIES` untouched.

### make exit-code propagation (correctness fix surfaced by the gate)
The build retry depends on `./make build` returning non-zero on failure — but the `make` dispatcher
(no `set -e`) called `do_it` inside the version loop **without capturing its rc**, then returned
`popd`'s success → a `docker buildx build` failure could make `./make build` exit 0. This made the
retry ineffective AND masked build failures pipeline-wide (they only surfaced later at push, when the
image was absent). Fixed: capture `do_it`'s rc in the loop and `return` it (still iterates every
version, then reports failure). This is a latent pre-existing bug, not introduced here.

### Tests / gates
- `tests/unit/build-retry.bats` (13) + `tests/unit/make-dispatcher-rc.bats` (7, proving make
  propagates do_it's rc and still attempts all versions). All existing suites green; shellcheck
  `-x -S warning` clean; actionlint no new findings; `grep steps.retry` → 0.
- Senior review (opus, applying the retry/idempotency/`set -e`/side-effect-lifecycle gotcha classes
  from the KB) + orthogonal gate (codex + copilot) — **dual-CLEAN**. Each retried op confirmed
  idempotent; `set -e` propagation of every wrap verified.

### Live validation (post-merge)
A transient push failure should retry the push (log `retry_with_backoff`) without re-building;
a build that fails 3× should fail cleanly with no partial push.

### Completes
This is the final slice of the #595 epic (slices 1-4): checkpoint bootstrap + durable carry-forward
(1), artifact-based attribution (2), per-container issue lifecycle (3), command-scoped retry (4).
