### PR TITLE
fix(ci): drop docker.io dockerfile-frontend directive from github-runner

### DIFF
--- a/github-runner/Dockerfile.linux
+++ b/github-runner/Dockerfile.linux
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # GitHub Actions self-hosted runner — Linux template
 # Multi-distro: ubuntu-2404, ubuntu-2204, debian-trixie, debian-bookworm
 # Generated Dockerfiles are produced by generate-dockerfile.sh (do NOT edit generated output)

--- a/github-runner/Dockerfile.windows
+++ b/github-runner/Dockerfile.windows
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # GitHub Actions self-hosted runner — Windows ltsc2022
 # Multi-stage build:
 #   - base: servercore — lightweight runner for general workflows


### PR DESCRIPTION
## What

Removes the `# syntax=docker/dockerfile:1` parser directive from the github-runner Dockerfiles. That directive makes BuildKit fetch the Dockerfile frontend from `docker.io/docker/dockerfile:1` at the start of every build — the last avoidable docker.io egress in the steady-state build path. It caused a real build failure on a recent CI run (`docker.io/docker/dockerfile:1` i/o timeout).

The pinned BuildKit's built-in frontend already supports every feature these Dockerfiles use (the most advanced is `RUN --mount=type=cache`, in the frontend since 2020). Five other Dockerfiles in this repo (ansible, jekyll, terraform, web-shell, wordpress) already build with the same features and no `# syntax=` directive — proof the directive is unnecessary here.

Removing it from `Dockerfile.linux` (the template) also fixes the bake path: the generated `dockerfile-inline` content no longer carries the directive. `Dockerfile.windows` is cleaned too (it used no frontend features anyway). The four pre-generated per-distro Dockerfiles are regenerated from the template at build time, so they inherit the change.

## Result

Zero docker.io frontend pull on both the flat-matrix and bake-inline build paths for github-runner.

Refs #628 (docker.io egress elimination).
