### PR TITLE
fix(openresty): validate version + drop unused PCRE2 16/32 (closes #569)

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -140,8 +140,6 @@ RUN set -ex \
         --disable-never-backslash-C \
         --enable-newline-is-lf \
         --enable-pcre2-8 \
-        --enable-pcre2-16 \
-        --enable-pcre2-32 \
         --enable-pcre2grep-callout \
         --enable-pcre2grep-callout-fork \
         --disable-pcre2grep-libbz2 \

--- a/openresty/build
+++ b/openresty/build
@@ -29,6 +29,13 @@ else
     fi
 fi
 
+# Reject anything that is not a dotted numeric version (e.g. "alpine", "1.2.3-beta").
+# Both resolution paths (VERSION strip, version.sh --upstream) feed this guard.
+if [[ ! "$UPSTREAM_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
+    echo "ERROR: UPSTREAM_VERSION='$UPSTREAM_VERSION' is not a valid dotted numeric version" >&2
+    exit 1
+fi
+
 echo "Building OpenResty ${VERSION} (source: ${UPSTREAM_VERSION})"
 
 # Append dynamic args to CUSTOM_BUILD_ARGS (preserve existing cache overrides)

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -81,11 +81,11 @@ _scoped_tag() {
 }
 
 
-# Override build_ext_image from extension-utils.sh to inject --build-arg REMOTE_CR.
-# This ensures the trusted CI registry root reaches extension builder stages.
-# When BUILD_PLATFORM is set (CI per-arch leg), uses `docker buildx build --platform`
-# to build for that single architecture; without BUILD_PLATFORM, falls back to
-# plain `docker build` (host platform, local usage).
+# Override build_ext_image from extension-utils.sh for the CI buildx per-arch
+# path: explicit --platform builds, PR-scoped cache refs, separate compile/push
+# handling, and rc=2 for push failures. It also injects REMOTE_CR into extension
+# builder stages. Do not delete this override merely by upstreaming REMOTE_CR;
+# extension-utils.sh would need the whole buildx/cache/push path first.
 build_ext_image() {
     local ext_name="$1"
     local ext_version="$2"

--- a/tests/unit/openresty-build-version.bats
+++ b/tests/unit/openresty-build-version.bats
@@ -11,11 +11,12 @@
 # We extract UPSTREAM_VERSION from that line for assertions.
 #
 # Mutation each test catches:
-#   TC1: removing the VERSION branch → version.sh called, returns STUB-UPSTREAM-VAL ≠ "1.29.2.4"
+#   TC1: removing the VERSION branch → version.sh called, returns 9.8.7 ≠ "1.29.2.4"
 #   TC2: removing suffix strip → UPSTREAM_VERSION would equal "1.29.2.5-alpine" ≠ "1.29.2.5"
 #   TC3: removing the else branch → version.sh never called, UPSTREAM_VERSION empty or wrong
 #   TC4: removing the -z guard → script exits 0 and emits "(source: )" instead of error exit 1
 #   TC5: suffix strip using sed/grep instead of %-alpine → "1.29.2.4" (no suffix) would break
+#   TC6-TC8: removing dotted-numeric validation → invalid upstream versions pass
 
 bats_require_minimum_version 1.5.0
 
@@ -35,8 +36,8 @@ setup() {
     cp "$build_script" "$TEST_TEMP_DIR/build"
     chmod +x "$TEST_TEMP_DIR/build"
 
-    # Default stub: version.sh echoes a sentinel when called with --upstream.
-    _write_version_stub "STUB-UPSTREAM-VAL"
+    # Default stub: version.sh echoes a valid dotted numeric version when called with --upstream.
+    _write_version_stub "9.8.7"
 
     # Stub yq: the build script checks for yq but does not use it; stub satisfies
     # the `command -v yq` guard without installing the real binary.
@@ -127,13 +128,12 @@ _extract_resty_version() {
 
 @test "TC3: VERSION unset falls back to version.sh --upstream" {
     unset VERSION
-    _write_version_stub "STUB-UPSTREAM-VAL"
     _run_build
 
     [ "$status" -eq 0 ]
     local resty
     resty=$(_extract_resty_version)
-    [ "$resty" = "STUB-UPSTREAM-VAL" ]
+    [ "$resty" = "9.8.7" ]
 }
 
 # =============================================================================
@@ -160,4 +160,41 @@ _extract_resty_version() {
     local resty
     resty=$(_extract_resty_version)
     [ "$resty" = "1.29.2.4" ]
+}
+
+# =============================================================================
+# TC6: VERSION="alpine-alpine" -> RESTY_VERSION="alpine" -> invalid
+# =============================================================================
+
+@test "TC6: VERSION=alpine-alpine rejects non-numeric stripped version" {
+    export VERSION="alpine-alpine"
+    _run_build
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"UPSTREAM_VERSION='alpine' is not a valid dotted numeric version"* ]]
+}
+
+# =============================================================================
+# TC7: VERSION="1.29.2.5-alpine-beta" -> invalid
+# =============================================================================
+
+@test "TC7: VERSION=1.29.2.5-alpine-beta rejects prerelease suffix" {
+    export VERSION="1.29.2.5-alpine-beta"
+    _run_build
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"is not a valid dotted numeric version"* ]]
+}
+
+# =============================================================================
+# TC8: VERSION unset and version.sh --upstream returns garbage -> invalid
+# =============================================================================
+
+@test "TC8: VERSION unset rejects invalid version.sh --upstream output" {
+    unset VERSION
+    _write_version_stub "alpine"
+    _run_build
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"UPSTREAM_VERSION='alpine' is not a valid dotted numeric version"* ]]
 }


