### PR TITLE
refactor(terraform): drop the redundant build-time release-validation guard

### DIFF
--- a/terraform/build
+++ b/terraform/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Terraform build script - validates pinned tool releases and exports build args.
+# Terraform build script - reads pinned tool versions and exports build args.
 # config.yaml is the single source of truth for tool versions.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,84 +15,6 @@ config_build_arg() {
     local arg_name="$1"
     YQ_BUILD_ARG="$arg_name" yq -r '.build_args[strenv(YQ_BUILD_ARG)] // ""' "$CONFIG_FILE"
 }
-
-dependency_label() {
-    local dep_name="$1"
-    dep_name="${dep_name%_VERSION}"
-    dep_name="${dep_name//_/-}"
-    printf '%s' "${dep_name,,}"
-}
-
-github_release_status() {
-    local repo="$1"
-    local tag="$2"
-    local github_api_url="${GITHUB_API_URL:-https://api.github.com}"
-    local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-    local -a curl_args=(
-        -sS
-        -L
-        -o /dev/null
-        -w "%{http_code}"
-        --connect-timeout 10
-        --max-time 15
-        -H "Accept: application/vnd.github+json"
-    )
-
-    if [[ -n "$token" ]]; then
-        curl_args+=(-H "Authorization: Bearer ${token}")
-    fi
-
-    curl "${curl_args[@]}" "${github_api_url}/repos/${repo}/releases/tags/${tag}"
-}
-
-validate_github_release_pins() {
-    if ! command -v curl >/dev/null 2>&1; then
-        echo "::warning::curl is unavailable; skipping Terraform pinned GitHub release validation" >&2
-        return 0
-    fi
-
-    local dep_name repo strip_v version tag label http_status
-    while IFS=$'\t' read -r dep_name repo strip_v; do
-        [[ -n "$dep_name" ]] || continue
-
-        version=$(config_build_arg "$dep_name")
-        label=$(dependency_label "$dep_name")
-        if [[ -z "$version" || "$version" == "null" ]]; then
-            echo "::error::${label} has no pinned version in terraform/config.yaml build_args" >&2
-            return 1
-        fi
-
-        tag="$version"
-        if [[ "$strip_v" == "true" && "$tag" != v* ]]; then
-            tag="v${tag}"
-        fi
-
-        if ! http_status=$(github_release_status "$repo" "$tag" 2>/dev/null); then
-            echo "::warning::could not validate ${label} ${version} GitHub release; skipping pinned release check" >&2
-            continue
-        fi
-
-        case "$http_status" in
-            200)
-                ;;
-            404)
-                echo "::error::${label} ${version} has no published GitHub release/assets - pin points to an assetless tag" >&2
-                return 1
-                ;;
-            *)
-                echo "::warning::could not validate ${label} ${version} GitHub release (GitHub API HTTP ${http_status}); skipping pinned release check" >&2
-                ;;
-        esac
-    done < <(yq -r '
-        .dependency_sources // {}
-        | to_entries[]
-        | select(.value.type == "github-release" and (.value.monitor // true) != false)
-        | [.key, .value.repo, (.value.strip_v // false | tostring)]
-        | @tsv
-    ' "$CONFIG_FILE")
-}
-
-validate_github_release_pins || exit 1
 
 TFLINT_VERSION=$(config_build_arg TFLINT_VERSION)
 TRIVY_VERSION=$(config_build_arg TRIVY_VERSION)


### PR DESCRIPTION
Follow-up to #724: simplify `terraform/build` by removing the build-time GitHub-release validation guard.

The guard re-checked each pinned dependency version against the GitHub releases API before building. It is redundant and adds complexity:

- **Versions come solely from the `config.yaml` pins**, which upstream-monitor sets via the releases API — so a tag without a published release (the #724 cause) is never pinned in the first place. The binding is on releases, not tags.
- **A build-time check cannot prevent a release being yanked between the check and the asset download** (TOCTOU), so it does not actually guarantee the download succeeds.
- A genuinely bad pin still fails the build at the download step; the transient-download retries (already in place) cover brief blips.

So `terraform/build` now simply reads the config pins and exports the build args. Releases remain the single source of truth via discovery + pin.

## Verification

- `shellcheck` clean; `bash -n` passes.
- `VERSION=1.15.6-alpine bash terraform/build` prints the pinned tool versions and exports `CUSTOM_BUILD_ARGS` (UPSTREAM_VERSION=1.15.6) with no validation/network step.
- The PR build rebuilds terraform from the config pins.

Refs #724.
