### PR TITLE
feat(ci): bake can build the postgres final image (capability, opt-in)

### DIFF
--- a/postgres/generate-dockerfile.sh
+++ b/postgres/generate-dockerfile.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="${ROOT_DIR:-$PROJECT_ROOT}"
+export PROJECT_ROOT ROOT_DIR
+
+# shellcheck source=../helpers/extension-utils.sh
+source "${PROJECT_ROOT}/helpers/extension-utils.sh"
+
+template="${1:-Dockerfile}"
+flavor="${2:-base}"
+version="${3:-}"
+# Fourth argument is accepted for the generic bake-generator contract.
+: "${4:-}"
+
+if [[ -z "$version" ]]; then
+    printf 'ERROR: postgres/generate-dockerfile.sh requires <version>\n' >&2
+    exit 2
+fi
+
+pg_major="${version%%.*}"
+pg_major="${pg_major%%-*}"
+if [[ -z "$pg_major" || ! "$pg_major" =~ ^[0-9]+$ ]]; then
+    printf 'ERROR: cannot derive PostgreSQL major version from %q\n' "$version" >&2
+    exit 2
+fi
+
+generate_dockerfile \
+    "${PROJECT_ROOT}/postgres/extensions/config.yaml" \
+    "$template" \
+    "$flavor" \
+    "$pg_major"

--- a/postgres/variants.yaml
+++ b/postgres/variants.yaml
@@ -15,6 +15,9 @@ build:
   # Postgres builds all supported PG majors on every push (not just the latest line).
   # Rationale: each major is a long-lived supported release stream, not a rolling history.
   always_all_versions: true
+  # Explicit bake opt-in for the FINAL image only. Extension compilation remains
+  # owned by build-extensions; bake only consumes pre-built extension images.
+  bake_final_build: true
 # Versions to build (all maintained PostgreSQL releases)
 versions:
   - tag: "18"

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -23,7 +23,7 @@
 # target (no working-tree file written; compatible with --print and real builds):
 #   web-shell     — generate-dockerfile.sh <template> <flavor> <version>
 #   github-runner — generate-dockerfile.sh <template> <flavor> <version> <build_flavor>
-#   postgres      — uses single Dockerfile + FLAVOR build-arg (no template markers)
+#   postgres      — extension-marker template via generate-dockerfile.sh
 #
 # CUSTOM_BUILD_ARGS: operator-supplied extra args are applied at the R3 merge-job
 # layer via `bake --set "*.args.KEY=VAL"`, NOT embedded here.
