### PR TITLE
ci: reusable retry-run composite + harden buildkit preflight (#666 build-infra resilience)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -416,7 +416,7 @@ runs:
         while IFS= read -r file; do
           [[ -z "$file" ]] && continue
           case "$file" in
-            helpers/*|scripts/build-container.sh|scripts/build-extensions.sh|scripts/resolvers/*|.github/actions/build-container/*|.github/actions/preflight-buildkit/*)
+            helpers/*|scripts/build-container.sh|scripts/build-extensions.sh|scripts/resolvers/*|.github/actions/build-container/*|.github/actions/preflight-buildkit/*|.github/actions/retry-run/*)
               shared_infra_changed=true; break ;;
           esac
         done <<< "$changed_files"

--- a/.github/actions/preflight-buildkit/action.yaml
+++ b/.github/actions/preflight-buildkit/action.yaml
@@ -18,19 +18,30 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Verify BuildKit image is present in GHCR
+    # Validate format FIRST and fail-fast (no retry): a malformed/non-digest ref
+    # is a definitive config error, not a transient one.
+    - name: Validate BuildKit image ref format (fail-fast)
       shell: bash
       env:
         IMAGE: "${{ inputs.image }}"
       run: |
-        # Validate format: must be a digest-pinned image ref
-        # Accepts: <registry>/<path>@sha256:<64-hex>
-        # where registry may include an optional :port component
+        # Accepts: <registry>/<path>@sha256:<64-hex> (registry may include :port)
         if [[ ! "$IMAGE" =~ ^[a-z0-9._/-]+(:[0-9]+)?/[a-z0-9._/-]+@sha256:[0-9a-f]{64}$ ]]; then
           echo "::error::preflight-buildkit: refusing malformed/non-digest image ref (value redacted for safety)"
           exit 1
         fi
-        docker manifest inspect "$IMAGE" >/dev/null 2>&1 || {
-          echo "::error::buildkit builder image '$IMAGE' is not present in GHCR. It is seeded by the upstream-monitor workflow (Seed buildkit image to GHCR). Trigger upstream-monitor (workflow_dispatch) to seed it, then re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"
-          exit 1
-        }
+
+    # The GHCR presence probe is network-dependent: retry with backoff + a
+    # per-attempt timeout so a transient registry 5xx/429/timeout does not fail
+    # the build. The ref was format-validated (and is digest-pinned) above.
+    - name: Verify BuildKit image is present in GHCR (retry on transient)
+      uses: ./.github/actions/retry-run
+      with:
+        max-attempts: '4'
+        delay: '5'
+        timeout: '45s'
+        run: |
+          docker manifest inspect "${{ inputs.image }}" >/dev/null 2>&1 || {
+            echo "::error::buildkit builder image is not present in GHCR (after retries). It is seeded by the upstream-monitor workflow (Seed buildkit image to GHCR). Trigger upstream-monitor (workflow_dispatch) to seed it, then re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"
+            exit 1
+          }

--- a/.github/actions/retry-run/action.yaml
+++ b/.github/actions/retry-run/action.yaml
@@ -1,0 +1,64 @@
+name: Retry shell command with backoff
+description: |
+  Run a shell script with exponential-backoff retry and an optional per-attempt
+  timeout, sourcing the repo's helpers/retry.sh. Use this for any network-dependent
+  `run:` step (registry probe/pull/push, GHCR/API call) so a transient failure
+  retries with backoff instead of failing the job on the first blip.
+
+  Scope: this wraps a SHELL script. It cannot wrap a `uses:` action step (GitHub
+  composite actions cannot re-invoke another action) — for those (setup-buildx,
+  attest-sbom, upload-sarif) use a staged retry (attempt + conditional retry +
+  fatal gate) or the action's own retry/continue-on-error.
+
+  PREREQUISITE: the calling job has checked out the repository (helpers/retry.sh
+  must exist in the workspace).
+
+inputs:
+  run:
+    description: The shell script to execute. Retried as a single unit.
+    required: true
+  max-attempts:
+    description: Maximum number of attempts.
+    required: false
+    default: '3'
+  delay:
+    description: Initial backoff delay in seconds (doubles after each failed attempt).
+    required: false
+    default: '5'
+  timeout:
+    description: |
+      Per-attempt wall-clock timeout (coreutils `timeout` duration, e.g. `30s`, `5m`).
+      Kills a hung attempt so retry/backoff can proceed. Empty = no per-attempt timeout.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Run with backoff retry
+      shell: bash
+      env:
+        RR_RUN: ${{ inputs.run }}
+        RR_MAX: ${{ inputs.max-attempts }}
+        RR_DELAY: ${{ inputs.delay }}
+        RR_TIMEOUT: ${{ inputs.timeout }}
+      run: |
+        set -uo pipefail
+        # Anchor retry.sh to this action's location so it resolves regardless of
+        # the caller's checkout path. .github/actions/retry-run -> repo root.
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/retry.sh"
+
+        script="$(mktemp)"
+        printf '%s\n' "$RR_RUN" > "$script"
+        trap 'rm -f "$script"' EXIT
+
+        run_once() {
+          if [[ -n "$RR_TIMEOUT" ]] && command -v timeout >/dev/null 2>&1; then
+            timeout "$RR_TIMEOUT" bash -e -o pipefail "$script"
+          else
+            bash -e -o pipefail "$script"
+          fi
+        }
+
+        retry_with_backoff "$RR_MAX" "$RR_DELAY" run_once

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -74,6 +74,7 @@ on:
       - 'make'                                  # Top-level build orchestrator
       - '.github/actions/build-container/**'    # Composite action used by build matrix
       - '.github/actions/preflight-buildkit/**' # Preflight action (shared build infra)
+      - '.github/actions/retry-run/**'          # Reusable retry wrapper (shared build infra)
       - '!docs/**'                              # Jekyll site + ADRs (no build impact)
       - '!examples/**'                          # Docker Compose usage examples
       - '!tests/**'                             # Test suite (has its own CI)
@@ -101,6 +102,7 @@ on:
       - 'make'                                  # Top-level build orchestrator
       - '.github/actions/build-container/**'    # Composite action used by build matrix
       - '.github/actions/preflight-buildkit/**' # Preflight action (shared build infra)
+      - '.github/actions/retry-run/**'          # Reusable retry wrapper (shared build infra)
       - '!docs/**'                              # Jekyll site + ADRs (no build impact)
       - '!examples/**'                          # Docker Compose usage examples
       - '!tests/**'                             # Test suite (has its own CI)


### PR DESCRIPTION
## What & why

Network-dependent CI steps must not fail the build on a transient registry/API blip without a backoff. This introduces a **reusable building block** and applies it to the highest-value shared step — the first slice of a phased "no network step fails without backoff" sweep.

Origin: run `27169112038` failed on a **transient** amd64 BuildKit-preflight blip (arm64 passed on the same pinned digest); the re-dispatch passed. The preflight had a single bare `docker manifest inspect` with no retry.

## Changes

- **new `.github/actions/retry-run`** — a composite action that runs a shell script under `helpers/retry.sh::retry_with_backoff` with an optional per-attempt `timeout` (kills a hung attempt). One DRY unit for wrapping any network-dependent `run:` step. The script runs with `bash -e -o pipefail` so an early command failure isn't masked (matches GitHub `run:` semantics). It cannot wrap a `uses:` action step (composites can't re-invoke an action) — those need a staged retry or the action's own retry/`continue-on-error`.
- **`preflight-buildkit`** — split into a fail-fast format check (a malformed/non-digest ref is a definitive error, no retry) and a `docker manifest inspect` GHCR presence probe wrapped in `retry-run` (4 attempts, 5s backoff, 45s per-attempt timeout). This step is shared by every build job, so a transient GHCR hiccup no longer fails the whole build.
- **trigger + canary coverage for the new shared action**: added `.github/actions/retry-run/**` to both `auto-build.yaml` path allowlists (push + PR) AND to the `detect-containers` shared-infra classifier, so a `retry-run`-only change both starts the workflow and adds the postgres canary that exercises it (otherwise the action could change unexercised).

`retry.sh` vs `nick-fields/retry`: they overlap (both retry a shell command); `nick-fields` adds per-attempt timeout (closed here dep-free via coreutils `timeout`), retry-on-condition, Windows/pwsh, and YAML ergonomics. Neither can retry a `uses:` action. Kept `retry.sh` (zero new dependency).

## Scope

This is slice 1. A phased follow-up sweep will wrap the ~25 remaining bare durable network shell steps (notably `docker buildx bake --push`, the manifest `imagetools create` steps, the `yq`/`skopeo` installs, `gh` API calls, and the drift probes) and add staged-retry to the ~6 bare artifact-upload `uses:` steps. The flat-matrix transitional steps are intentionally skipped (ADR-014 / #666 convergence removes them).

## Validation

- `actionlint` clean; both action YAMLs + the workflow parse.
- Pre-PR orthogonal gate: **codex xhigh CLEAN** (it caught and we fixed: the no-`-e` masking risk, and the missing canary-classifier entry). copilot exogenously unavailable (account quota) → degraded GATE_OK.

Refs #666 (build-infra resilience).
