### PR TITLE
fix(terraform): render .tf.j2 templates in every flavor (replace dead j2cli)

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -110,6 +110,8 @@ COPY --from=security-tools /tflint /trivy /usr/local/bin/
 COPY --from=devops-tools /terragrunt /terraform-docs /infracost /gh /usr/local/bin/
 
 # Install base runtime dependencies (always needed)
+# py3-jinja2 + py3-yaml satisfy jinja2-cli's runtime deps from apk (musl wheels,
+# no build toolchain) so the pip install below is a pure-Python wrapper only.
 RUN apk --no-cache add \
     ca-certificates \
     curl \
@@ -119,7 +121,16 @@ RUN apk --no-cache add \
     jq \
     yq \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-jinja2 \
+    py3-yaml
+
+# Jinja2 templating CLI — used UNCONDITIONALLY by docker-entrypoint.sh to render
+# *.tf.j2 files, so it must be present in every flavor (not just full). Replaces
+# j2cli, which is dead on Python 3.12 (it imports the removed `imp` module).
+ARG JINJA2_CLI_VERSION
+RUN : "${JINJA2_CLI_VERSION:?required}" && \
+    pip3 install --break-system-packages --no-cache-dir jinja2-cli==${JINJA2_CLI_VERSION}
 
 # Cloud CLI installation based on FLAVOR
 ARG AWS_CLI_VERSION
@@ -157,8 +168,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             apk --no-cache add --virtual .build-deps gcc musl-dev libffi-dev python3-dev linux-headers && \
             pip3 install --break-system-packages \
                 awscli==${AWS_CLI_VERSION} \
-                azure-cli==${AZURE_CLI_VERSION} \
-                j2cli && \
+                azure-cli==${AZURE_CLI_VERSION} && \
             apk del .build-deps \
             ;; \
         *) \

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -35,7 +35,9 @@ All flavors include the core security and DevOps toolkit. The difference is whic
 | **aws** | AWS optimized | AWS CLI | AWS-only infrastructure |
 | **azure** | Azure optimized | Azure CLI | Azure-only infrastructure |
 | **gcp** | GCP optimized | Google Cloud SDK | GCP-only infrastructure |
-| **full** | All clouds | AWS CLI + Azure CLI + Google Cloud SDK + j2cli | Multi-cloud or development |
+| **full** | All clouds | AWS CLI + Azure CLI + Google Cloud SDK | Multi-cloud or development |
+
+> Jinja2 templating (`jinja2-cli`) is bundled in **every** flavor — the entrypoint renders `*.tf.j2` files unconditionally.
 
 ### Flavor Details
 
@@ -50,6 +52,7 @@ Includes Terraform, security scanning, linting, and documentation tools. No clou
 - terraform-docs (documentation generation)
 - Infracost (cost estimation)
 - GitHub CLI
+- jinja2-cli (Jinja2 templating)
 - Git, Jq, Yq
 
 #### AWS (`*-aws`)
@@ -72,7 +75,7 @@ Includes base + Google Cloud SDK for Google Cloud Platform infrastructure.
 - gcloud, gsutil, bq commands
 
 #### Full (`*-full`)
-Includes all cloud CLIs plus Jinja2 templating engine. Recommended for:
+Includes all cloud CLIs. Recommended for:
 - Multi-cloud environments
 - Development and testing
 - CI/CD pipelines
@@ -82,7 +85,6 @@ Includes all cloud CLIs plus Jinja2 templating engine. Recommended for:
 - AWS CLI
 - Azure CLI
 - Google Cloud SDK
-- j2cli (Jinja2 templating)
 
 ### Image Tags
 
@@ -112,7 +114,7 @@ All versions are pinned and automatically monitored for updates:
 | AWS CLI | 1.44.33 | Amazon Web Services CLI | aws, full |
 | Azure CLI | 2.83.0 | Microsoft Azure CLI | azure, full |
 | Google Cloud SDK | latest | Google Cloud Platform CLI | gcp, full |
-| j2cli | (latest) | Jinja2 templating CLI | full |
+| jinja2-cli | 1.0.1 | Jinja2 templating CLI | All |
 
 ### Built-in Utilities
 
@@ -120,6 +122,7 @@ All flavors include:
 - Git - Version control
 - Jq - JSON processor
 - Yq - YAML processor
+- jinja2-cli - Jinja2 templating
 - Bash - Shell scripting
 - Curl - HTTP client
 - Python 3 - Scripting runtime
