### PR TITLE
fix(terraform): build from pinned dep versions + retry transient downloads (#724)

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -107,7 +107,7 @@ RUN set -ex \
     && update-ca-certificates \
     && cd /tmp \
     && cd /tmp \
-    && curl -fSL "${RESTY_OPENSSL_URL_BASE}/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    && curl -fSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 "${RESTY_OPENSSL_URL_BASE}/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && cd openssl-${RESTY_OPENSSL_VERSION} \
     && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-2) = "3." ] ; then \
@@ -123,7 +123,7 @@ RUN set -ex \
     && make -j${RESTY_J} \
     && make -j${RESTY_J} install_sw \
     && cd /tmp \
-    && curl -fSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${RESTY_PCRE_VERSION}/pcre2-${RESTY_PCRE_VERSION}.tar.gz" -o pcre2-${RESTY_PCRE_VERSION}.tar.gz \
+    && curl -fSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${RESTY_PCRE_VERSION}/pcre2-${RESTY_PCRE_VERSION}.tar.gz" -o pcre2-${RESTY_PCRE_VERSION}.tar.gz \
     && echo "${RESTY_PCRE_SHA256}  pcre2-${RESTY_PCRE_VERSION}.tar.gz" | shasum -a 256 --check \
     && tar xzf pcre2-${RESTY_PCRE_VERSION}.tar.gz \
     && cd /tmp/pcre2-${RESTY_PCRE_VERSION} \
@@ -155,13 +155,13 @@ RUN set -ex \
     && CFLAGS="-g -O3" make -j${RESTY_J} \
     && CFLAGS="-g -O3" make -j${RESTY_J} install \
     && cd /tmp \
-    && curl -fSL https://openresty.org/download/openresty-${UPSTREAM_VERSION}.tar.gz -o openresty-${UPSTREAM_VERSION}.tar.gz \
+    && curl -fSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://openresty.org/download/openresty-${UPSTREAM_VERSION}.tar.gz -o openresty-${UPSTREAM_VERSION}.tar.gz \
     && tar xzf openresty-${UPSTREAM_VERSION}.tar.gz
 
 # STEP 2 - Configure OpenResty
 RUN if [ "$ENABLE_HTTP_PROXY_CONNECT" == "true" ]; then \
     cd /tmp \
-    && curl -fSL https://github.com/chobits/ngx_http_proxy_connect_module/archive/v${NGX_PROXY_CONNECT_VERSION}.tar.gz -o ngx_http_proxy_connect_module.tar.gz \
+    && curl -fSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/chobits/ngx_http_proxy_connect_module/archive/v${NGX_PROXY_CONNECT_VERSION}.tar.gz -o ngx_http_proxy_connect_module.tar.gz \
     && export RESTY_CONFIG_OPTIONS="--add-module=/tmp/ngx_http_proxy_connect_module-${NGX_PROXY_CONNECT_VERSION} ${RESTY_CONFIG_OPTIONS}" \
     && tar zxf ngx_http_proxy_connect_module.tar.gz; fi \
     && cd /tmp/openresty-${UPSTREAM_VERSION} \
@@ -176,7 +176,7 @@ RUN cd /tmp/openresty-${UPSTREAM_VERSION} \
     && make -j${RESTY_J} \
     && make -j${RESTY_J} install \
     && cd /tmp \
-    && curl -fSL https://luarocks.org/releases/luarocks-${LUAROCKS_VERSION}.tar.gz -o luarocks-${LUAROCKS_VERSION}.tar.gz \
+    && curl -fSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://luarocks.org/releases/luarocks-${LUAROCKS_VERSION}.tar.gz -o luarocks-${LUAROCKS_VERSION}.tar.gz \
     && tar zxf luarocks-${LUAROCKS_VERSION}.tar.gz \
     && cd /tmp/luarocks-${LUAROCKS_VERSION} \
     && export PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin \

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -36,9 +36,9 @@ RUN set -ex \
         make \
         libcap-ng-dev \
         libcap-dev \
-    && cd /tmp && curl -sSL https://github.com/openvpn/openvpn/archive/$DOWNLOAD_VERSION.tar.gz --output openvpn.tgz \
+    && cd /tmp && curl -sSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/openvpn/openvpn/archive/$DOWNLOAD_VERSION.tar.gz --output openvpn.tgz \
     # Download pinned version of OpenSC pkcs11-helper
