### PR TITLE
docs(site): close out dashboard polish (token, ext freshness, blog URLs, >1GB callout)

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -4,6 +4,7 @@ description: >-
   version classification, and CI/CD pipelines.
 baseurl: "/docker-containers"
 url: "https://oorabona.github.io"
+permalink: /blog/:slug/
 
 # Collections
 collections:

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -1,6 +1,17 @@
 <!-- Container row card — details/summary expand pattern (D1 refactor) -->
 {%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
 {%- assign default_variant_tag = default_variant.tag | default: include.current_version | default: "latest" -%}
+{%- assign size_amd64_label = include.size_amd64 | default: "—" -%}
+{%- assign size_amd64_raw = include.size_amd64 | default: "" | strip -%}
+{%- assign size_amd64_compact = size_amd64_raw | remove: " " | downcase -%}
+{%- assign size_amd64_large = false -%}
+{%- if size_amd64_compact contains "gb" -%}
+  {%- assign size_amd64_value = size_amd64_compact | remove: "gb" | plus: 0 -%}
+  {%- if size_amd64_value > 0 -%}{%- assign size_amd64_large = true -%}{%- endif -%}
+{%- elsif size_amd64_compact contains "mb" -%}
+  {%- assign size_amd64_value = size_amd64_compact | remove: "mb" | plus: 0 -%}
+  {%- if size_amd64_value > 1024 -%}{%- assign size_amd64_large = true -%}{%- endif -%}
+{%- endif -%}
 {%- capture default_image_ref -%}{{ include.name }}:{{ default_variant_tag }}{%- endcapture -%}
 <details class="container-card glass status-{{ include.status_color | default: 'secondary' }}"
          data-container="{{ include.name }}"
@@ -96,7 +107,7 @@
     <!-- Pull count + size stats -->
     <div class="row-stats">
       <span><i class="ti ti-download" aria-hidden="true"></i>{{ include.pull_count_formatted | default: "—" }}</span>
-      <span><i class="ti ti-cube" aria-hidden="true"></i><span data-meta="size-amd64">{{ include.size_amd64 | default: "—" }}</span></span>
+      <span><i class="ti ti-cube" aria-hidden="true"></i><span data-meta="size-amd64"{% if size_amd64_large %} class="image-size--large" title="Large image (>1 GB)" aria-label="Image size {{ size_amd64_label | escape }}. Large image (>1 GB)"{% endif %}>{{ size_amd64_label }}{% if size_amd64_large %}<span class="sr-only"> Large image (>1 GB)</span>{% endif %}</span></span>
     </div>
 
     <!-- Spacer + toggle chevron -->

--- a/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
+++ b/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
@@ -6,7 +6,7 @@ date: 2026-05-04 10:00:00 +0000
 tags: [openvpn, docker, security, alpine, networking, pkcs11]
 ---
 
-The [sslh post](/docker-containers/2026/04/24/sslh-docker-port-multiplexing.html) showed how to multiplex OpenVPN on port 443 alongside SSH and HTTPS. This post is the companion: the OpenVPN server itself, in a 15 MB hardened container.
+The [sslh post]({{ '/blog/sslh-docker-port-multiplexing/' | relative_url }}) showed how to multiplex OpenVPN on port 443 alongside SSH and HTTPS. This post is the companion: the OpenVPN server itself, in a 15 MB hardened container.
 
 Running OpenVPN in Docker is [famously easy to get wrong](https://github.com/kylemanna/docker-openvpn/issues). The default answer is `--privileged` because the daemon needs to create a `tun` device. The better answer is: `cap_drop: ALL` + `cap_add: NET_ADMIN` and let the kernel mediate exactly what OpenVPN can do.
 
@@ -129,7 +129,7 @@ Expose nothing to the outside; query from sidecar containers or host scripts:
 echo -e "status\nquit" | nc 127.0.0.1 7505
 ```
 
-Pipe to Prometheus via an exporter, alert on drops. The Vector container ([post](/docker-containers/2026/05/06/vendor-free-observability-vector-postgres.html)) handles this use case well.
+Pipe to Prometheus via an exporter, alert on drops. The Vector container ([post]({{ '/blog/vendor-free-observability-vector-postgres/' | relative_url }})) handles this use case well.
 
 ## Gotchas
 
@@ -162,6 +162,6 @@ docker compose up -d
 
 Full config reference and client examples at the [container dashboard](/docker-containers/container/openvpn/).
 
-Paired with [sslh](/docker-containers/2026/04/24/sslh-docker-port-multiplexing.html), you get OpenVPN on port 443 alongside SSH and HTTPS on the same IP. Works through almost every hotel Wi-Fi.
+Paired with [sslh]({{ '/blog/sslh-docker-port-multiplexing/' | relative_url }}), you get OpenVPN on port 443 alongside SSH and HTTPS on the same IP. Works through almost every hotel Wi-Fi.
 
 [⭐ Star on GitHub](https://github.com/oorabona/docker-containers) if the hardening recipe helped.

--- a/docs/site/_posts/2026-05-06-vendor-free-observability-vector-postgres.md
+++ b/docs/site/_posts/2026-05-06-vendor-free-observability-vector-postgres.md
@@ -52,7 +52,7 @@ docker pull ghcr.io/oorabona/vector:latest-alpine
 - **Multi-arch** (amd64, arm64)
 - **Non-root** (uid 1000)
 - **HEALTHCHECK** via Vector's `/health` endpoint
-- Auto-tracked from [vectordotdev/vector](https://github.com/vectordotdev/vector) releases (with a regex that correctly ignores their `vdev-v*` CLI subproject releases — story [here](/docker-containers/2026/04/24/sslh-docker-port-multiplexing.html))
+- Auto-tracked from [vectordotdev/vector](https://github.com/vectordotdev/vector) releases (with a regex that correctly ignores their `vdev-v*` CLI subproject releases — story [here]({{ '/blog/sslh-docker-port-multiplexing/' | relative_url }}))
 
 ## A minimal config: Nginx logs to Postgres
 

--- a/docs/site/_posts/2026-06-04-multi-arch-is-a-distributed-systems-problem.md
+++ b/docs/site/_posts/2026-06-04-multi-arch-is-a-distributed-systems-problem.md
@@ -92,4 +92,4 @@ The real fix is the ownership rule. CI owns the canonical tags. Local builds —
 - **Keep local tooling out of canonical tags.** CI writes `:trixie`; laptops write `:trixie-dev` or an arch suffix, enforced by a push guard — not by remembering.
 - **Put an audit trail on your tags.** The only reason I could say "a laptop did this" instead of "somehow this happened" was one `runtime: Podman` line in a lineage record.
 
-None of this was an arm64 bug, the same way [the last one wasn't either](/docker-containers/2026/06/01/arm64-three-bugs-none-about-arm64.html). arm64 just reads the entry nobody else was reading.
+None of this was an arm64 bug, the same way [the last one wasn't either]({{ '/blog/arm64-three-bugs-none-about-arm64/' | relative_url }}). arm64 just reads the entry nobody else was reading.

--- a/docs/site/_posts/2026-06-06-the-dependency-graph-i-forgot-to-plug-in.md
+++ b/docs/site/_posts/2026-06-06-the-dependency-graph-i-forgot-to-plug-in.md
@@ -49,6 +49,6 @@ That closes the loud failure mode — a base change now rebuilds its consumers i
 - **In a monorepo of images that build on each other, the build graph is a graph.** Change detection that maps files to containers one-to-one is correct for leaves and wrong for everything with something on top of it. It has to walk the edges.
 - **Derive the edges, don't declare them.** A `FROM`-derived graph can't drift from reality. A hand-maintained `depends_on:` list can, and you won't notice until it silently skips a rebuild.
 - **Before you build infrastructure, grep for it.** I was about to write a reverse-dependency walker that already existed in my own repo, tested, used daily — for one of the two callers that needed it. The expensive part wasn't the graph. It was noticing I'd only plugged it in once.
-- **A base change that doesn't rebuild its consumers is a staleness bug on a delay fuse** — exactly the kind that surfaced when [a base quietly lost an architecture](/docker-containers/2026/06/04/multi-arch-is-a-distributed-systems-problem.html) and the consumers on top of it found out months later.
+- **A base change that doesn't rebuild its consumers is a staleness bug on a delay fuse** — exactly the kind that surfaced when [a base quietly lost an architecture]({{ '/blog/multi-arch-is-a-distributed-systems-problem/' | relative_url }}) and the consumers on top of it found out months later.
 
 The graph was the easy part. I'd done it. I'd just done it for the job that runs at 6 AM and not for the one that runs on every push.

--- a/docs/site/assets/css/blog.css
+++ b/docs/site/assets/css/blog.css
@@ -77,7 +77,7 @@
   font-size: 0.7rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--accent-green, var(--color-feedback-success-fg, #22c55e));
+  color: var(--color-feedback-success-fg, #22c55e);
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;

--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -350,7 +350,7 @@
     }
 
     .stat-icon.blue { background: linear-gradient(135deg, var(--accent-blue), var(--color-blue-400)); }
-    .stat-icon.green { background: linear-gradient(135deg, var(--accent-green), var(--color-green-400)); }
+    .stat-icon.green { background: linear-gradient(135deg, var(--color-green-500), var(--color-green-400)); }
     .stat-icon.yellow { background: linear-gradient(135deg, var(--accent-yellow), var(--color-amber-400)); }
     .stat-icon.purple { background: linear-gradient(135deg, var(--accent-purple), var(--color-violet-400)); }
 
@@ -493,6 +493,23 @@
       white-space: nowrap;
     }
     .row-stats span i { margin-right: 0.25rem; }
+    .row-stats [data-meta="size-amd64"] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .row-stats [data-meta="size-amd64"].image-size--large {
+      color: var(--color-feedback-warning-fg);
+    }
+    .row-stats [data-meta="size-amd64"].image-size--large::after {
+      content: '';
+      width: 0.38rem;
+      height: 0.38rem;
+      border-radius: 50%;
+      background: currentColor;
+      box-shadow: 0 0 0 2px var(--color-feedback-warning-bg);
+      flex: 0 0 auto;
+    }
 
     /* Spacer keeps chevron aligned to the rightmost column */
     .row-toggle-spacer { display: block; }

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -142,6 +142,37 @@
       });
     }
 
+    function isLargeImageSize(size) {
+      var match = String(size || '').trim().match(/^([0-9]+(?:\.[0-9]+)?)\s*(MB|GB)$/i);
+      if (!match) return false;
+
+      var value = parseFloat(match[1]);
+      var unit = match[2].toUpperCase();
+      if (!Number.isFinite(value) || value <= 0) return false;
+
+      return unit === 'GB' || (unit === 'MB' && value > 1024);
+    }
+
+    function setAmd64SizeMeta(element, size) {
+      var displaySize = size || '—';
+      element.textContent = displaySize;
+
+      var isLarge = isLargeImageSize(displaySize);
+      element.classList.toggle('image-size--large', isLarge);
+      if (isLarge) {
+        element.title = 'Large image (>1 GB)';
+        element.setAttribute('aria-label', 'Image size ' + displaySize + '. Large image (>1 GB)');
+
+        var sr = document.createElement('span');
+        sr.className = 'sr-only';
+        sr.textContent = ' Large image (>1 GB)';
+        element.appendChild(sr);
+      } else {
+        element.removeAttribute('title');
+        element.removeAttribute('aria-label');
+      }
+    }
+
     // Select a variant tag and update pull command + metadata
     function selectVariantTag(element) {
       var card = element.closest('.container-card');
@@ -191,7 +222,7 @@
 
       var sizeAmd64El = card.querySelector('[data-meta="size-amd64"]');
       var sizeArm64El = card.querySelector('[data-meta="size-arm64"]');
-      if (sizeAmd64El) sizeAmd64El.textContent = element.dataset.sizeAmd64 || '—';
+      if (sizeAmd64El) setAmd64SizeMeta(sizeAmd64El, element.dataset.sizeAmd64 || '—');
       if (sizeArm64El) sizeArm64El.textContent = element.dataset.sizeArm64 || '—';
 
       // Phase B: dispatch event for vanilla custom-element trust strip + Security Scan section

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -30,6 +30,7 @@ trap 'rm -f -- "$TRIVY_CACHE_FILE"' EXIT
 DATA_FILE="$SCRIPT_DIR/docs/site/_data/containers.yml"
 STATS_FILE="$SCRIPT_DIR/docs/site/_data/stats.yml"
 CONTAINERS_DIR="$SCRIPT_DIR/docs/site/_containers"
+DASHBOARD_BUILD_DATE="$(date -u +"%Y-%m-%d")"
 
 # --- Lineage resolution helpers ---
 
@@ -1129,12 +1130,24 @@ generate_container_page() {
 
     # Append README content (strip front matter if present)
     if [[ -f "$container/README.md" ]]; then
-        awk '
+        local extension_versions_note=""
+        if [[ "$container" == "postgres" ]]; then
+            extension_versions_note="_Extension versions as of the last dashboard build (${DASHBOARD_BUILD_DATE})._"
+        fi
+
+        awk -v note="$extension_versions_note" '
             BEGIN { in_fm = 0; fm_done = 0 }
             NR == 1 && /^---$/ { in_fm = 1; next }
             in_fm && /^---$/ { in_fm = 0; fm_done = 1; next }
             in_fm { next }
-            { print }
+            {
+                print
+                if (note != "" && !inserted && /^### Compiled Extensions[[:space:]]*$/) {
+                    print ""
+                    print note
+                    inserted = 1
+                }
+            }
         ' "$container/README.md" >> "$page_file"
     else
         echo "" >> "$page_file"


### PR DESCRIPTION
## What

Closes out the remaining docs-site polish across **#568** and **#767** — 4 small items.

## Changes

- **#568 — last deprecated token**: `dashboard.css` `.stat-icon.green` now uses `var(--color-green-500)` (paired with `--color-green-400`) instead of the deprecated `var(--accent-green)`; the `blog.css` fallback that referenced it is dropped. 0 `var(--accent-green)` usages remain under `docs/site/`. (#721 had migrated the two `.activity-icon.success` usages but missed these.)
- **#568 — extension-version freshness**: `generate-dashboard.sh` now emits `_Extension versions as of the last dashboard build (<date>)._` next to the postgres extension table, so the values can't silently look current between builds.
- **#767 — canonical blog permalinks**: posts now serve at `/blog/:slug/` (was the Jekyll default `/YYYY/MM/DD/slug.html`); old date-based cross-links inside 4 posts updated.
- **#767 — large-image callout**: images larger than 1 GB get a subtle dashboard callout (warning-tinted size + dot) with an accessible label, both in the static card and on variant change (`dashboard.js`); parsing tolerates `MB`/`GB` with or without a space and the `—`/empty case.

## Verification

Built the site locally with the repo's own `jekyll` container (`docker run -v <docs/site>:/site ghcr.io/oorabona/jekyll build`) — **build succeeds**, and the generated HTML confirms:
- blog posts now at `/blog/<slug>/index.html`;
- with a >1 GB size injected into a build copy, the card renders `class="image-size--large" title="Large image (>1 GB)"` (and correctly nothing for the all-<1 GB real data);
- `### Compiled Extensions` anchor exists in `postgres/README.md` (the generator injects the freshness note after it; verified separately via an isolated generator run);
- 0 `var(--accent-green)` left.
The 2 Liquid warnings in the build are pre-existing blog-post snippets, unrelated to this change.

Closes #568.
Closes #767.
