### PR TITLE
refactor(ci): emit REMOTE_CR explicitly in the matrix build-arg assembler (#666)

### DIFF
--- a/helpers/build-args-utils.sh
+++ b/helpers/build-args-utils.sh
@@ -92,6 +92,18 @@ prepare_build_args() {
         fi
     fi
 
+    # Emit REMOTE_CR unconditionally — all matrix Dockerfiles declare ARG REMOTE_CR.
+    # Value mirrors the bake path (scripts/generate-bake-hcl.sh L45): env-or-default.
+    # Validate before emitting: REMOTE_CR enters a word-split arg string, so a value
+    # containing whitespace or flag-like tokens would inject extra Docker CLI args.
+    # Allow only the safe registry-reference charset: letters, digits, and ._-:/
+    local remote_cr="${REMOTE_CR:-ghcr.io/oorabona}"
+    if [[ ! "$remote_cr" =~ ^[A-Za-z0-9._:/-]+$ ]]; then
+        log_error "REMOTE_CR value is unsafe and was rejected: '${remote_cr}'" >&2
+        return 1
+    fi
+    _BUILD_ARGS="$_BUILD_ARGS --build-arg REMOTE_CR=$remote_cr"
+
     [[ -n "$flavor" ]] && _BUILD_ARGS="$_BUILD_ARGS --build-arg FLAVOR=$flavor"
     [[ -n "${NPROC:-}" ]] && _BUILD_ARGS="$_BUILD_ARGS --build-arg NPROC=$NPROC"
 

--- a/tests/unit/build-args-utils.bats
+++ b/tests/unit/build-args-utils.bats
@@ -241,8 +241,8 @@ EOF
     [[ "$_BUILD_ARGS" =~ "--build-arg VERSION=8.4" ]]
     [[ "$_BUILD_ARGS" =~ "--build-arg COMPOSER_VERSION=2.9.8" ]]
     [[ "$_BUILD_ARGS" =~ "--build-arg APCU_VERSION=5.1.28" ]]
-    # Must NOT contain REMOTE_CR
-    [[ ! "$_BUILD_ARGS" =~ "REMOTE_CR" ]]
+    # REMOTE_CR must be present (emitted unconditionally by prepare_build_args)
+    [[ "$_BUILD_ARGS" =~ "--build-arg REMOTE_CR=" ]]
 }
 
 # Regression lock: no config.yaml → prepare_build_args still succeeds (no abort)
@@ -252,4 +252,77 @@ EOF
     prepare_build_args "2.0"
     [ $? -eq 0 ]
     cd ..
+}
+
+# ─── REMOTE_CR emission from prepare_build_args ───────────────────────────────
+
+@test "PAB-REMOTE_CR-01: prepare_build_args emits default REMOTE_CR when env unset" {
+    make_container "." "$(cat <<'EOF'
+build_args:
+  COMPOSER_VERSION: "2.9.8"
+EOF
+)"
+    make_version_stub
+    unset REMOTE_CR
+    prepare_build_args "8.4"
+    [ $? -eq 0 ]
+    [[ "$_BUILD_ARGS" =~ "--build-arg REMOTE_CR=ghcr.io/oorabona" ]]
+}
+
+@test "PAB-REMOTE_CR-02: prepare_build_args emits REMOTE_CR from env when set" {
+    make_container "." "$(cat <<'EOF'
+build_args:
+  COMPOSER_VERSION: "2.9.8"
+EOF
+)"
+    make_version_stub
+    export REMOTE_CR="ghcr.io/fork"
+    prepare_build_args "8.4"
+    local rc=$?
+    unset REMOTE_CR
+    [ $rc -eq 0 ]
+    [[ "$_BUILD_ARGS" =~ "--build-arg REMOTE_CR=ghcr.io/fork" ]]
+    # Must NOT fall back to default when env is explicitly set
+    [[ ! "$_BUILD_ARGS" =~ "--build-arg REMOTE_CR=ghcr.io/oorabona" ]]
+}
+
+# ─── REMOTE_CR injection-guard: reject unsafe values (fail-closed) ────────────
+
+@test "PAB-REMOTE_CR-03: prepare_build_args rejects REMOTE_CR with injected flag (space+--no-cache), blocks injection" {
+    make_container "." "$(cat <<'EOF'
+build_args:
+  COMPOSER_VERSION: "2.9.8"
+EOF
+)"
+    make_version_stub
+    export REMOTE_CR="ghcr.io/x --no-cache"
+    # Reset _BUILD_ARGS; capture rc via if-clause (avoids set-e killing the test)
+    _BUILD_ARGS=""
+    local rc=0
+    if ! prepare_build_args "8.4" 2>/dev/null; then rc=1; fi
+    local captured_build_args="$_BUILD_ARGS"
+    unset REMOTE_CR
+    # Must fail closed — non-zero exit
+    [ $rc -ne 0 ]
+    # Injected token must NOT appear in _BUILD_ARGS (the actual docker arg string)
+    [[ ! "$captured_build_args" =~ "--no-cache" ]]
+}
+
+@test "PAB-REMOTE_CR-04: prepare_build_args rejects REMOTE_CR with shell-metachar injection (semicolon), blocks injection" {
+    make_container "." "$(cat <<'EOF'
+build_args:
+  COMPOSER_VERSION: "2.9.8"
+EOF
+)"
+    make_version_stub
+    export REMOTE_CR="ghcr.io/x;rm -rf /"
+    _BUILD_ARGS=""
+    local rc=0
+    if ! prepare_build_args "8.4" 2>/dev/null; then rc=1; fi
+    local captured_build_args="$_BUILD_ARGS"
+    unset REMOTE_CR
+    # Must fail closed — non-zero exit
+    [ $rc -ne 0 ]
+    # Destructive token must NOT appear in _BUILD_ARGS
+    [[ ! "$captured_build_args" =~ "rm -rf" ]]
 }


