### PR TITLE
feat(ci): retained bake-managed builds → bake for standalone containers (#666 B1-core)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -655,6 +655,7 @@ runs:
         BUILD_SCOPE: ${{ inputs.scope }}
         EVENT_NAME: ${{ github.event_name }}
         RUN_TESTS: ${{ inputs.run_tests }}
+        BUILD_ALL_RETAINED: ${{ inputs.build_all_retained }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC1091
@@ -688,7 +689,7 @@ runs:
           force_matrix="true"
         fi
 
-        partitioned=$(partition_builds "$builds_input" "$force_matrix")
+        partitioned=$(partition_builds "$builds_input" "$force_matrix" "$BUILD_ALL_RETAINED")
 
         bake_builds=$(echo "$partitioned" | jq -c '.bake')
         matrix_builds=$(echo "$partitioned" | jq -c '.matrix')

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -213,6 +213,7 @@ env:
   DOCKER_NO_CACHE: ${{ inputs.rebuild == 'force' && 'true' || 'false' }}
   # Variant scope filter (free-text, matched against variant/os/build_flavor fields)
   BUILD_SCOPE: ${{ inputs.scope || '' }}
+  BUILD_ALL_RETAINED: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || 'false' }}
 
 jobs:
   detect-containers:
@@ -1584,8 +1585,11 @@ jobs:
           set -euo pipefail
           # Extract unique container names from the bake_builds cell array (injection-safe via env)
           containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          retained_containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[] | select(.is_latest_version != true) | .container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
           echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+          echo "retained_containers=${retained_containers}" >> "$GITHUB_OUTPUT"
           echo "::notice::bake containers (amd64): ${containers}"
+          echo "::notice::bake retained-eligible containers (amd64): ${retained_containers:-<none>}"
 
       - name: Resolve github-runner version from bake set
         id: resolve-gh-version
@@ -1634,6 +1638,7 @@ jobs:
         id: bake-build
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
           ARCH_SUFFIX: -amd64
           IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
@@ -1659,9 +1664,8 @@ jobs:
           # with `docker buildx bake -f <(...)` on some buildkit versions).
           # Using the real REMOTE_CR ensures base FROM refs resolve.
           #
-          # Bake is latest-only by design: retained (non-latest) cells are routed to the
-          # flat matrix by partition_builds, so they never reach this job.
-          # No --all-retained flag is passed here.
+          # Bake defaults to latest-only.  When build_all_retained is true,
+          # partition_builds admits only B1-core retained-eligible cells here.
           bake_file="${RUNNER_TEMP}/bake-amd64.json"
           # BAKE_CACHE_EXPORT gates cache-to emission in the generator:
           #   true  → real publish path (push/dispatch): emit cache-to so master builds
@@ -1674,10 +1678,39 @@ jobs:
           if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
             bake_cache_export="true"
           fi
+          bake_latest_file="${RUNNER_TEMP}/bake-amd64-latest.json"
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
-          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" \
-            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=false \
+            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_latest_file"
+          cp "$bake_latest_file" "$bake_file"
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            bake_retained_file="${RUNNER_TEMP}/bake-amd64-retained.json"
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=true \
+              ./scripts/generate-bake-hcl.sh --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
+            # Merge latest + retained HCL. On a target-key collision (a container's
+            # latest target appears in both passes) the retained pass wins. Safe
+            # ONLY because BAKE_RETAINED_CONTAINERS are retained-eligible, i.e. have
+            # NO internal base dependency (_bake_retained_eligible in
+            # helpers/bake-managed.sh) → their targets carry no `contexts` key, so
+            # both definitions are byte-identical and $extra-wins is a no-op. If a
+            # chained container is ever admitted to retained-bake (B1b), this
+            # object-merge would silently drop the latest target's `contexts` —
+            # revisit the merge then (e.g. emit retained cells only).
+            jq -s '
+              .[0] as $base | .[1] as $extra |
+              ($base.group.default.targets + $extra.group.default.targets) as $default_targets |
+              $base
+              | .target = ($base.target + $extra.target)
+              | .group = ($base.group + $extra.group)
+              | .group.default.targets = (
+                  reduce $default_targets[] as $t ([]; if index($t) then . else . + [$t] end)
+                )
+            ' "$bake_latest_file" "$bake_retained_file" > "$bake_file"
+          fi
 
           # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
           no_cache_flag=""
@@ -1715,22 +1748,32 @@ jobs:
         if: always() && env.DRY_RUN != 'true'
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
         run: |
           set -euo pipefail
           chmod +x helpers/bake-buildresult.sh
           source helpers/bake-buildresult.sh
 
-          # Bake is latest-only by design; emit covers only the latest cells.
-          export BAKE_GENERATE_ALL_RETAINED=false
-
           mkdir -p .build-lineage
           # BAKE_CONTAINERS is operator-set (trusted context)
