### PR TITLE
chore: backlog wave 1 — ext-tag cleanup (#566), docs polish (#568), bats flake retry

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      execute_ext_cleanup:
+        description: 'Actually delete out-of-window extension tags (default: dry-run)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   packages: write
@@ -63,4 +68,32 @@ jobs:
             ./scripts/cleanup-outdated-tags.sh "$CONTAINER_FILTER"
           else
             ./scripts/cleanup-outdated-tags.sh
+          fi
+
+  cleanup-ext-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Independent lifecycle job — not in any build/consume path.
+    # Runs monthly on schedule, or on operator dispatch with explicit opt-in.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install yq
+        shell: bash
+        run: yq --version
+
+      - name: Prune out-of-window extension image tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          # Boolean input moved to env to avoid expression injection in run:
+          EXECUTE_EXT_CLEANUP: ${{ inputs.execute_ext_cleanup || 'false' }}
+        run: |
+          # Default: dry-run.  Operator must set execute_ext_cleanup=true to delete.
+          if [[ "$EXECUTE_EXT_CLEANUP" == "true" ]]; then
+            ./scripts/cleanup-ext-images.sh --execute
+          else
+            ./scripts/cleanup-ext-images.sh --dry-run
           fi

--- a/docs/site/_posts/2026-05-02-zero-touch-docker-sbom-sigstore-upstream-tracking.md
+++ b/docs/site/_posts/2026-05-02-zero-touch-docker-sbom-sigstore-upstream-tracking.md
@@ -3,6 +3,7 @@ layout: post
 title: "Zero-Touch Docker Image Maintenance: SBOMs, Sigstore, and Automated Upstream Tracking for 13 Containers"
 description: "How we keep 13 container images in sync with upstream releases, signed with Sigstore, and shipped with SPDX SBOMs — without anyone manually running docker build."
 date: 2026-05-02 10:00:00 +0000
+dateModified: 2026-06-11
 tags: [docker, supply-chain-security, sbom, sigstore, github-actions, ci-cd]
 ---
 
@@ -12,7 +13,7 @@ This post is about how we keep **13 Docker images** fresh without anyone running
 
 ## The fleet
 
-Pulls on Docker Hub (last check):
+Pulls on Docker Hub (last check, 2026-05-02 — numbers will drift):
 
 | Container | Pulls | Role |
 |---|---|---|

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -349,10 +349,10 @@
       font-size: 1.5rem;
     }
 
