### PR TITLE
fix(ci): guard local single-arch push from clobbering a published multi-arch tag (#624)

### DIFF
--- a/scripts/push-container.sh
+++ b/scripts/push-container.sh
@@ -14,6 +14,82 @@ source "$PROJECT_ROOT/helpers/retry.sh"
 # Source build utilities for platform detection
 source "$SCRIPT_DIR/build-container.sh"
 
+# Count distinct linux/* platforms from "docker buildx imagetools inspect" output.
+# Shared by both _guard_local_single_arch_push and _ghcr_source_is_single_arch.
+# Prints the count; returns 0 on success, 1 if inspect failed (tag absent /
+# registry unreachable).
+_count_linux_platforms() {
+    local ref="$1"
+
+    local inspect_out
+    inspect_out=$($DOCKER buildx imagetools inspect "$ref" 2>&1) || return 1
+
+    printf '%s\n' "$inspect_out" \
+        | grep -oE 'linux/(amd64|arm64|arm/v[0-9]+|386|s390x|ppc64le|riscv64)' \
+        | sort -u \
+        | wc -l
+}
+
+# Returns 0 (true) if the ref is confirmed multi-arch (>1 linux/* platforms).
+# Returns 1 (false) for single-arch, absent, or any probe failure.
+# Used to decide whether a skopeo --all copy is safe to skip the target guard:
+# only a positively-confirmed multi-arch GHCR source is safe to mirror without
+# guarding the target (it faithfully reproduces multi-arch on the destination).
+# Any uncertainty — including probe failure — falls through to the target guard.
+_ghcr_source_is_multiarch() {
+    local ref="$1"
+
+    local count
+    count=$(_count_linux_platforms "$ref") || return 1
+
+    [[ "$count" -gt 1 ]]
+}
+
+# Guard against a local single-arch bare-tag push clobbering a published
+# multi-arch OCI image index.  Only fires when ALL of these are true:
+#   - Running outside CI (GITHUB_ACTIONS unset or not "true")
+#   - Single-arch local build (platform_suffix is empty, no QEMU)
+#   - ALLOW_MULTIARCH_CLOBBER is NOT set to 1 or true
+# Probes the target ref with "docker buildx imagetools inspect".
+# Fail-open: if the ref is absent or the registry is unreachable the push is
+# allowed.  Only a positively-confirmed multi-platform manifest blocks.
+# Returns: 0 = safe to push, 1 = blocked (clobber detected)
+_guard_local_single_arch_push() {
+    local ref="$1"
+
+    # No-op in CI
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        return 0
+    fi
+
+    # Override: operator explicitly allows the clobber
+    if [[ "${ALLOW_MULTIARCH_CLOBBER:-0}" == "1" || "${ALLOW_MULTIARCH_CLOBBER:-}" == "true" ]]; then
+        log_warning "ALLOW_MULTIARCH_CLOBBER override active — skipping multi-arch clobber guard for $ref"
+        return 0
+    fi
+
+    # Count distinct non-unknown linux/* platform entries reported by inspect.
+    local platform_count
+    platform_count=$(_count_linux_platforms "$ref") || {
+        # inspect failed — tag absent or registry unreachable; fail-open
+        return 0
+    }
+
+    if [[ "$platform_count" -gt 1 ]]; then
+        log_error "REFUSED: $ref is a multi-platform manifest ($platform_count platforms)."
+        log_error "A local single-arch push would overwrite the multi-arch OCI index"
+        log_error "and break consumers on the other architecture(s)."
+        log_error "Escape hatches:"
+        log_error "  (a) Let CI publish the canonical tag via GitHub Actions."
+        log_error "  (b) Push to a namespace you own: GITHUB_REPOSITORY_OWNER=<you> ./make push ..."
+        log_error "  (c) Override intentionally:   ALLOW_MULTIARCH_CLOBBER=1 ./make push ..."
+        return 1
+    fi
+
+    # Single-arch or empty manifest — no clobber risk
+    return 0
+}
+
 # Get platform configuration - sets global variables
 # After calling: PLATFORM_CONFIG_PLATFORMS, PLATFORM_CONFIG_SUFFIX, PLATFORM_CONFIG_EFFECTIVE_TAG
 get_platform_config() {
@@ -102,6 +178,18 @@ push_ghcr() {
     log_success "Build args: $build_args"
     log_success "Cache: $cache_image"
 
+    # Guard: refuse if a local single-arch push would clobber a multi-arch tag.
+    # Fires only when ALL of:
+    #   - no arch suffix (bare-tag path)
+    #   - single-arch build (not the QEMU multi-platform linux/amd64,linux/arm64 path)
+    # Probes every tag that will be pushed (effective_tag and, when wanted=latest, :latest).
+    if [[ -z "$platform_suffix" && "$platforms" == "linux/amd64" ]]; then
+        _guard_local_single_arch_push "$ghcr_image:$effective_tag" || return 1
+        if [[ "$wanted" == "latest" ]]; then
+            _guard_local_single_arch_push "$ghcr_image:latest" || return 1
+        fi
+    fi
+
     # Build and push with retry (includes cache update)
     retry_with_backoff 3 5 $DOCKER buildx build \
         --platform "$platforms" \
@@ -153,6 +241,19 @@ push_dockerhub() {
     if command -v skopeo >/dev/null 2>&1; then
         log_info "Using skopeo copy: GHCR → Docker Hub (no rebuild)"
 
+        # Source-aware clobber guard for the skopeo path:
+        # skopeo copy --all mirrors whatever the GHCR source contains.  When
+        # the GHCR source is single-arch (or when the source probe fails for
+        # any reason) and the Docker Hub target is currently multi-arch, --all
+        # would overwrite the multi-arch index with a single-arch image.
+        # Apply the target guard unless the GHCR source is positively confirmed
+        # to be multi-arch (the only case where --all is a safe faithful mirror).
+        # Fail-closed on probe failure: uncertainty about the source defaults
+        # to guarding the target.
+        if ! _ghcr_source_is_multiarch "$ghcr_image:$effective_tag"; then
+            _guard_local_single_arch_push "$dockerhub_image:$effective_tag" || return 1
+        fi
+
         # Copy the tagged image
         if retry_with_backoff 5 10 $SKOPEO copy \
             --all \
@@ -163,6 +264,10 @@ push_dockerhub() {
 
             # Also copy as :latest if requested
             if [[ "$wanted" == "latest" ]]; then
+                # Guard the :latest target unless the GHCR source is confirmed multi-arch
+                if ! _ghcr_source_is_multiarch "$ghcr_image:$effective_tag"; then
+                    _guard_local_single_arch_push "$dockerhub_image:latest" || return 1
+                fi
                 $SKOPEO copy --all \
                     "docker://$ghcr_image:$effective_tag" \
                     "docker://$dockerhub_image:latest" 2>/dev/null || \
@@ -197,6 +302,16 @@ push_dockerhub() {
 
     log_success "Image: $dockerhub_image:$effective_tag"
     log_success "Platform: $platforms"
+
+    # Guard: a local single-arch buildx fallback must not overwrite a published
+    # multi-arch Docker Hub tag (mirrors the GHCR guard in push_ghcr). Fires only
+    # on the bare-tag single-arch local path; no-op in CI and the QEMU multi-arch path.
+    if [[ -z "$platform_suffix" && "$platforms" == "linux/amd64" ]]; then
+        _guard_local_single_arch_push "$dockerhub_image:$effective_tag" || return 1
+        if [[ "$wanted" == "latest" ]]; then
+            _guard_local_single_arch_push "$dockerhub_image:latest" || return 1
+        fi
+    fi
 
     retry_with_backoff 5 10 $DOCKER buildx build \
         --platform "$platforms" \

--- a/tests/unit/push-container.bats
+++ b/tests/unit/push-container.bats
@@ -222,7 +222,10 @@ teardown() {
 # =============================================================================
 
 @test "push_ghcr calls docker buildx build with correct registry" {
-    # Mock check_multiplatform_support
+    # Pin single-arch path via the cache var — re-source-proof (build-container.sh
+    # checks MULTIPLATFORM_SUPPORTED before running detection logic).
+    export MULTIPLATFORM_SUPPORTED=false
+    # Keep function override as belt-and-suspenders before sourcing.
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -250,6 +253,7 @@ EOF
 }
 
 @test "push_ghcr includes cache-to for writing cache" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -280,6 +284,7 @@ EOF
 # =============================================================================
 
 @test "push_dockerhub calls docker buildx build with correct registry" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -294,7 +299,21 @@ echo "DOCKER: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
 exit 0
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+
+    # Skopeo stub: exits non-zero immediately so the test reaches the buildx
+    # fallback path deterministically on any host (with or without real skopeo).
+    # retry_with_backoff is overridden below so the stub failure doesn't cause
+    # 150 s of exponential-backoff sleep (5 retries × 10/20/40/80 s).
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    # No-sleep retry: skopeo fails fast, guard probe needs no retry; this
+    # prevents a 150 s stall from retry_with_backoff 5 10 on the skopeo call.
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
 
     create_mock_container "testcontainer" "1.0.0"
 
@@ -306,6 +325,7 @@ EOF
 }
 
 @test "push_dockerhub uses read-only cache (no cache-to)" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -320,7 +340,16 @@ echo "DOCKER: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
 exit 0
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+
+    # Skopeo stub + no-sleep retry (same rationale as push_dockerhub/registry test).
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
 
     create_mock_container "testcontainer" "1.0.0"
 
@@ -338,6 +367,7 @@ EOF
 # =============================================================================
 
 @test "push_container calls both registries" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -352,7 +382,15 @@ echo "DOCKER: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
 exit 0
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+    # Skopeo stub + no-sleep retry: push_dockerhub uses skopeo when available;
+    # stub forces the buildx fallback deterministically without slow retries.
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
 
     create_mock_container "testcontainer" "1.0.0"
 
@@ -365,6 +403,7 @@ EOF
 }
 
 @test "push_container continues if Docker Hub fails" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -383,7 +422,14 @@ fi
 exit 0
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+    # Skopeo stub + no-sleep retry (same rationale as push_container/both-registries test).
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
 
     create_mock_container "testcontainer" "1.0.0"
 
@@ -395,6 +441,7 @@ EOF
 }
 
 @test "push_container fails if GHCR fails" {
+    export MULTIPLATFORM_SUPPORTED=false
     check_multiplatform_support() { return 1; }
     export -f check_multiplatform_support
 
@@ -413,7 +460,14 @@ fi
 exit 0
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+    # Skopeo stub + no-sleep retry (same rationale as push_container/both-registries test).
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
 
     create_mock_container "testcontainer" "1.0.0"
 
@@ -422,4 +476,711 @@ EOF
 
     # Should fail since GHCR is primary
     [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# _guard_local_single_arch_push tests
+# Mutation articulated for each case: without the guard the single-arch push
+# would silently overwrite a multi-arch OCI image index on the bare tag.
+# =============================================================================
+
+# Helper: build a mock docker binary inside TEST_TEMP_DIR/bin that logs calls
+# and responds to "buildx imagetools inspect <ref>" with caller-supplied output
+# and exit code.  All other docker sub-commands succeed.
+_setup_docker_mock_with_inspect() {
+    local inspect_output="$1"
+    local inspect_rc="${2:-0}"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    # Write inspect output and rc to files so the heredoc can reference them
+    printf '%s' "$inspect_output" > "$TEST_TEMP_DIR/inspect_output"
+    printf '%s' "$inspect_rc"     > "$TEST_TEMP_DIR/inspect_rc"
+
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "DOCKER_CALL: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+if [[ "$1 $2 $3" == "buildx imagetools inspect" ]]; then
+    cat "$TEST_TEMP_DIR/inspect_output"
+    exit "$(cat "$TEST_TEMP_DIR/inspect_rc")"
+fi
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+@test "guard: local single-arch push blocked when target is multi-platform" {
+    # Mutation: without the guard, push_ghcr would invoke 'docker buildx build
+    # --push' and overwrite the multi-arch OCI index with a single-arch image.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # imagetools inspect returns two distinct linux/* platforms → multi-arch
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:abc123
+
+Manifests:
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:aaa
+  MediaType: application/vnd.oci.image.manifest.v1+json
+  Platform:  linux/amd64
+
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:bbb
+  MediaType: application/vnd.oci.image.manifest.v1+json
+  Platform:  linux/arm64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$multiarch_inspect" 0
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must be refused (non-zero)
+    [ "$status" -ne 0 ]
+    # The actual buildx build --push must NOT have been invoked
+    ! grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log" 2>/dev/null
+    # Error message must mention the clobber
+    [[ "$output" == *"multi-platform"* ]] || [[ "$output" == *"REFUSED"* ]]
+}
+
+@test "guard: local single-arch Docker Hub fallback push blocked when target is multi-platform" {
+    # Mutation: without the guard in push_dockerhub's buildx fallback, a local
+    # single-arch push (skopeo unavailable) would overwrite a multi-arch Docker Hub
+    # tag — the same clobber class as GHCR, on the secondary registry.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      docker.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$multiarch_inspect" 0
+
+    # Skopeo stub: exits non-zero immediately so push_dockerhub falls through to
+    # the buildx path on any host (with or without real skopeo installed).
+    # Choice: fast-failing stub + no-sleep retry override beats stripping PATH
+    # (too fragile) and beats a non-executable stub (command -v would fall
+    # through to any system skopeo).  retry_with_backoff 5 10 on a failing skopeo
+    # would sleep 150 s; the override makes it a single-attempt, no-sleep call.
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    # No-sleep retry: one attempt, no sleep — prevents slow retry on skopeo failure.
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must be refused (non-zero); the buildx build --push must NOT have run
+    [ "$status" -ne 0 ]
+    ! grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log" 2>/dev/null
+    [[ "$output" == *"multi-platform"* ]] || [[ "$output" == *"REFUSED"* ]]
+}
+
+@test "guard: local single-arch push allowed when target tag is absent (fail-open)" {
+    # Mutation: if the guard incorrectly blocked on a missing tag, a first-time
+    # push would always fail — demonstrating the guard fires only on confirmed
+    # multi-arch manifests, not on probe failures.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # imagetools inspect exits non-zero (tag does not exist)
+    _setup_docker_mock_with_inspect "manifest unknown" 1
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed (fail-open on missing tag)
+    [ "$status" -eq 0 ]
+    grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log"
+}
+
+@test "guard: local single-arch push allowed when target tag is single-arch" {
+    # Mutation: if the guard over-blocked single-arch targets, it would break
+    # legitimate first-arch pushes to containers that never had multi-arch.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # imagetools inspect returns only one linux/* platform
+    local singlearch_inspect
+    singlearch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.manifest.v1+json
+Digest:    sha256:abc123
+Platform:  linux/amd64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$singlearch_inspect" 0
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — no clobber risk
+    [ "$status" -eq 0 ]
+    grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log"
+}
+
+@test "guard: ALLOW_MULTIARCH_CLOBBER=1 bypasses guard even when target is multi-platform" {
+    # Mutation: if the override were ignored, the operator escape hatch would
+    # not work and intentional clobbers (e.g. emergency rollback) would fail.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    export ALLOW_MULTIARCH_CLOBBER=1
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:abc123
+
+Manifests:
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:aaa
+  Platform:  linux/amd64
+
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:bbb
+  Platform:  linux/arm64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$multiarch_inspect" 0
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — operator override is active
+    [ "$status" -eq 0 ]
+    grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log"
+}
+
+@test "guard: GITHUB_ACTIONS=true bypasses guard even when target is multi-platform" {
+    # Mutation: if CI were not excluded, the bake/CI path (which sets
+    # GITHUB_ACTIONS=true) would hit the imagetools inspect probe on every
+    # push, adding latency and a potential point of failure in CI.
+    # The guard must be a strict no-op in CI regardless of the manifest state.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    export GITHUB_ACTIONS="true"
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:abc123
+
+Manifests:
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:aaa
+  Platform:  linux/amd64
+
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:bbb
+  Platform:  linux/arm64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$multiarch_inspect" 0
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — CI is never blocked by the guard
+    [ "$status" -eq 0 ]
+    grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log"
+}
+
+@test "guard: local single-arch push refused when :latest tag is multi-platform" {
+    # Mutation: without probing the :latest tag, a push with wanted=latest
+    # would silently overwrite the multi-arch :latest index even when the
+    # versioned tag probe succeeds or is absent.  Both tags that a single
+    # buildx call will push must each be probed independently.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:latest
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:abc123
+
+Manifests:
+  Name:      ghcr.io/testowner/testcontainer:latest@sha256:aaa
+  Platform:  linux/amd64
+
+  Name:      ghcr.io/testowner/testcontainer:latest@sha256:bbb
+  Platform:  linux/arm64
+INSPECT
+)"
+    # The versioned tag is absent (inspect fails), but :latest is multi-arch
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    printf '%s' "$multiarch_inspect" > "$TEST_TEMP_DIR/inspect_output_latest"
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "DOCKER_CALL: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+if [[ "$1 $2 $3" == "buildx imagetools inspect" ]]; then
+    ref="$4"
+    if [[ "$ref" == *":latest" ]]; then
+        cat "$TEST_TEMP_DIR/inspect_output_latest"
+        exit 0
+    fi
+    echo "manifest unknown" >&2
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must be refused because :latest is multi-arch
+    [ "$status" -ne 0 ]
+    ! grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log" 2>/dev/null
+}
+
+# Helper: docker mock that returns different inspect output depending on the ref.
+# Callers pre-write <TEST_TEMP_DIR>/inspect_output_<safe_ref> files (where
+# <safe_ref> replaces ':' and '/' with '_') and set inspect_rc_<safe_ref> files.
+# Falls back to inspect_output / inspect_rc files when no per-ref file exists.
+_setup_docker_mock_with_per_ref_inspect() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "DOCKER_CALL: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+if [[ "$1 $2 $3" == "buildx imagetools inspect" ]]; then
+    ref="$4"
+    safe_ref="${ref//[:\/]/_}"
+    out_file="$TEST_TEMP_DIR/inspect_output_${safe_ref}"
+    rc_file="$TEST_TEMP_DIR/inspect_rc_${safe_ref}"
+    # Fall back to generic files when no per-ref file exists
+    [[ -f "$out_file" ]] || out_file="$TEST_TEMP_DIR/inspect_output"
+    [[ -f "$rc_file"  ]] || rc_file="$TEST_TEMP_DIR/inspect_rc"
+    [[ -f "$out_file" ]] && cat "$out_file"
+    exit "$(cat "$rc_file" 2>/dev/null || echo 1)"
+fi
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+@test "guard: QEMU multi-platform path is never refused even when target is multi-platform" {
+    # Mutation: if the guard fired on the QEMU path (platforms=linux/amd64,linux/arm64)
+    # it would prevent a legitimate multi-arch rebuild of an existing multi-arch
+    # index.  The guard must be restricted to the single-arch case
+    # (platforms == linux/amd64) and must not trigger on QEMU builds.
+
+    # Pin multi-platform path via the cache var BEFORE sourcing — re-source-proof.
+    # build-container.sh checks MULTIPLATFORM_SUPPORTED first; setting it here
+    # prevents the post-source function override from being the sole guarantee.
+    export MULTIPLATFORM_SUPPORTED=true
+
+    source_push_script
+
+    # Function override kept as belt-and-suspenders (runs after re-source).
+    check_multiplatform_support() { return 0; }
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    local multiarch_inspect
+    multiarch_inspect="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:abc123
+
+Manifests:
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:aaa
+  Platform:  linux/amd64
+
+  Name:      ghcr.io/testowner/testcontainer:1.0.0@sha256:bbb
+  Platform:  linux/arm64
+INSPECT
+)"
+    _setup_docker_mock_with_inspect "$multiarch_inspect" 0
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_ghcr "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — QEMU multi-platform push does not clobber a multi-arch index
+    [ "$status" -eq 0 ]
+    grep -q "buildx build" "$TEST_TEMP_DIR/docker_calls.log"
+}
+
+# =============================================================================
+# skopeo copy path — source-aware clobber guard tests
+# Mutation articulated for each case: without the source-aware guard, a
+# skopeo copy --all of a single-arch GHCR source would silently overwrite
+# a multi-arch Docker Hub OCI index.
+# =============================================================================
+
+@test "skopeo path: GHCR source single-arch + Docker Hub target multi-arch → refused" {
+    # Mutation: without the source-aware guard, skopeo copy --all of the
+    # single-arch GHCR source would overwrite the multi-arch Docker Hub index.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # GHCR source: single-arch (only linux/amd64)
+    local ghcr_single
+    ghcr_single="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.manifest.v1+json
+Platform:  linux/amd64
+INSPECT
+)"
+    # Docker Hub target: multi-arch
+    local dh_multi
+    dh_multi="$(cat << 'INSPECT'
+Name:      docker.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    _setup_docker_mock_with_per_ref_inspect
+
+    # Write per-ref inspect files using the same key-encoding as the mock
+    # (replace ':' and '/' with '_')
+    printf '%s' "$ghcr_single" > "$TEST_TEMP_DIR/inspect_output_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '0'                  > "$TEST_TEMP_DIR/inspect_rc_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '%s' "$dh_multi"    > "$TEST_TEMP_DIR/inspect_output_docker.io_testowner_testcontainer_1.0.0"
+    printf '0'                  > "$TEST_TEMP_DIR/inspect_rc_docker.io_testowner_testcontainer_1.0.0"
+
+    # skopeo stub exits 0 so we reach the copy path and can assert the guard
+    # fires BEFORE the copy (i.e. push_dockerhub returns non-zero without
+    # executing skopeo copy).
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+echo "SKOPEO_CALL: $*" >> "$TEST_TEMP_DIR/skopeo_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+
+    # No-sleep retry to keep the test fast
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must be refused
+    [ "$status" -ne 0 ]
+    # skopeo copy --all must NOT have been executed
+    ! grep -q "copy" "$TEST_TEMP_DIR/skopeo_calls.log" 2>/dev/null
+    [[ "$output" == *"multi-platform"* ]] || [[ "$output" == *"REFUSED"* ]]
+}
+
+@test "skopeo path: GHCR source multi-arch + Docker Hub target multi-arch → allowed (legitimate mirror)" {
+    # Mutation: if the guard were source-unaware and blocked on the target
+    # being multi-arch regardless of the source, this legitimate multi-arch
+    # mirror would be incorrectly refused.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # GHCR source: multi-arch
+    local ghcr_multi
+    ghcr_multi="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+    # Docker Hub target: also multi-arch
+    local dh_multi
+    dh_multi="$(cat << 'INSPECT'
+Name:      docker.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    _setup_docker_mock_with_per_ref_inspect
+
+    printf '%s' "$ghcr_multi" > "$TEST_TEMP_DIR/inspect_output_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '0'                 > "$TEST_TEMP_DIR/inspect_rc_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '%s' "$dh_multi"   > "$TEST_TEMP_DIR/inspect_output_docker.io_testowner_testcontainer_1.0.0"
+    printf '0'                 > "$TEST_TEMP_DIR/inspect_rc_docker.io_testowner_testcontainer_1.0.0"
+
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+echo "SKOPEO_CALL: $*" >> "$TEST_TEMP_DIR/skopeo_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — multi-arch source faithfully mirrors to Docker Hub
+    [ "$status" -eq 0 ]
+    grep -q "copy" "$TEST_TEMP_DIR/skopeo_calls.log"
+}
+
+@test "skopeo path: Docker Hub target absent → push proceeds (no clobber risk)" {
+    # Mutation: if the guard incorrectly blocked on a missing Docker Hub target,
+    # a first-time skopeo mirror would always fail.  The fail-open semantics
+    # must allow the copy when the target tag is absent.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # GHCR source: single-arch
+    local ghcr_single
+    ghcr_single="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.manifest.v1+json
+Platform:  linux/amd64
+INSPECT
+)"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    _setup_docker_mock_with_per_ref_inspect
+
+    printf '%s' "$ghcr_single"  > "$TEST_TEMP_DIR/inspect_output_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '0'                   > "$TEST_TEMP_DIR/inspect_rc_ghcr.io_testowner_testcontainer_1.0.0"
+    # Docker Hub inspect fails (tag absent)
+    printf 'manifest unknown'   > "$TEST_TEMP_DIR/inspect_output_docker.io_testowner_testcontainer_1.0.0"
+    printf '1'                   > "$TEST_TEMP_DIR/inspect_rc_docker.io_testowner_testcontainer_1.0.0"
+
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+echo "SKOPEO_CALL: $*" >> "$TEST_TEMP_DIR/skopeo_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — absent target is fail-open
+    [ "$status" -eq 0 ]
+    grep -q "copy" "$TEST_TEMP_DIR/skopeo_calls.log"
+}
+
+@test "skopeo path: GITHUB_ACTIONS=true bypasses source-aware guard" {
+    # Mutation: if the guard fired in CI, the skopeo mirror step in GitHub
+    # Actions would be blocked even for legitimate production pushes.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    export GITHUB_ACTIONS="true"
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # GHCR source: single-arch; Docker Hub target: multi-arch
+    local ghcr_single
+    ghcr_single="$(cat << 'INSPECT'
+Name:      ghcr.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.manifest.v1+json
+Platform:  linux/amd64
+INSPECT
+)"
+    local dh_multi
+    dh_multi="$(cat << 'INSPECT'
+Name:      docker.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    _setup_docker_mock_with_per_ref_inspect
+
+    printf '%s' "$ghcr_single" > "$TEST_TEMP_DIR/inspect_output_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '0'                  > "$TEST_TEMP_DIR/inspect_rc_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '%s' "$dh_multi"    > "$TEST_TEMP_DIR/inspect_output_docker.io_testowner_testcontainer_1.0.0"
+    printf '0'                  > "$TEST_TEMP_DIR/inspect_rc_docker.io_testowner_testcontainer_1.0.0"
+
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+echo "SKOPEO_CALL: $*" >> "$TEST_TEMP_DIR/skopeo_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must succeed — CI is never blocked by the guard
+    [ "$status" -eq 0 ]
+    grep -q "copy" "$TEST_TEMP_DIR/skopeo_calls.log"
+}
+
+@test "skopeo path: GHCR source probe fails + Docker Hub target multi-arch → refused (fail-closed)" {
+    # Mutation: if a failed GHCR source probe caused the guard to be skipped
+    # (fail-open), a single-arch GHCR source that is only temporarily
+    # unreachable for inspection could still clobber a multi-arch Docker Hub
+    # index when skopeo can still copy.  The guard must apply on uncertainty.
+    export MULTIPLATFORM_SUPPORTED=false
+    check_multiplatform_support() { return 1; }
+    export -f check_multiplatform_support
+
+    source_push_script
+
+    unset GITHUB_ACTIONS
+    unset ALLOW_MULTIARCH_CLOBBER
+    export GITHUB_REPOSITORY_OWNER="testowner"
+
+    # Docker Hub target: multi-arch
+    local dh_multi
+    dh_multi="$(cat << 'INSPECT'
+Name:      docker.io/testowner/testcontainer:1.0.0
+MediaType: application/vnd.oci.image.index.v1+json
+
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+INSPECT
+)"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    _setup_docker_mock_with_per_ref_inspect
+
+    # GHCR source probe fails (inspect exits non-zero)
+    printf 'manifest unknown' > "$TEST_TEMP_DIR/inspect_output_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '1'                 > "$TEST_TEMP_DIR/inspect_rc_ghcr.io_testowner_testcontainer_1.0.0"
+    printf '%s' "$dh_multi"   > "$TEST_TEMP_DIR/inspect_output_docker.io_testowner_testcontainer_1.0.0"
+    printf '0'                 > "$TEST_TEMP_DIR/inspect_rc_docker.io_testowner_testcontainer_1.0.0"
+
+    cat > "$TEST_TEMP_DIR/bin/skopeo" << 'EOF'
+#!/bin/bash
+echo "SKOPEO_CALL: $*" >> "$TEST_TEMP_DIR/skopeo_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/skopeo"
+
+    retry_with_backoff() { local _max=$1 _delay=$2; shift 2; "$@"; }
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    cd "$TEST_TEMP_DIR"
+    run push_dockerhub "testcontainer" "1.0.0" "1.0.0" "latest"
+
+    # Must be refused — GHCR source probe failure defaults to guarding the target
+    [ "$status" -ne 0 ]
+    ! grep -q "copy" "$TEST_TEMP_DIR/skopeo_calls.log" 2>/dev/null
+    [[ "$output" == *"multi-platform"* ]] || [[ "$output" == *"REFUSED"* ]]
 }


### PR DESCRIPTION
## What & why

A local single-arch `docker buildx build --push` to a bare tag overwrote CI's published multi-arch OCI image index with a single-arch manifest, silently breaking the other architecture's consumers. The real incident: `ghcr.io/oorabona/debian:trixie` became amd64-only (a local Podman push), which broke `github-runner:debian-trixie (arm64)` at `FROM`.

This adds a clobber guard across **every local single-arch push path**, so a local push can never reduce a published multi-arch tag to single-arch.

## The guard

`_guard_local_single_arch_push <ref>` (in `scripts/push-container.sh`): probes the target with `docker buildx imagetools inspect` and **refuses** if it is already a multi-platform manifest. It is a no-op in CI (`GITHUB_ACTIONS`), no-op in the QEMU real-multi-arch path, **fail-open** when the target is absent/unreachable (a missing tag can't be clobbered), and overridable with `ALLOW_MULTIARCH_CLOBBER=1`.

Call sites (all three local single-arch push routes):
- **GHCR** (`push_ghcr`): bare-tag single-arch build → guard the GHCR target (`:tag`, `:latest`).
- **Docker Hub buildx fallback** (`push_dockerhub`): the single-arch fallback build → guard the Docker Hub target.
- **Docker Hub skopeo copy** (`push_dockerhub`): `skopeo copy --all` mirrors GHCR→Docker Hub. `--all` copies *whatever the source has* — so a **single-arch GHCR source** mirrored over a **multi-arch Docker Hub tag** also clobbers. Source-aware fix: probe the GHCR source; only when it is **confirmed multi-arch** is the copy a faithful mirror (no guard); otherwise (single-arch / absent / probe-failed → fail-closed) guard the Docker Hub target before the copy.

Also fixes a misleading escape-hatch message: the push namespace is controlled by `GITHUB_REPOSITORY_OWNER`, not `REMOTE_CR` (which only affects base-image resolution).

`push-container.sh` is a developer-local path — no CI workflow invokes it, so this has zero CI build blast radius.

## Validation

- `tests/unit/push-container.bats`: guard coverage for all three paths — GHCR bare-tag, Docker Hub buildx fallback, and Docker Hub skopeo (single-arch-source-over-multi-arch-target → refused; multi-arch-source → allowed; absent → fail-open; CI → no-op). Tests are **hermetic**: single/multi-arch is pinned via `MULTIPLATFORM_SUPPORTED` (survives the helper re-source), and skopeo is stubbed deterministically (fast — no real backoff sleeps).
- shellcheck clean.
- Orthogonal gate: codex CLEAN (copilot exogenously unavailable → degraded GATE_OK). codex correctly held this back until the skopeo `--all` single-arch-source clobber was guarded.

Closes #624.
