### PR TITLE
refactor(ci): centralize default-variant :latest tag routing in compute_cell_tags

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -222,6 +222,10 @@ runs:
           source ./helpers/variant-utils.sh 2>/dev/null || true
           if declare -f variant_property >/dev/null 2>&1; then
             local_is_default=$(variant_property "$container" "${variant:-$flavor}" "default" 2>/dev/null || echo "false")
+            # variant_property exits 0 with empty output when the variant doesn't exist
+            # in variants.yaml; the || fallback above does NOT catch that case.
+            # Coerce the empty result to "false" so the is_default output is always set.
+            [[ -z "$local_is_default" ]] && local_is_default="false"
           fi
         else
           # No flavor = single-variant container, always default

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -221,7 +221,7 @@ runs:
         if [[ -n "$flavor" ]]; then
           source ./helpers/variant-utils.sh 2>/dev/null || true
           if declare -f variant_property >/dev/null 2>&1; then
-            local_is_default=$(variant_property "$container" "$flavor" "default" 2>/dev/null || echo "false")
+            local_is_default=$(variant_property "$container" "${variant:-$flavor}" "default" 2>/dev/null || echo "false")
           fi
         else
           # No flavor = single-variant container, always default
@@ -436,11 +436,15 @@ runs:
 
         # Build via ./make — sources container build files, handles CUSTOM_BUILD_ARGS
         build_flavor="${{ inputs.build_flavor }}"
+        is_default="${{ steps.check-build.outputs.is_default }}"
         make_args=("build" "$container" "$build_version")
         [[ -n "$current_tag" ]] && make_args+=("$current_tag")
         [[ -n "$flavor" ]] && make_args+=("--flavor" "$flavor")
         [[ -n "$build_flavor" ]] && make_args+=("--build-flavor" "$build_flavor")
         [[ -n "$dockerfile" && "$dockerfile" != "Dockerfile" ]] && make_args+=("--dockerfile" "$dockerfile")
+        # Thread the variant-name-based is_default so compute_cell_tags routes the
+        # default variant's rolling tag to bare :latest (not :latest-<flavor>).
+        [[ -n "$is_default" ]] && make_args+=("--is-default" "$is_default")
 
         # shellcheck source=helpers/retry.sh
         source ./helpers/retry.sh

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -285,6 +285,61 @@ variant_image_tag() {
     fi
 }
 
