### PR TITLE
docs(adr): ADR-013 — decide on buildx bake (Option B)

### DIFF
--- a/docs/adr/ADR-013-dependency-ordered-builds.md
+++ b/docs/adr/ADR-013-dependency-ordered-builds.md
@@ -1,10 +1,10 @@
 # ADR-013: Dependency-ordered container builds
 
-**Status:** Proposed (v2)
+**Status:** Accepted
 **Date:** 2026-06-05
 **Issues:** #628 (origin: `github-runner:debian-trixie` and `web-shell:debian` failed on arm64 because a consumer built in parallel with its base and raced the base's transient single-arch tag)
 **Supersedes:** None
-**Siblings:** ADR-010 (chained-on-own & digest drift), ADR-011 (cascade-aware drift detection), ADR-006 (multi-distro template)
+**Siblings:** ADR-001 (native multi-arch runners), ADR-010 (chained-on-own & digest drift), ADR-011 (cascade-aware drift detection), ADR-006 (multi-distro template)
 
 ## Context
 
@@ -16,78 +16,96 @@ debian → web-shell:debian
 php    → wordpress
 ```
 
-A dependency graph already exists and is well-tested: `helpers/dependency-graph.sh` exposes `_depgraph_get_deps`, `_depgraph_get_deps_transitive` (leaves-first transitive closure of one container — **not** a global layering), `_depgraph_get_consumers` (reverse lookup), and `_depgraph_validate_no_cycles`; 64 bats. It is sourced by exactly one caller: `scripts/detect-base-digest-drift.sh` (the daily drift job). **The build pipeline never uses it.**
+A dependency graph already exists and is well-tested: `helpers/dependency-graph.sh` (`_depgraph_get_deps`, `_depgraph_get_deps_transitive`, `_depgraph_get_consumers`, `_depgraph_validate_no_cycles`; 64 bats). It is sourced by exactly one caller — `scripts/detect-base-digest-drift.sh` (the daily drift job). **The build pipeline never uses it.**
 
-`auto-build.yaml` treats containers as independent: `detect-containers` maps changed files 1:1 to containers (no consumer expansion); `build-and-push` is a single flat matrix (`build × arch`, `max-parallel: 10`, no inter-cell ordering); `create-manifest` is a global barrier after all build legs.
+`auto-build.yaml` treats containers as independent: `detect-containers` maps changed files 1:1 to containers (no consumer expansion); `build-and-push` is a single flat matrix (`build × arch`, no inter-cell ordering); `create-manifest` is a global barrier after all build legs.
 
 Empirically confirmed by run `26976283697`: a carry-all rebuilt all 13 containers; `debian` and its consumers built as concurrent cells; `github-runner:debian-trixie` + `web-shell:debian` failed on arm64 while everything else went green; the checkpoint correctly isolated `failed_containers: ["github-runner", "web-shell"]`.
 
+**Priority order for this decision** (governs the option choice):
+1. **Reproducibility / determinism** — the same inputs produce the same build, every time.
+2. **Remote (CI) operation is the product** — the GitHub Actions pipeline is what must work; native multi-arch on the respective native runners (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`) is a **hard requirement** (ADR-001). QEMU emulation of arm64 on amd64 runners is explicitly **not** acceptable for CI.
+3. **Local debuggability is a force-multiplier, not the goal** — being able to reproduce/debug the ordering on a laptop, with zero GitHub round-trips, is worth a lot, but it serves the remote goal; it is not "local-first" for its own sake.
+
 ## Problem
 
-Three interacting defects, not two:
+Four interacting defects:
 
 **Gap A — expansion.** A change to `debian/` queues only `debian`, never its consumers.
 
-**Gap B — ordering + transient single-arch tag.** The `Create early tag alias` step (`build-container/action.yaml:737-788`) writes the bare canonical tag single-arch after each per-arch leg; the multi-arch manifest is assembled only later by `create-manifest`. A consumer building in the same flat parallel matrix does `FROM debian:trixie` during the single-arch window → `no match for platform` on arm64.
+**Gap B — ordering + transient single-arch tag.** The `Create early tag alias` step (`build-container/action.yaml`) writes the bare canonical tag single-arch after each per-arch leg; the multi-arch manifest is assembled only later by `create-manifest`. A consumer building in the same flat parallel matrix does `FROM debian:trixie` during the single-arch window → `no match for platform` on arm64.
 
