### PR TITLE
perf(ci): restore cross-run registry cache on the bake build path

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1633,9 +1633,21 @@ jobs:
           # flat matrix by partition_builds, so they never reach this job.
           # No --all-retained flag is passed here.
           bake_file="${RUNNER_TEMP}/bake-amd64.json"
+          # BAKE_CACHE_EXPORT gates cache-to emission in the generator:
+          #   true  → real publish path (push/dispatch): emit cache-to so master builds
+          #           write to the canonical buildcache refs.
+          #   false → PR build-only (IS_PR=true) or DRY_RUN: emit cache-from only;
+          #           the HCL has no cache-to → PR code cannot poison canonical buildcache.
+          # This is the only correct place to set it: the generator reads it at HCL-
+          # generation time, before the three-way DRY_RUN/IS_PR/push branch below.
+          bake_cache_export="false"
+          if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
+            bake_cache_export="true"
+          fi
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
-          REMOTE_CR="$REMOTE_CR" ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" \
+            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
 
           # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
           no_cache_flag=""
@@ -1986,9 +1998,16 @@ jobs:
           # flat matrix by partition_builds, so they never reach this job.
           # No --all-retained flag is passed here.
           bake_file="${RUNNER_TEMP}/bake-arm64.json"
+          # BAKE_CACHE_EXPORT gates cache-to emission: true only on the real publish
+          # path (not IS_PR, not DRY_RUN).  See amd64 step comment for full rationale.
+          bake_cache_export="false"
+          if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
+            bake_cache_export="true"
+          fi
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
-          REMOTE_CR="$REMOTE_CR" ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" \
+            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
 
           # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
           no_cache_flag=""

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -50,6 +50,8 @@ build_valid_tags() {
   fi
 
   # Tags from builds + latest + buildcache + latest-{variant}
+  # buildcache        — flat-matrix per-container registry cache (mode=max)
+  # buildcache-*      — bake per-target registry cache (keyed by container+tag+arch)
   local tags
   tags=$(echo "$builds_json" | jq -r '.[].tag')
   tags+=$'\n'"latest"
@@ -84,6 +86,42 @@ is_valid_tag() {
   base_tag="${base_tag%-arm64}"
   if [[ "$base_tag" != "$tag" ]] && echo "$valid_tags" | grep -qxF "$base_tag"; then
     return 0
+  fi
+
+  # Bake per-target registry cache tags: buildcache-<base-tag>-{amd64,arm64}
+  # (e.g. buildcache-2.334.0-amd64, buildcache-2.334.0-dev-arm64).
+  # A bake cache tag is valid IFF its underlying base tag is itself valid.
+  # This prevents stale cache entries for rotated-out versions from accumulating.
+  # Bare "buildcache" (flat-matrix cache, no arch suffix) is already covered by
+  # the direct-match path above (it's emitted into valid_tags by build_valid_tags).
+  if [[ "$tag" == buildcache-* ]]; then
+    # Strip the "buildcache-" prefix to get the remainder
+    local remainder="${tag#buildcache-}"
+
+    # Guard against malformed double-prefix (buildcache-buildcache-...)
+    if [[ "$remainder" == buildcache-* || -z "$remainder" ]]; then
+      return 1
+    fi
+
+    # Strip exactly the arch suffix (anchored to end) to recover the base tag
+    local cache_base_tag="$remainder"
+    if [[ "$cache_base_tag" == *-amd64 ]]; then
+      cache_base_tag="${cache_base_tag%-amd64}"
+    elif [[ "$cache_base_tag" == *-arm64 ]]; then
+      cache_base_tag="${cache_base_tag%-arm64}"
+    else
+      # No recognised arch suffix — not a bake cache tag we manage; treat as invalid
+      return 1
+    fi
+
+    # Base tag must be non-empty after stripping
+    if [[ -z "$cache_base_tag" ]]; then
+      return 1
+    fi
+
+    # The cache tag is valid iff its underlying base tag is currently valid
+    is_valid_tag "$cache_base_tag" "$valid_tags"
+    return $?
   fi
 
   return 1

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -906,6 +906,35 @@ _on_cell_bake() {
             '$t + {contexts: $c}')
     fi
 
+    # Registry cache: per-target ref keyed by container+tag+arch so each target
+    # reuses its own layer cache across runs.  ARCH_SUFFIX is the bake variable
+    # (declared in the document header); it interpolates to -amd64/-arm64 at bake
+    # invocation time.  ignore-error on cache-to ensures a transient GHCR export
+    # failure never fails the build job.
+    #
+    # cache-from is UNCONDITIONAL — reading is always safe and PR/dry-run builds
+    # benefit from master's warm cache.
+    # cache-to is GATED on BAKE_CACHE_EXPORT=true — writing to canonical GHCR
+    # buildcache refs must only happen on the real publish path (push/dispatch).
+    # PR builds have packages:write but must NOT poison the canonical buildcache
+    # that master builds consume via cache-from.
+    local cache_ref="${_BAKE_REMOTE_CR}/${c}:buildcache-${tag}\${ARCH_SUFFIX}"
+    local cache_from_json
+    cache_from_json=$(jq -cn --arg ref "$cache_ref" \
+        '[{"type": "registry", "ref": $ref}]')
+    target_obj=$(jq -cn --argjson t "$target_obj" \
+        --argjson cf "$cache_from_json" \
+        '$t + {"cache-from": $cf}')
+
+    if [[ "${BAKE_CACHE_EXPORT:-false}" == "true" ]]; then
+        local cache_to_json
+        cache_to_json=$(jq -cn --arg ref "$cache_ref" \
+            '[{"type": "registry", "ref": $ref, "mode": "max", "ignore-error": true}]')
+        target_obj=$(jq -cn --argjson t "$target_obj" \
+            --argjson ct "$cache_to_json" \
+            '$t + {"cache-to": $ct}')
+    fi
+
     # Accumulate into caller-scope variables (set -n nameref not in bash 4.3; use globals)
     targets_json=$(jq -cn --argjson base "$targets_json" \
         --arg tid "$tid" --argjson obj "$target_obj" \

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/cleanup-outdated-tags.sh
+# Focus: is_valid_tag — bake cache tag validity derived from underlying base tag
+
+# Source is_valid_tag from the script.
+# The script has top-level guards (GH_TOKEN, OWNER) and a main loop; we set
+# dummy env vars and an empty CONTAINERS so the loop is a no-op on source.
+# We do NOT use bats `run` for is_valid_tag since that would re-execute the
+# main loop in the subshell.  Instead we call the function directly and check
+# the return code.
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+
+    export GH_TOKEN="test-token"
+    export OWNER="test-owner"
+    export DRY_RUN="true"
+    # Empty CONTAINERS prevents the main loop from iterating anything
+    export CONTAINERS=""
+
+    # Create a stub make so the script doesn't call the real one
+    _STUB_DIR="$(mktemp -d)"
+    mkdir -p "$_STUB_DIR"
+    printf '#!/bin/bash\necho ""\n' > "$_STUB_DIR/make"
+    chmod +x "$_STUB_DIR/make"
+    export PATH="$_STUB_DIR:$PATH"
+
+    # Source the script; the main loop runs but CONTAINERS="" → no iterations
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" 2>/dev/null || true
+
+    export _STUB_DIR
+}
+
+teardown() {
+    rm -rf "${_STUB_DIR:-}"
+    unset GH_TOKEN OWNER DRY_RUN CONTAINERS _STUB_DIR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a newline-separated valid-tag list
+# ---------------------------------------------------------------------------
+make_valid_tags() {
+    printf '%s\n' "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Direct-match tests (regression: existing behaviour must be preserved)
+# ---------------------------------------------------------------------------
+
+@test "is_valid_tag: exact match returns valid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "2.334.0" "$valid_tags"
+}
+
+@test "is_valid_tag: unknown tag returns invalid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "9.9.9" "$valid_tags"
+}
+
+@test "is_valid_tag: arch-specific of a valid base tag (amd64) returns valid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "2.334.0-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: arch-specific of a valid base tag (arm64) returns valid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "2.334.0-arm64" "$valid_tags"
+}
+
+# ---------------------------------------------------------------------------
+# Bare buildcache (flat-matrix rolling cache) — must stay preserved
+# ---------------------------------------------------------------------------
+
+@test "is_valid_tag: bare 'buildcache' preserved via direct match" {
+    # bare buildcache is emitted into valid_tags by build_valid_tags; direct match
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "buildcache" "$valid_tags"
+}
+
+# ---------------------------------------------------------------------------
+# Bake cache tags — new derived-validity logic
+# ---------------------------------------------------------------------------
+
+@test "is_valid_tag: buildcache-<valid-tag>-amd64 is kept when base tag is valid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "buildcache-2.334.0-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache-<valid-tag>-arm64 is kept when base tag is valid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "buildcache-2.334.0-arm64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache-<rotated-out-tag>-amd64 is purged when base tag is invalid" {
+    # 1.0.0 is no longer in valid_tags (rotated out)
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-1.0.0-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache-<rotated-out-tag>-arm64 is purged when base tag is invalid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-1.0.0-arm64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache with variant suffix preserved when variant base is valid" {
+    # buildcache-2.334.0-dev-amd64 → base tag = 2.334.0-dev
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0-dev" "latest" "buildcache")
+    is_valid_tag "buildcache-2.334.0-dev-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache with variant suffix purged when variant base is invalid" {
+    # 2.334.0-dev rotated out; only 2.334.0 remains
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-2.334.0-dev-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache with distro-qualified tag (trixie) preserved when base valid" {
+    # buildcache-trixie-amd64 → base tag = trixie
+    local valid_tags
+    valid_tags=$(make_valid_tags "trixie" "latest" "buildcache")
+    is_valid_tag "buildcache-trixie-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache with distro-qualified tag purged when base invalid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-trixie-amd64" "$valid_tags"
+}
+
+# ---------------------------------------------------------------------------
+# Arch suffix anchored at end — must not strip mid-tag -amd64 substrings
+# ---------------------------------------------------------------------------
+
+@test "is_valid_tag: trailing -amd64 stripped only from end, not mid-tag" {
+    # buildcache-foo-amd64-bar-amd64 → strip trailing -amd64 → base = foo-amd64-bar
+    local valid_tags
+    valid_tags=$(make_valid_tags "foo-amd64-bar" "latest" "buildcache")
+    is_valid_tag "buildcache-foo-amd64-bar-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: trailing -amd64 stripped at end only, base not in valid tags → invalid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "foo-amd64" "latest" "buildcache")
+    # buildcache-foo-amd64-bar-amd64 → base = foo-amd64-bar, NOT in valid_tags
+    ! is_valid_tag "buildcache-foo-amd64-bar-amd64" "$valid_tags"
+}
+
+# ---------------------------------------------------------------------------
+# Malformed / edge cases
+# ---------------------------------------------------------------------------
+
+@test "is_valid_tag: buildcache tag without arch suffix is invalid" {
+    # buildcache-2.334.0 (no -amd64/-arm64) → no recognised arch suffix → invalid
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-2.334.0" "$valid_tags"
+}
+
+@test "is_valid_tag: double-prefix buildcache-buildcache- is invalid" {
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    ! is_valid_tag "buildcache-buildcache-2.334.0-amd64" "$valid_tags"
+}
+
+@test "is_valid_tag: buildcache-amd64 is valid as arch-specific variant of bare buildcache" {
+    # buildcache-amd64 is matched by the arch-specific-suffix branch (not the buildcache-* branch):
+    # strip trailing -amd64 → 'buildcache', which IS in valid_tags → valid.
+    # This preserves the per-arch flat-matrix cache entries.
+    local valid_tags
+    valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
+    is_valid_tag "buildcache-amd64" "$valid_tags"
+}

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1117,3 +1117,150 @@ YAML
     [ "$status" -eq 0 ]
     [[ "$output" == *"github-runner"* ]] && [[ "$output" == *"bake_latest_only"* || "$output" == *"latest-only"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Registry cache: per-target cache-from/cache-to (MG18)
+#   MG18: Omit cache-from → bake builds cold; emit cache-to unconditionally → PR poisons canonical buildcache
+#
+# cache-from is UNCONDITIONAL (always emitted; reading is always safe).
+# cache-to is GATED on BAKE_CACHE_EXPORT=true (only the real publish path writes
+# to canonical buildcache refs — PR/dry-run builds must never poison it).
+# ---------------------------------------------------------------------------
+
+@test "GBH-50: MG18 — every bake target has cache-from unconditionally (BAKE_CACHE_EXPORT unset)" {
+    # cache-from must be present regardless of BAKE_CACHE_EXPORT
+    _run_generator debian
+    [ "$status" -eq 0 ]
+
+    # Every target must have cache-from: [{type: registry, ref: ...}]
+    local missing_cf
+    missing_cf=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | select(."value"."cache-from" == null or (."value"."cache-from" | length) == 0)
+    ] | length')
+    [ "$missing_cf" -eq 0 ]
+
+    # Every cache-from ref must be type=registry
+    local wrong_type
+    wrong_type=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | ."value"."cache-from"[]
+        | select(.type != "registry")
+    ] | length')
+    [ "$wrong_type" -eq 0 ]
+
+    # Every cache-from ref must contain "buildcache-"
+    local bad_ref
+    bad_ref=$(echo "$output" | jq -r '[
+        .target | to_entries[]
+        | ."value"."cache-from"[]
+        | .ref
+        | select(contains("buildcache-") | not)
+    ] | length')
+    [ "$bad_ref" -eq 0 ]
+
+    # Every cache-from ref must end with the literal "${ARCH_SUFFIX}" bake token
+    local no_arch_suffix
+    no_arch_suffix=$(echo "$output" | jq --arg suffix '${ARCH_SUFFIX}' '[
+        .target | to_entries[]
+        | ."value"."cache-from"[]
+        | .ref
+        | select(endswith($suffix) | not)
+    ] | length')
+    [ "$no_arch_suffix" -eq 0 ]
+}
+
+@test "GBH-50b: MG18 — cache-from also present when BAKE_CACHE_EXPORT=true (publish path)" {
+    # cache-from must also be present on the publish path (reads from prior master cache)
+    run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
+    [ "$status" -eq 0 ]
+
+    local missing_cf
+    missing_cf=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | select(."value"."cache-from" == null or (."value"."cache-from" | length) == 0)
+    ] | length')
+    [ "$missing_cf" -eq 0 ]
+}
+
+@test "GBH-51: MG18 — BAKE_CACHE_EXPORT=true: every target has cache-to with mode=max and ignore-error=true" {
+    # Cache-to must be present ONLY when BAKE_CACHE_EXPORT=true (the publish path).
+    run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
+    [ "$status" -eq 0 ]
+
+    # Every target must have cache-to
+    local missing_ct
+    missing_ct=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | select(."value"."cache-to" == null or (."value"."cache-to" | length) == 0)
+    ] | length')
+    [ "$missing_ct" -eq 0 ]
+
+    # mode=max required
+    local wrong_mode
+    wrong_mode=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | ."value"."cache-to"[]
+        | select(.mode != "max")
+    ] | length')
+    [ "$wrong_mode" -eq 0 ]
+
+    # ignore-error=true required (transient GHCR cache-export must not fail build)
+    local missing_ie
+    missing_ie=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | ."value"."cache-to"[]
+        | select(."ignore-error" != true)
+    ] | length')
+    [ "$missing_ie" -eq 0 ]
+}
+
+@test "GBH-51b: MG18 — BAKE_CACHE_EXPORT unset/false: NO cache-to emitted (PR/dry-run safety gate)" {
+    # When BAKE_CACHE_EXPORT is unset (default), cache-to must be absent from all targets.
+    # This is the PR/dry-run path — we must never poison canonical buildcache from unmerged code.
+    _run_generator debian
+    [ "$status" -eq 0 ]
+
+    local has_cache_to
+    has_cache_to=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | select(."value"."cache-to" != null and (."value"."cache-to" | length) > 0)
+    ] | length')
+    [ "$has_cache_to" -eq 0 ]
+}
+
+@test "GBH-51c: MG18 — BAKE_CACHE_EXPORT=false: NO cache-to emitted" {
+    # Explicit false must also suppress cache-to.
+    run env BAKE_CACHE_EXPORT=false bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
+    [ "$status" -eq 0 ]
+
+    local has_cache_to
+    has_cache_to=$(echo "$output" | jq '[
+        .target | to_entries[]
+        | select(."value"."cache-to" != null and (."value"."cache-to" | length) > 0)
+    ] | length')
+    [ "$has_cache_to" -eq 0 ]
+}
+
+@test "GBH-52: MG18 — two different bake targets (different containers or tags) get DISTINCT cache refs" {
+    # Request two containers with distinct tags so both produce cache refs.
+    # Verify no two targets share the same cache-from ref.
+    run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian sslh
+    [ "$status" -eq 0 ]
+
+    # Collect all cache-from refs across all targets
+    local all_refs
+    all_refs=$(echo "$output" | jq -r '[
+        .target | to_entries[]
+        | ."value"."cache-from"[]
+        | .ref
+    ]')
+
+    local total_refs unique_refs
+    total_refs=$(echo "$all_refs" | jq 'length')
+    unique_refs=$(echo "$all_refs" | jq 'unique | length')
+
+    # Every ref must be unique — no two targets share a cache ref
+    [ "$total_refs" -gt 1 ]
+    [ "$unique_refs" -eq "$total_refs" ]
+}


