### PR TITLE
refactor(ci): digest-parse helper + script-hardening (closes #544, #578)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -67,6 +67,9 @@ outputs:
   count:
     description: 'Number of containers to build'
     value: ${{ steps.find-containers.outputs.count }}
+  changed_files_file:
+    description: 'Path to the temporary changed-files list consumed by compute-expand-map'
+    value: ${{ steps.find-containers.outputs.changed_files_file }}
   versions:
     description: 'JSON object mapping container names to their versions'
     value: ${{ steps.compute-versions.outputs.versions }}

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1261,9 +1261,12 @@ jobs:
     # for ordering (run after sync attempts), but outcome does not matter.
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Serialize concurrent cron + workflow_dispatch runs (never cancel mid-run)
     concurrency:
-      group: digest-drift-detect
+      # Repeated manual dispatches supersede the pending detect (idempotent re-probe of
+      # current registry state); cancel-in-progress stays false so a scoped manual run
+      # near the daily cron cannot cancel the full scheduled scan. Group is namespaced
+      # to the workflow since GHA concurrency groups are otherwise repo-wide.
+      group: ${{ github.workflow }}-digest-drift-detect
       cancel-in-progress: false
     permissions:
       contents: read
@@ -1461,8 +1464,8 @@ jobs:
     # Per-container concurrency lane: each matrix entry gets its own group so
     # GitHub's 1-running-1-pending limit does not cancel pending drift PRs for
     # other containers when multiple containers drift simultaneously.
-    # The broader digest-drift-detect group (on detect-digest-drift job) still
-    # serialises the detect phase across concurrent workflow runs.
+    # The broader workflow-namespaced detect group still serialises the detect
+    # phase across concurrent workflow runs.
     concurrency:
       group: digest-drift-${{ matrix.container }}
       cancel-in-progress: false
@@ -1756,8 +1759,8 @@ jobs:
     # Per-container concurrency lane: each matrix entry gets its own group so
     # GitHub's 1-running-1-pending limit does not cancel pending drift PRs for
     # other containers when multiple containers drift simultaneously.
-    # The broader digest-drift-detect group (on detect-digest-drift job) still
-    # serialises the detect phase across concurrent workflow runs.
+    # The broader workflow-namespaced detect group still serialises the detect
+    # phase across concurrent workflow runs.
     concurrency:
       group: digest-drift-${{ matrix.container }}
       cancel-in-progress: false

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -526,7 +526,10 @@ sync_base_images_to_ghcr() {
     fi
 
     local count
-    count=$(echo "$images_json" | jq 'length')
+    count=$(printf '%s' "$images_json" | jq -e 'if type=="array" then length else error("images_json is not an array") end') || {
+        log_error "sync_base_images_to_ghcr: images_json is not a JSON array"
+        return 1
+    }
 
     if [[ "$count" -eq 0 ]]; then
         echo "ℹ️ No base images to sync"

--- a/helpers/registry-utils.sh
+++ b/helpers/registry-utils.sh
@@ -184,6 +184,22 @@ _ghcr_keyfile() {
     printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'
 }
 
+# _ghcr_extract_content_digest_hex <header_text>
+# Extracts the 64-char sha256 hex from a Docker-Content-Digest line, or empty.
+# Returns 0 on hit, 1 if no parseable digest.
+_ghcr_extract_content_digest_hex() {
+    local hdrs="$1"
+    local line hex=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*sha256:([a-f0-9]{64})[[:space:]]*$ ]]; then
+            hex="${BASH_REMATCH[1]}"
+            break
+        fi
+    done <<< "$hdrs"
+    [[ -n "$hex" ]] || return 1
+    printf '%s\n' "$hex"
+}
+
 # Verify that a cached file's sha256 matches an expected digest hex.
 # Usage: _ghcr_verify_content_digest <file> <expected_sha256_hex>
 # Returns 0 on match, 1 on mismatch or invalid input.