-**Gap C — non-strict manifest + mutable-tag identity (surfaced in review).** Even with ordering, two holes remain:
-- `helpers/create-manifest.sh` has single-arch **fallback** paths. For a rolling-tagged internal base like `debian:trixie` (non-numeric), `_compute_version_specific_tag_args` resolves the version-specific anchor to the rolling tag itself, so on partial-arch failure the fallback **publishes a single-arch `debian:trixie` and returns success** — a consumer in the next layer then builds against a structurally single-arch base and fails anyway.
-- Consumers reference a **mutable rolling tag** (`FROM debian:trixie`), so ordering guarantees *a* manifest exists but not that the consumer pulled the *exact* index this run produced (cross-run retarget, rerun, local clobber #624).
+**Gap C — non-strict manifest + mutable-tag identity.** Even with ordering: `create-manifest`'s single-arch fallback can still publish a single-arch rolling tag for an internal base on partial-arch failure; and consumers reference a **mutable rolling tag**, so ordering guarantees *a* manifest exists but not the *exact* index this run produced (cross-run retarget, rerun, local clobber #624).
 
-And one amplifier (surfaced in review):
+**Gap D — smart-skip defeats expansion.** `SKIP_EXISTING_BUILDS` keys on a source/config build digest that excludes the base manifest digest, so a `debian/` change can queue `web-shell` yet `web-shell` then **skips** (its own files unchanged).
 
-**Gap D — smart-skip defeats expansion.** `SKIP_EXISTING_BUILDS` + a source/config-based build digest (`helpers/build-cache-utils.sh`) that does **not** include the resolved base manifest digest means a `debian/` change can queue `web-shell`, but `web-shell` then **skips** because its own Dockerfile/config didn't change. Expansion alone does not guarantee the consumer rebuilds.
-
-Critically: **fixing Gap A without B+C fires the race on every base change.** Expansion, ordering, manifest-strictness, identity, and skip-semantics must be designed together.
+The defects are coupled: the flat parallel matrix is the root — it has no notion that one container's build depends on another's. Any fix must make the build itself dependency-aware.
 
 ## Considered options
 
-**A — Layering + runtime digest handoff + strict manifest (chosen).** Order via bounded static GHA layer jobs driven by the graph; hand the base's freshly-assembled manifest **digest** to consumers in-pipeline; make canonical-tag publication strict. Detail in Decision.
+**B — `docker buildx bake` with `target:` contexts (chosen).** BuildKit builds the dependency graph in a single invocation and passes each built image to its dependents **in memory**, with no registry round-trip — so the base→child race cannot occur by construction. It is compatible with native multi-arch on separate runners (see Decision) and is **reproducible and debuggable locally** (`docker buildx bake --print` shows the resolved DAG; an actual `bake` builds the chain on a laptop). **Validated e2e locally** (see Validation).
 
-**B — `docker buildx bake` with `target:` contexts.** BuildKit orders + dedups + avoids the registry round-trip race within one invocation. Rejected for v1: replaces the per-container `./make build` path, extension staging, lineage/SBOM/flatten/push, and smart-skip all at once; platform-set-compatibility constraint (buildx #2486). A plausible later consolidation once the current pipeline is correct.
+**A — bounded static GHA layer jobs + runtime digest handoff + strict manifest.** Order via a fixed chain of `(build-layerN → manifest-layerN)` jobs driven by the graph; hand the base's freshly-assembled manifest digest to consumers; make canonical-tag publication strict. Rejected as the primary: it only *timing-closes* the race (the base is still consumed through a mutable registry tag, requiring strict-manifest + digest-handoff bolt-ons to be safe), its **ordering lives in GHA job orchestration and is therefore only testable in CI** — it reproduces the very "visible-only-in-CI" failure mode this project keeps paying for. It remains a viable fallback if Option B's pipeline rewrite proves too costly.
 
-**C — static digest pins committed in Dockerfiles/config** (`FROM debian@sha256:…` checked in). Rejected: requires a commit+push to every consumer on every base bump (Renovate-style churn). The **runtime** digest handoff in Option A gives the same hermetic-identity guarantee with zero per-update commits.
+**C — static digest pins committed in Dockerfiles** (`FROM debian@sha256:…`). Rejected: a commit+push to every consumer on every base bump (Renovate-style churn). Bake's in-memory handoff gives the same hermetic identity with zero per-update commits.
 
-**D — externalize bases / adopt Dagger·Earthly·Bazel.** Rejected: disproportionate for a depth-2 graph.
+**D — externalize bases / adopt Dagger·Earthly·Bazel.** Rejected: disproportionate adoption cost for a depth-2 graph; bake is BuildKit-native and the repo already uses buildx.
+
+## Validation (e2e, local)
+
+On a developer laptop (x86_64, podman + brew `docker-buildx` v0.34.1 + rootless `buildkitd` 0.30.0), with a hand-written bake file modelling `debian → {github-runner:debian-trixie, web-shell:debian}`:
+
+- `docker buildx bake --print` resolves the DAG and shows each consumer's `contexts` pointing at `target:debian` — the dependency edge.
+- An actual `bake` of `github-runner-debian-trixie-base` built `debian` **first**, then built github-runner on top of it **in memory**: the build log shows debian's stages running inside the consumer target, the `FROM …/debian:trixie` resolved to the local target (no registry pull, no `no match for platform`), and the build proceeded through the consumer's own stages. It stopped only at `COPY runner.tar.gz` — a missing build-context artifact the CI normally pre-fetches, **not** an ordering/race failure.
+
+Conclusion: the base→child ordering and in-memory handoff work, the multi-arch race is structurally impossible, and the whole thing is reproducible on a laptop with no CI round-trip.
 
 ## Decision
 
-Three coordinated mechanisms — order, identity, safety — plus skip and rollout discipline.
+Make the build dependency-aware by adopting **`docker buildx bake`** as the build engine, driven by the existing dependency graph, with **native per-arch builds on respective runners + manifest merge**.
 
-### 1. Expansion (Gap A) — shadow first
-`detect-containers` sources `dependency-graph.sh` (config-only path; `_DEPGRAPH_LINEAGE_DIR` pinned empty to avoid the fail-closed `./make list-builds` fan-out) and expands each changed container with `_depgraph_get_consumers` (transitive) into the impacted set. **Phase 1 emits this and the layer outputs as SHADOW outputs only** — the live `builds`/`containers` behaviour is unchanged until Phase 2, so expansion never reaches the flat matrix (which would trigger the race).
+### 1. Build order — BuildKit, not GHA
+A generated `docker-bake.hcl` declares every image as a `target`, with each consumer's base reference remapped to the producing target:
+```hcl
+contexts = { "ghcr.io/oorabona/debian:trixie" = "target:debian" }
+```
+BuildKit then builds bases before consumers, deduplicates shared bases, and hands the base image to consumers **in memory**. This subsumes Gap B (ordering) and the timing race entirely, and Gap C's identity problem within a run (the consumer builds against the exact base produced this run, not a mutable registry tag). The HCL is generated from `variants.yaml` so it covers the template-generator containers, retained versions, and the postgres extension sub-pipeline.
 
-### 2. Topological layering (Gap B — order)
-A **new** partition step (this is genuinely new code; the helper gives per-container transitive deps, not a global level map) assigns each impacted build a layer index = longest internal-dep path within the **impacted induced subgraph**, **densely renumbered** (if only `wordpress` changes it is `layer0`, not `layer1`). It emits one build matrix per layer (`layer0..layer{LAYER_MAX}`, initial `LAYER_MAX=3`), **failing closed** if real depth exceeds the cap. Layer unit = **container** (coarsest safe granularity): all of a multi-distro container's cells (incl. its external-base distros and its windows/arm64-excluded rows) ride in its container's layer — accepting over-serialization of independent distros in exchange for simplicity and safety. Diamonds (a container consumed by two bases) resolve to one layer (max of the two).
+### 2. Native multi-arch on respective runners + merge (Gap B across arches; no QEMU)
+QEMU on amd64 runners is rejected. Instead, run **one per-arch bake on each native runner**, then merge:
+```
+job build-amd64 (ubuntu-latest):     bake --set "*.platform=linux/amd64" --push   → <img>:<tag>-amd64
+job build-arm64 (ubuntu-24.04-arm):  bake --set "*.platform=linux/arm64" --push   → <img>:<tag>-arm64
+job manifest    (needs both):        imagetools create <img>:<tag> <img>:<tag>-{amd64,arm64}
+```
+Within each per-arch bake, the consumer consumes the **correct-arch** base in memory (bake builds `debian-<arch>` then `github-runner-<arch>` from it) — native, ordered, no QEMU, no per-arch registry round-trip. The only cross-runner artifact is the final manifest list. (An advanced alternative — a multi-node buildx builder spanning both runners with a single `bake --platform amd64,arm64` — is possible but needs cross-runner buildkit networking; the two-job + merge form is simpler and matches ADR-001.)
 
-The workflow declares a fixed chain `build-layer0 → manifest-layer0 → build-layer1 → manifest-layer1 → …`: `manifest-layerN needs build-layerN`; `build-layer{N+1} needs manifest-layerN`. Each job guards `if: needs.detect-containers.outputs.layerN != '[]'`. The `strategy.matrix` (arch list + windows-arm64 `exclude` + `max-parallel`) is **replicated identically per layer** (an actionlint/bats check asserts the blocks stay in sync). All downstream jobs (`summary`, `publish-coverage-checkpoint`, `cache-lineage`, `sync-registries`) are rewired to depend on every layer/manifest job with `always()`/`!cancelled()` + explicit `needs.*.result` checks.
+### 3. Expansion — the graph decides *what* to build (Gap A)
+`detect-containers` sources `dependency-graph.sh` and expands changed→consumers (transitive) so the per-arch bake targets the impacted set (changed ∪ consumers). The graph chooses *which* targets; BuildKit orders them. This also removes the bespoke `SKIP_EXISTING_BUILDS` correctness hole (Gap D): build skipping becomes BuildKit's content-addressed cache, which already accounts for the (in-memory) base.
 
-### 3. Runtime digest handoff (Gap C — identity)
-When `manifest-layerN` assembles a base's multi-arch index, capture its **manifest-list digest** and pass it to that base's consumers in `build-layer{N+1}` via their **existing base build-arg**: `DEBIAN_TRIXIE_BASE=ghcr.io/oorabona/debian@sha256:<digest>`, etc. The consumer is then hermetic to the exact index built this run — eliminating both the transient single-arch window and cross-run mutable-tag drift. github-runner already takes a full-ref build-arg (free); web-shell's generated `FROM` takes a tag and needs the ref form; **wordpress needs a one-time refactor** of `FROM ${REMOTE_CR}/php:${PHP_TAG}` to accept a full `repo@sha256` ref. These are one-time plumbing changes, **not** committed static digests.
+### 4. Strict published manifest (Gap C — across runners)
+The `manifest` job publishes the canonical/rolling tag **only** when the full required platform set was pushed; never a single-arch fallback for an internal base. The old `create-manifest` single-arch fallback for internal-base rolling tags is removed.
 
-### 4. Strict canonical-tag publication (Gap C — safety)
-`create-manifest` must **never** publish a canonical/rolling tag for an **internal base** unless the full required platform set exists. Remove the single-arch fallback for internal-base rolling tags: on partial-arch failure the manifest job **fails** (which blocks the dependent layer) instead of publishing a single-arch rolling tag and returning success. The layer→layer edge additionally verifies the base manifest is multi-arch (`imagetools inspect` asserting both platforms), not merely that the job's exit code was 0.
-
-### 5. Base-aware smart-skip (Gap D)
-A dependency-triggered consumer must not be skipped when its base changed. Either force-rebuild dependency-expanded consumers, or — preferred — fold the resolved base manifest digest into the build-cache digest (`build-cache-utils.sh`) so a base change naturally busts the consumer's skip.
+### 5. Context-artifact pre-fetch
+Targets that need build-context artifacts (e.g. `github-runner`'s `runner.tar.gz`, `web-shell`'s `ttyd`) get a pre-fetch step before bake (or a bake-managed remote context / secret). This is the integration surface the local e2e surfaced.
 
 ## Out of scope (v1)
 
-- **Silent staleness on non-file-change base rebuilds** (CVE rebase with no `debian/` diff): still owned by the daily drift cron + ADR-011 cascade.
-- **Migration to buildx bake** (Option B) — future ADR.
-- **Graphs deeper than `LAYER_MAX`** — fail-closed guard, not dynamic layer creation (GHA cannot create `needs:` edges at runtime).
-- **Local-build clobber of canonical tags** — that is #624 (push guard), independent.
+- **Replacing the coverage-checkpoint / failure-attribution machinery** — it adapts to the new job shape (per-arch bake jobs + manifest) but its logic (#595) is unchanged in intent.
+- **Silent staleness on non-file-change base rebuilds** — still owned by the daily drift cron + ADR-011 cascade.
+- **Local multi-arch** — QEMU is a *local convenience only* (rootful binfmt), never a CI mechanism; the host-arch build is enough to validate ordering locally.
+- **Local-build clobber of canonical tags** — #624 (push guard), independent.
 
 ## Consequences
 
 ### Positive
-- A base change rebuilds its consumers, in correct order, hermetically pinned to the exact base index — the build finally uses the graph it owns.
-- The multi-arch race becomes genuinely impossible (not just timing-closed): order + digest identity + strict manifest together.
-- Reuses the tested topo helper; no new build tool; no committed static digests / no per-update churn.
+- **Native multi-arch with no QEMU in CI** — arm64 builds on the arm64 runner, its arm64 base built in the same in-memory bake. Directly satisfies ADR-001 + the reproducibility priority.
+- **The base→child race is impossible by construction** (in-memory context; no registry round-trip, no transient single-arch tag, no mutable-tag dependence within a run).
+- **Reproducible and debuggable locally** — `bake --print` and a laptop build reproduce the ordering with zero GitHub round-trips (the property that would have prevented this whole class of incident).
+- The dependency graph the repo already owns is finally used by the build (for expansion); BuildKit owns ordering.
 
 ### Negative / Limitations
-- **Phase 2 is a core pipeline rewrite**, not a YAML tweak: layer topology, manifest strictness, base-aware skip, downstream result aggregation, and digest handoff plumbing. The 30/20/50 framing under-weights this — treat Phase 2 as the project.
-- **More wall-clock**: layers serialize; a slow base (e.g. debian's arm64 leg, the #628 culprit) head-of-line-blocks all consumers; the windows variant of github-runner (~60-120 min) now waits behind debian's manifest despite not depending on it (the cost of container-granular layering).
-- **`LAYER_MAX` ceiling**: deeper graph needs a new layer stanza; the guard makes overflow loud, not silent.
-- **wordpress `FROM` refactor** is a real (one-time) change; web-shell generator tweak likewise.
-- **Blast radius**: every container's build path + all downstream reporting jobs change; must roll out with live multi-arch validation and a Windows-tag post-run check (the early-alias comment claiming the manifest job skips Windows is stale — create-manifest does handle Windows; removal is safe but must be verified).
+- **A from-the-studs pipeline rewrite**: per-arch bake jobs replace the `(container × arch)` flat matrix; the post-build steps (Trivy, SBOM/attestation, flatten, multi-registry push, lineage) must be re-homed around bake's outputs; the HCL must be generated from `variants.yaml` covering the template-generator, retained-version, and extension patterns; context-artifact pre-fetch must be wired. Highest blast radius of any option.
+- **Per-container build-result attribution** (coverage checkpoint, #595) must be re-derived from the new job shape.
+- **Local multi-arch needs rootful QEMU** (a one-time host setup), but this is dev-convenience only; CI uses native runners.
+- **Rollout must be incremental and gated**, with live native multi-arch validation (amd64 runner + arm64 runner + merge) and a Windows-tag post-run check.


### PR DESCRIPTION
ADR-013 decision switched to Option B (docker buildx bake with target: contexts): in-memory base->child ordering (race impossible by construction), native multi-arch via per-arch bake on each native runner + manifest merge (no QEMU in CI), reproducible/debuggable locally (validated e2e). Status: Accepted. Refs #628.