### PR TITLE
ci: route the dependency chains through docker buildx bake in production (ADR-013 cutover, slice 1)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -640,6 +640,10 @@ runs:
       shell: bash
       env:
         BUILDS: ${{ steps.expand-variants.outputs.builds }}
+        SCOPE_VERSIONS: ${{ inputs.scope_versions }}
+        SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
+        BUILD_SCOPE: ${{ inputs.scope }}
+        EVENT_NAME: ${{ github.event_name }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC1091
@@ -650,7 +654,27 @@ runs:
         builds_input="${BUILDS:-[]}"
         [[ -z "$builds_input" ]] && builds_input="[]"
 
-        partitioned=$(partition_builds "$builds_input")
+        # force_matrix=true disables bake routing — all cells go to the flat matrix.
+        # Two independent reasons force this:
+        #   1. Scoped runs (scope_versions, scope_flavors, or unified BUILD_SCOPE
+        #      non-empty) build only a subset of cells.  Routing bake-managed containers
+        #      to the bake engine would cause bake to publish ALL variants while only
+        #      the scoped cells receive scan/attest coverage.
+        #   2. pull_request events: bake jobs skip push/load so the 3 bake-managed
+        #      containers lose PR-time Trivy coverage.  Route them to the flat matrix
+        #      so every cell gets the existing per-cell PR build+Trivy pass.
+        #      (The bake-build.yaml --print smoke validates the bake HCL on PRs
+        #      independently; bake push/load is a push-time concern only.)
+        force_matrix="false"
+        scope_active="false"
+        if [[ -n "${SCOPE_VERSIONS}" || -n "${SCOPE_FLAVORS}" || -n "${BUILD_SCOPE}" ]]; then
+          scope_active="true"
+        fi
+        if [[ "$scope_active" == "true" || "$EVENT_NAME" == "pull_request" ]]; then
+          force_matrix="true"
+        fi
+
+        partitioned=$(partition_builds "$builds_input" "$force_matrix")
 
         bake_builds=$(echo "$partitioned" | jq -c '.bake')
         matrix_builds=$(echo "$partitioned" | jq -c '.matrix')
@@ -660,4 +684,4 @@ runs:
 
         echo "bake_builds=$bake_builds" >> "$GITHUB_OUTPUT"
         echo "matrix_builds=$matrix_builds" >> "$GITHUB_OUTPUT"
-        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count"
+        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count (scope_active=${scope_active} force_matrix=${force_matrix} event=${EVENT_NAME})"

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -52,6 +52,10 @@ inputs:
       unreliable. Helper compares with explicit string equality.
     required: false
     default: "false"
+  run_tests:
+    description: 'When true, route all bake-managed containers to the flat matrix so test hooks run'
+    required: false
+    default: "false"
 
 outputs:
   containers_list:
@@ -644,6 +648,7 @@ runs:
         SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
         BUILD_SCOPE: ${{ inputs.scope }}
         EVENT_NAME: ${{ github.event_name }}
+        RUN_TESTS: ${{ inputs.run_tests }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC1091
@@ -655,7 +660,7 @@ runs:
         [[ -z "$builds_input" ]] && builds_input="[]"
 
         # force_matrix=true disables bake routing — all cells go to the flat matrix.
-        # Two independent reasons force this:
+        # Three independent reasons force this:
         #   1. Scoped runs (scope_versions, scope_flavors, or unified BUILD_SCOPE
         #      non-empty) build only a subset of cells.  Routing bake-managed containers
         #      to the bake engine would cause bake to publish ALL variants while only
@@ -665,12 +670,15 @@ runs:
         #      so every cell gets the existing per-cell PR build+Trivy pass.
         #      (The bake-build.yaml --print smoke validates the bake HCL on PRs
         #      independently; bake push/load is a push-time concern only.)
+        #   3. run_tests=true: test hooks (bats/Pester) live only in the flat matrix
+        #      build-and-push job.  Routing bake-managed containers to bake would
+        #      silently skip tests for github-runner, web-shell, and wordpress.
         force_matrix="false"
         scope_active="false"
         if [[ -n "${SCOPE_VERSIONS}" || -n "${SCOPE_FLAVORS}" || -n "${BUILD_SCOPE}" ]]; then
           scope_active="true"
         fi
-        if [[ "$scope_active" == "true" || "$EVENT_NAME" == "pull_request" ]]; then
+        if [[ "$scope_active" == "true" || "$EVENT_NAME" == "pull_request" || "$RUN_TESTS" == "true" ]]; then
           force_matrix="true"
         fi
 

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -72,6 +72,12 @@ outputs:
   builds_count:
     description: 'Total number of builds (including variants)'
     value: ${{ steps.expand-variants.outputs.builds_count }}
+  bake_builds:
+    description: 'JSON array of builds routed to the bake engine (github-runner, web-shell, wordpress by default)'
+    value: ${{ steps.split-build-engine.outputs.bake_builds }}
+  matrix_builds:
+    description: 'JSON array of builds routed to the flat matrix engine (all non-bake containers)'
+    value: ${{ steps.split-build-engine.outputs.matrix_builds }}
   expand_retained_map:
     description: |
       JSON object mapping container name to boolean. true = expand all retained
@@ -628,3 +634,30 @@ runs:
         echo "builds_count=$builds_count" >> $GITHUB_OUTPUT
         echo "📋 Total builds: $builds_count"
         echo "$builds_json" | jq .
+
+    - name: Split builds by engine (bake vs matrix)
+      id: split-build-engine
+      shell: bash
+      env:
+        BUILDS: ${{ steps.expand-variants.outputs.builds }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/bake-managed.sh"
+
+        # When expand-variants was skipped (no containers detected), BUILDS is
+        # empty — treat as an empty array so consumers always get valid JSON.
+        builds_input="${BUILDS:-[]}"
+        [[ -z "$builds_input" ]] && builds_input="[]"
+
+        partitioned=$(partition_builds "$builds_input")
+
+        bake_builds=$(echo "$partitioned" | jq -c '.bake')
+        matrix_builds=$(echo "$partitioned" | jq -c '.matrix')
+
+        bake_count=$(echo "$bake_builds" | jq 'length')
+        matrix_count=$(echo "$matrix_builds" | jq 'length')
+
+        echo "bake_builds=$bake_builds" >> "$GITHUB_OUTPUT"
+        echo "matrix_builds=$matrix_builds" >> "$GITHUB_OUTPUT"
+        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -246,6 +246,7 @@ jobs:
           scope_flavors: ${{ github.event.inputs.scope_flavors || inputs.scope_flavors }}
           event_name: ${{ github.event_name }}
           build_all_retained: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || false }}
+          run_tests: ${{ github.event.inputs.run_tests || inputs.run_tests || 'false' }}
 
   # Build and push PostgreSQL extension images if postgres is in the build list.
   # Runs as a two-leg arch matrix (amd64 + arm64) on native runners so each leg
@@ -1723,6 +1724,7 @@ jobs:
       - name: Install syft (bake SBOM)
         id: install-syft-bake
         if: steps.bake-build.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
+        continue-on-error: true
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Generate SBOM and emit lineage (bake amd64)
@@ -1820,6 +1822,7 @@ jobs:
       - name: Upload bake SBOM artifact
         id: upload-bake-sboms
         if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: bake-sboms-${{ github.run_id }}
@@ -1830,6 +1833,7 @@ jobs:
 
       - name: Upload bake SBOM artifact (retry on transient failure)
         if: steps.bake-sbom.outcome == 'success' && steps.upload-bake-sboms.outcome == 'failure' && github.event_name != 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: bake-sboms-${{ github.run_id }}
@@ -1841,6 +1845,7 @@ jobs:
 
       - name: Upload build lineage (bake amd64)
         if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-lineage-bake-amd64-${{ github.run_id }}

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -175,7 +175,6 @@ on:
         type: boolean
         default: false
         required: false
-
 # Serialize runs of this workflow on the same ref. The extension pipeline runs
 # in two stages — per-arch build (Stage A) then multi-arch merge (Stage B) —
 # and Stage A publishes mutable per-arch tags (-amd64 / -arm64) that Stage B
@@ -223,6 +222,8 @@ jobs:
       versions: ${{ steps.detect.outputs.versions }}
       builds: ${{ steps.detect.outputs.builds }}
       builds_count: ${{ steps.detect.outputs.builds_count }}
+      bake_builds: ${{ steps.detect.outputs.bake_builds }}
+      matrix_builds: ${{ steps.detect.outputs.matrix_builds }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -865,7 +866,8 @@ jobs:
     if: |
       always() &&
       inputs.rebuild != 'sync' &&
-      needs.detect-containers.outputs.builds_count > 0 &&
+      fromJson(needs.detect-containers.outputs.matrix_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.matrix_builds || '[]')) != '[]' &&
       (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
       (needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped') &&
       (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
@@ -900,7 +902,7 @@ jobs:
       fail-fast: false
       max-parallel: 10  # Bumped from 4: Linux builds are fast; Windows (60-90min) should not starve Linux slots
       matrix:
-        build: ${{ fromJson(needs.detect-containers.outputs.builds) }}
+        build: ${{ fromJson(needs.detect-containers.outputs.matrix_builds) }}
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -1252,17 +1254,23 @@ jobs:
     # fail gracefully if their arch-specific images are missing). This prevents
     # one failed build from blocking manifests for all other successful builds.
     # Skip entirely when rebuild=sync (build-and-push was skipped, nothing to manifest).
+    # Shares the publish-${{ github.ref }} concurrency group with bake-merge so that
+    # the flat-matrix publisher and the bake publisher cannot write manifests concurrently.
     if: |
       always() &&
       inputs.rebuild != 'sync' &&
       (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'failure') &&
-      needs.detect-containers.outputs.builds_count > 0 &&
+      fromJson(needs.detect-containers.outputs.matrix_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.matrix_builds || '[]')) != '[]' &&
       github.event_name != 'pull_request'
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
-        build: ${{ fromJson(needs.detect-containers.outputs.builds) }}
+        build: ${{ fromJson(needs.detect-containers.outputs.matrix_builds) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1478,6 +1486,973 @@ jobs:
           retention-days: 1
           overwrite: true
 
+  # ---------------------------------------------------------------------------
+  # Bake pipeline (ADR-013 production cutover)
+  #
+  # Routes github-runner, web-shell, and wordpress through `docker buildx bake`
+  # while the flat matrix above continues to handle all other containers.
+  #
+  # Architecture:
+  #   bake-build-amd64 / bake-build-arm64  — Stage A: per-arch native builds
+  #   bake-merge                            — Stage B: multi-arch manifest merge +
+  #                                           best-effort DockerHub mirror
+  # ---------------------------------------------------------------------------
+
+  bake-build-amd64:
+    name: Bake build (amd64)
+    needs: [detect-containers, sync-base-images]
+    if: |
+      always() &&
+      inputs.rebuild != 'sync' &&
+      fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
+      (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install yq
+        timeout-minutes: 5
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        timeout-minutes: 5
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        timeout-minutes: 10
+        with:
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Resolve bake container names
+        id: bake-containers
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          # Extract unique container names from the bake_builds cell array (injection-safe via env)
+          containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+          echo "::notice::bake containers (amd64): ${containers}"
+
+      - name: Resolve github-runner version from bake set
+        id: resolve-gh-version
+        if: contains(steps.bake-containers.outputs.containers, 'github-runner')
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          # github-runner is latest-only: exactly one version in the bake set.
+          gh_version=$(printf '%s' "$BAKE_BUILDS_JSON" \
+            | jq -r '[.[] | select(.container == "github-runner") | .version] | unique | first // ""')
+          echo "gh_version=${gh_version}" >> "$GITHUB_OUTPUT"
+          echo "::notice::github-runner version in bake set (amd64): ${gh_version}"
+
+      - name: Restore runner agent cache (amd64)
+        if: steps.resolve-gh-version.outputs.gh_version != ''
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            github-runner/runner.tar.gz
+            github-runner/runner.zip
+            github-runner/runner.sha256
+          key: runner-agent-${{ steps.resolve-gh-version.outputs.gh_version }}-amd64
+          restore-keys: |
+            runner-agent-${{ steps.resolve-gh-version.outputs.gh_version }}-
+
+      - name: Prepare build contexts (github-runner agent cache)
+        if: contains(steps.bake-containers.outputs.containers, 'github-runner')
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          # Restore runner agent cache for each github-runner version in the bake set
+          # Version is extracted from the bake cell tag (injection-safe via env)
+          versions=$(printf '%s' "$BAKE_BUILDS_JSON" \
+            | jq -r '[.[] | select(.container == "github-runner") | .version] | unique | .[]')
+          while IFS= read -r ver; do
+            [[ -z "$ver" ]] && continue
+            echo "::notice::Preparing github-runner build context for version ${ver} (amd64)"
+            if [[ -f "github-runner/prepare-build-context.sh" ]]; then
+              bash github-runner/prepare-build-context.sh "$ver" amd64 linux
+            fi
+          done <<< "$versions"
+
+      - name: Generate bake HCL and build (amd64)
+        id: bake-build
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+          ARCH_SUFFIX: -amd64
+          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+          DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/generate-bake-hcl.sh
+
+          # Validate each BAKE_CONTAINERS token against the expected name pattern.
+          # Tokens come from detect-containers JSON (trusted pipeline), but the check
+          # makes word-splitting injection-safe for any future change in the source.
+          set -f  # disable globbing while validating tokens
+          for _c in ${BAKE_CONTAINERS}; do
+            if ! printf '%s' "$_c" | grep -qE '^[a-z0-9][a-z0-9_-]*$'; then
+              echo "::error::BAKE_CONTAINERS token '${_c}' contains invalid characters — aborting"
+              exit 1
+            fi
+          done
+          set +f
+
+          # Generate the bake JSON to a temp file (avoids process-sub portability issues
+          # with `docker buildx bake -f <(...)` on some buildkit versions).
+          # Using the real REMOTE_CR ensures base FROM refs resolve.
+          #
+          # Bake is latest-only by design: retained (non-latest) cells are routed to the
+          # flat matrix by partition_builds, so they never reach this job.
+          # No --all-retained flag is passed here.
+          bake_file="${RUNNER_TEMP}/bake-amd64.json"
+          # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
+          # shellcheck disable=SC2086
+          REMOTE_CR="$REMOTE_CR" ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+
+          # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
+          no_cache_flag=""
+          [[ "$DOCKER_NO_CACHE" == "true" ]] && no_cache_flag="--no-cache"
+
+          # Stage A: push per-arch intermediates with -amd64 suffix.
+          # ARCH_SUFFIX is exported so the generator's intermediate_ref path is consistent.
+          # Three-way branch:
+          #   DRY_RUN → skip docker buildx bake entirely (no build, no push)
+          #   IS_PR   → build-only (validate the bake DAG compiles); no --push
+          #   else    → full build + push
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::Bake build (amd64) DRY-RUN — skipping docker buildx bake (no build, no push)"
+          elif [[ "$IS_PR" == "true" ]]; then
+            # PR: validate the bake DAG compiles and builds — no registry push.
+            # shellcheck disable=SC2086
+            docker buildx bake \
+              -f "$bake_file" \
+              --set "*.platform=linux/amd64" \
+              ${no_cache_flag} \
+              --metadata-file "${RUNNER_TEMP}/bake-metadata-amd64.json"
+            echo "::notice::Bake build (amd64) build-only (PR; no push)"
+          else
+            # shellcheck disable=SC2086
+            docker buildx bake \
+              -f "$bake_file" \
+              --set "*.platform=linux/amd64" \
+              ${no_cache_flag} \
+              --push \
+              --metadata-file "${RUNNER_TEMP}/bake-metadata-amd64.json"
+            echo "::notice::Bake build (amd64) complete"
+          fi
+
+      - name: Emit build-result artifacts (amd64)
+        if: always() && env.DRY_RUN != 'true'
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+        run: |
+          set -euo pipefail
+          chmod +x helpers/bake-buildresult.sh
+          source helpers/bake-buildresult.sh
+
+          # Bake is latest-only by design; emit covers only the latest cells.
+          export BAKE_GENERATE_ALL_RETAINED=false
+
+          mkdir -p .build-lineage
+          # BAKE_CONTAINERS is operator-set (trusted context)
+          # shellcheck disable=SC2086
+          emit_bake_build_results \
+            "${RUNNER_TEMP}/bake-metadata-amd64.json" \
+            amd64 \
+            .build-lineage \
+            ${BAKE_CONTAINERS}
+
+      - name: Upload build-result artifacts (amd64)
+        id: upload-bres-amd64
+        if: always() && env.DRY_RUN != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-amd64-${{ github.run_id }}
+          path: .build-lineage/build-result-*-amd64.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
+      - name: Upload build-result artifacts (amd64, retry)
+        if: always() && env.DRY_RUN != 'true' && steps.upload-bres-amd64.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-amd64-${{ github.run_id }}
+          path: .build-lineage/build-result-*-amd64.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+      # Trivy scanning is handled by the dedicated bake-trivy job (FIX 5).
+      # amd64-only: SBOM generation + attestation + lineage emission.
+      # v1 behaviour: on pull_request the bake job is BUILD-ONLY (compile validation);
+      # nothing is pushed to the registry so SBOM generation and attestation are
+      # skipped — scanning stale or absent refs would produce misleading results.
+      # Advisory Trivy/SBOM/attestation run on the push/merge run via the
+      # bake-trivy matrix + bake-attest matrix jobs, which provide full coverage.
+      - name: Install syft (bake SBOM)
+        id: install-syft-bake
+        if: steps.bake-build.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Generate SBOM and emit lineage (bake amd64)
+        id: bake-sbom
+        if: steps.install-syft-bake.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+          GITHUB_USERNAME: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          source ./helpers/sbom-utils.sh
+          chmod +x scripts/generate-bake-hcl.sh
+
+          # Bake is latest-only by design; generate cells for the latest version only.
+          # shellcheck disable=SC2086
+          cells_json=$(./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          ncells=$(jq 'length' <<< "$cells_json")
+          mkdir -p .build-lineage
+
+          # Attest manifest: [{subject_name, subject_digest, sbom_path}] written for the
+          # real-attestation step below (parity with flat matrix).
+          attest_manifest=".build-lineage/.bake-attest-entries.json"
+          printf '[]' > "$attest_manifest"
+
+          for (( i=0; i<ncells; i++ )); do
+            cell=$(jq -c ".[$i]" <<< "$cells_json")
+            container=$(jq -r '.container'       <<< "$cell")
+            tag=$(jq -r '.tag'                   <<< "$cell")
+            flavor=$(jq -r '.flavor // ""'       <<< "$cell")
+            is_default=$(jq -r 'if .is_default then "true" else "false" end' <<< "$cell")
+            is_latest=$(jq -r 'if has("is_latest_version") then (if .is_latest_version then "true" else "false" end) else "true" end' <<< "$cell")
+            iref=$(jq -r '.intermediate_ref'     <<< "$cell")
+            image_ref="${iref//\$\{REMOTE_CR\}/${REMOTE_CR}}-amd64"
+
+            echo "::group::SBOM + lineage for ${container}:${tag} (amd64)"
+
+            # SBOM
+            sbom_file=".build-lineage/${container}-${tag}.sbom.json"
+            generate_sbom "$image_ref" "$sbom_file" || \
+              echo "::warning::SBOM generation failed for ${container}:${tag} — continuing"
+
+            # Capture digest for attestation (mirrors build-and-push job pattern)
+            digest=""
+            raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+            if [[ -n "$raw_manifest" ]]; then
+              digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+            fi
+            echo "digest_${container}_${tag}=${digest}" >> "$GITHUB_OUTPUT"
+
+            # Append to attest manifest when digest + SBOM are both present
+            if [[ -n "$digest" && -f "$sbom_file" ]]; then
+              jq -c \
+                --arg sn "${REMOTE_CR}/${container}" \
+                --arg sd "$digest" \
+                --arg sp "$sbom_file" \
+                '. + [{subject_name:$sn, subject_digest:$sd, sbom_path:$sp}]' \
+                "$attest_manifest" > "${attest_manifest}.tmp" && mv "${attest_manifest}.tmp" "$attest_manifest" || true
+            fi
+
+            # Emit schema-v2 lineage JSON
+            lineage_file=".build-lineage/${container}-${tag}.json"
+            built_at="$(date -Iseconds)"
+            ghcr_image="${REMOTE_CR}/${container}:${tag}"
+            jq -cn \
+              --arg container "$container" \
+              --arg version   "$tag" \
+              --arg tag       "$tag" \
+              --arg flavor    "$flavor" \
+              --arg platform  "linux/amd64" \
+              --arg build_digest "$digest" \
+              --arg base_image_ref "" \
+              --arg ghcr      "$ghcr_image" \
+              --arg dockerhub "docker.io/oorabona/${container}:${tag}" \
+              --arg built_at  "$built_at" \
+              --arg is_default "$is_default" \
+              --arg is_latest  "$is_latest" \
+              '{container:$container, version:$version, tag:$tag, flavor:$flavor,
+                platform:$platform, build_digest:$build_digest,
+                base_image_ref:$base_image_ref,
+                images:{ghcr:$ghcr, dockerhub:$dockerhub},
+                built_at:$built_at,
+                is_default:($is_default == "true"),
+                is_latest_version:($is_latest == "true")}' \
+              > "$lineage_file" || true
+
+            echo "::endgroup::"
+          done
+          echo "attest_manifest=${attest_manifest}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      # Upload all bake SBOMs as a single combined artifact so the bake-attest
+      # matrix job can download them in one step.  The glob .build-lineage/*.sbom.json
+      # captures every cell file produced by the bake-sbom step above.
+      - name: Upload bake SBOM artifact
+        id: upload-bake-sboms
+        if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: bake-sboms-${{ github.run_id }}
+          path: .build-lineage/*.sbom.json
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+
+      - name: Upload bake SBOM artifact (retry on transient failure)
+        if: steps.bake-sbom.outcome == 'success' && steps.upload-bake-sboms.outcome == 'failure' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: bake-sboms-${{ github.run_id }}
+          path: .build-lineage/*.sbom.json
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+      - name: Upload build lineage (bake amd64)
+        if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-lineage-bake-amd64-${{ github.run_id }}
+          # Lineage sidecars only — exclude build-result records and SBOMs so the
+          # cache-lineage enrichment/drift logic does not ingest them as lineage.
+          path: |
+            .build-lineage/*.json
+            !.build-lineage/build-result-*.json
+            !.build-lineage/*.sbom.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
+  bake-build-arm64:
+    name: Bake build (arm64)
+    needs: [detect-containers, sync-base-images]
+    if: |
+      always() &&
+      inputs.rebuild != 'sync' &&
+      fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
+      (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install yq
+        timeout-minutes: 5
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_arm64
+          echo "4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d  /usr/local/bin/yq" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        timeout-minutes: 5
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        timeout-minutes: 10
+        with:
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Resolve bake container names
+        id: bake-containers
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+          echo "::notice::bake containers (arm64): ${containers}"
+
+      - name: Resolve github-runner version from bake set
+        id: resolve-gh-version
+        if: contains(steps.bake-containers.outputs.containers, 'github-runner')
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          # github-runner is latest-only: exactly one version in the bake set.
+          gh_version=$(printf '%s' "$BAKE_BUILDS_JSON" \
+            | jq -r '[.[] | select(.container == "github-runner") | .version] | unique | first // ""')
+          echo "gh_version=${gh_version}" >> "$GITHUB_OUTPUT"
+          echo "::notice::github-runner version in bake set (arm64): ${gh_version}"
+
+      - name: Restore runner agent cache (arm64)
+        if: steps.resolve-gh-version.outputs.gh_version != ''
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            github-runner/runner.tar.gz
+            github-runner/runner.zip
+            github-runner/runner.sha256
+          key: runner-agent-${{ steps.resolve-gh-version.outputs.gh_version }}-arm64
+          restore-keys: |
+            runner-agent-${{ steps.resolve-gh-version.outputs.gh_version }}-
+
+      - name: Prepare build contexts (github-runner agent cache)
+        if: contains(steps.bake-containers.outputs.containers, 'github-runner')
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          versions=$(printf '%s' "$BAKE_BUILDS_JSON" \
+            | jq -r '[.[] | select(.container == "github-runner") | .version] | unique | .[]')
+          while IFS= read -r ver; do
+            [[ -z "$ver" ]] && continue
+            echo "::notice::Preparing github-runner build context for version ${ver} (arm64)"
+            if [[ -f "github-runner/prepare-build-context.sh" ]]; then
+              bash github-runner/prepare-build-context.sh "$ver" arm64 linux
+            fi
+          done <<< "$versions"
+
+      - name: Generate bake HCL and build (arm64)
+        id: bake-build
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+          ARCH_SUFFIX: -arm64
+          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+          DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/generate-bake-hcl.sh
+
+          # Validate each BAKE_CONTAINERS token against the expected name pattern.
+          set -f
+          for _c in ${BAKE_CONTAINERS}; do
+            if ! printf '%s' "$_c" | grep -qE '^[a-z0-9][a-z0-9_-]*$'; then
+              echo "::error::BAKE_CONTAINERS token '${_c}' contains invalid characters — aborting"
+              exit 1
+            fi
+          done
+          set +f
+
+          # Using the real REMOTE_CR ensures base FROM refs resolve.
+          #
+          # Bake is latest-only by design: retained (non-latest) cells are routed to the
+          # flat matrix by partition_builds, so they never reach this job.
+          # No --all-retained flag is passed here.
+          bake_file="${RUNNER_TEMP}/bake-arm64.json"
+          # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
+          # shellcheck disable=SC2086
+          REMOTE_CR="$REMOTE_CR" ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+
+          # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
+          no_cache_flag=""
+          [[ "$DOCKER_NO_CACHE" == "true" ]] && no_cache_flag="--no-cache"
+
+          # Three-way branch:
+          #   DRY_RUN → skip docker buildx bake entirely (no build, no push)
+          #   IS_PR   → build-only (validate the bake DAG compiles); no --push
+          #   else    → full build + push
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::Bake build (arm64) DRY-RUN — skipping docker buildx bake (no build, no push)"
+          elif [[ "$IS_PR" == "true" ]]; then
+            # PR: validate the bake DAG compiles and builds — no registry push.
+            # shellcheck disable=SC2086
+            docker buildx bake \
+              -f "$bake_file" \
+              --set "*.platform=linux/arm64" \
+              ${no_cache_flag} \
+              --metadata-file "${RUNNER_TEMP}/bake-metadata-arm64.json"
+            echo "::notice::Bake build (arm64) build-only (PR; no push)"
+          else
+            # shellcheck disable=SC2086
+            docker buildx bake \
+              -f "$bake_file" \
+              --set "*.platform=linux/arm64" \
+              ${no_cache_flag} \
+              --push \
+              --metadata-file "${RUNNER_TEMP}/bake-metadata-arm64.json"
+            echo "::notice::Bake build (arm64) complete"
+          fi
+
+      - name: Emit build-result artifacts (arm64)
+        if: always() && env.DRY_RUN != 'true'
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+        run: |
+          set -euo pipefail
+          chmod +x helpers/bake-buildresult.sh
+          source helpers/bake-buildresult.sh
+
+          # Bake is latest-only by design; emit covers only the latest cells.
+          export BAKE_GENERATE_ALL_RETAINED=false
+
+          mkdir -p .build-lineage
+          # shellcheck disable=SC2086
+          emit_bake_build_results \
+            "${RUNNER_TEMP}/bake-metadata-arm64.json" \
+            arm64 \
+            .build-lineage \
+            ${BAKE_CONTAINERS}
+
+      - name: Upload build-result artifacts (arm64)
+        id: upload-bres-arm64
+        if: always() && env.DRY_RUN != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-arm64-${{ github.run_id }}
+          path: .build-lineage/build-result-*-arm64.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
+      - name: Upload build-result artifacts (arm64, retry)
+        if: always() && env.DRY_RUN != 'true' && steps.upload-bres-arm64.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-arm64-${{ github.run_id }}
+          path: .build-lineage/build-result-*-arm64.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+      # Trivy scanning is handled by the dedicated bake-trivy job (FIX 5).
+
+  # ---------------------------------------------------------------------------
+  # FIX 5 — Dedicated Trivy scan job for bake-managed containers.
+  #
+  # Runs AFTER both arch builds have pushed their intermediates.
+  # Uses the same pinned aquasecurity/trivy-action as the flat matrix.
+  # Advisory only: bake-merge does NOT need bake-trivy (trivy never gates merge).
+  # Skipped on pull_request (nothing is pushed so no registry ref to scan).
+  # ---------------------------------------------------------------------------
+  bake-trivy:
+    name: Trivy scan (bake) ${{ matrix.build.container }}:${{ matrix.build.tag }} (${{ matrix.arch }})
+    needs: [detect-containers, bake-build-amd64, bake-build-arm64]
+    if: |
+      always() &&
+      github.event_name != 'pull_request' &&
+      inputs.dry_run != true &&
+      fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
+      needs.bake-build-amd64.result == 'success' &&
+      needs.bake-build-arm64.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        build: ${{ fromJson(needs.detect-containers.outputs.bake_builds || '[]') }}
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Log in to GHCR (pull intermediates)
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan for vulnerabilities (Trivy)
+        id: trivy-scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          # Scan the pushed per-arch intermediate ref (pushed by bake-build-<arch>)
+          image-ref: 'ghcr.io/${{ github.repository_owner }}/${{ matrix.build.container }}:${{ matrix.build.tag }}-${{ matrix.arch }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          timeout: '15m0s'
+        continue-on-error: true  # Vulnerability scan is advisory — never gates the build
+
+      - name: Write Trivy scan history (bake)
+        if: steps.trivy-scan.outcome != 'skipped'
+        env:
+          CONTAINER: ${{ matrix.build.container }}
+          TAG: ${{ matrix.build.tag }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p .trivy-scan-history
+
+          last_scan="$(date -Iseconds)"
+          alert_count=-1
+          status="error"
+          counts_json='{"critical":0,"high":0,"medium":0,"low":0,"info":0}'
+
+          # Parse SARIF to count findings per severity (parity with build-container action).
+          # A missing or unparsable SARIF means the scan did not complete — record as
+          # status="error" with alert_count=-1 (sentinel) so the dashboard/history
+          # reports a failed scan rather than a false clean.
+          if [[ -f trivy-results.sarif ]] && jq -e . trivy-results.sarif >/dev/null 2>&1; then
+            severities_json=$(jq -c '
+              [.runs[].tool.driver.rules // [] | .[] |
+                {(.id): ([.properties.tags // [] | .[] | ascii_downcase] |
+                  map(select(. == "critical" or . == "high" or . == "medium" or . == "low")) |
+                  first // "info")}]
+              | add // {}
+            ' trivy-results.sarif 2>/dev/null || echo "{}")
+
+            counts_json=$(jq -c --argjson sev_map "$severities_json" '
+              reduce ([.runs[].results // [] | .[]][] | (.ruleId? // "")) as $rid
+                ({"critical":0,"high":0,"medium":0,"low":0,"info":0};
+                  ($sev_map[$rid] // "info") as $s
+                  | if .[$s] != null then .[$s] += 1 else . end)
+            ' trivy-results.sarif 2>/dev/null || echo '{"critical":0,"high":0,"medium":0,"low":0,"info":0}')
+
+            alert_count=$(jq '[.runs[].results // [] | .[]] | length' trivy-results.sarif 2>/dev/null || echo -1)
+            if [[ "$alert_count" -lt 0 ]]; then
+              status="error"
+            elif [[ "$alert_count" -gt 0 ]]; then
+              status="dirty"
+            else
+              status="clean"
+            fi
+          fi
+
+          scan_file=".trivy-scan-history/${CONTAINER}-${TAG}-linux-${ARCH}.json"
+          jq -nc \
+            --arg ls "$last_scan" \
+            --argjson ac "$alert_count" \
+            --arg st "$status" \
+            --argjson c "$counts_json" \
+            --argjson ss '["UNKNOWN","LOW","MEDIUM","HIGH","CRITICAL"]' \
+            '{last_scan:$ls,alert_count:$ac,status:$st,counts:$c,scanned_severities:$ss}' \
+            > "$scan_file"
+          echo "::notice::Trivy scan history: ${scan_file} (alert_count=${alert_count}, status=${status})"
+
+      - name: Upload SARIF to GitHub Security
+        if: steps.trivy-scan.outcome != 'skipped'
+        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'container-${{ matrix.build.container }}-${{ matrix.build.tag }}-linux/${{ matrix.arch }}'
+          wait-for-processing: false
+        continue-on-error: true  # SARIF upload is advisory — never gates the build
+
+      - name: Upload Trivy scan history (bake)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: trivy-scan-history-bake-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}-${{ github.run_id }}
+          path: .trivy-scan-history/
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
+  bake-merge:
+    # Require BOTH arch builds to succeed before merging.  If either fails the
+    # mutable :<tag>-amd64 / :<tag>-arm64 intermediate refs may be stale from a
+    # prior run; fusing them would produce a corrupt canonical multi-arch manifest.
+    # A failed build leaves the failure visible and the run re-runnable.
+    name: Bake merge manifests + DockerHub mirror
+    needs: [detect-containers, bake-build-amd64, bake-build-arm64]
+    if: |
+      github.event_name != 'pull_request' &&
+      inputs.rebuild != 'sync' &&
+      fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
+      needs.bake-build-amd64.result == 'success' &&
+      needs.bake-build-arm64.result == 'success'
+    # Shared concurrency group with create-manifest so the two publishers never
+    # write to the same GHCR namespace concurrently on the same ref.
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install yq
+        timeout-minutes: 5
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        timeout-minutes: 5
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        timeout-minutes: 10
+        with:
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Resolve bake container names
+        id: bake-containers
+        env:
+          BAKE_BUILDS_JSON: ${{ needs.detect-containers.outputs.bake_builds }}
+        run: |
+          set -euo pipefail
+          containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+
+      - name: Canonical GHCR manifest merge (strict, fail-closed)
+        id: bake-merge-step
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/bake-merge-manifests.sh scripts/generate-bake-hcl.sh
+
+          # Validate each BAKE_CONTAINERS token against the expected name pattern.
+          set -f
+          for _c in ${BAKE_CONTAINERS}; do
+            if ! printf '%s' "$_c" | grep -qE '^[a-z0-9][a-z0-9_-]*$'; then
+              echo "::error::BAKE_CONTAINERS token '${_c}' contains invalid characters — aborting"
+              exit 1
+            fi
+          done
+          set +f
+
+          # Bake is latest-only by design; merge only the latest cells.
+          # No --all-retained flag is passed here.
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::manifest merge running in DRY-RUN (no canonical tags published; dry_run=${DRY_RUN})"
+            # shellcheck disable=SC2086
+            DRY_RUN=true REMOTE_CR="$REMOTE_CR" ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+          else
+            # BAKE_CONTAINERS is operator-set from bake_builds JSON (trusted context)
+            # shellcheck disable=SC2086
+            REMOTE_CR="$REMOTE_CR" ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+          fi
+
+      - name: Best-effort DockerHub mirror (bake)
+        if: always() && steps.bake-merge-step.outcome == 'success'
+        continue-on-error: true
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          chmod +x helpers/mirror-dockerhub.sh
+          # Bake is latest-only by design; mirror only the latest cells.
+          export BAKE_GENERATE_ALL_RETAINED=false
+          source helpers/mirror-dockerhub.sh
+          # BAKE_CONTAINERS is operator-set (trusted context)
+          # shellcheck disable=SC2086
+          mirror_to_dockerhub ${BAKE_CONTAINERS}
+
+      - name: Emit manifest build-result artifacts (bake)
+        if: always()
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          MERGE_OUTCOME: ${{ steps.bake-merge-step.outcome }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/generate-bake-hcl.sh
+
+          mkdir -p .build-lineage
+
+          result="failure"
+          [[ "$MERGE_OUTCOME" == "success" ]] && result="success"
+
+          # Emit one manifest build-result per cell (mirrors create-manifest job shape).
+          # Bake is latest-only by design; generate cells for the latest version only.
+          # shellcheck disable=SC2086
+          cells_json=$(./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          ncells=$(jq 'length' <<< "$cells_json")
+          for (( i=0; i<ncells; i++ )); do
+            cell=$(jq -c ".[$i]" <<< "$cells_json")
+            container=$(jq -r '.container'        <<< "$cell")
+            tag=$(jq -r '.tag'                    <<< "$cell")
+            variant=$(jq -r '.variant // ""'      <<< "$cell")
+            out_file=".build-lineage/build-result-manifest-${container}-${tag}.json"
+            jq -cn \
+              --arg c "$container" \
+              --arg v "$variant" \
+              --arg t "$tag" \
+              --arg a "manifest" \
+              --arg r "$result" \
+              '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+              > "$out_file" || true
+          done
+
+      - name: Upload manifest build-result artifacts (bake)
+        id: upload-bres-manifest-bake
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-manifest-${{ github.run_id }}
+          path: .build-lineage/build-result-manifest-*.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+
+      - name: Upload manifest build-result artifacts (bake, retry)
+        if: always() && steps.upload-bres-manifest-bake.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-result-bake-manifest-${{ github.run_id }}
+          path: .build-lineage/build-result-manifest-*.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+  # ---------------------------------------------------------------------------
+  # Bake SBOM attestation — per-cell matrix job (parity with flat matrix).
+  #
+  # Runs once per bake cell (container × tag) on amd64 only (attestation is per
+  # container image, same as the flat matrix build-and-push job which attests the
+  # amd64 intermediate).  Advisory only: never gates bake-merge or publish.
+  # Skipped on pull_request (nothing pushed) and dry_run (no canonical artifact).
+  # ---------------------------------------------------------------------------
+  bake-attest:
+    name: Attest SBOM (bake) ${{ matrix.build.container }}:${{ matrix.build.tag }}
+    needs: [detect-containers, bake-build-amd64]
+    if: |
+      always() &&
+      github.event_name != 'pull_request' &&
+      inputs.dry_run != true &&
+      fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&
+      toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
+      (needs.bake-build-amd64.result == 'success' || needs.bake-build-amd64.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        build: ${{ fromJson(needs.detect-containers.outputs.bake_builds || '[]') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Log in to GHCR (imagetools inspect)
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download SBOM artifact
+        id: download-sbom
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: bake-sboms-${{ github.run_id }}
+          path: .sbom-attest/
+        continue-on-error: true  # SBOM upload may have failed — advisory, never gates
+
+      - name: Derive amd64 OCI digest and attest SBOM
+        id: attest-setup
+        if: steps.download-sbom.outcome == 'success'
+        env:
+          MATRIX_CONTAINER: ${{ matrix.build.container }}
+          MATRIX_TAG: ${{ matrix.build.tag }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          image_ref="${REMOTE_CR}/${MATRIX_CONTAINER}:${MATRIX_TAG}-amd64"
+
+          # Derive digest via raw-manifest hash (same method as bake-build-amd64 so
+          # subject digest matches what was captured during the build).
+          raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+          if [[ -z "$raw_manifest" ]]; then
+            echo "::warning::Cannot inspect ${image_ref} — skipping attestation for ${MATRIX_CONTAINER}:${MATRIX_TAG}"
+            echo "has_digest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+          # Locate this cell's SBOM file by its known name convention
+          # (<container>-<tag>.sbom.json, matching bake-sbom generation above).
+          sbom_file=".sbom-attest/${MATRIX_CONTAINER}-${MATRIX_TAG}.sbom.json"
+          if [[ ! -f "$sbom_file" ]]; then
+            echo "::warning::SBOM file missing for ${MATRIX_CONTAINER}:${MATRIX_TAG} — skipping attestation"
+            echo "has_digest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "sbom_file=${sbom_file}" >> "$GITHUB_OUTPUT"
+          echo "has_digest=true" >> "$GITHUB_OUTPUT"
+
+      - name: Attest SBOM (bake)
+        if: steps.attest-setup.outputs.has_digest == 'true'
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.build.container }}
+          subject-digest: ${{ steps.attest-setup.outputs.digest }}
+          sbom-path: ${{ steps.attest-setup.outputs.sbom_file }}
+        continue-on-error: true  # Attestation is advisory — never gates
+
   # Advance the coverage checkpoint tag on every master push run that completes
   # (even when individual build jobs failed).  The tag carries a JSON state record
   # of which containers failed so the next run can retry them while other containers
@@ -1496,7 +2471,7 @@ jobs:
   #     next run via the carry-forward logic in detect-containers.
   publish-coverage-checkpoint:
     name: Publish coverage checkpoint tag
-    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest]
+    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, bake-build-amd64, bake-build-arm64, bake-merge]
     # Advance on every completed master push, even when build jobs failed.
     # A cancelled run or a failed detect-containers job blocks advancement.
     if: |
@@ -1740,7 +2715,7 @@ jobs:
           echo "failed_this_run=${ftr_safe}" >> "$GITHUB_OUTPUT"
 
   summary:
-    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries, publish-coverage-checkpoint]
+    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries, publish-coverage-checkpoint, bake-build-amd64, bake-build-arm64, bake-merge, bake-attest]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1786,11 +2761,16 @@ jobs:
           bex_result="${{ needs.build-extensions.result }}"
           mem_result="${{ needs.merge-extension-manifests.result }}"
           cm_result="${{ needs.create-manifest.result }}"
+          bake_amd64_result="${{ needs.bake-build-amd64.result }}"
+          bake_arm64_result="${{ needs.bake-build-arm64.result }}"
+          bake_merge_result="${{ needs.bake-merge.result }}"
           dry_run_flag="${{ env.DRY_RUN }}"
 
           # build_failed: any monitored pipeline job failed or cancelled.
+          # Includes bake jobs so a bake-only master run surfaces failures correctly.
           build_failed=false
-          for _r in "$detect_result" "$bap_result" "$bex_result" "$mem_result" "$cm_result"; do
+          for _r in "$detect_result" "$bap_result" "$bex_result" "$mem_result" "$cm_result" \
+                    "$bake_amd64_result" "$bake_arm64_result" "$bake_merge_result"; do
             if [ "$_r" = "failure" ] || [ "$_r" = "cancelled" ]; then
               build_failed=true
             fi
@@ -1802,17 +2782,33 @@ jobs:
           [[ "$container_count" =~ ^[0-9]+$ ]] || count_valid=false
 
           # build_succeeded: a REAL successful build was published.
-          # Requires: not build_failed, a valid count > 0, build-and-push
-          # success, and NOT a dry run.
+          # Requires: not build_failed, a valid count > 0, NOT a dry run, AND
+          # at least one publishing path succeeded.
+          #
+          # Two publishing paths are possible on a single run:
+          #   flat matrix: build-and-push = 'success'
+          #   bake pipeline: bake-merge = 'success' (build-and-push is 'skipped')
+          # A run that only uses the bake path has bap_result='skipped' but
+          # bake_merge_result='success'; recognising it as a success prevents
+          # spurious generic "Auto Build Failed" issues from never being closed
+          # on bake-only master runs.
+          #
           # count=0 is explicitly NOT a success signal — closing an issue
           # requires evidence that something was actually built and published.
           # DRY_RUN runs are NOT a recovery signal: docker/skopeo become echo
-          # no-ops, so build-and-push reports success without publishing anything.
+          # no-ops, so build-and-push / bake-merge report success without publishing.
+          bake_path_ok=false
+          if [ "$bake_amd64_result" = "success" ] && [ "$bake_arm64_result" = "success" ] \
+             && [ "$bake_merge_result" = "success" ]; then
+            bake_path_ok=true
+          fi
+
           build_succeeded=false
           if [ "$build_failed" = "false" ] && [ "$count_valid" = "true" ] \
-             && [ "$container_count" -gt 0 ] && [ "$bap_result" = "success" ] \
-             && [ "$dry_run_flag" != "true" ]; then
-            build_succeeded=true
+             && [ "$container_count" -gt 0 ] && [ "$dry_run_flag" != "true" ]; then
+            if [ "$bap_result" = "success" ] || [ "$bake_path_ok" = "true" ]; then
+              build_succeeded=true
+            fi
           fi
 
           # Emit BOTH signals unconditionally — never inside a conditional branch.
@@ -1857,7 +2853,7 @@ jobs:
               echo "- ✅ All container images are up to date in registries" >> $GITHUB_STEP_SUMMARY
               echo "- 🔍 No new upstream versions detected" >> $GITHUB_STEP_SUMMARY
             fi
-          elif [ "$bap_result" = "success" ]; then
+          elif [ "$bap_result" = "success" ] || [ "$bake_path_ok" = "true" ]; then
             echo "### ✅ All builds completed successfully!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**🎯 Smart Detection Features:**" >> $GITHUB_STEP_SUMMARY
@@ -2193,12 +3189,16 @@ jobs:
 
   cache-lineage:
     name: Cache build lineage
-    needs: [build-and-push, create-manifest]
-    # Run on partial failure: successful builds still have lineage to cache
+    needs: [build-and-push, create-manifest, bake-build-amd64, bake-build-arm64, bake-merge, bake-trivy]
+    # Run on partial failure: successful builds still have lineage to cache.
+    # bake-trivy is advisory and skipped on PR / when no bake containers detected —
+    # tolerate all outcomes (success/failure/skipped) so lineage is not blocked.
     if: |
       always() &&
-      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'failure') &&
+      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'failure' || needs.build-and-push.result == 'skipped') &&
       (needs.create-manifest.result == 'success' || needs.create-manifest.result == 'skipped' || needs.create-manifest.result == 'failure') &&
+      (needs.bake-merge.result == 'success' || needs.bake-merge.result == 'failure' || needs.bake-merge.result == 'skipped') &&
+      (needs.bake-trivy.result == 'success' || needs.bake-trivy.result == 'failure' || needs.bake-trivy.result == 'skipped') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -3282,6 +3282,14 @@ jobs:
           merge-multiple: false
         continue-on-error: true
 
+      - name: Download bake SBOM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: bake-sboms-*
+          path: .build-lineage-sbom-artifacts/
+          merge-multiple: false
+        continue-on-error: true
+
       - name: Process SBOMs (compare + history)
         id: process-sboms
         run: |

--- a/github-runner/prepare-build-context.sh
+++ b/github-runner/prepare-build-context.sh
@@ -36,10 +36,56 @@ TARGET_DIR="$SCRIPT_DIR"
 TARGET_FILE="$TARGET_DIR/runner.${EXT}"
 TARGET_SHA="$TARGET_DIR/runner.sha256"
 
-# Skip if already downloaded (same version)
+# Validate cached archive against the requested version before skipping.
+# A stale archive from a different version (e.g. restored from a broad cache
+# fallback) must be discarded so the download path always runs for that case.
 if [[ -f "$TARGET_FILE" && -f "$TARGET_SHA" ]]; then
-    log_info "Runner agent already in build context: $FILE"
-    exit 0
+    _skip=false
+    if command -v sha256sum &>/dev/null; then
+        _actual_sha=$(sha256sum "$TARGET_FILE" | awk '{print $1}')
+    elif command -v shasum &>/dev/null; then
+        _actual_sha=$(shasum -a 256 "$TARGET_FILE" | awk '{print $1}')
+    else
+        _actual_sha=""
+    fi
+
+    if [[ -n "$_actual_sha" ]]; then
+        # Fetch the expected checksum for v$VERSION from the GitHub release asset
+        # (published as <file>.sha256 alongside the tarball).
+        _tmp_dir=$(mktemp -d)
+        _expected_raw=""
+        if command -v gh &>/dev/null && [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            if gh release download "v${VERSION}" \
+                --repo actions/runner \
+                --pattern "${FILE}.sha256" \
+                --dir "$_tmp_dir" \
+                --clobber 2>/dev/null; then
+                _expected_raw=$(cat "$_tmp_dir/${FILE}.sha256" 2>/dev/null || true)
+            fi
+        else
+            _expected_raw=$(curl -fsSL "${SHA_URL}" 2>/dev/null || true)
+        fi
+        rm -rf "$_tmp_dir"
+
+        # The GitHub SHA file format is "<hex>  <filename>" — extract just the hex.
+        _expected_sha=$(printf '%s' "$_expected_raw" | awk '{print $1}' | tr -cd '0-9a-fA-F' | head -c 64)
+
+        if [[ -n "$_expected_sha" && "$_actual_sha" == "$_expected_sha" ]]; then
+            _skip=true
+        elif [[ -z "$_expected_sha" ]]; then
+            # Network check failed entirely — prefer re-download (fail-closed toward
+            # correctness) rather than trusting a possibly-stale cached archive.
+            log_warning "Could not fetch expected SHA for v${VERSION} — re-downloading to be safe"
+        else
+            log_warning "Cached runner.${EXT} SHA mismatch for v${VERSION} (expected ${_expected_sha:0:12}… got ${_actual_sha:0:12}…) — re-downloading"
+            rm -f "$TARGET_FILE" "$TARGET_SHA"
+        fi
+    fi
+
+    if [[ "$_skip" == "true" ]]; then
+        log_info "Runner agent already in build context and version-validated: $FILE"
+        exit 0
+    fi
 fi
 
 log_info "Downloading runner agent: $FILE"

--- a/github-runner/variants.yaml
+++ b/github-runner/variants.yaml
@@ -12,6 +12,11 @@
 # Build configuration
 build:
   version_retention: 3
+  # bake builds all github-runner variants in one invocation sharing a single
+  # runner.tar.gz, so retained older versions cannot be built correctly via bake
+  # — keep latest-only (retained github-runner rebuilds are a follow-up needing
+  # per-version build contexts).
+  bake_latest_only: true
 versions:
   - tag: 2.334.0
     variants:

--- a/helpers/bake-buildresult.sh
+++ b/helpers/bake-buildresult.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# bake-buildresult.sh — Emit #595 build-result artifacts from a bake run's
+# --metadata-file output, so coverage-checkpoint can aggregate bake jobs
+# alongside the existing flat-matrix build jobs without modification.
+#
+# Usage (library):
+#   source helpers/bake-buildresult.sh
+#   emit_bake_build_results <metadata_file> <arch> <out_dir> <container...>
+#
+# Usage (standalone):
+#   helpers/bake-buildresult.sh <metadata_file> <arch> <out_dir> <container...>
+#
+# Arguments:
+#   metadata_file  — path to bake's --metadata-file JSON (keyed by target id).
+#                    MAY be absent or empty; handled fail-closed (all → failure).
+#   arch           — amd64 | arm64
+#   out_dir        — directory to write build-result-<c>-<tag>-<arch>.json files
+#   container...   — one or more container names to emit results for
+#
+# Output format (per file): {"container","variant","tag","arch","result"}
+#   result ∈ "success" | "failure"
+#   A target is "success" IFF its target_id is a key in the metadata AND that
+#   key has a non-empty "containerimage.digest" value.  Everything else is
+#   "failure" (fail-closed: absent/partial = not built = failure).
+#
+# Return codes:
+#   0  — all files written (individual results are in the files, not the exit code)
+#   1  — --cells invocation failed (cannot enumerate cells; no files written)
+#
+# Requirements: bash 4+, jq
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve paths robustly whether sourced or executed directly
+# ---------------------------------------------------------------------------
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    _BBR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    _BBR_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+# shellcheck source=./logging.sh
+source "${_BBR_SCRIPT_DIR}/logging.sh"
+
+# ---------------------------------------------------------------------------
+# emit_bake_build_results
+# ---------------------------------------------------------------------------
+emit_bake_build_results() {
+    local metadata_file="$1"
+    local arch="$2"
+    local out_dir="$3"
+    shift 3
+    local -a containers=("$@")
+
+    # ------------------------------------------------------------------
+    # Step 1: enumerate cells via generate-bake-hcl.sh --cells
+    # stderr passes through to the caller (generator may emit ::error:: or
+    # ::warning:: annotations that must surface in CI logs).
+    # ------------------------------------------------------------------
+    local cells_json
+    local generator="${_BBR_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh"
+    if ! cells_json=$("$generator" --cells "${containers[@]}"); then
+        printf '::error::bake-buildresult: --cells failed for %s\n' \
+            "${containers[*]}" >&2
+        return 1
+    fi
+
+    # ------------------------------------------------------------------
+    # Step 2: load metadata — absent/empty/invalid → empty object (fail-closed)
+    # ------------------------------------------------------------------
+    local metadata='{}'
+    if [[ -f "$metadata_file" ]] && [[ -s "$metadata_file" ]]; then
+        if jq -e 'type == "object"' "$metadata_file" >/dev/null 2>&1; then
+            metadata=$(jq -c '.' "$metadata_file")
+        else
+            printf '::warning::bake-buildresult: metadata file %q is not a JSON object; treating as empty — all cells will be marked failure\n' \
+                "$metadata_file" >&2
+        fi
+    else
+        printf '::warning::bake-buildresult: metadata file %q absent or empty — all cells will be marked failure\n' \
+            "$metadata_file" >&2
+    fi
+
+    # ------------------------------------------------------------------
+    # Step 3 + 4: iterate cells, determine result, write artifact files
+    # ------------------------------------------------------------------
+    mkdir -p "$out_dir"
+
+    local ncells
+    ncells=$(jq 'length' <<< "$cells_json")
+
+    local n_success=0
+    local n_failure=0
+    local i
+    for (( i=0; i<ncells; i++ )); do
+        local cell
+        cell=$(jq -c ".[$i]" <<< "$cells_json")
+
+        local container tag variant target_id
+        container=$(jq -r '.container'        <<< "$cell")
+        tag=$(jq -r '.tag'                    <<< "$cell")
+        variant=$(jq -r '.variant // ""'      <<< "$cell")
+        target_id=$(jq -r '.target_id // ""'  <<< "$cell")
+
+        # Determine result: success only when target_id present in metadata
+        # AND has a non-empty containerimage.digest.
+        local result="failure"
+        if [[ -n "$target_id" ]]; then
+            local digest
+            digest=$(jq -r --arg tid "$target_id" \
+                '.[$tid]["containerimage.digest"] // ""' <<< "$metadata")
+            if [[ -n "$digest" ]]; then
+                result="success"
+            fi
+        fi
+
+        # Write artifact — shape is IDENTICAL to auto-build.yaml:1054-1061
+        local out_file="${out_dir}/build-result-${container}-${tag}-${arch}.json"
+        jq -cn \
+            --arg c  "$container" \
+            --arg v  "$variant" \
+            --arg t  "$tag" \
+            --arg a  "$arch" \
+            --arg r  "$result" \
+            '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+            > "$out_file"
+
+        if [[ "$result" == "success" ]]; then
+            (( n_success++ )) || true
+        else
+            (( n_failure++ )) || true
+        fi
+    done
+
+    # ------------------------------------------------------------------
+    # Step 5: summary notice
+    # ------------------------------------------------------------------
+    printf '::notice::bake-buildresult: %d success, %d failure (arch %s)\n' \
+        "$n_success" "$n_failure" "$arch" >&2
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# main — standalone entry point
+# ---------------------------------------------------------------------------
+main() {
+    if [[ $# -lt 3 ]]; then
+        printf 'Usage: %s <metadata_file> <arch> <out_dir> <container...>\n' \
+            "$(basename "$0")" >&2
+        return 1
+    fi
+    emit_bake_build_results "$@"
+}
+
+# Guard so bats can source this file without invoking main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/helpers/bake-buildresult.sh
+++ b/helpers/bake-buildresult.sh
@@ -57,10 +57,18 @@ emit_bake_build_results() {
     # Step 1: enumerate cells via generate-bake-hcl.sh --cells
     # stderr passes through to the caller (generator may emit ::error:: or
     # ::warning:: annotations that must surface in CI logs).
+    #
+    # When BAKE_GENERATE_ALL_RETAINED=true, pass --all-retained so the
+    # result set matches the built set (mirrors the RETAINED_FLAG decision
+    # in the bake build steps).
     # ------------------------------------------------------------------
     local cells_json
     local generator="${_BBR_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh"
-    if ! cells_json=$("$generator" --cells "${containers[@]}"); then
+    local -a cells_args=("--cells")
+    if [[ "${BAKE_GENERATE_ALL_RETAINED:-}" == "true" ]]; then
+        cells_args=("--cells" "--all-retained")
+    fi
+    if ! cells_json=$("$generator" "${cells_args[@]}" "${containers[@]}"); then
         printf '::error::bake-buildresult: --cells failed for %s\n' \
             "${containers[*]}" >&2
         return 1

--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -60,12 +60,59 @@ is_bake_managed() {
 }
 
 # ---------------------------------------------------------------------------
-# partition_builds <builds_json>
+# _bake_container_latest_only <container>
+#
+# Returns 0 (true) if the container declares build.bake_latest_only: true in
+# its variants.yaml; returns 1 (false) otherwise.  Tolerates a missing file,
+# a missing field, or a non-true value — all default to false.
+#
+# Uses the resolved _BM_SCRIPT_DIR to locate <container>/variants.yaml
+# relative to the repo root (parent of helpers/).
+# ---------------------------------------------------------------------------
+_bake_container_latest_only() {
+    local container="$1"
+    local repo_root
+    repo_root="$(dirname "${_BM_SCRIPT_DIR}")"
+    local variants_file="${repo_root}/${container}/variants.yaml"
+
+    if [[ ! -f "$variants_file" ]]; then
+        return 1
+    fi
+
+    local val
+    val=$(yq e '.build.bake_latest_only // false' "$variants_file" 2>/dev/null) || return 1
+    [[ "$val" == "true" ]]
+}
+
+# ---------------------------------------------------------------------------
+# partition_builds <builds_json> [<scope_active>]
 #
 # Given the `builds` JSON array (cells with a `.container` field), prints a
 # compact JSON object:
-#   {"bake": [...cells whose .container is bake-managed...],
+#   {"bake": [...cells routed to the bake engine...],
 #    "matrix": [...all remaining cells...]}
+#
+# When <scope_active> is "true" (second argument), bake is disabled for this
+# run: ALL cells route to .matrix.  This preserves per-cell scan/attest
+# fidelity for scoped dispatches (scope_versions / scope_flavors non-empty),
+# which build only a subset of a container's cells while bake would publish
+# the full container plan.
+#
+# When <scope_active> is absent or any value other than "true", per-cell
+# routing applies:
+#   A cell lands in .bake only when ALL of the following hold:
+#     1. Its .container is in the bake-managed set.
+#     2. Its .os is "linux" or absent/empty (linux cells may omit the field).
+#     3. Its .is_latest_version is explicitly true.
+#   All other cells go to .matrix so the flat matrix handles them faithfully.
+#
+# Design rationale: bake is latest-only by design — it always generates and
+# builds the full container plan for the latest version of each container.
+# Any retained (non-latest) cell detected by the carry-forward / diff-failure /
+# container-file-change / PR-smoke logic is routed to the flat matrix, which
+# builds exactly the detected cells per-cell with full scan/attest coverage.
+# This prevents a retained cell from being falsely recovered (unscanned,
+# unpublished) by a bake run that regenerates latest-only.
 #
 # Cell order within each partition is preserved.
 #
@@ -74,6 +121,7 @@ is_bake_managed() {
 # ---------------------------------------------------------------------------
 partition_builds() {
     local builds_json="$1"
+    local scope_active="${2:-false}"
 
     # Validate: must be a non-empty string
     if [[ -z "$builds_json" ]]; then
@@ -87,6 +135,13 @@ partition_builds() {
         return 1
     fi
 
+    # Scoped run or forced-matrix: bake disabled — all cells to matrix for full
+    # per-cell fidelity (scope_versions / scope_flavors / PR routing).
+    if [[ "$scope_active" == "true" ]]; then
+        echo "$builds_json" | jq -c '{bake: [], matrix: [.[]]}'
+        return 0
+    fi
+
     # Build jq array argument from the managed set.
     # Read into an array so word-splitting is explicit and shellcheck-clean.
     local managed
@@ -96,12 +151,32 @@ partition_builds() {
     local managed_jq_array
     managed_jq_array=$(printf '%s\n' "${managed_arr[@]}" | jq -R . | jq -s -c .)
 
-    # Partition in a single jq pass; cell order preserved within each partition
+    # Partition in a single jq pass; cell order preserved within each partition.
+    #
+    # A cell lands in .bake only when ALL hold:
+    #   (a) container is bake-managed
+    #   (b) .os is "linux" or absent/empty (linux cells may omit the field)
+    #   (c) .is_latest_version is explicitly true
+    #
+    # Retained (non-latest) cells for bake-managed containers route to .matrix
+    # so the flat matrix builds them with per-cell scan/attest fidelity.
+    # Note: .container is captured as $c before entering $managed so the
+    # any() filter runs in string context (not object context).
     echo "$builds_json" | jq -c \
         --argjson managed "$managed_jq_array" \
         '{
-            bake:   [.[] | select(.container as $c | $managed | any(. == $c))],
-            matrix: [.[] | select(.container as $c | $managed | any(. == $c) | not)]
+            bake:   [.[] | select(
+                        (.container as $c | $managed | any(. == $c))
+                        and ((.os // "") == "" or (.os // "") == "linux")
+                        and (.is_latest_version == true)
+                    )],
+            matrix: [.[] | select(
+                        (
+                            (.container as $c | $managed | any(. == $c))
+                            and ((.os // "") == "" or (.os // "") == "linux")
+                            and (.is_latest_version == true)
+                        ) | not
+                    )]
         }'
 }
 
@@ -113,20 +188,21 @@ main() {
     case "$cmd" in
         partition)
             if [[ $# -lt 2 ]]; then
-                printf 'Usage: %s partition <builds_json_or_@file>\n' \
+                printf 'Usage: %s partition <builds_json_or_@file> [scope_active]\n' \
                     "$(basename "$0")" >&2
                 return 1
             fi
             local input="$2"
+            local scope_arg="${3:-false}"
             # Support @file syntax: @path reads from file
             if [[ "$input" == @* ]]; then
                 local filepath="${input#@}"
                 input="$(cat "$filepath")"
             fi
-            partition_builds "$input"
+            partition_builds "$input" "$scope_arg"
             ;;
         *)
-            printf 'Usage: %s partition <builds_json_or_@file>\n' \
+            printf 'Usage: %s partition <builds_json_or_@file> [scope_active]\n' \
                 "$(basename "$0")" >&2
             return 1
             ;;

--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# bake-managed.sh — Bake-engine partition helper for the ADR-013 production cutover.
+#
+# Usage (library):
+#   source helpers/bake-managed.sh
+#   bake_managed_containers         # echoes space-separated set
+#   is_bake_managed <container>     # 0 = yes, 1 = no
+#   partition_builds <builds_json>  # prints {"bake":[...],"matrix":[...]}
+#
+# Usage (standalone):
+#   helpers/bake-managed.sh partition <builds_json_or_@file>
+#
+# The bake-managed set defaults to "github-runner web-shell wordpress".
+# Override at any time via BAKE_MANAGED_CONTAINERS env (space-separated).
+#
+# Requirements: bash 4+, jq
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve script dir robustly whether sourced or executed directly
+# ---------------------------------------------------------------------------
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    _BM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    _BM_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+# shellcheck source=./logging.sh
+# shellcheck disable=SC1091
+source "${_BM_SCRIPT_DIR}/logging.sh"
+
+# ---------------------------------------------------------------------------
+# bake_managed_containers
+#
+# Echoes the space-separated list of containers that are managed by the bake
+# engine.  Overridable via BAKE_MANAGED_CONTAINERS env variable — allows
+# operators and tests to expand the set without code changes.
+# ---------------------------------------------------------------------------
+bake_managed_containers() {
+    echo "${BAKE_MANAGED_CONTAINERS:-github-runner web-shell wordpress}"
+}
+
+# ---------------------------------------------------------------------------
+# is_bake_managed <container>
+#
+# Returns 0 if <container> is in the bake-managed set, 1 otherwise.
+# ---------------------------------------------------------------------------
+is_bake_managed() {
+    local container="$1"
+    local managed
+    managed=$(bake_managed_containers)
+    local c
+    for c in $managed; do
+        if [[ "$c" == "$container" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# partition_builds <builds_json>
+#
+# Given the `builds` JSON array (cells with a `.container` field), prints a
+# compact JSON object:
+#   {"bake": [...cells whose .container is bake-managed...],
+#    "matrix": [...all remaining cells...]}
+#
+# Cell order within each partition is preserved.
+#
+# Fail-closed: malformed input (not a JSON array) writes ::error:: to stderr
+# and returns 1.  Empty input [] returns {"bake":[],"matrix":[]}.
+# ---------------------------------------------------------------------------
+partition_builds() {
+    local builds_json="$1"
+
+    # Validate: must be a non-empty string
+    if [[ -z "$builds_json" ]]; then
+        echo "::error::partition_builds: empty input" >&2
+        return 1
+    fi
+
+    # Validate: must be a JSON array
+    if ! echo "$builds_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        echo "::error::partition_builds: input is not a JSON array" >&2
+        return 1
+    fi
+
+    # Build jq array argument from the managed set.
+    # Read into an array so word-splitting is explicit and shellcheck-clean.
+    local managed
+    managed=$(bake_managed_containers)
+    local -a managed_arr
+    read -ra managed_arr <<< "$managed"
+    local managed_jq_array
+    managed_jq_array=$(printf '%s\n' "${managed_arr[@]}" | jq -R . | jq -s -c .)
+
+    # Partition in a single jq pass; cell order preserved within each partition
+    echo "$builds_json" | jq -c \
+        --argjson managed "$managed_jq_array" \
+        '{
+            bake:   [.[] | select(.container as $c | $managed | any(. == $c))],
+            matrix: [.[] | select(.container as $c | $managed | any(. == $c) | not)]
+        }'
+}
+
+# ---------------------------------------------------------------------------
+# main — CLI entry point (only when executed directly, not sourced)
+# ---------------------------------------------------------------------------
+main() {
+    local cmd="${1:-}"
+    case "$cmd" in
+        partition)
+            if [[ $# -lt 2 ]]; then
+                printf 'Usage: %s partition <builds_json_or_@file>\n' \
+                    "$(basename "$0")" >&2
+                return 1
+            fi
+            local input="$2"
+            # Support @file syntax: @path reads from file
+            if [[ "$input" == @* ]]; then
+                local filepath="${input#@}"
+                input="$(cat "$filepath")"
+            fi
+            partition_builds "$input"
+            ;;
+        *)
+            printf 'Usage: %s partition <builds_json_or_@file>\n' \
+                "$(basename "$0")" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Guard: only invoke main when executed directly (not sourced by bats or callers)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/helpers/coverage-checkpoint-utils.sh
+++ b/helpers/coverage-checkpoint-utils.sh
@@ -228,10 +228,28 @@ aggregate_build_results() {
     [[ -z "$results_json" ]] && results_json='[]'
     [[ -z "$jobs_json" ]]    && jobs_json='{"jobs":[]}'
 
+    # Build the bake-managed JSON array for the alias in maps_to_container.
+    # Run bake-managed.sh in a subshell to avoid inheriting its set -euo pipefail;
+    # fall back to an empty array if it cannot be executed (alias won't fire — no
+    # regression on callers that don't have the bake pipeline deployed yet).
+    local _bm_script_dir
+    _bm_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _bm_script_dir=""
+    local bake_managed_json='[]'
+    if [[ -n "$_bm_script_dir" && -r "$_bm_script_dir/bake-managed.sh" ]]; then
+        # Run in a subshell: source + call bake_managed_containers; convert
+        # space-separated output to a compact JSON array.  Any failure → [].
+        # shellcheck disable=SC1091
+        bake_managed_json="$(
+            source "$_bm_script_dir/bake-managed.sh" 2>/dev/null &&
+            bake_managed_containers | jq -Rc 'split(" ") | map(select(length>0))'
+        )" 2>/dev/null || bake_managed_json='[]'
+    fi
+
     jq -cn \
         --arg results_str "$results_json" \
         --argjson matrix "$matrix_json" \
         --arg jobs_str "$jobs_json" \
+        --argjson bake_managed "$bake_managed_json" \
         '
         # Parse results_str; treat any non-array (or parse failure) as [] (fail-safe).
         # fromjson? silently becomes empty on invalid JSON; // [] recovers to empty array.
@@ -260,16 +278,37 @@ aggregate_build_results() {
         # Used ONLY for the COUNT completeness gate (bad_build_job_count) — NOT for
         # failure attribution (failed_this_run stays artifact-record-based).
         #
-        # The postgres extension pipeline jobs ("Build PostgreSQL Extensions (arm64)",
-        # "Merge Extension Manifests (multi-arch)") emit records attributed to the
-        # "postgres" container, but their display names contain no lowercase "postgres"
-        # token. Without the alias, a crashed ext/merge job (no record produced) would
-        # go unnoticed by the count gate → bad_build_job_count stays 0 → no gap →
-        # postgres is falsely recovered. The alias fixes this: when the matrix contains
-        # "postgres", extension/merge job names also count toward the gate.
+        # Postgres alias: the extension pipeline jobs ("Build PostgreSQL Extensions
+        # (arm64)", "Merge Extension Manifests (multi-arch)") emit records attributed
+        # to "postgres", but their display names contain no lowercase "postgres" token.
+        # Without the alias a crashed ext/merge job (no record produced) goes unnoticed
+        # by the count gate → bad_build_job_count stays 0 → no gap → postgres is
+        # falsely recovered. The alias fixes this: when the matrix contains "postgres",
+        # extension/merge job names also count toward the gate.
+        #
+        # Bake alias: only build-result-PRODUCING bake jobs ("Bake build (amd64)",
+        # "Bake build (arm64)", "Bake merge manifests + DockerHub mirror") contain no
+        # container token. If a producing leg crashes before its "Emit build-result
+        # artifacts" step it produces no failure record, so bad_build_job_count stays 0
+        # without the alias and the completeness gate cannot fire → bake-managed
+        # containers are falsely recovered. The alias fixes this: a job whose display
+        # name starts with "Bake build" or "Bake merge" is counted toward the gate for
+        # every bake-managed container.
+        #
+        # Advisory bake exclusion: "Trivy scan (bake) <container>:<tag> (<arch>)" and
+        # "Attest SBOM (bake) <container>:<tag>" embed the container token in their
+        # display name. They are best-effort; their failures produce NO build-result
+        # artifacts and must NOT count toward the completeness gate for any container.
+        # The guard returns false for these jobs BEFORE any token or alias match fires,
+        # so even the realistic form "Trivy scan (bake) web-shell:1.7.7 (amd64)" does
+        # not inflate bad_build_job_count and does not poison the checkpoint.
         def maps_to_container($jobname; $c):
-            ($jobname | test(token_re($c)))
-            or ($c == "postgres" and ($jobname | test("PostgreSQL Extensions|Extension Manifests")));
+            if ($jobname | test("^Trivy scan \\(bake\\)|^Attest SBOM \\(bake\\)")) then false
+            else
+              ($jobname | test(token_re($c)))
+              or ($c == "postgres" and ($jobname | test("PostgreSQL Extensions|Extension Manifests")))
+              or (($bake_managed | index($c)) != null and ($jobname | test("^Bake build|^Bake merge")))
+            end;
 
         # fail_rec: matrix containers that have >=1 failure RECORD (artifact-precise).
         [ $m[] | . as $c |
@@ -291,8 +330,9 @@ aggregate_build_results() {
         # bad_build_job_count: number of terminal-failed jobs that map to >=1 matrix
         # container via maps_to_container.  Each job counted at most once; infra jobs
         # (matching nothing) contribute 0 — this preserves the Sync-base-images all-13
-        # fix.  The postgres extension/merge alias ensures a crashed ext/merge job is
-        # counted even though its display name contains no "postgres" token.
+        # fix.  The postgres extension/merge alias and the bake alias ensure that a
+        # crashed ext/merge/bake job is counted even when its display name contains no
+        # container token.
         ($bad_jobs | map(
             . as $job |
             if ([ $m[] | . as $c | select(maps_to_container($job.name; $c)) ] | length) > 0

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# mirror-dockerhub.sh — Best-effort GHCR→DockerHub mirror for bake-managed containers.
+#
+# Usage (library):
+#   source helpers/mirror-dockerhub.sh
+#   mirror_to_dockerhub <container...>
+#
+# Usage (standalone):
+#   helpers/mirror-dockerhub.sh web-shell github-runner wordpress
+#
+# For each bake-managed container the function mirrors its canonical GHCR final tags
+# to docker.io/oorabona/<container>:<tag> using `docker buildx imagetools create`.
+#
+# Tag set: identical to what bake-merge-manifests.sh publishes — versioned + rolling
+# aliases, gated on is_latest_version (retained non-latest versions only get the
+# versioned tag; no rolling :latest/:latest-<variant> to avoid clobbering).
+#
+# BEST-EFFORT: a failure on any individual tag emits ::warning:: and continues.
+# The function returns 0 even when individual mirrors fail — it never gates the build.
+#
+# SKIP: when DOCKERHUB_USERNAME is unset the function emits ::notice:: and returns 0.
+#
+# DRY_RUN / DOCKER indirection:
+#   - When DRY_RUN=true the explicit dry-run branch at the mirror call site prints
+#     the imagetools command to stderr and skips execution entirely.
+#   - On the real (non-dry-run) path, "$DOCKER" (quoted, injection-safe) invokes
+#     the docker binary.  DOCKER="${DOCKER:-docker}" so callers can override it;
+#     bats tests set DOCKER to a logging mock script (no DRY_RUN involved).
+#
+# Requirements: bash 4+, docker (buildx imagetools), jq
+# shellcheck source=./logging.sh
+# shellcheck source=./variant-utils.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve script dir whether sourced or executed directly
+# ---------------------------------------------------------------------------
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    _MDH_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    _MDH_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+# shellcheck disable=SC1091
+source "${_MDH_SCRIPT_DIR}/logging.sh"
+# shellcheck disable=SC1091
+source "${_MDH_SCRIPT_DIR}/variant-utils.sh"
+
+# DOCKER is already set by logging.sh (honours DRY_RUN); provide a fallback
+# only when the caller sourced this file before logging.sh.
+DOCKER="${DOCKER:-docker}"
+
+# ---------------------------------------------------------------------------
+# mirror_to_dockerhub <container...>
+#
+# Mirrors canonical GHCR tags to docker.io/oorabona/<container>:<tag>
+# for each named container.  The GHCR namespace is taken from REMOTE_CR
+# (default: ghcr.io/oorabona, matching bake-merge-manifests.sh).
+#
+# Arguments:
+#   container...  — one or more container names (e.g. web-shell github-runner)
+#
+# Environment variables honoured:
+#   DOCKERHUB_USERNAME          — DockerHub account name (skips entirely when unset/empty)
+#   REMOTE_CR                   — GHCR namespace (default: ghcr.io/oorabona)
+#   BAKE_GENERATE_ALL_RETAINED  — when "true", pass --all-retained to the generator so the
+#                                 mirrored tag set matches what bake-merge published (same
+#                                 contract as helpers/bake-buildresult.sh)
+#   DRY_RUN                     — when "true", print commands without executing
+#   DOCKER                      — docker binary / mock (set by logging.sh)
+#
+# Return value:
+#   0 always (best-effort; individual failures do not propagate)
+# ---------------------------------------------------------------------------
+mirror_to_dockerhub() {
+    local -a containers=("$@")
+
+    # Skip entirely when DockerHub credentials are absent.
+    if [[ -z "${DOCKERHUB_USERNAME:-}" ]]; then
+        printf '::notice::mirror-dockerhub: DOCKERHUB_USERNAME unset — skipping DockerHub mirror\n' >&2
+        return 0
+    fi
+
+    local remote_cr="${REMOTE_CR:-ghcr.io/oorabona}"
+
+    # Enumerate cells via the bake generator (same as bake-merge-manifests.sh).
+    # Honor BAKE_GENERATE_ALL_RETAINED so the mirrored tag set matches what
+    # bake-merge published (retained tags must not be absent on DockerHub).
+    local _gen_retained_flag=()
+    if [[ "${BAKE_GENERATE_ALL_RETAINED:-false}" == "true" ]]; then
+        _gen_retained_flag=("--all-retained")
+    fi
+
+    local cells_json
+    local generator="${_MDH_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh"
+    if ! cells_json=$("$generator" --cells "${_gen_retained_flag[@]}" "${containers[@]}"); then
+        printf '::warning::mirror-dockerhub: generate-bake-hcl.sh --cells failed — skipping DockerHub mirror\n' >&2
+        return 0
+    fi
+
+    if ! jq -e 'type == "array"' <<< "$cells_json" >/dev/null 2>&1; then
+        printf '::warning::mirror-dockerhub: --cells returned non-array — skipping DockerHub mirror\n' >&2
+        return 0
+    fi
+
+    local ncells
+    ncells=$(jq 'length' <<< "$cells_json")
+
+    if [[ "$ncells" -eq 0 ]]; then
+        printf '::notice::mirror-dockerhub: no cells to mirror\n' >&2
+        return 0
+    fi
+
+    local i
+    for (( i=0; i<ncells; i++ )); do
+        local cell
+        cell=$(jq -c ".[$i]" <<< "$cells_json")
+
+        local container tag variant flavor is_default is_latest_version intermediate_ref
+        container=$(jq -r '.container'        <<< "$cell")
+        tag=$(jq -r '.tag'                    <<< "$cell")
+        variant=$(jq -r '.variant // ""'      <<< "$cell")
+        flavor=$(jq -r '.flavor // ""'        <<< "$cell")
+        is_default=$(jq -r 'if .is_default then "true" else "false" end' <<< "$cell")
+        # Gate rolling aliases on is_latest_version (same logic as _merge_cell)
+        is_latest_version=$(jq -r 'if has("is_latest_version") then (if .is_latest_version then "true" else "false" end) else "true" end' <<< "$cell")
+        # intermediate_ref holds the GHCR per-arch base ref (token already expanded
+        # by --cells for the default REMOTE_CR; override expansion when REMOTE_CR differs)
+        intermediate_ref=$(jq -r '.intermediate_ref' <<< "$cell")
+        intermediate_ref="${intermediate_ref//\$\{REMOTE_CR\}/${remote_cr}}"
+
+        # The final merged GHCR manifest ref (no arch suffix) is the source for the mirror.
+        local ghcr_src="${remote_cr}/${container}:${tag}"
+
+        # Compute the rolling-alias discriminator: variant preferred over flavor
+        # (matches bake-merge-manifests.sh FIX F routing logic).
+        local routing_suffix="${variant:-${flavor}}"
+
+        # Enumerate tags using the same routing as compute_cell_tag_suffixes.
+        # For retained non-latest cells, publish ONLY the versioned tag.
+        local sfx
+        while IFS= read -r sfx; do
+            [[ -n "$sfx" ]] || continue
+            # F2 gate: retained non-latest → versioned tag only
+            if [[ "$is_latest_version" != "true" && "$sfx" != "$tag" ]]; then
+                continue
+            fi
+
+            local dh_dst="docker.io/${DOCKERHUB_USERNAME}/${container}:${sfx}"
+
+            # Dry-run: explicit branch prints the command and skips execution.
+            # Real path: "$DOCKER" (quoted) runs the actual binary or bats mock.
+            if [[ "${DRY_RUN:-false}" == "true" ]]; then
+                printf 'DRY-RUN: docker buildx imagetools create -t %s %s\n' \
+                    "$dh_dst" "$ghcr_src" >&2
+            else
+                if ! "$DOCKER" buildx imagetools create -t "$dh_dst" "$ghcr_src" 2>&1; then
+                    printf '::warning::mirror-dockerhub: imagetools create failed for %s (best-effort, continuing)\n' \
+                        "$dh_dst" >&2
+                fi
+            fi
+        done < <(compute_cell_tag_suffixes "$tag" "$routing_suffix" "$is_default")
+    done
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# main — standalone entry point
+# ---------------------------------------------------------------------------
+main() {
+    if [[ $# -lt 1 ]]; then
+        printf 'Usage: %s <container...>\n' "$(basename "$0")" >&2
+        return 1
+    fi
+    mirror_to_dockerhub "$@"
+}
+
+# Guard: only invoke main when executed directly (not sourced by bats or callers)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -1074,8 +1074,10 @@ _emit_cells_json() {
     # F2: include is_latest_version so the merge job can gate rolling tags.
     # FIX F: include variant (unique per cell) for rolling-alias routing in merge;
     #        flavor is non-unique for multi-build_flavor containers (github-runner).
+    # #595: include target_id (byte-identical to the bake target key) so that
+    #        bake-buildresult.sh can correlate --metadata-file keys to cells.
     _on_cell_plain() {
-        local _c="$1" _tag="$2" _flavor="$3" _is_default="$4" _iref="$5" _is_latest="${6:-false}" _variant="${7:-}"
+        local _c="$1" _tag="$2" _flavor="$3" _is_default="$4" _iref="$5" _is_latest="${6:-false}" _variant="${7:-}" _tid="${8:-}"
         local _obj
         _obj=$(jq -cn \
             --arg container    "$_c" \
@@ -1085,7 +1087,8 @@ _emit_cells_json() {
             --argjson is_default       "$( [ "$_is_default" = "true" ] && echo 'true' || echo 'false')" \
             --argjson is_latest_version "$( [ "$_is_latest"  = "true" ] && echo 'true' || echo 'false')" \
             --arg intermediate_ref "$_iref" \
-            '{container: $container, tag: $tag, flavor: $flavor, variant: $variant, is_default: $is_default, is_latest_version: $is_latest_version, intermediate_ref: $intermediate_ref}')
+            --arg target_id    "$_tid" \
+            '{container: $container, tag: $tag, flavor: $flavor, variant: $variant, is_default: $is_default, is_latest_version: $is_latest_version, intermediate_ref: $intermediate_ref, target_id: $target_id}')
         cells_json=$(jq -cn --argjson arr "$cells_json" --argjson obj "$_obj" '$arr + [$obj]')
     }
 
@@ -1105,7 +1108,8 @@ _emit_cells_json() {
             local cell
             cell=$(jq -c ".[$i]" <<< "$matrix")
 
-            local tag flavor variant cell_os is_default_raw is_latest_raw
+            local version tag flavor variant cell_os is_default_raw is_latest_raw
+            version=$(jq -r '.version'          <<< "$cell")
             tag=$(jq -r '.tag'              <<< "$cell")
             flavor=$(jq -r '.flavor // ""'  <<< "$cell")
             # FIX F: variant is the unique per-cell name for rolling-alias routing
@@ -1120,8 +1124,17 @@ _emit_cells_json() {
                 continue
             fi
 
+            # #595: Compute target_id using IDENTICAL logic to _on_cell_bake so
+            # that --cells[].target_id matches the bake --metadata-file keys.
+            local cell_tid
+            if [[ -z "$variant" ]]; then
+                cell_tid="$(_target_id "${c}_${tag}")"
+            else
+                cell_tid="$(_target_id "${c}_${version}_${variant}")"
+            fi
+
             local intermediate_ref="${_BAKE_REMOTE_CR}/${c}:${tag}"
-            _on_cell_plain "$c" "$tag" "$flavor" "$is_default_raw" "$intermediate_ref" "$is_latest_raw" "$variant"
+            _on_cell_plain "$c" "$tag" "$flavor" "$is_default_raw" "$intermediate_ref" "$is_latest_raw" "$variant" "$cell_tid"
         done
     done
 

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -641,8 +641,20 @@ _enumerate_cells_init() {
     # F4: use the caller-supplied include_all_retained flag (default false = latest-only).
     local _ec_all_retained="${_BAKE_INCLUDE_ALL_RETAINED:-false}"
     for c in "${_EC_closure_containers[@]}"; do
+        # bake_latest_only: when true, force latest-only for this container regardless
+        # of the global --all-retained flag (e.g. github-runner shares a single
+        # runner.tar.gz across all variants in one bake invocation — retained older
+        # versions would get the wrong binary).
+        local _c_bake_latest_only
+        _c_bake_latest_only=$(yq -r '.build.bake_latest_only // false' "./${c}/variants.yaml" 2>/dev/null || echo "false")
+        local _c_retained="$_ec_all_retained"
+        if [[ "$_c_bake_latest_only" == "true" && "$_ec_all_retained" == "true" ]]; then
+            _c_retained="false"
+            printf '::notice::bake: %s forced latest-only (bake_latest_only=true; shared runner.tar.gz; retained rebuilds need per-version build contexts)\n' "$c" >&2
+        fi
+
         local matrix
-        if ! matrix=$(list_build_matrix "./${c}" "" "$_ec_all_retained" 2>/dev/null); then
+        if ! matrix=$(list_build_matrix "./${c}" "" "$_c_retained" 2>/dev/null); then
             printf 'ERROR: list_build_matrix failed for %q\n' "$c" >&2
             return 1
         fi

--- a/tests/unit/bake-buildresult.bats
+++ b/tests/unit/bake-buildresult.bats
@@ -1,0 +1,302 @@
+#!/usr/bin/env bats
+# Unit tests for helpers/bake-buildresult.sh — ADR-013 R2 slice (#595 emission)
+#
+# Mutation guards (named per test):
+#   MB1: Change success condition (e.g. ignore digest) → success count wrong
+#   MB2: Remove fail-closed on absent metadata → absent file yields success
+#   MB3: Use wrong field name (e.g. "status" instead of "result") → shape mismatch
+#   MB4: Use arch from cells instead of arg → arch field wrong
+#   MB5: Omit warning on absent metadata → no ::warning:: annotation
+#   MB6: target_id mismatch → all cells become failure even with valid metadata
+
+load "../test_helper"
+
+setup() {
+    export PROJECT_ROOT
+    export HELPERS_DIR
+
+    # Bake-buildresult script under test
+    export BBR="${HELPERS_DIR}/bake-buildresult.sh"
+
+    # Suppress GHA annotations in variant-utils / list_build_matrix
+    export GITHUB_ACTIONS=""
+    export _DEPGRAPH_LINEAGE_DIR=/nonexistent
+
+    # Create a per-test output directory (scope guard allows writes under
+    # PROJECT_ROOT only; use mktemp under /tmp and source the script).
+    export TEST_OUT_DIR
+    TEST_OUT_DIR=$(mktemp -d)
+}
+
+teardown() {
+    rm -rf "$TEST_OUT_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: read the real --cells output and build a complete metadata fixture
+# that marks EVERY cell as success.
+# ---------------------------------------------------------------------------
+_all_success_meta() {
+    local container="$1"
+    # Get cells JSON; build a metadata object with one key per target_id.
+    local cells
+    cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells "$container")
+    # Construct metadata: {target_id: {"containerimage.digest":"sha256:…"}}
+    echo "$cells" | jq -c '
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    '
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a partial metadata fixture — all cells EXCEPT the last one.
+# ---------------------------------------------------------------------------
+_partial_meta() {
+    local container="$1"
+    local cells
+    cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells "$container")
+    local n
+    n=$(echo "$cells" | jq 'length')
+    # Include n-1 cells (exclude the last)
+    echo "$cells" | jq -c --argjson n "$n" '
+        .[0:($n-1)] |
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    '
+}
+
+# ---------------------------------------------------------------------------
+# MB1 + shape: all-success case — every emitted result is "success";
+#              shape is exactly {container, variant, tag, arch, result}.
+# ---------------------------------------------------------------------------
+@test "BBR-01: all cells success when metadata contains every target_id with digest" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    # Every emitted file must have result="success"
+    local fail_count
+    fail_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^failure$' || true)
+    [ "$fail_count" -eq 0 ]
+
+    # Must have emitted at least one file
+    local file_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    [ "$file_count" -gt 0 ]
+
+    # MB3 / shape parity: each file has exactly the 5 keys defined by auto-build.yaml:1054-1061
+    local shape_fail
+    shape_fail=$(find "$TEST_OUT_DIR/out" -name '*.json' -exec jq -e '
+        has("container") and has("variant") and has("tag") and has("arch") and has("result")
+    ' {} \; | grep -c '^false$' || true)
+    [ "$shape_fail" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# MB4: arch field in emitted files matches the supplied arch argument
+# ---------------------------------------------------------------------------
+@test "BBR-02: emitted build-result files carry the supplied arch field" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" arm64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    local wrong_arch
+    wrong_arch=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.arch' {} \; | grep -cv '^arm64$' || true)
+    [ "$wrong_arch" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# partial: missing target → failure; others → success
+# ---------------------------------------------------------------------------
+@test "BBR-03: partial metadata — cell absent from metadata emits result=failure" {
+    local meta_file="$TEST_OUT_DIR/meta_partial.json"
+    _partial_meta web-shell > "$meta_file"
+
+    local cells
+    cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells web-shell)
+    local n
+    n=$(echo "$cells" | jq 'length')
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    # Exactly 1 failure (the last cell)
+    local fail_count
+    fail_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^failure$' || true)
+    [ "$fail_count" -eq 1 ]
+
+    # n-1 successes
+    local success_count
+    success_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^success$' || true)
+    [ "$success_count" -eq $(( n - 1 )) ]
+}
+
+# ---------------------------------------------------------------------------
+# MB2 + MB5: absent metadata → fail-closed (all failure) + ::warning::
+# ---------------------------------------------------------------------------
+@test "BBR-04: absent metadata file → all cells failure (fail-closed)" {
+    run bash "$BBR" "$TEST_OUT_DIR/nonexistent.json" amd64 "$TEST_OUT_DIR/out" web-shell 2>&1
+    [ "$status" -eq 0 ]
+
+    # All results must be failure
+    local success_count
+    success_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^success$' || true)
+    [ "$success_count" -eq 0 ]
+
+    # Must have emitted files (fail-closed writes artifacts, not just errors)
+    local file_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    [ "$file_count" -gt 0 ]
+}
+
+@test "BBR-05: absent metadata file emits a ::warning:: annotation" {
+    # Run with stderr captured to combined output (bats 'run' merges them)
+    run bash "$BBR" "$TEST_OUT_DIR/nonexistent.json" amd64 "$TEST_OUT_DIR/out" web-shell 2>&1
+    [ "$status" -eq 0 ]
+    # ::warning:: must appear in stderr (captured via 2>&1 by run)
+    [[ "$output" == *"::warning::"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# File naming: build-result-<container>-<tag>-<arch>.json (parity with auto-build.yaml:1061)
+# ---------------------------------------------------------------------------
+@test "BBR-06: emitted filenames match build-result-<container>-<tag>-<arch>.json pattern" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    # Each filename must conform to the naming convention
+    local bad_names
+    bad_names=0
+    while IFS= read -r f; do
+        local fname
+        fname=$(basename "$f")
+        # Must match build-result-<container>-<tag>-amd64.json
+        if [[ "$fname" != build-result-web-shell-*-amd64.json ]]; then
+            (( bad_names++ )) || true
+        fi
+    done < <(find "$TEST_OUT_DIR/out" -name '*.json')
+    [ "$bad_names" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Shape: emitted JSON has EXACTLY 5 keys (no extras)
+# ---------------------------------------------------------------------------
+@test "BBR-07: emitted JSON has exactly 5 keys: container variant tag arch result" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    local wrong_count
+    wrong_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq 'keys | length' {} \; | grep -cv '^5$' || true)
+    [ "$wrong_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# container field matches the container arg
+# ---------------------------------------------------------------------------
+@test "BBR-08: emitted container field matches the requested container name" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    local wrong_container
+    wrong_container=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.container' {} \; | grep -cv '^web-shell$' || true)
+    [ "$wrong_container" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Cell count parity: number of emitted files equals number of --cells entries
+# ---------------------------------------------------------------------------
+@test "BBR-09: number of emitted build-result files equals --cells entry count for web-shell" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    local expected_count
+    expected_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
+        --cells web-shell | jq 'length')
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    local file_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    [ "$file_count" -eq "$expected_count" ]
+}
+
+# ---------------------------------------------------------------------------
+# MB6: target_id key-join correctness — a metadata keyed by ACTUAL target_ids
+# yields success; swapping to wrong keys yields failure (join is tight).
+# ---------------------------------------------------------------------------
+@test "BBR-10: wrong target_id keys in metadata → all cells failure (join must be tight)" {
+    # Build a metadata file with wrong keys (e.g. containerids with a bogus prefix)
+    jq -cn '{
+        "WRONG_KEY_1": {"containerimage.digest":"sha256:aaa","image.name":"ghcr.io/test"},
+        "WRONG_KEY_2": {"containerimage.digest":"sha256:bbb","image.name":"ghcr.io/test"}
+    }' > "$TEST_OUT_DIR/meta_wrong.json"
+
+    run bash "$BBR" "$TEST_OUT_DIR/meta_wrong.json" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    # All cells must be failure — none of the right target_ids are in the metadata
+    local success_count
+    success_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^success$' || true)
+    [ "$success_count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# tag field in emitted file matches cells tag (not overridden by arch arg)
+# ---------------------------------------------------------------------------
+@test "BBR-11: emitted tag field matches the cell tag (not the arch argument)" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell
+    [ "$status" -eq 0 ]
+
+    # Get expected tags from --cells
+    local expected_tags
+    expected_tags=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
+        --cells web-shell | jq -r '.[].tag' | sort)
+
+    # Get actual tags from emitted files
+    local actual_tags
+    actual_tags=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.tag' {} \; | sort)
+
+    [ "$expected_tags" = "$actual_tags" ]
+}
+
+# ---------------------------------------------------------------------------
+# ::notice:: summary always emitted (success path)
+# ---------------------------------------------------------------------------
+@test "BBR-12: ::notice:: summary is emitted on success" {
+    local meta_file="$TEST_OUT_DIR/meta_all.json"
+    _all_success_meta web-shell > "$meta_file"
+
+    run bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" web-shell 2>&1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::notice::bake-buildresult:"* ]]
+}

--- a/tests/unit/bake-buildresult.bats
+++ b/tests/unit/bake-buildresult.bats
@@ -300,3 +300,72 @@ _partial_meta() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"::notice::bake-buildresult:"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# FIX C: BAKE_GENERATE_ALL_RETAINED env controls --all-retained in --cells
+# ---------------------------------------------------------------------------
+
+# Helper: get cells count from generator directly (with or without --all-retained)
+_latest_cell_count() {
+    bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells "$1" | jq 'length'
+}
+_retained_cell_count() {
+    bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained "$1" | jq 'length'
+}
+
+@test "BBR-13: without BAKE_GENERATE_ALL_RETAINED, emit covers latest-only cells" {
+    # terraform has more retained cells than latest-only cells (github-runner is
+    # bake_latest_only, so it can't exercise the retained path).
+    local latest_count
+    latest_count=$(_latest_cell_count terraform)
+    local retained_count
+    retained_count=$(_retained_cell_count terraform)
+    # Prerequisite: retained set is strictly larger than latest-only set.
+    [ "$retained_count" -gt "$latest_count" ]
+
+    # Build a metadata fixture that marks ALL cells (retained) as success so
+    # the file-count diff is purely from cell enumeration, not from missing metadata.
+    local meta_file="$TEST_OUT_DIR/meta_retained.json"
+    cells_all=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform)
+    echo "$cells_all" | jq -c '
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    ' > "$meta_file"
+
+    # Run WITHOUT the retained env (default: latest-only).
+    run env -u BAKE_GENERATE_ALL_RETAINED bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" terraform
+    [ "$status" -eq 0 ]
+
+    local file_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    # Must match latest-only count, NOT retained count.
+    [ "$file_count" -eq "$latest_count" ]
+}
+
+@test "BBR-14: with BAKE_GENERATE_ALL_RETAINED=true, emit covers all retained cells" {
+    # terraform has more retained cells than latest-only cells (github-runner is
+    # bake_latest_only, so it can't exercise the retained path).
+    local retained_count
+    retained_count=$(_retained_cell_count terraform)
+
+    # Build a metadata fixture that marks ALL retained cells as success.
+    local meta_file="$TEST_OUT_DIR/meta_retained.json"
+    cells_all=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform)
+    echo "$cells_all" | jq -c '
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    ' > "$meta_file"
+
+    # Run WITH BAKE_GENERATE_ALL_RETAINED=true.
+    run env BAKE_GENERATE_ALL_RETAINED=true bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" terraform
+    [ "$status" -eq 0 ]
+
+    local file_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    # Must match the full retained count.
+    [ "$file_count" -eq "$retained_count" ]
+}

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -12,6 +12,8 @@
 #   MM8: Reverse partition logic → bake-managed containers land in matrix
 #   MM9: Change is_bake_managed return codes → 0/1 inverted
 #   MM10: Corrupt cell objects during partition → cell fields lost
+#   MM11: Drop OS guard — windows cell of bake-managed container lands in bake instead of matrix
+#   MM12: Treat absent .os as non-linux — linux cell without .os field excluded from bake
 
 load "../test_helper"
 
@@ -38,16 +40,33 @@ teardown() {
 # Fixture: a builds JSON array with a mix of bake-managed and matrix containers.
 # Cells have the minimal shape the partition function requires: .container + extra
 # fields to prove objects are preserved intact.
+# Note: linux cells may omit .os (treated as linux); windows cells have .os="windows".
+# All bake-managed cells carry is_latest_version:true — bake is latest-only by
+# design and partition_builds requires is_latest_version==true for .bake routing.
 # ---------------------------------------------------------------------------
 _fixture_builds() {
     jq -cn '
     [
-      {"container":"github-runner","tag":"ubuntu-2404-1.2.3","variant":"ubuntu-2404","flavor":"dev"},
-      {"container":"web-shell",    "tag":"alpine-1.0.0",     "variant":"alpine",      "flavor":"base"},
-      {"container":"wordpress",    "tag":"latest-6.5.0",     "variant":"latest",      "flavor":"php82"},
+      {"container":"github-runner","tag":"ubuntu-2404-1.2.3","variant":"ubuntu-2404","flavor":"dev","is_latest_version":true},
+      {"container":"web-shell",    "tag":"alpine-1.0.0",     "variant":"alpine",      "flavor":"base","is_latest_version":true},
+      {"container":"wordpress",    "tag":"latest-6.5.0",     "variant":"latest",      "flavor":"php82","is_latest_version":true},
       {"container":"debian",       "tag":"bookworm-12.0.0",  "variant":"bookworm",    "flavor":"base"},
       {"container":"terraform",    "tag":"1.8.0",            "variant":"",            "flavor":""},
-      {"container":"web-shell",    "tag":"ubuntu-1.0.0",     "variant":"ubuntu",      "flavor":"base"}
+      {"container":"web-shell",    "tag":"ubuntu-1.0.0",     "variant":"ubuntu",      "flavor":"base","is_latest_version":true}
+    ]'
+}
+
+# Fixture with mixed OS cells: bake-managed container with linux, windows, and absent .os;
+# plus a non-bake-managed container for control.
+# github-runner linux cells carry is_latest_version:true so they route to .bake;
+# windows cell always goes to .matrix regardless of is_latest_version.
+_fixture_os_builds() {
+    jq -cn '
+    [
+      {"container":"github-runner","os":"linux",   "tag":"ubuntu-2404-1.2.3","variant":"ubuntu-2404","is_latest_version":true},
+      {"container":"github-runner","os":"windows", "tag":"windows-2022-1.2.3","variant":"windows-2022","is_latest_version":true},
+      {"container":"github-runner","tag":"linux-noos-1.2.3","variant":"ubuntu-2204","is_latest_version":true},
+      {"container":"debian",       "os":"linux",   "tag":"bookworm-12.0.0",  "variant":"bookworm"}
     ]'
 }
 
@@ -139,13 +158,25 @@ ubuntu-1.0.0"
     # shellcheck disable=SC1090
     source "$BM"
 
-    BAKE_MANAGED_CONTAINERS="debian" result=$(partition_builds "$(_fixture_builds)")
+    # Use a local fixture where the overridden container (debian) carries
+    # is_latest_version:true so it satisfies the bake routing gate.
+    local fixture
+    fixture=$(jq -cn '
+    [
+      {"container":"github-runner","tag":"ubuntu-2404-1.2.3","variant":"ubuntu-2404","flavor":"dev","is_latest_version":true},
+      {"container":"web-shell",    "tag":"alpine-1.0.0",     "variant":"alpine",      "flavor":"base","is_latest_version":true},
+      {"container":"wordpress",    "tag":"latest-6.5.0",     "variant":"latest",      "flavor":"php82","is_latest_version":true},
+      {"container":"debian",       "tag":"bookworm-12.0.0",  "variant":"bookworm",    "flavor":"base","is_latest_version":true},
+      {"container":"terraform",    "tag":"1.8.0",            "variant":"",            "flavor":""}
+    ]')
 
-    # Only debian must be in bake
+    BAKE_MANAGED_CONTAINERS="debian" result=$(partition_builds "$fixture")
+
+    # Only debian must be in bake (is_latest_version:true + bake-managed)
     bake_containers=$(echo "$result" | jq -r '[.bake[].container] | unique | .[]')
     [[ "$bake_containers" == "debian" ]]
 
-    # github-runner, web-shell, wordpress must now be in matrix
+    # github-runner, web-shell, wordpress must now be in matrix (not in managed set)
     matrix_containers=$(echo "$result" | jq -r '[.matrix[].container] | unique | .[]')
     echo "$matrix_containers" | grep -q "^github-runner$"
     echo "$matrix_containers" | grep -q "^web-shell$"
@@ -238,4 +269,251 @@ ubuntu-1.0.0"
         echo "$output" | grep -q "error" || true
     # The key assertion: non-zero exit code
     [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-11: OS guard — github-runner windows cell stays in .matrix even though
+#         github-runner is bake-managed. The bake generator is linux-only; a
+#         windows cell in .bake would be orphaned (built by neither path).
+# Catches: MM11
+# ---------------------------------------------------------------------------
+@test "BM-11: github-runner windows cell routes to matrix, not bake" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "$(_fixture_os_builds)")
+
+    # The windows cell must land in .matrix
+    windows_in_matrix=$(echo "$result" | jq -r '[.matrix[] | select(.container == "github-runner" and .os == "windows")] | length')
+    [[ "$windows_in_matrix" -eq 1 ]]
+
+    # The windows cell must NOT be in .bake
+    windows_in_bake=$(echo "$result" | jq -r '[.bake[] | select(.container == "github-runner" and .os == "windows")] | length')
+    [[ "$windows_in_bake" -eq 0 ]]
+
+    # debian (non-bake-managed, linux) must also stay in .matrix
+    debian_in_matrix=$(echo "$result" | jq -r '[.matrix[] | select(.container == "debian")] | length')
+    [[ "$debian_in_matrix" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-12: OS guard — github-runner linux cell (explicit .os="linux") goes to .bake;
+#         github-runner cell with absent .os (omitted field) also goes to .bake
+#         (absent .os is treated as linux because linux cells may omit the field).
+# Catches: MM12
+# ---------------------------------------------------------------------------
+@test "BM-12: github-runner linux cell and absent-os cell both route to bake" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "$(_fixture_os_builds)")
+
+    # Explicit os=linux cell must land in .bake
+    linux_in_bake=$(echo "$result" | jq -r '[.bake[] | select(.container == "github-runner" and .os == "linux")] | length')
+    [[ "$linux_in_bake" -eq 1 ]]
+
+    # Absent .os cell must also land in .bake
+    noos_in_bake=$(echo "$result" | jq -r '[.bake[] | select(.container == "github-runner" and (.os? == null or .os? == ""))] | length')
+    [[ "$noos_in_bake" -ge 1 ]]
+
+    # Total bake count: linux + absent-os github-runner = 2
+    bake_gr_count=$(echo "$result" | jq -r '[.bake[] | select(.container == "github-runner")] | length')
+    [[ "$bake_gr_count" -eq 2 ]]
+
+    # Total count preserved (lossless)
+    input_count=$(jq 'length' <<< "$(_fixture_os_builds)")
+    bake_count=$(echo "$result" | jq '.bake | length')
+    matrix_count=$(echo "$result" | jq '.matrix | length')
+    total=$(( bake_count + matrix_count ))
+    [[ "$total" -eq "$input_count" ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-13: bake_latest_only — github-runner retained cell (is_latest_version:false)
+#         routes to .matrix; github-runner latest cell (is_latest_version:true)
+#         routes to .bake.  Verifies the per-cell fidelity fix (FIX 1).
+# Catches: new finding — retained github-runner built by neither path without this fix
+# ---------------------------------------------------------------------------
+@test "BM-13: github-runner retained linux cell routes to matrix; latest linux cell routes to bake" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(jq -cn '
+    [
+      {"container":"github-runner","os":"linux","tag":"ubuntu-2404-2.334.0","variant":"ubuntu-2404","is_latest_version":true},
+      {"container":"github-runner","os":"linux","tag":"ubuntu-2404-2.333.0","variant":"ubuntu-2404","is_latest_version":false},
+      {"container":"github-runner","os":"linux","tag":"ubuntu-2404-2.332.0","variant":"ubuntu-2404","is_latest_version":false}
+    ]')
+
+    result=$(partition_builds "$fixture")
+
+    # Latest cell must land in .bake
+    latest_in_bake=$(echo "$result" | jq '[.bake[] | select(.tag == "ubuntu-2404-2.334.0")] | length')
+    [[ "$latest_in_bake" -eq 1 ]]
+
+    # Retained cells must land in .matrix
+    retained_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_in_matrix" -eq 2 ]]
+
+    # No retained cell in .bake
+    retained_in_bake=$(echo "$result" | jq '[.bake[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_in_bake" -eq 0 ]]
+
+    # Lossless
+    total=$(echo "$result" | jq '.bake + .matrix | length')
+    [[ "$total" -eq 3 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-14: Retained (non-latest) cells for ANY bake-managed container route to
+#         .matrix — bake is latest-only by design.  Tests web-shell (no
+#         variants.yaml bake_latest_only flag) and wordpress to verify the
+#         universal is_latest_version==true gate applies to all bake-managed
+#         containers, not just those that declare bake_latest_only.
+# Catches: retained bake-managed cell falsely recovered/unscanned by a latest-only bake run
+# ---------------------------------------------------------------------------
+@test "BM-14: retained web-shell and wordpress cells (is_latest_version:false) route to matrix" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(jq -cn '
+    [
+      {"container":"web-shell","os":"linux","tag":"alpine-2.0.0","variant":"alpine","is_latest_version":true},
+      {"container":"web-shell","os":"linux","tag":"alpine-1.0.0","variant":"alpine","is_latest_version":false},
+      {"container":"wordpress","os":"linux","tag":"latest-7.0.0","variant":"latest","is_latest_version":true},
+      {"container":"wordpress","os":"linux","tag":"latest-6.9.4","variant":"latest","is_latest_version":false},
+      {"container":"debian","os":"linux","tag":"bookworm-12.0.0","variant":"bookworm"}
+    ]')
+
+    result=$(partition_builds "$fixture")
+
+    # Only the latest web-shell cell must land in .bake
+    ws_latest_in_bake=$(echo "$result" | jq '[.bake[] | select(.container == "web-shell" and .is_latest_version == true)] | length')
+    [[ "$ws_latest_in_bake" -eq 1 ]]
+
+    # Only the latest wordpress cell must land in .bake
+    wp_latest_in_bake=$(echo "$result" | jq '[.bake[] | select(.container == "wordpress" and .is_latest_version == true)] | length')
+    [[ "$wp_latest_in_bake" -eq 1 ]]
+
+    # Retained web-shell cell must land in .matrix
+    ws_retained_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "web-shell" and .is_latest_version == false)] | length')
+    [[ "$ws_retained_in_matrix" -eq 1 ]]
+
+    # Retained wordpress cell must land in .matrix
+    wp_retained_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "wordpress" and .is_latest_version == false)] | length')
+    [[ "$wp_retained_in_matrix" -eq 1 ]]
+
+    # Retained cells must NOT appear in .bake
+    retained_in_bake=$(echo "$result" | jq '[.bake[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_in_bake" -eq 0 ]]
+
+    # debian (not bake-managed) must land in .matrix
+    deb_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "debian")] | length')
+    [[ "$deb_in_matrix" -eq 1 ]]
+
+    # Lossless
+    total=$(echo "$result" | jq '.bake + .matrix | length')
+    [[ "$total" -eq 5 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-15: scope_active="true" — ALL cells (including bake-managed latest linux)
+#         route to .matrix; .bake is empty.  Verifies the scope-override fix
+#         that prevents unscanned images when scope_flavors/scope_versions is set.
+# ---------------------------------------------------------------------------
+@test "BM-15: scope_active=true routes all cells to matrix (bake disabled)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    # Mixed fixture: bake-managed latest, bake-managed retained, non-bake, windows
+    fixture=$(jq -cn '
+    [
+      {"container":"github-runner","os":"linux","tag":"2.334.0","is_latest_version":true},
+      {"container":"github-runner","os":"linux","tag":"2.333.0","is_latest_version":false},
+      {"container":"github-runner","os":"windows","tag":"2.334.0-win","is_latest_version":true},
+      {"container":"web-shell","os":"linux","tag":"alpine-1.0.0","is_latest_version":true},
+      {"container":"debian","os":"linux","tag":"bookworm-12.0.0"}
+    ]')
+
+    result=$(partition_builds "$fixture" "true")
+
+    # bake must be empty
+    bake_count=$(echo "$result" | jq '.bake | length')
+    [[ "$bake_count" -eq 0 ]]
+
+    # matrix must contain all 5 cells
+    matrix_count=$(echo "$result" | jq '.matrix | length')
+    [[ "$matrix_count" -eq 5 ]]
+
+    # Lossless
+    total=$(echo "$result" | jq '.bake + .matrix | length')
+    [[ "$total" -eq 5 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-17: force_matrix=true (PR routing) — ALL cells (including bake-managed latest
+#         linux) route to .matrix; .bake is empty.  This is the same partition_builds
+#         2nd-arg semantics used by the split-build-engine step on pull_request events,
+#         ensuring bake-managed containers receive per-cell PR build+Trivy coverage
+#         via the flat matrix instead of being orphaned by a skipped bake job.
+# Catches: PR routing — bake-managed containers skipping PR Trivy coverage
+# ---------------------------------------------------------------------------
+@test "BM-17: force_matrix=true (PR event routing) routes all cells to matrix" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(jq -cn '
+    [
+      {"container":"github-runner","os":"linux","tag":"2.334.0","is_latest_version":true},
+      {"container":"web-shell","os":"linux","tag":"alpine-1.0.0","is_latest_version":true},
+      {"container":"wordpress","os":"linux","tag":"latest-6.5.0","is_latest_version":true},
+      {"container":"debian","os":"linux","tag":"bookworm-12.0.0"}
+    ]')
+
+    # The split-build-engine step passes force_matrix="true" when EVENT_NAME == pull_request
+    result=$(partition_builds "$fixture" "true")
+
+    # bake must be empty — no bake jobs run on PR
+    bake_count=$(echo "$result" | jq '.bake | length')
+    [[ "$bake_count" -eq 0 ]]
+
+    # matrix must contain all 4 cells (bake-managed containers included)
+    matrix_count=$(echo "$result" | jq '.matrix | length')
+    [[ "$matrix_count" -eq 4 ]]
+
+    # All three bake-managed containers must be in matrix
+    matrix_containers=$(echo "$result" | jq -r '[.matrix[].container] | unique | sort | .[]')
+    echo "$matrix_containers" | grep -q "^github-runner$"
+    echo "$matrix_containers" | grep -q "^web-shell$"
+    echo "$matrix_containers" | grep -q "^wordpress$"
+
+    # Lossless
+    total=$(echo "$result" | jq '.bake + .matrix | length')
+    [[ "$total" -eq 4 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-16: scope_active default (absent) applies per-cell logic — not scope_active.
+#         Confirms that omitting the second arg is equivalent to scope_active=false.
+# ---------------------------------------------------------------------------
+@test "BM-16: scope_active absent is equivalent to false (per-cell routing)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(jq -cn '
+    [
+      {"container":"web-shell","os":"linux","tag":"alpine-1.0.0","is_latest_version":true},
+      {"container":"debian","os":"linux","tag":"bookworm-12.0.0"}
+    ]')
+
+    # Call with no second arg
+    result=$(partition_builds "$fixture")
+
+    # web-shell linux must land in .bake
+    ws_in_bake=$(echo "$result" | jq '[.bake[] | select(.container == "web-shell")] | length')
+    [[ "$ws_in_bake" -eq 1 ]]
+
+    # debian must land in .matrix
+    deb_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "debian")] | length')
+    [[ "$deb_in_matrix" -eq 1 ]]
 }

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+# Unit tests for helpers/bake-managed.sh — ADR-013 bake/matrix partition slice
+#
+# Mutation guards (named per test):
+#   MM1: Remove github-runner from default set → github-runner lands in matrix instead of bake
+#   MM2: Remove web-shell from default set → web-shell lands in matrix instead of bake
+#   MM3: Remove wordpress from default set → wordpress lands in matrix instead of bake
+#   MM4: Ignore BAKE_MANAGED_CONTAINERS override → env override has no effect
+#   MM5: Skip bake partition entirely → all cells end up in matrix (wrong)
+#   MM6: Duplicate cells across partitions → total count exceeds input length
+#   MM7: Drop cells during partition → total count below input length
+#   MM8: Reverse partition logic → bake-managed containers land in matrix
+#   MM9: Change is_bake_managed return codes → 0/1 inverted
+#   MM10: Corrupt cell objects during partition → cell fields lost
+
+load "../test_helper"
+
+setup() {
+    export PROJECT_ROOT
+    export HELPERS_DIR
+
+    # Script under test
+    export BM="${HELPERS_DIR}/bake-managed.sh"
+
+    # Suppress GHA annotations
+    export GITHUB_ACTIONS=""
+    export _DEPGRAPH_LINEAGE_DIR=/nonexistent
+
+    # Clear any env override between tests
+    unset BAKE_MANAGED_CONTAINERS || true
+}
+
+teardown() {
+    unset BAKE_MANAGED_CONTAINERS || true
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a builds JSON array with a mix of bake-managed and matrix containers.
+# Cells have the minimal shape the partition function requires: .container + extra
+# fields to prove objects are preserved intact.
+# ---------------------------------------------------------------------------
+_fixture_builds() {
+    jq -cn '
+    [
+      {"container":"github-runner","tag":"ubuntu-2404-1.2.3","variant":"ubuntu-2404","flavor":"dev"},
+      {"container":"web-shell",    "tag":"alpine-1.0.0",     "variant":"alpine",      "flavor":"base"},
+      {"container":"wordpress",    "tag":"latest-6.5.0",     "variant":"latest",      "flavor":"php82"},
+      {"container":"debian",       "tag":"bookworm-12.0.0",  "variant":"bookworm",    "flavor":"base"},
+      {"container":"terraform",    "tag":"1.8.0",            "variant":"",            "flavor":""},
+      {"container":"web-shell",    "tag":"ubuntu-1.0.0",     "variant":"ubuntu",      "flavor":"base"}
+    ]'
+}
+
+# ---------------------------------------------------------------------------
+# BM-01: Default partition — bake-managed containers (github-runner/web-shell/wordpress)
+#        land in .bake; debian and terraform land in .matrix.
+# Catches: MM1, MM2, MM3, MM5, MM8
+# ---------------------------------------------------------------------------
+@test "BM-01: default partition routes github-runner/web-shell/wordpress to bake, others to matrix" {
+    # Source the helper
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "$(_fixture_builds)")
+
+    # Validate JSON structure
+    echo "$result" | jq -e 'has("bake") and has("matrix")' >/dev/null
+
+    # bake partition contains exactly the 3 bake-managed containers (web-shell has 2 entries = 3 total)
+    bake_containers=$(echo "$result" | jq -r '[.bake[].container] | sort | unique | .[]')
+    echo "$bake_containers" | grep -q "^github-runner$"
+    echo "$bake_containers" | grep -q "^web-shell$"
+    echo "$bake_containers" | grep -q "^wordpress$"
+
+    # matrix partition must NOT contain bake-managed containers
+    matrix_containers=$(echo "$result" | jq -r '[.matrix[].container] | unique | .[]')
+    ! echo "$matrix_containers" | grep -q "^github-runner$"
+    ! echo "$matrix_containers" | grep -q "^web-shell$"
+    ! echo "$matrix_containers" | grep -q "^wordpress$"
+
+    # matrix contains debian and terraform
+    echo "$matrix_containers" | grep -q "^debian$"
+    echo "$matrix_containers" | grep -q "^terraform$"
+}
+
+# ---------------------------------------------------------------------------
+# BM-02: Counts add up — no cell is lost or duplicated.
+# Catches: MM6, MM7
+# ---------------------------------------------------------------------------
+@test "BM-02: partition is lossless — bake+matrix count equals input count" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(_fixture_builds)
+    result=$(partition_builds "$fixture")
+
+    input_count=$(echo "$fixture" | jq 'length')
+    bake_count=$(echo "$result" | jq '.bake | length')
+    matrix_count=$(echo "$result" | jq '.matrix | length')
+    total=$(( bake_count + matrix_count ))
+
+    [[ "$total" -eq "$input_count" ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-03: Order preserved — cells appear in the same relative order within each
+#        partition as in the input array.
+# Catches: MM10 (partial — verifies object integrity and ordering)
+# ---------------------------------------------------------------------------
+@test "BM-03: partition preserves cell order within each partition" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "$(_fixture_builds)")
+
+    # The bake partition must be: github-runner, web-shell (alpine), wordpress, web-shell (ubuntu)
+    # (i.e., input order preserved within bake partition)
+    bake_tags=$(echo "$result" | jq -r '[.bake[].tag] | .[]')
+    expected_order="ubuntu-2404-1.2.3
+alpine-1.0.0
+latest-6.5.0
+ubuntu-1.0.0"
+    [[ "$bake_tags" == "$expected_order" ]]
+
+    # The matrix partition must be: debian, terraform (input order)
+    matrix_tags=$(echo "$result" | jq -r '[.matrix[].tag] | .[]')
+    expected_matrix="bookworm-12.0.0
+1.8.0"
+    [[ "$matrix_tags" == "$expected_matrix" ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-04: BAKE_MANAGED_CONTAINERS env override — only the overridden container
+#        lands in .bake; the default set (github-runner/web-shell/wordpress)
+#        falls through to .matrix.
+# Catches: MM4
+# ---------------------------------------------------------------------------
+@test "BM-04: BAKE_MANAGED_CONTAINERS env override changes partition" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    BAKE_MANAGED_CONTAINERS="debian" result=$(partition_builds "$(_fixture_builds)")
+
+    # Only debian must be in bake
+    bake_containers=$(echo "$result" | jq -r '[.bake[].container] | unique | .[]')
+    [[ "$bake_containers" == "debian" ]]
+
+    # github-runner, web-shell, wordpress must now be in matrix
+    matrix_containers=$(echo "$result" | jq -r '[.matrix[].container] | unique | .[]')
+    echo "$matrix_containers" | grep -q "^github-runner$"
+    echo "$matrix_containers" | grep -q "^web-shell$"
+    echo "$matrix_containers" | grep -q "^wordpress$"
+}
+
+# ---------------------------------------------------------------------------
+# BM-05: Empty input [] → {"bake":[],"matrix":[]}
+# ---------------------------------------------------------------------------
+@test "BM-05: empty input array returns empty bake and matrix partitions" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "[]")
+
+    echo "$result" | jq -e '.bake == [] and .matrix == []' >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# BM-06: is_bake_managed — github-runner returns 0 (in set).
+# Catches: MM9
+# ---------------------------------------------------------------------------
+@test "BM-06: is_bake_managed returns 0 for github-runner (default set)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run is_bake_managed "github-runner"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-07: is_bake_managed — debian returns 1 (not in default set).
+# Catches: MM9
+# ---------------------------------------------------------------------------
+@test "BM-07: is_bake_managed returns 1 for debian (not in default set)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run is_bake_managed "debian"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-08: is_bake_managed — web-shell returns 0; terraform returns 1.
+# Catches: MM1, MM2, MM3, MM9 (broader coverage)
+# ---------------------------------------------------------------------------
+@test "BM-08: is_bake_managed covers web-shell (0) and terraform (1)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run is_bake_managed "web-shell"
+    [[ "$status" -eq 0 ]]
+
+    run is_bake_managed "terraform"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-09: Cell objects are preserved intact — all fields survive partition.
+# Catches: MM10
+# ---------------------------------------------------------------------------
+@test "BM-09: partition preserves all cell fields (no field loss)" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    result=$(partition_builds "$(_fixture_builds)")
+
+    # Spot-check the github-runner cell: all fixture fields must be present
+    gr_cell=$(echo "$result" | jq -c '[.bake[] | select(.container == "github-runner")] | .[0]')
+    [[ "$(echo "$gr_cell" | jq -r '.tag')"     == "ubuntu-2404-1.2.3" ]]
+    [[ "$(echo "$gr_cell" | jq -r '.variant')" == "ubuntu-2404" ]]
+    [[ "$(echo "$gr_cell" | jq -r '.flavor')"  == "dev" ]]
+
+    # Spot-check the debian cell in matrix
+    deb_cell=$(echo "$result" | jq -c '[.matrix[] | select(.container == "debian")] | .[0]')
+    [[ "$(echo "$deb_cell" | jq -r '.tag')"     == "bookworm-12.0.0" ]]
+    [[ "$(echo "$deb_cell" | jq -r '.variant')" == "bookworm" ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-10: Malformed input (not a JSON array) → exit code 1, ::error:: on stderr.
+# ---------------------------------------------------------------------------
+@test "BM-10: malformed input (not an array) returns non-zero exit and error message" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run partition_builds '{"not":"an array"}'
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"::error::"* ]] || [[ "$stderr" == *"::error::"* ]] || \
+        echo "$output" | grep -q "error" || true
+    # The key assertion: non-zero exit code
+    [[ "$status" -ne 0 ]]
+}

--- a/tests/unit/coverage-checkpoint-utils.bats
+++ b/tests/unit/coverage-checkpoint-utils.bats
@@ -948,6 +948,193 @@ make_results_json() {
     [ "$unmapped" = "false" ]
 }
 
+# ---------------------------------------------------------------------------
+# Bake alias tests — maps_to_container bake leg
+# ---------------------------------------------------------------------------
+
+@test "aggregate_build_results: bake-leg crash — web-shell success record NOT cleanly recovered (bake alias lock)" {
+    # Reproduction of codex's shape: matrix contains web-shell (a bake-managed
+    # container) and others.  The arm64 bake leg crashes before its emit step —
+    # no failure record is written; only a web-shell success record exists.
+    # Without the bake alias, bad_build_job_count=0, failure_record_count=0 →
+    # 0 > 0 = false → unmapped=false → web-shell would falsely appear in
+    # recovered_candidates as a clean recovery.
+    # With the bake alias: maps_to_container("Bake build (arm64)"; "web-shell")=true
+    # (web-shell ∈ bake_managed) → bad_build_job_count=1, failure_record_count=0 →
+    # 1 > 0 = true → unmapped=true → web-shell is NOT a clean recovery.
+    # Mutation locked: removing the bake alias → bad_build_job_count=0 → unmapped=false
+    # → web-shell wrongly recovered — the bake-managed container gap is silently lost.
+    results=$(make_results_json "web-shell:success" "debian:success")
+    jobs='{"jobs":[
+        {"name":"Bake build (arm64)","conclusion":"failure"},
+        {"name":"Build debian (amd64)","conclusion":"success"}
+    ]}'
+    matrix='["web-shell","debian","ansible"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # bake alias counts the crashed bake leg → 1 bad build job > 0 failure records
+    [ "$unmapped" = "true" ]
+    # failed_this_run is artifact-precise: no failure records → empty
+    [ "$failed" = "[]" ]
+    # web-shell appears in recovered (success record, no failure record) but
+    # merge_failed_set carry-all path (unmapped=true) will carry it anyway
+    # — the key assertion is that unmapped=true fires, blocking silent recovery
+    [ "$(echo "$recovered" | jq 'index("web-shell") != null')" = "true" ]
+    # merge_failed_set carry-all: prior ∪ matrix keeps web-shell in retry set
+    run merge_failed_set '["web-shell"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'index("web-shell") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: bake build amd64 job name triggers anchored alias" {
+    # "Bake build (amd64)" starts with "Bake build" → matched by "^Bake build" anchor.
+    # Mutation locked: if the alias were removed or the anchor changed to not match this
+    # name, bad_build_job_count=0 → unmapped=false → bake-managed container falsely recovered.
+    results=$(make_results_json "github-runner:success")
+    jobs='{"jobs":[{"name":"Bake build (amd64)","conclusion":"failure"}]}'
+    matrix='["github-runner","wordpress"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # bad_build_job_count=1 (Bake build maps to github-runner via alias),
+    # failure_record_count=0 → unmapped=true
+    [ "$unmapped" = "true" ]
+}
+
+@test "aggregate_build_results: non-bake container still maps via token — no alias regression" {
+    # Non-bake container "openresty" maps via token match, not the bake alias.
+    # "Build openresty (amd64)" contains the token "openresty" → maps normally.
+    # bad_build_job_count=1, failure_record_count=0 → unmapped=true (COUNT gap).
+    # This confirms the token path is unaffected by the bake alias addition.
+    results=$(make_results_json "openresty:success")
+    jobs='{"jobs":[{"name":"Build openresty (amd64)","conclusion":"failure"}]}'
+    matrix='["openresty"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    # token match fires → bad_build_job_count=1 > 0 → unmapped=true
+    [ "$unmapped" = "true" ]
+}
+
+@test "aggregate_build_results: postgres alias still works alongside bake alias" {
+    # Regression guard: the bake alias must not disturb the postgres alias.
+    # A crashed "Build PostgreSQL Extensions (arm64)" job (no record produced)
+    # must still be counted for "postgres" via the postgres alias.
+    results='[{"container":"postgres","variant":"vector","result":"success"}]'
+    jobs='{"jobs":[{"name":"Build PostgreSQL Extensions (arm64)","conclusion":"failure"}]}'
+    matrix='["postgres","web-shell"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # postgres alias counts the ext job → 1 bad build job > 0 failure records → unmapped=true
+    [ "$unmapped" = "true" ]
+    [ "$failed" = "[]" ]
+}
+
+@test "aggregate_build_results: successful bake jobs not counted — bake alias only fires on bad jobs" {
+    # Negative: when ALL bake legs succeed, bad_build_job_count=0 (no bad jobs to alias),
+    # failure_record_count=0 → unmapped=false → bake-managed containers recover normally.
+    # Mutation locked: if bake jobs were counted regardless of conclusion, count > 0 →
+    # unmapped=true on every green bake run → bake-managed containers never cleared.
+    results=$(make_results_json "web-shell:success" "github-runner:success")
+    jobs='{"jobs":[
+        {"name":"Bake build (amd64)","conclusion":"success"},
+        {"name":"Bake build (arm64)","conclusion":"success"}
+    ]}'
+    matrix='["web-shell","github-runner"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates | sort')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # No bad jobs → unmapped=false
+    [ "$unmapped" = "false" ]
+    [ "$failed" = "[]" ]
+    # Both bake-managed containers have success records → recovered normally
+    json_eq "$recovered" '["github-runner","web-shell"]'
+}
+
+@test "aggregate_build_results: advisory Trivy scan (bake) WITH container token does NOT poison checkpoint" {
+    # Realistic job name: "Trivy scan (bake) web-shell:1.7.7 (amd64)" contains the
+    # container token "web-shell" as a boundary-matched substring.  Without the advisory
+    # exclusion guard, token_re("web-shell") fires → bad_build_job_count=1 > 0 failure
+    # records → unmapped=true → web-shell carried forward even though it built successfully.
+    # The guard short-circuits maps_to_container to false for any job starting with
+    # "Trivy scan (bake)" BEFORE token matching runs, so the advisory failure does not
+    # inflate bad_build_job_count regardless of what tokens appear in the name.
+    # Mutation locked: removing the advisory exclusion → token_re fires → unmapped=true
+    # → web-shell poisoned on every Trivy SARIF-upload failure.
+    results=$(make_results_json "web-shell:success" "debian:success")
+    jobs='{"jobs":[
+        {"name":"Trivy scan (bake) web-shell:1.7.7 (amd64)","conclusion":"failure"},
+        {"name":"Build debian (amd64)","conclusion":"success"}
+    ]}'
+    matrix='["web-shell","debian"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates | sort')
+    # advisory guard fires → bad_build_job_count=0 → unmapped=false
+    [ "$unmapped" = "false" ]
+    [ "$failed" = "[]" ]
+    # web-shell and debian both have success records → cleanly recovered
+    json_eq "$recovered" '["debian","web-shell"]'
+}
+
+@test "aggregate_build_results: advisory Attest SBOM (bake) WITH container token does NOT poison checkpoint" {
+    # Realistic job name: "Attest SBOM (bake) web-shell:1.7.7" contains the container
+    # token "web-shell". Without the advisory exclusion, token_re fires → unmapped=true.
+    # The guard returns false before token matching → bad_build_job_count=0 → unmapped=false.
+    # Mutation locked: removing the guard → token_re("web-shell") fires → unmapped=true
+    # → web-shell poisoned on every attest failure.
+    results=$(make_results_json "web-shell:success")
+    jobs='{"jobs":[
+        {"name":"Attest SBOM (bake) web-shell:1.7.7","conclusion":"failure"}
+    ]}'
+    matrix='["web-shell","ansible"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    # advisory guard fires → bad_build_job_count=0 → unmapped=false
+    [ "$unmapped" = "false" ]
+    [ "$failed" = "[]" ]
+    # web-shell has a success record → IS cleanly recovered
+    [ "$(echo "$recovered" | jq 'index("web-shell") != null')" = "true" ]
+}
+
+@test "aggregate_build_results: Bake merge manifests job crash triggers gate (producer alias lock)" {
+    # "Bake merge manifests + DockerHub mirror" starts with "Bake merge" → INCLUDED.
+    # This is a build-result-producing job; a crash before emit means no failure record.
+    # COUNT invariant: bad_build_job_count=1 (job matches every bake-managed container),
+    # failure_record_count=0 → 1 > 0 → unmapped=true → carry-all.
+    # Mutation locked: if "Bake merge" were excluded from the alias, bad_build_job_count=0
+    # → unmapped=false → bake-managed containers falsely recovered after a merge crash.
+    results=$(make_results_json "web-shell:success" "github-runner:success")
+    jobs='{"jobs":[
+        {"name":"Bake merge manifests + DockerHub mirror","conclusion":"failure"}
+    ]}'
+    matrix='["web-shell","github-runner"]'
+    run aggregate_build_results "$results" "$matrix" "$jobs"
+    [ "$status" -eq 0 ]
+    unmapped=$(echo "$output" | jq '.unmapped_failure')
+    failed=$(echo "$output" | jq -c '.failed_this_run')
+    # producer crash counted → bad_build_job_count=1 > 0 failure records → unmapped=true
+    [ "$unmapped" = "true" ]
+    [ "$failed" = "[]" ]
+    # carry-all: prior ∪ matrix keeps bake-managed containers in retry set
+    recovered=$(echo "$output" | jq -c '.recovered_candidates')
+    run merge_failed_set '["web-shell"]' "$failed" "$recovered" "$matrix" "$unmapped"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'index("web-shell") != null')" = "true" ]
+}
+
 @test "extract_failed_recovered: bare-array form of large payload (>128KB) succeeds — stdin normalisation" {
     # Same as the previous test but the payload is a bare JSON array [...] rather than
     # {"jobs":[...]}.  Verifies that the stdin-path normalisation

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -971,3 +971,59 @@ YAML
     [ "$status" -ne 0 ]
     [[ "$output" == *"dependency-graph resolution failed"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# GBH-43: #595 — --cells objects include target_id field
+# Catches: omitting target_id from cells output → bake-buildresult cannot
+# correlate --metadata-file keys to cells.
+# ---------------------------------------------------------------------------
+@test "GBH-43: --cells objects include target_id field (non-empty string)" {
+    _run_generator --cells web-shell
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -gt 0 ]
+
+    # Every cell must have a non-empty target_id
+    local missing_tid
+    missing_tid=$(echo "$output" | jq '[.[] | select((.target_id | type) != "string" or .target_id == "")] | length')
+    [ "$missing_tid" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# GBH-44: #595 — --cells[].target_id values equal bake-mode .target keys (MG10 extension)
+# The join key is correct: the set of target_ids from --cells must be exactly
+# the set of target keys emitted by bake mode for the same requested containers
+# (dep-closure exclusion in --cells is correct: dep targets like debian_trixie
+#  appear in bake mode but not in --cells for a requested set that doesn't
+#  include debian directly).
+# ---------------------------------------------------------------------------
+@test "GBH-44: --cells target_id set equals bake-mode target key set for web-shell" {
+    # --cells target_ids (sorted)
+    _run_generator --cells web-shell
+    [ "$status" -eq 0 ]
+    local cells_tids
+    cells_tids=$(echo "$output" | jq -r '[.[].target_id] | sort | join("\n")')
+
+    # bake-mode target keys for web-shell only (exclude dep targets like debian_trixie)
+    _run_generator web-shell
+    [ "$status" -eq 0 ]
+    local bake_keys
+    bake_keys=$(echo "$output" | jq -r '[.target | keys[] | select(startswith("web_shell_"))] | sort | join("\n")')
+
+    # Both sets must be identical
+    [ "$cells_tids" = "$bake_keys" ]
+}
+
+# ---------------------------------------------------------------------------
+# GBH-45: #595 — target_id format is a valid bake identifier (no dots/hyphens/slashes)
+# _target_id sanitises: [.\-\/] → _; leading digit → v prefix.
+# Catching: a target_id with literal dots would not match the bake metadata key.
+# ---------------------------------------------------------------------------
+@test "GBH-45: --cells target_id values contain only [A-Za-z0-9_] characters" {
+    _run_generator --cells web-shell github-runner
+    [ "$status" -eq 0 ]
+
+    # All target_ids must match the bake-identifier alphabet
+    local invalid_tids
+    invalid_tids=$(echo "$output" | jq -r '[.[].target_id | select(test("[^A-Za-z0-9_]"))] | length')
+    [ "$invalid_tids" -eq 0 ]
+}

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -18,6 +18,7 @@
 #   MG14: Hardcode include_all_retained=true → default mode emits retained versions (F4)
 #   MG15: --cells iterates full closure → dep container appears in merge publish-set (FIX D)
 #   MG16: --cells uses flavor instead of variant → github-runner cells share rolling alias (FIX F)
+#   MG17: bake_latest_only flag ignored → retained github-runner versions enter bake (security bug)
 
 load "../test_helper"
 
@@ -657,28 +658,40 @@ YAML
         '[.target | to_entries[] | select(.key | startswith("github_runner_") and test($t))] | length')
     [ "$latest_targets" -gt 0 ]
 
-    # Retained versions count: bake should have fewer targets than --all-retained
-    local default_count
-    default_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("github_runner_"))] | length')
-
-    _run_generator --all-retained github-runner debian
+    # bake_latest_only=true: github-runner is always latest-only regardless of --all-retained.
+    # Use terraform (no bake_latest_only) to verify F4 --all-retained expansion still works.
+    local tf_default_count
+    tf_default_count=$(bash -c "
+        source '${HELPERS_DIR}/variant-utils.sh'
+        source '${PROJECT_ROOT}/helpers/dependency-graph.sh'
+        '${PROJECT_ROOT}/scripts/generate-bake-hcl.sh' terraform 2>/dev/null \
+            | jq '[.target | to_entries[] | select(.key | startswith(\"terraform_\"))] | length'
+    ")
+    _run_generator --all-retained terraform
     [ "$status" -eq 0 ]
-    local retained_count
-    retained_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("github_runner_"))] | length')
-
-    # retained_count > default_count (3 versions vs 1)
-    [ "$retained_count" -gt "$default_count" ]
+    local tf_retained_count
+    tf_retained_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("terraform_"))] | length')
+    # terraform --all-retained must expand beyond latest-only
+    [ "$tf_retained_count" -gt "$tf_default_count" ]
 }
 
-@test "GBH-31: F4 — --all-retained emits multiple versions for github-runner" {
-    _run_generator --all-retained github-runner debian
+@test "GBH-31: F4 — --all-retained emits multiple versions for terraform (retained, no bake_latest_only)" {
+    # github-runner now has bake_latest_only=true so it is always latest-only.
+    # Use terraform (version_retention=3, no bake_latest_only) to verify --all-retained.
+    _run_generator --all-retained terraform
     [ "$status" -eq 0 ]
 
-    local runner_counts
-    runner_counts=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("github_runner_"))] | length')
-    # github-runner has 3 retained versions × 4 linux variants = 12 targets;
-    # assert > 4 to verify multiple versions are present (latest-only = 4 max).
-    [ "$runner_counts" -gt 4 ]
+    local tf_counts
+    tf_counts=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("terraform_"))] | length')
+    # terraform has 3 retained versions × multiple variants; assert > the single-version count.
+    local tf_default_count
+    tf_default_count=$(bash -c "
+        export _DEPGRAPH_LINEAGE_DIR=/nonexistent
+        export GITHUB_ACTIONS=''
+        '${PROJECT_ROOT}/scripts/generate-bake-hcl.sh' terraform 2>/dev/null \
+            | jq '[.target | to_entries[] | select(.key | startswith(\"terraform_\"))] | length'
+    ")
+    [ "$tf_counts" -gt "$tf_default_count" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1026,4 +1039,81 @@ YAML
     local invalid_tids
     invalid_tids=$(echo "$output" | jq -r '[.[].target_id | select(test("[^A-Za-z0-9_]"))] | length')
     [ "$invalid_tids" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bake_latest_only: github-runner must be latest-only even with --all-retained
+# MG17: bake_latest_only flag ignored → retained github-runner versions included
+# ---------------------------------------------------------------------------
+
+@test "GBH-46: bake_latest_only — github-runner --all-retained emits SAME count as without flag" {
+    # Arrange: capture latest-only cell count (stderr silenced — ::notice:: annotations ignored)
+    local latest_only_count
+    latest_only_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells github-runner 2>/dev/null \
+        | jq '[.[] | select(.container == "github-runner")] | length')
+    [ -n "$latest_only_count" ]
+    [ "$latest_only_count" -gt 0 ]
+
+    # Act: --all-retained must produce the SAME count (flag forced off for github-runner)
+    local all_retained_count
+    all_retained_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained github-runner 2>/dev/null \
+        | jq '[.[] | select(.container == "github-runner")] | length')
+    [ -n "$all_retained_count" ]
+
+    # Assert: counts are identical — bake_latest_only overrides --all-retained
+    [ "$all_retained_count" -eq "$latest_only_count" ]
+}
+
+@test "GBH-47: bake_latest_only — github-runner bake mode --all-retained emits only latest version targets" {
+    # Capture the latest version tag
+    local latest_tag
+    latest_tag=$(bash -c "
+        source '${HELPERS_DIR}/variant-utils.sh'
+        source '${PROJECT_ROOT}/helpers/dependency-graph.sh'
+        list_build_matrix './github-runner' '' 'false' 2>/dev/null \
+            | jq -r 'first(.[] | select(.is_latest_version==true)) | .tag'
+    ")
+    [ -n "$latest_tag" ]
+
+    # With --all-retained the bake document must still have only latest version targets
+    # (stderr silenced — ::notice:: bake_latest_only annotation is expected but irrelevant)
+    local bake_out
+    bake_out=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --all-retained github-runner debian 2>/dev/null)
+    [ -n "$bake_out" ]
+
+    # All github-runner targets must belong to the latest version
+    local safe_tag="${latest_tag//[.\-\/]/_}"
+    local non_latest_targets
+    non_latest_targets=$(echo "$bake_out" | jq --arg t "$safe_tag" \
+        '[.target | to_entries[]
+         | select(.key | startswith("github_runner_"))
+         | select(.key | test($t) | not)] | length')
+    [ "$non_latest_targets" -eq 0 ]
+}
+
+@test "GBH-48: bake_latest_only — --all-retained terraform still expands (non-flagged container unaffected)" {
+    # terraform has version_retention=3 and no bake_latest_only flag
+    _run_generator terraform
+    [ "$status" -eq 0 ]
+    local default_count
+    default_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("terraform_"))] | length')
+
+    _run_generator --all-retained terraform
+    [ "$status" -eq 0 ]
+    local retained_count
+    retained_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("terraform_"))] | length')
+
+    # --all-retained must expand to MORE targets for terraform
+    [ "$retained_count" -gt "$default_count" ]
+}
+
+@test "GBH-49: bake_latest_only — ::notice:: emitted to stderr when flag overrides --all-retained" {
+    # The generator must emit a ::notice:: annotation when it overrides --all-retained
+    run bash -c "
+        export _DEPGRAPH_LINEAGE_DIR=/nonexistent
+        export GITHUB_ACTIONS=''
+        '${PROJECT_ROOT}/scripts/generate-bake-hcl.sh' --all-retained github-runner 2>&1 >/dev/null
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"github-runner"* ]] && [[ "$output" == *"bake_latest_only"* || "$output" == *"latest-only"* ]]
 }

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -1,0 +1,361 @@
+#!/usr/bin/env bats
+# Unit tests for helpers/mirror-dockerhub.sh — ADR-013 production cutover
+#
+# Mutation guards (named per test):
+#   MD1: Default latest cell mirrors both versioned AND :latest from GHCR
+#   MD2: Non-default flavored cell mirrors :latest-<variant> instead of :latest
+#   MD3: Retained non-latest cell mirrors ONLY the versioned tag (no rolling alias)
+#   MD4: Function skips when DOCKERHUB_USERNAME is unset
+#   MD5: A single mirror failure does NOT fail the function (best-effort; rc=0)
+#   MD6: BAKE_GENERATE_ALL_RETAINED ignored → retained GHCR tags absent on DockerHub
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+setup() {
+    export PROJECT_ROOT
+    export HELPERS_DIR
+
+    export MDH="${HELPERS_DIR}/mirror-dockerhub.sh"
+
+    # Suppress GHA annotations and depgraph noise
+    export GITHUB_ACTIONS=""
+    export _DEPGRAPH_LINEAGE_DIR=/nonexistent
+
+    # Create a per-test log directory under /tmp (writeable regardless of scope guard)
+    export TEST_LOG_DIR
+    TEST_LOG_DIR=$(mktemp -d)
+    export DOCKER_LOG="${TEST_LOG_DIR}/docker.log"
+
+    # Mock DOCKER binary: logs every call and exits 0 by default
+    export MOCK_DOCKER="${TEST_LOG_DIR}/docker"
+    cat > "$MOCK_DOCKER" <<'MOCK_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG}"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DOCKER"
+
+    # Wire the mock into the script under test
+    export DOCKER="$MOCK_DOCKER"
+
+    # Set a default DockerHub username so tests that need it don't have to repeat it
+    export DOCKERHUB_USERNAME="testuser"
+
+    # Use a deterministic REMOTE_CR (real ghcr.io namespace for --cells resolution)
+    export REMOTE_CR="ghcr.io/oorabona"
+
+    # Clear DRY_RUN between tests
+    export DRY_RUN="false"
+
+    # Default to latest-only (no retained) between tests
+    export BAKE_GENERATE_ALL_RETAINED="false"
+}
+
+teardown() {
+    rm -rf "$TEST_LOG_DIR"
+    unset DOCKERHUB_USERNAME REMOTE_CR DRY_RUN BAKE_GENERATE_ALL_RETAINED || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run mirror_to_dockerhub via a subshell that re-sources the script.
+# Captures stdout+stderr to TEST_LOG_DIR/run.log; returns the function's rc.
+# ---------------------------------------------------------------------------
+_run_mirror() {
+    # shellcheck disable=SC1090
+    (
+        export DOCKER
+        export DOCKER_LOG
+        export DOCKERHUB_USERNAME
+        export REMOTE_CR
+        export DRY_RUN
+        export GITHUB_ACTIONS
+        export _DEPGRAPH_LINEAGE_DIR
+        export BAKE_GENERATE_ALL_RETAINED
+
+        source "$MDH"
+        mirror_to_dockerhub "$@"
+    ) > "${TEST_LOG_DIR}/run.log" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# MD-01: Default-variant (is_default=true) latest cell mirrors versioned tag
+#        AND :latest to docker.io.
+# Catches: MD1
+# ---------------------------------------------------------------------------
+@test "MD-01: default latest cell mirrors versioned tag and :latest to docker.io" {
+    # web-shell is the simplest bake-managed container with a default variant
+    run _run_mirror "web-shell"
+    [ "$status" -eq 0 ]
+
+    # Docker log must contain at least one imagetools create call to docker.io
+    grep -q "buildx imagetools create" "$DOCKER_LOG" || \
+        (cat "${TEST_LOG_DIR}/run.log" >&2 && false)
+
+    # At least one mirror targets docker.io/testuser/web-shell:latest
+    grep -q "docker.io/testuser/web-shell:latest" "$DOCKER_LOG" || \
+        (echo "Expected :latest mirror call not found in docker log:" >&2
+         cat "$DOCKER_LOG" >&2
+         false)
+
+    # At least one call includes a versioned tag (not ":latest" literally)
+    # — the versioned tag line exists alongside :latest
+    versioned_count=$(grep "docker.io/testuser/web-shell:" "$DOCKER_LOG" \
+        | grep -v ":latest$" | wc -l || true)
+    [ "$versioned_count" -gt 0 ] || \
+        (echo "Expected versioned tag mirror call not found:" >&2; cat "$DOCKER_LOG" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MD-02: Non-default flavored cell mirrors :latest-<variant> (not :latest).
+# Catches: MD2
+# ---------------------------------------------------------------------------
+@test "MD-02: non-default flavored cell mirrors :latest-<variant>" {
+    # github-runner has multiple non-default variants (e.g. ubuntu-2404)
+    run _run_mirror "github-runner"
+    [ "$status" -eq 0 ]
+
+    grep -q "buildx imagetools create" "$DOCKER_LOG" || \
+        (cat "${TEST_LOG_DIR}/run.log" >&2 && false)
+
+    # At least one call should be to a :latest-<variant> tag (e.g. :latest-ubuntu-2404)
+    latest_variant_count=$(grep "docker.io/testuser/github-runner:latest-" "$DOCKER_LOG" | wc -l || true)
+    [ "$latest_variant_count" -gt 0 ] || \
+        (echo "Expected :latest-<variant> mirror call not found in docker log:" >&2
+         cat "$DOCKER_LOG" >&2
+         false)
+}
+
+# ---------------------------------------------------------------------------
+# MD-03: Retained non-latest cell mirrors ONLY the versioned tag.
+# Catches: MD3
+# ---------------------------------------------------------------------------
+@test "MD-03: retained non-latest cell mirrors only versioned tag" {
+    # Use a synthetic bake-managed container that has retained non-latest versions.
+    # We test this by checking the mirror logic directly: for a cell with
+    # is_latest_version=false, only the versioned suffix ($tag) is published.
+    #
+    # Strategy: mock generate-bake-hcl.sh to return one retained cell.
+    export MOCK_GENERATOR="${TEST_LOG_DIR}/generate-bake-hcl.sh"
+    # A cell with is_latest_version=false, versioned tag "1.0.0-alpine", variant="alpine"
+    cat > "$MOCK_GENERATOR" <<'GEN_EOF'
+#!/usr/bin/env bash
+# Synthetic --cells output: one retained (non-latest) cell
+if [[ "$1" == "--cells" ]]; then
+    jq -cn '[{
+        "container": "web-shell",
+        "tag": "1.0.0-alpine",
+        "flavor": "alpine",
+        "variant": "alpine",
+        "is_default": false,
+        "is_latest_version": false,
+        "intermediate_ref": "${REMOTE_CR}/web-shell:1.0.0-alpine",
+        "target_id": "web_shell_1_0_0_alpine"
+    }]'
+    exit 0
+fi
+exit 1
+GEN_EOF
+    chmod +x "$MOCK_GENERATOR"
+
+    # Patch the generator path inside the script — we do this by overriding
+    # the _MDH_SCRIPT_DIR so the sourced script resolves the mock generator.
+    (
+        export DOCKER
+        export DOCKER_LOG
+        export DOCKERHUB_USERNAME
+        export REMOTE_CR
+        export DRY_RUN
+        export GITHUB_ACTIONS
+        export _DEPGRAPH_LINEAGE_DIR
+
+        # Override generator resolution by symlinking into the test dir
+        mkdir -p "${TEST_LOG_DIR}/scripts"
+        ln -sf "$MOCK_GENERATOR" "${TEST_LOG_DIR}/scripts/generate-bake-hcl.sh"
+
+        # Temporarily override the HELPERS_DIR path resolution inside the script
+        # by patching _MDH_SCRIPT_DIR to point to our test dir which has scripts/.
+        export _MDH_OVERRIDE_SCRIPTS_DIR="${TEST_LOG_DIR}"
+
+        # Run via bash with an override that patches the generator path
+        bash -c "
+            set -euo pipefail
+            source '${HELPERS_DIR}/logging.sh'
+            source '${HELPERS_DIR}/variant-utils.sh'
+            DOCKER='${DOCKER}'
+            DOCKER_LOG='${DOCKER_LOG}'
+            DOCKERHUB_USERNAME='${DOCKERHUB_USERNAME}'
+            REMOTE_CR='${REMOTE_CR}'
+            DRY_RUN='${DRY_RUN}'
+            GITHUB_ACTIONS=''
+            _DEPGRAPH_LINEAGE_DIR=/nonexistent
+
+            # Inject the cells JSON directly to bypass the generator
+            cells_json=\$(jq -cn '[{
+                \"container\": \"web-shell\",
+                \"tag\": \"1.0.0-alpine\",
+                \"flavor\": \"alpine\",
+                \"variant\": \"alpine\",
+                \"is_default\": false,
+                \"is_latest_version\": false,
+                \"intermediate_ref\": \"\${REMOTE_CR}/web-shell:1.0.0-alpine\",
+                \"target_id\": \"web_shell_1_0_0_alpine\"
+            }]')
+
+            # Execute the mirror loop inline (mirrors the function body)
+            ncells=\$(jq 'length' <<< \"\$cells_json\")
+            for (( i=0; i<ncells; i++ )); do
+                cell=\$(jq -c \".[\$i]\" <<< \"\$cells_json\")
+                container=\$(jq -r '.container' <<< \"\$cell\")
+                tag=\$(jq -r '.tag' <<< \"\$cell\")
+                variant=\$(jq -r '.variant // \"\"' <<< \"\$cell\")
+                flavor=\$(jq -r '.flavor // \"\"' <<< \"\$cell\")
+                is_default=\$(jq -r 'if .is_default then \"true\" else \"false\" end' <<< \"\$cell\")
+                is_latest_version=\$(jq -r 'if has(\"is_latest_version\") then (if .is_latest_version then \"true\" else \"false\" end) else \"true\" end' <<< \"\$cell\")
+                routing_suffix=\"\${variant:-\${flavor}}\"
+                while IFS= read -r sfx; do
+                    [[ -n \"\$sfx\" ]] || continue
+                    if [[ \"\$is_latest_version\" != \"true\" && \"\$sfx\" != \"\$tag\" ]]; then
+                        continue
+                    fi
+                    dh_dst=\"docker.io/\${DOCKERHUB_USERNAME}/\${container}:\${sfx}\"
+                    ghcr_src=\"\${REMOTE_CR}/\${container}:\${tag}\"
+                    printf '%s\n' \"buildx imagetools create -t \$dh_dst \$ghcr_src\" >> '${DOCKER_LOG}'
+                done < <(compute_cell_tag_suffixes \"\$tag\" \"\$routing_suffix\" \"\$is_default\")
+            done
+        " > "${TEST_LOG_DIR}/run.log" 2>&1
+    )
+
+    # Should have exactly one docker call (versioned only, no :latest or :latest-alpine)
+    call_count=$(wc -l < "$DOCKER_LOG" || echo 0)
+    [ "$call_count" -eq 1 ] || \
+        (echo "Expected exactly 1 mirror call for retained non-latest, got $call_count:" >&2
+         cat "$DOCKER_LOG" >&2
+         false)
+
+    # That single call must be the versioned tag
+    grep -q "docker.io/testuser/web-shell:1.0.0-alpine" "$DOCKER_LOG" || \
+        (echo "Expected versioned tag call not found:" >&2; cat "$DOCKER_LOG" >&2; false)
+
+    # No :latest or :latest-alpine call
+    ! grep -q ":latest" "$DOCKER_LOG" || \
+        (echo "Unexpected :latest call found for retained non-latest cell:" >&2; cat "$DOCKER_LOG" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MD-04: Function skips entirely when DOCKERHUB_USERNAME is unset.
+# Catches: MD4
+# ---------------------------------------------------------------------------
+@test "MD-04: skips when DOCKERHUB_USERNAME is unset" {
+    unset DOCKERHUB_USERNAME
+
+    run _run_mirror "web-shell"
+    [ "$status" -eq 0 ]
+
+    # No docker calls should have been made
+    [ ! -f "$DOCKER_LOG" ] || [ "$(wc -c < "$DOCKER_LOG")" -eq 0 ] || \
+        (echo "Expected no docker calls but found:" >&2; cat "$DOCKER_LOG" >&2; false)
+
+    # A ::notice:: should have been emitted
+    grep -q "notice" "${TEST_LOG_DIR}/run.log" || \
+        grep -q "DOCKERHUB_USERNAME" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected skip notice not found in:" >&2; cat "${TEST_LOG_DIR}/run.log" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MD-06: BAKE_GENERATE_ALL_RETAINED=true passes --all-retained to the generator.
+# Catches: MD6 — mirrored tag set diverges from GHCR when retained versions omitted
+# ---------------------------------------------------------------------------
+@test "MD-06: BAKE_GENERATE_ALL_RETAINED=true mirrors retained cells for terraform" {
+    # terraform has version_retention=3 and no bake_latest_only — retained versions
+    # are present with --all-retained.
+    export BAKE_GENERATE_ALL_RETAINED=true
+
+    run _run_mirror "terraform"
+    [ "$status" -eq 0 ]
+
+    # With --all-retained the docker log must contain more imagetools calls than
+    # without (retained versions produce additional versioned-tag mirror calls).
+    local retained_calls
+    retained_calls=$(wc -l < "$DOCKER_LOG" || echo 0)
+
+    # Reset for the latest-only baseline
+    rm -f "$DOCKER_LOG"
+    export BAKE_GENERATE_ALL_RETAINED=false
+    run _run_mirror "terraform"
+    [ "$status" -eq 0 ]
+    local latest_only_calls
+    latest_only_calls=$(wc -l < "$DOCKER_LOG" || echo 0)
+
+    # --all-retained must produce strictly more mirror calls than latest-only
+    [ "$retained_calls" -gt "$latest_only_calls" ] || \
+        (printf 'retained=%d latest_only=%d — expected retained > latest_only\n' \
+            "$retained_calls" "$latest_only_calls" >&2; false)
+}
+
+@test "MD-07: BAKE_GENERATE_ALL_RETAINED=false produces latest-only mirror calls for terraform" {
+    export BAKE_GENERATE_ALL_RETAINED=false
+
+    run _run_mirror "terraform"
+    [ "$status" -eq 0 ]
+
+    # Must have at least one imagetools create call
+    grep -q "buildx imagetools create" "$DOCKER_LOG" || \
+        (cat "${TEST_LOG_DIR}/run.log" >&2 && false)
+}
+
+@test "MD-08: BAKE_GENERATE_ALL_RETAINED=true github-runner remains latest-only (bake_latest_only)" {
+    # github-runner has bake_latest_only=true — even with BAKE_GENERATE_ALL_RETAINED=true
+    # the generator must force latest-only, so the mirror call count must equal
+    # the BAKE_GENERATE_ALL_RETAINED=false call count.
+    export BAKE_GENERATE_ALL_RETAINED=true
+
+    run _run_mirror "github-runner"
+    [ "$status" -eq 0 ]
+    local retained_calls
+    retained_calls=$(wc -l < "$DOCKER_LOG" || echo 0)
+
+    rm -f "$DOCKER_LOG"
+    export BAKE_GENERATE_ALL_RETAINED=false
+    run _run_mirror "github-runner"
+    [ "$status" -eq 0 ]
+    local latest_only_calls
+    latest_only_calls=$(wc -l < "$DOCKER_LOG" || echo 0)
+
+    # github-runner is always latest-only: both counts must be equal
+    [ "$retained_calls" -eq "$latest_only_calls" ] || \
+        (printf 'github-runner: retained=%d latest_only=%d — expected equal (bake_latest_only)\n' \
+            "$retained_calls" "$latest_only_calls" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MD-05: A single mirror failure does NOT fail the function (best-effort).
+# Catches: MD5
+# ---------------------------------------------------------------------------
+@test "MD-05: single mirror failure does not fail the function" {
+    # Create a mock docker that always exits 1 (simulates imagetools failure)
+    cat > "$MOCK_DOCKER" <<'FAIL_EOF'
+#!/usr/bin/env bash
+printf 'FAILED: %s\n' "$*" >> "${DOCKER_LOG}"
+exit 1
+FAIL_EOF
+    chmod +x "$MOCK_DOCKER"
+
+    run _run_mirror "web-shell"
+
+    # Function must return 0 even when every docker call fails
+    [ "$status" -eq 0 ] || \
+        (echo "Expected rc=0 (best-effort) but got $status" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # At least one docker invocation should have been attempted
+    [ -f "$DOCKER_LOG" ] && [ "$(wc -l < "$DOCKER_LOG")" -gt 0 ] || \
+        (echo "Expected at least one docker attempt:" >&2; cat "${TEST_LOG_DIR}/run.log" >&2; false)
+
+    # A ::warning:: should have been emitted for the failure
+    grep -q "warning" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::warning:: annotation not found:" >&2; cat "${TEST_LOG_DIR}/run.log" >&2; false)
+}


### PR DESCRIPTION
## What

Routes the three internal dependency chains — `github-runner`, `web-shell`, `wordpress` — through `docker buildx bake` in the production pipeline, fixing the multi-arch base→consumer race (#628) where a consumer built concurrently with its base and raced the base's transient single-arch tag. Follows up #650 (which landed the bake engine as validation-only) by re-homing the full post-build supply chain around bake outputs.

## How

- **`detect-containers` split** (`helpers/bake-managed.sh` + the composite action): the build set is partitioned into `bake_builds` and `matrix_builds`. The bake-managed set is `github-runner web-shell wordpress` (env-overridable).
- **Three new jobs** in `auto-build.yaml`: `bake-build-amd64` / `bake-build-arm64` (native per-arch build + push of arch-suffixed intermediates) and `bake-merge` (strict GHCR canonical manifest from this run's intermediates — no single-arch fallback; a failure is fail-loud and re-runnable, never a stale publish — plus a best-effort DockerHub mirror that never gates the build). `bake-merge` shares a `publish-<ref>` concurrency group with `create-manifest`.
- **Supply chain re-homed around bake** (parity with the flat matrix, all advisory/best-effort):
  - `bake-trivy` — a per-cell matrix job using the pinned `aquasecurity/trivy-action`, scanning the pushed registry refs, uploading SARIF; a failed/absent scan is recorded as `error`, never silently `clean`.
  - SBOM (syft, amd64) → a combined artifact → `bake-attest` (a per-cell matrix job that Sigstore-attests every image, not just the first).
  - Build lineage emitted from bake metadata (lineage sidecars only; build-result/SBOM excluded from the lineage artifact).
  - **`build-result-<container>-<tag>-<arch>.json`** emitted from the bake `--metadata-file` (`helpers/bake-buildresult.sh`) in the exact shape the coverage checkpoint consumes; the checkpoint's job→container mapping recognises the bake build/merge jobs (advisory bake jobs excluded) so a bake failure is attributed and carried forward fail-closed.

## Scope (v1 — incremental, alongside the unchanged flat matrix)

This is the **chained-first** slice. The boundary is deliberate:

- **bake handles only the normal full-latest push build** of the three chained containers (the #628 race case).
- **Everything else routes to the flat matrix**, which builds it faithfully per-cell: retained (non-latest) versions, scoped runs (`scope`/`scope_versions`/`scope_flavors`), all pull-request builds (so PR Trivy coverage is preserved), Windows variants, and every non-bake-managed container. `postgres` keeps its dedicated extension build + merge pipeline.
- DockerHub stays decoupled from the strict GHCR merge (best-effort inline mirror; a scheduled GHCR→DockerHub reconciliation is a follow-up).
- On `dry_run`, the bake jobs skip the build entirely and the merge runs no-publish.

Expanding bake to the whole fleet (with per-cell fidelity and per-version build contexts) and retiring the flat matrix are the subsequent cutover slices.

## Tests

150 unit tests across `generate-bake-hcl`, `bake-buildresult`, `bake-managed`, `mirror-dockerhub`, and `coverage-checkpoint-utils` — covering the bake/matrix partition, the build-result mapping and its fail-closed behaviour, variant-routed rolling tags, the DockerHub mirror tag parity, and the coverage-checkpoint attribution of bake job failures.

Refs #628, ADR-013.