@@ -158,8 +158,9 @@ _expand_closure() {
         fi
         local dep
         for dep in ${deps}; do
-            # F1: extension containers must not appear in the closure even as deps.
-            if _is_extension_container "$dep"; then
+            # F1: extension compilation stays out of bake; a flag-gated FINAL
+            # image build may enter the graph when explicitly requested.
+            if _is_bake_excluded_extension_container "$dep"; then
                 printf '::notice::Skipping %s from bake graph (extension sub-pipeline owns it; see build-extensions)\n' \
                     "$dep" >&2
                 continue
@@ -1075,9 +1076,8 @@ _on_cell_bake() {
     fi
 
     # Accumulate into caller-scope variables (set -n nameref not in bash 4.3; use globals)
-    targets_json=$(jq -cn --argjson base "$targets_json" \
-        --arg tid "$tid" --argjson obj "$target_obj" \
-        '$base + {($tid): $obj}')
+    targets_json=$(printf '%s\n%s\n' "$targets_json" "$target_obj" | \
+        jq -sc --arg tid "$tid" '.[0] + {($tid): .[1]}')
 
     container_targets=$(jq -cn --argjson arr "$container_targets" --arg tid "$tid" \
         '$arr + [$tid]')
@@ -1222,16 +1222,14 @@ _build_bake_json() {
     # variable would allow a bake-time override that diverges from the concrete
     # contexts keys, breaking BuildKit named-context matching.
     # ARCH_SUFFIX and NPROC genuinely vary per-arch job and remain bake variables.
-    bake_doc=$(jq -cn \
-        --argjson targets "$targets_json" \
-        --argjson groups  "$groups_json" \
+    bake_doc=$(printf '%s\n%s\n' "$targets_json" "$groups_json" | jq -sc \
         '{
             variable: {
                 ARCH_SUFFIX: { default: "" },
                 NPROC:       { default: "1" }
             },
-            target:   $targets,
-            group:    $groups
+            target:   .[0],
+            group:    .[1]
         }')
 
     # Belt-and-suspenders: verify the assembled document is valid JSON
@@ -1363,16 +1361,33 @@ _emit_cells_json() {
 }
 
 # ---------------------------------------------------------------------------
-# Extension-sub-pipeline exclusion check (F1).
+# Extension-sub-pipeline exclusion checks (F1).
 #
-# Returns 0 (true) when a container has <container>/extensions/config.yaml,
-# meaning it is owned by the build-extensions sub-pipeline and must NOT
-# enter the bake graph.  Generation for such containers is not deterministic
-# or network-free (skopeo/manifest-inspect fires during generate_dockerfile).
+# _is_extension_container returns 0 when a container has
+# <container>/extensions/config.yaml. Extension COMPILATION remains excluded;
+# only the FINAL image build (flag-gated by build.bake_final_build) may enter
+# the graph.
 # ---------------------------------------------------------------------------
 _is_extension_container() {
     local container="$1"
     [[ -f "${PROJECT_ROOT}/${container}/extensions/config.yaml" ]]
+}
+
+_bake_final_build_enabled() {
+    local container="$1"
+    local variants_file="${PROJECT_ROOT}/${container}/variants.yaml"
+    [[ -f "$variants_file" ]] || return 1
+
+    local flag
+    flag=$(yq -r '.build.bake_final_build // false' "$variants_file" 2>/dev/null || echo "false")
+    [[ "$flag" == "true" ]]
+}
+
+_is_bake_excluded_extension_container() {
+    local container="$1"
+    _is_extension_container "$container" || return 1
+    _bake_final_build_enabled "$container" && return 1
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -1455,7 +1470,7 @@ main() {
     # the fleet enumeration).
     local -a filtered_requested=()
     for c in "${requested[@]}"; do
-        if _is_extension_container "$c"; then
+        if _is_bake_excluded_extension_container "$c"; then
             printf '::notice::Skipping %s from bake graph (extension sub-pipeline owns it; see build-extensions)\n' \
                 "$c" >&2
         else

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -10,6 +10,7 @@
 #   scripts/generate-bake-hcl.sh --cells --scope-versions 1.31 openresty
 #   scripts/generate-bake-hcl.sh --scope-flavors aws terraform
 #   scripts/generate-bake-hcl.sh --scope alpine web-shell
+#   scripts/generate-bake-hcl.sh --include-final-build postgres
 #
 # Output is a JSON bake file (same schema as HCL; docker-buildx bake -f -)
 # written to stdout.  It is a generated artifact — do NOT commit it.
@@ -112,6 +113,9 @@ Usage:
 Options:
   --cells                 Emit compact cell JSON instead of a bake document.
   --all-retained          Include retained versions where allowed.
+  --include-final-build   include flag-marked extension containers' FINAL image build in the graph
+                          (requires their extension lineage artifacts to be present; used by the
+                          postgres bake routing -- NOT by the whole-fleet smoke).
   --scope-versions <csv>  Keep versions matching a comma-separated version list.
   --scope-flavors <csv>   Keep cells whose flavor is in a comma-separated list.
   --scope <str>           Keep cells whose variant/os/build_flavor/flavor contains this string.
@@ -1386,7 +1390,16 @@ _bake_final_build_enabled() {
 _is_bake_excluded_extension_container() {
     local container="$1"
     _is_extension_container "$container" || return 1
-    _bake_final_build_enabled "$container" && return 1
+
+    # build.bake_final_build is only a capability marker. Existing whole-fleet
+    # smoke (bake-build.yaml) and bake_managed fleet builds do not pass
+    # --include-final-build, so postgres stays excluded there; only the future
+    # postgres bake-build job, after downloading extension lineage artifacts,
+    # should activate final-image inclusion.
+    if [[ "${_BAKE_INCLUDE_FINAL_BUILD:-}" == "1" ]] && _bake_final_build_enabled "$container"; then
+        return 1
+    fi
+
     return 0
 }
 
@@ -1397,13 +1410,17 @@ main() {
     local -a requested=()
     local mode="bake"      # default mode
     local include_all_retained="false"   # F4: default = latest-only
+    local include_final_build=""
     local scope_versions=""
     local scope_flavors=""
     local scope=""
 
+    unset _BAKE_INCLUDE_FINAL_BUILD
+
     # Parse flags (order-independent):
     #   --cells                → cells plan mode
     #   --all-retained         → pass include_all_retained=true to list_build_matrix
+    #   --include-final-build  → include flag-marked extension final image builds
     #   --scope-versions <csv> → scope version filter
     #   --scope-flavors <csv>  → scope flavor filter
     #   --scope <str>          → free-form variant/os/build_flavor/flavor filter
@@ -1412,6 +1429,7 @@ main() {
         case "$1" in
             --cells)        mode="cells" ;;
             --all-retained) include_all_retained="true" ;;
+            --include-final-build) include_final_build="1" ;;
             --scope-versions)
                 if [[ $# -lt 2 ]]; then
                     printf 'ERROR: --scope-versions requires a value\n' >&2
@@ -1450,6 +1468,10 @@ main() {
         esac
         shift
     done
+
+    if [[ "$include_final_build" == "1" ]]; then
+        export _BAKE_INCLUDE_FINAL_BUILD=1
+    fi
 
     if [[ ${#args[@]} -gt 0 ]]; then
         requested=("${args[@]}")

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -418,8 +418,16 @@ _compute_cell_build_args() {
     local args
     args="$config_args"
 
-    # 2. VERSION
-    args=$(jq -cn --argjson base "$args" --arg v "$version" '$base + {VERSION: $v}')
+    # 2. VERSION — mirror the non-bake build's base_image_version
+    #    (build-container.sh: "${major_version}${base_suffix}"). postgres declares
+    #    base_suffix "-alpine", and its Dockerfile does FROM library/postgres:${VERSION},
+    #    so VERSION must carry the suffix ("18" -> "18-alpine") or the bake build would
+    #    pull the Debian base and publish *-alpine tags backed by the wrong distro.
+    #    base_suffix is empty for every container except postgres today, so this is a
+    #    no-op for the rest of the fleet.
+    local _base_sfx
+    _base_sfx=$(base_suffix "${PROJECT_ROOT}/${container}" 2>/dev/null || echo "")
+    args=$(jq -cn --argjson base "$args" --arg v "${version}${_base_sfx}" '$base + {VERSION: $v}')
 
     # 3. MAJOR_VERSION (leading integer: "18" from "18-alpine", "2" from "2.334.0")
     local major

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -12,7 +12,7 @@
 #   MG8: --cells emits bake document instead of array → type check fails
 #   MG9: intermediate_ref includes ${ARCH_SUFFIX} → merge consumer would double-suffix sources
 #   MG10: Cell set for --cells differs from bake mode → plan drift between generator and merge job
-#   MG11: Allow postgres into bake graph → extension sub-pipeline conflict (F1)
+#   MG11: Allow unflagged extension containers into bake graph -> extension sub-pipeline conflict (F1)
 #   MG12: Omit is_latest_version from --cells output → merge job cannot gate rolling tags (F2)
 #   MG13: Remove absolute-path guard in _resolve_cell_base_ref → doubled path → empty contexts (F3)
 #   MG14: Hardcode include_all_retained=true → default mode emits retained versions (F4)
@@ -39,6 +39,25 @@ teardown() {
 # ---------------------------------------------------------------------------
 _run_generator() {
     run bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" "$@"
+}
+
+_run_generator_with_lineage_root() {
+    local lineage_root="$1"
+    shift
+    run env ROOT_DIR="$lineage_root" GITHUB_REPOSITORY_OWNER=oorabona \
+        bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" "$@"
+}
+
+_make_timescaledb_lineage_root() {
+    local lineage_root="$1"
+    mkdir -p "${lineage_root}/.build-lineage"
+
+    local pg
+    for pg in 18 17 16; do
+        jq -nc --arg pg "$pg" \
+            '{ext:"timescaledb", pg_major:$pg, ceiling:"2.27.2", resolved:["2.27.2"], available:["2.27.2"], excluded:[]}' \
+            > "${lineage_root}/.build-lineage/ext-timescaledb-pg${pg}-versionset.json"
+    done
 }
 
 # ---------------------------------------------------------------------------
@@ -555,16 +574,74 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-25: F1 — postgres excluded from bake graph (extension sub-pipeline)
-# Catches MG11: allowing postgres to enter the graph would invoke the
-# extension generator which is not network-free.
+# GBH-25: F1 — postgres final image is explicitly bake-emittable
+# Catches: dropping build.bake_final_build support would re-exclude postgres.
 # ---------------------------------------------------------------------------
-@test "GBH-25: postgres is excluded from bake graph with exit 0 and skip notice" {
-    run bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" postgres 2>&1
-    # Must exit 0 (skip, not failure)
+@test "GBH-25: postgres --cells emits 21 final-image cells across all supported majors/flavors" {
+    _run_generator --cells postgres
     [ "$status" -eq 0 ]
-    # The skip ::notice:: must appear somewhere in combined output (stderr or stdout)
-    [[ "$output" == *"Skipping postgres"* ]] || [[ "$output" == *"extension sub-pipeline"* ]]
+
+    local count majors flavor_count
+    count=$(echo "$output" | jq '[.[] | select(.container == "postgres")] | length')
+    majors=$(echo "$output" | jq -r '[.[].tag | capture("^(?<major>[0-9]+)").major] | unique | sort | join(" ")')
+    flavor_count=$(echo "$output" | jq '[.[].flavor] | unique | length')
+
+    [ "$count" -eq 21 ]
+    [ "$majors" = "16 17 18" ]
+    [ "$flavor_count" -eq 7 ]
+}
+
+@test "GBH-25b: postgres bake graph materializes inline base/vector/timeseries Dockerfiles offline" {
+    local lineage_root
+    lineage_root=$(mktemp -d)
+    _make_timescaledb_lineage_root "$lineage_root"
+
+    _run_generator_with_lineage_root "$lineage_root" postgres
+    rm -rf "$lineage_root"
+    [ "$status" -eq 0 ]
+
+    local target_count
+    target_count=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("postgres_"))] | length')
+    [ "$target_count" -eq 21 ]
+
+    local base_inline vector_inline timeseries_inline
+    base_inline=$(echo "$output" | jq -r '.target.postgres_18_base["dockerfile-inline"] // ""')
+    vector_inline=$(echo "$output" | jq -r '.target.postgres_18_vector["dockerfile-inline"] // ""')
+    timeseries_inline=$(echo "$output" | jq -r '.target.postgres_18_timeseries["dockerfile-inline"] // ""')
+
+    [ -n "$base_inline" ]
+    [ -n "$vector_inline" ]
+    [ -n "$timeseries_inline" ]
+    [[ "$base_inline" != *"@@"* ]]
+    [[ "$vector_inline" != *"@@"* ]]
+    [[ "$timeseries_inline" != *"@@"* ]]
+
+    local base_ext_from_count
+    base_ext_from_count=$(printf '%s\n' "$base_inline" | grep -cE '^FROM .*ext-' || true)
+    [ "$base_ext_from_count" -eq 0 ]
+
+    [[ "$vector_inline" == *"FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2 AS ext-pgvector"* ]]
+    [[ "$vector_inline" == *"COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/"* ]]
+    [[ "$timeseries_inline" == *"FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.27.2 AS ext-timescaledb"* ]]
+}
+
+@test "GBH-25c: postgres inline Dockerfiles escape bake interpolation triggers" {
+    local lineage_root
+    lineage_root=$(mktemp -d)
+    _make_timescaledb_lineage_root "$lineage_root"
+
+    _run_generator_with_lineage_root "$lineage_root" postgres
+    rm -rf "$lineage_root"
+    [ "$status" -eq 0 ]
+
+    local all_inline stripped_doubles bare_count
+    all_inline=$(echo "$output" | jq -r '[.target | to_entries[] | select(.key | startswith("postgres_")) | .value["dockerfile-inline"] // empty] | join("\n")')
+    [ -n "$all_inline" ]
+    [[ "$all_inline" == *'$${REMOTE_CR}'* ]]
+
+    stripped_doubles="${all_inline//\$\$\{/ESCAPED}"
+    bare_count=$(printf '%s' "$stripped_doubles" | grep -cF '${' || true)
+    [ "$bare_count" -eq 0 ]
 }
 
 @test "GBH-26: F1 — whole-fleet generate has no postgres target" {
@@ -575,6 +652,50 @@ YAML
     local postgres_targets
     postgres_targets=$(echo "$output" | jq '[.target | to_entries[] | select(.key | startswith("postgres_"))] | length')
     [ "$postgres_targets" -eq 0 ]
+}
+
+@test "GBH-26b: F1 — extension container without bake_final_build remains excluded" {
+    local variants backup out err
+    variants="${PROJECT_ROOT}/postgres/variants.yaml"
+    backup=$(mktemp)
+    out=$(mktemp)
+    err=$(mktemp)
+
+    run bash -c '
+        set -euo pipefail
+        variants="$1"
+        backup="$2"
+        out="$3"
+        err="$4"
+        cp "$variants" "$backup"
+        restore() { cp "$backup" "$variants"; }
+        trap restore EXIT
+        yq -i "del(.build.bake_final_build)" "$variants"
+        "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" postgres >"$out" 2>"$err"
+    ' bash "$variants" "$backup" "$out" "$err"
+
+    [ "$status" -eq 0 ]
+    grep -q "Skipping postgres" "$err"
+    [ "$(jq '.target | length' "$out")" -eq 0 ]
+
+    rm -f "$backup" "$out" "$err"
+}
+
+@test "GBH-26c: non-postgres extensionless graph stays on the committed-Dockerfile path" {
+    [ ! -f "${PROJECT_ROOT}/debian/extensions/config.yaml" ]
+    [ "$(yq -r '.build.bake_final_build // false' "${PROJECT_ROOT}/debian/variants.yaml")" = "false" ]
+
+    _run_generator debian
+    [ "$status" -eq 0 ]
+    local first="$output"
+
+    _run_generator debian
+    [ "$status" -eq 0 ]
+    local second="$output"
+
+    [ "$(jq -cS . <<< "$first")" = "$(jq -cS . <<< "$second")" ]
+    [ "$(echo "$first" | jq '[.target | to_entries[] | select(.key | startswith("debian_")) | select(.value["dockerfile-inline"] != null)] | length')" -eq 0 ]
+    [ "$(echo "$first" | jq -r '.target.debian_trixie.dockerfile')" = "Dockerfile" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -574,11 +574,11 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-25: F1 — postgres final image is explicitly bake-emittable
+# GBH-25: F1 — postgres final image is explicitly bake-emittable when activated
 # Catches: dropping build.bake_final_build support would re-exclude postgres.
 # ---------------------------------------------------------------------------
-@test "GBH-25: postgres --cells emits 21 final-image cells across all supported majors/flavors" {
-    _run_generator --cells postgres
+@test "GBH-25: postgres --include-final-build --cells emits 21 final-image cells across all supported majors/flavors" {
+    _run_generator --include-final-build --cells postgres
     [ "$status" -eq 0 ]
 
     local count majors flavor_count
@@ -596,7 +596,7 @@ YAML
     lineage_root=$(mktemp -d)
     _make_timescaledb_lineage_root "$lineage_root"
 
-    _run_generator_with_lineage_root "$lineage_root" postgres
+    _run_generator_with_lineage_root "$lineage_root" --include-final-build postgres
     rm -rf "$lineage_root"
     [ "$status" -eq 0 ]
 
@@ -630,7 +630,7 @@ YAML
     lineage_root=$(mktemp -d)
     _make_timescaledb_lineage_root "$lineage_root"
 
-    _run_generator_with_lineage_root "$lineage_root" postgres
+    _run_generator_with_lineage_root "$lineage_root" --include-final-build postgres
     rm -rf "$lineage_root"
     [ "$status" -eq 0 ]
 
@@ -642,6 +642,30 @@ YAML
     stripped_doubles="${all_inline//\$\$\{/ESCAPED}"
     bare_count=$(printf '%s' "$stripped_doubles" | grep -cF '${' || true)
     [ "$bare_count" -eq 0 ]
+}
+
+@test "GBH-25d: no-arg whole-fleet generate excludes postgres without final-build activation" {
+    local lineage_root out err
+    lineage_root=$(mktemp -d)
+    out=$(mktemp)
+    err=$(mktemp)
+
+    run bash -c '
+        set -euo pipefail
+        lineage_root="$1"
+        out="$2"
+        err="$3"
+        ROOT_DIR="$lineage_root" GITHUB_REPOSITORY_OWNER=oorabona \
+            "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" >"$out" 2>"$err"
+    ' bash "$lineage_root" "$out" "$err"
+    rm -rf "$lineage_root"
+    [ "$status" -eq 0 ]
+
+    local postgres_targets
+    postgres_targets=$(jq '[.target | to_entries[] | select(.key | startswith("postgres_"))] | length' "$out")
+    [ "$postgres_targets" -eq 0 ]
+
+    rm -f "$out" "$err"
 }
 
 @test "GBH-26: F1 — whole-fleet generate has no postgres target" {

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -625,6 +625,24 @@ YAML
     [[ "$timeseries_inline" == *"FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.27.2 AS ext-timescaledb"* ]]
 }
 
+@test "GBH-25e: postgres bake VERSION build arg carries base_suffix (matches the non-bake base image)" {
+    local lineage_root
+    lineage_root=$(mktemp -d)
+    _make_timescaledb_lineage_root "$lineage_root"
+
+    _run_generator_with_lineage_root "$lineage_root" --include-final-build postgres
+    rm -rf "$lineage_root"
+    [ "$status" -eq 0 ]
+
+    # postgres declares base_suffix "-alpine" + FROM library/postgres:${VERSION};
+    # the bake VERSION arg must be "<major>-alpine", not the bare major, else the
+    # build pulls the Debian base and publishes *-alpine tags backed by it.
+    [ "$(echo "$output" | jq -r '.target.postgres_18_base.args.VERSION')" = "18-alpine" ]
+    [ "$(echo "$output" | jq -r '.target.postgres_17_vector.args.VERSION')" = "17-alpine" ]
+    [ "$(echo "$output" | jq -r '.target.postgres_16_full.args.VERSION')" = "16-alpine" ]
+    [ "$(echo "$output" | jq -r '.target.postgres_18_base.args.MAJOR_VERSION')" = "18" ]
+}
+
 @test "GBH-25c: postgres inline Dockerfiles escape bake interpolation triggers" {
     local lineage_root
     lineage_root=$(mktemp -d)


### PR DESCRIPTION
First step toward building the PostgreSQL final image (the multi-stage image that consumes the pre-built extension images) through `docker buildx bake` instead of the flat matrix. This PR only adds the generator capability — no CI routing changes yet.

- A small `postgres/generate-dockerfile.sh` wrapper lets the bake generator materialize postgres's flavor Dockerfiles the same way the existing build does. Its output is identical to the current path.
- A `build.bake_final_build` flag in `postgres/variants.yaml` marks postgres as bake-buildable, and the generator includes it only when explicitly activated with `--include-final-build`. Every existing caller (the whole-fleet smoke and the per-container fleet build) is unchanged — postgres stays on the matrix until a later PR wires the routing.
- The bake `VERSION` build arg carries the `-alpine` base suffix, matching the current build, so the image is built from the correct base.

Verification: shellcheck + 93 unit tests green; offline checks confirm postgres emits 21 targets only under the activation flag, the no-arg whole-fleet build still excludes postgres and succeeds, and the rest of the fleet is unchanged.

Refs #666.
