### PR TITLE
test: anchor rendered-output assertions to whole lines (#565)

### DIFF
--- a/tests/unit/collector-emitter.bats
+++ b/tests/unit/collector-emitter.bats
@@ -121,7 +121,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # Collector stage must be declared
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -Eqx '^FROM scratch AS ext_collect_timescaledb$'
 
     # Per-version COPYs inside collector must use repo@digest format
     local pinned_count
@@ -129,8 +129,8 @@ EOF
     [ "$pinned_count" -eq 3 ]
 
     # Each per-version COPY must land at /<ver>/ inside the collector
-    echo "$output" | grep -qE "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:.* /output/ /2\.23\.0/"
-    echo "$output" | grep -qE "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:.* /output/ /2\.27\.1/"
+    echo "$output" | grep -Eqx '^COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:[a-f0-9]+ /output/ /2\.23\.0/$'
+    echo "$output" | grep -Eqx '^COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:[a-f0-9]+ /output/ /2\.27\.1/$'
 
     # Exactly ONE final-stage COPY from the collector
     local final_count
@@ -161,7 +161,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # Collector stage present
-    echo "$output" | grep -q "^FROM scratch AS ext_collect_timescaledb"
+    echo "$output" | grep -Eqx '^FROM scratch AS ext_collect_timescaledb$'
 
     # Per-version COPYs inside collector use tag-based refs (no @digest)
     local per_ver_count
@@ -202,7 +202,7 @@ EOF
     [ "$from_count" -eq 1 ]
 
     # Flat COPY paths (no /<ver>/ subdirectory)
-    echo "$output" | grep -q "COPY --from=ext-timescaledb /output/extension/ /tmp/ext/timescaledb/extension/"
+    echo "$output" | grep -Eqx '^COPY --from=ext-timescaledb /output/extension/ /tmp/ext/timescaledb/extension/$'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -620,9 +620,9 @@ YAML
     base_ext_from_count=$(printf '%s\n' "$base_inline" | grep -cE '^FROM .*ext-' || true)
     [ "$base_ext_from_count" -eq 0 ]
 
-    [[ "$vector_inline" == *"FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2 AS ext-pgvector"* ]]
-    [[ "$vector_inline" == *"COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/"* ]]
-    [[ "$timeseries_inline" == *"FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.27.2 AS ext-timescaledb"* ]]
+    grep -Fxq 'FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2 AS ext-pgvector' <<< "$vector_inline"
+    grep -Fxq 'COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/' <<< "$vector_inline"
+    grep -Fxq 'FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.27.2 AS ext-timescaledb' <<< "$timeseries_inline"
 }
 
 @test "GBH-25e: postgres bake VERSION build arg carries base_suffix (matches the non-bake base image)" {

--- a/tests/unit/template-utils.bats
+++ b/tests/unit/template-utils.bats
@@ -65,12 +65,12 @@ with open('$file', 'w') as f:
     _make_template_marker_last "$tpl"
 
     run expand_template "$tpl" \
-        "BLOCK_A" "FROM builder AS stage1" \
+        "BLOCK_A" $'FROM builder AS stage1\n' \
         "BLOCK_B" "COPY --from=stage1 /out /app"
 
     [ "$status" -eq 0 ]
-    echo "$output" | grep -q "FROM builder AS stage1"
-    echo "$output" | grep -q "COPY --from=stage1 /out /app"
+    echo "$output" | grep -Fqx 'FROM builder AS stage1'
+    echo "$output" | grep -Fqx 'COPY --from=stage1 /out /app'
 }
 
 # ---------------------------------------------------------------------------
@@ -87,11 +87,11 @@ with open('$file', 'w') as f:
 
     # BLOCK_B is the last line; empty replacement triggers the spurious-1 bug.
     run expand_template "$tpl" \
-        "BLOCK_A" "FROM builder AS stage1" \
+        "BLOCK_A" $'FROM builder AS stage1\n' \
         "BLOCK_B" ""
 
     [ "$status" -eq 0 ]
-    echo "$output" | grep -q "FROM builder AS stage1"
+    echo "$output" | grep -Fqx 'FROM builder AS stage1'
     # Marker line is suppressed (empty replacement → nothing printed)
     ! echo "$output" | grep -q "@@BLOCK_B@@"
 }
@@ -110,7 +110,7 @@ with open('$file', 'w') as f:
     [ "$status" -eq 0 ]
     ! echo "$output" | grep -q "@@BLOCK_A@@"
     ! echo "$output" | grep -q "@@BLOCK_B@@"
-    echo "$output" | grep -q "ARG VERSION"
+    echo "$output" | grep -Fqx 'ARG VERSION'
 }
 
 # ---------------------------------------------------------------------------
@@ -125,8 +125,8 @@ with open('$file', 'w') as f:
         "BLOCK_B" ""
 
     [ "$status" -eq 0 ]
-    echo "$output" | grep -q "ARG VERSION"
-    echo "$output" | grep -q 'CMD \["postgres"\]'
+    echo "$output" | grep -Fqx 'ARG VERSION'
+    echo "$output" | grep -Fqx 'CMD ["postgres"]'
 }
 
 # ---------------------------------------------------------------------------
@@ -163,6 +163,6 @@ with open('$file', 'w') as f:
         "BLOCK_B" ""
 
     [ "$status" -eq 0 ]
-    echo "$output" | grep -q "ARG VERSION"
-    echo "$output" | grep -q 'CMD \["postgres"\]'
+    echo "$output" | grep -Fqx 'ARG VERSION'
+    echo "$output" | grep -Fqx 'CMD ["postgres"]'
 }


### PR DESCRIPTION
Finishes the #565 sweep: convert substring-presence assertions on **rendered output** to whole-line anchored matches, so a concatenated or garbled line fails the test instead of passing.

A `grep -q '<fragment>'` passes whenever the fragment appears *somewhere* — including on a glued line like `…/timescaledb/COPY --from=…` (the exact bug that motivated this issue, where a mangled newline concatenated two Dockerfile lines and only review caught it). An anchored match (`grep -Fqx` / `grep -Eqx '^…$'`) requires the line to be exactly correct.

Converted the rendered-output assertions in three suites:

- **`collector-emitter.bats`** — the generated collector-stage `FROM`/`COPY` lines (the same `generate_dockerfile` path the original concatenation bug lived on).
- **`template-utils.bats`** — `expand_template` output lines. The block fixtures are now newline-terminated to match `expand_template`'s contract (replacement content carries its own line breaks); the old substring checks silently passed on a block glued into the following line.
- **`generate-bake-hcl.bats`** — the generated bake `dockerfile-inline` lines.

Free-form assertions (command logs, `::error::`/`::warning::` diagnostics, summaries, JSON-field checks) and negative assertions are intentionally left as substring checks per the issue.

## Verification

- Full unit suite green: `bats tests/unit/*.bats` → 1842/1842.
- Mutation proof per file: appending a no-newline suffix to an asserted line (a deliberate concatenation) makes the corresponding anchored test FAIL; reverting restores green — confirming the anchor catches what the substring check missed.

Closes #565.
