### PR TITLE
fix(openresty): ship perl for resty CLI + working wget healthcheck

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -230,13 +230,16 @@ ARG _RESTY_CONFIG_DEPS="--with-pcre \
     --with-ld-opt='-L/usr/local/openresty/pcre2/lib -L/usr/local/openresty/openssl/lib -Wl,-rpath,/usr/local/openresty/pcre2/lib:/usr/local/openresty/openssl/lib' \
     "
 
-# Runtime dependencies only (matches the package set the single-stage image
-# shipped after `apk del .build-deps`).
+# Runtime dependencies. gd/geoip/libgcc/libxslt/zlib back the dynamic modules and
+# the linked binaries; perl is required by the bundled `resty` CLI (a Perl script)
+# — without it `resty` errors with "can't execute 'perl'". The HEALTHCHECK below
+# uses busybox `wget` (already in the base), so no curl is needed at runtime.
 RUN apk add --no-cache \
         gd \
         geoip \
         libgcc \
         libxslt \
+        perl \
         zlib \
         ${RESTY_ADD_PACKAGE_RUNDEPS}
 
@@ -276,9 +279,13 @@ RUN addgroup -g 101 -S nginx \
     && chown -R nginx:nginx /var/cache/nginx /var/log/nginx /var/run/openresty \
     && chown -R nginx:nginx /usr/local/openresty/nginx/logs
 
-# Add healthcheck to verify OpenResty is responding
+# Add healthcheck to verify OpenResty is responding. Uses busybox wget (present
+# in the alpine base; curl is not installed at runtime) against `/`, which the
+# stock OpenResty config serves with 200 — `/nginx_status` is only available when
+# the user adds a stub_status location (see README), so it can't be the default
+# probe target.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost/nginx_status || exit 1
+    CMD wget -q -O /dev/null http://localhost/ || exit 1
 
 LABEL org.opencontainers.image.title="OpenResty" \
       org.opencontainers.image.description="OpenResty (Nginx + Lua) with LuaRocks and custom modules" \

--- a/openresty/test.sh
+++ b/openresty/test.sh
@@ -30,7 +30,7 @@ fi
 # Test Lua module availability (optional)
 echo "  Testing Lua module..."
 if docker exec "$CONTAINER_NAME" which resty &>/dev/null; then
-    lua_test=$(docker exec "$CONTAINER_NAME" sh -c 'echo "print(1+1)" | resty' 2>/dev/null) || lua_test=""
+    lua_test=$(docker exec "$CONTAINER_NAME" resty -e 'print(1+1)' 2>/dev/null) || lua_test=""
     if [ "$lua_test" = "2" ]; then
         echo "  ✅ Lua/resty working"
     else


### PR DESCRIPTION
## Problem (#773)

The openresty runtime image invoked two tools it doesn't ship — both were pulled
in only via the `.build-deps` virtual package and removed by `apk del`:
- the bundled `resty` CLI is a Perl script → errored `can't execute 'perl'`;
- the `HEALTHCHECK` ran `curl` → never present at runtime.

The HEALTHCHECK also targeted `/nginx_status`, which the **stock** OpenResty
config doesn't serve (it requires a user-added `stub_status` location — see
README), so it would 404 even with a working HTTP client.

## Fix

- Add `perl` to the runtime deps so `resty` works (`resty -e 'print(1+1)'` → `2`).
- Switch the HEALTHCHECK to busybox `wget` (already in the alpine base) against
  `/`, which the stock config serves with `200`.
- `test.sh`: the resty check used `echo "…" | resty`, but resty doesn't read Lua
  from stdin, so it never actually exercised resty. Use `resty -e` instead.

## Trade-off

Image grows **~151 MB → 193 MB** (perl ≈ 42 MB). Accepted: shipping a `resty`
CLI that can't run is worse than the size.

## Verified (local amd64 build)

- `resty -e 'print(1+1)'` → `2` (was `can't execute 'perl'`).
- `wget -q -O /dev/null http://localhost/` → success (healthcheck passes).
- `nginx -t` OK; `luarocks --version` → 3.13.0 (no regression).

Closes #773
