### PR TITLE
test(push-container): expect the REMOTE_CR base default from get_build_args (#671)

### DIFF
--- a/tests/unit/push-container.bats
+++ b/tests/unit/push-container.bats
@@ -192,16 +192,21 @@ teardown() {
     [[ "$output" == *"--no-cache --pull"* ]]
 }
 
-@test "get_build_args returns empty for no version and no extras" {
+@test "get_build_args emits only the REMOTE_CR default for no version and no extras" {
     source_push_script
 
     unset NPROC
     unset CUSTOM_BUILD_ARGS
+    unset REMOTE_CR
 
     run get_build_args ""
 
-    # Output should be empty or just whitespace
-    [ -z "$(echo "$output" | tr -d '[:space:]')" ]
+    # prepare_build_args always emits the base-image registry namespace
+    # (REMOTE_CR defaults to ghcr.io/oorabona — the egress-mitigation base
+    # default). With no version and no extras that is the ONLY build arg.
+    [[ "$output" == *"--build-arg REMOTE_CR=ghcr.io/oorabona"* ]]
+    [[ "$output" != *"VERSION="* ]]
+    [[ "$output" != *"NPROC="* ]]
 }
 
 @test "get_build_args combines all arguments" {


### PR DESCRIPTION
Fixes a stale unit expectation (full-suite only; not in the bake CI gate). `get_build_args` delegates to `prepare_build_args`, which since #671 always emits the base-image registry namespace (`REMOTE_CR`, default `ghcr.io/oorabona`) so every `FROM` resolves through the mirror instead of Docker Hub. The 'returns empty for no version and no extras' case predated that and asserted no build args at all.

Updated to the current contract: with no version and no extras, `REMOTE_CR` is the only build arg (and VERSION/NPROC are absent). Sibling get_build_args tests are substring-based and unaffected.

Test-only; no production change. This was the last known full-suite red (after #709 SMOKE-10 and #711 GHA-INJ-2b). Refs #671.