### PR DESCRIPTION
## What & why

On the **bake** path, `REMOTE_CR` (the `FROM ${REMOTE_CR}/<base>` registry prefix) is an explicit pipeline value: emitted unconditionally by `generate-bake-hcl.sh`. On the **flat-matrix** path it was *not* emitted by `prepare_build_args` — it only appeared as a side effect of the `base_image_cache` probe (`emit_reachable_cache_args`), otherwise relying on the Dockerfile `ARG REMOTE_CR=ghcr.io/oorabona` default. So REMOTE_CR's matrix source was implicit and probe-conditional, which made even trivial base-cache cleanups hard to reason about.

This makes the matrix path source `REMOTE_CR` explicitly, the same way bake does.

## Change

- `helpers/build-args-utils.sh::prepare_build_args` now emits `--build-arg REMOTE_CR=${REMOTE_CR:-ghcr.io/oorabona}` for every matrix build — an explicit, consistent source with the same env-or-default semantics as the bake path. All 10 matrix-built Dockerfiles declare `ARG REMOTE_CR`, so this is never an unused build-arg. Production resolves to `ghcr.io/oorabona`; the probe still narrows to the owner namespace only when reachable (so fork PRs keep pulling the seeded `oorabona` bases).
- **Injection hardening**: `_BUILD_ARGS` is word-split into the `docker build` command, and `REMOTE_CR` comes from the environment. The value is now validated against a safe container-registry-reference charset (`^[A-Za-z0-9._:/-]+$`) and the build-arg prep **fails closed** on violation — a whitespace/flag/metachar value (e.g. `ghcr.io/x --no-cache`) can no longer inject Docker CLI flags. (The bake path is already injection-safe via `jq --arg`.)

## Validation

- `tests/unit/build-args-utils.bats`: 21/21 — including unset→default, env override, and two injection-guard cases (`ghcr.io/x --no-cache` and `ghcr.io/x;rm -rf /` → rejected, no malicious tokens emitted).
- base-cache unit suite untouched and green (128/128); shellcheck clean.
- Orthogonal gate (codex CLEAN; copilot exogenously unable to assess → degraded GATE_OK).
- End-to-end: this PR's `pull_request` auto-build builds the fleet via the FLAT MATRIX with the new explicit REMOTE_CR — all matrix Linux builds + postgres staying green is the fleet-wide proof.

## Scope note

This is the REMOTE_CR-source groundwork extracted from a larger attempt. The #666 **A1** cleanup (dropping wordpress's `base_image_cache`) was found to be coupled — that entry also drives a php-published probe (same-run sequencing) and the daily cache audit — so A1 is **deferred** to Phase A2 (matrix ordering), not landed here. Refs #666.
