### PR TITLE
ci(bake): retry the build/publish ops on transient registry blips (#691 phase 1)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1216,6 +1216,8 @@ jobs:
           TAG: ${{ matrix.build.tag }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: |
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
           source ./helpers/sbom-utils.sh
           image_ref="ghcr.io/${GITHUB_USERNAME}/${CONTAINER}:${TAG}-amd64"
           sbom_file=".build-lineage/${CONTAINER}-${TAG}.sbom.json"
@@ -1230,7 +1232,7 @@ jobs:
           # `--format '{{.Digest}}'` proved unreliable in CI (empty output);
           # `docker inspect ... RepoDigests` returns the LOCAL pre-flatten
           # digest, which would mismatch the post-flatten registry artifact.
-          raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+          raw_manifest=$(retry_with_backoff 3 10 docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
           if [[ -n "$raw_manifest" ]]; then
             digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
           else
@@ -1418,6 +1420,8 @@ jobs:
           TAG: ${{ matrix.build.tag }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: |
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
           source ./helpers/sbom-utils.sh
           image_ref="ghcr.io/${GITHUB_USERNAME}/${CONTAINER}:${TAG}-amd64"
           sbom_file=".build-lineage/${CONTAINER}-${TAG}.sbom.json"
@@ -1426,7 +1430,7 @@ jobs:
           echo "sbom_file=$sbom_file" >> "$GITHUB_OUTPUT"
 
           # Capture digest for attestation
-          digest=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$image_ref" 2>/dev/null \
+          digest=$(retry_with_backoff 3 10 docker buildx imagetools inspect --format '{{json .Manifest}}' "$image_ref" 2>/dev/null \
             | jq -r '.digest // empty' || echo "")
           if [[ -z "$digest" ]]; then
             digest=$(docker inspect --format='{{range .RepoDigests}}{{.}}{{end}}' "$image_ref" 2>/dev/null \
@@ -1658,6 +1662,8 @@ jobs:
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |
           set -euo pipefail
+          source helpers/logging.sh
+          source helpers/retry.sh
           chmod +x scripts/generate-bake-hcl.sh
 
           # Validate each BAKE_CONTAINERS token against the expected name pattern.
@@ -1747,7 +1753,7 @@ jobs:
           elif [[ "$IS_PR" == "true" ]]; then
             # PR: validate the bake DAG compiles and builds — no registry push.
             # shellcheck disable=SC2086
-            docker buildx bake \
+            retry_with_backoff 3 10 docker buildx bake \
               -f "$bake_file" \
               --set "*.platform=linux/amd64" \
               ${no_cache_flag} \
@@ -1755,7 +1761,7 @@ jobs:
             echo "::notice::Bake build (amd64) build-only (PR; no push)"
           else
             # shellcheck disable=SC2086
-            docker buildx bake \
+            retry_with_backoff 3 10 docker buildx bake \
               -f "$bake_file" \
               --set "*.platform=linux/amd64" \
               ${no_cache_flag} \
@@ -1843,6 +1849,8 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
           source ./helpers/sbom-utils.sh
           chmod +x scripts/generate-bake-hcl.sh
 
@@ -1894,7 +1902,7 @@ jobs:
 
             # Capture digest for attestation (mirrors build-and-push job pattern)
             digest=""
-            raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+            raw_manifest=$(retry_with_backoff 3 10 docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
             if [[ -n "$raw_manifest" ]]; then
               digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
             fi
@@ -2130,6 +2138,8 @@ jobs:
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |
           set -euo pipefail
+          source helpers/logging.sh
+          source helpers/retry.sh
           chmod +x scripts/generate-bake-hcl.sh
 
           # Validate each BAKE_CONTAINERS token against the expected name pattern.
@@ -2208,7 +2218,7 @@ jobs:
           elif [[ "$IS_PR" == "true" ]]; then
             # PR: validate the bake DAG compiles and builds — no registry push.
             # shellcheck disable=SC2086
-            docker buildx bake \
+            retry_with_backoff 3 10 docker buildx bake \
               -f "$bake_file" \
               --set "*.platform=linux/arm64" \
               ${no_cache_flag} \
@@ -2216,7 +2226,7 @@ jobs:
             echo "::notice::Bake build (arm64) build-only (PR; no push)"
           else
             # shellcheck disable=SC2086
-            docker buildx bake \
+            retry_with_backoff 3 10 docker buildx bake \
               -f "$bake_file" \
               --set "*.platform=linux/arm64" \
               ${no_cache_flag} \
@@ -2772,12 +2782,14 @@ jobs:
           REMOTE_CR: ghcr.io/${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
 
           image_ref="${REMOTE_CR}/${MATRIX_CONTAINER}:${MATRIX_TAG}-amd64"
 
           # Derive digest via raw-manifest hash (same method as bake-build-amd64 so
           # subject digest matches what was captured during the build).
-          raw_manifest=$(docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+          raw_manifest=$(retry_with_backoff 3 10 docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
           if [[ -z "$raw_manifest" ]]; then
             echo "::warning::Cannot inspect ${image_ref} — skipping attestation for ${MATRIX_CONTAINER}:${MATRIX_TAG}"
             echo "has_digest=false" >> "$GITHUB_OUTPUT"

--- a/helpers/create-manifest.sh
+++ b/helpers/create-manifest.sh
@@ -130,9 +130,9 @@ create_registry_manifest() {
     version_specific_tag_args=$(_compute_version_specific_tag_args "$target_image" 2>/dev/null) || true
 
     # Try multi-arch manifest first (amd64 + arm64).
-    # retry_with_backoff 3 5: imagetools create is idempotent (same manifest list on retry).
+    # retry_with_backoff 3 10: imagetools create is idempotent (same manifest list on retry).
     local err_output
-    if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $tag_args \
+    if err_output=$(retry_with_backoff 3 10 $DOCKER buildx imagetools create $tag_args \
         "$source_image:$TAG-amd64" \
         "$source_image:$TAG-arm64" 2>&1); then
         echo "::notice::Multi-arch manifest created successfully for $target_image:$TAG"
@@ -142,8 +142,8 @@ create_registry_manifest() {
 
     # Fallback amd64-only — skip if no safe version-specific anchor (P2 fix)
     if [[ -n "$version_specific_tag_args" ]]; then
-        # retry_with_backoff 3 5: idempotent — recreates the same single-arch manifest.
-        if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $version_specific_tag_args \
+        # retry_with_backoff 3 10: idempotent — recreates the same single-arch manifest.
+        if err_output=$(retry_with_backoff 3 10 $DOCKER buildx imagetools create $version_specific_tag_args \
             "$source_image:$TAG-amd64" 2>&1); then
             echo "::warning::Manifest created with amd64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
             return 0
@@ -155,8 +155,8 @@ create_registry_manifest() {
 
     # Fallback arm64-only — skip if no safe version-specific anchor (P2 fix)
     if [[ -n "$version_specific_tag_args" ]]; then
-        # retry_with_backoff 3 5: idempotent — recreates the same single-arch manifest.
-        if err_output=$(retry_with_backoff 3 5 $DOCKER buildx imagetools create $version_specific_tag_args \
+        # retry_with_backoff 3 10: idempotent — recreates the same single-arch manifest.
+        if err_output=$(retry_with_backoff 3 10 $DOCKER buildx imagetools create $version_specific_tag_args \
             "$source_image:$TAG-arm64" 2>&1); then
             echo "::warning::Manifest created with arm64 only for $target_image:$TAG (version-specific tag only; rolling/latest preserved)"
             return 0

--- a/scripts/bake-merge-manifests.sh
+++ b/scripts/bake-merge-manifests.sh
@@ -154,7 +154,7 @@ _merge_cell() {
     fi
 
     local err_output
-    if ! err_output=$(retry_with_backoff 3 5 \
+    if ! err_output=$(retry_with_backoff 3 10 \
         "$DOCKER" buildx imagetools create \
         "${ghcr_tag_args[@]}" \
         "$src_amd64" \


### PR DESCRIPTION
Phase 1 of the resilience sweep (#691): wraps the core bake network operations in exponential-backoff retry so a transient registry/API hiccup no longer fails the build on the first attempt.

- `docker buildx bake` build+push — both amd64 and arm64 (the most impactful: a mid-push blip used to fail the whole bake).
- Canonical GHCR multi-arch manifest merge.
- The digest-resolve and SBOM `imagetools inspect` probes (retry the transient fetch, keep the existing fallback after).
- Aligns the existing manifest-create retries to the same 3×/backoff policy.

Advisory fail-soft tag-alias creates are left unwrapped (already non-fatal). DRY-RUN paths do no network and are untouched. All ops are idempotent on retry (bake re-evaluates the DAG; inspect/create are read/declarative).

Verification: bake unit suite green; YAML parses; shellcheck clean; the wrapped calls confirmed under `retry_with_backoff`.

Refs #691. Phases 2-4 (binary installs, GitHub API probes, `uses:` artifact uploads) follow.