### PR TITLE
fix(ci): keep bake-hcl tests green after the timescaledb 2.28.0 bump

### DIFF
--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -55,7 +55,7 @@ _make_timescaledb_lineage_root() {
     local pg
     for pg in 18 17 16; do
         jq -nc --arg pg "$pg" \
-            '{ext:"timescaledb", pg_major:$pg, ceiling:"2.27.2", resolved:["2.27.2"], available:["2.27.2"], excluded:[]}' \
+            '{ext:"timescaledb", pg_major:$pg, ceiling:"2.28.0", resolved:["2.28.0"], available:["2.28.0"], excluded:[]}' \
             > "${lineage_root}/.build-lineage/ext-timescaledb-pg${pg}-versionset.json"
     done
 }
@@ -622,7 +622,7 @@ YAML
 
     grep -Fxq 'FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2 AS ext-pgvector' <<< "$vector_inline"
     grep -Fxq 'COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/' <<< "$vector_inline"
-    grep -Fxq 'FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.27.2 AS ext-timescaledb' <<< "$timeseries_inline"
+    grep -Fxq 'FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.28.0 AS ext-timescaledb' <<< "$timeseries_inline"
 }
 
 @test "GBH-25e: postgres bake VERSION build arg carries base_suffix (matches the non-bake base image)" {


### PR DESCRIPTION
## What
`generate-bake-hcl.bats` hardcoded timescaledb **2.27.2** in its lineage fixture (`_make_timescaledb_lineage_root`) and one `FROM` assertion. #754 (merged today) bumped timescaledb to **2.28.0** in `postgres/extensions/config.yaml` + `timescaledb-version-set.json`.

## Why it broke
The generator is fail-closed by design: when a versionset's single available version does not equal the configured ceiling, it refuses to emit (it cannot know the ceiling image was built). The stale 2.27.2 fixture vs the 2.28.0 ceiling made `generate-bake-hcl.sh --include-final-build postgres` exit non-zero, turning the **unit-tests** job red on master (GBH-25b/25c/25e) and blocking all PRs.

## Fix
Test-only: bump the fixture and the FROM assertion to 2.28.0. pgvector (0.8.2) unchanged.

## Verification
`bats tests/unit/generate-bake-hcl.bats` → **75 passed, 0 failed** (was 3 failing).