### PR TITLE
refactor(ci): make the daily sync the only job that contacts Docker Hub

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -812,19 +812,23 @@ jobs:
         shell: bash
         env:
           OWNER: ${{ github.repository_owner }}
+          SYNC_MANIFEST_OUT: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           set -euo pipefail
           source ./helpers/base-cache-utils.sh
+          mkdir -p "$(dirname "$SYNC_MANIFEST_OUT")"
+          : > "$SYNC_MANIFEST_OUT"
           echo "::notice::Seeding buildkit image to GHCR: ghcr.io/${OWNER}/buildkit:buildx-stable-1"
-          _sync_one_with_backoff \
-            "docker.io/moby/buildkit:buildx-stable-1" \
-            "ghcr.io/${OWNER}/buildkit:buildx-stable-1"
+          buildkit_images=$(jq -nc --arg owner "$OWNER" \
+            '[{source:"moby/buildkit",tag:"buildx-stable-1",sync_image:("ghcr.io/" + $owner + "/buildkit:buildx-stable-1")}]')
+          sync_base_images_to_ghcr "$buildkit_images"
 
       - name: Sync base images to GHCR (all containers)
         id: sync
         shell: bash
         env:
           OWNER: ${{ github.repository_owner }}
+          SYNC_MANIFEST_OUT: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           set -euo pipefail
           source ./helpers/base-cache-utils.sh
@@ -860,6 +864,27 @@ jobs:
             echo "success=false" >> "$GITHUB_OUTPUT"
             exit "$sync_rc"
           fi
+
+      - name: Upload base sync manifest
+        id: upload_base_sync_manifest
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest/base-sync-manifest.jsonl
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload base sync manifest (retry on transient failure)
+        if: always() && steps.upload_base_sync_manifest.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest/base-sync-manifest.jsonl
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -1417,20 +1442,17 @@ jobs:
 
   detect-digest-drift:
     name: Detect base image digest drift
-    # Wait for sync-base-images so probes compare against today's freshly-synced
-    # GHCR mirror rather than yesterday's copy.  Without this ordering, a real
+    # Wait for sync-base-images so Docker Hub-origin refs are compared against
+    # today's freshly recorded blind-sync manifest. Without this ordering, a real
     # upstream rebase that happened since the previous sync would be invisible for
     # the current day's run.
     # NOTE: create-dependency-update-prs is intentionally NOT in needs — drift
     # detection is independent of dep-PR fanout.  Including it would silently
     # skip drift detection whenever skip_dep_fanout (or equivalent) is set.
     needs: [sync-base-images]
-    # No `if:` gate on sync_succeeded: drift detection probes UPSTREAM via
-    # `buildx imagetools inspect` and does NOT read from the local GHCR mirror
-    # that sync-base-images populates.  The two jobs are orthogonal.  Gating on
-    # sync_succeeded caused one transient per-image 429/blip to skip drift
-    # detection for ALL containers — a silent miss repo-wide.  `needs` is kept
-    # for ordering (run after sync attempts), but outcome does not matter.
+    # No `if:` gate on sync_succeeded: the manifest carries per-base success and
+    # failure status. Failed/absent records become per-variant error statuses
+    # rather than skipping drift detection for ALL containers.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
@@ -1462,15 +1484,12 @@ jobs:
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
 
-      - name: Log in to Docker Hub
-        # Authenticated probes avoid 429 rate-limiting that would silently drop
-        # drift signals for busy Docker Hub images.
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download base sync manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         continue-on-error: true
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest
 
       - name: Log in to GitHub Container Registry
         # GHCR login avoids rate-limiting for base_image_ref values pointing at
@@ -1504,6 +1523,7 @@ jobs:
           # to prevent GHA expression injection in the run: shell body.
           # Never reference ${{ inputs.container }} inside run: directly.
           REQUESTED_CONTAINER: ${{ inputs.container }}
+          SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
           detect_rc=0
@@ -1629,7 +1649,7 @@ jobs:
 
   open-drift-prs-leaves:
     name: Open drift PR (leaf) for ${{ matrix.container }}
-    needs: [detect-digest-drift]
+    needs: [detect-digest-drift, sync-base-images]
     if: |
       needs.detect-digest-drift.result == 'success' &&
       needs.detect-digest-drift.outputs.drift_matrix_leaves != '[]' &&
@@ -1678,15 +1698,12 @@ jobs:
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
 
-      - name: Log in to Docker Hub
-        # Re-detect probes registry anonymously without this; anonymous Docker Hub
-        # requests are rate-limited and can silently fail → false "no drift" result.
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download base sync manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         continue-on-error: true
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest
 
       - name: Log in to GitHub Container Registry
         # Required when base_image_ref points to the GHCR mirror (ghcr.io/owner/*).
