### PR TITLE
feat(ci): route scoped builds through bake (#666 B4)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -650,9 +650,6 @@ runs:
       shell: bash
       env:
         BUILDS: ${{ steps.expand-variants.outputs.builds }}
-        SCOPE_VERSIONS: ${{ inputs.scope_versions }}
-        SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
-        BUILD_SCOPE: ${{ inputs.scope }}
         EVENT_NAME: ${{ github.event_name }}
         BUILD_ALL_RETAINED: ${{ inputs.build_all_retained }}
         RUN_TESTS: ${{ inputs.run_tests }}
@@ -671,15 +668,18 @@ runs:
         [[ -z "$builds_input" ]] && builds_input="[]"
 
         # force_matrix=true disables bake routing — all cells go to the flat matrix.
-        # Two independent reasons force this:
-        #   1. Scoped runs (scope_versions, scope_flavors, or unified BUILD_SCOPE
-        #      non-empty) build only a subset of cells.  Routing bake-managed containers
-        #      to the bake engine would cause bake to publish ALL variants while only
-        #      the scoped cells receive scan/attest coverage.
-        #   2. fork pull_request: a fork cannot rely on the owner's GHCR base-image
+        # Scope inputs do NOT force the matrix: expand-variants has already filtered
+        # BUILDS to the scoped subset before this partition step, so scoped
+        # bake-managed Linux latest cells may route to bake.  auto-build forwards
+        # the same scope flags to the bake generator so the emitted bake graph and
+        # cell plans stay aligned with this routed subset.
+        # Two independent reasons still force the matrix:
+        #   1. fork pull_request: a fork cannot rely on the owner's GHCR base-image
         #      mirror (PR sync is skipped + the fork token may not read it); the
         #      flat matrix's use_base_cache falls back to direct upstream pulls, so
         #      fork PRs stay on the matrix.
+        #   2. run_tests=true on pull_request: bake-test needs pushed per-arch refs,
+        #      which do not exist on PR build-only runs.
         # run_tests=true no longer disables bake routing: bake-managed Linux bats
         # tests run in the bake-test job, while Windows Pester stays in build-and-push.
         # SAME-REPO pull_request events route bake-managed Linux cells through
@@ -692,15 +692,11 @@ runs:
         # postgres/windows/non-bake cells stay on the flat matrix through the
         # normal partition gates.
         force_matrix="false"
-        scope_active="false"
-        if [[ -n "${SCOPE_VERSIONS}" || -n "${SCOPE_FLAVORS}" || -n "${BUILD_SCOPE}" ]]; then
-          scope_active="true"
-        fi
         # run_tests on a pull_request stays on the matrix: bake-test needs a
         # PUSHED per-arch ref to pull, which does not exist on a PR (build-only).
         # run_tests is dispatch-only in practice, so this is a belt-and-suspenders
         # guard for a workflow_call-from-PR carrying run_tests=true.
-        if [[ "$scope_active" == "true" || "${IS_FORK_PR:-false}" == "true" || ( "${RUN_TESTS:-false}" == "true" && "$EVENT_NAME" == "pull_request" ) ]]; then
+        if [[ "${IS_FORK_PR:-false}" == "true" || ( "${RUN_TESTS:-false}" == "true" && "$EVENT_NAME" == "pull_request" ) ]]; then
           force_matrix="true"
         fi
 
@@ -716,4 +712,4 @@ runs:
         echo "bake_builds=$bake_builds" >> "$GITHUB_OUTPUT"
         echo "matrix_builds=$matrix_builds" >> "$GITHUB_OUTPUT"
         echo "postgres_matrix_builds=$postgres_matrix_builds" >> "$GITHUB_OUTPUT"
-        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count (scope_active=${scope_active} force_matrix=${force_matrix} event=${EVENT_NAME})"
+        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count (force_matrix=${force_matrix} event=${EVENT_NAME})"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -211,8 +211,10 @@ env:
   SKIP_EXISTING_BUILDS: ${{ (inputs.rebuild == 'all' || inputs.rebuild == 'force' || inputs.force_rebuild == true) && 'false' || 'true' }}
   # Pass --no-cache to docker build when rebuild=force
   DOCKER_NO_CACHE: ${{ inputs.rebuild == 'force' && 'true' || 'false' }}
+  SCOPE_VERSIONS: ${{ github.event.inputs.scope_versions || inputs.scope_versions || '' }}
+  SCOPE_FLAVORS: ${{ github.event.inputs.scope_flavors || inputs.scope_flavors || '' }}
   # Variant scope filter (free-text, matched against variant/os/build_flavor fields)
-  BUILD_SCOPE: ${{ inputs.scope || '' }}
+  BUILD_SCOPE: ${{ github.event.inputs.scope || inputs.scope || '' }}
   BUILD_ALL_RETAINED: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || 'false' }}
 
 jobs:
