### PR TITLE
fix(ci): stop create-manifest emitting cross-version stripped tags

### DIFF
--- a/helpers/create-manifest.sh
+++ b/helpers/create-manifest.sh
@@ -33,10 +33,17 @@ _compute_tag_args() {
     # Enables dashboard version tracking via registry pattern matching
     # Guard: TAG must start with VERSION to safely strip the prefix (P3 fix)
     if [[ -n "${FULL_VERSION:-}" && "$FULL_VERSION" != "$TAG" && "$TAG" == "$VERSION"* ]]; then
-        local rest="${TAG#$VERSION}"
+        local rest="${TAG#"$VERSION"}"
         local full_numeric
         full_numeric=$(echo "$FULL_VERSION" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
-        if [[ -n "$full_numeric" ]]; then
+        local version_numeric
+        version_numeric=$(echo "$VERSION" | grep -oE '^[0-9]+(\.[0-9]+)*' || true)
+        # Only emit when FULL_VERSION's numeric STRICTLY EXTENDS the cell's VERSION
+        # numeric (e.g. 18 -> 18.3). Skip a different or equal version: a retained
+        # cell whose FULL_VERSION carries the latest (e.g. terraform 1.15.4 built with
+        # FULL_VERSION=1.15.6) would otherwise mis-tag a cross-version, -alpine-stripped
+        # alias (1.15.6 onto the 1.15.4 image).
+        if [[ -n "$full_numeric" && -n "$version_numeric" && "$full_numeric" == "$version_numeric".* ]]; then
             local full_tag="${full_numeric}${rest}"
             if [[ "$full_tag" != "$TAG" ]]; then
                 tag_args="$tag_args -t $target_image:$full_tag"
@@ -94,7 +101,13 @@ _compute_version_specific_tag_args() {
         local rest="${TAG#"$VERSION"}"
         local full_numeric
         full_numeric=$(echo "$FULL_VERSION" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?' || true)
-        if [[ -n "$full_numeric" ]]; then
+        local version_numeric
+        version_numeric=$(echo "$VERSION" | grep -oE '^[0-9]+(\.[0-9]+)*' || true)
+        # Only emit when FULL_VERSION's numeric STRICTLY EXTENDS the cell's VERSION
+        # numeric (e.g. 18 -> 18.3). Skip a different/equal version so a terraform-style
+        # full-version TAG falls through to Path C (TAG itself) instead of a
+        # cross-version, -alpine-stripped alias.
+        if [[ -n "$full_numeric" && -n "$version_numeric" && "$full_numeric" == "$version_numeric".* ]]; then
             local full_tag="${full_numeric}${rest}"
             if [[ "$full_tag" != "$TAG" ]]; then
                 echo "-t $target_image:$full_tag"

--- a/tests/unit/create-manifest-tags.bats
+++ b/tests/unit/create-manifest-tags.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# Regression lock for create-manifest.sh tag computation.
+# Guards the "version-specific tag" block against emitting a CROSS-VERSION,
+# base-suffix-stripped alias for full-version-tag containers (terraform), while
+# preserving postgres's legitimate major->specific version tag (18 -> 18.3).
+
+setup() {
+  ROOT_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/helpers/create-manifest.sh"
+}
+
+# ── terraform: full-version tags, version.sh returns latest for every cell ──
+
+@test "terraform retained cell does NOT get a cross-version stripped tag" {
+  # 1.15.4 retained cell built with FULL_VERSION = latest (1.15.6) — the bug case.
+  export TAG="1.15.4-alpine-base" VERSION="1.15.4-alpine" FULL_VERSION="1.15.6-alpine"
+  export VARIANT="base" IS_DEFAULT="false" IS_LATEST_VERSION="false"
+  run _compute_tag_args "ghcr.io/o/terraform"
+  [ "$status" -eq 0 ]
+  # must NOT alias the latest version onto this retained image
+  [[ "$output" != *"1.15.6"* ]]
+  # must NOT emit a base-suffix-stripped tag of this version either
+  [[ "$output" != *":1.15.4-base"* ]]
+  # the correct versioned tag is still present
+  [[ "$output" == *"-t ghcr.io/o/terraform:1.15.4-alpine-base"* ]]
+}
+
+@test "terraform latest cell does NOT get a base-stripped tag" {
+  export TAG="1.15.6-alpine-base" VERSION="1.15.6-alpine" FULL_VERSION="1.15.6-alpine"
+  export VARIANT="base" IS_DEFAULT="false" IS_LATEST_VERSION="true"
+  run _compute_tag_args "ghcr.io/o/terraform"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *":1.15.6-base"* ]]
+  [[ "$output" == *"-t ghcr.io/o/terraform:1.15.6-alpine-base"* ]]
+}
+
+@test "_compute_version_specific_tag_args (fallback) skips cross-version for terraform" {
+  export TAG="1.15.4-alpine-base" VERSION="1.15.4-alpine" FULL_VERSION="1.15.6-alpine"
+  run _compute_version_specific_tag_args "ghcr.io/o/terraform"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"1.15.6"* ]]
+  # Path C: TAG itself is the version-specific form
+  [[ "$output" == "-t ghcr.io/o/terraform:1.15.4-alpine-base" ]]
+}
+
+# ── postgres: legitimate major -> specific version tag must be preserved ──
+
+@test "postgres rolling major cell still gets the specific version tag" {
+  # 18-alpine-vector rolling tag, FULL_VERSION 18.3-alpine -> add 18.3-alpine-vector
+  export TAG="18-alpine-vector" VERSION="18" FULL_VERSION="18.3-alpine"
+  export VARIANT="vector" IS_DEFAULT="false" IS_LATEST_VERSION="true"
+  run _compute_tag_args "ghcr.io/o/postgres"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-t ghcr.io/o/postgres:18.3-alpine-vector"* ]]
+  [[ "$output" == *"-t ghcr.io/o/postgres:18-alpine-vector"* ]]
+}


