### PR TITLE
feat(ci): per-container build scope via container_scopes dispatch input (#599)

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: 'Specific container to build (overrides detection)'
     required: false
     default: ''
+  container_scopes:
+    description: 'JSON map of per-container scope. When non-empty, keys are the containers to build and values may contain versions/flavors/extensions.'
+    required: false
+    default: ''
   force_rebuild:
     description: '[deprecated] Force rebuild even if image exists — use rebuild=all instead'
     required: false
@@ -100,6 +104,9 @@ outputs:
       versions, false = latest version only. Computed by compute_expand_retained_map
       helper. Consumed downstream by the Expand variants step.
     value: ${{ steps.compute-expand-map.outputs.map }}
+  container_scopes:
+    description: 'Normalized JSON map of per-container scopes, or empty for legacy callers'
+    value: ${{ steps.find-containers.outputs.container_scopes }}
   carried_forward:
     description: |
       JSON array of container names that were newly appended to the build list
@@ -249,12 +256,22 @@ runs:
         # Passed via env (not inline ${{ }}) to avoid injection through JSON content.
         BASELINE_FAILED: ${{ steps.resolve-coverage-baseline.outputs.baseline_failed_containers }}
         BASELINE_VALID: ${{ steps.resolve-coverage-baseline.outputs.baseline_valid }}
+        CONTAINER_SCOPES_INPUT: ${{ inputs.container_scopes }}
       run: |
         set -e
         # shellcheck disable=SC1091  # path resolved at runtime in the action dir
         source "${GITHUB_ACTION_PATH}/../../../helpers/coverage-checkpoint-utils.sh"
+        # shellcheck disable=SC1091  # path resolved at runtime in the action dir
+        source "${GITHUB_ACTION_PATH}/../../../helpers/container-scopes.sh"
         diff_rc=0
+        changed_files=""
+        coverage_fallback=false
         containers_to_build=()
+        normalized_container_scopes=""
+
+        if [[ -n "${CONTAINER_SCOPES_INPUT:-}" ]]; then
+          normalized_container_scopes=$(normalize_container_scopes "$CONTAINER_SCOPES_INPUT") || exit 1
+        fi
 
         # Get list of valid containers from make script (source of truth)
         echo "🔍 Getting list of valid containers from make script..."
@@ -267,10 +284,16 @@ runs:
 
         echo "📋 Valid containers from make: $(echo "$valid_containers" | tr '\n' ' ')"
 
+        # If per-container scopes are provided, their keys are the requested containers.
+        if [[ -n "$normalized_container_scopes" ]]; then
+          echo "🎯 Validating container_scopes keys..."
+          validate_container_scope_keys "$normalized_container_scopes" "$valid_containers" || exit 1
+          mapfile -t containers_to_build < <(container_scope_keys "$normalized_container_scopes")
+          echo "✅ container_scopes keys validated"
         # If specific container requested, validate it
-        if [ -n "${{ inputs.container }}" ]; then
+        elif [ -n "${{ inputs.container }}" ]; then
           echo "🎯 Validating specific container: ${{ inputs.container }}"
-          if echo "$valid_containers" | grep -qx "${{ inputs.container }}"; then
+          if echo "$valid_containers" | grep -Fxq "${{ inputs.container }}"; then
             containers_to_build=("${{ inputs.container }}")
             echo "✅ Container validated"
           else
@@ -449,7 +472,7 @@ runs:
         # carried = baseline_failed ∩ valid  (all valid prior-failed containers)
         # queued' = queued ∪ carried         (full build list, deduped)
         carried_forward_json='[]'
-        if [[ "$BASELINE_VALID" == "true" && "$coverage_fallback" != "true" \
+        if [[ -z "$normalized_container_scopes" && "$BASELINE_VALID" == "true" && "$coverage_fallback" != "true" \
               && -n "$BASELINE_FAILED" && "$BASELINE_FAILED" != "[]" ]]; then
           if [ ${#containers_to_build[@]} -eq 0 ]; then
             queued_json='[]'
@@ -467,6 +490,7 @@ runs:
         fi
 
         # Create outputs (CSV first, then JSON for matrix compatibility)
+        echo "container_scopes=$normalized_container_scopes" >> $GITHUB_OUTPUT
         if [ ${#containers_to_build[@]} -eq 0 ]; then
           echo "containers_list=" >> $GITHUB_OUTPUT
           echo "containers=[]" >> $GITHUB_OUTPUT
@@ -574,77 +598,25 @@ runs:
         SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
         BUILD_SCOPE: ${{ inputs.scope }}
         EXPAND_RETAINED_MAP: ${{ steps.compute-expand-map.outputs.map }}
+        CONTAINER_SCOPES: ${{ steps.find-containers.outputs.container_scopes }}
       run: |
         set -e
         # shellcheck disable=SC1091
         source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/container-scopes.sh"
         containers_json='${{ steps.find-containers.outputs.containers }}'
         versions_json='${{ steps.compute-versions.outputs.versions }}'
 
-        builds_json="[]"
-        builds_count=0
-
-        for container in $(echo "$containers_json" | jq -r '.[]'); do
-          version=$(echo "$versions_json" | jq -r --arg c "$container" '.[$c]')
-          echo "📦 Expanding builds for $container (version: $version)..."
-
-          expand_for_container=$(echo "$EXPAND_RETAINED_MAP" | jq -r --arg c "$container" '.[$c] // "false"')
-          # scope_versions is an explicit user request for specific versions. Pre-filtering
-          # to latest-only would defeat it. Bypass the filter when scope_versions is set.
-          if [[ -n "$SCOPE_VERSIONS" ]]; then
-            expand_for_container="true"
-          fi
-          container_builds=$(list_container_builds "$container" "$version" "$expand_for_container")
-
-          # Apply scope_versions / scope_flavors filters (legacy inputs)
-          if [[ -n "$SCOPE_VERSIONS" || -n "$SCOPE_FLAVORS" ]]; then
-            # Convert comma-separated values to JSON arrays for jq
-            versions_filter="[]"
-            if [[ -n "$SCOPE_VERSIONS" ]]; then
-              versions_filter=$(echo "$SCOPE_VERSIONS" | tr ',' '\n' | jq -R . | jq -s -c .)
-            fi
-            flavors_filter="[]"
-            if [[ -n "$SCOPE_FLAVORS" ]]; then
-              flavors_filter=$(echo "$SCOPE_FLAVORS" | tr ',' '\n' | jq -R . | jq -s -c .)
-            fi
-
-            before_count=$(echo "$container_builds" | jq 'length')
-            container_builds=$(echo "$container_builds" | jq -c \
-              --argjson sv "$versions_filter" --argjson sf "$flavors_filter" \
-              '[.[] | select(
-                (($sv | length) == 0 or (.version as $v | $sv | any(. as $s | $v == $s or ($v | startswith($s + ".")) or ($v | startswith($s + "-"))))) and
-                (($sf | length) == 0 or (.flavor as $f | $sf | any(. == $f)))
-              )]')
-            after_count=$(echo "$container_builds" | jq 'length')
-
-            if [[ "$before_count" != "$after_count" ]]; then
-              echo "  🔍 Scope filter: $before_count → $after_count builds (versions=${SCOPE_VERSIONS:-all}, flavors=${SCOPE_FLAVORS:-all})"
-            fi
-          fi
-
-          # Apply BUILD_SCOPE filter (new unified scope input)
-          # Matches against: variant, os, build_flavor — any field containing the scope string
-          if [[ -n "$BUILD_SCOPE" ]]; then
-            before_count=$(echo "$container_builds" | jq 'length')
-            container_builds=$(echo "$container_builds" | jq -c \
-              --arg s "$BUILD_SCOPE" \
-              '[.[] | select(
-                (.variant // "" | contains($s)) or
-                (.os // "" | contains($s)) or
-                (.build_flavor // "" | contains($s)) or
-                (.flavor // "" | contains($s))
-              )]')
-            after_count=$(echo "$container_builds" | jq 'length')
-            echo "  🔍 BUILD_SCOPE \"$BUILD_SCOPE\" filter: $before_count → $after_count builds"
-          fi
-
-          count=$(echo "$container_builds" | jq 'length')
-
-          builds_json=$(echo "$builds_json" | jq -c ". + $container_builds")
-          builds_count=$((builds_count + count))
-          echo "  → $count build(s)"
-          echo "$container_builds" | jq -c '.[]'
-        done
+        builds_json=$(expand_variants_for_containers \
+          "$containers_json" \
+          "$versions_json" \
+          "$EXPAND_RETAINED_MAP" \
+          "$CONTAINER_SCOPES" \
+          "$SCOPE_VERSIONS" \
+          "$SCOPE_FLAVORS" \
+          "$BUILD_SCOPE")
+        builds_count=$(echo "$builds_json" | jq 'length')
 
         echo "builds=$builds_json" >> $GITHUB_OUTPUT
         echo "builds_count=$builds_count" >> $GITHUB_OUTPUT

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -8,6 +8,11 @@ on:
         description: 'Specific container to build (leave empty for all)'
         required: false
         type: string
+      container_scopes:
+        description: 'JSON map of per-container scope for batched recovery dispatch, e.g. {"postgres":{"versions":"17","flavors":"full","extensions":"pgvector"},"debian":{}}. When non-empty, its KEYS are the containers to build and each value carries that container''s scope (any of versions/flavors/extensions; omit/empty = no scope for that container). Takes precedence over `container` and diff detection. Empty = legacy container/diff path.'
+        required: false
+        type: string
+        default: ''
       force_rebuild:
         description: '[deprecated] Force rebuild even if up-to-date — use rebuild=all instead'
         required: false
@@ -123,6 +128,11 @@ on:
         description: 'Specific container to build (leave empty for all)'
         required: false
         type: string
+      container_scopes:
+        description: 'JSON map of per-container scope for batched recovery dispatch, e.g. {"postgres":{"versions":"17","flavors":"full","extensions":"pgvector"},"debian":{}}. When non-empty, its KEYS are the containers to build and each value carries that container''s scope (any of versions/flavors/extensions; omit/empty = no scope for that container). Takes precedence over `container` and diff detection. Empty = legacy container/diff path.'
+        required: false
+        type: string
+        default: ''
       force_rebuild:
         description: '[deprecated] Force rebuild even if no updates — use rebuild=all instead'
         required: false
@@ -213,6 +223,7 @@ env:
   DOCKER_NO_CACHE: ${{ inputs.rebuild == 'force' && 'true' || 'false' }}
   SCOPE_VERSIONS: ${{ github.event.inputs.scope_versions || inputs.scope_versions || '' }}
   SCOPE_FLAVORS: ${{ github.event.inputs.scope_flavors || inputs.scope_flavors || '' }}
+  CONTAINER_SCOPES: ${{ github.event.inputs.container_scopes || inputs.container_scopes || '' }}
   # Variant scope filter (free-text, matched against variant/os/build_flavor fields)
   BUILD_SCOPE: ${{ github.event.inputs.scope || inputs.scope || '' }}
   BUILD_ALL_RETAINED: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || 'false' }}
@@ -232,6 +243,7 @@ jobs:
       extension_builds: ${{ steps.detect.outputs.extension_builds }}
       bake_final_builds: ${{ steps.detect.outputs.bake_final_builds }}
       postgres_matrix_builds: ${{ steps.detect.outputs.postgres_matrix_builds }}
+      container_scopes: ${{ steps.detect.outputs.container_scopes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -247,6 +259,7 @@ jobs:
         uses: ./.github/actions/detect-containers
         with:
           container: ${{ github.event.inputs.container || inputs.container }}
+          container_scopes: ${{ github.event.inputs.container_scopes || inputs.container_scopes || '' }}
           force_rebuild: ${{ github.event.inputs.force_rebuild || inputs.force_rebuild }}
           rebuild: ${{ env.REBUILD_MODE }}
           scope: ${{ env.BUILD_SCOPE }}
@@ -369,6 +382,9 @@ jobs:
       - name: Get versions requiring extensions
         id: ext-versions
         timeout-minutes: 5
+        env:
+          CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+          EXTENSION_CONTAINERS_JSON: ${{ needs.detect-containers.outputs.container_scopes != '' && needs.detect-containers.outputs.extension_builds || '' }}
         run: |
           chmod +x scripts/list-extension-versions.sh
           scripts/list-extension-versions.sh
@@ -380,6 +396,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOPE_VERSIONS: ${{ github.event.inputs.scope_versions || inputs.scope_versions }}
           SCOPE_EXTENSIONS: ${{ github.event.inputs.scope_extensions || inputs.scope_extensions }}
+          CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
           REBUILD: ${{ env.REBUILD_MODE }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
           # USE_BASE_CACHE mirrors the use_base_cache gate in build-container: true only for
@@ -423,15 +440,21 @@ jobs:
             [[ -z "$entry" ]] && continue
             container="${entry%%:*}"
             versions="${entry#*:}"
+            container_scope_versions="$SCOPE_VERSIONS"
+            container_scope_extensions="$SCOPE_EXTENSIONS"
+            if [[ -n "$CONTAINER_SCOPES" ]]; then
+              container_scope_versions=$(echo "$CONTAINER_SCOPES" | jq -r --arg c "$container" '.[$c].versions // ""')
+              container_scope_extensions=$(echo "$CONTAINER_SCOPES" | jq -r --arg c "$container" '.[$c].extensions // ""')
+            fi
 
             IFS=',' read -ra VERSION_LIST <<< "$versions"
             for major_version in "${VERSION_LIST[@]}"; do
               [[ -z "$major_version" ]] && continue
 
               # Skip versions not in scope (if scope_versions is set)
-              if [[ -n "$SCOPE_VERSIONS" ]]; then
-                if ! echo ",$SCOPE_VERSIONS," | grep -q ",$major_version,"; then
-                  echo "⏭️ Skipping extensions for $container v$major_version (not in scope: $SCOPE_VERSIONS)"
+              if [[ -n "$container_scope_versions" ]]; then
+                if ! echo ",$container_scope_versions," | grep -q ",$major_version,"; then
+                  echo "⏭️ Skipping extensions for $container v$major_version (not in scope: $container_scope_versions)"
                   continue
                 fi
               fi
@@ -462,9 +485,9 @@ jobs:
               export REMOTE_CR
 
               # Build specific extensions or all
-              if [[ -n "$SCOPE_EXTENSIONS" ]]; then
-                echo "🔧 Building scoped extensions ($SCOPE_EXTENSIONS) for $container v$major_version..."
-                IFS=',' read -ra EXT_LIST <<< "$SCOPE_EXTENSIONS"
+              if [[ -n "$container_scope_extensions" ]]; then
+                echo "🔧 Building scoped extensions ($container_scope_extensions) for $container v$major_version..."
+                IFS=',' read -ra EXT_LIST <<< "$container_scope_extensions"
                 for ext in "${EXT_LIST[@]}"; do
                   [[ -z "$ext" ]] && continue
                   ./scripts/build-extensions.sh "$container" --major-version "$major_version" --extension "$ext" "${force_arg[@]}"
@@ -644,6 +667,9 @@ jobs:
       - name: Get versions requiring extensions
         id: ext-versions
         timeout-minutes: 5
+        env:
+          CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+          EXTENSION_CONTAINERS_JSON: ${{ needs.detect-containers.outputs.container_scopes != '' && needs.detect-containers.outputs.extension_builds || '' }}
         run: |
           chmod +x scripts/list-extension-versions.sh
           scripts/list-extension-versions.sh
@@ -655,6 +681,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOPE_VERSIONS: ${{ github.event.inputs.scope_versions || inputs.scope_versions }}
           SCOPE_EXTENSIONS: ${{ github.event.inputs.scope_extensions || inputs.scope_extensions }}
+          CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
           REPO_OWNER: ${{ github.repository_owner }}
           # BB-1: must match the suffix used by the build-extensions stage A leg so
@@ -679,14 +706,20 @@ jobs:
             [[ -z "$entry" ]] && continue
             container="${entry%%:*}"
             versions="${entry#*:}"
+            container_scope_versions="$SCOPE_VERSIONS"
+            container_scope_extensions="$SCOPE_EXTENSIONS"
+            if [[ -n "$CONTAINER_SCOPES" ]]; then
+              container_scope_versions=$(echo "$CONTAINER_SCOPES" | jq -r --arg c "$container" '.[$c].versions // ""')
+              container_scope_extensions=$(echo "$CONTAINER_SCOPES" | jq -r --arg c "$container" '.[$c].extensions // ""')
+            fi
 
             IFS=',' read -ra VERSION_LIST <<< "$versions"
             for major_version in "${VERSION_LIST[@]}"; do
               [[ -z "$major_version" ]] && continue
 
-              if [[ -n "$SCOPE_VERSIONS" ]]; then
-                if ! echo ",$SCOPE_VERSIONS," | grep -q ",$major_version,"; then
-                  echo "Skipping manifest merge for $container v$major_version (not in scope: $SCOPE_VERSIONS)"
+              if [[ -n "$container_scope_versions" ]]; then
+                if ! echo ",$container_scope_versions," | grep -q ",$major_version,"; then
+                  echo "Skipping manifest merge for $container v$major_version (not in scope: $container_scope_versions)"
                   continue
                 fi
               fi
@@ -700,8 +733,8 @@ jobs:
               fi
               export REMOTE_CR
 
-              if [[ -n "$SCOPE_EXTENSIONS" ]]; then
-                IFS=',' read -ra EXT_LIST <<< "$SCOPE_EXTENSIONS"
+              if [[ -n "$container_scope_extensions" ]]; then
+                IFS=',' read -ra EXT_LIST <<< "$container_scope_extensions"
                 for ext in "${EXT_LIST[@]}"; do
                   [[ -z "$ext" ]] && continue
                   ./scripts/build-extensions.sh "$container" --major-version "$major_version" \
@@ -1598,6 +1631,8 @@ jobs:
       (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
     permissions:
       contents: read
       packages: write
@@ -1776,6 +1811,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           final_args=()
           if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
             final_args=(--include-final-build)
@@ -1934,6 +1970,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           final_args=()
           if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
             final_args=(--include-final-build)
@@ -2098,6 +2135,8 @@ jobs:
       (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
+    env:
+      CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
     permissions:
       contents: read
       packages: write
@@ -2264,6 +2303,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           final_args=()
           if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
             final_args=(--include-final-build)
@@ -2623,6 +2663,8 @@ jobs:
     # serialization is needed (same rationale as build-and-push).
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
     permissions:
       contents: read
       packages: write
@@ -2709,6 +2751,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           final_args=()
           if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
             final_args=(--include-final-build)
@@ -2757,6 +2800,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           # BAKE_CONTAINERS is operator-set (trusted context)
           export BAKE_GENERATE_ALL_RETAINED=false
           # shellcheck disable=SC2086
@@ -2789,6 +2833,7 @@ jobs:
           [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
           [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
           [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
           final_args=()
           if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
             final_args=(--include-final-build)

--- a/helpers/bake-buildresult.sh
+++ b/helpers/bake-buildresult.sh
@@ -81,6 +81,7 @@ emit_bake_build_results() {
     [[ -n "${SCOPE_VERSIONS:-}" ]] && cells_args+=("--scope-versions" "${SCOPE_VERSIONS}")
     [[ -n "${SCOPE_FLAVORS:-}" ]] && cells_args+=("--scope-flavors" "${SCOPE_FLAVORS}")
     [[ -n "${BUILD_SCOPE:-}" ]] && cells_args+=("--scope" "${BUILD_SCOPE}")
+    [[ -n "${CONTAINER_SCOPES:-}" ]] && cells_args+=("--container-scopes" "${CONTAINER_SCOPES}")
     if ! cells_json=$("$generator" "${cells_args[@]}" "${containers[@]}"); then
         printf '::error::bake-buildresult: --cells failed for %s\n' \
             "${containers[*]}" >&2

--- a/helpers/container-scopes.sh
+++ b/helpers/container-scopes.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Helpers for auto-build container_scopes workflow input.
+#
+# Library usage expects helpers/variant-utils.sh to be sourced first when calling
+# expand_variants_for_containers, because that function delegates to
+# list_container_builds.
+
+normalize_container_scopes() {
+    local container_scopes="${1:-}"
+
+    if [[ -z "$container_scopes" ]]; then
+        printf ''
+        return 0
+    fi
+
+    local normalized
+    if ! normalized=$(printf '%s' "$container_scopes" | jq -c '
+        if type == "object" and
+           all(.[]; type == "object" and
+             (.versions == null or (.versions | type == "string")) and
+             (.flavors == null or (.flavors | type == "string")) and
+             (.extensions == null or (.extensions | type == "string")))
+        then .
+        else error("container_scopes must be a JSON object whose values are scope objects")
+        end
+    ' 2>/dev/null); then
+        echo "::error::container_scopes must be a valid JSON object whose values are objects with optional string versions/flavors/extensions fields" >&2
+        return 1
+    fi
+
+    if jq -e 'keys | length == 0' <<< "$normalized" >/dev/null; then
+        printf ''
+        return 0
+    fi
+
+    printf '%s\n' "$normalized"
+}
+
+container_scope_keys() {
+    local container_scopes="${1:-}"
+    [[ -z "$container_scopes" ]] && return 0
+
+    printf '%s' "$container_scopes" | jq -r 'keys[]'
+}
+
+validate_container_scope_keys() {
+    local container_scopes="${1:-}"
+    local valid_containers="${2:-}"
+    local valid_json
+    local bad
+    local bad_keys
+
+    [[ -z "$container_scopes" ]] && return 0
+
+    valid_json=$(printf '%s\n' "$valid_containers" | jq -R . | jq -s -c 'map(select(length > 0))')
+    bad=$(printf '%s' "$container_scopes" | jq -c --argjson valid "$valid_json" '(keys - $valid)')
+
+    if [[ "$bad" != "[]" ]]; then
+        bad_keys=$(printf '%s' "$bad" | jq -r '.[] | @json')
+        bad_keys=${bad_keys//$'\n'/, }
+        echo "::error::container_scopes key(s) $bad_keys are not valid containers" >&2
+        return 1
+    fi
+}
+
+container_scope_field() {
+    local container_scopes="${1:-}"
+    local container="${2:-}"
+    local field="${3:-}"
+
+    [[ -z "$container_scopes" || -z "$container" || -z "$field" ]] && return 0
+    printf '%s' "$container_scopes" | jq -r --arg c "$container" --arg f "$field" '.[$c][$f] // ""'
+}
+
+filter_builds_by_version_flavor_scope() {
+    local container_builds="$1"
+    local scope_versions="${2:-}"
+    local scope_flavors="${3:-}"
+
+    # Convert comma-separated values to JSON arrays for jq. Keep this logic
+    # byte-equivalent to the legacy inline action filter.
+    local versions_filter="[]"
+    if [[ -n "$scope_versions" ]]; then
+        versions_filter=$(echo "$scope_versions" | tr ',' '\n' | jq -R . | jq -s -c .)
+    fi
+    local flavors_filter="[]"
+    if [[ -n "$scope_flavors" ]]; then
+        flavors_filter=$(echo "$scope_flavors" | tr ',' '\n' | jq -R . | jq -s -c .)
+    fi
+
+    echo "$container_builds" | jq -c \
+      --argjson sv "$versions_filter" --argjson sf "$flavors_filter" \
+      '[.[] | select(
+        (($sv | length) == 0 or (.version as $v | $sv | any(. as $s | $v == $s or ($v | startswith($s + ".")) or ($v | startswith($s + "-"))))) and
+        (($sf | length) == 0 or (.flavor as $f | $sf | any(. == $f)))
+      )]'
+}
+
+expand_variants_for_containers() {
+    local containers_json="$1"
+    local versions_json="$2"
+    local expand_retained_map="$3"
+    local container_scopes="${4:-}"
+    local global_scope_versions="${5:-}"
+    local global_scope_flavors="${6:-}"
+    local build_scope="${7:-}"
+
+    local builds_json="[]"
+    local container
+
+    for container in $(echo "$containers_json" | jq -r '.[]'); do
+        local version
+        version=$(echo "$versions_json" | jq -r --arg c "$container" '.[$c]')
+        echo "Expanding builds for $container (version: $version)..." >&2
+
+        local scope_versions="$global_scope_versions"
+        local scope_flavors="$global_scope_flavors"
+        if [[ -n "$container_scopes" ]]; then
+            scope_versions=$(container_scope_field "$container_scopes" "$container" "versions")
+            scope_flavors=$(container_scope_field "$container_scopes" "$container" "flavors")
+        fi
+
+        local expand_for_container
+        expand_for_container=$(echo "$expand_retained_map" | jq -r --arg c "$container" '.[$c] // "false"')
+        # scope_versions is an explicit user request for specific versions. Pre-filtering
+        # to latest-only would defeat it. Bypass the filter when scope_versions is set.
+        if [[ -n "$scope_versions" ]]; then
+            expand_for_container="true"
+        fi
+        local container_builds
+        container_builds=$(list_container_builds "$container" "$version" "$expand_for_container")
+
+        # Apply scope_versions / scope_flavors filters (legacy inputs, or per-container map)
+        if [[ -n "$scope_versions" || -n "$scope_flavors" ]]; then
+            local before_count
+            before_count=$(echo "$container_builds" | jq 'length')
+            container_builds=$(filter_builds_by_version_flavor_scope "$container_builds" "$scope_versions" "$scope_flavors")
+            local after_count
+            after_count=$(echo "$container_builds" | jq 'length')
+
+            if [[ "$before_count" != "$after_count" ]]; then
+                echo "  Scope filter: $before_count -> $after_count builds (versions=${scope_versions:-all}, flavors=${scope_flavors:-all})" >&2
+            fi
+        fi
+
+        # Apply BUILD_SCOPE filter (new unified scope input)
+        # Matches against variant, os, build_flavor, or flavor.
+        if [[ -n "$build_scope" ]]; then
+            local before_count
+            before_count=$(echo "$container_builds" | jq 'length')
+            container_builds=$(echo "$container_builds" | jq -c \
+              --arg s "$build_scope" \
+              '[.[] | select(
+                (.variant // "" | contains($s)) or
+                (.os // "" | contains($s)) or
+                (.build_flavor // "" | contains($s)) or
+                (.flavor // "" | contains($s))
+              )]')
+            local after_count
+            after_count=$(echo "$container_builds" | jq 'length')
+            echo "  BUILD_SCOPE \"$build_scope\" filter: $before_count -> $after_count builds" >&2
+        fi
+
+        local count
+        count=$(echo "$container_builds" | jq 'length')
+
+        builds_json=$(echo "$builds_json" | jq -c ". + $container_builds")
+        echo "  -> $count build(s)" >&2
+        echo "$container_builds" | jq -c '.[]' >&2
+    done
+
+    echo "$builds_json"
+}
+
+export -f normalize_container_scopes container_scope_keys validate_container_scope_keys
+export -f container_scope_field filter_builds_by_version_flavor_scope expand_variants_for_containers

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -9,6 +9,7 @@
 #   scripts/generate-bake-hcl.sh github-runner     # github-runner + debian dep
 #   scripts/generate-bake-hcl.sh --cells --scope-versions 1.31 openresty
 #   scripts/generate-bake-hcl.sh --scope-flavors aws terraform
+#   scripts/generate-bake-hcl.sh --container-scopes '{"terraform":{"flavors":"aws"}}' terraform
 #   scripts/generate-bake-hcl.sh --scope alpine web-shell
 #   scripts/generate-bake-hcl.sh --include-final-build postgres
 #
@@ -119,6 +120,9 @@ Options:
   --scope-versions <csv>  Keep versions matching a comma-separated version list.
   --scope-flavors <csv>   Keep cells whose flavor is in a comma-separated list.
   --scope <str>           Keep cells whose variant/os/build_flavor/flavor contains this string.
+  --container-scopes <json>
+                          Per-container scope map:
+                          {"<container>":{"versions":"csv","flavors":"csv","extensions":"csv"}}
   -h, --help              Show this help.
 EOF
 }
@@ -177,19 +181,52 @@ _expand_closure() {
     printf '%s\n' "${closure[@]:-}"
 }
 
-# _cell_passes_scope <version> <flavor> <variant> <os> <build_flavor>
+# _effective_scope_filters <container>
+# Prints "<versions>\t<flavors>" for the container's effective scope filters.
+# A per-container map entry overrides the global version/flavor filters for
+# that container; containers absent from the map keep the global filters.
+_effective_scope_filters() {
+    local container="$1"
+    local scope_versions="${_BAKE_SCOPE_VERSIONS:-}"
+    local scope_flavors="${_BAKE_SCOPE_FLAVORS:-}"
+
+    if [[ -n "${_BAKE_CONTAINER_SCOPES:-}" ]] && \
+       jq -e --arg c "$container" 'has($c)' <<< "$_BAKE_CONTAINER_SCOPES" >/dev/null; then
+        scope_versions=$(jq -r --arg c "$container" '.[$c].versions // ""' <<< "$_BAKE_CONTAINER_SCOPES")
+        scope_flavors=$(jq -r --arg c "$container" '.[$c].flavors // ""' <<< "$_BAKE_CONTAINER_SCOPES")
+    fi
+
+    printf '%s\t%s\n' "$scope_versions" "$scope_flavors"
+}
+
+_scope_filters_active_for_container() {
+    local container="$1"
+    local filters
+    filters=$(_effective_scope_filters "$container")
+    local scope_versions="${filters%%$'\t'*}"
+    local scope_flavors="${filters#*$'\t'}"
+
+    [[ -n "$scope_versions" || -n "$scope_flavors" || -n "${_BAKE_SCOPE:-}" ]]
+}
+
+# _cell_passes_scope <container> <version> <flavor> <variant> <os> <build_flavor>
 # Returns 0 if the cell passes the active bake scope filters.
 # Empty scope variables mean pass-all.
 _cell_passes_scope() {
-    local version="$1"
-    local flavor="$2"
-    local variant="$3"
-    local cell_os="$4"
-    local build_flavor="$5"
+    local container="$1"
+    local version="$2"
+    local flavor="$3"
+    local variant="$4"
+    local cell_os="$5"
+    local build_flavor="$6"
+    local filters
+    filters=$(_effective_scope_filters "$container")
+    local scope_versions="${filters%%$'\t'*}"
+    local scope_flavors="${filters#*$'\t'}"
 
-    if [[ -n "${_BAKE_SCOPE_VERSIONS:-}" ]]; then
+    if [[ -n "$scope_versions" ]]; then
         local version_match="false"
-        local versions_csv="${_BAKE_SCOPE_VERSIONS},"
+        local versions_csv="${scope_versions},"
         local scope_version
         while [[ "$versions_csv" == *,* ]]; do
             scope_version="${versions_csv%%,*}"
@@ -208,9 +245,9 @@ _cell_passes_scope() {
         [[ "$version_match" == "true" ]] || return 1
     fi
 
-    if [[ -n "${_BAKE_SCOPE_FLAVORS:-}" ]]; then
+    if [[ -n "$scope_flavors" ]]; then
         local flavor_match="false"
-        local flavors_csv="${_BAKE_SCOPE_FLAVORS},"
+        local flavors_csv="${scope_flavors},"
         local scope_flavor
         while [[ "$flavors_csv" == *,* ]]; do
             scope_flavor="${flavors_csv%%,*}"
@@ -787,8 +824,7 @@ _enumerate_cells_init() {
         _EC_all_matrix_json[$c]="$matrix"
 
         local first_entry
-        if [[ -n "${_requested_set[$c]+set}" && \
-              ( -n "${_BAKE_SCOPE_VERSIONS:-}" || -n "${_BAKE_SCOPE_FLAVORS:-}" || -n "${_BAKE_SCOPE:-}" ) ]]; then
+        if [[ -n "${_requested_set[$c]+set}" ]] && _scope_filters_active_for_container "$c"; then
             first_entry=""
             local _first_ncells
             _first_ncells=$(jq 'length' <<< "$matrix")
@@ -807,7 +843,7 @@ _enumerate_cells_init() {
                 if [[ "$_first_os" == "windows" ]]; then
                     continue
                 fi
-                if _cell_passes_scope "$_first_version" "$_first_flavor" "$_first_variant" \
+                if _cell_passes_scope "$c" "$_first_version" "$_first_flavor" "$_first_variant" \
                         "$_first_os" "$_first_build_flavor"; then
                     first_entry="$_first_cell"
                     break
@@ -892,7 +928,7 @@ _enumerate_cells() {
             if [[ "$cell_os" == "windows" ]]; then
                 continue
             fi
-            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
+            if ! _cell_passes_scope "$c" "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1164,7 +1200,7 @@ _build_bake_json() {
                 continue
             fi
             if [[ -n "${_requested_set[$c]+set}" ]] && \
-                    ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
+                    ! _cell_passes_scope "$c" "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1350,7 +1386,7 @@ _emit_cells_json() {
             if [[ "$cell_os" == "windows" ]]; then
                 continue
             fi
-            if ! _cell_passes_scope "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
+            if ! _cell_passes_scope "$c" "$version" "$flavor" "$variant" "$cell_os" "$build_flavor"; then
                 continue
             fi
 
@@ -1422,6 +1458,7 @@ main() {
     local scope_versions=""
     local scope_flavors=""
     local scope=""
+    local container_scopes=""
 
     unset _BAKE_INCLUDE_FINAL_BUILD
 
@@ -1432,6 +1469,8 @@ main() {
     #   --scope-versions <csv> → scope version filter
     #   --scope-flavors <csv>  → scope flavor filter
     #   --scope <str>          → free-form variant/os/build_flavor/flavor filter
+    #   --container-scopes <json>
+    #                           → per-container version/flavor scope map
     local -a args=()
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1468,6 +1507,16 @@ main() {
                 shift
                 ;;
             --scope=*)      scope="${1#*=}" ;;
+            --container-scopes)
+                if [[ $# -lt 2 ]]; then
+                    printf 'ERROR: --container-scopes requires a JSON object value\n' >&2
+                    _usage >&2
+                    exit 2
+                fi
+                container_scopes="$2"
+                shift
+                ;;
+            --container-scopes=*) container_scopes="${1#*=}" ;;
             -h|--help)
                 _usage
                 exit 0
@@ -1476,6 +1525,19 @@ main() {
         esac
         shift
     done
+
+    if [[ -n "$container_scopes" ]]; then
+        if ! jq -e '
+            type == "object"
+            and all(.[]; type == "object")
+            and all(.[]; ((.versions? // "") | type == "string"))
+            and all(.[]; ((.flavors? // "") | type == "string"))
+            and all(.[]; ((.extensions? // "") | type == "string"))
+        ' <<< "$container_scopes" >/dev/null 2>&1; then
+            printf 'ERROR: --container-scopes must be a JSON object mapping container names to scope objects with string versions/flavors/extensions fields\n' >&2
+            exit 2
+        fi
+    fi
 
     if [[ "$include_final_build" == "1" ]]; then
         export _BAKE_INCLUDE_FINAL_BUILD=1
@@ -1527,6 +1589,7 @@ main() {
     export _BAKE_SCOPE_VERSIONS="$scope_versions"
     export _BAKE_SCOPE_FLAVORS="$scope_flavors"
     export _BAKE_SCOPE="$scope"
+    export _BAKE_CONTAINER_SCOPES="$container_scopes"
 
     if [[ "$mode" == "cells" ]]; then
         _emit_cells_json "${requested[@]}"

--- a/scripts/list-extension-versions.sh
+++ b/scripts/list-extension-versions.sh
@@ -14,10 +14,24 @@ source "$PROJECT_ROOT/helpers/variant-utils.sh"
 
 containers_with_extensions=""
 versions_by_container=""
+extension_containers_json="${EXTENSION_CONTAINERS_JSON:-}"
+
+if [[ -n "$extension_containers_json" ]]; then
+    if ! extension_containers_json=$(printf '%s' "$extension_containers_json" | jq -c 'if type == "array" then . else error("not array") end' 2>/dev/null); then
+        echo "::error::EXTENSION_CONTAINERS_JSON must be a JSON array when set" >&2
+        exit 1
+    fi
+fi
 
 for container_dir in "$PROJECT_ROOT"/*/; do
     container="$(basename "$container_dir")"
     [[ ! -f "$container_dir/variants.yaml" ]] && continue
+
+    if [[ -n "$extension_containers_json" ]]; then
+        if ! printf '%s' "$extension_containers_json" | jq -e --arg c "$container" 'index($c) != null' >/dev/null; then
+            continue
+        fi
+    fi
 
     if requires_extensions "$container_dir"; then
         echo "::notice::Container $container requires extensions"

--- a/tests/unit/bake-buildresult.bats
+++ b/tests/unit/bake-buildresult.bats
@@ -404,3 +404,42 @@ _retained_cell_count() {
         -exec jq -r '.tag' {} \; | sort)
     [ "$actual_tags" = "$expected_tags" ]
 }
+
+@test "BBR-16: container_scopes build-result enumeration ignores scoped-out github-runner flavors" {
+    local container_scopes='{"github-runner":{"flavors":"debian-trixie"}}'
+    local scoped_cells
+    scoped_cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
+        --cells --container-scopes "$container_scopes" github-runner)
+
+    local scoped_count unscoped_count
+    scoped_count=$(echo "$scoped_cells" | jq 'length')
+    unscoped_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
+        --cells github-runner | jq 'length')
+    [ "$scoped_count" -gt 0 ]
+    [ "$unscoped_count" -gt "$scoped_count" ]
+
+    local meta_file="$TEST_OUT_DIR/meta_container_scopes.json"
+    echo "$scoped_cells" | jq -c '
+        reduce .[] as $cell (
+            {};
+            . + {($cell.target_id): {"containerimage.digest":("sha256:" + $cell.target_id), "image.name":"ghcr.io/test"}}
+        )
+    ' > "$meta_file"
+
+    run env CONTAINER_SCOPES="$container_scopes" bash "$BBR" "$meta_file" amd64 "$TEST_OUT_DIR/out" github-runner
+    [ "$status" -eq 0 ]
+
+    local file_count fail_count
+    file_count=$(find "$TEST_OUT_DIR/out" -name 'build-result-*.json' | wc -l)
+    fail_count=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.result' {} \; | grep -c '^failure$' || true)
+
+    [ "$file_count" -eq "$scoped_count" ]
+    [ "$fail_count" -eq 0 ]
+
+    local expected_tags actual_tags
+    expected_tags=$(echo "$scoped_cells" | jq -r '.[].tag' | sort)
+    actual_tags=$(find "$TEST_OUT_DIR/out" -name '*.json' \
+        -exec jq -r '.tag' {} \; | sort)
+    [ "$actual_tags" = "$expected_tags" ]
+}

--- a/tests/unit/container-scopes.bats
+++ b/tests/unit/container-scopes.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    source "$ORIG_DIR/helpers/variant-utils.sh"
+    source "$ORIG_DIR/helpers/container-scopes.sh"
+
+    create_postgres_variants "postgres"
+    create_debian_variants "debian"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+create_postgres_variants() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'YAML'
+build:
+  base_suffix: "-alpine"
+  requires_extensions: true
+
+versions:
+  - tag: "18"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+      - name: full
+        suffix: "-full"
+        flavor: full
+  - tag: "17"
+    variants:
+      - name: base
+        suffix: ""
+        flavor: base
+        default: true
+      - name: full
+        suffix: "-full"
+        flavor: full
+YAML
+}
+
+create_debian_variants() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/variants.yaml" <<'YAML'
+build:
+  base_suffix: ""
+
+versions:
+  - tag: "12"
+    variants:
+      - name: bookworm
+        suffix: ""
+        flavor: base
+        default: true
+      - name: slim
+        suffix: "-slim"
+        flavor: slim
+YAML
+}
+
+normalize_json() {
+    jq -S -c . <<< "$1"
+}
+
+@test "empty object container_scopes normalizes to empty string" {
+    run --separate-stderr normalize_container_scopes '{}'
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "container_scopes map applies per-container versions and leaves unscoped containers unfiltered" {
+    scopes=$(normalize_container_scopes '{"postgres":{"versions":"17"},"debian":{}}')
+
+    run --separate-stderr expand_variants_for_containers \
+        '["postgres","debian"]' \
+        '{"postgres":"18","debian":"12"}' \
+        '{"postgres":false,"debian":false}' \
+        "$scopes" \
+        "" \
+        "" \
+        ""
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '[.[] | select(.container == "postgres") | .version] | unique | join(",")' <<< "$output")" = "17" ]
+    [ "$(jq '[.[] | select(.container == "debian")] | length' <<< "$output")" -eq 2 ]
+    [ "$(jq -r '[.[] | select(.container == "debian") | .variant] | sort | join(",")' <<< "$output")" = "bookworm,slim" ]
+}
+
+@test "container_scopes map applies per-container flavor filter" {
+    scopes=$(normalize_container_scopes '{"postgres":{"flavors":"full"}}')
+
+    run --separate-stderr expand_variants_for_containers \
+        '["postgres"]' \
+        '{"postgres":"18"}' \
+        '{"postgres":false}' \
+        "$scopes" \
+        "" \
+        "" \
+        ""
+
+    [ "$status" -eq 0 ]
+    [ "$(jq 'length' <<< "$output")" -eq 1 ]
+    [ "$(jq -r '.[0].container' <<< "$output")" = "postgres" ]
+    [ "$(jq -r '.[0].flavor' <<< "$output")" = "full" ]
+}
+
+@test "container_scopes rejects invalid container keys" {
+    scopes=$(normalize_container_scopes '{"nonexistent":{}}')
+
+    run --separate-stderr validate_container_scope_keys "$scopes" $'postgres\ndebian'
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"nonexistent"* ]]
+}
+
+@test "container_scopes rejects regex-like container keys" {
+    run --separate-stderr validate_container_scope_keys '{"post.*":{}}' $'postgres\ndebian'
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"post.*"* ]]
+}
+
+@test "container_scopes rejects keys containing newlines" {
+    run --separate-stderr validate_container_scope_keys '{"postgres\ndebian":{"versions":"17"}}' $'postgres\ndebian'
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"postgres"* ]]
+    [[ "$stderr" == *"debian"* ]]
+}
+
+@test "container_scopes rejects keys containing control characters" {
+    run --separate-stderr validate_container_scope_keys '{"postgres\u0001":{"versions":"17"}}' $'postgres\ndebian'
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"postgres"* ]]
+}
+
+@test "container_scopes accepts valid multiple container keys" {
+    run --separate-stderr validate_container_scope_keys '{"postgres":{"versions":"17"},"debian":{}}' $'postgres\ndebian'
+
+    [ "$status" -eq 0 ]
+}
+
+@test "container_scopes rejects malformed JSON with workflow error annotation" {
+    run --separate-stderr normalize_container_scopes '{"postgres":'
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"::error::container_scopes"* ]]
+}
+
+@test "empty object container_scopes preserves legacy global scope_versions filtering" {
+    scopes=$(normalize_container_scopes '{}')
+    [ -z "$scopes" ]
+
+    run --separate-stderr container_scope_keys "$scopes"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+
+    all_postgres=$(list_container_builds "postgres" "18" "true")
+    expected=$(filter_builds_by_version_flavor_scope "$all_postgres" "17" "")
+
+    run --separate-stderr expand_variants_for_containers \
+        '["postgres"]' \
+        '{"postgres":"18"}' \
+        '{"postgres":false}' \
+        "$scopes" \
+        "17" \
+        "" \
+        ""
+
+    [ "$status" -eq 0 ]
+    [ "$(normalize_json "$output")" = "$(normalize_json "$expected")" ]
+}
+
+@test "empty container_scopes preserves legacy global scope_versions filtering" {
+    all_postgres=$(list_container_builds "postgres" "18" "true")
+    expected=$(filter_builds_by_version_flavor_scope "$all_postgres" "17" "")
+
+    run --separate-stderr expand_variants_for_containers \
+        '["postgres"]' \
+        '{"postgres":"18"}' \
+        '{"postgres":false}' \
+        "" \
+        "17" \
+        "" \
+        ""
+
+    [ "$status" -eq 0 ]
+    [ "$(normalize_json "$output")" = "$(normalize_json "$expected")" ]
+}
+
+@test "empty container_scopes and empty scopes preserve unfiltered legacy matrix" {
+    postgres_builds=$(list_container_builds "postgres" "18" "true")
+    debian_builds=$(list_container_builds "debian" "12" "false")
+    expected=$(jq -c --argjson pg "$postgres_builds" --argjson deb "$debian_builds" '$pg + $deb' <<< '{}')
+
+    run --separate-stderr expand_variants_for_containers \
+        '["postgres","debian"]' \
+        '{"postgres":"18","debian":"12"}' \
+        '{"postgres":true,"debian":false}' \
+        "" \
+        "" \
+        "" \
+        ""
+
+    [ "$status" -eq 0 ]
+    [ "$(normalize_json "$output")" = "$(normalize_json "$expected")" ]
+}

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1566,3 +1566,129 @@ YAML
 
     [ "$actual_keys" = "$expected_keys" ]
 }
+
+@test "GBH-61: container scopes — terraform flavor scope keeps only aws cells" {
+    _run_generator --cells --container-scopes '{"terraform":{"flavors":"aws"}}' terraform
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_flavors per_container_json
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_flavors=$(echo "$output" | jq '[.[] | select(.flavor != "aws")] | length')
+    per_container_json=$(echo "$output" | jq -cS '.')
+
+    _run_generator --cells --scope-flavors aws terraform
+    [ "$status" -eq 0 ]
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$bad_flavors" -eq 0 ]
+    [ "$per_container_json" = "$(echo "$output" | jq -cS '.')" ]
+}
+
+@test "GBH-62: container scopes — terraform retained version scope keeps only 1.15.4 cells" {
+    local unscoped_count
+    unscoped_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform 2>/dev/null \
+        | jq 'length')
+    [ "$unscoped_count" -gt 0 ]
+
+    _run_generator --cells --all-retained --container-scopes '{"terraform":{"versions":"1.15.4"}}' terraform
+    [ "$status" -eq 0 ]
+
+    local scoped_count bad_tags
+    scoped_count=$(echo "$output" | jq 'length')
+    bad_tags=$(echo "$output" | jq '[.[] | select(.tag | startswith("1.15.4-alpine") | not)] | length')
+
+    [ "$scoped_count" -gt 0 ]
+    [ "$scoped_count" -lt "$unscoped_count" ]
+    [ "$bad_tags" -eq 0 ]
+}
+
+@test "GBH-63: container scopes — different containers keep isolated scope filters" {
+    _run_generator --cells debian
+    [ "$status" -eq 0 ]
+    local unscoped_debian_count
+    unscoped_debian_count=$(echo "$output" | jq 'length')
+    [ "$unscoped_debian_count" -gt 0 ]
+
+    _run_generator --cells --container-scopes '{"terraform":{"flavors":"aws"},"debian":{}}' terraform debian
+    [ "$status" -eq 0 ]
+
+    local terraform_count terraform_bad_flavors debian_count
+    terraform_count=$(echo "$output" | jq '[.[] | select(.container == "terraform")] | length')
+    terraform_bad_flavors=$(echo "$output" | jq '[.[] | select(.container == "terraform" and .flavor != "aws")] | length')
+    debian_count=$(echo "$output" | jq '[.[] | select(.container == "debian")] | length')
+
+    [ "$terraform_count" -gt 0 ]
+    [ "$terraform_bad_flavors" -eq 0 ]
+    [ "$debian_count" -eq "$unscoped_debian_count" ]
+}
+
+@test "GBH-64: container scopes — containers absent from the map fall back to global flavor scope" {
+    _run_generator --cells --include-final-build \
+        --container-scopes '{"terraform":{"flavors":"aws"}}' \
+        --scope-flavors full postgres terraform
+    [ "$status" -eq 0 ]
+
+    local terraform_count terraform_bad_flavors postgres_count postgres_bad_flavors
+    terraform_count=$(echo "$output" | jq '[.[] | select(.container == "terraform")] | length')
+    terraform_bad_flavors=$(echo "$output" | jq '[.[] | select(.container == "terraform" and .flavor != "aws")] | length')
+    postgres_count=$(echo "$output" | jq '[.[] | select(.container == "postgres")] | length')
+    postgres_bad_flavors=$(echo "$output" | jq '[.[] | select(.container == "postgres" and .flavor != "full")] | length')
+
+    [ "$terraform_count" -gt 0 ]
+    [ "$terraform_bad_flavors" -eq 0 ]
+    [ "$postgres_count" -gt 0 ]
+    [ "$postgres_bad_flavors" -eq 0 ]
+}
+
+@test "GBH-65: container scopes — scoped github-runner graph keeps debian dependency target and contexts" {
+    _run_generator --container-scopes '{"github-runner":{"flavors":"debian-trixie"}}' github-runner
+    [ "$status" -eq 0 ]
+
+    local has_base bad_runner_targets ctx_count dangling_count
+    has_base=$(echo "$output" | jq -r '.target | has("debian_trixie")')
+    bad_runner_targets=$(echo "$output" | jq '[
+        .target
+        | to_entries[]
+        | select(.key | startswith("github_runner_"))
+        | select((.key | contains("_debian_trixie_")) | not)
+    ] | length')
+    ctx_count=$(echo "$output" | jq '[
+        .target
+        | to_entries[]
+        | select((.key | startswith("github_runner_")) and (.key | contains("_debian_trixie_")))
+        | (.value.contexts // {})
+        | to_entries[]
+        | select(.value == "target:debian_trixie")
+    ] | length')
+    dangling_count=$(echo "$output" | jq '
+        .target as $targets
+        | [
+            .target
+            | to_entries[]
+            | (.value.contexts // {})
+            | to_entries[]
+            | .value
+            | select(type == "string" and startswith("target:"))
+            | sub("^target:"; "") as $target_id
+            | select(($targets | has($target_id)) | not)
+            | $target_id
+        ]
+        | length')
+
+    [ "$has_base" = "true" ]
+    [ "$bad_runner_targets" -eq 0 ]
+    [ "$ctx_count" -gt 0 ]
+    [ "$dangling_count" -eq 0 ]
+}
+
+@test "GBH-66: container scopes — empty map is byte-identical to no container scope flag" {
+    _run_generator terraform debian
+    [ "$status" -eq 0 ]
+    local no_flag_json
+    no_flag_json=$(echo "$output" | jq -cS '.')
+
+    _run_generator --container-scopes '{}' terraform debian
+    [ "$status" -eq 0 ]
+
+    [ "$(echo "$output" | jq -cS '.')" = "$no_flag_json" ]
+}


### PR DESCRIPTION
Adds a `container_scopes` input to auto-build (`workflow_dispatch` + `workflow_call`) so a **single** build run can rebuild **many** containers, each with its **own** scope.

## What it does

`container_scopes` is a JSON map — its keys are the containers to build, and each value carries that container's own scope:

```json
{"postgres":{"versions":"17","flavors":"full"},"debian":{},"terraform":{"flavors":"aws"}}
```

When set, the keys are the build list (taking precedence over `container` and diff detection), and each container's `versions`/`flavors`/`extensions` are applied to that container only. `detect-containers` validates the map (keys must be real containers; malformed JSON, regex, newline and control-character keys are rejected), and the per-container scope is threaded through all three build paths so they stay consistent:

- **flat matrix** — variant expansion filters each container by its own scope;
- **extension pipeline** — per-container `extensions`/`versions` drive which extensions build/merge;
- **bake** — `generate-bake-hcl.sh` gains `--container-scopes`, so scoped bake cells (and their build-result lineage) match the scoped plan instead of publishing every variant.

## Dormant and backward compatible

Nothing dispatches `container_scopes` yet, so this changes no current behaviour: when it's empty (every existing caller), scope still comes from the global `scope_versions`/`scope_flavors`/`scope_extensions` inputs, byte-for-byte. An empty map `{}` is treated as the legacy path. This is the capability; the upstream-monitor change that uses it (batching the per-container recovery dispatches into one, so they stop evicting each other) follows in a separate PR.

Refs #599.

## Verification

- Full unit suite green: `bats tests/unit/*.bats` → 1839/1839, including new per-container scope tests across matrix, extension, and bake paths (allowlist bypass, empty-map, per-container isolation, bake build-result lineage).
- `yq -e .` parses the workflow; `shellcheck` clean on the changed helpers; `git diff --check` clean.