@@ -1678,11 +1680,15 @@ jobs:
           if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
             bake_cache_export="true"
           fi
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
           bake_latest_file="${RUNNER_TEMP}/bake-amd64-latest.json"
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
           REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=false \
-            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_latest_file"
+            ./scripts/generate-bake-hcl.sh "${scope_args[@]}" ${BAKE_CONTAINERS} > "$bake_latest_file"
           cp "$bake_latest_file" "$bake_file"
 
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
@@ -1690,7 +1696,7 @@ jobs:
             # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
             # shellcheck disable=SC2086
             REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=true \
-              ./scripts/generate-bake-hcl.sh --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
+              ./scripts/generate-bake-hcl.sh "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
             # Merge latest + retained HCL. On a target-key collision (a container's
             # latest target appears in both passes) the retained pass wins. Safe
             # ONLY because BAKE_RETAINED_CONTAINERS are retained-eligible, i.e. have
@@ -1824,8 +1830,13 @@ jobs:
           source ./helpers/sbom-utils.sh
           chmod +x scripts/generate-bake-hcl.sh
 
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+
           # shellcheck disable=SC2086
-          cells_json=$(./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          cells_json=$(./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" ${BAKE_CONTAINERS})
           # B1-core: also SBOM the retained cells of eligible containers, else
           # bake-attest (which matrices over all bake_builds incl. retained) finds
           # no SBOM and silently skips attestation for retained images. Merge +
@@ -1833,7 +1844,7 @@ jobs:
           # the SBOM loop is per-cell independent).
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
             # shellcheck disable=SC2086
-            retained_cells=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells --all-retained ${BAKE_RETAINED_CONTAINERS})
+            retained_cells=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS})
             cells_json=$(jq -s '(.[0] + .[1]) | unique_by([.container, (.tag // ""), (.flavor // "")])' <<< "$cells_json"$'\n'"$retained_cells")
           fi
           ncells=$(jq 'length' <<< "$cells_json")
@@ -2090,11 +2101,15 @@ jobs:
           if [[ "$IS_PR" != "true" && "$DRY_RUN" != "true" ]]; then
             bake_cache_export="true"
           fi
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
           bake_latest_file="${RUNNER_TEMP}/bake-arm64-latest.json"
           # BAKE_CONTAINERS is operator-set (from bake_builds JSON, trusted context)
           # shellcheck disable=SC2086
           REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=false \
-            ./scripts/generate-bake-hcl.sh ${BAKE_CONTAINERS} > "$bake_latest_file"
+            ./scripts/generate-bake-hcl.sh "${scope_args[@]}" ${BAKE_CONTAINERS} > "$bake_latest_file"
           cp "$bake_latest_file" "$bake_file"
 
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
@@ -2102,7 +2117,7 @@ jobs:
             # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
             # shellcheck disable=SC2086
             REMOTE_CR="$REMOTE_CR" BAKE_CACHE_EXPORT="$bake_cache_export" _BAKE_INCLUDE_ALL_RETAINED=true \
-              ./scripts/generate-bake-hcl.sh --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
+              ./scripts/generate-bake-hcl.sh "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS} > "$bake_retained_file"
             # Merge latest + retained HCL. On a target-key collision (a container's
             # latest target appears in both passes) the retained pass wins. Safe
             # ONLY because BAKE_RETAINED_CONTAINERS are retained-eligible, i.e. have
@@ -2636,29 +2651,34 @@ jobs:
           done
           set +f
 
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+
           # Bake defaults to latest-only.  When build_all_retained is true,
           # merge retained cells only for the retained-eligible container subset.
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "::notice::manifest merge running in DRY-RUN (no canonical tags published; dry_run=${DRY_RUN})"
             # shellcheck disable=SC2086
             DRY_RUN=true REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=false \
-              ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+              ./scripts/bake-merge-manifests.sh "${scope_args[@]}" ${BAKE_CONTAINERS}
           else
             # BAKE_CONTAINERS is operator-set from bake_builds JSON (trusted context)
             # shellcheck disable=SC2086
             REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=false \
-              ./scripts/bake-merge-manifests.sh ${BAKE_CONTAINERS}
+              ./scripts/bake-merge-manifests.sh "${scope_args[@]}" ${BAKE_CONTAINERS}
           fi
 
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
             if [[ "$DRY_RUN" == "true" ]]; then
               # shellcheck disable=SC2086
               DRY_RUN=true REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=true \
