### PR TITLE
feat(ci): nightly DockerHub reconciliation cron for bake-managed containers

### DIFF
--- a/.github/workflows/dockerhub-reconcile.yaml
+++ b/.github/workflows/dockerhub-reconcile.yaml
@@ -1,0 +1,121 @@
+name: DockerHub Reconciliation
+
+on:
+  schedule:
+    - cron: '0 21 * * *'  # 9 PM UTC — end-of-day gap fill after bake-merge runs
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — print imagetools commands, no writes'
+        required: false
+        type: boolean
+        default: false
+      all_retained:
+        description: 'Mirror retained (non-latest) tags too'
+        required: false
+        type: boolean
+        default: true
+      containers:
+        description: 'Override bake-managed containers (space-separated, optional)'
+        required: false
+        type: string
+        default: ''
+
+# Never cancel — a partial run leaves DockerHub inconsistent.
+concurrency:
+  group: dockerhub-reconcile
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  reconcile:
+    name: Reconcile GHCR → DockerHub (bake-managed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: refs/heads/master
+
+      - name: Install yq
+        timeout-minutes: 5
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        timeout-minutes: 5
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        timeout-minutes: 10
+        with:
+          driver: docker-container
+          version: 'v0.33.0'
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Mirror GHCR → DockerHub (bake-managed containers)
+        id: mirror
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+          BAKE_GENERATE_ALL_RETAINED: ${{ (github.event_name == 'workflow_dispatch' && inputs.all_retained == false) && 'false' || 'true' }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          BAKE_MANAGED_CONTAINERS: ${{ inputs.containers }}
+          MIRROR_STRICT: 'true'
+        run: |
+          set -euo pipefail
+          chmod +x helpers/mirror-dockerhub.sh helpers/bake-managed.sh scripts/generate-bake-hcl.sh
+          # shellcheck source=helpers/bake-managed.sh
+          source helpers/bake-managed.sh
+          # Read containers: honour BAKE_MANAGED_CONTAINERS override (set via inputs.containers);
+          # falls back to default "github-runner web-shell wordpress" when empty.
+          read -ra containers <<< "$(bake_managed_containers)"
+          # Fail closed if the parsed array is empty — a whitespace-only override is a
+          # misconfiguration; silently falling back to the whole fleet would be wrong.
+          if [[ ${#containers[@]} -eq 0 ]]; then
+            echo "::error::dockerhub-reconcile: empty container set (whitespace-only override?) — refusing whole-fleet fallback" >&2
+            exit 1
+          fi
+          # Validate every container token against a strict allowlist — rejects flag injection
+          # (e.g. --all-retained) and shell metacharacters before any downstream use.
+          for _c in "${containers[@]}"; do
+            if [[ ! "$_c" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+              echo "::error::Invalid container name in reconcile set: '$_c'" >&2
+              exit 1
+            fi
+          done
+          echo "::notice::Reconciling DockerHub for: ${containers[*]} (all_retained=${BAKE_GENERATE_ALL_RETAINED} dry_run=${DRY_RUN})"
+          # shellcheck source=helpers/mirror-dockerhub.sh
+          source helpers/mirror-dockerhub.sh
+          mirror_to_dockerhub "${containers[@]}"
+
+      - name: Summary
+        if: always()
+        env:
+          MIRROR_OUTCOME: ${{ steps.mirror.outcome }}
+        run: |
+          if [[ "$MIRROR_OUTCOME" == "success" ]]; then
+            echo "### DockerHub Reconciliation: success" >> "$GITHUB_STEP_SUMMARY"
+            echo "Reconciliation completed (see warnings above for any per-tag failures)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### DockerHub Reconciliation: FAILED" >> "$GITHUB_STEP_SUMMARY"
+            echo "DockerHub mirroring did not succeed for any tag (check credentials / GHCR source)." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -15,10 +15,17 @@
 # aliases, gated on is_latest_version (retained non-latest versions only get the
 # versioned tag; no rolling :latest/:latest-<variant> to avoid clobbering).
 #
-# BEST-EFFORT: a failure on any individual tag emits ::warning:: and continues.
+# BEST-EFFORT (default): a failure on any individual tag emits ::warning:: and continues.
 # The function returns 0 even when individual mirrors fail — it never gates the build.
 #
-# SKIP: when DOCKERHUB_USERNAME is unset the function emits ::notice:: and returns 0.
+# STRICT MODE (MIRROR_STRICT=true): fail-closed on total/structural failure.
+# Returns non-zero when credentials are absent, the generator fails, no cells are
+# produced, or every attempted mirror call fails (0/<n> succeeded).  Partial success
+# (_succeeded > 0) still returns 0 — transient single-tag flakes must not red the
+# nightly cron.  Emits ::notice:: with counts on success, ::error:: on total failure.
+#
+# SKIP: when DOCKERHUB_USERNAME is unset the function emits ::notice:: and returns 0
+# (or ::error:: + returns 1 in strict mode).
 #
 # DRY_RUN / DOCKER indirection:
 #   - When DRY_RUN=true the explicit dry-run branch at the mirror call site prints
@@ -69,16 +76,35 @@ DOCKER="${DOCKER:-docker}"
 #                                 contract as helpers/bake-buildresult.sh)
 #   DRY_RUN                     — when "true", print commands without executing
 #   DOCKER                      — docker binary / mock (set by logging.sh)
+#   MIRROR_STRICT               — when "true", enables fail-closed return semantics:
+#                                 returns non-zero on structural error (unset username,
+#                                 generator failure, no cells produced) OR when
+#                                 _attempted > 0 && _succeeded == 0 (total failure).
+#                                 Partial success (_succeeded > 0) still returns 0 —
+#                                 transient single-tag flakes must not red the nightly job.
+#                                 Emits a ::notice:: summary on success and ::error:: on
+#                                 total failure to stderr.  Default mode (MIRROR_STRICT
+#                                 unset/false) is unchanged: always returns 0 (best-effort).
 #
 # Return value:
-#   0 always (best-effort; individual failures do not propagate)
+#   Default mode (MIRROR_STRICT != "true"):
+#     0 always (best-effort; individual failures do not propagate)
+#   Strict mode (MIRROR_STRICT == "true"):
+#     0 — at least one tag mirrored successfully (full or partial success)
+#     1 — structural error (credentials absent, generator failed, no cells) or
+#         total failure (_attempted > 0 && _succeeded == 0)
 # ---------------------------------------------------------------------------
 mirror_to_dockerhub() {
     local -a containers=("$@")
+    local _strict="${MIRROR_STRICT:-false}"
 
     # Skip entirely when DockerHub credentials are absent.
     if [[ -z "${DOCKERHUB_USERNAME:-}" ]]; then
         printf '::notice::mirror-dockerhub: DOCKERHUB_USERNAME unset — skipping DockerHub mirror\n' >&2
+        if [[ "$_strict" == "true" ]]; then
+            printf '::error::mirror-dockerhub: DOCKERHUB_USERNAME unset — reconciliation cannot proceed\n' >&2
+            return 1
+        fi
         return 0
     fi
 
@@ -93,14 +119,24 @@ mirror_to_dockerhub() {
     fi
 
     local cells_json
-    local generator="${_MDH_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh"
+    # _MDH_GENERATOR_OVERRIDE allows bats tests to inject a mock generator without
+    # patching the filesystem.  Not used in production (env var not set by callers).
+    local generator="${_MDH_GENERATOR_OVERRIDE:-${_MDH_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh}"
     if ! cells_json=$("$generator" --cells "${_gen_retained_flag[@]}" "${containers[@]}"); then
         printf '::warning::mirror-dockerhub: generate-bake-hcl.sh --cells failed — skipping DockerHub mirror\n' >&2
+        if [[ "$_strict" == "true" ]]; then
+            printf '::error::mirror-dockerhub: generator failed — reconciliation cannot proceed\n' >&2
+            return 1
+        fi
         return 0
     fi
 
     if ! jq -e 'type == "array"' <<< "$cells_json" >/dev/null 2>&1; then
         printf '::warning::mirror-dockerhub: --cells returned non-array — skipping DockerHub mirror\n' >&2
+        if [[ "$_strict" == "true" ]]; then
+            printf '::error::mirror-dockerhub: generator returned non-array — reconciliation cannot proceed\n' >&2
+            return 1
+        fi
         return 0
     fi
 
@@ -109,8 +145,16 @@ mirror_to_dockerhub() {
 
     if [[ "$ncells" -eq 0 ]]; then
         printf '::notice::mirror-dockerhub: no cells to mirror\n' >&2
+        if [[ "$_strict" == "true" ]]; then
+            printf '::error::mirror-dockerhub: generator produced no cells — reconciliation cannot proceed\n' >&2
+            return 1
+        fi
         return 0
     fi
+
+    # Counters for strict-mode observability: track across all cells/tags.
+    local _attempted=0
+    local _succeeded=0
 
     local i
     for (( i=0; i<ncells; i++ )); do
@@ -155,13 +199,27 @@ mirror_to_dockerhub() {
                 printf 'DRY-RUN: docker buildx imagetools create -t %s %s\n' \
                     "$dh_dst" "$ghcr_src" >&2
             else
-                if ! "$DOCKER" buildx imagetools create -t "$dh_dst" "$ghcr_src" 2>&1; then
+                (( _attempted++ )) || true
+                if "$DOCKER" buildx imagetools create -t "$dh_dst" "$ghcr_src" 2>&1; then
+                    (( _succeeded++ )) || true
+                else
                     printf '::warning::mirror-dockerhub: imagetools create failed for %s (best-effort, continuing)\n' \
                         "$dh_dst" >&2
                 fi
             fi
         done < <(compute_cell_tag_suffixes "$tag" "$routing_suffix" "$is_default")
     done
+
+    # Strict-mode: emit summary and return non-zero on total failure.
+    if [[ "$_strict" == "true" ]]; then
+        if [[ "$_attempted" -gt 0 && "$_succeeded" -eq 0 ]]; then
+            printf '::error::mirror-dockerhub: 0/%d tags mirrored — reconciliation failed\n' \
+                "$_attempted" >&2
+            return 1
+        fi
+        printf '::notice::mirror-dockerhub: %d/%d tags mirrored\n' \
+            "$_succeeded" "$_attempted" >&2
+    fi
 
     return 0
 }

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -8,6 +8,12 @@
 #   MD4: Function skips when DOCKERHUB_USERNAME is unset
 #   MD5: A single mirror failure does NOT fail the function (best-effort; rc=0)
 #   MD6: BAKE_GENERATE_ALL_RETAINED ignored → retained GHCR tags absent on DockerHub
+#   MS1: MIRROR_STRICT unset → returns 0 even when all imagetools fail (best-effort preserved)
+#   MS2: MIRROR_STRICT=true + all imagetools succeed → returns 0
+#   MS3: MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0) → returns non-zero
+#   MS4: MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0
+#   MS5: MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero (structural)
+#   MS6: MIRROR_STRICT=true + generator yields no cells → returns non-zero (structural)
 
 load "../test_helper"
 
@@ -52,11 +58,14 @@ MOCK_EOF
 
     # Default to latest-only (no retained) between tests
     export BAKE_GENERATE_ALL_RETAINED="false"
+
+    # Default to best-effort (strict mode off) between tests
+    export MIRROR_STRICT="false"
 }
 
 teardown() {
     rm -rf "$TEST_LOG_DIR"
-    unset DOCKERHUB_USERNAME REMOTE_CR DRY_RUN BAKE_GENERATE_ALL_RETAINED || true
+    unset DOCKERHUB_USERNAME REMOTE_CR DRY_RUN BAKE_GENERATE_ALL_RETAINED MIRROR_STRICT _MDH_GENERATOR_OVERRIDE || true
 }
 
 # ---------------------------------------------------------------------------
@@ -74,6 +83,8 @@ _run_mirror() {
         export GITHUB_ACTIONS
         export _DEPGRAPH_LINEAGE_DIR
         export BAKE_GENERATE_ALL_RETAINED
+        export MIRROR_STRICT
+        export _MDH_GENERATOR_OVERRIDE
 
         source "$MDH"
         mirror_to_dockerhub "$@"
@@ -358,4 +369,175 @@ FAIL_EOF
     # A ::warning:: should have been emitted for the failure
     grep -q "warning" "${TEST_LOG_DIR}/run.log" || \
         (echo "Expected ::warning:: annotation not found:" >&2; cat "${TEST_LOG_DIR}/run.log" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-01: MIRROR_STRICT unset → returns 0 even when all imagetools fail.
+# Catches: MS1 — best-effort behavior must be unchanged when strict mode is off.
+# ---------------------------------------------------------------------------
+@test "MS-01: MIRROR_STRICT unset returns 0 even when all imagetools fail" {
+    unset MIRROR_STRICT
+
+    # All docker calls fail
+    cat > "$MOCK_DOCKER" <<'FAIL_EOF'
+#!/usr/bin/env bash
+printf 'FAILED: %s\n' "$*" >> "${DOCKER_LOG}"
+exit 1
+FAIL_EOF
+    chmod +x "$MOCK_DOCKER"
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -eq 0 ] || \
+        (echo "Expected rc=0 (best-effort, MIRROR_STRICT unset) but got $status" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-02: MIRROR_STRICT=true + all imagetools succeed → returns 0.
+# Catches: MS2 — strict mode must not break the happy path.
+# ---------------------------------------------------------------------------
+@test "MS-02: MIRROR_STRICT=true all-succeed returns 0" {
+    export MIRROR_STRICT="true"
+
+    # MOCK_DOCKER already exits 0 (default setup)
+    run _run_mirror "web-shell"
+
+    [ "$status" -eq 0 ] || \
+        (echo "Expected rc=0 (strict, all succeed) but got $status" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # ::notice:: summary must be emitted
+    grep -q "notice.*mirror-dockerhub:.*/" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::notice:: summary not found:" >&2; cat "${TEST_LOG_DIR}/run.log" >&2; false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-03: MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0)
+#        → returns non-zero.
+# Catches: MS3 — total failure must be observable in strict mode.
+# ---------------------------------------------------------------------------
+@test "MS-03: MIRROR_STRICT=true all-fail returns non-zero" {
+    export MIRROR_STRICT="true"
+
+    # All docker calls fail
+    cat > "$MOCK_DOCKER" <<'FAIL_EOF'
+#!/usr/bin/env bash
+printf 'FAILED: %s\n' "$*" >> "${DOCKER_LOG}"
+exit 1
+FAIL_EOF
+    chmod +x "$MOCK_DOCKER"
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -ne 0 ] || \
+        (echo "Expected non-zero rc (strict, all fail) but got 0" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # ::error:: annotation must be emitted
+    grep -q "error.*mirror-dockerhub:.*0/" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::error:: total-failure annotation not found:" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-04: MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0.
+# Catches: MS4 — transient single-tag flakes must not red the nightly cron.
+#
+# Strategy: the first imagetools call succeeds, subsequent ones fail.
+# web-shell produces at least 2 tags (versioned + :latest), so the counter
+# will have succeeded≥1 and attempted≥2.
+# ---------------------------------------------------------------------------
+@test "MS-04: MIRROR_STRICT=true partial-success returns 0" {
+    export MIRROR_STRICT="true"
+
+    # First call succeeds, all subsequent fail
+    cat > "$MOCK_DOCKER" <<'PARTIAL_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG}"
+# Succeed only on first invocation (line count == 1 after writing)
+lines=$(wc -l < "${DOCKER_LOG}")
+if [[ "$lines" -eq 1 ]]; then
+    exit 0
+fi
+exit 1
+PARTIAL_EOF
+    chmod +x "$MOCK_DOCKER"
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -eq 0 ] || \
+        (echo "Expected rc=0 (strict, partial success) but got $status" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # ::notice:: summary (not ::error::) must be emitted
+    grep -q "notice.*mirror-dockerhub:.*/" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::notice:: summary not found (should be partial success):" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-05: MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero.
+# Catches: MS5 — missing credentials is a structural misconfiguration.
+# ---------------------------------------------------------------------------
+@test "MS-05: MIRROR_STRICT=true DOCKERHUB_USERNAME unset returns non-zero" {
+    export MIRROR_STRICT="true"
+    unset DOCKERHUB_USERNAME
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -ne 0 ] || \
+        (echo "Expected non-zero rc (strict, no credentials) but got 0" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # ::error:: annotation must be emitted
+    grep -q "error.*mirror-dockerhub:.*DOCKERHUB_USERNAME" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::error:: credentials annotation not found:" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+}
+
+# ---------------------------------------------------------------------------
+# MS-06: MIRROR_STRICT=true + generator yields no cells → returns non-zero.
+# Catches: MS6 — empty cell set is a structural failure (no-op reconciliation).
+#
+# Strategy: set _MDH_GENERATOR_OVERRIDE to a mock that returns an empty JSON array.
+# ---------------------------------------------------------------------------
+@test "MS-06: MIRROR_STRICT=true generator no-cells returns non-zero" {
+    export MIRROR_STRICT="true"
+
+    # Mock generator returns an empty array
+    export MOCK_GENERATOR="${TEST_LOG_DIR}/generate-bake-hcl-empty.sh"
+    cat > "$MOCK_GENERATOR" <<'GEN_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--cells" ]]; then
+    printf '[]'
+    exit 0
+fi
+exit 1
+GEN_EOF
+    chmod +x "$MOCK_GENERATOR"
+    export _MDH_GENERATOR_OVERRIDE="$MOCK_GENERATOR"
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -ne 0 ] || \
+        (echo "Expected non-zero rc (strict, no cells) but got 0" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # ::error:: annotation must be emitted
+    grep -q "error.*mirror-dockerhub:" "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected ::error:: no-cells annotation not found:" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    unset _MDH_GENERATOR_OVERRIDE
 }


### PR DESCRIPTION
## What

Adds a nightly DockerHub reconciliation cron for the bake-managed containers, closing the gap where the inline best-effort DockerHub mirror in `bake-merge` (latest-only, returns success even on per-tag failure) can silently drift.

## How

- New workflow `.github/workflows/dockerhub-reconcile.yaml`: runs on a daily schedule (`0 21 * * *`, end-of-day) and on `workflow_dispatch` (with `dry_run`, `all_retained`, and `containers` inputs). It logs into GHCR + DockerHub, sets up buildx, and re-mirrors GHCR→docker.io for the bake-managed set via the existing `mirror_to_dockerhub` helper (idempotent `imagetools create` re-tag, no layer transfer). Unlike the inline mirror, it defaults to `all_retained=true`, so it also covers retained (non-latest) tags.
- The workflow only runs on `master` (scheduled) or manual dispatch, never on PR branches, and pins the same buildx/buildkit/checkout SHAs the rest of the pipeline uses.
- Input hardening: each container token is validated against `^[a-z0-9][a-z0-9._-]*$` (rejects flag/value injection into the generator), and an empty/whitespace-only override fails closed rather than falling back to a whole-fleet mirror. The `all_retained` value is computed so a scheduled run always mirrors retained tags (no unset-input coercion to the wrong default).
- **Observable, fail-closed**: a new opt-in `MIRROR_STRICT` mode in `helpers/mirror-dockerhub.sh` tracks attempted vs succeeded mirrors and returns non-zero on total failure (nothing mirrored — e.g. expired credentials) while tolerating transient partial failures. The cron runs with `MIRROR_STRICT=true` and no `continue-on-error`, so a totally-broken reconciliation surfaces as a red job instead of silent green. The inline bake-merge mirror keeps its default best-effort behaviour (unchanged).

## Tests

`tests/unit/mirror-dockerhub.bats` extended with strict-mode coverage (best-effort default unchanged; strict total-failure → non-zero; strict partial → zero; strict structural error → non-zero). 14 tests passing.

Refs #628, ADR-013.
