### PR TITLE
docs(site): dashboard a11y + accurate hero status

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -1,5 +1,7 @@
 <!-- Container row card — details/summary expand pattern (D1 refactor) -->
 {%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
+{%- assign default_variant_tag = default_variant.tag | default: include.current_version | default: "latest" -%}
+{%- capture default_image_ref -%}{{ include.name }}:{{ default_variant_tag }}{%- endcapture -%}
 <details class="container-card glass status-{{ include.status_color | default: 'secondary' }}"
          data-container="{{ include.name }}"
          data-github-username="{{ include.github_username }}"
@@ -14,7 +16,7 @@
 
     <!-- Name + version -->
     <div class="row-id">
-      <div class="row-id-name">{{ include.name }}</div>
+      <h3 class="row-id-name">{{ include.name }}</h3>
       <div class="row-id-version{% if include.status_color == 'warning' %} warn{% endif %}">{{ include.current_version | default: default_variant.tag | default: 'unknown' }}</div>
     </div>
 
@@ -30,8 +32,10 @@
          {% if default_variant.attestation_url and default_variant.attestation_id %}
            href="{{ default_variant.attestation_url }}"
            title="View Sigstore attestation for this image's SBOM"
+           aria-label="View SBOM attestation for {{ default_image_ref | escape }}"
          {% else %}
            title="SBOM attestation not yet generated. Will populate on next successful build with cosign attestation."
+           aria-label="SBOM attestation pending for {{ default_image_ref | escape }}"
          {% endif %}
          rel="noopener"
          >{% if default_variant.attestation_url and default_variant.attestation_id %}📋 SBOM{% else %}📋 SBOM{% endif %}</a>
@@ -81,6 +85,7 @@
            data-trust="multi-arch"
            href="https://github.com/{{ include.github_username }}/docker-containers/pkgs/container/{{ include.name }}"
            rel="noopener"
+           aria-label="Multi-arch manifest for {{ default_image_ref | escape }}: {{ default_variant.multi_arch_platforms | join: ', ' | escape }}"
            title="View this image's multi-arch manifest on GHCR">🏗 ×{{ default_variant.multi_arch_platforms | size }}</a>
       {%- else -%}
         <!-- aria-hidden hides the anchor from the AT tree while it carries display:none (WCAG 4.1.2). trust-strip.js removes the attribute on the show path. href matches the visible-branch destination so a future variant change reveals a working link. -->
@@ -105,7 +110,7 @@
     <!-- About -->
     {% if include.description %}
     <section>
-      <h3>About</h3>
+      <h4>About</h4>
       <p class="card-description">{{ include.description }}</p>
     </section>
     {% endif %}
@@ -113,7 +118,7 @@
     <!-- Pull command -->
     {% if include.ghcr_image and include.dockerhub_image %}
     <section>
-      <h3>Pull command</h3>
+      <h4>Pull command</h4>
       <div class="pull-section"
            data-ghcr-base="ghcr.io/{{ include.github_username }}/{{ include.name }}"
            data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"
@@ -161,6 +166,10 @@
                 {%- endcomment -%}
                 {%- assign synthetic = false -%}
                 {%- if variant.name == "" or variant.name == nil -%}{%- assign synthetic = true -%}{%- endif -%}
+                {%- assign variant_label = variant.name -%}
+                {%- if variant_label == "" or variant_label == nil -%}
+                  {%- assign variant_label = variant.tag | default: version.base_tag | default: version.tag -%}
+                {%- endif -%}
                 <span class="variant-tag{% if forloop.first and forloop.parentloop.first %} selected{% endif %}"
                       {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
                       title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
@@ -174,8 +183,8 @@
                       role="button"
                       tabindex="0"
                       aria-pressed="{% if forloop.first and forloop.parentloop.first %}true{% else %}false{% endif %}"
-                      aria-label="Select variant {{ variant.name }}{% if variant.is_default %} (default){% endif %}">
-                  :{{ variant.name }}
+                      aria-label="Select variant {{ variant_label | escape }}{% if variant.is_default %} (default){% endif %}">
+                  :{{ variant_label }}
                   {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
                 </span>
               {% endfor %}
@@ -186,6 +195,7 @@
           <!-- Single-version structure -->
           <div class="variant-tags">
             {% for variant in include.variants %}
+              {%- assign variant_label = variant.tag | default: variant.name -%}
               <span class="variant-tag{% if forloop.first %} selected{% endif %}"
                     title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
                     data-tag="{{ variant.tag }}"
@@ -198,8 +208,8 @@
                     role="button"
                     tabindex="0"
                     aria-pressed="{% if forloop.first %}true{% else %}false{% endif %}"
-                    aria-label="Select variant {{ variant.tag }}{% if variant.is_default %} (default){% endif %}">
-                :{{ variant.tag }}
+                    aria-label="Select variant {{ variant_label | escape }}{% if variant.is_default %} (default){% endif %}">
+                :{{ variant_label }}
                 {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
               </span>
             {% endfor %}

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -39,22 +39,27 @@
     {%- assign total = s.total_containers | default: 0 -%}
     {%- assign updates = s.updates_available | default: 0 -%}
     {%- assign success_rate = s.build_success_rate | default: 100 -%}
-    {%- if success_rate < 80 -%}
-      {%- assign health_status = "err" -%}
-      {%- assign health_label = "Build failures detected" -%}
-      {%- assign health_icon = "ti-circle-x" -%}
-    {%- elsif success_rate < 95 -%}
+    {%- assign stats_updated = s.last_updated | default: "unknown" -%}
+    {%- assign current_issue_count = 0 -%}
+    {%- for container in site.data.containers -%}
+      {%- unless container.status_color == "green" -%}
+        {%- assign current_issue_count = current_issue_count | plus: 1 -%}
+      {%- endunless -%}
+    {%- endfor -%}
+    {%- if current_issue_count > 0 -%}
       {%- assign health_status = "warn" -%}
-      {%- assign health_label = "Build attention needed" -%}
-      {%- assign health_icon = "ti-alert-triangle" -%}
-    {%- elsif updates > 0 -%}
-      {%- assign health_status = "info" -%}
-      {%- if updates == 1 -%}
-        {%- assign health_label = "1 update available" -%}
+      {%- if updates > 0 and updates == current_issue_count -%}
+        {%- if updates == 1 -%}
+          {%- assign health_label = "1 update available" -%}
+        {%- else -%}
+          {%- assign health_label = updates | append: " updates available" -%}
+        {%- endif -%}
+      {%- elsif current_issue_count == 1 -%}
+        {%- assign health_label = "1 container needs attention" -%}
       {%- else -%}
-        {%- assign health_label = updates | append: " updates available" -%}
+        {%- assign health_label = current_issue_count | append: " containers need attention" -%}
       {%- endif -%}
-      {%- assign health_icon = "ti-arrow-up-circle" -%}
+      {%- assign health_icon = "ti-alert-triangle" -%}
     {%- else -%}
       {%- assign health_status = "ok" -%}
       {%- assign health_label = "All systems green" -%}
@@ -62,10 +67,16 @@
     {%- endif -%}
 
     <section class="dashboard-hero" aria-labelledby="dashboard-hero-title">
-      <span class="status-pill status-pill-{{ health_status }}">
-        <i class="ti {{ health_icon }}" aria-hidden="true"></i>
-        {{ health_label }}
-      </span>
+      <div class="dashboard-hero-status">
+        <span class="status-pill status-pill-{{ health_status }}">
+          <i class="ti {{ health_icon }}" aria-hidden="true"></i>
+          {{ health_label }}
+        </span>
+        <span class="dashboard-hero-build-stat">
+          Build success: {{ success_rate }}%
+          <span class="dashboard-hero-freshness">Updated {{ stats_updated }}</span>
+        </span>
+      </div>
       <h1 id="dashboard-hero-title" class="dashboard-hero-title">
         Open-source Docker images,<br>
         <span class="dashboard-hero-accent">built and signed every day.</span>

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -458,7 +458,12 @@
 
     /* Name + version column */
     .row-id { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
-    .row-id-name { font-size: 0.95rem; font-weight: 600; }
+    .row-id-name {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin: 0;
+      line-height: 1.2;
+    }
     .row-id-version {
       font-family: var(--font-family-mono);
       font-size: 0.72rem;
@@ -514,7 +519,7 @@
 
     .row-body section { min-width: 0; }
 
-    .row-body section h3 {
+    .row-body section h4 {
       font-family: var(--font-family-mono);
       font-size: 0.7rem;
       text-transform: uppercase;
@@ -1010,6 +1015,30 @@
       margin: 3rem auto 2rem;
       padding: 0 1.25rem;
       text-align: center;
+    }
+
+    .dashboard-hero-status {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.5rem 0.75rem;
+    }
+
+    .dashboard-hero-build-stat {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      color: var(--color-text-secondary);
+      font-size: 0.78rem;
+      font-weight: 500;
+    }
+
+    .dashboard-hero-freshness {
+      color: var(--color-text-muted);
+      font-size: 0.72rem;
     }
 
     .dashboard-hero-title {

--- a/docs/site/assets/js/components/trust-strip.js
+++ b/docs/site/assets/js/components/trust-strip.js
@@ -28,18 +28,29 @@
 
     _update(variant) {
       if (!variant) return;
-      this._updateSbom(variant.attestation_url, variant.attestation_id);
+      this._updateSbom(variant);
       this._updateTrivy(variant.trivy_summary);
       this._updateMultiArch(variant.multi_arch_platforms);
     }
 
-    _updateSbom(url, id) {
+    _imageRef(tag) {
+      const card = this.closest('.container-card');
+      const name = card && card.dataset ? card.dataset.container : '';
+      if (name && tag) return name + ':' + tag;
+      return tag || 'this image';
+    }
+
+    _updateSbom(variant) {
       const el = this.querySelector('[data-trust="sbom"]');
       if (!el) return;
+      const url = variant.attestation_url;
+      const id = variant.attestation_id;
+      const imageRef = this._imageRef(variant.tag);
       const isCardSurface = !!this.closest('.container-card');
       if (url && id) {
         el.setAttribute('href', url);
         el.title = "View Sigstore attestation for this image's SBOM";
+        el.setAttribute('aria-label', 'View SBOM attestation for ' + imageRef);
         el.style.display = '';
         el.classList.remove('is-pending');
         el.textContent = isCardSurface ? '📋 SBOM' : '📋 SBOM ATTESTED';
@@ -48,6 +59,7 @@
         el.removeAttribute('href');
         el.classList.add('is-pending');
         el.title = 'SBOM attestation not yet generated. Will populate on next successful build with cosign attestation.';
+        el.setAttribute('aria-label', 'SBOM attestation pending for ' + imageRef);
         el.textContent = isCardSurface ? '📋 SBOM' : '📋 SBOM PENDING';
       }
     }


### PR DESCRIPTION
## What

Dashboard a11y + accurate hero status — the "should-fix" follow-ups from the browser audit in #767.

## Fixes

1. **Hero status pill now reflects current container health.** It was driven by the cumulative
   historical `build_success_rate` (`< 95` → "Build attention needed"), so a single past failure kept
   a permanent warning while every container was green. The pill is now computed from the current
   per-container status (`site.data.containers`, all-green → "All systems green"); the success rate is
   kept as an informational sub-stat with an "Updated …" freshness label.
2. **Variant buttons get a meaningful `aria-label`** (and visible label) for every container via a
   name → tag fallback — 21/79 buttons previously rendered `aria-label="Select variant "` (empty).
3. **SBOM and multi-arch trust badges get descriptive `aria-label`s** (static in the template, and
   kept current on variant change in `trust-strip.js`) — they previously exposed only the raw emoji.
4. **Container name is now an `<h3>` heading** (inner "About"/"Pull command" demoted to `<h4>`) so
   heading-navigation names each container; `dashboard.css` updated (`.row-body section h3`→`h4`,
   `.row-id-name` margin/line-height) to preserve the visual layout.

## Verification

Built the site locally with the repo's own `jekyll` container
(`docker run -v <docs/site>:/site ghcr.io/oorabona/jekyll build`) — **build succeeds**, and the
generated HTML confirms: 0 empty variant aria-labels (was 21), SBOM/multi-arch aria-labels populated
with the image ref, `<h3 class="row-id-name">` per container, and the hero pill renders
`status-pill-ok "All systems green"` even with a 90% historical rate (proving the pill is now driven
by current container health, not the rate). The 2 Liquid warnings in the build are pre-existing blog
posts, not these templates.

Part of #767 (leaves the optional polish items — blog permalinks, >1 GB image callout).
