### PR TITLE
fix(ci): only probe the GHCR base cache for distros that use it

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -405,7 +405,11 @@ runs:
         # GHCR cache images may not exist there — fall back to Docker Hub defaults.
         if [[ "${{ inputs.use_base_cache }}" == "true" ]]; then
           source ./helpers/base-cache-utils.sh
-          if has_base_cache "./$container"; then
+          if ! distro_uses_base_cache "./$container/config.yaml" "$flavor"; then
+            echo "::notice::Skipping GHCR base cache probe for $container distro '$flavor' because distros.$flavor.use_base_cache is false"
+          elif [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+            echo "::notice::Skipping GHCR base cache probe on Windows runner"
+          elif has_base_cache "./$container"; then
               # Probe every base_image_cache entry individually for GHCR accessibility.
               # Only reachable entries contribute to the final build args.
               #

--- a/github-runner/config.yaml
+++ b/github-runner/config.yaml
@@ -59,6 +59,8 @@ distros:
       amd64: x64
       arm64: arm64
   debian-trixie:
+    # Already GHCR, so the GHCR base-cache mirror is not used.
+    use_base_cache: false
     base_image: "ghcr.io/oorabona/debian:trixie"
     base_image_arg: DEBIAN_TRIXIE_BASE
     pkg_manager: apt
@@ -70,6 +72,8 @@ distros:
       amd64: x64
       arm64: arm64
   windows-ltsc2022:
+    # MCR Windows base requires EULA flow and is not GHCR-cacheable.
+    use_base_cache: false
     base_image: "mcr.microsoft.com/windows/servercore:ltsc2022"
     pkg_manager: none # chocolatey / direct download
     runner_user: runneradmin

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -196,6 +196,19 @@ has_base_cache() {
         yq -e '.base_image_cache | length > 0' "$config_file" &>/dev/null
 }
 
+# distro_uses_base_cache <config_file> <distro>
+# True (default) unless the distro entry explicitly sets use_base_cache: false.
+# Containers with no distros block, or an empty/unknown distro, default to true.
+distro_uses_base_cache() {
+    local config_file="$1" distro="$2"
+    [[ -z "$distro" ]] && return 0
+
+    local val
+    val=$(yq -r ".distros.\"${distro}\".use_base_cache" "$config_file" 2>/dev/null || echo "true")
+    [[ -z "$val" || "$val" == "null" ]] && val="true"
+    [[ "$val" != "false" ]]
+}
+
 # Collect all cache images across all containers, deduplicated
 # Usage: collect_all_cache_images <containers_json> <versions_json> <owner>
 #   containers_json: JSON array of container names, e.g. '["ansible","postgres"]'
@@ -758,4 +771,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr
+export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -4,6 +4,7 @@
 # Covers: resolve_cache_check_tag  — tag resolution for GHCR accessibility checks
 #         emit_reachable_cache_args — --build-arg emission (sole validated emitter)
 #         remote_cr_applicable      — REMOTE_CR applicability decision (pure function)
+#         distro_uses_base_cache    — distro-level base-cache opt-out
 #         collect_all_cache_images / _collect_entry_tags — image dest path for old and new styles
 
 setup() {
@@ -22,6 +23,52 @@ teardown() {
     unset SYNC_MANIFEST_OUT
     cd "$ORIG_DIR" || true
     rm -rf "$TEST_DIR"
+}
+
+# --- distro_uses_base_cache ---
+
+@test "BCU-DISTRO-01: distro_uses_base_cache returns false for explicit opt-out" {
+    cat > config.yaml <<'EOF'
+distros:
+  debian:
+    use_base_cache: false
+EOF
+
+    run distro_uses_base_cache "config.yaml" "debian"
+    [ "$status" -eq 1 ]
+}
+
+@test "BCU-DISTRO-02: distro_uses_base_cache returns true when key is absent" {
+    cat > config.yaml <<'EOF'
+distros:
+  alpine:
+    base_image: "alpine:3.21"
+EOF
+
+    run distro_uses_base_cache "config.yaml" "alpine"
+    [ "$status" -eq 0 ]
+}
+
+@test "BCU-DISTRO-03: distro_uses_base_cache returns true without distros block" {
+    cat > config.yaml <<'EOF'
+base_image_cache:
+  - source: library/alpine
+    tags: ["3.21"]
+EOF
+
+    run distro_uses_base_cache "config.yaml" "alpine"
+    [ "$status" -eq 0 ]
+}
+
+@test "BCU-DISTRO-04: distro_uses_base_cache returns true for empty distro arg" {
+    cat > config.yaml <<'EOF'
+distros:
+  debian:
+    use_base_cache: false
+EOF
+
+    run distro_uses_base_cache "config.yaml" ""
+    [ "$status" -eq 0 ]
 }
 
 # --- resolve_cache_check_tag ---

--- a/web-shell/config.yaml
+++ b/web-shell/config.yaml
@@ -43,6 +43,8 @@ base_image_cache:
 # Each distro declares its base image, package manager, user setup, and package groups
 distros:
   debian:
+    # Already GHCR, so the GHCR base-cache mirror is not used.
+    use_base_cache: false
     base_image: "ghcr.io/oorabona/debian:${DEBIAN_TAG}"
     pkg_manager: apt
     install_cmd: "apt-get update && apt-get install -y --no-install-recommends"


### PR DESCRIPTION
## What

Make the GHCR base-cache egress-containment probe **variant-aware**: probe only the base(s) a building distro actually uses.

## Why

The probe ran for **every** distro of a container whenever `config.yaml` declared a `base_image_cache`, even distros that build from a non-cached base:
- `github-runner` / `windows-ltsc2022` → `mcr.microsoft.com/windows/...` (EULA, not GHCR-cacheable)
- `github-runner` / `debian-trixie` → `ghcr.io/oorabona/debian:trixie` (already GHCR)
- `web-shell` / `debian` → `ghcr.io/oorabona/debian:${DEBIAN_TAG}` (already GHCR)

These were probed against an upstream mirror (ubuntu / alpine / rocky) they never use. For the windows build that could even **hard-fail** the job when the mirror was momentarily unseeded — failing a build for a base it does not consume.

## How

- New helper `distro_uses_base_cache <config> <distro>` in `helpers/base-cache-utils.sh` — returns true by default, false only when the distro entry sets `use_base_cache: false`. Containers with no `distros:` block, or an empty/unknown distro, default to true.
- The probe block in `.github/actions/build-container/action.yaml` now skips when the building distro (`flavor`) opts out (a Windows-runner skip is kept as a secondary guard).
- `use_base_cache: false` declared on `github-runner` `debian-trixie` + `windows-ltsc2022` and `web-shell` `debian`.

The 10 single-distro containers (ansible, postgres, terraform, …) are unaffected — the `// true` default keeps their probe running exactly as before.

## Verification

- `bats tests/unit/base-cache-utils.bats` → **63 passed, 0 failed** (4 new cases: opt-out distro → false; distro without the key → true; no `distros:` block → true; empty distro → true).
- `yq` parse OK on the edited action + both config.yaml files.

Closes #760.
