### PR TITLE
fix(ci): drop publish concurrency group + verify Windows buildx with sha256sum

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -162,8 +162,7 @@ runs:
 
         retry_with_backoff 3 10 curl -fsSL -o "$dest" "$url"
 
-        actual=$(powershell.exe -NoProfile -Command \
-          "(Get-FileHash -Algorithm SHA256 '$(cygpath -w "$dest")').Hash.ToLower()")
+        actual=$(sha256sum "$dest" | awk '{print $1}')
         if [ "$actual" != "$BUILDX_WIN_SHA256" ]; then
           echo "SHA256 mismatch for buildx-${BUILDX_VERSION}.windows-amd64.exe: expected $BUILDX_WIN_SHA256 got $actual" >&2
           exit 1

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1255,8 +1255,10 @@ jobs:
     # fail gracefully if their arch-specific images are missing). This prevents
     # one failed build from blocking manifests for all other successful builds.
     # Skip entirely when rebuild=sync (build-and-push was skipped, nothing to manifest).
-    # Shares the publish-${{ github.ref }} concurrency group with bake-merge so that
-    # the flat-matrix publisher and the bake publisher cannot write manifests concurrently.
+    # NOTE: No job-level concurrency here — each matrix cell targets a unique
+    # (container, tag) ref; bake-merge and create-manifest write disjoint ref sets
+    # so no serialization is needed.  Job-level concurrency on a matrix job evicts
+    # pending cells (GHA holds only 1 pending slot), silently dropping manifests.
     if: |
       always() &&
       inputs.rebuild != 'sync' &&
@@ -1264,9 +1266,6 @@ jobs:
       fromJson(needs.detect-containers.outputs.matrix_builds || '[]') != null &&
       toJson(fromJson(needs.detect-containers.outputs.matrix_builds || '[]')) != '[]' &&
       github.event_name != 'pull_request'
-    concurrency:
-      group: publish-${{ github.ref }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -2207,11 +2206,10 @@ jobs:
       toJson(fromJson(needs.detect-containers.outputs.bake_builds || '[]')) != '[]' &&
       needs.bake-build-amd64.result == 'success' &&
       needs.bake-build-arm64.result == 'success'
-    # Shared concurrency group with create-manifest so the two publishers never
-    # write to the same GHCR namespace concurrently on the same ref.
-    concurrency:
-      group: publish-${{ github.ref }}
-      cancel-in-progress: false
+    # NOTE: No job-level concurrency here — bake-merge writes only the
+    # linux-latest refs for github-runner/web-shell/wordpress; create-manifest
+    # writes retained + windows refs.  The ref sets are disjoint, so no
+    # serialization is needed (same rationale as build-and-push).
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What

Two post-cutover CI correctness fixes.

### 1. Drop the publish concurrency group that silently cancelled matrix manifests

`create-manifest` (a matrix job) and `bake-merge` shared `concurrency: { group: publish-${{ github.ref }}, cancel-in-progress: false }`. GitHub Actions holds only one *running* plus one *pending* slot per concurrency group, and a new pending arrival evicts the previous pending one even with `cancel-in-progress: false`. When all `create-manifest` matrix cells became eligible at once (after the last build finished), all but one were silently cancelled — retained and Windows manifests were never created (observed on a master run: 12 of 14 cells cancelled).

`bake-merge` and `create-manifest` write provably disjoint refs (bake = latest-linux of the three chained containers; matrix = retained + Windows), so no serialization is needed. Removing the group from both jobs restores the pre-cutover parallel manifest creation. This mirrors the existing `build-and-push` rationale, which already documents "No job-level concurrency here — caused unexpected mid-build cancellations".

### 2. Verify the Windows buildx binary with `sha256sum`

The Windows buildx integrity check used PowerShell `Get-FileHash` with the download path interpolated into the command string and the result piped through `cygpath`. That coupled correctness to the runner's PTY line-ending handling and embedded a path in a PowerShell string. Replaced with `sha256sum` (Git Bash coreutils, already the tool the `yq` install uses): no PowerShell, no `cygpath`, no carriage-return dependency, no string-interpolation surface.

## Tests

`actionlint` clean on the changed workflow (only pre-existing findings on unmodified lines); the buildx step keeps `set -euo pipefail` and fails closed on a hash mismatch.

Refs #628, #657, ADR-013.
