### PR TITLE
fix(ci): harden shared post-build steps against transient failures (refs #572)

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -626,12 +626,35 @@ runs:
 
     - name: Upload SARIF to GitHub Security
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' }}
+      id: sarif-upload
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
       with:
         sarif_file: 'trivy-results.sarif'
         category: 'container-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}-${{ inputs.platform }}'
         wait-for-processing: false
-      # No continue-on-error: SARIF upload to Security tab must succeed for visibility
+
+    - name: Wait before SARIF upload retry
+      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.sarif-upload.outcome == 'failure' }}
+      shell: bash
+      run: sleep 15
+
+    - name: Upload SARIF to GitHub Security (retry on transient failure)
+      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.sarif-upload.outcome == 'failure' }}
+      id: sarif-upload-retry
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+      with:
+        sarif_file: 'trivy-results.sarif'
+        category: 'container-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}-${{ inputs.platform }}'
+        wait-for-processing: false
+
+    - name: Fail if SARIF upload failed after retries
+      if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.sarif-upload.outcome == 'failure' && steps.sarif-upload-retry.outcome != 'success' }}
+      shell: bash
+      run: |
+        echo "::error::SARIF upload to GitHub Security failed after retries"
+        exit 1
 
     - name: Check scan result
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && github.event_name != 'pull_request' }}

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1172,7 +1172,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload build lineage
+        id: upload_build_lineage
         if: steps.build.outcome == 'success' && matrix.arch == 'amd64'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: build-lineage-${{ matrix.build.container }}-${{ matrix.build.tag }}
@@ -1181,8 +1183,21 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+      - name: Upload build lineage (retry on transient failure)
+        if: always() && steps.upload_build_lineage.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-lineage-${{ matrix.build.container }}-${{ matrix.build.tag }}
+          path: .build-lineage/${{ matrix.build.container }}-${{ matrix.build.tag }}.json
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
       - name: Upload Trivy scan history
+        id: upload_trivy_scan_history
         if: steps.build.outcome == 'success' && matrix.build.os != 'windows'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: trivy-scan-history-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
@@ -1190,6 +1205,17 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload Trivy scan history (retry on transient failure)
+        if: always() && steps.upload_trivy_scan_history.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: trivy-scan-history-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}
+          path: .trivy-scan-history/
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
       # SBOM generation (amd64 only — packages are identical across arches)
       - name: Install syft

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -19,6 +19,8 @@ else
     log_warning() { echo "WARN: $*" >&2; }
 fi
 
+source "$_SBOM_UTILS_DIR/retry.sh"
+
 # Install syft if not present
 # Downloads the latest release from Anchore's install script
 install_syft() {
@@ -58,7 +60,15 @@ generate_sbom() {
     mkdir -p "$output_dir"
 
     log_info "Generating SBOM for $image_ref..."
-    if syft "registry:${image_ref}" -o "spdx-json=${output_file}" --quiet 2>/dev/null; then
+    local syft_args=("registry:${image_ref}" -o "spdx-json=${output_file}" --quiet)
+    local syft_cmd=(syft)
+    if syft --timeout 10m --help &>/dev/null; then
+        syft_args=(--timeout 10m "${syft_args[@]}")
+    elif command -v timeout &>/dev/null; then
+        syft_cmd=(timeout 10m syft)
+    fi
+
+    if retry_with_backoff 2 30 "${syft_cmd[@]}" "${syft_args[@]}"; then
         log_success "SBOM generated: $output_file ($(wc -c < "$output_file") bytes)"
     else
         log_error "Failed to generate SBOM for $image_ref"


### PR DESCRIPTION
## What & why

A deliberately narrow slice of #572 — resilience for the post-build chain, scoped to **shared / method-agnostic code that survives the planned post-build convergence**. It cuts the ~20% `postgres:full`/`postgres:distributed` post-build flake now, without band-aiding the matrix-local-scan chain that #666 will restructure.

### Root cause (for context — not fully fixed here)

The flake is a symptom of a **divergent dual post-build chain**: the matrix path scans the locally-`--load`ed image, while bake pulls + scans the published per-arch ref. Loading locally is not free either (runner minutes, disk, its own network risk). The DRY fix is to converge both onto the published-artifact model (build → push → pull-and-scan) and drop the local load — that is **#666** (high blast radius, all builds), tracked there.

### Changes (all shared / convergence-safe)

- **`helpers/sbom-utils.sh::generate_sbom`** — the heaviest post-build network op (`syft "registry:${ref}"` pulls the multi-GB image) had no timeout and no retry. Now bounded to 10m (native `--timeout` when the installed syft supports it, else wrapped in coreutils `timeout 10m syft`) and retried 2× with backoff. This helper is shared by **both** the matrix SBOM step and the bake SBOM job, so the hardening is pure DRY.
- **`build-container` SARIF upload** — the only post-build network step that was fatal-and-unretried now retries once (15s wait) and fails the build **only after retries are exhausted**, preserving the "must surface in the Security tab" intent.
- **`auto-build` artifact uploads** — `Upload build lineage` and `Upload Trivy scan history` no longer hard-fail the job on a transient artifact-API hiccup (`continue-on-error` + one retry with `overwrite: true`, mirroring the existing build-result-artifact retry).

Excluded on purpose (would be restructured by the #666 convergence): `crane flatten` retry, local-scan instrumentation, any change to scan method / `--load`.

## Validation

- `shellcheck -x -S warning helpers/sbom-utils.sh` clean; both touched YAML files parse; `actionlint` clean.
- `generate_sbom` preserves its return contract; the only bats that references `sbom-utils` stubs it (21/21 green).
- Pre-PR orthogonal gate: **codex xhigh CLEAN** (no findings); copilot exogenously unavailable (account quota) → degraded GATE_OK.
- This PR's CI builds postgres full/distributed → exercises the hardened generate_sbom + SARIF + artifact-upload paths end-to-end.

Note: a single green run does not prove the flake is gone (it's ~20%); the real signal is the master flake rate over the next several runs. Refs #572 (kept open for the #666 convergence).