+# Compute the full set of image refs to tag for one build cell.
+#
+# This is the single source of truth for tag-set logic; build-container.sh
+# and any future bake-HCL generator must call this function instead of
+# duplicating the rules.
+#
+# Rules (same as the former inline block in build_container()):
+#   - Always emit the versioned ref on both docker.io and ghcr.io.
+#   - When tag != "latest":
+#       • flavor non-empty AND variant_property default == "true"
+#           → also emit :latest on both registries.
+#       • flavor non-empty AND default != "true"
+#           → also emit :latest-<flavor> on both registries.
+#       • flavor empty
+#           → also emit :latest on both registries.
+#
+# Usage: compute_cell_tags <container_dir> <tag> <flavor> <dockerhub_image> <ghcr_image>
+#   container_dir   : path to the container directory (for variant_property lookup)
+#   tag             : image tag for this build cell (e.g. "18-alpine", "1.14.6-alpine")
+#   flavor          : variant flavor name (e.g. "base", "vector", "") — empty for no-flavor containers
+#   dockerhub_image : docker.io/<owner>/<container>  (no tag)
+#   ghcr_image      : ghcr.io/<owner>/<container>   (no tag)
+#
+# Output: one fully-qualified image ref per line (no leading "-t").
+#         Caller reads into an array and prepends "-t" as needed.
+compute_cell_tags() {
+    local container_dir="$1"
+    local tag="$2"
+    local flavor="$3"
+    local dockerhub_image="$4"
+    local ghcr_image="$5"
+
+    # Versioned tag — always present on both registries
+    printf '%s:%s\n' "$dockerhub_image" "$tag"
+    printf '%s:%s\n' "$ghcr_image"      "$tag"
+
+    # Rolling latest tags — only when this is not already a "latest" tag
+    if [[ "$tag" != "latest" ]]; then
+        if [[ -n "$flavor" ]]; then
+            local is_default
+            is_default=$(variant_property "$container_dir" "$flavor" "default" 2>/dev/null || echo "false")
+            if [[ "$is_default" == "true" ]]; then
+                printf '%s:latest\n' "$dockerhub_image"
+                printf '%s:latest\n' "$ghcr_image"
+            else
+                printf '%s:latest-%s\n' "$dockerhub_image" "$flavor"
+                printf '%s:latest-%s\n' "$ghcr_image"      "$flavor"
+            fi
+        else
+            printf '%s:latest\n' "$dockerhub_image"
+            printf '%s:latest\n' "$ghcr_image"
+        fi
+    fi
+}
+
 # Check if a container always builds all retained versions (not just the latest)
 # Usage: always_all_versions <container_dir>
 # Returns: "true" or "false" on stdout

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -303,7 +303,10 @@ variant_image_tag() {
 #
 # Usage: compute_cell_tags <tag> <flavor> <is_default> <dockerhub_image> <ghcr_image>
 #   tag             : image tag for this build cell (e.g. "18-alpine", "1.14.6-alpine")
-#   flavor          : variant flavor name (e.g. "base", "vector", "") — empty for no-flavor containers
+#   flavor          : the variants.yaml `.flavor` field for this variant — the rolling-tag suffix source
+#                     (e.g. "base", "ubuntu-2404", "") — empty for no-flavor containers.
+#                     Distinct from `build_flavor` (the --build-arg FLAVOR value); for containers like
+#                     github-runner the variant name ("ubuntu-2404-base") differs from this flavor field.
 #   is_default      : "true" if this variant is the default; any other value means non-default.
 #                     Caller computes this via variant_property <dir> <variant_name> "default".
 #   dockerhub_image : docker.io/<owner>/<container>  (no tag)

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -291,29 +291,30 @@ variant_image_tag() {
 # and any future bake-HCL generator must call this function instead of
 # duplicating the rules.
 #
-# Rules (same as the former inline block in build_container()):
+# Rules:
 #   - Always emit the versioned ref on both docker.io and ghcr.io.
 #   - When tag != "latest":
-#       • flavor non-empty AND variant_property default == "true"
+#       • is_default == "true"
 #           → also emit :latest on both registries.
-#       • flavor non-empty AND default != "true"
+#       • is_default != "true" AND flavor non-empty
 #           → also emit :latest-<flavor> on both registries.
-#       • flavor empty
+#       • is_default != "true" AND flavor empty
 #           → also emit :latest on both registries.
 #
-# Usage: compute_cell_tags <container_dir> <tag> <flavor> <dockerhub_image> <ghcr_image>
-#   container_dir   : path to the container directory (for variant_property lookup)
+# Usage: compute_cell_tags <tag> <flavor> <is_default> <dockerhub_image> <ghcr_image>
 #   tag             : image tag for this build cell (e.g. "18-alpine", "1.14.6-alpine")
 #   flavor          : variant flavor name (e.g. "base", "vector", "") — empty for no-flavor containers
+#   is_default      : "true" if this variant is the default; any other value means non-default.
+#                     Caller computes this via variant_property <dir> <variant_name> "default".
 #   dockerhub_image : docker.io/<owner>/<container>  (no tag)
 #   ghcr_image      : ghcr.io/<owner>/<container>   (no tag)
 #
 # Output: one fully-qualified image ref per line (no leading "-t").
 #         Caller reads into an array and prepends "-t" as needed.
 compute_cell_tags() {
-    local container_dir="$1"
-    local tag="$2"
-    local flavor="$3"
+    local tag="$1"
+    local flavor="$2"
+    local is_default="$3"
     local dockerhub_image="$4"
     local ghcr_image="$5"
 
@@ -323,16 +324,12 @@ compute_cell_tags() {
 
     # Rolling latest tags — only when this is not already a "latest" tag
     if [[ "$tag" != "latest" ]]; then
-        if [[ -n "$flavor" ]]; then
-            local is_default
-            is_default=$(variant_property "$container_dir" "$flavor" "default" 2>/dev/null || echo "false")
-            if [[ "$is_default" == "true" ]]; then
-                printf '%s:latest\n' "$dockerhub_image"
-                printf '%s:latest\n' "$ghcr_image"
-            else
-                printf '%s:latest-%s\n' "$dockerhub_image" "$flavor"
-                printf '%s:latest-%s\n' "$ghcr_image"      "$flavor"
-            fi
+        if [[ "$is_default" == "true" ]]; then
+            printf '%s:latest\n' "$dockerhub_image"
+            printf '%s:latest\n' "$ghcr_image"
+        elif [[ -n "$flavor" ]]; then
+            printf '%s:latest-%s\n' "$dockerhub_image" "$flavor"
+            printf '%s:latest-%s\n' "$ghcr_image"      "$flavor"
         else
             printf '%s:latest\n' "$dockerhub_image"
             printf '%s:latest\n' "$ghcr_image"
@@ -802,4 +799,4 @@ latest_per_major_versions() {
 export -f resolve_major_version has_variants list_versions version_count list_variants variant_count
 export -f variant_property default_variant base_suffix version_retention
 export -f version_dockerfile requires_extensions variant_image_tag list_build_matrix list_container_builds list_variant_tags
-export -f always_all_versions compute_expand_retained_map latest_per_major_versions
+export -f always_all_versions compute_cell_tags compute_expand_retained_map latest_per_major_versions

--- a/make
+++ b/make
@@ -347,7 +347,7 @@ do_buildx() {
     if [[ -n "${FLAVOR:-}" ]]; then
       # Single-flavor build (CI mode or explicit --flavor)
       log_info "Building $container with flavor: $FLAVOR${BUILD_FLAVOR:+ (build_flavor: $BUILD_FLAVOR)}"
-      build_container "$container" "$VERSION" "$TAG" "$FLAVOR" "${DOCKERFILE:-Dockerfile}" "${BUILD_FLAVOR:-}" "${IS_DEFAULT:-false}"
+      build_container "$container" "$VERSION" "$TAG" "$FLAVOR" "${DOCKERFILE:-Dockerfile}" "${BUILD_FLAVOR:-}" "${IS_DEFAULT:-}"
     elif container_has_variants "$container"; then
       # Full variant expansion (local build)
       # VERSION may be a full version (e.g., "18.1-alpine") but variants.yaml

--- a/make
+++ b/make
@@ -347,7 +347,7 @@ do_buildx() {
     if [[ -n "${FLAVOR:-}" ]]; then
       # Single-flavor build (CI mode or explicit --flavor)
       log_info "Building $container with flavor: $FLAVOR${BUILD_FLAVOR:+ (build_flavor: $BUILD_FLAVOR)}"
-      build_container "$container" "$VERSION" "$TAG" "$FLAVOR" "${DOCKERFILE:-Dockerfile}" "${BUILD_FLAVOR:-}"
+      build_container "$container" "$VERSION" "$TAG" "$FLAVOR" "${DOCKERFILE:-Dockerfile}" "${BUILD_FLAVOR:-}" "${IS_DEFAULT:-false}"
     elif container_has_variants "$container"; then
       # Full variant expansion (local build)
       # VERSION may be a full version (e.g., "18.1-alpine") but variants.yaml
@@ -407,6 +407,11 @@ make() {
       --build-flavor)
         [[ -z "${2:-}" || "${2:-}" == --* ]] && { log_error "--build-flavor requires a value"; return 1; }
         export BUILD_FLAVOR="$2"
+        shift 2
+        ;;
+      --is-default)
+        [[ -z "${2:-}" || "${2:-}" == --* ]] && { log_error "--is-default requires a value"; return 1; }
+        export IS_DEFAULT="$2"
         shift 2
         ;;
       *)

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -437,23 +437,16 @@ build_container() {
         return 1
     }
 
-    # Prepare tags — versioned tag always included, plus rolling latest tags
-    local tag_args="-t $dockerhub_image:$tag -t $ghcr_image:$tag"
-    if [[ "$tag" != "latest" ]]; then
-        # For variant builds: add latest-{flavor} (e.g., latest-aws, latest-vector)
-        # For default/non-variant builds: add :latest
-        if [[ -n "$flavor" ]]; then
-            local is_default
-            is_default=$(variant_property "$PROJECT_ROOT/$container" "$flavor" "default" 2>/dev/null || echo "false")
-            if [[ "$is_default" == "true" ]]; then
-                tag_args="$tag_args -t $dockerhub_image:latest -t $ghcr_image:latest"
-            else
-                tag_args="$tag_args -t $dockerhub_image:latest-$flavor -t $ghcr_image:latest-$flavor"
-            fi
-        else
-            tag_args="$tag_args -t $dockerhub_image:latest -t $ghcr_image:latest"
-        fi
-    fi
+    # Prepare tags — versioned tag always included, plus rolling latest tags.
+    # compute_cell_tags (helpers/variant-utils.sh) is the single source of truth;
+    # see that function for the full rule-set.
+    local _cell_refs _ref
+    mapfile -t _cell_refs < <(compute_cell_tags "$PROJECT_ROOT/$container" "$tag" "$flavor" "$dockerhub_image" "$ghcr_image")
+    local tag_args=""
+    for _ref in "${_cell_refs[@]}"; do
+        tag_args="$tag_args -t $_ref"
+    done
+    tag_args="${tag_args# }"  # strip leading space
 
     local label_args=""
 

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -400,10 +400,12 @@ _emit_build_lineage() {
 }
 
 # Build container function
-# Usage: build_container <container> <version> <tag> [flavor] [dockerfile] [build_flavor]
+# Usage: build_container <container> <version> <tag> [flavor] [dockerfile] [build_flavor] [is_default]
 # flavor:       distro name from variants.yaml (e.g. ubuntu-2404) — used for tag logic
 # build_flavor: the value passed as --build-arg FLAVOR (e.g. base, dev)
 #               falls back to flavor when not provided (backward-compatible)
+# is_default:   "true" if this variant is the default (gets bare :latest); defaults to "false"
+#               Caller computes via variant_property <dir> <variant_name> "default"
 # If dockerfile is provided, uses -f <dockerfile> instead of default Dockerfile
 build_container() {
     local container="$1"
@@ -412,6 +414,7 @@ build_container() {
     local flavor="${4:-}"
     local dockerfile="${5:-Dockerfile}"
     local build_flavor="${6:-$flavor}"
+    local is_default="${7:-false}"
 
     local github_username="${GITHUB_REPOSITORY_OWNER:-oorabona}"
     local dockerhub_image="docker.io/$github_username/$container"
@@ -441,7 +444,7 @@ build_container() {
     # compute_cell_tags (helpers/variant-utils.sh) is the single source of truth;
     # see that function for the full rule-set.
     local _cell_refs _ref
-    mapfile -t _cell_refs < <(compute_cell_tags "$PROJECT_ROOT/$container" "$tag" "$flavor" "$dockerhub_image" "$ghcr_image")
+    mapfile -t _cell_refs < <(compute_cell_tags "$tag" "$flavor" "$is_default" "$dockerhub_image" "$ghcr_image")
     local tag_args=""
     for _ref in "${_cell_refs[@]}"; do
         tag_args="$tag_args -t $_ref"
@@ -692,18 +695,25 @@ build_container_variants() {
         build_flavor=$(variant_property "$container_dir" "$variant_name" "build_flavor" "$major_version")
         local description
         description=$(variant_property "$container_dir" "$variant_name" "description" "$major_version")
+        # Compute is_default from the VARIANT NAME (not the flavor) so that containers
+        # where variant name != flavor (e.g. github-runner: name=ubuntu-2404-base,
+        # flavor=ubuntu-2404) resolve correctly.
+        local is_default
+        is_default=$(variant_property "$container_dir" "$variant_name" "default" "$major_version" 2>/dev/null || echo "false")
+        [[ -z "$is_default" ]] && is_default="false"
 
         # Resolve dockerfile: variant-level > version-level > default
         local dockerfile
         dockerfile=$(variant_property "$container_dir" "$variant_name" "dockerfile" "$major_version")
         [[ -z "$dockerfile" ]] && dockerfile="${version_df:-Dockerfile}"
 
-        log_info "Building variant: $variant_name (tag: $variant_tag, flavor: $flavor, build_flavor: ${build_flavor:-$flavor}, dockerfile: $dockerfile)"
+        log_info "Building variant: $variant_name (tag: $variant_tag, flavor: $flavor, build_flavor: ${build_flavor:-$flavor}, is_default: $is_default, dockerfile: $dockerfile)"
 
         # Build the variant - pass base_image_version (e.g., "17-alpine") and dockerfile
         # build_flavor (e.g. base/dev) is passed as --build-arg FLAVOR; flavor (distro) is kept for tag logic
+        # is_default is passed so compute_cell_tags uses the correct variant-name-based value
         local status="built"
-        if ! build_container "$container" "$base_image_version" "$variant_tag" "$flavor" "$dockerfile" "$build_flavor"; then
+        if ! build_container "$container" "$base_image_version" "$variant_tag" "$flavor" "$dockerfile" "$build_flavor" "$is_default"; then
             log_error "Failed to build variant: $variant_name"
             status="failed"
             failed=true

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -414,7 +414,18 @@ build_container() {
     local flavor="${4:-}"
     local dockerfile="${5:-Dockerfile}"
     local build_flavor="${6:-$flavor}"
-    local is_default="${7:-false}"
+    local is_default="${7:-}"
+    # Restore the pre-refactor self-sufficient contract: when a caller omits
+    # is_default (direct/local `make --flavor`, legacy 6-arg callers), derive it
+    # from the variant config keyed by flavor — exactly as the original did.
+    # Explicit callers (build_container_variants, and the CI action via
+    # `make --is-default`) pass the correct variant-name-based value, which
+    # overrides this. compute_cell_tags consults is_default ONLY when flavor is
+    # non-empty, so no-flavor callers are unaffected regardless of this fallback.
+    if [[ -z "$is_default" && -n "$flavor" ]]; then
+        is_default=$(variant_property "$PROJECT_ROOT/$container" "$flavor" "default" 2>/dev/null || echo "false")
+    fi
+    [[ -z "$is_default" ]] && is_default="false"
 
     local github_username="${GITHUB_REPOSITORY_OWNER:-oorabona}"
     local dockerhub_image="docker.io/$github_username/$container"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -415,13 +415,25 @@ build_container() {
     local dockerfile="${5:-Dockerfile}"
     local build_flavor="${6:-$flavor}"
     local is_default="${7:-}"
-    # Restore the pre-refactor self-sufficient contract: when a caller omits
-    # is_default (direct/local `make --flavor`, legacy 6-arg callers), derive it
-    # from the variant config keyed by flavor — exactly as the original did.
-    # Explicit callers (build_container_variants, and the CI action via
-    # `make --is-default`) pass the correct variant-name-based value, which
-    # overrides this. compute_cell_tags consults is_default ONLY when flavor is
-    # non-empty, so no-flavor callers are unaffected regardless of this fallback.
+    # Self-heal (best-effort legacy-parity fallback for direct/6-arg callers):
+    # When is_default is omitted — e.g. `./make build github-runner <v> --flavor ubuntu-2404`
+    # without --is-default — derive it from variant config keyed by FLAVOR, matching
+    # the pre-refactor behaviour.
+    #
+    # Edge case — name != flavor: for containers where the variant NAME differs from its
+    # flavor (e.g. github-runner: variant name "ubuntu-2404-base", flavor "ubuntu-2404"),
+    # this lookup finds NO variant named "ubuntu-2404", returns empty, and is_default falls
+    # back to "false" → the rolling tag becomes :latest-ubuntu-2404 instead of :latest.
+    # This is intentional: a flavor→variant-name reverse lookup is ambiguous when multiple
+    # variants share a flavor, so we preserve the pre-refactor behaviour rather than guess.
+    #
+    # Authoritative callers are unaffected: build_container_variants passes the variant
+    # name explicitly, and the CI composite action resolves is_default via
+    # `variant_property … <variant_name>` before calling `make --is-default`. Published
+    # (CI) tags are always correct; only a direct local single-flavor build of a
+    # name-differs-from-flavor container is affected by this limitation.
+    # No-flavor callers are also unaffected (compute_cell_tags ignores is_default when
+    # flavor is empty).
     if [[ -z "$is_default" && -n "$flavor" ]]; then
         is_default=$(variant_property "$PROJECT_ROOT/$container" "$flavor" "default" 2>/dev/null || echo "false")
     fi

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -344,3 +344,76 @@ EOF
 
     unset GITHUB_REPOSITORY_OWNER
 }
+
+# =============================================================================
+# build_container self-heal regression tests (omitted is_default derives from
+# variant_property so direct/local callers still get the correct :latest tag)
+# =============================================================================
+
+@test "build_container: omitted is_default self-derives default variant -> bare :latest" {
+    export MULTIPLATFORM_SUPPORTED="false"
+    export GITHUB_REPOSITORY_OWNER="myowner"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "ARGS: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    source_build_script
+
+    # Override variant_property AFTER sourcing so it wins over the sourced version.
+    # Exported so the `run` subshell inherits it.
+    variant_property() { echo "true"; }
+    export -f variant_property
+
+    cd "$TEST_TEMP_DIR"
+    # Call with 4 positional args only (no 7th is_default) — mirrors `./make build --flavor base`
+    run build_container "testcontainer" "1.0.0" "1.0.0" "base"
+
+    [ "$status" -eq 0 ]
+
+    # Default variant must get bare rolling :latest on both registries, NOT :latest-base
+    grep -qE 'docker\.io/myowner/testcontainer:latest( |$)' "$TEST_TEMP_DIR/docker_calls.log"
+    grep -qE 'ghcr\.io/myowner/testcontainer:latest( |$)' "$TEST_TEMP_DIR/docker_calls.log"
+    ! grep -q ':latest-base' "$TEST_TEMP_DIR/docker_calls.log"
+
+    unset GITHUB_REPOSITORY_OWNER
+}
+
+@test "build_container: omitted is_default self-derives non-default variant -> :latest-<flavor>" {
+    export MULTIPLATFORM_SUPPORTED="false"
+    export GITHUB_REPOSITORY_OWNER="myowner"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "ARGS: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    source_build_script
+
+    # Override variant_property AFTER sourcing so it wins over the sourced version.
+    variant_property() { echo "false"; }
+    export -f variant_property
+
+    cd "$TEST_TEMP_DIR"
+    # Call with 4 positional args only (no 7th is_default) — mirrors `./make build --flavor vector`
+    run build_container "testcontainer" "1.0.0" "1.0.0" "vector"
+
+    [ "$status" -eq 0 ]
+
+    grep -q ':latest-vector' "$TEST_TEMP_DIR/docker_calls.log"
+
+    unset GITHUB_REPOSITORY_OWNER
+}

--- a/tests/unit/make-dispatcher-rc.bats
+++ b/tests/unit/make-dispatcher-rc.bats
@@ -249,3 +249,85 @@ _export_stubs() {
     [ -n "$return_line" ]
     [ "$return_line" -gt "$popd_line" ]
 }
+
+# ---------------------------------------------------------------------------
+# 8. --is-default flag: parsed into IS_DEFAULT and threaded to build_container
+# ---------------------------------------------------------------------------
+
+@test "make: --is-default true sets IS_DEFAULT and is passed as 7th arg to build_container" {
+    # Inline the flag-parsing loop from make() and the flavored build_container
+    # call from do_buildx(), mirroring the file's inline-stub approach.
+    # Uses a temp file (not an exported function var) to survive the bats subshell.
+    local recorded_args_file="$TEST_TEMP_DIR/recorded_args"
+
+    # Mirror the flag-parsing loop from make() + the single-flavor do_buildx path.
+    # build_container is stubbed inline to record its positional args to $recorded_args_file.
+    flavored_build() {
+        local FLAVOR="" DOCKERFILE="" BUILD_FLAVOR="" IS_DEFAULT=""
+        local positional_args=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --flavor)
+                    [[ -z "${2:-}" || "${2:-}" == --* ]] && { return 1; }
+                    FLAVOR="$2"; shift 2 ;;
+                --dockerfile)
+                    [[ -z "${2:-}" || "${2:-}" == --* ]] && { return 1; }
+                    DOCKERFILE="$2"; shift 2 ;;
+                --build-flavor)
+                    [[ -z "${2:-}" || "${2:-}" == --* ]] && { return 1; }
+                    BUILD_FLAVOR="$2"; shift 2 ;;
+                --is-default)
+                    [[ -z "${2:-}" || "${2:-}" == --* ]] && { return 1; }
+                    IS_DEFAULT="$2"; shift 2 ;;
+                *) positional_args+=("$1"); shift ;;
+            esac
+        done
+        [[ ${#positional_args[@]} -gt 0 ]] && set -- "${positional_args[@]}" || set --
+        local container=${1:-testcontainer}
+        local VERSION=${2:-1.0.0}
+        local TAG=${3:-1.0.0}
+        # Single-flavor build path (mirrors do_buildx when FLAVOR is set)
+        if [[ -n "${FLAVOR:-}" ]]; then
+            # Stub: record args to file instead of actually building
+            printf '%s\n' "$container" "$VERSION" "$TAG" "$FLAVOR" "${DOCKERFILE:-Dockerfile}" "${BUILD_FLAVOR:-}" "${IS_DEFAULT:-false}" > "$_ARGS_FILE"
+        fi
+    }
+    export -f flavored_build
+    export _ARGS_FILE="$recorded_args_file"
+
+    run bash -c '
+        flavored_build testcontainer 1.0.0 1.0.0 --flavor ubuntu-2404-base --is-default true
+    '
+    [ "$status" -eq 0 ]
+
+    # 7th positional arg recorded by build_container stub must be "true"
+    local seventh
+    seventh=$(sed -n '7p' "$recorded_args_file")
+    [ "$seventh" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# 9-11. Structural grep gates: confirm --is-default wiring is present in ./make
+#       and in the composite action (mirrors the style of tests 5-7).
+# ---------------------------------------------------------------------------
+
+@test "make script: --is-default flag exports IS_DEFAULT" {
+    grep -q -- '--is-default)' "$PROJECT_ROOT/make"
+    grep -q 'export IS_DEFAULT="\$2"' "$PROJECT_ROOT/make"
+}
+
+@test "make script: single-flavor build_container call passes IS_DEFAULT as 7th arg" {
+    # Extract do_buildx() body and confirm the flavored build_container invocation
+    # ends with "${IS_DEFAULT:-false}" as the 7th positional argument.
+    local do_buildx_fn
+    do_buildx_fn=$(awk '/^do_buildx\(\)/{found=1} found{print} found && /^}$/{exit}' "$PROJECT_ROOT/make")
+    echo "$do_buildx_fn" | grep -q '"${IS_DEFAULT:-false}"'
+}
+
+@test "build-container action: threads --is-default into make_args" {
+    local action="$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+    # Variant-name-based default lookup uses ${variant:-$flavor} not bare $flavor
+    grep -qF 'variant_property "$container" "${variant:-$flavor}" "default"' "$action"
+    # make_args append wires the flag through
+    grep -q 'make_args+=("--is-default"' "$action"
+}

--- a/tests/unit/make-dispatcher-rc.bats
+++ b/tests/unit/make-dispatcher-rc.bats
@@ -321,7 +321,7 @@ _export_stubs() {
     # ends with "${IS_DEFAULT:-false}" as the 7th positional argument.
     local do_buildx_fn
     do_buildx_fn=$(awk '/^do_buildx\(\)/{found=1} found{print} found && /^}$/{exit}' "$PROJECT_ROOT/make")
-    echo "$do_buildx_fn" | grep -q '"${IS_DEFAULT:-false}"'
+    echo "$do_buildx_fn" | grep -q '"${IS_DEFAULT:-}"'
 }
 
 @test "build-container action: threads --is-default into make_args" {

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -1128,40 +1128,19 @@ setup_fallback_test() {
 
 # --- compute_cell_tags ---
 #
+# New signature: compute_cell_tags <tag> <flavor> <is_default> <dockerhub_image> <ghcr_image>
+# is_default is now a caller-supplied boolean ("true"/"false"), computed from the
+# VARIANT NAME via variant_property — not looked up internally.
+#
 # Four cases per the spec:
-#   (a) no-flavor container   → versioned + :latest (both registries)
-#   (b) flavor + default=true → versioned + :latest (both registries)
-#   (c) flavor + default=false → versioned + :latest-<flavor> (both registries)
-#   (d) tag == "latest"       → only versioned refs, no rolling latest
-
-# Helper: create a variants.yaml with a named flavor, optionally marking it default
-_create_flavor_variants() {
-    local dir="$1"
-    local flavor_name="$2"
-    local is_default="${3:-false}"
-    mkdir -p "$dir"
-    cat > "$dir/variants.yaml" <<EOF
-build:
-  base_suffix: ""
-
-versions:
-  - tag: "1.0.0"
-    variants:
-      - name: ${flavor_name}
-        suffix: "-${flavor_name}"
-        flavor: ${flavor_name}
-        default: ${is_default}
-EOF
-}
+#   (a) no-flavor container (flavor="", is_default="false") → versioned + :latest (both registries)
+#   (b) flavor non-empty + is_default="true"  → versioned + :latest (both registries)
+#   (c) flavor non-empty + is_default="false" → versioned + :latest-<flavor> (both registries)
+#   (d) tag == "latest"                       → only versioned refs, no rolling latest
 
 @test "compute_cell_tags: (a) no-flavor → versioned + :latest on both registries" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
-    hash -r
-
-    mkdir -p "plain"
-    # No variants.yaml — no-flavor container, tag is a plain version string
-    run compute_cell_tags "plain" "2.3.1" "" "docker.io/owner/plain" "ghcr.io/owner/plain"
+    # No variants.yaml needed — function is now pure (no yq lookup)
+    run compute_cell_tags "2.3.1" "" "false" "docker.io/owner/plain" "ghcr.io/owner/plain"
     [ "$status" -eq 0 ]
     # Must contain exactly 4 lines: versioned×2 + latest×2
     [ "$(echo "$output" | wc -l)" -eq 4 ]
@@ -1173,13 +1152,8 @@ EOF
     [[ "$output" != *"latest-"* ]]
 }
 
-@test "compute_cell_tags: (b) flavor + default=true → versioned + :latest on both registries" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
-    hash -r
-
-    _create_flavor_variants "withflavor" "base" "true"
-    run compute_cell_tags "withflavor" "1.0.0-base" "base" "docker.io/owner/myapp" "ghcr.io/owner/myapp"
+@test "compute_cell_tags: (b) flavor + is_default=true → versioned + :latest on both registries" {
+    run compute_cell_tags "1.0.0-base" "base" "true" "docker.io/owner/myapp" "ghcr.io/owner/myapp"
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | wc -l)" -eq 4 ]
     [[ "$output" == *"docker.io/owner/myapp:1.0.0-base"* ]]
@@ -1190,13 +1164,8 @@ EOF
     [[ "$output" != *"latest-base"* ]]
 }
 
-@test "compute_cell_tags: (c) flavor + default=false → versioned + :latest-<flavor> on both registries" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
-    hash -r
-
-    _create_flavor_variants "withflavor2" "vector" "false"
-    run compute_cell_tags "withflavor2" "18-alpine-vector" "vector" "docker.io/owner/postgres" "ghcr.io/owner/postgres"
+@test "compute_cell_tags: (c) flavor + is_default=false → versioned + :latest-<flavor> on both registries" {
+    run compute_cell_tags "18-alpine-vector" "vector" "false" "docker.io/owner/postgres" "ghcr.io/owner/postgres"
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | wc -l)" -eq 4 ]
     [[ "$output" == *"docker.io/owner/postgres:18-alpine-vector"* ]]
@@ -1204,22 +1173,48 @@ EOF
     [[ "$output" == *"docker.io/owner/postgres:latest-vector"* ]]
     [[ "$output" == *"ghcr.io/owner/postgres:latest-vector"* ]]
     # Must NOT emit bare :latest (that's the default-flavor path)
-    # Check that no line is exactly "docker.io/owner/postgres:latest"
     local bare_latest_count
     bare_latest_count=$(echo "$output" | grep -cxF "docker.io/owner/postgres:latest" || true)
     [ "$bare_latest_count" -eq 0 ]
 }
 
 @test "compute_cell_tags: (d) tag==latest → only versioned refs, no rolling latest added" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
-    hash -r
-
-    mkdir -p "plain2"
-    run compute_cell_tags "plain2" "latest" "" "docker.io/owner/plain2" "ghcr.io/owner/plain2"
+    run compute_cell_tags "latest" "" "false" "docker.io/owner/plain2" "ghcr.io/owner/plain2"
     [ "$status" -eq 0 ]
     # Must contain exactly 2 lines: only the versioned (:latest) refs — no additional rolling tags
     [ "$(echo "$output" | wc -l)" -eq 2 ]
     [[ "$output" == *"docker.io/owner/plain2:latest"* ]]
     [[ "$output" == *"ghcr.io/owner/plain2:latest"* ]]
+}
+
+@test "compute_cell_tags: github-runner default variant (name!=flavor) → bare :latest via is_default=true" {
+    # Regression: github-runner variant ubuntu-2404-base has flavor=ubuntu-2404.
+    # Old code called variant_property(dir, "ubuntu-2404", "default") — wrong (flavor, not name).
+    # New code: caller passes is_default computed from variant NAME ubuntu-2404-base → "true".
+    run compute_cell_tags "2.334.0" "ubuntu-2404" "true" "docker.io/owner/github-runner" "ghcr.io/owner/github-runner"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+    [[ "$output" == *"docker.io/owner/github-runner:2.334.0"* ]]
+    [[ "$output" == *"ghcr.io/owner/github-runner:2.334.0"* ]]
+    # Default variant must get bare :latest, NOT :latest-ubuntu-2404
+    [[ "$output" == *"docker.io/owner/github-runner:latest"* ]]
+    [[ "$output" == *"ghcr.io/owner/github-runner:latest"* ]]
+    local flavor_latest_count
+    flavor_latest_count=$(echo "$output" | grep -c "latest-ubuntu-2404" || true)
+    [ "$flavor_latest_count" -eq 0 ]
+}
+
+@test "compute_cell_tags: github-runner non-default variant → :latest-<flavor>" {
+    # ubuntu-2404-dev has flavor=ubuntu-2404 but is NOT default → latest-ubuntu-2404
+    run compute_cell_tags "2.334.0-dev" "ubuntu-2404" "false" "docker.io/owner/github-runner" "ghcr.io/owner/github-runner"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+    [[ "$output" == *"docker.io/owner/github-runner:2.334.0-dev"* ]]
+    [[ "$output" == *"ghcr.io/owner/github-runner:2.334.0-dev"* ]]
+    [[ "$output" == *"docker.io/owner/github-runner:latest-ubuntu-2404"* ]]
+    [[ "$output" == *"ghcr.io/owner/github-runner:latest-ubuntu-2404"* ]]
+    # Must NOT emit bare :latest
+    local bare_latest_count
+    bare_latest_count=$(echo "$output" | grep -cxF "docker.io/owner/github-runner:latest" || true)
+    [ "$bare_latest_count" -eq 0 ]
 }

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -1125,3 +1125,101 @@ setup_fallback_test() {
     # Maps must be equal.
     [ "$(echo "$result_5arg" | jq -c 'to_entries | sort_by(.key)')" = "$(echo "$result_6arg" | jq -c 'to_entries | sort_by(.key)')" ]
 }
+
+# --- compute_cell_tags ---
+#
+# Four cases per the spec:
+#   (a) no-flavor container   → versioned + :latest (both registries)
+#   (b) flavor + default=true → versioned + :latest (both registries)
+#   (c) flavor + default=false → versioned + :latest-<flavor> (both registries)
+#   (d) tag == "latest"       → only versioned refs, no rolling latest
+
+# Helper: create a variants.yaml with a named flavor, optionally marking it default
+_create_flavor_variants() {
+    local dir="$1"
+    local flavor_name="$2"
+    local is_default="${3:-false}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<EOF
+build:
+  base_suffix: ""
+
+versions:
+  - tag: "1.0.0"
+    variants:
+      - name: ${flavor_name}
+        suffix: "-${flavor_name}"
+        flavor: ${flavor_name}
+        default: ${is_default}
+EOF
+}
+
+@test "compute_cell_tags: (a) no-flavor → versioned + :latest on both registries" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "plain"
+    # No variants.yaml — no-flavor container, tag is a plain version string
+    run compute_cell_tags "plain" "2.3.1" "" "docker.io/owner/plain" "ghcr.io/owner/plain"
+    [ "$status" -eq 0 ]
+    # Must contain exactly 4 lines: versioned×2 + latest×2
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+    [[ "$output" == *"docker.io/owner/plain:2.3.1"* ]]
+    [[ "$output" == *"ghcr.io/owner/plain:2.3.1"* ]]
+    [[ "$output" == *"docker.io/owner/plain:latest"* ]]
+    [[ "$output" == *"ghcr.io/owner/plain:latest"* ]]
+    # Must NOT contain any "latest-" rolling-flavor tag
+    [[ "$output" != *"latest-"* ]]
+}
+
+@test "compute_cell_tags: (b) flavor + default=true → versioned + :latest on both registries" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    _create_flavor_variants "withflavor" "base" "true"
+    run compute_cell_tags "withflavor" "1.0.0-base" "base" "docker.io/owner/myapp" "ghcr.io/owner/myapp"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+    [[ "$output" == *"docker.io/owner/myapp:1.0.0-base"* ]]
+    [[ "$output" == *"ghcr.io/owner/myapp:1.0.0-base"* ]]
+    [[ "$output" == *"docker.io/owner/myapp:latest"* ]]
+    [[ "$output" == *"ghcr.io/owner/myapp:latest"* ]]
+    # Must NOT emit :latest-base (that's the non-default flavor path)
+    [[ "$output" != *"latest-base"* ]]
+}
+
+@test "compute_cell_tags: (c) flavor + default=false → versioned + :latest-<flavor> on both registries" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    _create_flavor_variants "withflavor2" "vector" "false"
+    run compute_cell_tags "withflavor2" "18-alpine-vector" "vector" "docker.io/owner/postgres" "ghcr.io/owner/postgres"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+    [[ "$output" == *"docker.io/owner/postgres:18-alpine-vector"* ]]
+    [[ "$output" == *"ghcr.io/owner/postgres:18-alpine-vector"* ]]
+    [[ "$output" == *"docker.io/owner/postgres:latest-vector"* ]]
+    [[ "$output" == *"ghcr.io/owner/postgres:latest-vector"* ]]
+    # Must NOT emit bare :latest (that's the default-flavor path)
+    # Check that no line is exactly "docker.io/owner/postgres:latest"
+    local bare_latest_count
+    bare_latest_count=$(echo "$output" | grep -cxF "docker.io/owner/postgres:latest" || true)
+    [ "$bare_latest_count" -eq 0 ]
+}
+
+@test "compute_cell_tags: (d) tag==latest → only versioned refs, no rolling latest added" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    export PATH="${ORIG_DIR}/bin:${PATH#"$TEST_DIR"/bin:}"
+    hash -r
+
+    mkdir -p "plain2"
+    run compute_cell_tags "plain2" "latest" "" "docker.io/owner/plain2" "ghcr.io/owner/plain2"
+    [ "$status" -eq 0 ]
+    # Must contain exactly 2 lines: only the versioned (:latest) refs — no additional rolling tags
+    [ "$(echo "$output" | wc -l)" -eq 2 ]
+    [[ "$output" == *"docker.io/owner/plain2:latest"* ]]
+    [[ "$output" == *"ghcr.io/owner/plain2:latest"* ]]
+}


### PR DESCRIPTION
## What

Centralizes the per-cell rolling-tag (`:latest` / `:latest-<flavor>`) routing logic into a single function, `compute_cell_tags` (`helpers/variant-utils.sh`), and makes every build path feed it the correct `is_default` value.

Previously the routing was duplicated across `build-container.sh` (inline), the `./make` single-flavor path, and the composite `build-container` action's tag logic, and the "is this the default variant?" lookup was keyed by **flavor** instead of the **variant name** — so a default variant whose name differs from its flavor (e.g. `github-runner` default `ubuntu-2404-base`, flavor `ubuntu-2404`) was published as `:latest-ubuntu-2404` instead of the bare `:latest` its default status warrants.

## Changes

- **`helpers/variant-utils.sh`**: new `compute_cell_tags <tag> <flavor> <is_default> <dockerhub_image> <ghcr_image>` — the single source of truth for a cell's image refs (always versioned on both registries; rolling tag routed by `is_default`/flavor).
- **`scripts/build-container.sh`**: `build_container` consumes `compute_cell_tags`; the variant-expansion loop computes `is_default` from the variant **name**. When a caller omits `is_default`, `build_container` self-derives it from the variant config (preserving the original self-sufficient contract for direct/local and legacy callers).
- **`make`**: single-flavor build path threads `is_default` (new `--is-default` flag → `IS_DEFAULT`), passing empty when unset so `build_container` self-derives locally.
- **`.github/actions/build-container/action.yaml`**: derives `is_default` from the variant **name** (`${variant:-$flavor}`) and threads it into the `./make` call via `--is-default`.

## Tests

- `compute_cell_tags` unit cases (no-flavor, default+flavor, non-default+flavor, `tag==latest`).
- `build_container` behavioral regression tests: omitted `is_default` self-derives bare `:latest` for default variants and `:latest-<flavor>` otherwise.
- Structural grep gates pinning the `--is-default` wiring in `./make` and the composite action.

## Note

`github-runner`'s default variant now publishes a bare `:latest` (was previously `:latest-ubuntu-2404`) — a deliberate correction of the published-tag contract for the default variant.

Relates to ADR-013 (#628): the single `compute_cell_tags` source is reused by the upcoming bake-HCL generator.

## Test plan

- [ ] CI passes (shellcheck, bats)
- [ ] Default-variant images publish bare `:latest` (spot-check `github-runner`, `postgres`)
- [ ] Non-default variants publish `:latest-<flavor>`
