### PR TITLE
fix(github-runner): restore the MSVC compiler in the Windows dev image

### DIFF
--- a/github-runner/Dockerfile.windows
+++ b/github-runner/Dockerfile.windows
@@ -144,6 +144,7 @@ RUN Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vs_buildtools.exe' -Out
     Start-Process -Wait -FilePath C:\vs_buildtools.exe -ArgumentList \
       '--quiet', '--wait', '--norestart', \
       '--add', 'Microsoft.VisualStudio.Workload.VCTools', \
+      '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', \
       '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.26100'; \
     Remove-Item C:\vs_buildtools.exe -Force; \
     Remove-Item -Recurse -Force 'C:\ProgramData\Package Cache' -ErrorAction SilentlyContinue


### PR DESCRIPTION
## What

#745 dropped `--includeRecommended` from the Windows dev VS Build Tools install to
fix disk exhaustion — but that also dropped
`Microsoft.VisualStudio.Component.VC.Tools.x86.x64`, the actual **MSVC compiler**,
which is a *recommended* (not required) component of the VCTools workload. The dev
image then had no `cl.exe`/`link.exe`, and the PATH-setup step failed with
`Cannot find ...VC\Tools\MSVC`.

Add the `VC.Tools.x86.x64` component explicitly — the compiler is installed
without the full `--includeRecommended` bloat (CMake/ATL/ASAN/MFC/…) that had
exhausted the runner disk.

## Why

A health probe + the #745 merge build confirmed it empirically: the daemon-readiness
step (#745) let a run reach the VS Build Tools step, disk exhaustion was gone, but
the build then failed because the MSVC compiler directory didn't exist — the
recommended-component drop went one step too far.

## Verification

Windows images can't be built off a Linux host; verification is via CI on a run
that reaches the VS Build Tools step (the #745 daemon step makes that reachable
when MCR cooperates). Success criteria: the dev build completes and the PATH step
resolves the MSVC dir.

## Not in scope

The intermittent **MCR base-pull throttling** (`toomanyrequests` at the first
`FROM`) is a separate, deeper problem: mirroring the Windows base is license-
prohibited, and the runner-pre-cache mitigation touches build (no-`--pull`), the
runner pin (`windows-2022`), build-lineage (record the local digest), AND the
base-digest-drift detector (the pre-cached base can't be remediated by rebuild) —
a coherent multi-part redesign tracked separately, not bundled here.
