### PR TITLE
ci: retry binary installs (yq/skopeo) on transient download failures (#691 phase 2)

### DIFF
--- a/.github/actions/check-dependency-versions/action.yaml
+++ b/.github/actions/check-dependency-versions/action.yaml
@@ -26,9 +26,27 @@ runs:
       run: |
         # Install yq if not available
         if ! command -v yq &> /dev/null; then
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+          # Composite actions cannot invoke retry-run, so use the same helper inline.
+          # shellcheck disable=SC1091
+          source "${GITHUB_WORKSPACE}/helpers/retry.sh"
+
+          install_yq() {
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          }
+
+          install_yq_with_timeout() {
+            if command -v timeout >/dev/null 2>&1; then
+              timeout 60s bash -e -o pipefail -c install_yq
+            else
+              install_yq
+            fi
+          }
+
+          export -f install_yq
+          retry_with_backoff 3 5 install_yq_with_timeout
         fi
         # Install jq if not available
         if ! command -v jq &> /dev/null; then

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1538,10 +1538,14 @@ jobs:
 
       - name: Install yq
         timeout-minutes: 5
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Log in to container registries
         uses: ./.github/actions/docker-login
@@ -2017,10 +2021,14 @@ jobs:
 
       - name: Install yq
         timeout-minutes: 5
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_arm64
-          echo "4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_arm64
+            echo "4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Log in to container registries
         uses: ./.github/actions/docker-login
@@ -2513,10 +2521,14 @@ jobs:
 
       - name: Install yq
         timeout-minutes: 5
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Log in to container registries
         uses: ./.github/actions/docker-login
@@ -3448,10 +3460,13 @@ jobs:
         if: github.event_name != 'pull_request'
         continue-on-error: true
         timeout-minutes: 5
-        shell: bash
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y skopeo
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo apt-get update -qq
+            sudo apt-get install -y skopeo
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Install yq (summary job)
         # Required by check-version-drift.sh → helpers/variant-utils.sh.

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -76,16 +76,19 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install yq
-        shell: bash
-        run: |
-          # Install yq on PATH (mikefarah/yq action only runs yq inside the
-          # action itself, it does NOT put yq on PATH for subsequent steps).
-          # Mirror the exact pattern used in create-update-prs (line ~212).
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            # Install yq on PATH (mikefarah/yq action only runs yq inside the
+            # action itself, it does NOT put yq on PATH for subsequent steps).
+            # Mirror the exact pattern used in create-update-prs (line ~212).
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Check source liveness (HEAD each liveness_url)
         id: liveness
@@ -368,11 +371,15 @@ jobs:
           echo "Reason: $reason"
 
       - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Rotate version in variants.yaml
         id: rotate
@@ -785,11 +792,15 @@ jobs:
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Configure Git
         run: |
@@ -1056,9 +1067,13 @@ jobs:
           steps.prepare.outputs.update_count != '0' &&
           matrix.container == 'postgres' &&
           contains(steps.prepare.outputs.updates, '"timescaledb"')
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y skopeo
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo apt-get update -qq
+            sudo apt-get install -y skopeo
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Refresh timescaledb committed version-set
         # Runs when the postgres container has a timescaledb update so the PR
@@ -1311,16 +1326,19 @@ jobs:
         continue-on-error: true
 
       - name: Install yq
-        shell: bash
-        run: |
-          # Install yq on PATH (mikefarah/yq action only runs yq inside the
-          # action itself, it does NOT put yq on PATH for subsequent steps).
-          # Use checksum-verified version from create-update-prs to prevent tampering.
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            # Install yq on PATH (mikefarah/yq action only runs yq inside the
+            # action itself, it does NOT put yq on PATH for subsequent steps).
+            # Use checksum-verified version from create-update-prs to prevent tampering.
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Detect drift
         id: detect
@@ -1523,15 +1541,18 @@ jobs:
         continue-on-error: true
 
       - name: Install yq
-        shell: bash
-        run: |
-          # Install yq on PATH for list-builds calls. Use checksum-verified
-          # version to prevent tampering in this write-capable workflow.
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            # Install yq on PATH for list-builds calls. Use checksum-verified
+            # version to prevent tampering in this write-capable workflow.
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Re-detect drift for this container (idempotent)
         id: drift-data
@@ -1818,15 +1839,18 @@ jobs:
         continue-on-error: true
 
       - name: Install yq
-        shell: bash
-        run: |
-          # Install yq on PATH for list-builds calls. Use checksum-verified
-          # version to prevent tampering in this write-capable workflow.
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            # Install yq on PATH for list-builds calls. Use checksum-verified
+            # version to prevent tampering in this write-capable workflow.
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          max-attempts: '3'
+          timeout: '60s'
 
       - name: Re-detect drift for this container (idempotent)
         id: drift-data


### PR DESCRIPTION
Phase 2 of the resilience sweep (#691): wraps the durable-job tool installs in backoff retry so a transient download/registry blip during setup no longer fails the job.

- `yq` (wget) and `skopeo` (apt-get) installs across `auto-build.yaml` (bake-build amd64/arm64, bake-merge, summary) and `upstream-monitor.yaml` (source-liveness, PR-create, drift jobs) — 11 install steps wrapped with the `retry-run` composite (all have a prior checkout, so `helpers/retry.sh` resolves).
- `check-dependency-versions` yq install: **pinned to v4.52.4 + sha256 checksum** (was unpinned/`latest`) and retried with a per-attempt timeout.

Idempotent (re-download/re-install). Unit suite green; YAML valid; the wrapped steps confirmed under `retry-run`/`retry_with_backoff`.

Refs #691. Phases 3-4 (GitHub-API probes, `uses:` artifact uploads via staged-retry) follow.