-    && curl -sSL https://github.com/opensc/pkcs11-helper/archive/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.gz --output pkcs11-helper.tgz \
+    && curl -sSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/opensc/pkcs11-helper/archive/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.gz --output pkcs11-helper.tgz \
     && tar zxvf pkcs11-helper.tgz \
     && cd pkcs11-helper-pkcs11-helper-${PKCS11_HELPER_VERSION} \
     && autoreconf -ivf \

--- a/sslh/Dockerfile
+++ b/sslh/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex \
         # For healthcheck binary (static)
         busybox-static \
     # Download and extract sslh source
-    && wget -q https://github.com/yrutschle/sslh/archive/$DOWNLOAD_VERSION.tar.gz \
+    && wget -q --tries=3 --waitretry=2 --retry-connrefused --retry-on-http-error=404,429,500,502,503,504 https://github.com/yrutschle/sslh/archive/$DOWNLOAD_VERSION.tar.gz \
     && tar zxf $DOWNLOAD_VERSION.tar.gz \
     && cd /build/sslh-* \
     # Configure for dynamic build (musl shared libs are small)

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -36,11 +36,11 @@ RUN apk add --no-cache curl unzip ca-certificates && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     # TFLint - Terraform linter (supports amd64/arm64)
     echo "Downloading TFLint v${TFLINT_VERSION} for ${TARGETARCH}" && \
-    curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH}.zip" -o tflint.zip && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TARGETARCH}.zip" -o tflint.zip && \
     unzip tflint.zip && chmod +x tflint && \
     # Trivy - Security scanner (supports 64bit/ARM64)
     echo "Downloading Trivy v${TRIVY_VERSION} for ${TRIVY_ARCH}" && \
-    curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" -o trivy.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" -o trivy.tar.gz && \
     tar -xzf trivy.tar.gz trivy && \
     chmod +x trivy
 
@@ -56,17 +56,17 @@ ARG GITHUB_CLI_VERSION
 RUN : "${TERRAGRUNT_VERSION:?required}" "${TERRAFORM_DOCS_VERSION:?required}" "${INFRACOST_VERSION:?required}" "${GITHUB_CLI_VERSION:?required}"
 RUN apk add --no-cache curl tar ca-certificates && \
     # Terragrunt - Terraform wrapper (supports amd64/arm64)
-    curl -fsSL https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TARGETARCH} -o terragrunt && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TARGETARCH} -o terragrunt && \
     chmod +x terragrunt && \
     # Terraform-docs - Generate docs from modules (supports amd64/arm64)
-    curl -fsSL https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${TARGETARCH}.tar.gz -o terraform-docs.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${TARGETARCH}.tar.gz -o terraform-docs.tar.gz && \
     tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && \
     # Infracost - Cloud cost estimation (supports amd64/arm64)
-    curl -fsSL https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${TARGETARCH}.tar.gz -o infracost.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${TARGETARCH}.tar.gz -o infracost.tar.gz && \
     tar -xzf infracost.tar.gz && chmod +x infracost-linux-${TARGETARCH} && \
     mv infracost-linux-${TARGETARCH} infracost && \
     # GitHub CLI (supports amd64/arm64)
-    curl -fsSL https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETARCH}.tar.gz -o gh.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETARCH}.tar.gz -o gh.tar.gz && \
     tar -xzf gh.tar.gz && \
     mv gh_${GITHUB_CLI_VERSION}_linux_${TARGETARCH}/bin/gh . && \
     chmod +x gh

--- a/terraform/build
+++ b/terraform/build
@@ -1,86 +1,108 @@
 #!/bin/bash
 
-# Terraform build script - fetches latest tool versions and updates config.yaml
-# config.yaml is the single source of truth for build args
+# Terraform build script - validates pinned tool releases and exports build args.
+# config.yaml is the single source of truth for tool versions.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
 
-# Source the git-tags helper
-source "$SCRIPT_DIR/../helpers/git-tags"
-# Source the python-tags helper
-source "$SCRIPT_DIR/../helpers/python-tags"
-
 if ! command -v yq >/dev/null 2>&1; then
-    echo "ERROR: yq is required to read/update config.yaml" >&2
+    echo "ERROR: yq is required to read config.yaml" >&2
     exit 1
 fi
 
