### PR TITLE
fix(ci): repair Windows github-runner builds (buildx sha256 + base freshness) (#669)

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -155,6 +155,8 @@ runs:
         set -euo pipefail
         # shellcheck source=helpers/retry.sh
         source ./helpers/retry.sh
+        # shellcheck source=helpers/hash-utils.sh
+        source ./helpers/hash-utils.sh
 
         dest="$USERPROFILE/.docker/cli-plugins/docker-buildx.exe"
         mkdir -p "$(dirname "$dest")"
@@ -162,7 +164,7 @@ runs:
 
         retry_with_backoff 3 10 curl -fsSL -o "$dest" "$url"
 
-        actual=$(sha256sum "$dest" | awk '{print $1}')
+        actual=$(sha256_file "$dest")
         if [ "$actual" != "$BUILDX_WIN_SHA256" ]; then
           echo "SHA256 mismatch for buildx-${BUILDX_VERSION}.windows-amd64.exe: expected $BUILDX_WIN_SHA256 got $actual" >&2
           exit 1

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -335,8 +335,11 @@ runs:
           }
         }
 
-        # Docker cleanup
-        docker system prune -af --volumes 2>$null
+        # No `docker system prune` here: GitHub-hosted Windows runners are ephemeral
+        # (fresh VM per job), so there is nothing from a prior job to reclaim — and a
+        # full prune would delete the Windows base images (servercore/nanoserver) the
+        # runner image pre-caches, forcing a slow multi-GB re-pull during the build.
+        # The Remove-Item cleanup above frees the actual reclaimable space.
 
         $after = [math]::Round((Get-PSDrive C).Free / 1GB, 1)
         Write-Host "::notice::Disk space after cleanup: $after GB (freed $([math]::Round($after - $before, 1)) GB)"