-                ./scripts/bake-merge-manifests.sh --all-retained ${BAKE_RETAINED_CONTAINERS}
+                ./scripts/bake-merge-manifests.sh "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS}
             else
               # shellcheck disable=SC2086
               REMOTE_CR="$REMOTE_CR" _BAKE_INCLUDE_ALL_RETAINED=true \
-                ./scripts/bake-merge-manifests.sh --all-retained ${BAKE_RETAINED_CONTAINERS}
+                ./scripts/bake-merge-manifests.sh "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS}
             fi
           fi
 
@@ -2674,16 +2694,20 @@ jobs:
           set -euo pipefail
           chmod +x helpers/mirror-dockerhub.sh
           source helpers/mirror-dockerhub.sh
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
           # BAKE_CONTAINERS is operator-set (trusted context)
           export BAKE_GENERATE_ALL_RETAINED=false
           # shellcheck disable=SC2086
-          mirror_to_dockerhub ${BAKE_CONTAINERS}
+          mirror_to_dockerhub "${scope_args[@]}" ${BAKE_CONTAINERS}
 
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
             export BAKE_GENERATE_ALL_RETAINED=true
             # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
             # shellcheck disable=SC2086
-            mirror_to_dockerhub ${BAKE_RETAINED_CONTAINERS}
+            mirror_to_dockerhub "${scope_args[@]}" ${BAKE_RETAINED_CONTAINERS}
           fi
 
       - name: Emit manifest build-result artifacts (bake)
@@ -2700,6 +2724,11 @@ jobs:
 
           result="failure"
           [[ "$MERGE_OUTCOME" == "success" ]] && result="success"
+
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
 
           emit_manifest_results() {
             local cells_json="$1"
@@ -2724,13 +2753,13 @@ jobs:
 
           # BAKE_CONTAINERS is operator-set (trusted context)
           # shellcheck disable=SC2086
-          cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=false ./scripts/generate-bake-hcl.sh --cells ${BAKE_CONTAINERS})
+          cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=false ./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" ${BAKE_CONTAINERS})
           emit_manifest_results "$cells_json"
 
           if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
             # BAKE_RETAINED_CONTAINERS is derived from bake_builds retained cells.
             # shellcheck disable=SC2086
-            cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells --all-retained ${BAKE_RETAINED_CONTAINERS})
+            cells_json=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS})
             emit_manifest_results "$cells_json"
           fi
 

