### PR TITLE
fix(tests): derive GBH-25b pgvector version from config (stop version drift)

### DIFF
--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -620,7 +620,15 @@ YAML
     base_ext_from_count=$(printf '%s\n' "$base_inline" | grep -cE '^FROM .*ext-' || true)
     [ "$base_ext_from_count" -eq 0 ]
 
-    grep -Fxq 'FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2 AS ext-pgvector' <<< "$vector_inline"
+    # pgvector has no test lineage fixture (unlike timescaledb below), so the
+    # generator resolves its version straight from the real
+    # postgres/extensions/config.yaml. Read it from that same source instead of
+    # hardcoding, so an upstream-monitor version bump can't drift this test out
+    # from under CI (#779 — broke when the bot bumped pgvector 0.8.2 -> 0.8.3).
+    local pgvector_ver
+    pgvector_ver=$(yq -r '.extensions.pgvector.version' "${PROJECT_ROOT}/postgres/extensions/config.yaml")
+    [ -n "$pgvector_ver" ]
+    grep -Fxq "FROM ghcr.io/oorabona/ext-pgvector:pg18-${pgvector_ver} AS ext-pgvector" <<< "$vector_inline"
     grep -Fxq 'COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/' <<< "$vector_inline"
     grep -Fxq 'FROM ghcr.io/oorabona/ext-timescaledb:pg18-2.28.0 AS ext-timescaledb' <<< "$timeseries_inline"
 }


### PR DESCRIPTION
## Root cause (it's drift, not a flake)

`GBH-25b` asserted the generated inline Dockerfile contained
`FROM ghcr.io/oorabona/ext-pgvector:pg18-0.8.2`. Unlike timescaledb — which the
test supplies via its own lineage fixture (`_make_timescaledb_lineage_root`) —
pgvector has **no** test fixture, so the generator resolves its version straight
from the real `postgres/extensions/config.yaml`.

When the upstream-monitor bot bumped pgvector `0.8.2 → 0.8.3` (#774), the test's
hardcoded `0.8.2` went stale. The apparent "flakiness" (pass on one run, fail on
another for the "same" SHA) was the **push vs pull_request ref difference**:

- `push` check → branch HEAD on its pre-bump base → config still `0.8.2` → pass.
- `pull_request` check → branch *merged with current master* (incl. #774) →
  config `0.8.3` → the `0.8.2` assertion fails.

Deterministic, not random. This is the same class as the timescaledb fixture
drift in #762.

## Fix

Read the pgvector version from the same `postgres/extensions/config.yaml` the
generator uses, instead of hardcoding it — so future bot bumps track
automatically. The assertion keeps its teeth: it still verifies the generator
propagates the *configured* version into the vector inline Dockerfile.

timescaledb is left hardcoded on purpose: its version comes from the test's own
lineage fixture, not from config, so config bumps can't drift it.

## Verified

`bats tests/unit/generate-bake-hcl.bats` — 75/75 pass against the current config
(pgvector 0.8.3), including GBH-25b.

Closes #779