-    .stat-icon.blue { background: linear-gradient(135deg, var(--accent-blue), #60a5fa); }
-    .stat-icon.green { background: linear-gradient(135deg, var(--accent-green), #34d399); }
-    .stat-icon.yellow { background: linear-gradient(135deg, var(--accent-yellow), #fbbf24); }
-    .stat-icon.purple { background: linear-gradient(135deg, var(--accent-purple), #a78bfa); }
+    .stat-icon.blue { background: linear-gradient(135deg, var(--accent-blue), var(--color-blue-400)); }
+    .stat-icon.green { background: linear-gradient(135deg, var(--accent-green), var(--color-green-400)); }
+    .stat-icon.yellow { background: linear-gradient(135deg, var(--accent-yellow), var(--color-amber-400)); }
+    .stat-icon.purple { background: linear-gradient(135deg, var(--accent-purple), var(--color-violet-400)); }
 
     .stat-value {
       font-size: 2.5rem;
@@ -724,7 +724,7 @@
 
     .activity-icon.success {
       background: rgba(16, 185, 129, 0.2);
-      color: var(--accent-green);
+      color: var(--color-feedback-success-fg);
     }
 
     .activity-icon.failure {
@@ -794,7 +794,7 @@
 
     .health-value {
       font-weight: 600;
-      color: var(--accent-green);
+      color: var(--color-feedback-success-fg);
     }
 
     /* Focus visible styles for accessibility */

--- a/scripts/cleanup-ext-images.sh
+++ b/scripts/cleanup-ext-images.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+# Prune GHCR extension image versions that fall OUTSIDE the current resolver window.
+#
+# Extension images are published as:
+#   ghcr.io/<OWNER>/ext-<ext>:pg<major>-<version>
+#   ghcr.io/<OWNER>/ext-<ext>:pg<major>-<version>-<arch>
+#   e.g.  ghcr.io/oorabona/ext-timescaledb:pg17-2.27.1-amd64
+#
+# When the retention window advances (floor rises or a PG major reaches EOL),
+# tags from previous versions accumulate forever.  This script prunes them.
+#
+# GHCR deletes package version records, not individual tags.  A single record can
+# carry multiple tags, so deletion is decided for the whole record:
+#   - delete only when every tag is a managed pg<major>-<version>[-arch] tag
+#     and every managed tag is outside that major's resolver window.
+#   - keep the record if any tag is retained, unparseable/foreign, or belongs
+#     to a major whose resolver window could not be computed.
+#
+# FAIL-CLOSED by design (deletes registry version records):
+#   - DRY-RUN is the DEFAULT.  Pass --execute (or --no-dry-run) to actually delete.
+#   - If the window computation is empty/uncertain/errors for (ext, pg_major),
+#     tags for that major are treated as KEEP — never delete when the keep-set is unknown.
+#   - Every decision (keep / prune / skip) is logged.
+#
+# Required env vars: GH_TOKEN, OWNER
+# Optional env vars:
+#   EXT_CONFIG  — path to postgres/extensions/config.yaml (default: auto-detected)
+#   PG_VERSIONS — space-separated additional PG major versions (registry majors are always included)
+#
+# Usage:
+#   cleanup-ext-images.sh [--execute | --no-dry-run] [ext_name...]
+#   cleanup-ext-images.sh --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Source shared helpers ────────────────────────────────────────────────────
+# shellcheck source=helpers/logging.sh
+source "${ROOT_DIR}/helpers/logging.sh"
+
+# shellcheck source=helpers/version-set-resolver.sh
+source "${ROOT_DIR}/helpers/version-set-resolver.sh"
+
+# ── Internal helpers (testable functions) ────────────────────────────────────
+
+_usage() {
+    cat >&2 <<'EOF'
+Usage: cleanup-ext-images.sh [OPTIONS] [ext_name...]
+
+Prune GHCR extension image version records whose full tag set falls OUTSIDE the
+current resolver retention window.
+
+Options:
+  --execute / --no-dry-run   Actually delete version records (default: dry-run)
+  --dry-run                  Dry-run mode (default, no deletions)
+  --help / -h                Show this help
+
+Arguments:
+  ext_name...   Optional: restrict processing to these extensions only.
+                Defaults to all extensions with a version_set.resolver.
+
+Environment:
+  GH_TOKEN  (required)  GitHub token with packages:write
+  OWNER     (required)  GitHub owner/org (e.g. oorabona)
+  EXT_CONFIG            Path to postgres/extensions/config.yaml
+  PG_VERSIONS           Space-separated additional PG major versions
+EOF
+}
+
+# All extension names from config that have a version_set.resolver configured.
+# Extensions without a resolver only have a single version — their tags are
+# managed by the standard cleanup-outdated-tags.sh flow.
+_discover_resolver_extensions() {
+    local config_file="$1"
+    yq -r '
+      .extensions
+      | to_entries[]
+      | select(.value.version_set.resolver != null)
+      | .key
+    ' "$config_file" 2>/dev/null
+}
+
+# Supported PG major versions from config
+_discover_pg_versions() {
+    local config_file="$1"
+    yq -r '.pg_versions[]' "$config_file" 2>/dev/null
+}
+
+# List GHCR package version records for an extension package.
+# Output: compact JSON array of {version_id,name,tags[]} records.
+# Returns 1 on API error so callers can skip fail-closed.
+_list_ghcr_ext_version_records() {
+    local package_name="$1"   # e.g. ext-timescaledb
+    local owner="${OWNER:?OWNER is required}"
+
+    local raw_versions
+    raw_versions=$(gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/users/${owner}/packages/container/${package_name}/versions" \
+        --paginate 2>/dev/null) || return 1
+
+    if [[ -z "$raw_versions" ]]; then
+        printf '[]\n'
+        return 0
+    fi
+
+    jq -c -s '
+      [.[][] | {
+        version_id: (.id | tostring),
+        name: (.name // ""),
+        tags: (.metadata.container.tags // [])
+      }]
+    ' <<< "$raw_versions"
+}
+
+# Discover every pg<major>- prefix present in GHCR version record tags.
+_discover_registry_pg_majors() {
+    local version_records_json="$1"
+
+    jq -r '
+      .[]
+      | .tags[]?
+      | select(test("^pg[0-9]+-"))
+      | capture("^pg(?<major>[0-9]+)-").major
+    ' <<< "$version_records_json" | sort -n -u
+}
+
+# Delete a GHCR package version record by version id.
+_delete_ghcr_ext_version() {
+    local package_name="$1"   # e.g. ext-timescaledb
+    local version_id="$2"
+    local tags_csv="$3"
+    local owner="${OWNER:?OWNER is required}"
+
+    if gh api \
+        --method DELETE \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/users/${owner}/packages/container/${package_name}/versions/${version_id}" 2>/dev/null; then
+        log_success "  Deleted ${package_name} version_id=${version_id} (tags: ${tags_csv})"
+    else
+        log_error "  Failed to delete ${package_name} version_id=${version_id} (tags: ${tags_csv})"
+        return 1
+    fi
+}
+
+# Check whether a version string is present in a JSON array of versions.
+# Returns 0 if in window, 1 if not.
+_version_in_window() {
+    local version="$1"
+    local window_json="$2"
+
+    jq -e --arg v "$version" 'any(. == $v)' <<< "$window_json" >/dev/null 2>&1
+}
+
+# Parse a managed extension tag.
+# Accepts:
+#   pg<major>-<numeric.dotted.version>
+#   pg<major>-<numeric.dotted.version>-amd64
+#   pg<major>-<numeric.dotted.version>-arm64
+# Prints: <pg_major>|<version>
+# Unknown shapes/suffixes return 1 so callers keep the whole record fail-closed.
+_parse_ext_managed_tag() {
+    local tag="$1"
+    local managed_re='^pg([0-9]+)-([0-9]+([.][0-9]+)*)(-(amd64|arm64))?$'
+
+    [[ "$tag" =~ $managed_re ]] || return 1
+    printf '%s|%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+}
+
+# Extract the resolver version from a managed extension tag for a specific major.
+_derive_ext_tag_window_version() {
+    local tag="$1"
+    local pg_major="$2"
+    local parsed
+    local parsed_major
+    local version
+
+    parsed=$(_parse_ext_managed_tag "$tag") || return 1
+    IFS='|' read -r parsed_major version <<< "$parsed"
+    [[ "$parsed_major" == "$pg_major" ]] || return 1
+    printf '%s\n' "$version"
+}
+
+_version_record_tags_csv() {
+    local record_json="$1"
+
+    jq -r '
+      (.tags // []) as $tags
+      | if ($tags | length) > 0 then ($tags | join(",")) else "(none)" end
+    ' <<< "$record_json"
+}
+
+# ── Main entry point ─────────────────────────────────────────────────────────
+
+main() {
+    : "${GH_TOKEN:?GH_TOKEN is required}"
+    : "${OWNER:?OWNER is required}"
+
+    local ext_config="${EXT_CONFIG:-${ROOT_DIR}/postgres/extensions/config.yaml}"
+    local dry_run="true"
+    local -a ext_filter=()
+
+    # Argument parsing
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --execute|--no-dry-run)
+                dry_run="false"
+                shift
+                ;;
+            --dry-run)
+                dry_run="true"
+                shift
+                ;;
+            --help|-h)
+                _usage
+                return 0
+                ;;
+            --)
+                shift
+                ext_filter+=("$@")
+                break
+                ;;
+            -*)
+                log_error "Unknown flag: $1"
+                _usage
+                return 1
+                ;;
+            *)
+                ext_filter+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if [[ ! -f "$ext_config" ]]; then
+        log_error "Extension config not found: $ext_config"
+        return 1
+    fi
+
+    # Discover extensions to process
+    local -a extensions=()
+    if [[ ${#ext_filter[@]} -gt 0 ]]; then
+        extensions=("${ext_filter[@]}")
+    else
+        mapfile -t extensions < <(_discover_resolver_extensions "$ext_config")
+    fi
+
+    if [[ ${#extensions[@]} -eq 0 ]]; then
+        log_info "No extensions with version_set.resolver found in $ext_config — nothing to do."
+        return 0
+    fi
+
+    # Configured PG majors are retained for compatibility, but registry-derived
+    # majors are authoritative for cleanup coverage.  Retired majors that still
+    # have published tags must be considered.
+    local -a configured_pg_majors=()
+    if [[ -n "${PG_VERSIONS:-}" ]]; then
+        # shellcheck disable=SC2206
+        configured_pg_majors=($PG_VERSIONS)
+    else
+        mapfile -t configured_pg_majors < <(_discover_pg_versions "$ext_config")
+    fi
+
+    local total_kept=0
+    local total_pruned=0
+    local total_delete_failures=0
+    local total_skipped_pairs=0
+    local total_listing_failures=0
+
+    if [[ "$dry_run" == "true" ]]; then
+        log_warning "DRY-RUN MODE — no version records will be deleted (pass --execute to delete)"
+    else
+        log_warning "EXECUTE MODE — version records outside the retention window WILL be deleted"
+    fi
+
+    for ext_name in "${extensions[@]}"; do
+        local package_name="ext-${ext_name}"
+        local version_records_json=""
+
+        echo ""
+        echo "========================================"
+        log_info "Extension: ${ext_name}  (package: ${package_name})"
+        echo "========================================"
+
+        if ! version_records_json=$(_list_ghcr_ext_version_records "$package_name"); then
+            log_warning "  GHCR version listing failed for ${package_name} — SKIPPING extension (fail-closed)"
+            total_listing_failures=$((total_listing_failures + 1))
+            continue
+        fi
+
+        local version_record_count
+        version_record_count=$(jq 'length' <<< "$version_records_json")
+        log_info "  Found ${version_record_count} GHCR version records"
+
+        if [[ "$version_record_count" -eq 0 ]]; then
+            log_info "  No GHCR version records found — nothing to prune"
+            continue
+        fi
+
+        local -a registry_pg_majors=()
+        mapfile -t registry_pg_majors < <(_discover_registry_pg_majors "$version_records_json")
+
+        local -A pg_major_seen=()
+        local -a pg_majors=()
+        local pg_major
+        for pg_major in "${configured_pg_majors[@]}" "${registry_pg_majors[@]}"; do
+            [[ -n "$pg_major" ]] || continue
+            if [[ ! "$pg_major" =~ ^[0-9]+$ ]]; then
+                log_warning "  Ignoring invalid PG major: ${pg_major}"
+                continue
+            fi
+            if [[ -z "${pg_major_seen[$pg_major]:-}" ]]; then
+                pg_major_seen[$pg_major]=1
+                pg_majors+=("$pg_major")
+            fi
+        done
+
+        if [[ ${#registry_pg_majors[@]} -gt 0 ]]; then
+            log_info "  Registry PG majors: ${registry_pg_majors[*]}"
+        else
+            log_info "  No pg<major>- tags found in registry records"
+        fi
+
+        if [[ ${#pg_majors[@]} -eq 0 ]]; then
+            log_info "  No PG majors to resolve — nothing to prune"
+            continue
+        fi
+
+        local -A window_by_major=()
+        local -A window_known_by_major=()
+        for pg_major in "${pg_majors[@]}"; do
+            echo ""
+            log_step "  PG major: ${pg_major}"
+
+            # Compute retention window — fail-closed on any error
+            local window_json=""
+            if ! window_json=$(resolve_version_set "$ext_name" "$pg_major" "$ext_config" 2>/dev/null); then
+                log_warning "  Resolver failed for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+                total_skipped_pairs=$((total_skipped_pairs + 1))
+                continue
+            fi
+
+            if [[ -z "$window_json" ]]; then
+                log_warning "  Empty window for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+                total_skipped_pairs=$((total_skipped_pairs + 1))
+                continue
+            fi
+
+            local window_count
+            window_count=$(jq 'if type=="array" and length>0 then length else 0 end' <<< "$window_json" 2>/dev/null || echo "0")
+            if [[ "${window_count}" -le 0 ]]; then
+                log_warning "  Resolver returned empty/non-array for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+                total_skipped_pairs=$((total_skipped_pairs + 1))
+                continue
+            fi
+
+            window_json=$(jq -c '.' <<< "$window_json")
+            window_by_major[$pg_major]="$window_json"
+            window_known_by_major[$pg_major]="true"
+            log_info "    Retention window (${window_count} versions): $(jq -r 'join(", ")' <<< "$window_json")"
+        done
+
+        local kept_count=0
+        local pruned_count=0
+        local delete_failures=0
+        local record_json
+
+        while IFS= read -r record_json; do
+            [[ -n "$record_json" ]] || continue
+
+            local version_id
+            local tags_csv
+            local tag_count
+            version_id=$(jq -r '.version_id' <<< "$record_json")
+            tags_csv=$(_version_record_tags_csv "$record_json")
+            tag_count=$(jq '(.tags // []) | length' <<< "$record_json")
+
+            local should_delete="true"
+            local keep_reason=""
+
+            if [[ "$tag_count" -eq 0 ]]; then
+                should_delete="false"
+                keep_reason="no tags on version record; fail-closed"
+            fi
+
+            local tag
+            while [[ "$should_delete" == "true" ]] && IFS= read -r tag; do
+                [[ -n "$tag" ]] || continue
+
+                local parsed
+                local tag_major
+                local tag_version
+                if ! parsed=$(_parse_ext_managed_tag "$tag"); then
+                    should_delete="false"
+                    keep_reason="contains unmanaged/unparseable tag: ${tag}"
+                    break
+                fi
+
+                IFS='|' read -r tag_major tag_version <<< "$parsed"
+                if [[ "${window_known_by_major[$tag_major]:-false}" != "true" ]]; then
+                    should_delete="false"
+                    keep_reason="window unknown for pg${tag_major}: ${tag}"
+                    break
+                fi
+
+                if _version_in_window "$tag_version" "${window_by_major[$tag_major]}"; then
+                    should_delete="false"
+                    keep_reason="contains retained tag: ${tag}"
+                    break
+                fi
+            done < <(jq -r '.tags[]?' <<< "$record_json")
+
+            if [[ "$should_delete" == "true" ]]; then
+                log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${tags_csv}) — all managed tags outside window"
+                if [[ "$dry_run" == "true" ]]; then
+                    log_info "      [DRY-RUN] Would delete ${package_name} version_id=${version_id} (tags: ${tags_csv})"
+                    pruned_count=$((pruned_count + 1))
+                else
+                    if _delete_ghcr_ext_version "$package_name" "$version_id" "$tags_csv"; then
+                        pruned_count=$((pruned_count + 1))
+                    else
+                        delete_failures=$((delete_failures + 1))
+                    fi
+                fi
+            else
+                log_info "    ✓ KEEP  version_id=${version_id} (tags: ${tags_csv}) — ${keep_reason}"
+                kept_count=$((kept_count + 1))
+            fi
+        done < <(jq -c '.[]' <<< "$version_records_json")
+
+        log_info "    Summary: kept=${kept_count}, pruned=${pruned_count}, failed=${delete_failures}"
+        total_kept=$((total_kept + kept_count))
+        total_pruned=$((total_pruned + pruned_count))
+        total_delete_failures=$((total_delete_failures + delete_failures))
+    done
+
+    echo ""
+    echo "========================================"
+    echo "Extension image cleanup summary"
+    echo "========================================"
+    echo "  Version records kept  : ${total_kept}"
+    echo "  Version records pruned: ${total_pruned}"
+    echo "  Delete failures: ${total_delete_failures}"
+    echo "  (ext,major) pairs skipped (uncertain window): ${total_skipped_pairs}"
+    echo "  Extensions skipped (listing failed): ${total_listing_failures}"
+    if [[ "$dry_run" == "true" ]]; then
+        echo "  Mode: DRY-RUN (no deletions performed)"
+    else
+        echo "  Mode: EXECUTE"
+    fi
+    echo "========================================"
+
+    if [[ "$dry_run" != "true" && "$total_delete_failures" -gt 0 ]]; then
+        return 1
+    fi
+}
+
+# ── Entry point guard (allows sourcing for tests) ────────────────────────────
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -58,6 +58,59 @@ install_bats() {
     log_success "bats installed locally"
 }
 
+# Run a single bats invocation with retry-on-flake protection.
+#
+# A "flake" is defined as: exit code != 0 AND zero "^not ok" lines in the
+# captured output.  That matches the known bats-core-under-load crashes:
+#   - "Executed N instead of expected M tests"
+#   - "printf: not a valid identifier"
+#   - Python/generator segfault (status 139)
+# All of these produce no assertion failures — they abort before any test
+# completes.  A run with >=1 "not ok" line is a GENUINE failure and is
+# surfaced immediately without retrying.
+#
+# Usage: _bats_with_retry <bats_args...>
+_bats_with_retry() {
+    local max_retries=2
+    local retry_delay=3
+    local attempt=0
+    local bats_rc
+    local not_ok_count
+    local out_file
+    out_file="$(mktemp /tmp/bats-run-XXXXXX.tap)"
+
+    while true; do
+        attempt=$(( attempt + 1 ))
+
+        # Run bats, capturing both stdout and stderr; stream to terminal too.
+        bats "$@" 2>&1 | tee "$out_file"; bats_rc=${PIPESTATUS[0]}
+
+        if [[ $bats_rc -eq 0 ]]; then
+            rm -f "$out_file"
+            return 0
+        fi
+
+        # Count genuine assertion failures in the captured output.
+        not_ok_count=$(grep -c '^not ok' "$out_file" 2>/dev/null || true)
+
+        if [[ "$not_ok_count" -gt 0 ]]; then
+            # Real failures present — do NOT retry, propagate immediately.
+            rm -f "$out_file"
+            return "$bats_rc"
+        fi
+
+        # Zero "not ok" lines + non-zero exit → flake signature.
+        if [[ $attempt -le $max_retries ]]; then
+            log_warning "bats exited $bats_rc with 0 assertion failures (suspected flake). Retry $attempt/$max_retries in ${retry_delay}s..."
+            sleep "$retry_delay"
+        else
+            log_error "bats flake persisted after $max_retries retries (exit $bats_rc, 0 not-ok lines). Suspected-flake exhaustion — treating as failure."
+            rm -f "$out_file"
+            return "$bats_rc"
+        fi
+    done
+}
+
 # Run tests
 run_tests() {
     local test_pattern="${1:-}"
@@ -71,10 +124,10 @@ run_tests() {
 
     if [[ -n "$test_pattern" ]]; then
         log_info "Running tests matching: $test_pattern"
-        bats --tap --jobs 4 "$SCRIPT_DIR/unit/"*"$test_pattern"*.bats
+        _bats_with_retry --tap --jobs 4 "$SCRIPT_DIR/unit/"*"$test_pattern"*.bats
     else
         log_info "Running all unit tests..."
-        bats --tap --jobs 4 "$SCRIPT_DIR/unit/"*.bats
+        _bats_with_retry --tap --jobs 4 "$SCRIPT_DIR/unit/"*.bats
     fi
 }
 

--- a/tests/unit/cleanup-ext-images.bats
+++ b/tests/unit/cleanup-ext-images.bats
@@ -1,0 +1,342 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/cleanup-ext-images.sh.
+#
+# These tests mock GHCR as package VERSION RECORDS:
+#   [{ id, metadata: { container: { tags: [...] } } }]
+#
+# They never hit the real network.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+
+    export GH_TOKEN="test-token"
+    export OWNER="test-owner"
+
+    mkdir -p "$TEST_TEMP_DIR/postgres/extensions"
+    cat > "$TEST_TEMP_DIR/postgres/extensions/config.yaml" <<'EOF'
+pg_versions:
+  - "17"
+extensions:
+  timescaledb:
+    version: "2.27.2"
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+      retain_count: 12
+EOF
+    export EXT_CONFIG="$TEST_TEMP_DIR/postgres/extensions/config.yaml"
+
+    # shellcheck disable=SC1091
+    source "$PROJECT_ROOT/scripts/cleanup-ext-images.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+    unset GH_TOKEN OWNER EXT_CONFIG
+}
+
+_write_window() {
+    local windows_dir="$1"
+    local pg_major="$2"
+    local window_json="$3"
+
+    mkdir -p "$windows_dir"
+    printf '%s\n' "$window_json" > "$windows_dir/pg${pg_major}.json"
+}
+
+_run_cleanup_main_with_records() {
+    local records_file="$1"
+    local windows_dir="$2"
+    local delete_mode="$3"
+    local delete_calls_file="$4"
+    local list_mode="$5"
+    shift 5
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        EXT_CONFIG="$EXT_CONFIG" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        CLEANUP_RECORDS_FILE="$records_file" \
+        CLEANUP_WINDOWS_DIR="$windows_dir" \
+        CLEANUP_DELETE_MODE="$delete_mode" \
+        CLEANUP_DELETE_CALLS_FILE="$delete_calls_file" \
+        CLEANUP_LIST_MODE="$list_mode" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-ext-images.sh"
+
+            _discover_resolver_extensions() { printf "%s\n" "timescaledb"; }
+            _discover_pg_versions() { printf "%s\n" "17"; }
+            resolve_version_set() {
+                local pg_major="$2"
+                local window_file="$CLEANUP_WINDOWS_DIR/pg${pg_major}.json"
+                [[ -f "$window_file" ]] || return 1
+                cat "$window_file"
+            }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    local arg
+                    local last_arg=""
+                    for arg in "$@"; do
+                        last_arg="$arg"
+                    done
+                    printf "DELETE:%s\n" "${last_arg##*/}" >> "$CLEANUP_DELETE_CALLS_FILE"
+                    [[ "$CLEANUP_DELETE_MODE" != "fail" ]]
+                    return
+                fi
+
+                [[ "$CLEANUP_LIST_MODE" != "fail" ]] || return 1
+                cat "$CLEANUP_RECORDS_FILE"
+            }
+
+            main "$@"
+        ' _ "$@"
+}
+
+@test "_parse_ext_managed_tag parses base and arch extension tags" {
+    [[ "$(_parse_ext_managed_tag "pg17-2.27.1")" == "17|2.27.1" ]]
+    [[ "$(_parse_ext_managed_tag "pg17-2.27.1-amd64")" == "17|2.27.1" ]]
+    [[ "$(_parse_ext_managed_tag "pg17-2.27.1-arm64")" == "17|2.27.1" ]]
+}
+
+@test "_parse_ext_managed_tag rejects unparseable and foreign tags" {
+    ! _parse_ext_managed_tag "pg17-latest"
+    ! _parse_ext_managed_tag "pg17-2.27.1-windows"
+    ! _parse_ext_managed_tag "latest"
+    ! _parse_ext_managed_tag "other-image-tag"
+}
+
+@test "mixed-tag version record is kept; separate all-stale record is selected" {
+    local records_file="$TEST_TEMP_DIR/mixed-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/mixed-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  {
+    "id": 101,
+    "name": "sha256:mixed",
+    "metadata": { "container": { "tags": ["pg17-2.27.1", "pg17-2.23.0"] } }
+  },
+  {
+    "id": 102,
+    "name": "sha256:stale",
+    "metadata": { "container": { "tags": ["pg17-2.22.0"] } }
+  }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=101"* ]]
+    [[ "$output" == *"contains retained tag: pg17-2.27.1"* ]]
+    [[ "$output" != *"Would delete ext-timescaledb version_id=101"* ]]
+    [[ "$output" == *"PRUNE version_id=102"* ]]
+    [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=102"* ]]
+    [[ "$output" == *"Summary: kept=1, pruned=1, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "P1 arch siblings: in-window records kept and out-of-window records pruned" {
+    local records_file="$TEST_TEMP_DIR/arch-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/arch-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 201, "metadata": { "container": { "tags": ["pg17-2.27.1"] } } },
+  { "id": 202, "metadata": { "container": { "tags": ["pg17-2.27.1-amd64"] } } },
+  { "id": 203, "metadata": { "container": { "tags": ["pg17-2.27.1-arm64"] } } },
+  { "id": 204, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } },
+  { "id": 205, "metadata": { "container": { "tags": ["pg17-2.23.0-amd64"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=201"* ]]
+    [[ "$output" == *"KEEP  version_id=202"* ]]
+    [[ "$output" == *"KEEP  version_id=203"* ]]
+    [[ "$output" != *"PRUNE version_id=202"* ]]
+    [[ "$output" != *"PRUNE version_id=203"* ]]
+    [[ "$output" == *"PRUNE version_id=204"* ]]
+    [[ "$output" == *"PRUNE version_id=205"* ]]
+    [[ "$output" == *"Summary: kept=3, pruned=2, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "retired registry-derived major is enumerated and pruned when stale" {
+    local records_file="$TEST_TEMP_DIR/retired-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/retired-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 301, "metadata": { "container": { "tags": ["pg15-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+    _write_window "$windows_dir" "15" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Registry PG majors: 15"* ]]
+    [[ "$output" == *"PG major: 15"* ]]
+    [[ "$output" == *"PRUNE version_id=301"* ]]
+    [[ "$output" == *"Version records pruned: 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "retired registry-derived major is kept fail-closed when its window cannot be computed" {
+    local records_file="$TEST_TEMP_DIR/retired-fail-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/retired-fail-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 311, "metadata": { "container": { "tags": ["pg15-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Resolver failed for timescaledb/pg15"* ]]
+    [[ "$output" == *"KEEP  version_id=311"* ]]
+    [[ "$output" == *"window unknown for pg15: pg15-2.23.0"* ]]
+    [[ "$output" == *"Summary: kept=1, pruned=0, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "unparseable or foreign tag protects the entire version record" {
+    local records_file="$TEST_TEMP_DIR/foreign-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/foreign-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 401, "metadata": { "container": { "tags": ["pg17-2.23.0", "pg17-latest"] } } },
+  { "id": 402, "metadata": { "container": { "tags": ["pg17-2.23.0", "latest"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=401"* ]]
+    [[ "$output" == *"contains unmanaged/unparseable tag: pg17-latest"* ]]
+    [[ "$output" == *"KEEP  version_id=402"* ]]
+    [[ "$output" == *"contains unmanaged/unparseable tag: latest"* ]]
+    [[ "$output" == *"Summary: kept=2, pruned=0, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "P2 execute mode: failed delete exits non-zero and is not counted as pruned" {
+    local records_file="$TEST_TEMP_DIR/delete-failure-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/delete-failure-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 501, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "fail" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -ne 0 ]]
+    [[ -f "$delete_calls_file" ]]
+    grep -q "DELETE:501" "$delete_calls_file"
+    [[ "$output" == *"PRUNE version_id=501"* ]]
+    [[ "$output" == *"Failed to delete ext-timescaledb version_id=501"* ]]
+    [[ "$output" == *"Summary: kept=0, pruned=0, failed=1"* ]]
+    [[ "$output" == *"Version records pruned: 0"* ]]
+    [[ "$output" == *"Delete failures: 1"* ]]
+}
+
+@test "P2 execute mode: successful delete exits zero and is counted as pruned" {
+    local records_file="$TEST_TEMP_DIR/delete-success-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/delete-success-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 502, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -eq 0 ]]
+    [[ -f "$delete_calls_file" ]]
+    grep -q "DELETE:502" "$delete_calls_file"
+    [[ "$output" == *"PRUNE version_id=502"* ]]
+    [[ "$output" == *"Deleted ext-timescaledb version_id=502"* ]]
+    [[ "$output" == *"Summary: kept=0, pruned=1, failed=0"* ]]
+    [[ "$output" == *"Version records pruned: 1"* ]]
+    [[ "$output" == *"Delete failures: 0"* ]]
+}
+
+@test "dry-run default: stale record is selected but no delete call is made" {
+    local records_file="$TEST_TEMP_DIR/dry-run-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/dry-run-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 601, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"DRY-RUN MODE"* ]]
+    [[ "$output" == *"PRUNE version_id=601"* ]]
+    [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=601"* ]]
+    [[ "$output" == *"Version records pruned: 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "GHCR version listing failure skips extension fail-closed" {
+    local records_file="$TEST_TEMP_DIR/list-fail-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/list-fail-calls"
+
+    printf '[]\n' > "$records_file"
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "fail"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"GHCR version listing failed for ext-timescaledb"* ]]
+    [[ "$output" == *"Extensions skipped (listing failed): 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "--help flag exits 0 and prints usage" {
+    run bash "$PROJECT_ROOT/scripts/cleanup-ext-images.sh" --help
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"--execute"* ]]
+}
+
+@test "unknown flag exits non-zero" {
+    run bash "$PROJECT_ROOT/scripts/cleanup-ext-images.sh" --unknown-flag
+
+    [[ "$status" -ne 0 ]]
+}


### PR DESCRIPTION
Batch of three small, independent backlog items (disjoint files, no container rebuilds). Each is its own atomic commit.

## `feat(ci)`: window-aware cleanup of retained extension image tags — Closes #566
New `scripts/cleanup-ext-images.sh` (monthly-cron lifecycle job, off the build path) prunes published `ext-<ext>:pg<major>-<version>` tags that fall outside the current retention window. It works on **GHCR version records** (a digest can carry several tags), derives the PG majors to consider **from the registry** (so a major retired from config is still cleaned), and deletes a version record only when **every** tag on it is a managed `pg<major>-<version>[-amd64|-arm64]` tag outside its window. Any in-window tag, any unparseable/foreign tag, or a tag whose window can't be computed keeps the whole record — so per-arch manifest siblings and shared-digest tags are never destroyed. Dry-run is the default (`--execute` to delete); a failed delete is surfaced and makes the run exit non-zero. Completes the lifecycle piece of the TimescaleDB version-retention work (#558).

## `docs(site)`: post freshness + color-token migration — Refs #568
Adds a `dateModified` field to the post carrying a dated fleet pull-count table, migrates the deprecated `--accent-green` alias to `--color-feedback-success-fg`, and replaces hardcoded hex stops in the `.stat-icon` gradients with defined color tokens. (The stale extension-version table from #568 lives in an auto-generated, gitignored page — it regenerates each dashboard build, and a durable freshness note for it belongs in the generator, so that item is left for a separate generator-side change.)

## `test`: retry bats runs on the under-load flake signature
Wraps the bats invocations in `tests/run-tests.sh` so a run that exits non-zero with **zero** `not ok` lines (the known bats-core under-load crash — spurious "Executed N instead of M", "not a valid identifier", generator segfault) is retried up to twice. A run with one or more real `not ok` assertions is surfaced immediately and never retried; a flake surviving the retries fails rather than being masked.

## Verification

- Full unit suite green: `bats tests/unit/*.bats` → 1855/1855, including new version-record tests for the cleanup (mixed-tag record kept, arch siblings kept, retired-major pruned, delete-failure surfaced, dry-run default).
- `shellcheck` clean on the changed scripts; `yq -e .` parses the workflow; CSS tokens verified defined.