--- a/helpers/hash-utils.sh
+++ b/helpers/hash-utils.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Hashing helpers for docker-containers build scripts.
+#
+# sha256_file is backslash-safe: it feeds the file via stdin so GNU coreutils
+# never escapes a filename containing backslashes or newlines (which on Windows
+# Git Bash paths like C:\Users\... would otherwise prefix the hash output with
+# '\', breaking awk '{print $1}' extraction).
+#
+# Usage: source this file, then call sha256_file <path>
+#
+# Do NOT add set -e at file scope; this is a sourced helper.
+
+# sha256_file <path>
+# Prints the lowercase hex SHA-256 of the file at <path>.
+# Returns 1 if the file cannot be read.
+sha256_file() {
+    local file="${1:?sha256_file: file path required}"
+    [[ -r "$file" ]] || { echo "sha256_file: cannot read '$file'" >&2; return 1; }
+    sha256sum < "$file" | awk '{print $1}'
+}

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -567,8 +567,14 @@ build_container() {
         fi
 
         if [[ -z "${_PLATFORMS:-}" ]]; then
-            # Windows runner: plain docker build (no buildx, no --platform, no --load needed)
+            # Windows runner: plain docker build (no buildx, no --platform, no --load needed).
+            # --pull ensures the rolling base tag (mcr.microsoft.com/windows/servercore:ltsc2022 /
+            # server:ltsc2022) is re-fetched from the registry, keeping the build aligned with the
+            # remote digest recorded by `docker buildx imagetools inspect` above.  Without --pull an
+            # ephemeral runner's pre-cached layer could be used while the lineage records a different
+            # (current) digest.  Docker still reuses cached layers when the remote tag is unchanged.
             $DOCKER build \
+                --pull \
                 -f "$dockerfile" \
                 ${_target_arg} \
                 ${_no_cache} \

--- a/tests/unit/hash-utils.bats
+++ b/tests/unit/hash-utils.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/hash-utils.sh
+#
+# Regression lock: sha256_file must return a bare 64-hex-char hash even when
+# the file path contains backslashes.  GNU sha256sum escapes such filenames by
+# prefixing the output line with '\', so the old
+#   sha256sum "$f" | awk '{print $1}'
+# approach yielded '\<hash>' (with leading backslash), causing hash comparisons
+# to always fail on Windows Git Bash where USERPROFILE contains backslashes.
+#
+# The fix feeds the file via stdin (sha256sum < "$file") so the "filename"
+# reported by sha256sum is '-', which is never escaped.
+
+load "../test_helper"
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    setup_temp_dir
+
+    # shellcheck source=/dev/null
+    source "$HELPERS_DIR/hash-utils.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# ---------------------------------------------------------------------------
+# Happy path — normal filename
+# ---------------------------------------------------------------------------
+
+@test "sha256_file: returns a bare 64-hex-char hash for a normal-named file" {
+    local file="$TEST_TEMP_DIR/normal.bin"
+    printf 'hello world\n' > "$file"
+
+    run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    # Must be exactly 64 lowercase hex characters (no trailing newline counted)
+    [[ "$output" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "sha256_file: matches sha256sum < file | awk for a normal-named file" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    printf 'test data for sha256\n' > "$file"
+
+    expected=$(sha256sum < "$file" | awk '{print $1}')
+    run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+}
+
+# ---------------------------------------------------------------------------
+# Regression lock — backslash in filename
+# ---------------------------------------------------------------------------
+
+@test "sha256_file: returns a clean 64-hex hash for a file whose name contains a backslash" {
+    # On Linux, '\' is a legal filename character.  This simulates Windows
+    # Git Bash paths like C:\Users\runner\... that trigger GNU sha256sum's
+    # filename-escaping behaviour.
+    local file="$TEST_TEMP_DIR/foo\\bar.exe"
+    printf 'buildx binary simulation\n' > "$file"
+
+    run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    # (a) Exactly 64 hex characters — no leading backslash, no other prefix
+    [[ "$output" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "OLD approach: sha256sum on a backslash-named file DOES produce a leading backslash (documents the bug)" {
+    # This test intentionally demonstrates the bug the fix prevents.
+    # sha256sum escapes filenames containing backslashes by prefixing the line
+    # with '\', so awk '{print $1}' returns '\<hash>' — not a bare hash.
+    local file="$TEST_TEMP_DIR/foo\\bar.exe"
+    printf 'buildx binary simulation\n' > "$file"
+
+    old_result=$(sha256sum "$file" | awk '{print $1}')
+    # The old approach starts with a backslash — this is the bug
+    [[ "$old_result" == \\* ]]
+}
+
+@test "sha256_file: backslash-named file hash equals sha256sum-stdin hash" {
+    local file="$TEST_TEMP_DIR/foo\\bar.exe"
+    printf 'consistent data\n' > "$file"
+
+    expected=$(sha256sum < "$file" | awk '{print $1}')
+    run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fail-closed — missing or unreadable file
+# ---------------------------------------------------------------------------
+
+@test "sha256_file: returns non-zero for a missing file" {
+    run sha256_file "$TEST_TEMP_DIR/does-not-exist.bin"
+    [ "$status" -ne 0 ]
+}
+
+@test "sha256_file: returns non-zero for an unreadable file" {
+    local file="$TEST_TEMP_DIR/unreadable.bin"
+    printf 'secret\n' > "$file"
+    chmod 000 "$file"
+
+    run sha256_file "$file"
+    [ "$status" -ne 0 ]
+
+    # Restore so teardown can clean up
+    chmod 644 "$file"
+}
+
+@test "sha256_file: returns non-zero when called without arguments" {
+    run sha256_file
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Repairs the `github-runner` **Windows** builds, which failed on master. Three coupled fixes, each exposing the next:

## 1. buildx SHA256 verification — backslash-safe (the original #669)

GNU `sha256sum` prefixes its output line with `\` and escapes the filename when the path contains backslashes. On Windows Git Bash, `$USERPROFILE` → `C:\Users\runner`, so `dest="$USERPROFILE/.docker/cli-plugins/docker-buildx.exe"` contained backslashes and `sha256sum "$dest" | awk '{print $1}'` returned `\<hash>` → the comparison always failed at ~30s. New `helpers/hash-utils.sh::sha256_file()` hashes **via stdin** (filename `-`, never escaped); the Windows buildx step uses it. Regression test `tests/unit/hash-utils.bats` (8/8, runs in CI) locks a backslash-named-file case and documents the old failing pattern.

## 2. Drop `docker system prune` from the Windows disk-cleanup step

Once buildx passed, the build reached the cleanup step and `docker system prune -af --volumes` returned non-zero (PowerShell propagates native non-zero exits; `2>$null` only hid stderr). GitHub-hosted Windows runners are **ephemeral** — nothing from a prior job to reclaim — and a full prune deletes the pre-cached Windows base images, forcing a slow multi-GB re-pull. Removed it; the `Remove-Item` cleanup frees the actual reclaimable space.

## 3. `--pull` the rolling Windows base on build

Keeping the pre-cached base (no prune) re-opened a provenance gap: the Windows classic `docker build` had **no `--pull`**, so it could build from a stale cached `servercore/server:ltsc2022` (rolling tag, no digest pin) while the lineage records the **current remote** digest (`imagetools inspect`, before the build). Added `--pull` to the **Windows-only** branch in `scripts/build-container.sh` so the build stays aligned with the recorded base (layers still cache when the tag is unchanged). The Linux/buildx path keeps `--pull=never` (GHCR-seeded).

## Validation

- Unit: `hash-utils.bats` 8/8, `build-container.bats` 17/17; shellcheck clean.
- Orthogonal gate (codex + copilot) CLEAN on the full branch.
- End-to-end: first validation run already showed both Windows variants pass the buildx step and `windows-ltsc2022-base` builds fully green; a fresh run on this branch confirms both variants — linked in a follow-up comment.

Closes #669.