--- a/helpers/bake-buildresult.sh
+++ b/helpers/bake-buildresult.sh
@@ -66,8 +66,14 @@ emit_bake_build_results() {
     local generator="${_BBR_SCRIPT_DIR}/../scripts/generate-bake-hcl.sh"
     local -a cells_args=("--cells")
     if [[ "${BAKE_GENERATE_ALL_RETAINED:-}" == "true" ]]; then
-        cells_args=("--cells" "--all-retained")
+        cells_args+=("--all-retained")
     fi
+    # Match the scoped bake build set. If this helper enumerates unscoped
+    # cells, scoped-out targets that are absent from metadata become false
+    # failures in coverage lineage.
+    [[ -n "${SCOPE_VERSIONS:-}" ]] && cells_args+=("--scope-versions" "${SCOPE_VERSIONS}")
+    [[ -n "${SCOPE_FLAVORS:-}" ]] && cells_args+=("--scope-flavors" "${SCOPE_FLAVORS}")
+    [[ -n "${BUILD_SCOPE:-}" ]] && cells_args+=("--scope" "${BUILD_SCOPE}")
     if ! cells_json=$("$generator" "${cells_args[@]}" "${containers[@]}"); then
         printf '::error::bake-buildresult: --cells failed for %s\n' \
             "${containers[*]}" >&2

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -7,6 +7,9 @@
 #   scripts/generate-bake-hcl.sh                  # whole fleet
 #   scripts/generate-bake-hcl.sh wordpress         # wordpress + dep closure
 #   scripts/generate-bake-hcl.sh github-runner     # github-runner + debian dep
+#   scripts/generate-bake-hcl.sh --cells --scope-versions 1.31 openresty
+#   scripts/generate-bake-hcl.sh --scope-flavors aws terraform
+#   scripts/generate-bake-hcl.sh --scope alpine web-shell
 #
 # Output is a JSON bake file (same schema as HCL; docker-buildx bake -f -)
 # written to stdout.  It is a generated artifact — do NOT commit it.
@@ -100,6 +103,22 @@ _assert_arg_key() {
     fi
 }
 
+# Print CLI help.
+_usage() {
+    cat <<'EOF'
+Usage:
+  scripts/generate-bake-hcl.sh [options] [container ...]
+
+Options:
+  --cells                 Emit compact cell JSON instead of a bake document.
+  --all-retained          Include retained versions where allowed.
+  --scope-versions <csv>  Keep versions matching a comma-separated version list.
+  --scope-flavors <csv>   Keep cells whose flavor is in a comma-separated list.
+  --scope <str>           Keep cells whose variant/os/build_flavor/flavor contains this string.
+  -h, --help              Show this help.
+EOF
+}
+
 # Enumerate all containers from `./make list`, strictly filtered to container-
 # name characters to drop any diagnostic noise.
 _list_all_containers() {
@@ -151,6 +170,65 @@ _expand_closure() {
     done
 
     printf '%s\n' "${closure[@]:-}"
+}
+
+# _cell_passes_scope <version> <flavor> <variant> <os> <build_flavor>
+# Returns 0 if the cell passes the active bake scope filters.
+# Empty scope variables mean pass-all.
+_cell_passes_scope() {
+    local version="$1"
+    local flavor="$2"
+    local variant="$3"
+    local cell_os="$4"
+    local build_flavor="$5"
+
+    if [[ -n "${_BAKE_SCOPE_VERSIONS:-}" ]]; then
+        local version_match="false"
+        local versions_csv="${_BAKE_SCOPE_VERSIONS},"
+        local scope_version
+        while [[ "$versions_csv" == *,* ]]; do
+            scope_version="${versions_csv%%,*}"
+            versions_csv="${versions_csv#*,}"
+
+            # Keep byte-identical semantics with
+            # .github/actions/detect-containers/action.yaml scope_versions jq:
+            # V == S OR V startswith(S + ".") OR V startswith(S + "-").
+            if [[ "$version" == "$scope_version" || \
+                  "$version" == "$scope_version."* || \
+                  "$version" == "$scope_version-"* ]]; then
+                version_match="true"
+                break
+            fi
+        done
+        [[ "$version_match" == "true" ]] || return 1
+    fi
+
+    if [[ -n "${_BAKE_SCOPE_FLAVORS:-}" ]]; then
+        local flavor_match="false"
+        local flavors_csv="${_BAKE_SCOPE_FLAVORS},"
+        local scope_flavor
+        while [[ "$flavors_csv" == *,* ]]; do
+            scope_flavor="${flavors_csv%%,*}"
+            flavors_csv="${flavors_csv#*,}"
+            if [[ "$flavor" == "$scope_flavor" ]]; then
+                flavor_match="true"
+                break
+            fi
+        done
+        [[ "$flavor_match" == "true" ]] || return 1
+    fi
+
+    if [[ -n "${_BAKE_SCOPE:-}" ]]; then
+        local scope="${_BAKE_SCOPE}"
+        if [[ "$variant" != *"$scope"* && \
+              "$cell_os" != *"$scope"* && \
+              "$build_flavor" != *"$scope"* && \
+              "$flavor" != *"$scope"* ]]; then
+            return 1
+        fi
+    fi
+
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -690,8 +768,35 @@ _enumerate_cells_init() {
         _EC_all_matrix_json[$c]="$matrix"
 
         local first_entry
-        first_entry=$(jq -c 'first(.[] | select(.is_latest_version == true)) // .[0]' \
-            <<< "$matrix" 2>/dev/null) || first_entry=""
+        if [[ -n "${_BAKE_SCOPE_VERSIONS:-}" || -n "${_BAKE_SCOPE_FLAVORS:-}" || -n "${_BAKE_SCOPE:-}" ]]; then
+            first_entry=""
+            local _first_ncells
+            _first_ncells=$(jq 'length' <<< "$matrix")
+            local _first_i
+            for (( _first_i=0; _first_i<_first_ncells; _first_i++ )); do
+                local _first_cell
+                _first_cell=$(jq -c ".[$_first_i]" <<< "$matrix")
+
+                local _first_version _first_flavor _first_variant _first_os _first_build_flavor
+                _first_version=$(jq -r '.version' <<< "$_first_cell")
+                _first_flavor=$(jq -r '.flavor // ""' <<< "$_first_cell")
+                _first_variant=$(jq -r '.variant // ""' <<< "$_first_cell")
+                _first_os=$(jq -r '.os // "linux"' <<< "$_first_cell")
+                _first_build_flavor=$(jq -r '.build_flavor // ""' <<< "$_first_cell")
+
+                if [[ "$_first_os" == "windows" ]]; then
+                    continue
+                fi
+                if _cell_passes_scope "$_first_version" "$_first_flavor" "$_first_variant" \
+                        "$_first_os" "$_first_build_flavor"; then
+                    first_entry="$_first_cell"
+                    break
+                fi
+            done
+        else
+            first_entry=$(jq -c 'first(.[] | select(.is_latest_version == true)) // .[0]' \
+                <<< "$matrix" 2>/dev/null) || first_entry=""
+        fi
         if [[ -n "$first_entry" && "$first_entry" != "null" ]]; then
             local fver fvariant ftag
             fver=$(jq -r '.version'           <<< "$first_entry")
@@ -765,6 +870,9 @@ _enumerate_cells() {
 
             # Skip Windows cells — bake/linux-native only.
             if [[ "$cell_os" == "windows" ]]; then
+                continue
+            fi
+            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1030,6 +1138,9 @@ _build_bake_json() {
             if [[ "$cell_os" == "windows" ]]; then
                 continue
             fi
+            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
+                continue
+            fi
 
             _on_cell_bake "$c" "$cell" "$dep_target_ids_json" "$config_args" \
                 "$version" "$variant" "$tag" "$flavor" "$build_flavor" \
@@ -1173,10 +1284,11 @@ _emit_cells_json() {
             local cell
             cell=$(jq -c ".[$i]" <<< "$matrix")
 
-            local version tag flavor variant cell_os is_default_raw is_latest_raw
+            local version tag flavor build_flavor variant cell_os is_default_raw is_latest_raw
             version=$(jq -r '.version'          <<< "$cell")
             tag=$(jq -r '.tag'              <<< "$cell")
             flavor=$(jq -r '.flavor // ""'  <<< "$cell")
+            build_flavor=$(jq -r '.build_flavor // ""' <<< "$cell")
             # FIX F: variant is the unique per-cell name for rolling-alias routing
             variant=$(jq -r '.variant // ""' <<< "$cell")
             cell_os=$(jq -r '.os // "linux"' <<< "$cell")
@@ -1186,6 +1298,9 @@ _emit_cells_json() {
 
             # Skip Windows cells — same filter as bake mode
             if [[ "$cell_os" == "windows" ]]; then
+                continue
+            fi
+            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1227,18 +1342,58 @@ main() {
     local -a requested=()
     local mode="bake"      # default mode
     local include_all_retained="false"   # F4: default = latest-only
+    local scope_versions=""
+    local scope_flavors=""
+    local scope=""
 
     # Parse flags (order-independent):
-    #   --cells        → cells plan mode
-    #   --all-retained → pass include_all_retained=true to list_build_matrix
+    #   --cells                → cells plan mode
+    #   --all-retained         → pass include_all_retained=true to list_build_matrix
+    #   --scope-versions <csv> → scope version filter
+    #   --scope-flavors <csv>  → scope flavor filter
+    #   --scope <str>          → free-form variant/os/build_flavor/flavor filter
     local -a args=()
-    local arg
-    for arg in "$@"; do
-        case "$arg" in
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
             --cells)        mode="cells" ;;
             --all-retained) include_all_retained="true" ;;
-            *)              args+=("$arg") ;;
+            --scope-versions)
+                if [[ $# -lt 2 ]]; then
+                    printf 'ERROR: --scope-versions requires a value\n' >&2
+                    _usage >&2
+                    exit 2
+                fi
+                scope_versions="$2"
+                shift
+                ;;
+            --scope-versions=*) scope_versions="${1#*=}" ;;
+            --scope-flavors)
+                if [[ $# -lt 2 ]]; then
+                    printf 'ERROR: --scope-flavors requires a value\n' >&2
+                    _usage >&2
+                    exit 2
+                fi
+                scope_flavors="$2"
+                shift
+                ;;
+            --scope-flavors=*) scope_flavors="${1#*=}" ;;
+            --scope)
+                if [[ $# -lt 2 ]]; then
+                    printf 'ERROR: --scope requires a value\n' >&2
+                    _usage >&2
+                    exit 2
+                fi
+                scope="$2"
+                shift
+                ;;
+            --scope=*)      scope="${1#*=}" ;;
+            -h|--help)
+                _usage
+                exit 0
+                ;;
+            *)              args+=("$1") ;;
         esac
+        shift
     done
 
     if [[ ${#args[@]} -gt 0 ]]; then
@@ -1284,6 +1439,9 @@ main() {
 
     # Export include_all_retained so _enumerate_cells_init can read it.
     export _BAKE_INCLUDE_ALL_RETAINED="$include_all_retained"
+    export _BAKE_SCOPE_VERSIONS="$scope_versions"
+    export _BAKE_SCOPE_FLAVORS="$scope_flavors"
+    export _BAKE_SCOPE="$scope"
 
     if [[ "$mode" == "cells" ]]; then
         _emit_cells_json "${requested[@]}"

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -717,6 +717,12 @@ _contexts_for_cell() {
 _enumerate_cells_init() {
     local -a requested_containers=("$@")
 
+    local -A _requested_set=()
+    local _rc
+    for _rc in "${requested_containers[@]}"; do
+        _requested_set["$_rc"]=1
+    done
+
     # Validate each requested container against ./make list
     local all_containers_newline
     if ! all_containers_newline="$(_list_all_containers)"; then
@@ -768,7 +774,8 @@ _enumerate_cells_init() {
         _EC_all_matrix_json[$c]="$matrix"
 
         local first_entry
-        if [[ -n "${_BAKE_SCOPE_VERSIONS:-}" || -n "${_BAKE_SCOPE_FLAVORS:-}" || -n "${_BAKE_SCOPE:-}" ]]; then
+        if [[ -n "${_requested_set[$c]+set}" && \
+              ( -n "${_BAKE_SCOPE_VERSIONS:-}" || -n "${_BAKE_SCOPE_FLAVORS:-}" || -n "${_BAKE_SCOPE:-}" ) ]]; then
             first_entry=""
             local _first_ncells
             _first_ncells=$(jq 'length' <<< "$matrix")
@@ -1082,6 +1089,12 @@ _on_cell_bake() {
 _build_bake_json() {
     local -a requested_containers=("$@")
 
+    local -A _requested_set=()
+    local _rc
+    for _rc in "${requested_containers[@]}"; do
+        _requested_set["$_rc"]=1
+    done
+
     # Shared init: validate, expand closure, fetch matrices
     declare -a _EC_closure_containers=()
     declare -A _EC_all_matrix_json=()
@@ -1138,7 +1151,8 @@ _build_bake_json() {
             if [[ "$cell_os" == "windows" ]]; then
                 continue
             fi
-            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
+            if [[ -n "${_requested_set[$c]+set}" ]] && \
+                    ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1149,6 +1163,32 @@ _build_bake_json() {
 
         container_target_lists[$c]="$container_targets"
     done
+
+    local dangling_context_targets
+    dangling_context_targets=$(jq -r '
+        . as $targets
+        | [
+            to_entries[]
+            | (.value.contexts // {})
+            | to_entries[]
+            | .value
+            | select(type == "string" and startswith("target:"))
+            | sub("^target:"; "") as $target_id
+            | select(($targets | has($target_id)) | not)
+            | $target_id
+        ]
+        | unique
+        | .[]
+    ' <<< "$targets_json")
+    if [[ -n "$dangling_context_targets" ]]; then
+        local dangling_target
+        while IFS= read -r dangling_target; do
+            [[ -n "$dangling_target" ]] || continue
+            printf '::error::bake: dangling internal base context target:%s — refusing to emit an incomplete bake graph\n' \
+                "$dangling_target" >&2
+        done <<< "$dangling_context_targets"
+        return 1
+    fi
 
     # -----------------------------------------------------------------------
     # Group construction

--- a/tests/unit/bake-buildresult.bats
+++ b/tests/unit/bake-buildresult.bats
@@ -369,3 +369,38 @@ _retained_cell_count() {
     # Must match the full retained count.
     [ "$file_count" -eq "$retained_count" ]
 }
+
+@test "BBR-15: scoped build-result enumeration ignores scoped-out terraform flavors" {
+    local scoped_cells
+    scoped_cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
+        --cells --scope-flavors aws terraform)
+
+    local scoped_count
+    scoped_count=$(echo "$scoped_cells" | jq 'length')
+    [ "$scoped_count" -eq 1 ]
+
+    local meta_file="$TEST_OUT_DIR/meta_scoped.json"
+    echo "$scoped_cells" | jq -c '
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    ' > "$meta_file"
+
+    run env SCOPE_FLAVORS=aws bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" terraform
+    [ "$status" -eq 0 ]
+
+    local file_count fail_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    fail_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^failure$' || true)
+
+    [ "$file_count" -eq "$scoped_count" ]
+    [ "$fail_count" -eq 0 ]
+
+    local expected_tags actual_tags
+    expected_tags=$(echo "$scoped_cells" | jq -r '.[].tag' | sort)
+    actual_tags=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.tag' {} \; | sort)
+    [ "$actual_tags" = "$expected_tags" ]
+}

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -528,11 +528,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-15: scope_active="true" — ALL cells (including bake-managed latest linux)
-#         route to .matrix; .bake is empty.  Verifies the scope-override fix
-#         that prevents unscanned images when scope_flavors/scope_versions is set.
+# BM-15: scoped runs are filtered before partitioning and no longer force the
+#         matrix.  With force_matrix=false, scoped bake-managed latest Linux
+#         cells route to .bake, while retained/windows/non-bake cells stay in
+#         .matrix through the normal partition gates.
 # ---------------------------------------------------------------------------
-@test "BM-15: scope_active=true routes all cells to matrix (bake disabled)" {
+@test "BM-15: scoped subset allows bake-managed Linux cells to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -546,15 +547,28 @@ ubuntu-1.0.0"
       {"container":"debian","os":"linux","tag":"bookworm-12.0.0"}
     ]')
 
-    result=$(partition_builds "$fixture" "true")
+    # The split-build-engine step keeps force_matrix=false for scoped runs.
+    result=$(partition_builds "$fixture" "false")
 
-    # bake must be empty
+    # bake contains the scoped latest Linux bake-managed cells.
     bake_count=$(echo "$result" | jq '.bake | length')
-    [[ "$bake_count" -eq 0 ]]
+    [[ "$bake_count" -eq 2 ]]
 
-    # matrix must contain all 5 cells
+    # matrix keeps retained, Windows, and non-bake cells.
     matrix_count=$(echo "$result" | jq '.matrix | length')
-    [[ "$matrix_count" -eq 5 ]]
+    [[ "$matrix_count" -eq 3 ]]
+
+    gh_linux_bake_count=$(echo "$result" | jq '[.bake[] | select(.container == "github-runner" and .os == "linux" and .is_latest_version == true)] | length')
+    [[ "$gh_linux_bake_count" -eq 1 ]]
+
+    ws_bake_count=$(echo "$result" | jq '[.bake[] | select(.container == "web-shell")] | length')
+    [[ "$ws_bake_count" -eq 1 ]]
+
+    gh_retained_matrix_count=$(echo "$result" | jq '[.matrix[] | select(.container == "github-runner" and .os == "linux" and .is_latest_version == false)] | length')
+    [[ "$gh_retained_matrix_count" -eq 1 ]]
+
+    gh_windows_matrix_count=$(echo "$result" | jq '[.matrix[] | select(.container == "github-runner" and .os == "windows")] | length')
+    [[ "$gh_windows_matrix_count" -eq 1 ]]
 
     # Lossless
     total=$(echo "$result" | jq '.bake + .matrix | length')
@@ -607,10 +621,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-16: scope_active default (absent) applies per-cell logic — not scope_active.
-#         Confirms that omitting the second arg is equivalent to scope_active=false.
+# BM-16: force_matrix default (absent) applies per-cell logic.
+#         Confirms that omitting the second arg is equivalent to force_matrix=false.
 # ---------------------------------------------------------------------------
-@test "BM-16: scope_active absent is equivalent to false (per-cell routing)" {
+@test "BM-16: force_matrix absent is equivalent to false (per-cell routing)" {
     # shellcheck disable=SC1090
     source "$BM"
 

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1339,3 +1339,67 @@ YAML
     [ "$target_count" -eq 0 ]
     [ "$default_count" -eq 0 ]
 }
+
+@test "GBH-58: B4 gate — scoped github-runner graph keeps debian internal base target and contexts" {
+    _run_generator --scope-flavors debian-trixie github-runner
+    [ "$status" -eq 0 ]
+
+    local has_base
+    has_base=$(echo "$output" | jq -r '.target | has("debian_trixie")')
+    [ "$has_base" = "true" ]
+
+    local ctx_count
+    ctx_count=$(echo "$output" | jq '[
+        .target
+        | to_entries[]
+        | select((.key | startswith("github_runner_")) and (.key | contains("_debian_trixie_")))
+        | (.value.contexts // {})
+        | to_entries[]
+        | select(.value == "target:debian_trixie")
+    ] | length')
+    [ "$ctx_count" -gt 0 ]
+
+    local dangling_count
+    dangling_count=$(echo "$output" | jq '
+        .target as $targets
+        | [
+            .target
+            | to_entries[]
+            | (.value.contexts // {})
+            | to_entries[]
+            | .value
+            | select(type == "string" and startswith("target:"))
+            | sub("^target:"; "") as $target_id
+            | select(($targets | has($target_id)) | not)
+            | $target_id
+        ]
+        | length')
+    [ "$dangling_count" -eq 0 ]
+}
+
+@test "GBH-59: B4 gate — scoped github-runner --cells emits only requested scoped cells, not debian deps" {
+    _run_generator --cells --scope-flavors debian-trixie github-runner
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_containers bad_flavors debian_cells
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_containers=$(echo "$output" | jq '[.[] | select(.container != "github-runner")] | length')
+    bad_flavors=$(echo "$output" | jq '[.[] | select(.flavor != "debian-trixie")] | length')
+    debian_cells=$(echo "$output" | jq '[.[] | select(.container == "debian")] | length')
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$bad_containers" -eq 0 ]
+    [ "$bad_flavors" -eq 0 ]
+    [ "$debian_cells" -eq 0 ]
+}
+
+@test "GBH-60: B4 gate — unscoped github-runner graph target keys stay on the pre-fix default set" {
+    _run_generator github-runner
+    [ "$status" -eq 0 ]
+
+    local actual_keys
+    actual_keys=$(echo "$output" | jq -cS '.target | keys')
+    local expected_keys='["debian_trixie","github_runner_2_335_1_debian_trixie_base","github_runner_2_335_1_debian_trixie_dev","github_runner_2_335_1_ubuntu_2404_base","github_runner_2_335_1_ubuntu_2404_dev"]'
+
+    [ "$actual_keys" = "$expected_keys" ]
+}

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1264,3 +1264,78 @@ YAML
     [ "$total_refs" -gt 1 ]
     [ "$unique_refs" -eq "$total_refs" ]
 }
+
+# ---------------------------------------------------------------------------
+# B4 scope filters: generator-only filtering for bake/cells emission
+# ---------------------------------------------------------------------------
+
+@test "GBH-53: B4 — --scope-versions keeps only matching terraform retained-version cells" {
+    local unscoped_count
+    unscoped_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform 2>/dev/null \
+        | jq 'length')
+    [ "$unscoped_count" -gt 0 ]
+
+    _run_generator --cells --all-retained --scope-versions 1.15.4 terraform
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_tags
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_tags=$(echo "$output" | jq '[.[] | select(.tag | startswith("1.15.4-alpine") | not)] | length')
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$scoped_count" -lt "$unscoped_count" ]
+    [ "$bad_tags" -eq 0 ]
+}
+
+@test "GBH-54: B4 — --scope-flavors keeps only matching terraform flavor cells" {
+    _run_generator --cells --scope-flavors aws terraform
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_flavors
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_flavors=$(echo "$output" | jq '[.[] | select(.flavor != "aws")] | length')
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$bad_flavors" -eq 0 ]
+}
+
+@test "GBH-55: B4 — --scope filters terraform cells by variant substring" {
+    _run_generator --cells --scope azure terraform
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_variants
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_variants=$(echo "$output" | jq '[.[] | select(.variant | contains("azure") | not)] | length')
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$bad_variants" -eq 0 ]
+}
+
+@test "GBH-56: B4 — no scope flags preserve the latest-only terraform cell count" {
+    local expected_count
+    expected_count=$(bash -c "
+        source '${HELPERS_DIR}/variant-utils.sh'
+        list_build_matrix './terraform' '' 'false' 2>/dev/null \
+            | jq '[.[] | select((.os // \"linux\") != \"windows\")] | length'
+    ")
+    [ "$expected_count" -gt 0 ]
+
+    _run_generator --cells terraform
+    [ "$status" -eq 0 ]
+
+    local actual_count
+    actual_count=$(echo "$output" | jq 'length')
+    [ "$actual_count" -eq "$expected_count" ]
+}
+
+@test "GBH-57: B4 — over-narrow --scope-versions emits an empty bake target set" {
+    _run_generator --scope-versions 999 terraform
+    [ "$status" -eq 0 ]
+
+    local target_count default_count
+    target_count=$(echo "$output" | jq '.target | length')
+    default_count=$(echo "$output" | jq '.group.default.targets | length')
+
+    [ "$target_count" -eq 0 ]
+    [ "$default_count" -eq 0 ]
+}


### PR DESCRIPTION
Routes scoped builds (`scope_versions` / `scope_flavors` / `scope`) through the bake build path instead of the flat matrix. After this, the matrix serves only Windows variants, the postgres extension pipeline, retained non-latest versions, and fork PRs.

- The generator gains `--scope-versions` / `--scope-flavors` / `--scope` cell filtering, with version matching identical to the existing detect-containers filter so the bake graph and the routed cell set agree.
- Scope is dropped from the force-matrix condition, so scoped bake-managed Linux cells route to bake.
- Internal base-image targets (e.g. `github-runner` → `debian`) are preserved in a scoped graph, so a scoped child build uses the freshly-built base rather than a stale registry image.
- Build-result lineage is scoped too, so scoped-out flavors are not recorded as failures.

Unscoped and full-fleet builds are unchanged.

Verification: shellcheck + 102 unit tests green; offline graph checks confirm the scoped graph keeps internal base targets and the unscoped graph is unchanged; a scoped `web-shell` build was validated end-to-end via the bake path; all PR checks green.

Refs #666.