@@ -328,21 +344,10 @@ _ghcr_fetch_index() {
     # PID-reuse conflict, OOM mid-write, manual tampering).  A mismatch evicts
     # both cache files and falls through to the network fetch branch below.
     if [[ -s "$body_file" && -f "$hdrs_file" ]]; then
-        local cached_expected hdr_line
-        hdr_line=$(grep -i '^Docker-Content-Digest:' "$hdrs_file" 2>/dev/null || true)
-        cached_expected=""
-        if [[ -n "$hdr_line" ]]; then
-            # Strict single-token extraction: reject headers with multiple sha256:
-            # tokens (e.g. sha256:<good>sha256:<bad>) which greedy patterns would
-            # silently parse to the last token, bypassing digest verification.
-            local _hdr_norm
-            _hdr_norm=$(printf '%s' "$hdr_line" | tr -d '\r\n')
-            if [[ "$_hdr_norm" =~ ^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*sha256:([a-f0-9]{64})[[:space:]]*$ ]]; then
-                cached_expected="${BASH_REMATCH[1]}"
-            fi
-            # If pattern doesn't match exactly (malformed, multiple tokens, wrong
-            # length), cached_expected stays "" → length guard below skips
-            # verification → falls through to trust-cache path (same as no header).
+        local cached_expected hdrs_text
+        hdrs_text=$(cat "$hdrs_file" 2>/dev/null || true)
+        if ! cached_expected=$(_ghcr_extract_content_digest_hex "$hdrs_text"); then
+            cached_expected=""
         fi
         # Only trust the cache when we have a full 64-char lowercase hex digest to
         # verify against.  A missing, malformed, or short digest (e.g. the default
@@ -443,9 +448,11 @@ _ghcr_fetch_index() {
         # On mismatch: warn, clean up temps, and return 1.
         # The caller already has data in _GHCR_IDX_BODY/_GHCR_IDX_HDRS but a
         # digest mismatch signals a corrupt or tampered response — do not use it.
-        local idx_digest_header idx_digest_hex
-        idx_digest_header=$(printf '%s' "$hdrs" | grep -iE '^docker-content-digest:' 2>/dev/null | head -1 | tr -d '\r' || true)
-        if [[ -z "$idx_digest_header" ]]; then
+        local idx_digest_hex
+        if ! idx_digest_hex=$(_ghcr_extract_content_digest_hex "$hdrs"); then
+            idx_digest_hex=""
+        fi
+        if [[ -z "$idx_digest_hex" ]] && ! printf '%s' "$hdrs" | grep -qiE '^docker-content-digest:'; then
             # Fresh response carries no Docker-Content-Digest header.  GHCR is
             # documented to always send this header on manifest responses; its
             # absence signals a stripped/tampered response or a non-compliant
@@ -457,14 +464,6 @@ _ghcr_fetch_index() {
             _GHCR_IDX_BODY=""
             _GHCR_IDX_HDRS=""
             return 1
-        fi
-        # Strict single-token extraction: anchored regex rejects headers with
-        # multiple sha256: tokens (e.g. sha256:<good>sha256:<bad>) that greedy
-        # ##*sha256: would silently parse to the last token.
-        if [[ "$idx_digest_header" =~ ^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*sha256:([a-f0-9]{64})[[:space:]]*$ ]]; then
-            idx_digest_hex="${BASH_REMATCH[1]}"
-        else
-            idx_digest_hex=""
         fi
         if [[ "${#idx_digest_hex}" -ne 64 ]]; then
             # Header present but malformed (wrong length, non-hex, multiple tokens).
@@ -786,10 +785,12 @@ ghcr_get_multi_arch_digests() {
     fi
 
     # Index digest from the Docker-Content-Digest header.
-    # || true guards against grep returning 1 (no match) under set -euo pipefail.
-    local index_digest
-    index_digest=$(printf '%s' "$headers" | grep -iE '^docker-content-digest:' 2>/dev/null | awk '{print $2}' | tr -d '\r' | head -1 || true)
-    [[ -z "$index_digest" ]] && index_digest="null"
+    local index_digest index_digest_hex
+    if index_digest_hex=$(_ghcr_extract_content_digest_hex "$headers"); then
+        index_digest="sha256:${index_digest_hex}"
+    else
+        index_digest="null"
+    fi
 
     # Per-arch manifest digests from the body (.manifests[].{platform.architecture, digest}).
     # jq returns empty output (not "null") when the key is absent, so we test with [[ -z ]].

--- a/scripts/enrich-lineage.sh
+++ b/scripts/enrich-lineage.sh
@@ -47,23 +47,24 @@ done
 # Source helpers
 # ---------------------------------------------------------------------------
 # shellcheck source=../helpers/logging.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/helpers/logging.sh"
 # shellcheck source=../helpers/registry-utils.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/helpers/registry-utils.sh"
 # shellcheck source=../helpers/attestation-utils.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/helpers/attestation-utils.sh"
+# shellcheck source=../helpers/lineage-utils.sh
+# shellcheck disable=SC1091
+source "${PROJECT_ROOT}/helpers/lineage-utils.sh"
 
 # ---------------------------------------------------------------------------
 # Constants: files to skip (not container lineage files)
 # ---------------------------------------------------------------------------
 # Pattern matches: *.sbom.json  *.changelog.json  *.history.json  ext-*.json
 _is_skippable_file() {
-    local f="$1"
-    case "$f" in
-        *.sbom.json|*.changelog.json|*.history.json) return 0 ;;
-        ext-*.json) return 0 ;;
-        *) return 1 ;;
-    esac
+    is_lineage_sidecar "$1"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -736,6 +736,12 @@ EOF
     [[ "$output" == *"No base images to sync"* ]]
 }
 
+@test "sync_base_images_to_ghcr: non-array images_json returns error" {
+    run sync_base_images_to_ghcr '{"source":"library/alpine","tag":"3.18"}'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"sync_base_images_to_ghcr: images_json is not a JSON array"* ]]
+}
+
 @test "sync_base_images_to_ghcr: single library/X image uses explicit library/ prefix" {
     # Mock docker to capture the source_ref argument
     docker() {

--- a/tests/unit/registry-utils-cache.bats
+++ b/tests/unit/registry-utils-cache.bats
@@ -203,6 +203,39 @@ GH_SHIM
 # D2-test-1: cache_hit_no_refetch — the Observable Success proof
 # ---------------------------------------------------------------------------
 
+@test "content-digest extract: valid Docker-Content-Digest header returns hex" {
+    source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
+    source "$REPO_ROOT/helpers/registry-utils.sh"
+
+    local hex
+    hex="$(printf 'a%.0s' {1..64})"
+
+    run _ghcr_extract_content_digest_hex "Docker-Content-Digest: sha256:${hex}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$hex" ]
+}
+
+@test "content-digest extract: absent header returns 1 and empty output" {
+    source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
+    source "$REPO_ROOT/helpers/registry-utils.sh"
+
+    run _ghcr_extract_content_digest_hex $'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n'
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "content-digest extract: multi-header input returns digest hex" {
+    source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
+    source "$REPO_ROOT/helpers/registry-utils.sh"
+
+    local hex
+    hex="$(printf 'b%.0s' {1..64})"
+
+    run _ghcr_extract_content_digest_hex $'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nDocker-Content-Digest: sha256:'"$hex"$'\r\nX-Other: value\r\n'
+    [ "$status" -eq 0 ]
+    [ "$output" = "$hex" ]
+}
+
 @test "per-arch manifest served from cache on 2nd call (no re-fetch)" {
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"


### PR DESCRIPTION
## What & why

Pure-refactor / hardening bundle with **zero build-path change** — the first of two PRs draining the `#544`/`#569`/`#578` script-hardening cluster (PR-2 will take the openresty/extension build-path items).

### Changes

- **`#544` — single digest-parse helper.** `helpers/registry-utils.sh` now defines `_ghcr_extract_content_digest_hex` and all three `Docker-Content-Digest` parse sites call it: the `_ghcr_fetch_index` cache-hit and fresh-fetch branches (previously two byte-identical anchored regexes) and `ghcr_get_multi_arch_digests` (previously a looser `awk '{print $2}'` extraction, now the same strict anchored regex). The fail-closed semantics are preserved exactly: a missing header and a malformed header remain distinct, both refusing the response; the output-only multi-arch path now also rejects malformed digests.
- **`#569` — `enrich-lineage` dedup.** `scripts/enrich-lineage.sh::_is_skippable_file` delegates to `helpers/lineage-utils.sh::is_lineage_sidecar` instead of duplicating it — single source of truth.
- **`#569` — output contract.** `.github/actions/detect-containers/action.yaml` declares the previously-undocumented `changed_files_file` step output.
- **`#569` — base-cache shape guard.** `sync_base_images_to_ghcr` fails closed (logs + returns 1) when `images_json` is not a JSON array, instead of `jq 'length'` silently returning 0 on malformed input.
- **`#578` — concurrency hygiene.** The `digest-drift-detect` concurrency group in `upstream-monitor.yaml` is namespaced to the workflow and documented (repeated manual dispatches supersede the pending detect; `cancel-in-progress: false` so a scoped manual run near the daily cron can't cancel the full scan).

### Issue status

- **Closes #544** — helper extracted, all 3 sites consolidated, 3 direct unit tests added.
- **Closes #578** — the probe dedup + per-container scope (tasks 1–2) already shipped in #579, `setup-buildx` is already absent from the detect jobs (task 3), and this PR completes the remaining concurrency-hygiene item (task 6). The deferred skopeo-probe / parallelism evaluations (tasks 4–5) are documented non-goals.
- **Refs #569** — 3 of the 6 checklist items (lineage dedup, output-contract doc, base-cache guard). The remaining 3 are build-path changes (openresty RESTY_VERSION regex, PCRE2 slim, extension REMOTE_CR dedup) and land in PR-2 with a real build validation.

## Validation

- `shellcheck -x -S warning` (CI-equivalent) clean on all touched scripts.
- bats green: `registry-utils-cache` 50/50 (47 original + 3 new), `base-cache-utils` 58/58 (+1 non-array test), plus regression-clean on `enrich-lineage` 12/12, `lineage-utils` 11/11, `detect-base-digest-drift` 109/109.
- Both touched YAML files parse.
- Pre-PR orthogonal gate: **codex xhigh CLEAN** (explicitly confirmed the strict-malformed-header / fail-closed cache+fresh / base-cache type-guard properties). copilot exogenously unavailable (account quota) → degraded GATE_OK.