@@ -1715,6 +1732,7 @@ jobs:
         id: drift-data
         env:
           CONTAINER: ${{ matrix.container }}
+          SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
           # Unique temp paths per matrix entry — no cross-container contamination
@@ -1912,7 +1930,7 @@ jobs:
 
   open-drift-prs-consumers:
     name: Open drift PR (consumer) for ${{ matrix.container }}
-    needs: [detect-digest-drift, open-drift-prs-leaves]
+    needs: [detect-digest-drift, open-drift-prs-leaves, sync-base-images]
     # always() is required for two reasons:
     # 1. open-drift-prs-leaves is SKIPPED when no leaf container has drift (matrix
     #    is empty). Without always(), GitHub Actions would cascade-skip this consumer
@@ -1976,15 +1994,12 @@ jobs:
           key: build-lineage-${{ github.run_id }}
           restore-keys: build-lineage-
 
-      - name: Log in to Docker Hub
-        # Re-detect probes registry anonymously without this; anonymous Docker Hub
-        # requests are rate-limited and can silently fail → false "no drift" result.
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download base sync manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         continue-on-error: true
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest
 
       - name: Log in to GitHub Container Registry
         # Required when base_image_ref points to the GHCR mirror (ghcr.io/owner/*).
@@ -2013,6 +2028,7 @@ jobs:
         id: drift-data
         env:
           CONTAINER: ${{ matrix.container }}
+          SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           chmod +x scripts/detect-base-digest-drift.sh
           # Unique temp paths per matrix entry — no cross-container contamination
@@ -2433,46 +2449,55 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download base sync manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        continue-on-error: true
+        with:
+          name: base-sync-manifest-${{ github.run_id }}
+          path: base-sync-manifest
+
       - name: Detect buildkit digest drift
         id: detect
         env:
           OWNER: ${{ github.repository_owner }}
+          SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
           set -euo pipefail
 
-          # --- FINDING 1: verify GHCR mirror == docker.io upstream (fail-closed) ---
-          # The sync-base-images seed step runs with continue-on-error, so the GHCR
-          # tag may be stale (seed failure, 429 throttle, etc.).  We must not promote
-          # an UNVERIFIED digest.  Both registries are inspected; the bump only
-          # proceeds when the two digests are equal, proving the GHCR mirror is a
-          # current, faithful copy of official upstream.  Inequality → skip + warning.
-          # docker.io access is intentional here: this is the upstream-monitor job,
-          # the one job authorised to contact docker.io for upstream comparison.
+          # --- FINDING 1: verify GHCR mirror == sync-recorded upstream (fail-closed) ---
+          # The daily sync is the single docker.io touchpoint and runs as a blind
+          # copy (skip_present=false) before writing this manifest. A synced
+          # buildkit record therefore captures the upstream digest observed by
+          # that copy. The bump proceeds only when the current GHCR digest still
+          # equals the manifest digest; failed/absent records leave hub_digest
+          # empty and the existing guard skips the bump.
           ghcr_digest=$(docker buildx imagetools inspect \
             --format '{{json .Manifest}}' \
             "ghcr.io/${OWNER}/buildkit:buildx-stable-1" \
             2>/dev/null | jq -r '.digest // empty') || ghcr_digest=""
 