### PR DESCRIPTION
## What

Restores cross-run BuildKit registry cache on the bake build path. The flat matrix has used per-container registry cache (`ghcr.io/<owner>/<container>:buildcache`, `mode=max`) since day one via `build-container.sh::_configure_cache`. The ADR-013 bake cutover landed the three chained containers (github-runner, web-shell, wordpress) with **no** `cache-from`/`cache-to`, so every bake run built cold — a performance regression (github-runner is ~35 min, dominated by toolchain layers that the matrix used to cache).

## How

- **Per-target cache in `generate-bake-hcl.sh`**: every emitted bake target (consumer cells and in-memory closure base targets) gets `cache-from`/`cache-to type=registry`, keyed by its own `<container>:buildcache-<tag>${ARCH_SUFFIX}` so each target has a distinct cache namespace (a shared `*` ref would collide across targets in one bake invocation). `ARCH_SUFFIX` is the existing bake variable (`-amd64`/`-arm64`), emitted un-interpolated for bake to resolve. `cache-to` uses `mode=max` + `ignore-error=true` (a transient GHCR cache-export failure must not fail the build).
- **`cache-to` gated to the publish path**: a registry cache exporter writes to GHCR independently of `--push`, and the bake-build jobs also run on pull requests (build-only, no push) and could otherwise have unmerged PR code write the canonical `buildcache-*` refs that master later consumes. `cache-from` stays unconditional (reads are safe and let PR/dry-run builds benefit from master's warm cache), but `cache-to` is emitted only when `BAKE_CACHE_EXPORT=true`, which `auto-build.yaml` sets only on the real publish path (`!IS_PR && !DRY_RUN`, the same branch that runs `bake --push`).
- **Bounded cache cleanup in `cleanup-outdated-tags.sh`**: a `buildcache-<tag>-<arch>` tag is preserved only if its underlying `<tag>` is itself a currently-valid (retained) tag — so when a version rotates out, its cache tags become purgeable instead of accumulating unbounded. The matrix's bare `buildcache` tag keeps its existing handling.

## Tests

`generate-bake-hcl.bats` (cache-from unconditional; cache-to present only with `BAKE_CACHE_EXPORT=true`; distinct per-target refs) and a new `cleanup-outdated-tags.bats` (valid-base kept, rotated-out purged, arch suffix anchored, bare `buildcache` kept). Green.

Refs #628, ADR-013.
