### PR TITLE
feat(ci): route debian/vector/jekyll/ansible through bake (PR-B slice 1)

### DIFF
--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -10,7 +10,7 @@
 # Usage (standalone):
 #   helpers/bake-managed.sh partition <builds_json_or_@file>
 #
-# The bake-managed set defaults to "github-runner web-shell wordpress".
+# The bake-managed set defaults to "github-runner web-shell wordpress debian vector jekyll ansible".
 # Override at any time via BAKE_MANAGED_CONTAINERS env (space-separated).
 #
 # Requirements: bash 4+, jq
@@ -38,7 +38,7 @@ source "${_BM_SCRIPT_DIR}/logging.sh"
 # operators and tests to expand the set without code changes.
 # ---------------------------------------------------------------------------
 bake_managed_containers() {
-    echo "${BAKE_MANAGED_CONTAINERS:-github-runner web-shell wordpress}"
+    echo "${BAKE_MANAGED_CONTAINERS:-github-runner web-shell wordpress debian vector jekyll ansible}"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -5,6 +5,7 @@
 #   MM1: Remove github-runner from default set → github-runner lands in matrix instead of bake
 #   MM2: Remove web-shell from default set → web-shell lands in matrix instead of bake
 #   MM3: Remove wordpress from default set → wordpress lands in matrix instead of bake
+#   MM3b: Remove debian/vector/jekyll/ansible from default set → they land in matrix instead of bake
 #   MM4: Ignore BAKE_MANAGED_CONTAINERS override → env override has no effect
 #   MM5: Skip bake partition entirely → all cells end up in matrix (wrong)
 #   MM6: Duplicate cells across partitions → total count exceeds input length
@@ -72,7 +73,8 @@ _fixture_os_builds() {
 
 # ---------------------------------------------------------------------------
 # BM-01: Default partition — bake-managed containers (github-runner/web-shell/wordpress)
-#        land in .bake; debian and terraform land in .matrix.
+#        land in .bake; debian (no is_latest_version:true in fixture) and terraform
+#        land in .matrix.
 # Catches: MM1, MM2, MM3, MM5, MM8
 # ---------------------------------------------------------------------------
 @test "BM-01: default partition routes github-runner/web-shell/wordpress to bake, others to matrix" {
@@ -85,19 +87,20 @@ _fixture_os_builds() {
     # Validate JSON structure
     echo "$result" | jq -e 'has("bake") and has("matrix")' >/dev/null
 
-    # bake partition contains exactly the 3 bake-managed containers (web-shell has 2 entries = 3 total)
+    # bake partition contains the bake-managed containers that carry is_latest_version:true
+    # (web-shell has 2 entries; debian in fixture lacks is_latest_version:true so stays in matrix)
     bake_containers=$(echo "$result" | jq -r '[.bake[].container] | sort | unique | .[]')
     echo "$bake_containers" | grep -q "^github-runner$"
     echo "$bake_containers" | grep -q "^web-shell$"
     echo "$bake_containers" | grep -q "^wordpress$"
 
-    # matrix partition must NOT contain bake-managed containers
+    # matrix partition must NOT contain bake-managed containers that carried is_latest_version:true
     matrix_containers=$(echo "$result" | jq -r '[.matrix[].container] | unique | .[]')
     ! echo "$matrix_containers" | grep -q "^github-runner$"
     ! echo "$matrix_containers" | grep -q "^web-shell$"
     ! echo "$matrix_containers" | grep -q "^wordpress$"
 
-    # matrix contains debian and terraform
+    # debian fixture cell (no is_latest_version:true) and terraform route to matrix
     echo "$matrix_containers" | grep -q "^debian$"
     echo "$matrix_containers" | grep -q "^terraform$"
 }
@@ -208,15 +211,15 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-07: is_bake_managed — debian returns 1 (not in default set).
+# BM-07: is_bake_managed — debian returns 0 (now in default set, PR-B slice 1).
 # Catches: MM9
 # ---------------------------------------------------------------------------
-@test "BM-07: is_bake_managed returns 1 for debian (not in default set)" {
+@test "BM-07: is_bake_managed returns 0 for debian (now in default set)" {
     # shellcheck disable=SC1090
     source "$BM"
 
     run is_bake_managed "debian"
-    [[ "$status" -eq 1 ]]
+    [[ "$status" -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -228,6 +231,30 @@ ubuntu-1.0.0"
     source "$BM"
 
     run is_bake_managed "web-shell"
+    [[ "$status" -eq 0 ]]
+
+    run is_bake_managed "terraform"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-08b: is_bake_managed — PR-B slice 1 new containers (debian/vector/jekyll/ansible)
+#          return 0 (in default set); terraform returns 1 (still matrix-only).
+# ---------------------------------------------------------------------------
+@test "BM-08b: is_bake_managed returns 0 for debian/vector/jekyll/ansible; 1 for terraform" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run is_bake_managed "debian"
+    [[ "$status" -eq 0 ]]
+
+    run is_bake_managed "vector"
+    [[ "$status" -eq 0 ]]
+
+    run is_bake_managed "jekyll"
+    [[ "$status" -eq 0 ]]
+
+    run is_bake_managed "ansible"
     [[ "$status" -eq 0 ]]
 
     run is_bake_managed "terraform"
@@ -291,7 +318,7 @@ ubuntu-1.0.0"
     windows_in_bake=$(echo "$result" | jq -r '[.bake[] | select(.container == "github-runner" and .os == "windows")] | length')
     [[ "$windows_in_bake" -eq 0 ]]
 
-    # debian (non-bake-managed, linux) must also stay in .matrix
+    # debian (bake-managed but no is_latest_version:true in fixture) must also stay in .matrix
     debian_in_matrix=$(echo "$result" | jq -r '[.matrix[] | select(.container == "debian")] | length')
     [[ "$debian_in_matrix" -eq 1 ]]
 }
@@ -407,7 +434,7 @@ ubuntu-1.0.0"
     retained_in_bake=$(echo "$result" | jq '[.bake[] | select(.is_latest_version == false)] | length')
     [[ "$retained_in_bake" -eq 0 ]]
 
-    # debian (not bake-managed) must land in .matrix
+    # debian (bake-managed but no is_latest_version:true in fixture) must land in .matrix
     deb_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "debian")] | length')
     [[ "$deb_in_matrix" -eq 1 ]]
 


### PR DESCRIPTION
## What

PR-B slice 1: extends the bake-managed set with the four lowest-risk Linux containers — `debian`, `vector`, `jekyll`, `ansible` — moving them from the flat matrix to the bake build/merge path on push.

## How

A one-line change to the default in `helpers/bake-managed.sh`. The bake generator, the bake/matrix partition, and the `bake-build`/`bake-merge` jobs are already fully generic (the generator was verified to emit correct targets for every Linux container, including build-arg cases). No workflow, variants, or generator changes are needed. The `BAKE_MANAGED_CONTAINERS` env override is unchanged.

These four are committed single-Dockerfile containers with external-only bases and static build args, with no internal consumers that would break. `debian` is already built on the bake graph as an in-memory dependency of github-runner/web-shell; this gives it its own first-class bake cell + canonical manifest.

Retained (non-latest) versions and any Windows variants still route to the flat matrix (unchanged). `postgres` stays on its extension pipeline.

## Validation

Gate-clean (codex + copilot). `bake-managed.bats` updated for the new managed set (the four are now `is_bake_managed`; terraform/openresty/sslh/openvpn/php/postgres still route to matrix); 18 tests pass. A controlled `workflow_dispatch` of `ansible` on this branch exercises the new bake path end-to-end (build → multi-arch manifest) before merge.

Part of the PR-B fleet migration (subsequent slices: sslh/openvpn, php→openresty, terraform). Refs #628, ADR-013.
