### PR TITLE
ci: retry transient GitHub-API/registry probes and the remaining artifact uploads (#691)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -836,6 +836,9 @@ jobs:
       matrix:
         build: ${{ fromJson(needs.detect-containers.outputs.builds) }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -863,10 +866,13 @@ jobs:
             exit 0
           fi
 
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
+
           src="docker://ghcr.io/$GITHUB_USERNAME/$CONTAINER:$TAG"
           dst="docker://docker.io/$DOCKERHUB_USERNAME/$CONTAINER:$TAG"
           echo "::notice::Syncing $src → $dst"
-          skopeo copy --all "$src" "$dst" || \
+          retry_with_backoff 3 5 skopeo copy --all "$src" "$dst" || \
             echo "::warning::Sync failed for $CONTAINER:$TAG — image may not exist on GHCR"
 
   build-and-push:
@@ -2899,13 +2905,17 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
           source "${GITHUB_WORKSPACE}/helpers/coverage-checkpoint-utils.sh"
+          # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
+          source "${GITHUB_WORKSPACE}/helpers/logging.sh"
+          # shellcheck disable=SC1091  # path resolved at runtime in GITHUB_WORKSPACE
+          source "${GITHUB_WORKSPACE}/helpers/retry.sh"
 
           # Step 1: Fetch this run's job conclusions (kept for fallback path).
           # On gh failure we cannot determine per-container outcomes via the fallback,
           # so we fail closed (force unmapped) rather than advancing the baseline while
           # silently dropping this run's real failures.
           set +e
-          jobs_json=$(gh run view "$GITHUB_RUN_ID" --json jobs --jq '{jobs: [.jobs[] | {name, conclusion}]}' 2>/dev/null)
+          jobs_json=$(retry_with_backoff 3 5 gh run view "$GITHUB_RUN_ID" --json jobs --jq '{jobs: [.jobs[] | {name, conclusion}]}' 2>/dev/null)
           gh_rc=$?
           set -e
           gh_failed=false
@@ -2929,7 +2939,7 @@ jobs:
           # Guard: use find+mapfile (not a glob) to count files — an empty download dir
           # leaves the glob un-expanded (nullglob off), which would feed the literal path
           # string to jq and produce a malformed payload instead of falling back.
-          gh run download "$GITHUB_RUN_ID" --pattern 'build-result-*' -D "$RUNNER_TEMP/bres" 2>/dev/null || true
+          retry_with_backoff 3 5 gh run download "$GITHUB_RUN_ID" --pattern 'build-result-*' -D "$RUNNER_TEMP/bres" 2>/dev/null || true
           mapfile -t _bres_files < <(find "$RUNNER_TEMP/bres" -type f -name '*.json' 2>/dev/null)
           if [[ ${#_bres_files[@]} -gt 0 ]]; then
             results_json=$(jq -s -c '.' "${_bres_files[@]}")
@@ -3265,6 +3275,9 @@ jobs:
           GH_RUN_ID: ${{ github.run_id }}
           GH_REPOSITORY: ${{ github.repository }}
         run: |
+          source ./helpers/logging.sh
+          source ./helpers/retry.sh
+
           commit_subject=$(git log -1 --format=%s "$GH_SHA" 2>/dev/null || true)
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -3289,7 +3302,7 @@ jobs:
             fi
           fi
 
-          failed_jobs_json=$(gh run view "$GH_RUN_ID" --repo "$GH_REPOSITORY" --json jobs \
+          failed_jobs_json=$(retry_with_backoff 3 5 gh run view "$GH_RUN_ID" --repo "$GH_REPOSITORY" --json jobs \
             --jq '[.jobs[] | select(.conclusion == "failure") | {name, id: .databaseId}] | .[:5]' \
             2>/dev/null || echo '[]')
 

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -477,7 +477,9 @@ jobs:
           done
 
       - name: Upload extension per-version lineage files (${{ matrix.arch }})
+        id: upload_ext_lineage_per_version
         if: always() && hashFiles('.build-lineage/ext-*.json') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           # Arch-specific artifact name: the versionset artifact (with bundle_digest)
@@ -492,6 +494,24 @@ jobs:
           # `.build-lineage/` is a dot-prefixed directory; v4 of upload-artifact
           # silently skips files inside hidden directories unless this is set.
           include-hidden-files: true
+
+      - name: Upload extension per-version lineage files (${{ matrix.arch }}) (retry on transient failure)
+        if: always() && steps.upload_ext_lineage_per_version.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          # Arch-specific artifact name: the versionset artifact (with bundle_digest)
+          # is written by merge-extension-manifests (stage B), not here.
+          # Per-version duration files use arch-suffixed names (ext-*-<ver>-amd64.json,
+          # etc.) to avoid collision when both arch artifacts are downloaded together;
+          # AX-3 consolidation in stage B merges them with MAX policy.
+          name: ext-lineage-${{ github.run_id }}-${{ matrix.arch }}
+          path: .build-lineage/ext-*.json
+          retention-days: 1
+          if-no-files-found: ignore
+          # `.build-lineage/` is a dot-prefixed directory; v4 of upload-artifact
+          # silently skips files inside hidden directories unless this is set.
+          include-hidden-files: true
+          overwrite: true
 
       - name: Emit build-result artifact (postgres extensions, ${{ matrix.arch }})
         if: always()
@@ -695,7 +715,9 @@ jobs:
           done
 
       - name: Upload canonical lineage (versionset + consolidated duration files)
+        id: upload_ext_lineage_canonical
         if: always() && hashFiles('.build-lineage/ext-*.json') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           # Canonical artifact: consumed by the postgres build-and-push job.
@@ -710,6 +732,24 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
           include-hidden-files: true
+
+      - name: Upload canonical lineage (versionset + consolidated duration files) (retry on transient failure)
+        if: always() && steps.upload_ext_lineage_canonical.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          # Canonical artifact: consumed by the postgres build-and-push job.
+          # Contains versionset artifacts (ext-*-versionset.json) and consolidated
+          # per-version duration files (ext-<ext>-pg<major>-<ver>.json, no arch suffix)
+          # after AX-3 MAX-policy consolidation by finalize_multiarch_manifests.
+          # Arch-specific duration files (*-amd64.json, *-arm64.json) are removed by
+          # AX-3 consolidation before upload; after consolidation only the canonical
+          # (un-suffixed) files remain.
+          name: ext-lineage-${{ github.run_id }}
+          path: .build-lineage/ext-*.json
+          retention-days: 1
+          if-no-files-found: ignore
+          include-hidden-files: true
+          overwrite: true
 
       - name: Emit build-result artifact (postgres extmerge)
         if: always()
@@ -1249,7 +1289,9 @@ jobs:
         continue-on-error: true
 
       - name: Upload SBOM artifact
+        id: upload_sbom_artifact
         if: steps.sbom.outcome == 'success'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: sbom-${{ matrix.build.container }}-${{ matrix.build.tag }}
@@ -1257,6 +1299,17 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload SBOM artifact (retry on transient failure)
+        if: always() && steps.upload_sbom_artifact.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: sbom-${{ matrix.build.container }}-${{ matrix.build.tag }}
+          path: ${{ steps.sbom.outputs.sbom_file }}
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
       - name: Attest SBOM
         if: steps.sbom.outcome == 'success' && steps.sbom.outputs.digest != ''
@@ -1446,7 +1499,9 @@ jobs:
         continue-on-error: true
 
       - name: Upload SBOM artifact (Windows)
+        id: upload_sbom_artifact_windows
         if: steps.sbom-windows.outcome == 'success'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: sbom-${{ matrix.build.container }}-${{ matrix.build.tag }}
@@ -1454,6 +1509,17 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload SBOM artifact (Windows) (retry on transient failure)
+        if: always() && steps.upload_sbom_artifact_windows.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: sbom-${{ matrix.build.container }}-${{ matrix.build.tag }}
+          path: ${{ steps.sbom-windows.outputs.sbom_file }}
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
       - name: Attest SBOM (Windows)
         if: steps.sbom-windows.outcome == 'success' && steps.sbom-windows.outputs.digest != ''
@@ -1987,6 +2053,7 @@ jobs:
           overwrite: true
 
       - name: Upload build lineage (bake amd64)
+        id: upload_build_lineage_bake_amd64
         if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
@@ -2001,6 +2068,22 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload build lineage (bake amd64) (retry on transient failure)
+        if: always() && steps.upload_build_lineage_bake_amd64.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: build-lineage-bake-amd64-${{ github.run_id }}
+          # Lineage sidecars only — exclude build-result records and SBOMs so the
+          # cache-lineage enrichment/drift logic does not ingest them as lineage.
+          path: |
+            .build-lineage/*.json
+            !.build-lineage/build-result-*.json
+            !.build-lineage/*.sbom.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
   bake-build-arm64:
     name: Bake build (arm64)
@@ -2478,16 +2561,28 @@ jobs:
           echo "::notice::Trivy scan history: ${scan_file} (alert_count=${alert_count}, status=${status})"
 
       - name: Upload SARIF to GitHub Security
+        id: upload_sarif_bake
         if: steps.trivy-scan.outcome != 'skipped'
+        continue-on-error: true  # SARIF upload is advisory — never gates the build
         uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'container-${{ matrix.build.container }}-${{ matrix.build.tag }}-linux/${{ matrix.arch }}'
           wait-for-processing: false
+
+      - name: Upload SARIF to GitHub Security (retry on transient failure)
+        if: always() && steps.upload_sarif_bake.outcome == 'failure'
         continue-on-error: true  # SARIF upload is advisory — never gates the build
+        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'container-${{ matrix.build.container }}-${{ matrix.build.tag }}-linux/${{ matrix.arch }}'
+          wait-for-processing: false
 
       - name: Upload Trivy scan history (bake)
+        id: upload_trivy_scan_history_bake
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: trivy-scan-history-bake-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}-${{ github.run_id }}
@@ -2495,6 +2590,18 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload Trivy scan history (bake) (retry on transient failure)
+        if: always() && steps.upload_trivy_scan_history_bake.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: trivy-scan-history-bake-${{ matrix.build.container }}-${{ matrix.build.tag }}-${{ matrix.arch }}-${{ github.run_id }}
+          path: .trivy-scan-history/
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
 
   bake-merge:
     # Require BOTH arch builds to succeed before merging.  If either fails the
@@ -3758,7 +3865,22 @@ jobs:
           echo "::notice::Processed $sbom_count SBOM(s); $sbom_failed processing error(s)"
 
       - name: Upload derived lineage files (changelog + history)
+        id: upload_derived_lineage
         if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: lineage-derived-${{ github.run_id }}
+          path: |
+            .build-lineage/*.changelog.json
+            .build-lineage/*.history.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+      - name: Upload derived lineage files (changelog + history) (retry on transient failure)
+        if: always() && steps.upload_derived_lineage.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: lineage-derived-${{ github.run_id }}

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -51,6 +51,10 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${PROJECT_ROOT}/helpers/lineage-utils.sh"
 # shellcheck source=../helpers/dependency-graph.sh
 source "${PROJECT_ROOT}/helpers/dependency-graph.sh"
+# shellcheck source=../helpers/logging.sh
+source "${PROJECT_ROOT}/helpers/logging.sh"
+# shellcheck source=../helpers/retry.sh
+source "${PROJECT_ROOT}/helpers/retry.sh"
 
 # ---------------------------------------------------------------------------
 # _escape_gha_command <value>
@@ -151,7 +155,7 @@ _probe_digest() {
     else
         # `--` separates options from the image ref: belt-and-suspenders against
         # dash-prefix option injection if a poisoned ref slips past _validate_image_ref.
-        raw=$(docker buildx imagetools inspect --format '{{json .Manifest}}' -- "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        raw=$(retry_with_backoff 3 5 docker buildx imagetools inspect --format '{{json .Manifest}}' -- "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1242,7 +1242,9 @@ STUB_EOF
     PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
 
     # The injected command must NOT appear as a standalone GHA command line
-    ! grep -q '^::add-mask::' "$stderr_log"
+    if grep -q '^::add-mask::' "$stderr_log"; then
+        return 1
+    fi
 
     # The ::error:: line must be present (probe failure was emitted)
     grep -q '::error::' "$stderr_log"
@@ -1491,9 +1493,9 @@ EOF
     # foo must appear (has error variant)
     [[ "$error_csv" == *"foo"* ]]
     # bar must NOT appear (only drift, no error)
-    ! [[ "$error_csv" == *"bar"* ]]
+    [[ "$error_csv" != *"bar"* ]]
     # baz must NOT appear (stable only)
-    ! [[ "$error_csv" == *"baz"* ]]
+    [[ "$error_csv" != *"baz"* ]]
 }
 
 @test "DefectL: error_containers_csv jq — mixed error+drift container appears in error CSV" {
@@ -1542,9 +1544,11 @@ EOF
     local fake_root="$TEST_TEMP_DIR/r7fix4a"
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
-    # The script sources PROJECT_ROOT/helpers/lineage-utils.sh and dependency-graph.sh — must exist in fake root
+    # The script sources PROJECT_ROOT/helpers/*.sh helpers — they must exist in fake root
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
 
     cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
 {
@@ -1581,6 +1585,8 @@ STUB
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
 
     cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
 {
@@ -2351,7 +2357,9 @@ STUB
     [ "$rc" -eq 0 ]
 
     # Probe must NOT have been called
-    ! echo "$stderr_out" | grep -q "PROBE WAS CALLED"
+    if grep -q "PROBE WAS CALLED" <<<"$stderr_out"; then
+        return 1
+    fi
 
     # r29 Finding 3: rejected ref emits error record (not empty array)
     local result_len err_reason
@@ -2893,10 +2901,6 @@ EOF
     local lineage_dir="$TEST_TEMP_DIR/r25a2/.build-lineage"
     mkdir -p "$lineage_dir"
 
-    # tag with embedded newline + injection payload after it
-    local poisoned_tag
-    poisoned_tag=$'1.0\n::add-mask::SECRET'
-
     # Write file with Python to preserve literal newline in JSON value
     python3 -c "
 import json, pathlib
@@ -3135,7 +3139,9 @@ EOF
     [ "$rc" -eq 0 ]
 
     # Probe must NOT have been called (SSRF prevention intact)
-    ! echo "$stderr_out" | grep -q "PROBE CALLED"
+    if grep -q "PROBE CALLED" <<<"$stderr_out"; then
+        return 1
+    fi
 
     # ::warning:: must still be emitted on stderr (audit trail preserved)
     echo "$stderr_out" | grep -q "Refusing to probe untrusted"
@@ -3269,7 +3275,8 @@ STUBEOF
 
     # Multi-line _ACTIVE_TAGS_OVERRIDE requires explicit export in subshell
     result=$(
-        export _VALID_CONTAINERS_OVERRIDE="$(printf 'myapp\nbaseA\nbaseB')"
+        _VALID_CONTAINERS_OVERRIDE="$(printf 'myapp\nbaseA\nbaseB')"
+        export _VALID_CONTAINERS_OVERRIDE
         export _DEPGRAPH_CONTAINERS_OVERRIDE="myapp baseA baseB"
         export _DEPGRAPH_LINEAGE_DIR="$lineage_dir"
         export _ACTIVE_TAGS_OVERRIDE_myapp
@@ -3336,6 +3343,8 @@ STUBEOF
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
 
     # A container with an internal-looking ref so _depgraph_get_deps must be called
     cat > "$fake_root/.build-lineage/myapp-1.0.json" <<'EOF'
@@ -3410,6 +3419,8 @@ STUB
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
 
     # Patch dependency-graph.sh: _depgraph_get_deps fails for "failcontainer",
     # succeeds (returns empty deps = leaf) for any other container.
@@ -3661,7 +3672,9 @@ EOF
     )
 
     # Valid name must not be rejected by the charset gate
-    ! grep -q 'invalid characters' "$stderr_log"
+    if grep -q 'invalid characters' "$stderr_log"; then
+        return 1
+    fi
     # Container must appear in output (unchanged status is OK)
     container_in_output=$(printf '%s' "$result" | jq -r '.[0].container // empty')
     [ "$container_in_output" = "web-shell" ]


### PR DESCRIPTION
Completes the resilience sweep in #691: no network-dependent CI step should fail the build on a transient registry/API/download blip without a backoff. Builds on the already-merged #712 and #716.

## GitHub-API and registry probes (durable steps)

- `gh run view` (coverage checkpoint + summary jobs) and the best-effort `gh run download` retry with backoff, preserving each call site's existing fail-closed / `|| true` handling — a genuine failure still hits the original error path.
- The base-digest-drift `docker buildx imagetools inspect` probe retries inside `detect-base-digest-drift.sh`, covering every variant call site at once; the existing empty-output and `probe_exit` error handling is unchanged.
- `skopeo copy --all` to Docker Hub (registry mirror) retries before falling back to the existing fallback copy.

## Remaining artifact uploads

Every `upload-artifact` / `upload-sarif` step that still lacked one now has a staged retry: the first attempt is `continue-on-error`, a sibling step re-runs it with `overwrite: true` only if the attempt failed. Required handoff uploads still fail the job if the retry also fails; SARIF uploads stay advisory (`continue-on-error` on both attempt and retry — they never gate the build).

## Intentionally excluded

The per-container build-trigger (`gh workflow run`) is **not** wrapped: re-issuing a workflow dispatch on a transient client error is not idempotent (it can double-trigger a build). Making multi-container recovery a single batched dispatch is the safe fix and is tracked separately under #599.

## Verification

- Full unit suite green: `bats tests/unit/*.bats` → 1820/1820.
- `yq -e .` parses the workflow; `git diff --check` clean.

Closes #691.