+          export BAKE_GENERATE_ALL_RETAINED=false
           # shellcheck disable=SC2086
           emit_bake_build_results \
             "${RUNNER_TEMP}/bake-metadata-amd64.json" \
             amd64 \
             .build-lineage \
             ${BAKE_CONTAINERS}
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            export BAKE_GENERATE_ALL_RETAINED=true
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            emit_bake_build_results \
+              "${RUNNER_TEMP}/bake-metadata-amd64.json" \
+              amd64 \
+              .build-lineage \
+              ${BAKE_RETAINED_CONTAINERS}
+          fi
 
       - name: Upload build-result artifacts (amd64)
         id: upload-bres-amd64
@@ -1773,6 +1816,7 @@ jobs:
         if: steps.install-syft-bake.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: |
@@ -1780,9 +1824,18 @@ jobs:
           source ./helpers/sbom-utils.sh
           chmod +x scripts/generate-bake-hcl.sh
 
-          # Bake is latest-only by design; generate cells for the latest version only.
           # shellcheck disable=SC2086
           cells_json=$(./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          # B1-core: also SBOM the retained cells of eligible containers, else
+          # bake-attest (which matrices over all bake_builds incl. retained) finds
+          # no SBOM and silently skips attestation for retained images. Merge +
+          # dedupe by version-keyed cell identity (unique_by reorders, harmless —
+          # the SBOM loop is per-cell independent).
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            # shellcheck disable=SC2086
+            retained_cells=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells --all-retained ${BAKE_RETAINED_CONTAINERS})
+            cells_json=$(jq -s '(.[0] + .[1]) | unique_by([.container, (.tag // ""), (.flavor // "")])' <<< "$cells_json"$'\n'"$retained_cells")
+          fi
           ncells=$(jq 'length' <<< "$cells_json")
           mkdir -p .build-lineage
 
@@ -1955,8 +2008,11 @@ jobs:
         run: |
           set -euo pipefail
           containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          retained_containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[] | select(.is_latest_version != true) | .container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
           echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+          echo "retained_containers=${retained_containers}" >> "$GITHUB_OUTPUT"
           echo "::notice::bake containers (arm64): ${containers}"
+          echo "::notice::bake retained-eligible containers (arm64): ${retained_containers:-<none>}"
 
       - name: Resolve github-runner version from bake set
         id: resolve-gh-version
@@ -2003,6 +2059,7 @@ jobs:
         id: bake-build
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
           ARCH_SUFFIX: -arm64
           IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
@@ -2024,9 +2081,8 @@ jobs:
 
           # Using the real REMOTE_CR ensures base FROM refs resolve.
           #
-          # Bake is latest-only by design: retained (non-latest) cells are routed to the
-          # flat matrix by partition_builds, so they never reach this job.
-          # No --all-retained flag is passed here.
+          # Bake defaults to latest-only.  When build_all_retained is true,
+          # partition_builds admits only B1-core retained-eligible cells here.
           bake_file="${RUNNER_TEMP}/bake-arm64.json"
           # BAKE_CACHE_EXPORT gates cache-to emission: true only on the real publish
           # path (not IS_PR, not DRY_RUN).  See amd64 step comment for full rationale.
@@ -2034,10 +2090,39 @@ jobs:
           if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
             bake_cache_export="true"
           fi
+          bake_latest_file="${RUNNER_TEMP}/bake-arm64-latest.json"
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
-          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" \
-            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_file"
+          REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=false \
+            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_latest_file"
+          cp "$bake_latest_file" "$bake_file"
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            bake_retained_file="${RUNNER_TEMP}/bake-arm64-retained.json"
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=true \
+              ./scripts/generate-bake-hcl.sh --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
+            # Merge latest + retained HCL. On a target-key collision (a container's
+            # latest target appears in both passes) the retained pass wins. Safe
+            # ONLY because BAKE_RETAINED_CONTAINERS are retained-eligible, i.e. have
+            # NO internal base dependency (_bake_retained_eligible in
+            # helpers/bake-managed.sh) → their targets carry no `contexts` key, so
+            # both definitions are byte-identical and $extra-wins is a no-op. If a
+            # chained container is ever admitted to retained-bake (B1b), this
+            # object-merge would silently drop the latest target's `contexts` —
+            # revisit the merge then (e.g. emit retained cells only).
+            jq -s '
+              .[0] as $base | .[1] as $extra |
+              ($base.group.default.targets + $extra.group.default.targets) as $default_targets |
+              $base
+              | .target = ($base.target + $extra.target)
+              | .group = ($base.group + $extra.group)
+              | .group.default.targets = (
+                  reduce $default_targets[] as $t ([]; if index($t) then . else . + [$t] end)
+                )
+            ' "$bake_latest_file" "$bake_retained_file" > "$bake_file"
+          fi
 
           # FIX 3: honor DOCKER_NO_CACHE (rebuild=force) → --no-cache
           no_cache_flag=""