### PR DESCRIPTION
## What

The "version-specific tag" block in `create-manifest.sh` was built for postgres's
rolling-major pattern (`TAG=18-alpine` + `FULL_VERSION=18.3-alpine` → also tag
`18.3-alpine`). For full-version-tag containers like **terraform** it misfired: a
retained `1.15.4` cell carries `FULL_VERSION=1.15.6-alpine` (terraform's
`version.sh` returns the latest regardless of the queried version), so the block
combined the numeric prefix of `FULL_VERSION` (`1.15.6`) with the
base-suffix-stripped remainder of `TAG` (`-base`) and tagged the **1.15.4 image**
as `terraform:1.15.6-base`. Net effect: `terraform:1.15.6` (and flavors) silently
served terraform **1.15.4/1.15.5**, recreated on every retained build.

Both the main (`_compute_tag_args`) and fallback (`_compute_version_specific_tag_args`)
computations now emit the version-specific tag **only when `FULL_VERSION`'s numeric
strictly extends the cell's `VERSION` numeric** (e.g. `18` → `18.3`). A different or
equal version is skipped, so a terraform-style full-version `TAG` falls through to
using `TAG` itself — no cross-version, no stripped alias.

## Why

Found while root-causing the recurring terraform drift (fixed separately by #743,
which made `bake-merge` publish the canonical `:<ver>-alpine` manifest). These
stripped `:1.15.6` tags are a distinct, active defect on the matrix/retained path:
they mis-point to old versions and can't be removed by the cleanup cron (they share
a GHCR version with a valid retained `:<ver>-alpine` tag). Stopping their creation
lets them self-clean as retained versions roll out of retention.

## Verification

- New bats regression lock `tests/unit/create-manifest-tags.bats` (4 cases): terraform
  retained + latest cells produce no cross-version / stripped tag; the
  `_compute_version_specific_tag_args` fallback skips it too; postgres's legitimate
  `18 → 18.3-alpine-vector` tag is preserved. All pass.
- `shellcheck -x` clean on the changed file at error severity (also quoted the prefix
  removal to match the fallback function).
- The documented `:<ver>-alpine` tags are unaffected (built by the matrix manifest
  and, for latest, by bake-merge after #743).
