### PR TITLE
fix(ci): retry build-result artifact upload on transient ECONNRESET

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -496,7 +496,9 @@ jobs:
             > ".build-lineage/build-result-postgres-ext-${{ matrix.arch }}.json" || true
 
       - name: Upload build-result artifact (postgres extensions, ${{ matrix.arch }})
+        id: upload_build_result_ext
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-result-postgres-ext-${{ matrix.arch }}
@@ -504,6 +506,17 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload build-result artifact (retry on transient failure) (postgres extensions, ${{ matrix.arch }})
+        if: always() && steps.upload_build_result_ext.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-postgres-ext-${{ matrix.arch }}
+          path: .build-lineage/build-result-postgres-ext-${{ matrix.arch }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
   # Stage B: merge per-arch extension manifests into multi-arch manifests and
   # write the versionset artifact with the multi-arch bundle INDEX digest.
@@ -692,7 +705,9 @@ jobs:
             > ".build-lineage/build-result-postgres-extmerge.json" || true
 
       - name: Upload build-result artifact (postgres extmerge)
+        id: upload_build_result_extmerge
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-result-postgres-extmerge
@@ -700,6 +715,17 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload build-result artifact (retry on transient failure) (postgres extmerge)
+        if: always() && steps.upload_build_result_extmerge.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-postgres-extmerge
+          path: .build-lineage/build-result-postgres-extmerge.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
   # Sync base images: blind-copy detected containers' base images from Docker Hub
   # to GHCR on every push. Consolidated with the daily upstream-monitor sync via
@@ -1009,7 +1035,9 @@ jobs:
             > ".build-lineage/build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}.json" || true
 
       - name: Upload build-result artifact
+        id: upload_build_result
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
@@ -1017,6 +1045,17 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload build-result artifact (retry on transient failure)
+        if: always() && steps.upload_build_result.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
+          path: .build-lineage/build-result-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
       - name: Run Pester tests (Windows)
         if: steps.build.outcome == 'success' && matrix.build.os == 'windows' && matrix.build.build_flavor == 'base' && inputs.run_tests == true
@@ -1385,7 +1424,9 @@ jobs:
             > ".build-lineage/build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}.json" || true
 
       - name: Upload build-result artifact (manifest)
+        id: upload_build_result_manifest
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}
@@ -1393,6 +1434,17 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload build-result artifact (retry on transient failure) (manifest)
+        if: always() && steps.upload_build_result_manifest.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}
+          path: .build-lineage/build-result-manifest-${{ matrix.build.container }}-${{ matrix.build.tag }}.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
   # Advance the coverage checkpoint tag on every master push run that completes
   # (even when individual build jobs failed).  The tag carries a JSON state record


### PR DESCRIPTION
## Summary

Add an idempotent retry to each build-result artifact upload so a transient `ECONNRESET` on `actions/upload-artifact@v4`'s `FinalizeArtifact` no longer leaves the artifact unregistered — which otherwise makes the matrix job fail with no failure-record and trips the coverage-checkpoint count-gate into a spurious full carry-all.

Closes #626.

## Root cause (run 26963349236)

`Build php (amd64)` built and pushed successfully (GHCR + Docker Hub), emitted its result JSON, uploaded the blob, then `##[error]Failed to FinalizeArtifact: ECONNRESET`. The upload step failed → job conclusion=`failure`, but no `build-result` artifact was registered. The checkpoint count-gate (`coverage-checkpoint-utils.sh:308-310`) saw `bad_build_job_count=8 > failure_record_count=7` → `unmapped_failure=true` → fail-closed carry-all of all 13 containers, even though only github-runner + web-shell arm64 truly failed and php was green (it was green again the next run).

The checkpoint attribution is **correct** (it conservatively carried everything because it could not account for a failure). This PR removes the *trigger*: it makes the artifact upload resilient to a transient finalize blip, so it no longer manufactures a phantom unaccounted failure.

## Change

`actions/upload-artifact@v4` has no user-configurable retry for `FinalizeArtifact`. At each of the 4 build-result upload steps (build-and-push, build-extensions, merge-extension-manifests, create-manifest):

- the primary upload step gets an `id:` and `continue-on-error: true` (a finalize blip no longer fails the job there);
- a second upload step runs only when the primary `outcome == 'failure'`, with the identical `name:`/`path:` and the same pinned SHA, plus `overwrite: true` (defensive against a partially-registered first attempt).

The retry has no `continue-on-error` — two consecutive ECONNRESETs on a ~300-byte payload is a genuine infra problem and should still fail. Happy-path overhead: one skipped conditional per matrix leg.

## Scope / verification

- One file: `.github/workflows/auto-build.yaml` (4 locations, +52 lines, YAML-only).
- No new dependency, no new pinned SHA, no artifact name change (consumer `gh run download --pattern 'build-result-*'` unaffected).
- `actionlint` clean on the changed steps; orthogonal gate (codex + copilot) CLEAN.
- Live: the upcoming targeted github-runner/web-shell rebuild exercises this path.
