### PR TITLE
fix(github-runner): Windows build — ensure docker daemon ready + shrink dev VS Build Tools

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1043,6 +1043,32 @@ jobs:
         shell: bash
         run: yq --version
 
+      - name: Ensure Docker daemon is ready (Windows)
+        # Hosted windows-latest VMs intermittently start with dockerd not running
+        # (npipe //./pipe/docker_engine missing) → the build dies at the first FROM.
+        # Probe, and restart + wait if the daemon is not responding. Best-effort:
+        # if it still won't come up the build fails with its own clear error.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          docker info *> $null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host 'Docker daemon not responding — restarting the docker service'
+            Restart-Service docker -Force -ErrorAction SilentlyContinue
+            $deadline = (Get-Date).AddMinutes(3)
+            do {
+              Start-Sleep -Seconds 5
+              docker info *> $null
+            } until ($LASTEXITCODE -eq 0 -or (Get-Date) -gt $deadline)
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host '::warning::Docker daemon still not ready after restart + 3min wait'
+            } else {
+              Write-Host 'Docker daemon ready after restart'
+            }
+          } else {
+            Write-Host 'Docker daemon already responding'
+          }
+
       - name: Build container with retry logic
         id: build
         uses: ./.github/actions/build-container

--- a/github-runner/Dockerfile.windows
+++ b/github-runner/Dockerfile.windows
@@ -144,11 +144,12 @@ RUN Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vs_buildtools.exe' -Out
     Start-Process -Wait -FilePath C:\vs_buildtools.exe -ArgumentList \
       '--quiet', '--wait', '--norestart', \
       '--add', 'Microsoft.VisualStudio.Workload.VCTools', \
-      '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.26100', \
-      '--includeRecommended'; \
-    Remove-Item C:\vs_buildtools.exe -Force
+      '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.26100'; \
+    Remove-Item C:\vs_buildtools.exe -Force; \
+    Remove-Item -Recurse -Force 'C:\ProgramData\Package Cache' -ErrorAction SilentlyContinue
 
-# Add MSVC + SDK tools to PATH (rc.exe, cl.exe, link.exe) + cleanup caches
+# Add MSVC + SDK tools to PATH (rc.exe, cl.exe, link.exe)
+# (the VS installer Package Cache is purged in the install layer above)
 # No double quotes — pwsh -Command from Docker SHELL breaks on embedded double quotes
 RUN $vsBase = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC'; \
     $msvcVer = (Get-ChildItem $vsBase -Directory | Sort-Object Name -Descending | Select-Object -First 1).Name; \
@@ -157,8 +158,7 @@ RUN $vsBase = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC
     Write-Host ('MSVC: ' + $msvcBin); \
     Write-Host ('SDK:  ' + $sdkBin); \
     $machPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); \
-    [System.Environment]::SetEnvironmentVariable('Path', ($machPath + ';' + $msvcBin + ';' + $sdkBin), 'Machine'); \
-    Remove-Item -Recurse -Force 'C:\ProgramData\Package Cache' -ErrorAction SilentlyContinue
+    [System.Environment]::SetEnvironmentVariable('Path', ($machPath + ';' + $msvcBin + ';' + $sdkBin), 'Machine')
 
 LABEL org.opencontainers.image.description="GitHub Actions self-hosted runner (Windows ltsc2022 — dev)"
 LABEL org.opencontainers.image.source="https://github.com/oorabona/docker-containers"


### PR DESCRIPTION
Two fixes for the Windows `github-runner` build, which has been failing on
`windows-latest` for two unrelated reasons.

## 1. Daemon readiness (the blocker)

Hosted `windows-latest` VMs intermittently start a job with **dockerd not running**
(the `//./pipe/docker_engine` named pipe is missing), so the build dies at the
**first `FROM`** with "The system cannot find the file specified" — on all 3 retry
attempts, since the retry never restarts the daemon. GitHub does not flag these
per-VM stalls (the status page stays "Actions: operational"), so there is no
incident to wait out.

New Windows-only pre-build step probes `docker info` and, if the daemon isn't
responding, restarts the docker service and waits up to 3 minutes. Best-effort:
if it still won't come up the build fails with its own clear error.

## 2. Dev-image disk exhaustion

The dev variant installed VS Build Tools with `--includeRecommended` on top of the
VCTools workload + Windows 11 SDK, pulling tens of GB of optional components
(CMake, ATL, ASAN, MFC, …). Once a build reached that step it **exhausted the
runner disk mid-install** (`not enough space on the disk`, then `hcsshim`
failures); `base` (no MSVC toolchain) was unaffected. Drop `--includeRecommended`
(keep the VCTools core + the explicit Windows 11 SDK) and purge the VS installer
Package Cache in the same install layer.

The two pair up: (1) lets a run actually reach the build, (2) lets the dev build
finish once it does.

## Verification

Windows images can't be built off a Linux host, so verification is via CI. Both
fixes were found empirically: a health probe showed `dev` failing on disk at the
VS Build Tools step, and the verification runs for this PR then hit the daemon
stall at `FROM` (confirming the daemon issue is real and distinct). Success
criteria on a run that lands a healthy daemon: `base` and `dev` both build, and
the dev image still resolves `cl.exe`/`link.exe`/`rc.exe` onto PATH (asserted by
the existing PATH step locating the installed MSVC directory).
