### PR TITLE
fix(ci): rotate version-keyed base_image_cache tags with the retention window (#552)

### DIFF
--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -18,7 +18,8 @@
 #      - latest_per_major without major_line: full re-resolution via
 #        latest_per_major_versions helper.
 #   2. count-based: read build.version_retention (exit 2 if absent/zero).
-#      2a. Check if new_version already exists (idempotent — exit 0).
+#      2a. Check if new_version already exists (idempotent — reconcile cache
+#          to the retained variants window, then exit 0).
 #      2b. If container has variants: copy variants from first versions[] entry.
 #      2c. Prepend new entry to versions[].
 #      2d. Trim to version_retention entries.
@@ -34,6 +35,139 @@ usage() {
     echo "Usage: $(basename "$0") <container_dir> <new_version> [major_line]" >&2
     echo "Exit codes: 0=success, 1=error, 2=not a version_retention container" >&2
     exit 1
+}
+
+numeric_version_components() {
+    local value="$1"
+    local remainder="$value"
+    local component
+
+    while [[ "$remainder" =~ ([0-9]+([.][0-9]+)*) ]]; do
+        component="${BASH_REMATCH[1]}"
+        printf '%s\n' "$component"
+        remainder="${remainder#*"$component"}"
+    done
+}
+
+first_numeric_version_component() {
+    local value="$1"
+
+    if [[ "$value" =~ ([0-9]+([.][0-9]+)*) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    return 1
+}
+
+version_component_in_window() {
+    local component="$1"
+    local variant_tag
+    local variant_component
+
+    for variant_tag in "${version_window_tags[@]}"; do
+        if ! variant_component=$(first_numeric_version_component "$variant_tag"); then
+            continue
+        fi
+
+        if [[ "$component" == "$variant_component" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+rotate_base_image_cache_tags() {
+    local config_file="$container_dir/config.yaml"
+    local entry_count
+    local tag_count
+    local i
+    local rotated=0
+
+    [[ -f "$config_file" ]] || return 0
+
+    entry_count=$(yq -r '.base_image_cache // [] | length' "$config_file" 2>/dev/null || echo "0")
+    [[ "$entry_count" =~ ^[0-9]+$ && "$entry_count" -gt 0 ]] || return 0
+
+    for ((i = 0; i < entry_count; i++)); do
+        tag_count=$(yq -r ".base_image_cache[$i].tags // [] | length" "$config_file" 2>/dev/null || echo "0")
+        [[ "$tag_count" =~ ^[0-9]+$ && "$tag_count" -gt 0 ]] || continue
+
+        local cache_tags=()
+        mapfile -t cache_tags < <(yq -r ".base_image_cache[$i].tags[]" "$config_file")
+
+        local cache_tag
+        local component
+        local tag_prefix
+        local tag_suffix
+        local tag_shape
+        local prefix=""
+        local suffix=""
+        local component_shape=""
+        local pattern_set=0
+        local overlaps_window=0
+        local version_keyed=1
+
+        for cache_tag in "${cache_tags[@]}"; do
+            if ! component=$(first_numeric_version_component "$cache_tag"); then
+                version_keyed=0
+                break
+            fi
+
+            tag_prefix="${cache_tag%%"$component"*}"
+            tag_suffix="${cache_tag#*"$component"}"
+            tag_shape="${component//[0-9]/}"
+
+            if [[ "$pattern_set" -eq 0 ]]; then
+                prefix="$tag_prefix"
+                suffix="$tag_suffix"
+                component_shape="$tag_shape"
+                pattern_set=1
+            elif [[ "$tag_prefix" != "$prefix" || "$tag_suffix" != "$suffix" || "$tag_shape" != "$component_shape" ]]; then
+                version_keyed=0
+                break
+            fi
+
+            if version_component_in_window "$component"; then
+                overlaps_window=1
+            fi
+        done
+
+        [[ "$overlaps_window" -eq 1 ]] || continue
+        [[ "$version_keyed" -eq 1 ]] || continue
+
+        local rotated_tags=()
+        local new_tag
+        local new_component
+        local new_component_shape
+
+        for new_tag in "${new_version_tags[@]}"; do
+            if ! new_component=$(first_numeric_version_component "$new_tag"); then
+                version_keyed=0
+                break
+            fi
+
+            new_component_shape="${new_component//[0-9]/}"
+            if [[ "$new_component_shape" != "$component_shape" ]]; then
+                version_keyed=0
+                break
+            fi
+
+            rotated_tags+=("${prefix}${new_component}${suffix}")
+        done
+
+        [[ "$version_keyed" -eq 1 ]] || continue
+
+        local tags_json
+        tags_json=$(printf '%s\n' "${rotated_tags[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+        TAGS="$tags_json" yq -i ".base_image_cache[$i].tags = env(TAGS) | .base_image_cache[$i].tags style=\"flow\"" "$config_file"
+        rotated=1
+    done
+
+    if [[ "$rotated" -eq 1 ]]; then
+        echo "Updated $config_file base_image_cache tags to mirror retained versions" >&2
+    fi
 }
 
 [[ $# -lt 2 ]] && usage
@@ -116,14 +250,18 @@ if [[ "$retention" -eq 0 ]]; then
     exit 2
 fi
 
+mapfile -t old_version_tags < <(yq -r '.versions[].tag' "$variants_file" 2>/dev/null)
+
 # Step 2: Check idempotence — does new_version already exist?
-existing_tags=$(yq -r '.versions[].tag' "$variants_file" 2>/dev/null)
-while IFS= read -r tag; do
+for tag in "${old_version_tags[@]}"; do
     if [[ "$tag" == "$new_version" ]]; then
-        echo "Version $new_version already exists in $variants_file — no changes needed" >&2
+        new_version_tags=("${old_version_tags[@]}")
+        version_window_tags=("${old_version_tags[@]}" "${new_version_tags[@]}")
+        rotate_base_image_cache_tags
+        echo "Version $new_version already exists in $variants_file — reconciled base_image_cache tags" >&2
         exit 0
     fi
-done <<< "$existing_tags"
+done
 
 # Step 3/4: Build the new version entry
 first_has_variants=$(yq -r '.versions[0].variants | length // 0' "$variants_file" 2>/dev/null || echo "0")
@@ -145,5 +283,9 @@ current_count=$(yq -r '.versions | length' "$variants_file")
 if [[ "$current_count" -gt "$retention" ]]; then
     yq -i ".versions |= .[:$retention]" "$variants_file"
 fi
+
+mapfile -t new_version_tags < <(yq -r '.versions[].tag' "$variants_file" 2>/dev/null)
+version_window_tags=("${old_version_tags[@]}" "${new_version_tags[@]}")
+rotate_base_image_cache_tags
 
 echo "Rotated $variants_file: added $new_version (retention: $retention)" >&2

--- a/tests/unit/rotate-versions.bats
+++ b/tests/unit/rotate-versions.bats
@@ -73,6 +73,34 @@ versions:
 EOF
 }
 
+create_retention_window_container() {
+    local dir="${1:-tf}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.15.4"
+  - tag: "1.15.3"
+  - tag: "1.15.2"
+EOF
+}
+
+create_rotated_retention_window_container() {
+    local dir="${1:-tf}"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'EOF'
+build:
+  version_retention: 3
+
+versions:
+  - tag: "1.15.5"
+  - tag: "1.15.4"
+  - tag: "1.15.3"
+EOF
+}
+
 # --- Tests ---
 
 @test "rotate: basic prepend + trim" {
@@ -126,6 +154,12 @@ EOF
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
 
     create_versioned_container "myapp"
+    cat > myapp/config.yaml <<'EOF'
+base_image_cache:
+  - source: example/myapp
+    tags: ["2.0.0", "1.9.0"]
+EOF
+
     run scripts/rotate-versions.sh "myapp" "2.0.0"
     [ "$status" -eq 0 ]
 
@@ -133,6 +167,10 @@ EOF
     local count
     count=$(yq -r '.versions | length' myapp/variants.yaml)
     [ "$count" -eq 2 ]
+
+    local tags
+    tags=$(yq -r '.base_image_cache[] | select(.source == "example/myapp") | .tags | join(",")' myapp/config.yaml)
+    [ "$tags" = "2.0.0,1.9.0" ]
 }
 
 @test "rotate: container with variants copies variants from first entry" {
@@ -168,4 +206,155 @@ EOF
     mkdir -p "nonexistent"
     run scripts/rotate-versions.sh "nonexistent" "1.0.0"
     [ "$status" -eq 1 ]
+}
+
+@test "rotate: base_image_cache version tags mirror retained variants" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
+base_image_cache:
+  - source: hashicorp/terraform
+    tags: ["1.15.4", "1.15.3", "1.15.2"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    local tags
+    tags=$(yq -r '.base_image_cache[] | select(.source == "hashicorp/terraform") | .tags | join(",")' tf/config.yaml)
+    [ "$tags" = "1.15.5,1.15.4,1.15.3" ]
+}
+
+@test "rotate: base_image_cache version tags preserve suffix format" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image_cache:
+  - source: hashicorp/terraform
+    tags: ["1.15.4-alpine", "1.15.3-alpine", "1.15.2-alpine"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    local tags
+    tags=$(yq -r '.base_image_cache[] | select(.source == "hashicorp/terraform") | .tags | join(",")' tf/config.yaml)
+    [ "$tags" = "1.15.5-alpine,1.15.4-alpine,1.15.3-alpine" ]
+}
+
+@test "rotate: idempotent variants path reconciles stale base_image_cache" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_rotated_retention_window_container "tf"
+    cp tf/variants.yaml tf/variants.before.yaml
+    cat > tf/config.yaml <<'EOF'
+base_image_cache:
+  - source: hashicorp/terraform
+    tags: ["1.15.4", "1.15.3", "1.15.2"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    cmp -s tf/variants.before.yaml tf/variants.yaml
+
+    local tags
+    tags=$(yq -r '.base_image_cache[] | select(.source == "hashicorp/terraform") | .tags | join(",")' tf/config.yaml)
+    [ "$tags" = "1.15.5,1.15.4,1.15.3" ]
+}
+
+@test "rotate: idempotent cache reconciliation leaves unrelated entries untouched" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_rotated_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image_cache:
+  - source: hashicorp/terraform
+    tags: ["1.15.4", "1.15.3", "1.15.2"]
+  - source: library/alpine
+    tags: ["latest"]
+  - source: library/python
+    tags: ["3.12-alpine"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    local terraform_tags
+    local alpine_tags
+    local python_tags
+    terraform_tags=$(yq -r '.base_image_cache[] | select(.source == "hashicorp/terraform") | .tags | join(",")' tf/config.yaml)
+    alpine_tags=$(yq -r '.base_image_cache[] | select(.source == "library/alpine") | .tags | join(",")' tf/config.yaml)
+    python_tags=$(yq -r '.base_image_cache[] | select(.source == "library/python") | .tags | join(",")' tf/config.yaml)
+
+    [ "$terraform_tags" = "1.15.5,1.15.4,1.15.3" ]
+    [ "$alpine_tags" = "latest" ]
+    [ "$python_tags" = "3.12-alpine" ]
+}
+
+@test "rotate: non-version base_image_cache entries are untouched" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image_cache:
+  - source: library/alpine
+    tags: ["latest"]
+  - source: library/python
+    tags: ["3.12-alpine"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    local alpine_tags
+    local python_tags
+    alpine_tags=$(yq -r '.base_image_cache[] | select(.source == "library/alpine") | .tags | join(",")' tf/config.yaml)
+    python_tags=$(yq -r '.base_image_cache[] | select(.source == "library/python") | .tags | join(",")' tf/config.yaml)
+
+    [ "$alpine_tags" = "latest" ]
+    [ "$python_tags" = "3.12-alpine" ]
+}
+
+@test "rotate: config without base_image_cache is unchanged" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
+build_args:
+  TFLINT_VERSION: "0.63.1"
+EOF
+    cp tf/config.yaml tf/config.before.yaml
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+    cmp -s tf/config.before.yaml tf/config.yaml
+}
+
+@test "rotate: mixed base_image_cache rotates only version-keyed entry" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    create_retention_window_container "tf"
+    cat > tf/config.yaml <<'EOF'
+base_image_cache:
+  - source: hashicorp/terraform
+    tags: ["1.15.4", "1.15.3", "1.15.2"]
+  - source: library/alpine
+    tags: ["latest"]
+EOF
+
+    run scripts/rotate-versions.sh "tf" "1.15.5"
+    [ "$status" -eq 0 ]
+
+    local terraform_tags
+    local alpine_tags
+    terraform_tags=$(yq -r '.base_image_cache[] | select(.source == "hashicorp/terraform") | .tags | join(",")' tf/config.yaml)
+    alpine_tags=$(yq -r '.base_image_cache[] | select(.source == "library/alpine") | .tags | join(",")' tf/config.yaml)
+
+    [ "$terraform_tags" = "1.15.5,1.15.4,1.15.3" ]
+    [ "$alpine_tags" = "latest" ]
 }


### PR DESCRIPTION
`rotate-versions.sh` rotated `variants.yaml` versions but left version-pinned `config.yaml::base_image_cache.tags` behind, so the cache window drifted and the next build failed (the new version's base was never synced to GHCR). Real case: terraform variants `[1.15.5,1.15.4,1.15.3]` vs cache `[1.15.4,1.15.3,1.15.2]`.

Now the script mirrors the retention rotation into version-keyed cache tag arrays, including on the idempotent rerun path (when `variants.yaml` already has the version) so a previously-drifted config is realigned rather than skipped. Version-keyed entries are detected by overlap with the retained window + version-shaped tags, so unrelated entries (`library/alpine: [latest]`, `library/python: [3.12-alpine]`) stay untouched; the tag format is preserved.

Verification: shellcheck clean; 13 unit tests incl. the drift/idempotent-rerun regression and the untouched-non-version-entry cases.

Closes #552.