### PR DESCRIPTION
## What & why

PR-2 of the `#544`/`#569`/`#578` script-hardening cluster — the build-path items (PR-1 #681 took the no-build-risk ones). **Closes #569.**

### Changes

- **openresty version validation** (`openresty/build`). The pre-build hook only checked `UPSTREAM_VERSION` non-empty after stripping `-alpine`, so garbage like `alpine` or `1.29.2.5-alpine-beta` would flow into the source download. Added one strict `^[0-9]+(\.[0-9]+)+$` guard after the resolution branch, covering BOTH the `VERSION`-strip and the `version.sh --upstream` fallback paths.
- **PCRE2 slim** (`openresty/Dockerfile`). Dropped `--enable-pcre2-16` / `--enable-pcre2-32` from the PCRE2 build. nginx/openresty link `libpcre2-8` only and `pcre2grep` is 8-bit, so the 16/32 code-unit-width libraries were built and never used — pure build-time + image-size cost.
- **`build_ext_image` override comment** (`scripts/build-extensions.sh`). The comment claimed the override exists to inject `--build-arg REMOTE_CR`; in reality its primary purpose is the CI buildx per-arch path (`--platform`, PR-scoped cache refs, separate compile/push, `rc=2` push-failure signal) that `extension-utils.sh`'s base builder lacks. Corrected so a future reader doesn't "just upstream REMOTE_CR and delete the override" and break multi-arch. Comment-only — no behavior change (this resolves the #569 dedup item as documented-intent rather than a risky refactor).

### Issue status

**Closes #569** — the remaining 3 checklist items. The other 3 (lineage dedup, `changed_files_file` output, base-cache shape guard) shipped in #681.

## Validation

- `shellcheck -x -S warning openresty/build scripts/build-extensions.sh` clean.
- `bats tests/unit/openresty-build-version.bats` 8/8 (added: non-numeric stripped version rejected, prerelease-suffix rejected, invalid `version.sh --upstream` output rejected).
- `build-extensions.sh` diff is comment-only (function body byte-identical).
- Pre-PR orthogonal gate: **codex xhigh CLEAN**; copilot exogenously unavailable (account quota) → degraded GATE_OK.
- The openresty build on this PR exercises both build-path changes end-to-end (version hook + PCRE2 configure).
