### PR TITLE
fix(php): install fcgi so the FPM healthcheck works

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -13,7 +13,7 @@ ARG APCU_VERSION
 RUN : "${APCU_VERSION:?required}"
 
 RUN set -ex \
-    && apk add --update libzip freetype libpng libjpeg-turbo git shadow \
+    && apk add --update libzip freetype libpng libjpeg-turbo git shadow fcgi \
     && apk add --update --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \
         icu-dev \


### PR DESCRIPTION
## Problem (#782)

The php image's `HEALTHCHECK` runs `healthcheck-fpm` (the renatomefi
php-fpm-healthcheck script), which requires `cgi-fcgi`. But `fcgi` was never
installed in the Dockerfile, so the script aborted immediately:

```
# php/scripts/healthcheck-fpm:53
FCGI_CMD_PATH=$(command -v cgi-fcgi) || { ... "Make sure fcgi is installed". exit 4; }
```

→ `HEALTHCHECK` always exited 4, container permanently `unhealthy`.

## Fix

Add `fcgi` to the runtime `apk add`. Verified `apk add fcgi` provides
`/usr/bin/cgi-fcgi`. The fpm status page is already configured
(`conf/fpm.conf`: `pm.status_path = /status`), so with `cgi-fcgi` present the
healthcheck probe now reaches it and succeeds.

Same bug class as #773 (openresty) — a Dockerfile invoked a binary at runtime it
never installed.

Closes #782
