### PR TITLE
fix(ci): retry the GHCR login inside the docker-login composite

### DIFF
--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -24,11 +24,29 @@ runs:
   using: composite
   steps:
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-      with:
-        registry: ghcr.io
-        username: ${{ inputs.ghcr_username }}
-        password: ${{ inputs.ghcr_password }}
+      shell: bash
+      env:
+        GHCR_USER: ${{ inputs.ghcr_username }}
+        GHCR_TOKEN: ${{ inputs.ghcr_password }}
+      run: |
+        # Retry the GHCR login: docker/login-action has no built-in retry, and a
+        # transient runner DNS/registry blip at login otherwise fails every build
+        # job (this composite is on the critical path). Mirrors the
+        # retry_with_backoff idiom used for the standalone GHCR logins (#736).
+        # GITHUB_ACTION_PATH is .github/actions/docker-login; ../../../ reaches the
+        # repo root where helpers/ lives (same anchor as the retry-run composite).
+        # NOTE: docker/login-action ran a post-job `docker logout`; a composite
+        # action has no post: hook, so this run: step cannot. Acceptable here:
+        # every caller runs on ephemeral GitHub-hosted runners, where the docker
+        # config is discarded with the VM. Revisit if ever run on a self-hosted /
+        # persistent runner.
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/logging.sh"
+        source "${GITHUB_ACTION_PATH}/../../../helpers/retry.sh"
+        ghcr_login() {
+          printf '%s\n' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+        }
+        retry_with_backoff 3 5 ghcr_login
 
     - name: Log in to Docker Hub
       if: inputs.dockerhub_username != '' && inputs.dockerhub_token != ''


### PR DESCRIPTION
## What

Make the GHCR login in the shared `.github/actions/docker-login` composite **retry** on transient runner network blips.

## Why

The composite logged in to GHCR via `docker/login-action`, which has no retry. A transient runner DNS/registry blip at login failed the whole build job — and this composite is on the critical path of every build. A composite step can't wrap per-step retry around a `uses:` action (that's why #736 only fixed the standalone logins).

## How

Replace the GHCR step with a `run:` step that wraps `docker login ghcr.io --password-stdin` in `retry_with_backoff 3 5` (3 attempts, exponential backoff), mirroring the standalone GHCR logins landed in #736. `helpers/` is sourced via `GITHUB_ACTION_PATH` (the same anchor the `retry-run` composite already uses). The token stays in `env:`, never on the command line. No call-site changes (11 callers across 4 workflows keep the same inputs/outputs).

## Trade-off (documented in-action)

`docker/login-action` ran a post-job `docker logout`; a composite action has no `post:` hook, so a `run:` step cannot. This is acceptable here because **every caller runs on ephemeral GitHub-hosted runners** (`ubuntu-latest` / `ubuntu-24.04-arm` / `windows-latest`), where the docker config is discarded with the VM — there is no persistent host for a leftover credential to linger on. A comment in the action flags this to revisit if the composite is ever used on a self-hosted/persistent runner.

## Verification

- `actionlint` + `shellcheck` validate the new composite step (the `run:` block carries `# shellcheck disable=SC1091` for the dynamic `source`).
- `retry_with_backoff` itself is covered by `tests/unit/build-retry.bats`.

Closes #737.