@@ -2073,21 +2158,31 @@ jobs:
         if: always() && env.DRY_RUN != 'true'
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
         run: |
           set -euo pipefail
           chmod +x helpers/bake-buildresult.sh
           source helpers/bake-buildresult.sh
 
-          # Bake is latest-only by design; emit covers only the latest cells.
-          export BAKE_GENERATE_ALL_RETAINED=false
-
           mkdir -p .build-lineage
+          export BAKE_GENERATE_ALL_RETAINED=false
           # shellcheck disable=SC2086
           emit_bake_build_results \
             "${RUNNER_TEMP}/bake-metadata-arm64.json" \
             arm64 \
             .build-lineage \
             ${BAKE_CONTAINERS}
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            export BAKE_GENERATE_ALL_RETAINED=true
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            emit_bake_build_results \
+              "${RUNNER_TEMP}/bake-metadata-arm64.json" \
+              arm64 \
+              .build-lineage \
+              ${BAKE_RETAINED_CONTAINERS}
+          fi
 
       - name: Upload build-result artifacts (arm64)
         id: upload-bres-arm64
@@ -2452,12 +2547,15 @@ jobs:
         run: |
           set -euo pipefail
           containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[].container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
+          retained_containers=$(printf '%s' "$BAKE_BUILDS_JSON" | jq -r '[.[] | select(.is_latest_version != true) | .container] | unique | .[]' | tr '\n' ' ' | sed 's/ $//')
           echo "containers=${containers}" >> "$GITHUB_OUTPUT"
+          echo "retained_containers=${retained_containers}" >> "$GITHUB_OUTPUT"
 
       - name: Canonical GHCR manifest merge (strict, fail-closed)
         id: bake-merge-step
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
           DRY_RUN: ${{ env.DRY_RUN }}
         run: |
@@ -2474,16 +2572,30 @@ jobs:
           done
           set +f
 
-          # Bake is latest-only by design; merge only the latest cells.
-          # No --all-retained flag is passed here.
+          # Bake defaults to latest-only.  When build_all_retained is true,
+          # merge retained cells only for the retained-eligible container subset.
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "::notice::manifest merge running in DRY-RUN (no canonical tags published; dry_run=${DRY_RUN})"
             # shellcheck disable=SC2086
-            DRY_RUN=true REMOTE_CR="$REMOTE_CR" ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+            DRY_RUN=true REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=false \
+              ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
           else
             # BAKE_CONTAINERS is operator-set from bake_builds JSON (trusted context)
             # shellcheck disable=SC2086
-            REMOTE_CR="$REMOTE_CR" ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+            REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=false \
+              ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+          fi
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              # shellcheck disable=SC2086
+              DRY_RUN=true REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=true \
+                ./scripts/bake-merge-manifests.sh --all-retained ${BAKE_RETAINED_CONTAINERS}
+            else
+              # shellcheck disable=SC2086
+              REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=true \
+                ./scripts/bake-merge-manifests.sh --all-retained ${BAKE_RETAINED_CONTAINERS}
+            fi
           fi
 
       - name: Best-effort DockerHub mirror (bake)
@@ -2491,22 +2603,30 @@ jobs:
         continue-on-error: true
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
         run: |
           set -euo pipefail
           chmod +x helpers/mirror-dockerhub.sh
-          # Bake is latest-only by design; mirror only the latest cells.
-          export BAKE_GENERATE_ALL_RETAINED=false
           source helpers/mirror-dockerhub.sh
           # BAKE_CONTAINERS is operator-set (trusted context)
+          export BAKE_GENERATE_ALL_RETAINED=false
           # shellcheck disable=SC2086
           mirror_to_dockerhub ${BAKE_CONTAINERS}
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            export BAKE_GENERATE_ALL_RETAINED=true
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            mirror_to_dockerhub ${BAKE_RETAINED_CONTAINERS}
+          fi
 
       - name: Emit manifest build-result artifacts (bake)
         if: always()
         env:
           BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
           MERGE_OUTCOME: ${{ steps.bake-merge-step.outcome }}
         run: |
           set -euo pipefail
@@ -2517,26 +2637,38 @@ jobs:
           result="failure"
           [[ "$MERGE_OUTCOME" == "success" ]] && result="success"
 
-          # Emit one manifest build-result per cell (mirrors create-manifest job shape).
-          # Bake is latest-only by design; generate cells for the latest version only.
+          emit_manifest_results() {
+            local cells_json="$1"
+            local ncells
+            ncells=$(jq 'length' <<< "$cells_json")
+            for (( i=0; i<ncells; i++ )); do
+              cell=$(jq -c ".[$i]" <<< "$cells_json")
+              container=$(jq -r '.container'        <<< "$cell")
+              tag=$(jq -r '.tag'                    <<< "$cell")
+              variant=$(jq -r '.variant // ""'      <<< "$cell")
+              out_file=".build-lineage/build-result-manifest-${container}-${tag}.json"
+              jq -cn \
+                --arg c "$container" \
+                --arg v "$variant" \
+                --arg t "$tag" \
+                --arg a "manifest" \
+                --arg r "$result" \
+                '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
+                > "$out_file" || true
+            done
+          }
+
+          # BAKE_CONTAINERS is operator-set (trusted context)
           # shellcheck disable=SC2086
