### PR TITLE
fix(postgres): derive JIT clang version from the base (unbreak extension builds)

### DIFF
--- a/postgres/extensions/build/citus.Dockerfile
+++ b/postgres/extensions/build/citus.Dockerfile
@@ -23,24 +23,27 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    llvm19-dev \
-    git \
-    curl-dev \
-    lz4-dev \
-    zstd-dev \
-    icu-dev \
-    libxml2-dev \
-    openssl-dev \
-    krb5-dev \
-    autoconf \
-    automake \
-    libtool \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        curl-dev \
+        lz4-dev \
+        zstd-dev \
+        icu-dev \
+        libxml2-dev \
+        openssl-dev \
+        krb5-dev \
+        autoconf \
+        automake \
+        libtool \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build Citus
 WORKDIR /build

--- a/postgres/extensions/build/hypopg.Dockerfile
+++ b/postgres/extensions/build/hypopg.Dockerfile
@@ -16,16 +16,18 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: clang19 and llvm19-dev required for LLVM JIT bitcode compilation
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build hypopg
 WORKDIR /build

--- a/postgres/extensions/build/paradedb.Dockerfile
+++ b/postgres/extensions/build/paradedb.Dockerfile
@@ -35,16 +35,14 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 # pgrx requires Rust, clang (for bindgen/libclang), and OpenSSL
 RUN apk add --no-cache \
     build-base \
-    clang19 \
-    clang19-libclang \
-    llvm19-dev \
+    clang-dev \
+    clang-libclang \
     openssl-dev \
     icu-dev \
     git \
     curl \
     pkgconf \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+    llvm-dev
 
 # Install Rust via rustup (required for pgrx)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/postgres/extensions/build/pg_cron.Dockerfile
+++ b/postgres/extensions/build/pg_cron.Dockerfile
@@ -24,16 +24,18 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: clang19 and llvm19-dev required for LLVM JIT bitcode compilation
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build pg_cron
 WORKDIR /build

--- a/postgres/extensions/build/pg_ivm.Dockerfile
+++ b/postgres/extensions/build/pg_ivm.Dockerfile
@@ -24,16 +24,18 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: clang19 and llvm19-dev required for LLVM JIT bitcode compilation
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build pg_ivm
 WORKDIR /build

--- a/postgres/extensions/build/pg_partman.Dockerfile
+++ b/postgres/extensions/build/pg_partman.Dockerfile
@@ -16,16 +16,18 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: clang19 and llvm19-dev required for LLVM JIT bitcode compilation
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build pg_partman
 WORKDIR /build

--- a/postgres/extensions/build/pg_qualstats.Dockerfile
+++ b/postgres/extensions/build/pg_qualstats.Dockerfile
@@ -16,16 +16,18 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: clang19 and llvm19-dev required for LLVM JIT bitcode compilation
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        git \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build pg_qualstats
 WORKDIR /build

--- a/postgres/extensions/build/pgvector.Dockerfile
+++ b/postgres/extensions/build/pgvector.Dockerfile
@@ -23,16 +23,15 @@ ARG TARGETARCH
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# Note: llvm19-dev and clang19 for LLVM JIT support
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    git \
-    icu-dev \
-    llvm19-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache build-base git icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download and build pgvector
 WORKDIR /build

--- a/postgres/extensions/build/postgis.Dockerfile
+++ b/postgres/extensions/build/postgis.Dockerfile
@@ -27,28 +27,30 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-# PostGIS requires GEOS, PROJ, GDAL, json-c, libxml2, protobuf-c for spatial operations
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    llvm19-dev \
-    autoconf \
-    automake \
-    libtool \
-    gettext-dev \
-    git \
-    icu-dev \
-    geos-dev \
-    proj-dev \
-    gdal-dev \
-    json-c-dev \
-    libxml2-dev \
-    protobuf-c-dev \
-    pcre2-dev \
-    perl \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        autoconf \
+        automake \
+        libtool \
+        gettext-dev \
+        git \
+        icu-dev \
+        geos-dev \
+        proj-dev \
+        gdal-dev \
+        json-c-dev \
+        libxml2-dev \
+        protobuf-c-dev \
+        pcre2-dev \
+        perl \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download PostGIS source
 WORKDIR /build

