### PR TITLE
fix(ci): gate bake-merge with !cancelled() so the canonical manifest publishes

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -2672,6 +2672,7 @@ jobs:
     name: Bake merge manifests + DockerHub mirror
     needs: [detect-containers, bake-build-amd64, bake-build-arm64]
     if: |
+      !cancelled() &&
       github.event_name != 'pull_request' &&
       inputs.rebuild != 'sync' &&
       fromJson(needs.detect-containers.outputs.bake_builds || '[]') != null &&


### PR DESCRIPTION
## What

`bake-merge` (which publishes the canonical multi-arch manifest) had no
status-check function in its `if:`, so GitHub applied the implicit `success()`
gate. For any non-postgres container the extension jobs (`build-extensions`,
`merge-extension-manifests`) are skipped; `bake-build` tolerates that and
succeeds, but `bake-merge` — relying on the implicit gate — is **skipped**
because a skipped job sits in its dependency chain. The canonical manifest is
therefore never published on push builds.

This adds `!cancelled() &&` to the gate (the same primitive already used by the
checkpoint job in this workflow): it replaces the implicit `success()` gate so
the job evaluates even when an upstream job was skipped, while still **not**
running during workflow cancellation — important because this job *publishes* a
manifest (unlike the advisory `bake-trivy`/`bake-attest` siblings). The explicit
`bake-build-amd64`/`bake-build-arm64` success checks are kept, so the merge runs
only when both arches built fresh.

## Why

This surfaced on **terraform**: `terraform:<version>-alpine` and its flavor tags
were absent from GHCR while the per-arch intermediates existed, so the
version-drift guard re-filed a drift issue every morning (#727 / #731 / #739) and
the upstream-monitor kept forcing a daily rebuild. The same gap silently affects
**every bake-managed container's** push-time manifest refresh — the canonical
manifests were only published during the one-off `workflow_dispatch` validation,
never refreshed on subsequent pushes.

## Verification

- `actionlint` (structural) clean; `python3` `yaml.safe_load` parses the workflow.
- `!cancelled()` matches the existing usage at the coverage-checkpoint gate in the
  same file.
- Post-merge: a controlled rebuild of terraform confirms that `bake-merge` now
  runs and publishes `terraform:1.15.6-alpine` (+ flavors) — the missing canonical
  manifest — after which the drift issues self-resolve. (Tracked; closing the
  drift issues only once the manifest is confirmed published.)

## Follow-up

Stale stripped manifests (`terraform:1.15.6`, `-base`, …) and orphaned per-arch
intermediate tags predate this fix and will be reconciled by the registry cleanup
once the correct `-alpine` manifests publish.