-# Function to get latest TFLint version
-get_tflint_version() {
-    latest-git-tag terraform-linters tflint | sed 's/^v//'
+config_build_arg() {
+    local arg_name="$1"
+    YQ_BUILD_ARG="$arg_name" yq -r '.build_args[strenv(YQ_BUILD_ARG)] // ""' "$CONFIG_FILE"
 }
 
-# Function to get latest Trivy version (replacement for deprecated TFSec)
-get_trivy_version() {
-    latest-git-tag aquasecurity trivy | sed 's/^v//'
+dependency_label() {
+    local dep_name="$1"
+    dep_name="${dep_name%_VERSION}"
+    dep_name="${dep_name//_/-}"
+    printf '%s' "${dep_name,,}"
 }
 
-# Function to get latest Terragrunt version
-get_terragrunt_version() {
-    latest-git-tag gruntwork-io terragrunt | sed 's/^v//'
-}
+github_release_status() {
+    local repo="$1"
+    local tag="$2"
+    local github_api_url="${GITHUB_API_URL:-https://api.github.com}"
+    local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+    local -a curl_args=(
+        -sS
+        -L
+        -o /dev/null
+        -w "%{http_code}"
+        --connect-timeout 10
+        --max-time 15
+        -H "Accept: application/vnd.github+json"
+    )
 
-# Function to get latest Terraform-docs version
-get_terraform_docs_version() {
-    latest-git-tag terraform-docs terraform-docs | sed 's/^v//'
-}
-
-# Function to get latest GitHub CLI version
-get_github_cli_version() {
-    latest-git-tag cli cli | sed 's/^v//'
-}
-
-# Function to get AWS CLI version
-get_aws_cli_version() {
-    local version=$(get_pypi_latest_version awscli)
-    if [[ "$version" == "unknown" ]]; then
-        echo "1.34.34"  # Fallback version
-    else
-        echo "$version"
+    if [[ -n "$token" ]]; then
+        curl_args+=(-H "Authorization: Bearer ${token}")
     fi
+
+    curl "${curl_args[@]}" "${github_api_url}/repos/${repo}/releases/tags/${tag}"
 }
 
-# Function to get Azure CLI version
-get_azure_cli_version() {
-    local version=$(get_pypi_latest_version azure-cli)
-    if [[ "$version" == "unknown" ]]; then
-        echo "2.67.0"  # Fallback version
-    else
-        echo "$version"
+validate_github_release_pins() {
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "::warning::curl is unavailable; skipping Terraform pinned GitHub release validation" >&2
+        return 0
     fi
+
+    local dep_name repo strip_v version tag label http_status
+    while IFS=$'\t' read -r dep_name repo strip_v; do
+        [[ -n "$dep_name" ]] || continue
+
+        version=$(config_build_arg "$dep_name")
+        label=$(dependency_label "$dep_name")
+        if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::error::${label} has no pinned version in terraform/config.yaml build_args" >&2
+            return 1
+        fi
+
+        tag="$version"
+        if [[ "$strip_v" == "true" && "$tag" != v* ]]; then
+            tag="v${tag}"
+        fi
+
+        if ! http_status=$(github_release_status "$repo" "$tag" 2>/dev/null); then
+            echo "::warning::could not validate ${label} ${version} GitHub release; skipping pinned release check" >&2
+            continue
+        fi
+
+        case "$http_status" in
+            200)
+                ;;
+            404)
+                echo "::error::${label} ${version} has no published GitHub release/assets - pin points to an assetless tag" >&2
+                return 1
+                ;;
+            *)
+                echo "::warning::could not validate ${label} ${version} GitHub release (GitHub API HTTP ${http_status}); skipping pinned release check" >&2
+                ;;
+        esac
+    done < <(yq -r '
+        .dependency_sources // {}
+        | to_entries[]
+        | select(.value.type == "github-release" and (.value.monitor // true) != false)
+        | [.key, .value.repo, (.value.strip_v // false | tostring)]
+        | @tsv
+    ' "$CONFIG_FILE")
 }
 
-# Function to get GCP CLI version
-get_gcp_cli_version() {
-    # Google Cloud SDK releases from GitHub
-    local version=$(latest-git-tag GoogleCloudPlatform cloud-sdk-docker | sed 's/^v//')
-    if [[ -z "$version" || "$version" == "unknown" ]]; then
-        echo "latest"
-    else
-        echo "$version"
-    fi
-}
+validate_github_release_pins || exit 1
 
-# Gather tool versions dynamically
-TFLINT_VERSION=$(get_tflint_version)
-TRIVY_VERSION=$(get_trivy_version)
-TERRAGRUNT_VERSION=$(get_terragrunt_version)
-TERRAFORM_DOCS_VERSION=$(get_terraform_docs_version)
-GITHUB_CLI_VERSION=$(get_github_cli_version)
-AWS_CLI_VERSION=$(get_aws_cli_version)
-AZURE_CLI_VERSION=$(get_azure_cli_version)
-GCP_CLI_VERSION=$(get_gcp_cli_version)
+TFLINT_VERSION=$(config_build_arg TFLINT_VERSION)
+TRIVY_VERSION=$(config_build_arg TRIVY_VERSION)
+TERRAGRUNT_VERSION=$(config_build_arg TERRAGRUNT_VERSION)
+TERRAFORM_DOCS_VERSION=$(config_build_arg TERRAFORM_DOCS_VERSION)
+INFRACOST_VERSION=$(config_build_arg INFRACOST_VERSION)
+GITHUB_CLI_VERSION=$(config_build_arg GITHUB_CLI_VERSION)
+AWS_CLI_VERSION=$(config_build_arg AWS_CLI_VERSION)
+AZURE_CLI_VERSION=$(config_build_arg AZURE_CLI_VERSION)
+GCP_CLI_VERSION=$(config_build_arg GCP_CLI_VERSION)
 
 # Get raw upstream version (without -alpine suffix) for source download
 # Honor $VERSION when set (CI/dep-rebuild path); fall back to upstream latest (local/manual invocation).
@@ -110,27 +132,16 @@ if ! [[ "$UPSTREAM_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
     exit 1
 fi
 
-echo "Building Terraform ${VERSION} (source: ${UPSTREAM_VERSION}) with tools:"
+echo "Building Terraform ${VERSION:-} (source: ${UPSTREAM_VERSION}) with pinned tools:"
 echo "  TFLint: ${TFLINT_VERSION}"
 echo "  Trivy: ${TRIVY_VERSION}"
 echo "  Terragrunt: ${TERRAGRUNT_VERSION}"
 echo "  Terraform-docs: ${TERRAFORM_DOCS_VERSION}"
+echo "  Infracost: ${INFRACOST_VERSION}"
 echo "  GitHub CLI: ${GITHUB_CLI_VERSION}"
 echo "  AWS CLI: ${AWS_CLI_VERSION}"
 echo "  Azure CLI: ${AZURE_CLI_VERSION}"
 echo "  GCP CLI: ${GCP_CLI_VERSION}"
-
-# Update config.yaml with fetched versions (single source of truth)
-yq -i ".build_args.TFLINT_VERSION = \"${TFLINT_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.TRIVY_VERSION = \"${TRIVY_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.TERRAGRUNT_VERSION = \"${TERRAGRUNT_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.TERRAFORM_DOCS_VERSION = \"${TERRAFORM_DOCS_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.GITHUB_CLI_VERSION = \"${GITHUB_CLI_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.AWS_CLI_VERSION = \"${AWS_CLI_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.AZURE_CLI_VERSION = \"${AZURE_CLI_VERSION}\"" "$CONFIG_FILE"
-yq -i ".build_args.GCP_CLI_VERSION = \"${GCP_CLI_VERSION}\"" "$CONFIG_FILE"
-
-echo "Updated config.yaml with latest tool versions"
 
 # Propagate UPSTREAM_VERSION so the Dockerfile's ${UPSTREAM_VERSION:-${VERSION}} resolves correctly
 # for retained-version builds (where VERSION carries the -alpine suffix).

--- a/terraform/config.yaml
+++ b/terraform/config.yaml
@@ -1,6 +1,6 @@
 # Terraform container configuration
 # Base image and third-party dependency versions
-# NOTE: Tool versions are auto-updated during build by terraform/build script
+# NOTE: Tool versions are pinned here and updated by upstream-monitor, not at build time.
 
 base_image: "${REMOTE_CR}/hashicorp/terraform:${UPSTREAM_VERSION}"
 base_image_cache:

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -24,10 +24,13 @@ RUN set -ex \
         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac \
     && apk add --no-cache ca-certificates tzdata \
-    && wget -qO- "https://github.com/vectordotdev/vector/releases/download/v${UPSTREAM_VERSION}/vector-${UPSTREAM_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
-        | tar xzf - -C /tmp/ \
+    && for attempt in 1 2 3; do \
+         wget -qO /tmp/vector.tgz "https://github.com/vectordotdev/vector/releases/download/v${UPSTREAM_VERSION}/vector-${UPSTREAM_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" && break; \
+         [ "$attempt" -lt 3 ] && sleep 2 || { echo "vector download failed after retries" >&2; exit 1; }; \
+       done \
+    && tar xzf /tmp/vector.tgz -C /tmp/ \
     && mv /tmp/vector-${ARCH}-unknown-linux-musl/bin/vector /usr/local/bin/vector \
-    && rm -rf /tmp/vector-* \
+    && rm -rf /tmp/vector-* /tmp/vector.tgz \
     && vector --version
 
 # Create vector user and data directory

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -40,7 +40,7 @@ ARG WPCLI_VERSION
 RUN : "${WPCLI_VERSION:?required}"
 
 RUN set -ex; \
-    curl -fsSL -o /usr/local/bin/wp https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar; \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 -o /usr/local/bin/wp https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar; \
     chmod +x /usr/local/bin/wp; \
     # Suppress deprecation warnings for CLI only (E_ALL & ~E_DEPRECATED = 22527)
     echo 'error_reporting = E_ALL & ~E_DEPRECATED' > /usr/local/etc/php/conf.d/cli-no-deprecated.ini; \
@@ -62,7 +62,7 @@ RUN set -ex; \
     WP_VERSION="${VERSION%%-*}"; \
     wp core download --path=/var/www/html --version="$WP_VERSION" --allow-root; \
     # Pre-install SQLite Database Integration plugin (used when WP_DB_TYPE=sqlite)
-    curl -fsSL -o /tmp/sqlite-plugin.zip \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 -o /tmp/sqlite-plugin.zip \
         "https://downloads.wordpress.org/plugin/sqlite-database-integration.${SQLITE_PLUGIN_VERSION}.zip"; \
     unzip -qo /tmp/sqlite-plugin.zip -d /var/www/html/wp-content/plugins/; \
     rm /tmp/sqlite-plugin.zip; \


### PR DESCRIPTION
terraform's build failed across all flavors (#724) because the build downloaded **Trivy v0.71.1**, a version with no published GitHub release / downloadable assets — the latest real release is v0.71.0, which `terraform/config.yaml` correctly pins.

## Root cause

`terraform/build` is sourced by `make` on every build and **re-discovered each dependency version at build time** via `git ls-remote --tags`, then wrote the result back into `config.yaml`. `git ls-remote --tags` returns every git tag — including a tag pushed upstream *without* a published release. Trivy pushed tag `v0.71.1` with no release assets; the script overrode the committed pin `0.71.0` with `0.71.1`, and the Dockerfile asset download 404'd. terraform was the only container doing this (others build from their config pins verbatim).

## Fix

1. **Use the pinned versions** — remove the build-time re-discovery and config write-back from `terraform/build`. terraform now builds from the `config.yaml` `build_args` pins like every other container; upstream-monitor remains the single updater of those pins (it discovers via the releases API, which only returns published releases). The script keeps its unique work (UPSTREAM_VERSION derivation, CUSTOM_BUILD_ARGS export).
2. **Fail fast on an assetless pin** — a pre-build guard checks each monitored github-release pin against the releases API and fails early with a clear message ("… has no published GitHub release/assets") if a pin ever points to a tag without a release, instead of an opaque mid-build 404. It fails closed on a definite missing release but fails open (warns and continues) when it cannot reach the API, so offline/local builds are unaffected.
3. **Retry transient download blips** — independently, every release-asset/archive download across six Dockerfiles (terraform, openresty, openvpn, wordpress, vector, sslh) that lacked retry now has it (curl `--retry-all-errors`, GNU wget `--retry-on-http-error`, and a BusyBox-safe retry loop for vector's plain-Alpine wget). This hardens against genuine transient CDN/network blips; it does not mask a real missing asset (the guard above handles that).

## Verification

- The PR build rebuilds the six affected containers; terraform now resolves Trivy `0.71.0` from its config pin.
- Forensic simulation: with a bogus `0.71.1` pin the guard fails early with the clear message; with the real `0.71.0` pin it passes; an unreachable API warns and continues.
- Full unit suite green (1855/1855); shellcheck clean on the changed scripts.

Closes #724.