-          cells_json=$(./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
-          ncells=$(jq 'length' <<< "$cells_json")
-          for (( i=0; i<ncells; i++ )); do
-            cell=$(jq -c ".[$i]" <<< "$cells_json")
-            container=$(jq -r '.container'        <<< "$cell")
-            tag=$(jq -r '.tag'                    <<< "$cell")
-            variant=$(jq -r '.variant // ""'      <<< "$cell")
-            out_file=".build-lineage/build-result-manifest-${container}-${tag}.json"
-            jq -cn \
-              --arg c "$container" \
-              --arg v "$variant" \
-              --arg t "$tag" \
-              --arg a "manifest" \
-              --arg r "$result" \
-              '{container:$c, variant:$v, tag:$t, arch:$a, result:$r}' \
-              > "$out_file" || true
-          done
+          cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=false ./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          emit_manifest_results "$cells_json"
+
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
+            # shellcheck disable=SC2086
+            cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells --all-retained ${BAKE_RETAINED_CONTAINERS})
+            emit_manifest_results "$cells_json"
+          fi
 
       - name: Upload manifest build-result artifacts (bake)
         id: upload-bres-manifest-bake

--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -5,7 +5,8 @@
 #   source helpers/bake-managed.sh
 #   bake_managed_containers         # echoes space-separated set
 #   is_bake_managed <container>     # 0 = yes, 1 = no
-#   partition_builds <builds_json>  # prints {"bake":[...],"matrix":[...]}
+#   _bake_retained_eligible <container>  # 0 = retained cells may route to bake
+#   partition_builds <builds_json>       # prints {"bake":[...],"matrix":[...]}
 #
 # Usage (standalone):
 #   helpers/bake-managed.sh partition <builds_json_or_@file>
@@ -87,7 +88,149 @@ _bake_container_latest_only() {
 }
 
 # ---------------------------------------------------------------------------
