### PR TITLE
docs(blog): CI-hardening series (4 posts, staggered publication)

### DIFF
--- a/docs/site/_posts/2026-06-04-multi-arch-is-a-distributed-systems-problem.md
+++ b/docs/site/_posts/2026-06-04-multi-arch-is-a-distributed-systems-problem.md
@@ -1,0 +1,95 @@
+---
+layout: post
+title: "Multi-arch is a distributed-systems problem"
+description: "A single-arch build from my laptop quietly overwrote a multi-arch manifest in my registry. Nothing broke for months — until an arm64 build went looking for a base that no longer had an arm64 in it. This is about what a tag actually is, why a registry is shared mutable state, and who should be allowed to write to one."
+date: 2026-06-04 06:00:00 +0000
+tags: [docker, multi-arch, oci, registry, ci, lessons-learned]
+---
+
+I run a small fleet of container images, and the thing about a fleet is that it isn't flat — the images build on each other. My `github-runner` and `web-shell` images don't start `FROM` Debian on Docker Hub; they start `FROM` *my* Debian, `ghcr.io/oorabona/debian:trixie`, built once so everything on top inherits a known base. A short chain. It works right up until one link changes shape under the others.
+
+It broke on a single line:
+
+```
+#6 [internal] load metadata for ghcr.io/oorabona/debian:trixie
+ERROR: failed to solve: no match for platform in manifest: not found
+```
+
+Only on arm64. The amd64 build of the same image, from the same `FROM`, was green. A base that existed, that I could pull, that half my builds were using *right now* — had no arm64 inside it. And it had been that way, quietly, for two months.
+
+## A tag is not an image
+
+The mental model that gets you here is that `debian:trixie` *is* an image. It isn't. On a modern registry a tag can point at a **manifest list** (Docker's name) or an **image index** (the OCI name): a small JSON document that says nothing about layers and everything about routing —
+
+```
+debian:trixie  (index)
+ ├─ linux/amd64 → sha256:aaaa…
+ └─ linux/arm64 → sha256:bbbb…
+```
+
+When buildx pulls `debian:trixie` on an arm64 runner, it reads that index, finds the `linux/arm64` entry, and pulls *that* digest. The tag is a pointer to a fan-out, and the fan-out is what makes one name work on two architectures.
+
+My CI builds it the honest way: the amd64 leg and the arm64 leg build independently, each pushes its own single-arch image, and a final step assembles the index over them —
+
+```bash
+docker buildx imagetools create -t ghcr.io/oorabona/debian:trixie \
+  ghcr.io/oorabona/debian:trixie-amd64 \
+  ghcr.io/oorabona/debian:trixie-arm64
+```
+
+After that, `:trixie` is an index with two entries, and `:trixie-amd64` / `:trixie-arm64` sit alongside it as the leaves it points at. Three tags, one of them a router.
+
+## How one arch went missing
+
+Here's the shape of what happened. The index was correct — CI had built it. Then, at some point, someone ran a plain build on a laptop and pushed it straight to the canonical tag:
+
+```bash
+podman build -t ghcr.io/oorabona/debian:trixie .
+podman push   ghcr.io/oorabona/debian:trixie
+```
+
+That laptop is amd64. `podman build` produces a single-platform image, and pushing it to `:trixie` doesn't *merge* anything — it overwrites the tag. The pointer that used to reference a two-entry index now references one amd64 image manifest. The arm64 leaf, `:trixie-arm64`, is still sitting there untouched. It's just that nothing points at it anymore.
+
+The registry won't warn you about this. An index and a single image are both perfectly valid things to put at a tag; swapping one for the other is a normal push, not a conflict. Nothing is corrupt. The object at `:trixie` simply got *smaller*.
+
+I only know it was a laptop because every build I publish writes a lineage record, and the one for that tag said:
+
+```json
+{ "github_actions": false, "runtime": "Podman" }
+```
+
+CI never sets those. That single line is the entire forensic trail — without it I'd have been left guessing at *how* a tag I thought CI owned had quietly gone single-arch.
+
+## Why nobody noticed for months
+
+Two properties combined to make this invisible, and they're the two that always make registry bugs invisible.
+
+It's a **partial** failure. The downgraded tag still serves amd64 flawlessly. Every amd64 consumer kept building and shipping. The system was *mostly up* — which is the exact state that hides a bug, because nothing alarms and nothing pages.
+
+And it's a **delayed** failure. The missing arm64 entry isn't an error until something reads it, and nothing reads it until something builds `FROM` it on arm64. I hadn't built these consumers on arm64 in a while. The write that broke it and the build that revealed it were separated by two months. By the time the lights came on, the cause was long out of the recent history and looked, briefly, like an arm64 problem. It wasn't. arm64 just happened to be the reader that finally dereferenced the gap.
+
+## The registry is shared mutable state
+
+This is a distributed-systems failure wearing Docker clothes.
+
+A tag is a **mutable pointer**. The registry that holds it has **multiple writers** — my CI runners and my laptop both have push rights — and **no coordination** between them. Mutable shared state, concurrent writers, no locking: last write wins. That it took months between the two writes instead of milliseconds doesn't change the category; it just makes the race quieter and the debugging worse.
+
+What makes the multi-arch version nastier than a normal last-write-wins clobber is that the writes aren't symmetric. CI writes an *index* — a fan-out. The laptop writes a *leaf* — a single image. When the leaf wins, the object doesn't just change value, it **loses structure**: a router becomes a destination. And because both are legal at a tag, nothing in the system treats the downgrade as wrong.
+
+Distributed systems have one answer to concurrent writers corrupting shared state: **ownership**. One writer owns the authoritative object; everyone else writes to their own namespace.
+
+## The fix, and the real fix
+
+The immediate fix is boring, which is the point: re-run the CI build of `debian`. Both legs build, `imagetools create` reassembles the index over the two arch leaves, `:trixie` is a router again, and the consumers resolve their arm64 base on the next try. No surgery — the arm64 leaf had been there the whole time; it just needed something pointing at it.
+
+The real fix is the ownership rule. CI owns the canonical tags. Local builds — which are legitimate; you need to build on your laptop — push to a namespace that can't collide with the authoritative one: an arch suffix, or a `:trixie-dev`, never the bare `:trixie`. A push guard that refuses a single-arch image onto a tag that currently resolves to an index turns the silent downgrade into a loud, immediate "no." The registry won't enforce that for you, so it has to live in the thing that does the pushing.
+
+## What I'd tell past-me
+
+- **A tag is a mutable pointer in shared state.** Treat a write to a canonical tag like a write to a shared database row — it needs an owner, not just push rights.
+- **Multi-arch makes the write asymmetric.** An index and a single image are both valid at a tag. Last-write-wins will silently swap a router for a leaf, and the registry won't call it an error.
+- **Partial-plus-delayed is the dangerous pair.** amd64 kept working, so nothing alarmed; the arm64 gap waited months for a reader. A periodic multi-arch consumer build is a cheap canary that makes the reader show up on *your* schedule, not chance.
+- **Keep local tooling out of canonical tags.** CI writes `:trixie`; laptops write `:trixie-dev` or an arch suffix, enforced by a push guard — not by remembering.
+- **Put an audit trail on your tags.** The only reason I could say "a laptop did this" instead of "somehow this happened" was one `runtime: Podman` line in a lineage record.
+
+None of this was an arm64 bug, the same way [the last one wasn't either](/docker-containers/2026/06/01/arm64-three-bugs-none-about-arm64.html). arm64 just reads the entry nobody else was reading.

--- a/docs/site/_posts/2026-06-06-the-dependency-graph-i-forgot-to-plug-in.md
+++ b/docs/site/_posts/2026-06-06-the-dependency-graph-i-forgot-to-plug-in.md
@@ -1,0 +1,54 @@
+---
+layout: post
+title: "The dependency graph I forgot to plug in"
+description: "My images build on each other, but changing a base only rebuilds the base — never the things on top of it. The fix turned out to be a dependency graph I'd already written, tested, and wired into exactly one of the two places that needed it."
+date: 2026-06-06 06:00:00 +0000
+tags: [ci, docker, monorepo, dependency-graph, github-actions, lessons-learned]
+---
+
+Several of my container images don't build from scratch — they build `FROM` one of the others. `github-runner` and `web-shell` sit on top of my own `debian`; `wordpress` sits on top of my own `php`. A little graph: a couple of bases, a few consumers hanging off them.
+
+The build system doesn't know that graph exists.
+
+I found that out the way you find out most things about a build system — by it not doing something I assumed it did. I'd changed `debian`, pushed, watched CI rebuild `debian`, and moved on. `github-runner` and `web-shell` — both of which start `FROM` that exact image — didn't rebuild. Not that run, not the next one. They just kept serving whatever they'd last been built against, on top of a base that had since moved.
+
+## What "detect what changed" actually does
+
+The job that decides what to build maps changed files to containers, and the mapping is as literal as it gets:
+
+```bash
+container="${file%%/*}"   # top-level dir of the changed path
+```
+
+Touch `debian/Dockerfile`, you get `debian`. Touch `web-shell/config.yaml`, you get `web-shell`. One file, one container, no second thought. It's a correct answer to the question "which container's *own files* changed" — and a completely wrong answer to the question I actually had, which was "what needs rebuilding now that `debian` did."
+
+A monorepo of images that build on each other only stays correct if you ask the second question. The first one treats every container as a leaf. Mine aren't leaves — some are routers with things hanging off them.
+
+Two ways to get hurt here. A base can change shape — drop a transitive package, lose an architecture — and the consumer that builds on it fails; but because it wasn't in the build matrix, the failure doesn't show up when the base changes. It waits, deferred, until something rebuilds the consumer for an unrelated reason, then detonates looking like a bug in the consumer. Or a base gets a CVE patch, rebuilds cleanly, and the consumers — which would happily pick up the fix — just don't, because nothing told them to. No error, no signal, indefinitely.
+
+## The part that stung
+
+So I went to add the obvious thing: expand a changed container to its consumers, so a `debian` change pulls `github-runner` and `web-shell` into the build along with it. A reverse-dependency walk. I started sketching how to parse every `FROM` and `base_image` across the fleet to build the edge list.
+
+Then I found `helpers/dependency-graph.sh`. In my own repo. With a function called `_depgraph_get_consumers`. With tests. Already merged.
+
+I'd written it months earlier — for the *other* place that needs this graph. Once a day a job walks every image and asks the registry whether the base it was built on has drifted; when it has, it opens a rebase PR. That detector classifies containers into bases and consumers, and it does it by calling `_depgraph_get_consumers`. The graph was real, it was correct, it was covered by tests, and it was answering "what depends on `debian`?" every single day.
+
+It just answered that question for *drift detection* and nowhere else. The build-change detector — the thing that decides what a push rebuilds — never asked. The same question had a working implementation sitting twenty files away, and the path that most needed it walked right past.
+
+## Wiring it where it was missing
+
+The fix isn't writing a dependency graph. It's calling the one that exists from the second place that needs it. After the change detector resolves the directly-changed containers, expand each through `_depgraph_get_consumers` and fold the results into the build set. A `debian/` change becomes `{debian, web-shell, github-runner}`; a `php/` change becomes `{php, wordpress}`.
+
+The important property is that the edges come from the actual `FROM` lines and `base_image` config, not a hand-maintained list. A declared `consumers:` field would have been faster to write and would have rotted the first time someone added a consumer without updating the base — a dependency list that lies is worse than none, because you trust it.
+
+That closes the loud failure mode — a base change now rebuilds its consumers in the same run, so a base that breaks them breaks loudly, immediately, attributed correctly. The quiet one — staleness between rebuilds — is already half-covered by the daily drift job; closing it fully means having the base's *successful publish* re-queue its consumers, which is the same graph again, called from a third place.
+
+## What I'd tell past-me
+
+- **In a monorepo of images that build on each other, the build graph is a graph.** Change detection that maps files to containers one-to-one is correct for leaves and wrong for everything with something on top of it. It has to walk the edges.
+- **Derive the edges, don't declare them.** A `FROM`-derived graph can't drift from reality. A hand-maintained `depends_on:` list can, and you won't notice until it silently skips a rebuild.
+- **Before you build infrastructure, grep for it.** I was about to write a reverse-dependency walker that already existed in my own repo, tested, used daily — for one of the two callers that needed it. The expensive part wasn't the graph. It was noticing I'd only plugged it in once.
+- **A base change that doesn't rebuild its consumers is a staleness bug on a delay fuse** — exactly the kind that surfaced when [a base quietly lost an architecture](/docker-containers/2026/06/04/multi-arch-is-a-distributed-systems-problem.html) and the consumers on top of it found out months later.
+
+The graph was the easy part. I'd done it. I'd just done it for the job that runs at 6 AM and not for the one that runs on every push.

--- a/docs/site/_posts/2026-06-08-the-284-byte-file-that-rebuilt-thirteen-containers.md
+++ b/docs/site/_posts/2026-06-08-the-284-byte-file-that-rebuilt-thirteen-containers.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: "The 284-byte file that rebuilt thirteen containers"
+description: "A transient network reset on a tiny artifact upload made my CI rebuild the entire fleet. The safety mechanism that did it was working exactly as designed — which is the whole point. This is about calibrating a fail-closed gate so it stops over-firing on noise without dulling the alarm."
+date: 2026-06-08 06:00:00 +0000
+tags: [ci, github-actions, fail-closed, reliability, lessons-learned]
+---
+
+I don't rebuild every image on every push — most pushes touch one or two. So there's a checkpoint: a git tag that records which containers failed in the last run. The next run rebuilds the ones whose files changed, *plus* the ones still carried as failing, and drops a container from the carry list only once it's built green. It keeps the build cheap without ever silently abandoning a broken image.
+
+One run carried all thirteen.
+
+Thirteen is the whole fleet. And it wasn't because thirteen things broke — most of them had built green that run. The checkpoint had looked at a run where three containers failed and decided to rebuild everything. I went in expecting a bug in the carry logic. What I found was the carry logic being exactly right about a situation I'd given it.
+
+## How the checkpoint decides
+
+Every build job, pass or fail, emits a tiny result record as an artifact — `{container, tag, arch, result}`, a few hundred bytes. After the matrix finishes, the checkpoint job downloads those records and reconciles them against the jobs that actually ran:
+
+- `failure_record_count` — how many records say `result: failure`
+- `bad_build_job_count` — how many jobs ended in a non-success state
+
+If those two agree, the checkpoint knows exactly which containers failed and carries precisely those. If `bad_build_job_count` is *greater* than `failure_record_count`, there's a failure it can't attribute — a job died without leaving a record saying which container it was. And at that point it does the only safe thing:
+
+```
+unmapped failure → carry everything (prior ∪ this run's matrix)
+```
+
+It refuses to claim it knows which containers are safe when there's a failure it can't account for. Fail-closed. Carry all thirteen, rebuild next run, sort it out when every cell has a record.
+
+## The 284 bytes
+
+So what was the unaccounted failure? The counts were 8 jobs bad, 7 records — a gap of one. The missing one was `php`, on amd64. And `php` had *built fine*. The image was pushed to both registries; the logs end with a clean success. Then this:
+
+```
+##[error]Failed to FinalizeArtifact: Unable to make request: ECONNRESET
+```
+
+That's the upload of the result record — a 284-byte JSON saying `php: success`. The Docker build worked, the push worked, the bytes of the record made it to blob storage, and then the *finalize* call that registers the artifact got its TCP connection reset. The upload step failed, which marked the whole job as failed. But no artifact was registered, so the checkpoint downloaded nothing for that cell.
+
+Eight failed jobs, seven failure records. One of those eight "failures" was a fully successful build whose 284-byte receipt didn't get filed. The gate saw a failure it couldn't map, did the safe thing, and rebuilt the fleet. A network blip on a tiny file rebuilt thirteen containers.
+
+## The tempting fix
+
+The tempting fix is to relax the count gate — tolerate a small gap, assume a missing record means success. Don't. The gate's strictness is the feature. The entire reason it exists is to never look at an unaccountable failure and quietly decide everything's fine; that's the failure mode it's there to prevent. Loosen it and you've reintroduced exactly the silent-gap bug it was built to stop, in exchange for saving the occasional redundant rebuild. Bad trade.
+
+The gate wasn't wrong. Its *input* was noisy. `php` looked like an unmapped failure only because a transient reset turned a successful build into a job with no record. Fix the noise, not the gate.
+
+`actions/upload-artifact` retries the data upload but not the finalize call, so an `ECONNRESET` there is fatal to that one upload. The fix is a gated retry around it: let the first upload fail soft, and if it did, run it again — same artifact, `overwrite: true`. Two consecutive resets on a 284-byte payload is a real problem worth failing on; one is just Tuesday on the internet. With the receipt reliably filed, a successful build stops occasionally presenting as an unaccountable failure, and the gate stops firing on phantom smoke.
+
+## What I'd tell past-me
+
+- **A fail-closed mechanism is supposed to over-react. The question is what it over-reacts *to*.** Reacting to a real unaccountable failure is correct. Reacting to a network blip on a receipt is the bug — and it lives in the input, not the gate.
+- **Don't dull the alarm to stop false alarms — remove the false smoke.** Relaxing the count gate would have "fixed" the symptom by reintroducing the exact silent failure the gate exists to catch. A fleet-wide rebuild over one dropped 284-byte file is the gate's false-positive cost showing up; make the trigger robust and that cost goes to near zero without touching the guarantee.
+- **`upload-artifact` doesn't retry finalize.** If a missing artifact has consequences downstream, wrap the upload in your own retry. The action's internal retries don't cover the call that actually registers the thing.
+
+The checkpoint did its job. It was handed a successful build wearing a failure's clothes and, not being able to tell, refused to guess.

--- a/docs/site/_posts/2026-06-10-when-your-tools-lie-to-you.md
+++ b/docs/site/_posts/2026-06-10-when-your-tools-lie-to-you.md
@@ -1,0 +1,78 @@
+---
+layout: post
+title: "When your tools lie to you"
+description: "In one CI cleanup, three tools told me things that weren't true: a run status that contradicted itself, a cancel that did nothing, and a review gate that refused code I hadn't written. None were broken. Each was answering a slightly different question than the one I thought I'd asked."
+date: 2026-06-10 06:00:00 +0000
+tags: [ci, github-actions, git, tooling, debugging, lessons-learned]
+---
+
+I had a stuck CI run to clear and a fix to ship behind it. Routine cleanup. Over the next hour, three different tools told me things that were false, and I believed each one a little too long. None of them was broken. Each was a faithful answer to a question I didn't realize I was asking.
+
+## Lie #1: the run status that wouldn't hold still
+
+A push run on `master` was sitting in the way, holding a concurrency lock so the next run couldn't start. I checked on it:
+
+```bash
+gh run view <id> --json status,jobs
+```
+
+It said `in_progress`, with jobs ticking along. A minute later, `completed`. A minute after that, `in_progress` again, jobs un-completing. The status was contradicting itself across reads that were seconds apart.
+
+`gh run view` reads a derived, cached projection of the run. Under load it lags and flickers — it's eventually consistent, and "eventually" was visibly losing to my refresh key. The authoritative source is the REST endpoint:
+
+```bash
+gh api repos/<owner>/<repo>/actions/runs/<id> --jq '{status, conclusion, updated_at}'
+```
+
+That one didn't flicker. It said `queued`, `updated_at` frozen at a timestamp from an hour earlier. The run wasn't progressing at all — it had never been assigned a runner. The porcelain had been inventing job progress; the plumbing told me the truth. When two views of the same object disagree, the cached one isn't a second opinion. It's noise.
+
+## Lie #2: the cancel that did nothing
+
+Fine — kill it and move on:
+
+```bash
+gh run cancel <id>
+```
+
+Returned success. The run stayed `queued`. Stayed `queued`. Kept holding the lock for another hour while I waited for it to die.
+
+`gh run cancel` signals the running jobs to stop. This run had no running jobs — it was `queued`, never scheduled, nothing to signal. The cancel succeeded at delivering a signal to zero recipients, which is to say it did nothing, and reported that nothing as success. A queued run that won't start also won't soft-cancel; there's no process to interrupt.
+
+What actually lands is force-cancel, which tears the run down at the control-plane level regardless of whether anything's running:
+
+```bash
+gh api -X POST repos/<owner>/<repo>/actions/runs/<id>/force-cancel
+```
+
+That killed it in seconds. The lock released, the queued run behind it started. "Success" from the soft cancel had meant "the message was sent," not "the thing you wanted happened" — and those are only the same when there's someone listening.
+
+## Lie #3: the review gate that refused code I hadn't written
+
+With the queue clear, I pushed the actual fix — a four-line change to one workflow file — through an orthogonal review gate before merging. It refused. The findings were about base-image staleness and digest freshness in a registry-sync helper. I hadn't touched that helper. It had been merged days earlier, in a different change.
+
+The gate wasn't hallucinating. It was reviewing exactly what it was handed — and it had been handed the wrong diff. The diff it reviews comes from:
+
+```bash
+git diff master...HEAD
+```
+
+Three dots. `A...B` doesn't diff `A` against `B`; it diffs the **merge base** of the two against `B` — everything on my branch since it last diverged from `master`. And my local `master` was stale: the things I'd merged in the last few days went in as squash commits on the remote, but my local `master` ref had never caught up. So the merge base was way back, and the three-dot range swept in every commit since — including the registry-sync change from days ago that was already live.
+
+The gate reviewed all of it and refused on the part that wasn't mine. Fixing it wasn't arguing with the gate; it was fixing the diff. Update local `master` to the remote, rebase the branch onto it so the range is just my four lines, re-run. Clean. The tool had been honest about a diff that wasn't the diff I thought I was showing it.
+
+## The thread
+
+Every one was a tool faithfully answering a question subtly different from the one in my head.
+
+`gh run view` answered "what does the cache say?" when I needed "what is true?" `gh run cancel` answered "did the signal send?" when I needed "did it stop?" `git diff A...B` answered "what's changed since the merge base?" when I thought I'd asked "what's in my change?" None lied in the sense of being wrong. They lied in the sense every map does — by being a representation, with a contract I'd half-remembered.
+
+The failure that fails first in an incident isn't usually the system. It's your model of what your tools are telling you. The map is not the territory.
+
+## What I'd tell past-me
+
+- **When two views of the same thing disagree, find the authoritative one.** `gh api` over `gh run view`. The plumbing doesn't flicker; the porcelain does. A self-contradicting status isn't a second opinion to average — it's a cache to stop trusting.
+- **"Success" from a command means the command succeeded, not that the world changed.** A soft cancel that signals zero jobs reports success and does nothing. Check the state you wanted, not the exit code you got. Know that force-cancel exists for the run that won't die.
+- **Know `..` from `...`.** A review or CI step that diffs `A...B` shows everything since the merge base, not your change — and a stale local base silently widens that range. If a gate flags code you don't recognize, suspect the diff base before the finding.
+- **In an incident, audit your tools first, the system second.** I lost two hours to three tools telling the truth about questions I hadn't meant to ask.
+
+The run was stuck, the cancel was a no-op, the gate was reviewing someone else's week-old code — and all three tools were behaving exactly as documented. The bug was that I'd stopped reading the documentation a long time ago and was going on memory.


### PR DESCRIPTION
Four blog posts from the recent CI-hardening work, future-dated for staggered publication via the daily Pages rebuild:

- 2026-06-04 — Multi-arch is a distributed-systems problem
- 2026-06-06 — The dependency graph I forgot to plug in
- 2026-06-08 — The 284-byte file that rebuilt thirteen containers
- 2026-06-10 — When your tools lie to you

`future: false` withholds the future-dated posts until their date; the daily 07:00 UTC update-dashboard cron publishes each on schedule. Post #1 (today) publishes on this merge.