-          hub_digest=$(docker buildx imagetools inspect \
-            --format '{{json .Manifest}}' \
-            "docker.io/moby/buildkit:buildx-stable-1" \
-            2>/dev/null | jq -r '.digest // empty') || hub_digest=""
+          hub_digest=$(jq -cser --arg source_ref "docker.io/moby/buildkit:buildx-stable-1" '
+            map(if type == "array" then .[] else . end)
+            | map(select((.source_ref // "") == $source_ref and (.status // "") == "synced"))
+            | last.digest // empty
+          ' "$SYNC_MANIFEST_FILE" 2>/dev/null) || hub_digest=""
 
           echo "::notice::GHCR mirror digest : ${ghcr_digest:-<empty>}"
-          echo "::notice::docker.io upstream  : ${hub_digest:-<empty>}"
+          echo "::notice::sync manifest digest: ${hub_digest:-<empty>}"
 
-          # Fail-closed: either digest empty → GHCR probe or docker.io unreachable.
+          # Fail-closed: either digest empty → GHCR probe failed or manifest
+          # absent/failed/digestless.
           if [[ -z "$ghcr_digest" || -z "$hub_digest" ]]; then
             echo "::warning::Could not read one or both digests (ghcr='${ghcr_digest:-<empty>}' hub='${hub_digest:-<empty>}') — skipping bump"
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Fail-closed: digests differ → seed did not refresh GHCR or upstream
-          # updated between the seed and this inspect.  Do not bump to a digest that
-          # hasn't been verified against the authoritative upstream source.
+          # Fail-closed: digests differ → GHCR no longer matches the digest
+          # captured by the blind sync. Do not bump to a digest that has not been
+          # verified by this cycle's single Docker Hub touchpoint.
           if [[ "$ghcr_digest" != "$hub_digest" ]]; then
-            echo "::warning::GHCR mirror digest (${ghcr_digest}) != docker.io upstream (${hub_digest}) — GHCR copy may be stale; skipping bump"
+            echo "::warning::GHCR mirror digest (${ghcr_digest}) != sync manifest (${hub_digest}) — GHCR copy may be stale; skipping bump"
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -467,6 +467,132 @@ _sync_one_with_backoff() {
     done
 }
 
+# base_cache_canonical_source_ref <source_img> <tag> [source_registry]
+#
+# Canonicalize the source side of a base_image_cache entry exactly as the
+# sync loop does: strip a chained-on-own leading slash, preserve multi-segment
+# paths, and add explicit library/ for single-segment Docker Hub names.
+base_cache_canonical_source_ref() {
+    local source_img="$1"
+    local tag="$2"
+    local source_registry="${3:-docker.io}"
+
+    if [[ -z "$source_registry" || -z "$source_img" || -z "$tag" ]]; then
+        return 1
+    fi
+
+    if [[ "$source_registry" =~ [[:cntrl:]] ]] \
+        || [[ "$source_img" =~ [[:cntrl:]] ]] \
+        || [[ "$tag" =~ [[:cntrl:]] ]]; then
+        return 1
+    fi
+
+    local src="${source_img#/}"
+    if [[ "$src" == */* ]]; then
+        printf '%s/%s:%s' "$source_registry" "$src" "$tag"
+    else
+        printf '%s/library/%s:%s' "$source_registry" "$src" "$tag"
+    fi
+}
+
+# base_cache_is_docker_io_origin_ref <image_ref>
+#
+# True for lineage-style refs that resolve to Docker Hub: bare names
+# (alpine:3.21), Docker Hub namespaces (hashicorp/terraform:...), and explicit
+# docker.io aliases. False for GHCR/MCR/other explicit registries.
+base_cache_is_docker_io_origin_ref() {
+    local image_ref="$1"
+    local ref="${image_ref%%@*}"
+
+    [[ -z "$ref" || "$ref" == -* || "$ref" == /* ]] && return 1
+    [[ "$ref" =~ [[:space:][:cntrl:]] ]] && return 1
+
+    if [[ "$ref" != */* ]]; then
+        return 0
+    fi
+
+    local first_segment="${ref%%/*}"
+    case "$first_segment" in
+        docker.io | registry-1.docker.io | index.docker.io)
+            return 0
+            ;;
+    esac
+
+    if [[ "$first_segment" != *"."* && "$first_segment" != *":"* ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# base_cache_canonical_docker_io_ref <image_ref>
+#
+# Convert a lineage base_image_ref that resolves to Docker Hub into the same
+# canonical source_ref emitted by sync_base_images_to_ghcr, e.g.
+# alpine:3.21 -> docker.io/library/alpine:3.21.
+base_cache_canonical_docker_io_ref() {
+    local image_ref="$1"
+    local ref="${image_ref%%@*}"
+
+    base_cache_is_docker_io_origin_ref "$image_ref" || return 1
+
+    local path_tag="$ref"
+    if [[ "$ref" == */* ]]; then
+        local first_segment="${ref%%/*}"
+        case "$first_segment" in
+            docker.io | registry-1.docker.io | index.docker.io)
+                path_tag="${ref#*/}"
+                ;;
+        esac
+    fi
+
+    local last_segment="${path_tag##*/}"
+    if [[ "$last_segment" != *:* ]]; then
+        return 1
+    fi
+
+    local source_img="${path_tag%:*}"
+    local tag="${path_tag##*:}"
+    [[ -z "$source_img" || -z "$tag" ]] && return 1
+
+    base_cache_canonical_source_ref "$source_img" "$tag" "docker.io"
+}
+
+# _append_base_sync_manifest_record <source_ref> <sync_image> <digest> <status>
+#
+# Append a JSONL record when SYNC_MANIFEST_OUT is set. Manifest write failures
+# are reported but do not alter sync counters or return code; consumers fail
+# closed when a record is absent or digestless.
+_append_base_sync_manifest_record() {
+    local manifest_out="${SYNC_MANIFEST_OUT:-}"
+    [[ -z "$manifest_out" ]] && return 0
+
+    local source_ref="$1"
+    local sync_image="$2"
+    local digest="$3"
+    local status="$4"
+    local synced_at
+    synced_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local manifest_dir
+    manifest_dir="$(dirname "$manifest_out")"
+    if [[ "$manifest_dir" != "." ]] && ! mkdir -p "$manifest_dir"; then
+        echo "::warning::sync_base_images_to_ghcr: could not create manifest directory ${manifest_dir}"
+        return 0
+    fi
+
+    if ! jq -cn \
+        --arg source_ref "$source_ref" \
+        --arg sync_image "$sync_image" \
+        --arg digest "$digest" \
+        --arg status "$status" \
+        --arg synced_at "$synced_at" \
+        '{source_ref: $source_ref, sync_image: $sync_image, digest: $digest, status: $status, synced_at: $synced_at}' \
+        >> "$manifest_out"; then
+        echo "::warning::sync_base_images_to_ghcr: could not append sync manifest record for ${sync_image}"
+    fi
+}
+
 # _escape_gha_command <value>
 #
 # Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
@@ -558,23 +684,15 @@ sync_base_images_to_ghcr() {
             continue
         fi
 
-        # Strip leading slash for chained-on-own markers (e.g. source: /php).
-        # This must happen BEFORE the slash-presence check so that single-segment
-        # chained sources (/php → php) route to the library/ branch, not the
-        # multi-segment branch. Without this strip, /php would match */* and
-        # produce docker.io/php:tag via double-slash collapse — which works for
-        # the Docker daemon (client-side aliasing) but NOT for skopeo or imagetools,
-        # breaking the idempotent-mirror goal.
-        local src="${source_img#/}"
-        if [[ "$src" == */* ]]; then
-            # Multi-segment path (e.g. library/postgres or /library/postgres after strip):
-            # use as-is — the caller has already provided the full registry path.
-            source_ref="${source_registry}/${src}:${tag}"
-        else
-            # Single-segment (e.g. php, debian): prepend explicit library/ so the
-            # resulting ref is docker.io/library/php:tag, not docker.io/php:tag.
-            source_ref="${source_registry}/library/${src}:${tag}"
-        fi
+        # Keep this canonicalization in one helper so the daily sync manifest and
+        # drift consumers share the exact Docker Hub key. The daily sync must keep
+        # skip_present=false (blind copy, documented above) so a status=synced
+        # manifest digest means GHCR == upstream for this cycle.
+        source_ref=$(base_cache_canonical_source_ref "$source_img" "$tag" "$source_registry") || {
+            echo "::warning::sync_base_images_to_ghcr: refusing image entry with invalid source ref"
+            failed=$((failed + 1))
+            continue
+        }
 
         echo ""
         echo "🔄 ${source_ref} → ${sync_image}"
@@ -592,6 +710,15 @@ sync_base_images_to_ghcr() {
 
         if output=$(_sync_one_with_backoff "$source_ref" "$sync_image"); then
             echo "  ✅ Synced"
+            if [[ -n "${SYNC_MANIFEST_OUT:-}" ]]; then
+                local sync_digest=""
+                sync_digest=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$sync_image" 2>/dev/null | jq -r '.digest // empty' 2>/dev/null || true)
+                if [[ -n "$sync_digest" && ! "$sync_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+                    echo "::warning::sync_base_images_to_ghcr: GHCR digest for ${sync_image} had unexpected shape; manifest record will fail closed"
+                    sync_digest=""
+                fi
+                _append_base_sync_manifest_record "$source_ref" "$sync_image" "$sync_digest" "synced"
+            fi
             synced=$((synced + 1))
         else
             echo "  ⚠️ Failed (continuing; daily sync will retry)"
@@ -611,6 +738,7 @@ sync_base_images_to_ghcr() {
             safe_source_ref=$(_escape_gha_command "$source_ref")
             safe_sync_image=$(_escape_gha_command "$sync_image")
             echo "::warning::sync_base_images_to_ghcr: failed to sync ${safe_source_ref} → ${safe_sync_image}"
+            _append_base_sync_manifest_record "$source_ref" "$sync_image" "" "failed"
             failed=$((failed + 1))
         fi
     done < <(echo "$images_json" | jq -c '.[]')
@@ -630,4 +758,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff _escape_gha_command sync_base_images_to_ghcr
+export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -29,6 +29,10 @@
 #                     (canonical multi-arch image-index digest via buildx
 #                     imagetools — order-independent, single source of truth,
 #                     matches scripts/build-container.sh digest extraction)
+#   SYNC_MANIFEST_FILE
+#                     Optional path to the daily base-image sync JSONL/JSON-array
+#                     manifest. When set, Docker Hub-origin base refs are resolved
+#                     from that manifest instead of probing docker.io.
 #
 # Exit codes:
 #   0   — Success (drift/unchanged/legacy/error records emitted; drift itself is NOT an error)
@@ -55,6 +59,8 @@ source "${PROJECT_ROOT}/helpers/dependency-graph.sh"
 source "${PROJECT_ROOT}/helpers/logging.sh"
 # shellcheck source=../helpers/retry.sh
 source "${PROJECT_ROOT}/helpers/retry.sh"
+# shellcheck source=../helpers/base-cache-utils.sh
+source "${PROJECT_ROOT}/helpers/base-cache-utils.sh"
 
 # ---------------------------------------------------------------------------
 # _escape_gha_command <value>
@@ -217,6 +223,56 @@ _probe_digest_cached() {
         return 0
     fi
     return 1   # failures left UNCACHED (smallest semantic change)
+}
+
+# ---------------------------------------------------------------------------
+# _sync_manifest_lookup_by_key <manifest_key> <manifest_value>
+#
+# Look up one manifest record by a supported manifest key. Supports
+# both JSONL (the workflow writer) and JSON-array inputs. Output is returned via
+# _SYNC_MANIFEST_LOOKUP_STATUS and _SYNC_MANIFEST_LOOKUP_DIGEST.
+# ---------------------------------------------------------------------------
+_SYNC_MANIFEST_LOOKUP_STATUS=""
+_SYNC_MANIFEST_LOOKUP_DIGEST=""
+_sync_manifest_lookup_by_key() {
+    local lookup_key="$1"
+    local lookup_value="$2"
+    local manifest_file="${SYNC_MANIFEST_FILE:-}"
+    _SYNC_MANIFEST_LOOKUP_STATUS=""
+    _SYNC_MANIFEST_LOOKUP_DIGEST=""
+
+    [[ -n "$manifest_file" && -f "$manifest_file" ]] || return 1
+
+    local record
+    record=$(jq -cser --arg lookup_key "$lookup_key" --arg lookup_value "$lookup_value" '
+        map(if type == "array" then .[] else . end)
+        | map(select(type == "object" and ((.[$lookup_key] // "") == $lookup_value)))
+        | last // empty
+    ' "$manifest_file" 2>/dev/null || true)
+
+    [[ -n "$record" ]] || return 1
+
+    _SYNC_MANIFEST_LOOKUP_STATUS=$(printf '%s' "$record" | jq -r '.status // empty' 2>/dev/null || true)
+    _SYNC_MANIFEST_LOOKUP_DIGEST=$(printf '%s' "$record" | jq -r '.digest // empty' 2>/dev/null || true)
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _sync_manifest_lookup <canonical_source_ref>
+#
+# Look up one canonical Docker Hub source_ref in the sync manifest.
+# ---------------------------------------------------------------------------
+_sync_manifest_lookup() {
+    _sync_manifest_lookup_by_key "source_ref" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# _sync_manifest_lookup_by_sync_image <sync_image>
+#
+# Look up one GHCR sync_image in the sync manifest.
+# ---------------------------------------------------------------------------
+_sync_manifest_lookup_by_sync_image() {
+    _sync_manifest_lookup_by_key "sync_image" "$1"
 }
 
 # ---------------------------------------------------------------------------
@@ -647,21 +703,63 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Probe current digest (memoized: same ref probed at most once per run).
-    # Use the output-variable pattern — NOT $(...) — so _DIGEST_CACHE writes
-    # propagate to the parent shell (command substitution creates a subshell
-    # whose variable writes are lost on exit).
+    # Resolve current digest. When the daily sync manifest is present, Docker
+    # Hub-origin refs must use the digest recorded by that blind sync. A failed
+    # or absent sync record means upstream state is unknown for this cycle; do
+    # not re-probe docker.io and amplify the same exhausted 429 path.
+    #
+    # GHCR mirror refs produced via REMOTE_CR are already sync_image values in
+    # the manifest. If a matching record failed this cycle, fail closed instead
+    # of live-probing stale GHCR state. Project-internal GHCR refs that are not
+    # in the manifest keep the existing live-probe behavior.
     current_digest=""
     probe_failed=false
-    _probe_digest_cached_out=""
-    if _probe_digest_cached "$base_image_ref"; then
-        current_digest="$_probe_digest_cached_out"
-    else
-        probe_failed=true
+    manifest_resolution_handled=false
+    if [[ -n "${SYNC_MANIFEST_FILE:-}" ]] && base_cache_is_docker_io_origin_ref "$base_image_ref"; then
+        manifest_resolution_handled=true
+        _manifest_source_ref=""
+        if _manifest_source_ref=$(base_cache_canonical_docker_io_ref "$base_image_ref"); then
+            if _sync_manifest_lookup "$_manifest_source_ref" \
+                && [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" == "synced" ]] \
+                && [[ -n "$_SYNC_MANIFEST_LOOKUP_DIGEST" ]]; then
+                current_digest="$_SYNC_MANIFEST_LOOKUP_DIGEST"
+            else
+                probe_failed=true
+                error_reason="base not synced this cycle (sync failed/absent); drift unknown, re-checked next sync"
+            fi
+        else
+            probe_failed=true
+            error_reason="base not synced this cycle (manifest key unavailable); drift unknown, re-checked next sync"
+        fi
+    elif [[ -n "${SYNC_MANIFEST_FILE:-}" && "$base_image_ref" == ghcr.io/* ]]; then
+        if _sync_manifest_lookup_by_sync_image "$base_image_ref"; then
+            manifest_resolution_handled=true
+            if [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" == "synced" && -n "$_SYNC_MANIFEST_LOOKUP_DIGEST" ]]; then
+                current_digest="$_SYNC_MANIFEST_LOOKUP_DIGEST"
+            else
+                probe_failed=true
+                error_reason="GHCR mirror not synced this cycle (sync failed/digestless); drift unknown, re-checked next sync"
+            fi
+        fi
+    fi
+
+    if [[ "$manifest_resolution_handled" != "true" ]]; then
+        # Probe current digest (memoized: same ref probed at most once per run).
+        # Use the output-variable pattern — NOT $(...) — so _DIGEST_CACHE writes
+        # propagate to the parent shell (command substitution creates a subshell
+        # whose variable writes are lost on exit).
+        _probe_digest_cached_out=""
+        if _probe_digest_cached "$base_image_ref"; then
+            current_digest="$_probe_digest_cached_out"
+        else
+            probe_failed=true
+        fi
     fi
 
     if [[ "$probe_failed" == "true" || -z "$current_digest" ]]; then
-        error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
+        if [[ -z "$error_reason" ]]; then
+            error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
+        fi
         printf '::error::probe-error: %s\n' "$(_escape_gha_command "$error_reason")" >&2
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -14,9 +14,12 @@ setup() {
     source "$ORIG_DIR/helpers/logging.sh"
     source "$ORIG_DIR/helpers/variant-utils.sh"
     source "$ORIG_DIR/helpers/base-cache-utils.sh"
+
+    unset SYNC_MANIFEST_OUT
 }
 
 teardown() {
+    unset SYNC_MANIFEST_OUT
     cd "$ORIG_DIR" || true
     rm -rf "$TEST_DIR"
 }
@@ -800,6 +803,52 @@ EOF
     # Workflow warning surfaced for each image AND for the summary
     [[ "$output" == *"::warning::sync_base_images_to_ghcr: failed to sync"* ]]
     [[ "$output" == *"::warning::sync_base_images_to_ghcr: 2 image(s) failed to sync"* ]]
+}
+
+@test "sync_base_images_to_ghcr: writes manifest records for synced and failed bases" {
+    local manifest_file="$TEST_DIR/base-sync-manifest.jsonl"
+    export SYNC_MANIFEST_OUT="$manifest_file"
+    export SLEEP_CMD=:
+
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            local source_ref="${6:-}"
+            if [[ "$source_ref" == "docker.io/library/alpine:3.18" ]]; then
+                return 0
+            fi
+            echo "simulated registry error" >&2
+            return 1
+        fi
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+            printf '{"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"}'
+            return 0
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"},{"source":"postgres","tag":"18-alpine","sync_image":"ghcr.io/x/library/postgres:18-alpine"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"1 synced"* ]]
+    [[ "$output" == *"1 failed"* ]]
+
+    [ -f "$manifest_file" ]
+    [ "$(jq -s 'length' "$manifest_file")" -eq 2 ]
+
+    local synced_digest failed_status failed_digest synced_source failed_source
+    synced_source=$(jq -sr 'map(select(.source_ref == "docker.io/library/alpine:3.18"))[0].source_ref' "$manifest_file")
+    synced_digest=$(jq -sr 'map(select(.source_ref == "docker.io/library/alpine:3.18"))[0].digest' "$manifest_file")
+    failed_source=$(jq -sr 'map(select(.source_ref == "docker.io/library/postgres:18-alpine"))[0].source_ref' "$manifest_file")
+    failed_status=$(jq -sr 'map(select(.source_ref == "docker.io/library/postgres:18-alpine"))[0].status' "$manifest_file")
+    failed_digest=$(jq -sr 'map(select(.source_ref == "docker.io/library/postgres:18-alpine"))[0].digest' "$manifest_file")
+
+    [ "$synced_source" = "docker.io/library/alpine:3.18" ]
+    [ "$synced_digest" = "sha256:1111111111111111111111111111111111111111111111111111111111111111" ]
+    [ "$failed_source" = "docker.io/library/postgres:18-alpine" ]
+    [ "$failed_status" = "failed" ]
+    [ "$failed_digest" = "" ]
+    jq -se 'map(select(.status == "synced" and .sync_image == "ghcr.io/x/library/alpine:3.18" and (.synced_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T")))) | length == 1' "$manifest_file" >/dev/null
 }
 
 @test "sync_base_images_to_ghcr: multiline docker stderr cannot inject workflow commands" {

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -39,9 +39,14 @@ myimage"
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT
     export FIXTURES_DIR_DRIFT
+
+    unset SYNC_MANIFEST_FILE
+    unset PROBE_SENTINEL
 }
 
 teardown() {
+    unset SYNC_MANIFEST_FILE
+    unset PROBE_SENTINEL
     teardown_temp_dir
 }
 
@@ -104,6 +109,23 @@ _make_digest_probe_stub() {
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$stub_path" <<STUB_EOF
 #!/usr/bin/env bash
+printf '{"digest":"%s"}' "${digest}"
+exit 0
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a probe stub that records if it was called.
+# ---------------------------------------------------------------------------
+_make_probe_sentinel_stub() {
+    local digest="$1"
+    local stub_path="$TEST_TEMP_DIR/bin/probe-sentinel-$$"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<STUB_EOF
+#!/usr/bin/env bash
+touch "\${PROBE_SENTINEL:?}"
 printf '{"digest":"%s"}' "${digest}"
 exit 0
 STUB_EOF
@@ -1549,6 +1571,8 @@ EOF
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
 
     cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
 {
@@ -1587,6 +1611,8 @@ STUB
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
 
     cat > "$fake_root/.build-lineage/foo-1.0.json" <<'EOF'
 {
@@ -2255,6 +2281,269 @@ EOF
     local status
     status=$(printf '%s' "$result" | jq -r '.[] | .variants[].status')
     [ "$status" = "drift" ]
+}
+
+@test "sync-manifest: docker.io base uses synced record and does not probe" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-hit/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "alpine:3.21" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest.jsonl"
+    jq -cn \
+        --arg source_ref "docker.io/library/alpine:3.21" \
+        --arg sync_image "ghcr.io/oorabona/library/alpine:3.21" \
+        --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+        '{source_ref:$source_ref,sync_image:$sync_image,digest:$digest,status:"synced",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ ! -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "drift" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest')" = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
+}
+
+@test "sync-manifest: failed docker.io record emits error without probe" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-failed/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "docker.io/library/alpine:3.21" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-failed.jsonl"
+    jq -cn \
+        --arg source_ref "docker.io/library/alpine:3.21" \
+        --arg sync_image "ghcr.io/oorabona/library/alpine:3.21" \
+        '{source_ref:$source_ref,sync_image:$sync_image,digest:"",status:"failed",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-failed"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ ! -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
+    [[ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" == *"base not synced this cycle"* ]]
+}
+
+@test "sync-manifest: absent docker.io record emits error without probe" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-absent/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "alpine:3.21" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-absent.jsonl"
+    jq -cn \
+        '{source_ref:"docker.io/library/debian:trixie",sync_image:"ghcr.io/oorabona/library/debian:trixie",digest:"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",status:"synced",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-absent"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ ! -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
+    [[ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" == *"base not synced this cycle"* ]]
+}
+
+@test "sync-manifest: failed ghcr mirror record emits error without probe" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-ghcr-mirror-failed/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "ghcr.io/owner/library/alpine:3.21" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-ghcr-mirror-failed.jsonl"
+    jq -cn \
+        --arg source_ref "docker.io/library/alpine:3.21" \
+        --arg sync_image "ghcr.io/owner/library/alpine:3.21" \
+        '{source_ref:$source_ref,sync_image:$sync_image,digest:"",status:"failed",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-ghcr-mirror-failed"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ ! -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" = "GHCR mirror not synced this cycle (sync failed/digestless); drift unknown, re-checked next sync" ]
+}
+
+@test "sync-manifest: synced ghcr mirror record uses recorded digest without probe" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-ghcr-mirror-hit/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "ghcr.io/owner/library/alpine:3.21" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-ghcr-mirror-hit.jsonl"
+    jq -cn \
+        --arg source_ref "docker.io/library/alpine:3.21" \
+        --arg sync_image "ghcr.io/owner/library/alpine:3.21" \
+        --arg digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+        '{source_ref:$source_ref,sync_image:$sync_image,digest:$digest,status:"synced",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-ghcr-mirror-hit"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ ! -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "drift" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest')" = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
+}
+
+@test "sync-manifest: absent project ghcr record keeps live probe path" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-ghcr-project-absent/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "ghcr.io/owner/debian:trixie" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-ghcr-project-absent.jsonl"
+    jq -cn \
+        '{source_ref:"docker.io/library/alpine:3.21",sync_image:"ghcr.io/owner/library/alpine:3.21",digest:"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",status:"synced",synced_at:"2026-06-16T00:00:00Z"}' \
+        > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-ghcr-project-absent"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "drift" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest')" = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ]
+}
+
+@test "sync-manifest: ghcr.io base keeps live probe path when manifest is set" {
+    local lineage_dir="$TEST_TEMP_DIR/syncmanifest-ghcr/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    jq -cn \
+        --arg container "myimage" \
+        --arg tag "1.0" \
+        --arg base_ref "ghcr.io/oorabona/debian:trixie" \
+        --arg recorded "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        '{"lineage_schema_version":2,"container":$container,"tag":$tag,"base_image_ref":$base_ref,"base_image_digest":$recorded}' \
+        > "$lineage_dir/myimage-1.0.json"
+
+    local manifest_file="$TEST_TEMP_DIR/base-sync-manifest-ghcr.jsonl"
+    : > "$manifest_file"
+
+    local marker="$TEST_TEMP_DIR/probe-called-ghcr"
+    local probe_stub
+    probe_stub=$(_make_probe_sentinel_stub "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="myimage" \
+        _DEPGRAPH_LINEAGE_DIR="$lineage_dir" \
+        _ACTIVE_TAGS_OVERRIDE_myimage="1.0" \
+        SYNC_MANIFEST_FILE="$manifest_file" \
+        PROBE_SENTINEL="$marker" \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ -f "$marker" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "drift" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest')" = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -3345,6 +3634,8 @@ STUBEOF
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
 
     # A container with an internal-looking ref so _depgraph_get_deps must be called
     cat > "$fake_root/.build-lineage/myapp-1.0.json" <<'EOF'
@@ -3421,6 +3712,8 @@ STUB
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
 
     # Patch dependency-graph.sh: _depgraph_get_deps fails for "failcontainer",
     # succeeds (returns empty deps = leaf) for any other container.


### PR DESCRIPTION
## What

Make the daily base-image **sync** the only job in `upstream-monitor.yaml` that contacts Docker Hub.

## Why

`detect-digest-drift` (plus its two re-detect jobs `open-drift-prs-leaves` / `open-drift-prs-consumers`) and `bump-buildkit-digest` each re-queried Docker Hub for digests the daily **blind** sync had already pulled — multiplying Docker Hub requests, and the intermittent `429`s, per monitor run.

## How

- The sync records, per base image, the upstream digest it copied (read from a **GHCR** probe — free, no Docker Hub), plus a `synced`/`failed` status and timestamp, into a `base-sync-manifest-<run_id>` artifact.
- The drift detector, its two re-detect jobs, and the buildkit-digest check read that manifest instead of probing Docker Hub.
- **Fail-closed:** a base whose sync failed/absent this cycle is reported as an explicit `error` status (re-checked next sync) — never a silent "no drift". This also covers GHCR **mirror** refs (`ghcr.io/<owner>/library/<name>` produced via `REMOTE_CR`): a failed mirror sync now fails closed instead of trusting the stale GHCR copy. Project-internal GHCR images (not in the manifest) keep their existing live GHCR probe.
- Docker Hub login is removed from the three drift jobs; only the sync still authenticates to Docker Hub.
- The source-ref canonicalization is shared between the sync writer and the drift consumer so both derive the exact same Docker Hub key. The daily sync stays a blind copy (`skip_present=false`) so a `synced` manifest digest means GHCR == upstream.

## Verification

- `bats tests/unit/detect-base-digest-drift.bats tests/unit/base-cache-utils.bats` → **175 passed, 0 failed**, including new cases: docker.io-origin and GHCR-mirror refs use the manifest with no Docker Hub probe; a `failed`/absent record yields `error` (not `unchanged`); a project-internal GHCR ref still uses the live probe.
- Blind-sync invariant (`skip_present=false`) preserved (existing `BCU-PRESGATE-*` tests green).

Closes #759.