-# partition_builds <builds_json> [<scope_active>]
+# _bake_retained_core_containers
+#
+# Echoes the B1-core retained-bake rollout set.  This is intentionally narrower
+# than bake_managed_containers while chained retained rebuilds are deferred.
+# Override via BAKE_RETAINED_CORE_CONTAINERS for focused tests only.
+# ---------------------------------------------------------------------------
+_bake_retained_core_containers() {
+    echo "${BAKE_RETAINED_CORE_CONTAINERS:-debian vector jekyll ansible sslh openvpn openresty terraform}"
+}
+
+# ---------------------------------------------------------------------------
+# _bake_is_retained_core_container <container>
+#
+# Returns 0 if <container> is in the B1-core retained-bake rollout set.
+# ---------------------------------------------------------------------------
+_bake_is_retained_core_container() {
+    local container="$1"
+    local core
+    core=$(_bake_retained_core_containers)
+    local c
+    for c in $core; do
+        if [[ "$c" == "$container" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# _bake_normalize_base_repo <base_image_ref>
+#
+# Prints the repository path after stripping known project registry prefixes.
+# Examples:
+#   ghcr.io/oorabona/debian:${TAG}  -> debian
+#   ${REMOTE_CR}/php:${TAG}         -> php
+#   ${REMOTE_CR}/library/debian:12  -> library/debian
+#
+# The library/ namespace is deliberately left intact: it denotes an external
+# mirror path, not a project-built bake-managed container.
+# ---------------------------------------------------------------------------
+_bake_normalize_base_repo() {
+    local ref="$1"
+    local repo_path="${ref%%@*}"
+    local leaf="${repo_path##*/}"
+
+    if [[ "$leaf" == *:* ]]; then
+        repo_path="${repo_path%:*}"
+    fi
+
+    repo_path="${repo_path#\$\{REMOTE_CR\}/}"
+    if [[ "$repo_path" == ghcr.io/*/* ]]; then
+        repo_path="${repo_path#ghcr.io/}"
+        repo_path="${repo_path#*/}"
+    fi
+
+    printf '%s\n' "$repo_path"
+}
+
+# ---------------------------------------------------------------------------
+# _bake_container_has_internal_base_dependency <container>
+#
+# Static chained-container detector for retained-bake routing.
+#
+# Returns:
+#   0 when any config.yaml base_image points at another bake-managed container
+#   1 when config.yaml is parseable and no managed base dependency is found
+#   2 when config.yaml is missing, unparsable, or has no base_image entries
+#
+# This uses only <container>/config.yaml.  It never runs ./make, Docker, or any
+# networked probe.  library/* refs are external mirrors and are not considered
+# managed-container dependencies even when the leaf name matches a container.
+# ---------------------------------------------------------------------------
+_bake_container_has_internal_base_dependency() {
+    local container="$1"
+    local repo_root
+    repo_root="$(dirname "${_BM_SCRIPT_DIR}")"
+    local config_file="${repo_root}/${container}/config.yaml"
+
+    if [[ ! -f "$config_file" ]]; then
+        return 2
+    fi
+
+    local refs
+    if ! refs=$(yq e '.. | select(has("base_image")) | .base_image | select(. != null)' \
+            "$config_file" 2>/dev/null); then
+        return 2
+    fi
+    if [[ -z "$refs" ]]; then
+        return 2
+    fi
+
+    local ref repo_path first_segment
+    while IFS= read -r ref; do
+        [[ -n "$ref" ]] || continue
+        repo_path=$(_bake_normalize_base_repo "$ref")
+        [[ -n "$repo_path" ]] || continue
+        if [[ "$repo_path" == library/* ]]; then
+            continue
+        fi
+        first_segment="${repo_path%%/*}"
+        if is_bake_managed "$first_segment"; then
+            return 0
+        fi
+    done <<< "$refs"
+
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# _bake_retained_eligible <container>
+#
+# Returns 0 iff retained (non-latest) Linux cells for <container> may route to
+# bake in B1-core:
+#   - the container is bake-managed,
+#   - it is in the B1-core standalone rollout set,
+#   - it is not build.bake_latest_only,
+#   - its config.yaml base_image entries do not reference a bake-managed
+#     project container.
+#
+# Missing or unparsable config.yaml fails closed to not eligible.
+# ---------------------------------------------------------------------------
+_bake_retained_eligible() {
+    local container="$1"
+    local chained_status
+
+    is_bake_managed "$container" || return 1
+    if _bake_container_latest_only "$container"; then
+        return 1
+    fi
+    _bake_is_retained_core_container "$container" || return 1
+
+    if _bake_container_has_internal_base_dependency "$container"; then
+        return 1
+    else
+        chained_status=$?
+        [[ "$chained_status" -eq 1 ]] || return 1
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# partition_builds <builds_json> [<scope_active>] [<include_retained>]
 #
 # Given the `builds` JSON array (cells with a `.container` field), prints a
 # compact JSON object:
@@ -105,16 +248,14 @@ _bake_container_latest_only() {
 #   A cell lands in .bake only when ALL of the following hold:
 #     1. Its .container is in the bake-managed set.
 #     2. Its .os is "linux" or absent/empty (linux cells may omit the field).
-#     3. Its .is_latest_version is explicitly true.
+#     3. Its .is_latest_version is explicitly true OR include_retained is
+#        "true" and the container is retained-eligible.
 #   All other cells go to .matrix so the flat matrix handles them faithfully.
 #
-# Design rationale: bake is latest-only by design — it always generates and
-# builds the full container plan for the latest version of each container.
-# Any retained (non-latest) cell detected by the carry-forward / diff-failure /
-# container-file-change / PR-smoke logic is routed to the flat matrix, which
-# builds exactly the detected cells per-cell with full scan/attest coverage.
-# This prevents a retained cell from being falsely recovered (unscanned,
-# unpublished) by a bake run that regenerates latest-only.
+# Design rationale: retained-bake is deliberately limited to B1-core standalone
+# containers.  latest-only and chained containers keep retained cells on the
+# flat matrix so cells are not dropped or rebuilt against the wrong internal
+# base-image target.
 #
 # Cell order within each partition is preserved.
 #
@@ -124,6 +265,7 @@ _bake_container_latest_only() {
 partition_builds() {
     local builds_json="$1"
     local scope_active="${2:-false}"
+    local include_retained="${3:-false}"
 
     # Validate: must be a non-empty string
     if [[ -z "$builds_json" ]]; then
@@ -144,39 +286,80 @@ partition_builds() {
         return 0
     fi
 
-    # Build jq array argument from the managed set.
+    # Build jq array arguments from the managed set and retained-eligible set.
     # Read into an array so word-splitting is explicit and shellcheck-clean.
     local managed
     managed=$(bake_managed_containers)
     local -a managed_arr
     read -ra managed_arr <<< "$managed"
     local managed_jq_array
-    managed_jq_array=$(printf '%s\n' "${managed_arr[@]}" | jq -R . | jq -s -c .)
+    if [[ ${#managed_arr[@]} -gt 0 ]]; then
+        managed_jq_array=$(printf '%s\n' "${managed_arr[@]}" | jq -R . | jq -s -c .)
+    else
+        managed_jq_array='[]'
+    fi
+
+    local eligible_jq_array='[]'
+    if [[ "$include_retained" == "true" ]]; then
+        local -a eligible_arr=()
+        local c
+        while IFS= read -r c; do
+            [[ -n "$c" ]] || continue
+            if _bake_retained_eligible "$c"; then
+                eligible_arr+=("$c")
+            fi
+        done < <(echo "$builds_json" | jq -r '
+            [.[] |
+                select((.os // "") == "" or (.os // "") == "linux") |
+                .container // empty
+            ] | unique | .[]')
+
+        if [[ ${#eligible_arr[@]} -gt 0 ]]; then
+            eligible_jq_array=$(printf '%s\n' "${eligible_arr[@]}" | jq -R . | jq -s -c .)
+        fi
+    fi
 
     # Partition in a single jq pass; cell order preserved within each partition.
     #
     # A cell lands in .bake only when ALL hold:
     #   (a) container is bake-managed
     #   (b) .os is "linux" or absent/empty (linux cells may omit the field)
-    #   (c) .is_latest_version is explicitly true
+    #   (c) .is_latest_version is explicitly true OR include_retained=true and
+    #       the container is retained-eligible
     #
-    # Retained (non-latest) cells for bake-managed containers route to .matrix
-    # so the flat matrix builds them with per-cell scan/attest fidelity.
+    # Non-eligible retained cells route to .matrix so the flat matrix builds
+    # them with per-cell scan/attest fidelity.
     # Note: .container is captured as $c before entering $managed so the
     # any() filter runs in string context (not object context).
     echo "$builds_json" | jq -c \
         --argjson managed "$managed_jq_array" \
+        --argjson eligible "$eligible_jq_array" \
+        --arg include_retained "$include_retained" \
         '{
             bake:   [.[] | select(
-                        (.container as $c | $managed | any(. == $c))
-                        and ((.os // "") == "" or (.os // "") == "linux")
-                        and (.is_latest_version == true)
+                        (
+                            (.container as $c | $managed | any(. == $c))
+                            and ((.os // "") == "" or (.os // "") == "linux")
+                            and (
+                                (.is_latest_version == true)
+                                or (
+                                    $include_retained == "true"
+                                    and (.container as $c | $eligible | any(. == $c))
+                                )
+                            )
+                        )
                     )],
             matrix: [.[] | select(
                         (
                             (.container as $c | $managed | any(. == $c))
                             and ((.os // "") == "" or (.os // "") == "linux")
-                            and (.is_latest_version == true)
+                            and (
+                                (.is_latest_version == true)
+                                or (
+                                    $include_retained == "true"
+                                    and (.container as $c | $eligible | any(. == $c))
+                                )
+                            )
                         ) | not
                     )]
         }'
@@ -190,21 +373,22 @@ main() {
     case "$cmd" in
         partition)
             if [[ $# -lt 2 ]]; then
-                printf 'Usage: %s partition <builds_json_or_@file> [scope_active]\n' \
+                printf 'Usage: %s partition <builds_json_or_@file> [scope_active] [include_retained]\n' \
                     "$(basename "$0")" >&2
                 return 1
             fi
             local input="$2"
             local scope_arg="${3:-false}"
+            local include_retained_arg="${4:-false}"
             # Support @file syntax: @path reads from file
             if [[ "$input" == @* ]]; then
                 local filepath="${input#@}"
                 input="$(cat "$filepath")"
             fi
-            partition_builds "$input" "$scope_arg"
+            partition_builds "$input" "$scope_arg" "$include_retained_arg"
             ;;
         *)
-            printf 'Usage: %s partition <builds_json_or_@file> [scope_active]\n' \
+            printf 'Usage: %s partition <builds_json_or_@file> [scope_active] [include_retained]\n' \
                 "$(basename "$0")" >&2
             return 1
             ;;

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -32,10 +32,12 @@ setup() {
 
     # Clear any env override between tests
     unset BAKE_MANAGED_CONTAINERS || true
+    unset BAKE_RETAINED_CORE_CONTAINERS || true
 }
 
 teardown() {
     unset BAKE_MANAGED_CONTAINERS || true
+    unset BAKE_RETAINED_CORE_CONTAINERS || true
 }
 
 # ---------------------------------------------------------------------------
@@ -74,6 +76,25 @@ _fixture_os_builds() {
       {"container":"github-runner","os":"windows", "tag":"windows-2022-1.2.3","variant":"windows-2022","is_latest_version":true},
       {"container":"github-runner","tag":"linux-noos-1.2.3","variant":"ubuntu-2204","is_latest_version":true},
       {"container":"debian",       "os":"linux",   "tag":"bookworm-12.0.0",  "variant":"bookworm"}
+    ]'
+}
+
+# Fixture for retained-bake B1-core routing.  It includes latest + retained
+# cells for one eligible container, three non-eligible bake-managed containers,
+# and one non-bake-managed control.
+_fixture_retained_bake_builds() {
+    jq -cn '
+    [
+      {"container":"debian",       "os":"linux","tag":"bookworm-13.0.0",     "variant":"bookworm","is_latest_version":true},
+      {"container":"debian",       "os":"linux","tag":"bookworm-12.0.0",     "variant":"bookworm","is_latest_version":false},
+      {"container":"github-runner","os":"linux","tag":"ubuntu-2404-2.334.0","variant":"ubuntu-2404","is_latest_version":true},
+      {"container":"github-runner","os":"linux","tag":"ubuntu-2404-2.333.0","variant":"ubuntu-2404","is_latest_version":false},
+      {"container":"wordpress",    "os":"linux","tag":"latest-6.5.0",       "variant":"latest","is_latest_version":true},
+      {"container":"wordpress",    "os":"linux","tag":"latest-6.4.0",       "variant":"latest","is_latest_version":false},
+      {"container":"web-shell",    "os":"linux","tag":"alpine-2.0.0",       "variant":"alpine","is_latest_version":true},
+      {"container":"web-shell",    "os":"linux","tag":"alpine-1.0.0",       "variant":"alpine","is_latest_version":false},
+      {"container":"postgres",     "os":"linux","tag":"17-alpine",          "variant":"17-alpine","is_latest_version":true},
+      {"container":"postgres",     "os":"linux","tag":"16-alpine",          "variant":"16-alpine","is_latest_version":false}
     ]'
 }
 
@@ -606,4 +627,117 @@ ubuntu-1.0.0"
     # debian must land in .matrix
     deb_in_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "debian")] | length')
     [[ "$deb_in_matrix" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-18: _bake_retained_eligible — direct eligibility checks for B1-core.
+# ---------------------------------------------------------------------------
+@test "BM-18: _bake_retained_eligible accepts standalone eligible containers only" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    run _bake_retained_eligible "debian"
+    [[ "$status" -eq 0 ]]
+
+    run _bake_retained_eligible "github-runner"
+    [[ "$status" -eq 1 ]]
+
+    run _bake_retained_eligible "wordpress"
+    [[ "$status" -eq 1 ]]
+
+    run _bake_retained_eligible "web-shell"
+    [[ "$status" -eq 1 ]]
+
+    run _bake_retained_eligible "postgres"
+    [[ "$status" -eq 1 ]]
+
+    run _bake_retained_eligible "php"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-19: _bake_retained_eligible — missing config.yaml fails closed even when a
+#         test override places the container in both managed and rollout sets.
+# ---------------------------------------------------------------------------
+@test "BM-19: _bake_retained_eligible fails closed for missing config.yaml" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    BAKE_MANAGED_CONTAINERS="missing-retained"
+    BAKE_RETAINED_CORE_CONTAINERS="missing-retained"
+
+    run _bake_retained_eligible "missing-retained"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-20: include_retained=true — eligible retained cells route to bake; retained
+#         cells for latest-only, chained, and non-bake containers stay matrix.
+# ---------------------------------------------------------------------------
+@test "BM-20: include_retained=true routes only eligible retained cells to bake" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(_fixture_retained_bake_builds)
+    result=$(partition_builds "$fixture" "false" "true")
+
+    # Eligible debian latest + retained both route to bake.
+    debian_bake=$(echo "$result" | jq '[.bake[] | select(.container == "debian")] | length')
+    [[ "$debian_bake" -eq 2 ]]
+    debian_retained_bake=$(echo "$result" | jq '[.bake[] | select(.container == "debian" and .is_latest_version == false)] | length')
+    [[ "$debian_retained_bake" -eq 1 ]]
+
+    # Non-eligible retained cells stay in matrix and do not vanish.
+    gr_retained_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "github-runner" and .is_latest_version == false)] | length')
+    [[ "$gr_retained_matrix" -eq 1 ]]
+    wp_retained_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "wordpress" and .is_latest_version == false)] | length')
+    [[ "$wp_retained_matrix" -eq 1 ]]
+    ws_retained_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "web-shell" and .is_latest_version == false)] | length')
+    [[ "$ws_retained_matrix" -eq 1 ]]
+
+    gr_retained_bake=$(echo "$result" | jq '[.bake[] | select(.container == "github-runner" and .is_latest_version == false)] | length')
+    [[ "$gr_retained_bake" -eq 0 ]]
+    wp_retained_bake=$(echo "$result" | jq '[.bake[] | select(.container == "wordpress" and .is_latest_version == false)] | length')
+    [[ "$wp_retained_bake" -eq 0 ]]
+    ws_retained_bake=$(echo "$result" | jq '[.bake[] | select(.container == "web-shell" and .is_latest_version == false)] | length')
+    [[ "$ws_retained_bake" -eq 0 ]]
+
+    # Latest cells for all bake-managed containers still route to bake.
+    gr_latest_bake=$(echo "$result" | jq '[.bake[] | select(.container == "github-runner" and .is_latest_version == true)] | length')
+    [[ "$gr_latest_bake" -eq 1 ]]
+    wp_latest_bake=$(echo "$result" | jq '[.bake[] | select(.container == "wordpress" and .is_latest_version == true)] | length')
+    [[ "$wp_latest_bake" -eq 1 ]]
+    ws_latest_bake=$(echo "$result" | jq '[.bake[] | select(.container == "web-shell" and .is_latest_version == true)] | length')
+    [[ "$ws_latest_bake" -eq 1 ]]
+
+    # Non-bake postgres stays matrix for both latest and retained.
+    postgres_matrix=$(echo "$result" | jq '[.matrix[] | select(.container == "postgres")] | length')
+    [[ "$postgres_matrix" -eq 2 ]]
+    postgres_bake=$(echo "$result" | jq '[.bake[] | select(.container == "postgres")] | length')
+    [[ "$postgres_bake" -eq 0 ]]
+
+    total=$(echo "$result" | jq '.bake + .matrix | length')
+    [[ "$total" -eq 10 ]]
+}
+
+# ---------------------------------------------------------------------------
+# BM-21: include_retained=false/absent preserves current retained routing.
+# ---------------------------------------------------------------------------
+@test "BM-21: include_retained false or absent leaves all retained cells on matrix" {
+    # shellcheck disable=SC1090
+    source "$BM"
+
+    fixture=$(_fixture_retained_bake_builds)
+
+    result_false=$(partition_builds "$fixture" "false" "false")
+    retained_bake_false=$(echo "$result_false" | jq '[.bake[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_bake_false" -eq 0 ]]
+    retained_matrix_false=$(echo "$result_false" | jq '[.matrix[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_matrix_false" -eq 5 ]]
+
+    result_absent=$(partition_builds "$fixture")
+    retained_bake_absent=$(echo "$result_absent" | jq '[.bake[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_bake_absent" -eq 0 ]]
+    retained_matrix_absent=$(echo "$result_absent" | jq '[.matrix[] | select(.is_latest_version == false)] | length')
+    [[ "$retained_matrix_absent" -eq 5 ]]
 }


### PR DESCRIPTION
## What & why

#666 phase B1-core (ADR-014): retained (non-latest) versions of the **8 standalone** bake-managed containers — `debian, vector, jekyll, ansible, sslh, openvpn, openresty, terraform` — now build through **bake** (when `build_all_retained` is set) instead of the flat matrix. This shrinks the dual-path surface: their retained builds get bake's in-memory DAG + GHCR-strict multi-arch manifests instead of the matrix.

**Deferred to B1b** (stay on the matrix for retained): chained containers `wordpress` (→php) and `web-shell` (→debian) need version-aware base-context mapping; `github-runner` is `bake_latest_only` (shared `runner.tar.gz`) + chained.

## Changes

- **`helpers/bake-managed.sh`**: `_bake_retained_eligible <container>` = bake-managed ∧ NOT `bake_latest_only` ∧ in the B1-core set ∧ NO internal base-image dependency (static `config.yaml` check, fail-closed on missing/unparsable). `partition_builds` gains a 3rd `include_retained` arg; a retained cell routes to `.bake` only when `include_retained` AND eligible. **`.matrix` is the exact complement of `.bake`** — no cell can ever vanish (worst case it stays on the matrix).
- **`detect-containers`**: thread `build_all_retained` as the 3rd `partition_builds` arg.
- **`auto-build` bake-build amd64/arm64**: when `build_all_retained`, generate a retained HCL for ONLY the eligible retained containers and merge it with the latest HCL (collision-safety documented inline — rests on the no-internal-dep invariant, so collided latest targets are byte-identical). SBOM step also enumerates the retained cells so `bake-attest` finds their SBOM (no supply-chain coverage gap). `BAKE_GENERATE_ALL_RETAINED` threaded into lineage/mirror/merge emits. **Push events unaffected** (`build_all_retained=false` → latest-only, byte-identical to before).
- **tests**: `_bake_retained_eligible` (eligible / latest_only / chained / non-bake / missing-config→fail-closed) + `partition_builds` retained routing (eligible→bake, github-runner/wordpress/web-shell→matrix-not-vanished, `include_retained=false`→all retained on matrix).

## Validation

- `shellcheck -x -S warning` clean; `bats tests/unit/bake-managed.bats` 24/24 (incl. the new BM-18…21); `actionlint` clean; YAML parse.
- Senior review: **REVIEW-CLEAN** (the two-pass HCL merge is collision-safe via the eligibility invariant).
- Pre-PR orthogonal gate: **codex xhigh CLEAN** (caught + fixed: retained cells missing SBOM/attest coverage). copilot exogenously unavailable → degraded GATE_OK.
- **End-to-end**: validated via a `build_all_retained=true` `workflow_dispatch` (see PR comment) — retained bake build produces a genuine multi-arch retained manifest and leaves `:latest` pointing at the latest cell.

Known follow-up (safe, deferred): the retained pass re-processes each eligible container's LATEST cell (idempotent re-push + identical build-result overwrite) — wasteful, not incorrect.

Refs #666 (B1-core), ADR-014.