--- a/postgres/extensions/build/timescaledb.Dockerfile
+++ b/postgres/extensions/build/timescaledb.Dockerfile
@@ -23,18 +23,21 @@ ARG MAJOR_VERSION
 # Validate required build args
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
-# Install build dependencies
-RUN apk add --no-cache \
-    build-base \
-    clang19 \
-    llvm19-dev \
-    cmake \
-    git \
-    krb5-dev \
-    openssl-dev \
-    icu-dev \
-    && ln -sf /usr/bin/clang-19 /usr/bin/clang \
-    && ln -sf /usr/bin/clang++-19 /usr/bin/clang++
+# Install build dependencies.
+# PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
+# major from the postgres base's Makefile.global and install exactly it, so the
+# toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        cmake \
+        git \
+        krb5-dev \
+        openssl-dev \
+        icu-dev \
+    && pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')" \
+    && : "${pg_clang_major:?could not determine postgres CLANG major}" \
+    && apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
 
 # Download TimescaleDB source
 WORKDIR /build

--- a/postgres/extensions/config.yaml
+++ b/postgres/extensions/config.yaml
@@ -25,7 +25,7 @@ extensions:
     repo: "pgvector/pgvector"
     build_deps:
       - build-base
-      - clang
+      - clang-dev
       - llvm-dev
     shared_preload: false
     priority: 1 # Build order (lower = first)
@@ -62,9 +62,9 @@ extensions:
       - build-base
       - rust
       - cargo
-      - clang19
-      - clang19-libclang
-      - llvm19-dev
+      - clang-dev
+      - clang-libclang
+      - llvm-dev
       - openssl-dev
       - icu-dev
     shared_preload: false # Not required for PG17+


### PR DESCRIPTION
## Problem (master red on every build)

The **Build PostgreSQL Extensions** jobs were failing on every master push
(#776, #777). Root cause — **not** pgvector 0.8.3:

- The `postgres:18-alpine` base rolled to **alpine 3.24**, which **dropped
  `clang19`** and now records `CLANG = clang-21` (`with_llvm = yes`) in PGXS's
  `Makefile.global`.
- All extension Dockerfiles hardcoded `clang19`/`llvm19-dev` + `ln -sf clang-19`
  → `apk add clang19` fails. The #774 pgvector bump just triggered the rebuild
  that exposed it; any extension rebuild fails the same way.

## Fix (drift-proof)

The 9 C/PGXS extensions now **derive** the clang major from the base at build
time and install exactly it:

```dockerfile
pg_clang_major="$(grep -oE 'clang-[0-9]+' "$(dirname "$(pg_config --pgxs)")/../Makefile.global" | head -1 | grep -oE '[0-9]+')"
apk add --no-cache "clang${pg_clang_major}" "llvm${pg_clang_major}-dev"
```

So the JIT toolchain **tracks the postgres base** and can't drift again when
alpine/postgres bumps its LLVM (clang19→21 won't recur as clang21→22, etc.). The
`clang-19` symlinks are dropped — PGXS calls the versioned `clang-N` directly.

paradedb (Rust/pgrx) uses clang only for bindgen, so it keeps unversioned
`clang-dev` + `clang-libclang` (version-tolerant).

## Verified

Built **pgvector 0.8.3** and **timescaledb 2.28.0** for pg18 against the real
`ghcr.io/oorabona/library/postgres:18-alpine` base — both derive `clang-21`,
emit JIT bitcode (`*.bc` + `llvm-lto`), and produce their `.so`.

Closes #776
Closes #777