@@ -178,9 +181,11 @@ docker run --rm -it \
   apply
 ```
 
-### Jinja2 Templating (full flavor only)
+### Jinja2 Templating
 
-The full flavor includes j2cli for template-based infrastructure:
+Every flavor includes `jinja2-cli` for template-based infrastructure. The
+entrypoint renders any `*.tf.j2` files in the working directory to `*.tf`
+(using `$CONFIGFILE`, default `config.json`) before running Terraform:
 
 ```bash
 # Create templated Terraform files with .j2 extension
@@ -201,7 +206,7 @@ resource "aws_instance" "{{ instance_name }}" {
 docker run --rm \
   -v $(pwd):/data \
   ghcr.io/oorabona/terraform:latest \
-  bash -c "for f in *.tf.j2; do j2 \$f config.json > \${f%.j2}; done && terraform plan"
+  bash -c "for f in *.tf.j2; do jinja2 \$f config.json > \${f%.j2}; done && terraform plan"
 ```
 
 ### Security Scanning
@@ -289,12 +294,13 @@ docker build --build-arg VERSION=latest --build-arg FLAVOR=base -t terraform:bas
 | `AWS_CLI_VERSION` | AWS CLI version | 1.44.33 |
 | `AZURE_CLI_VERSION` | Azure CLI version | 2.83.0 |
 | `GCP_CLI_VERSION` | GCP SDK version | latest |
+| `JINJA2_CLI_VERSION` | jinja2-cli version | 1.0.1 |
 
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CONFIGFILE` | Jinja2 configuration file (full flavor) | config.json |
+| `CONFIGFILE` | Jinja2 template data file (all flavors) | config.json |
 | `TERRAFORM_FLAVOR` | Flavor identifier | (set during build) |
 | `AWS_ACCESS_KEY_ID` | AWS credentials | (pass from environment) |
 | `AWS_SECRET_ACCESS_KEY` | AWS credentials | (pass from environment) |
@@ -441,8 +447,9 @@ This approach:
 Build-time `FLAVOR` argument determines:
 - Which cloud CLIs are installed via pip (AWS, Azure)
 - Whether Google Cloud SDK is copied from cloud-tools-gcp stage
-- Whether j2cli is installed (full flavor only)
 - Contents of environment variable `TERRAFORM_FLAVOR`
+
+(`jinja2-cli` is installed in every flavor, independent of `FLAVOR`.)
 
 ## CI/CD Integration
 

--- a/terraform/config.yaml
+++ b/terraform/config.yaml
@@ -26,6 +26,7 @@ build_args:
   AWS_CLI_VERSION: "1.45.32"
   AZURE_CLI_VERSION: "2.87.0"
   GCP_CLI_VERSION: "latest"
+  JINJA2_CLI_VERSION: "1.0.1"
 # Maps build_arg names to their upstream source for monitoring
 # All build_args with pinned versions MUST have an entry here:
 # - monitored deps: type + source info
@@ -73,4 +74,8 @@ dependency_sources:
     monitor: false
     lifecycle: untracked
     reason: "Always latest — no version to track"
+  JINJA2_CLI_VERSION:
+    lifecycle: tracked
+    type: pypi
+    package: jinja2-cli
 value_proposition: Multi-version retention (3 latest). GCP/AWS/Azure providers pre-fetched, full provider cache layer. Daily upstream monitoring of all dependencies.

--- a/terraform/docker-entrypoint.sh
+++ b/terraform/docker-entrypoint.sh
@@ -1,17 +1,15 @@
 #!/bin/bash -e
 CONFIGFILE=${CONFIGFILE:-config.json}
 
-# A function to display commands
-print_run() { echo "\$ $@" >&2 ; eval "$@" ; }
-
-# Generating final *.tf files when they are *.tf.j2
-find -name "*.j2" -type f | {
-  while read j2file
-  do
-    # Process *.tf.j2 to produce *.tf files
-    print_run j2 "${j2file}" ${CONFIGFILE} > "./${j2file//.tf.j2/.tf}"
-  done
-}
+# Render *.tf.j2 templates to *.tf (using $CONFIGFILE) before running Terraform.
+# jinja2 is invoked directly with quoted arguments — never eval — and filenames
+# are read NUL-delimited, so a crafted *.j2 filename or CONFIGFILE value in a
+# mounted working directory cannot inject shell commands.
+while IFS= read -r -d '' j2file; do
+  outfile="${j2file%.tf.j2}.tf"
+  echo "\$ jinja2 ${j2file} ${CONFIGFILE} > ${outfile}" >&2
+  jinja2 "${j2file}" "${CONFIGFILE}" > "${outfile}"
+done < <(find . -name "*.tf.j2" -type f -print0)
 
 # Run Terraform with supplied arguments
 exec /bin/terraform "$@"

--- a/terraform/variants.yaml
+++ b/terraform/variants.yaml
@@ -25,6 +25,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
       - name: aws
         suffix: "-aws"
         flavor: aws
@@ -36,6 +37,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
       - name: azure
         suffix: "-azure"
@@ -48,6 +50,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AZURE_CLI_VERSION
       - name: gcp
         suffix: "-gcp"
@@ -60,6 +63,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - GCP_CLI_VERSION
       - name: full
         suffix: ""
@@ -73,6 +77,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
           - AZURE_CLI_VERSION
           - GCP_CLI_VERSION
@@ -89,6 +94,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
       - name: aws
         suffix: "-aws"
         flavor: aws
@@ -100,6 +106,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
       - name: azure
         suffix: "-azure"
@@ -112,6 +119,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AZURE_CLI_VERSION
       - name: gcp
         suffix: "-gcp"
@@ -124,6 +132,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - GCP_CLI_VERSION
       - name: full
         suffix: ""
@@ -137,6 +146,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
           - AZURE_CLI_VERSION
           - GCP_CLI_VERSION
@@ -153,6 +163,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
       - name: aws
         suffix: "-aws"
         flavor: aws
@@ -164,6 +175,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
       - name: azure
         suffix: "-azure"
@@ -176,6 +188,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AZURE_CLI_VERSION
       - name: gcp
         suffix: "-gcp"
@@ -188,6 +201,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - GCP_CLI_VERSION
       - name: full
         suffix: ""
@@ -201,6 +215,7 @@ versions:
           - TERRAFORM_DOCS_VERSION
           - INFRACOST_VERSION
           - GITHUB_CLI_VERSION
+          - JINJA2_CLI_VERSION
           - AWS_CLI_VERSION
           - AZURE_CLI_VERSION
           - GCP_CLI_VERSION


### PR DESCRIPTION
## Summary

The terraform entrypoint renders `*.tf.j2` templates with a Jinja2 CLI on **every** startup, but `j2cli` was installed only in the `full` flavor — so `base`, `aws`, `azure`, and `gcp` crashed at startup whenever a `.tf.j2` file was present. `j2cli` is also dead on Python 3.12 (it imports the removed `imp` module), so even the `full` flavor was broken on fresh builds.

This replaces `j2cli` with `jinja2-cli`, installed in **every** flavor.

## Changes

- **Dockerfile** — `jinja2-cli` (pinned `JINJA2_CLI_VERSION`) installed in the always-run base layer for every flavor. `py3-jinja2` + `py3-yaml` come from `apk` (musl, no build toolchain), so the `pip` step adds only the pure-Python CLI wrapper. Removed `j2cli` from the `full` flavor.
- **docker-entrypoint.sh** — render via a direct, quoted `jinja2` invocation over NUL-delimited filenames (no `eval`), and process only `*.tf.j2` (deriving `*.tf` via suffix strip). A crafted filename or `CONFIGFILE` value can no longer inject shell commands, and a non-`.tf` `.j2` file is no longer self-truncated.
- **config.yaml** — `JINJA2_CLI_VERSION: "1.0.1"` plus a `dependency_sources` entry (`pypi` / `jinja2-cli`) so the daily upstream monitor tracks and bumps it, like `awscli`/`azure-cli`.
- **variants.yaml** — `JINJA2_CLI_VERSION` added to every flavor's `build_args_include`, so a version bump changes the build digest and triggers a real rebuild instead of being skipped as unchanged.
- **README.md** — templating documented as available in all flavors.

## Verification

- `jinja2-cli==1.0.1` installs on `alpine:latest` with no build toolchain and renders `*.tf.j2` → `*.tf` from both JSON and YAML config files (parity with the old `j2cli` behavior, including YAML support).
- A `.j2` file with a shell-metacharacter filename renders without executing any embedded command; a non-`.tf` `.j2` file is left untouched (not truncated, no stray output).
- `shellcheck` clean on the entrypoint.
- Unit-test bake subset green (162/162); the terraform build digest now includes `JINJA2_CLI_VERSION` for every flavor (verified per-flavor).

> Note: the orthogonal review's second engine was unavailable (exogenous quota) at gate time; the available engine passed clean on the final diff.

Closes #783
