### PR TITLE
test(ci): make 3 build-graph drift tests honest + CI-deterministic (toward #785)

### DIFF
--- a/tests/unit/dependency-graph.bats
+++ b/tests/unit/dependency-graph.bats
@@ -1641,20 +1641,39 @@ EOF
     printf '{"container":"wordpress","tag":"6.9-alpine","base_image_ref":"ghcr.io/oorabona/php:8.3","base_image_digest":"sha256:%064d"}' \
         0 > "$alt_lineage/wordpress-6.9-alpine.json"
 
-    # list-builds stub: exits 1 (simulates failure)
-    mkdir -p "$fake_root/make-stub"
-    printf '#!/usr/bin/env bash\nexit 1\n' > "$fake_root/make"
+    # ./make stub: "list" succeeds with valid container-name lines so valid-container
+    # enumeration cannot be the failure; "list-builds" fails to exercise the
+    # fail-closed active-tag filter path.
+    cat > "$fake_root/make" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list)
+    printf 'wordpress\nphp\n'
+    exit 0
+    ;;
+  list-builds)
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
     chmod +x "$fake_root/make"
 
     run bash -c "
-        export _DEPGRAPH_CONTAINERS_OVERRIDE='wordpress php'
+        unset _DEPGRAPH_CONTAINERS_OVERRIDE
+        unset _DEPGRAPH_OWNER_OVERRIDE
         export _DEPGRAPH_LINEAGE_DIR='${alt_lineage}'
         export PROJECT_ROOT='${fake_root}'
+        export GITHUB_REPOSITORY_OWNER='oorabona'
         source '${HELPERS_DIR}/dependency-graph.sh'
-        _depgraph_get_deps wordpress
+        _depgraph_get_deps wordpress 2>&1
     "
-    # Must return rc=2 (fail-closed), not rc=0
+    # Must return rc=2 from the list-builds fail-closed path, not owner lookup.
     [ "$status" -eq 2 ]
+    [[ "$output" == *"list-builds wordpress failed"* ]]
+    [[ "$output" == *"refusing to proceed"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -3615,14 +3615,14 @@ STUBEOF
 }
 
 # ---------------------------------------------------------------------------
-# Defect B.1 fix: _depgraph_get_deps failure → detect script exits non-zero (fail-closed)
+# Defect B.1 fix: _depgraph_get_deps failure → detect script emits an error record
 #
-# When _DEPGRAPH_CONTAINERS_OVERRIDE is unset and _depgraph_valid_containers
-# (which calls ./make list) fails, the dep-graph helper returns non-zero.
-# The detect script must propagate this as a non-zero exit rather than silently
-# producing internal_deps=[] and bypassing cascade gating.
+# When a ghcr.io/<owner>/... ref requires owner resolution but no owner source is
+# available, the dep-graph helper returns non-zero. The detect script must surface
+# the container as an error record rather than silently producing internal_deps=[]
+# and bypassing cascade gating.
 # ---------------------------------------------------------------------------
-@test "internal_deps: dep-graph helper failure → detect exits 0, container emitted as error record (F2 regression-lock)" {
+@test "internal_deps: owner unresolvable in dep-graph → detect exits 0, container emitted as error record (F2 regression-lock)" {
     # FIX 2: dep-graph failure must NOT abort the whole run (old behaviour: exit 1).
     # The failing container must be surfaced as status:error with error_reason:dep_graph_unavailable
     # and no internal_deps field — so it is excluded from the leaf/consumer matrices and
@@ -3648,18 +3648,14 @@ STUBEOF
 }
 EOF
 
-    # ./make list fails — dep-graph cannot enumerate containers
-    cat > "$fake_root/make" <<'STUB'
-#!/usr/bin/env bash
-exit 1
-STUB
-    chmod +x "$fake_root/make"
-
     local rc=0
     local result
     # _VALID_CONTAINERS_OVERRIDE set so detect script's own validation passes (only myapp processed),
-    # but _DEPGRAPH_CONTAINERS_OVERRIDE unset so _depgraph_valid_containers hits the failing ./make list.
+    # then the detector bridges it into _DEPGRAPH_CONTAINERS_OVERRIDE. Owner resolution is forced
+    # to fail deterministically by clearing the ambient owner env in this non-git fake root.
     result=$(cd "$fake_root" && \
+        env -u _DEPGRAPH_OWNER_OVERRIDE \
+        GITHUB_REPOSITORY_OWNER= \
         _VALID_CONTAINERS_OVERRIDE="myapp" \
         bash scripts/detect-base-digest-drift.sh ".build-lineage" 2>/dev/null) || rc=$?
 
@@ -4039,7 +4035,14 @@ php" \
     # No positional arg → LINEAGE_DIR defaults to PROJECT_ROOT/.build-lineage.
     # Uses ghcr.io/oorabona/php:8.3 with GITHUB_REPOSITORY_OWNER=oorabona.
     local default_lineage="$TEST_TEMP_DIR/.build-lineage"
-    mkdir -p "$default_lineage"
+    mkdir -p "$TEST_TEMP_DIR/scripts" "$TEST_TEMP_DIR/helpers" "$default_lineage"
+    cp "${DETECTOR_SCRIPT}" "$TEST_TEMP_DIR/scripts/detect-base-digest-drift.sh"
+    cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$TEST_TEMP_DIR/helpers/"
 
     jq -n '{
       lineage_schema_version: 2,
@@ -4056,13 +4059,13 @@ php" \
     chmod +x "$probe_stub"
 
     result=$(
+        cd "$TEST_TEMP_DIR" && \
         _VALID_CONTAINERS_OVERRIDE="wordpress
 php" \
         _DEPGRAPH_CONTAINERS_OVERRIDE="wordpress php" \
         GITHUB_REPOSITORY_OWNER="oorabona" \
         PROBE_CMD="$probe_stub" \
-        PROJECT_ROOT="$TEST_TEMP_DIR" \
-        bash "${DETECTOR_SCRIPT}" 2>/dev/null
+        bash scripts/detect-base-digest-drift.sh 2>/dev/null
     )
 
     printf '%s' "$result" | jq '.' >/dev/null


### PR DESCRIPTION
## Summary — Lot A of #785

Three tests in the `dependency-graph` / `detect-base-digest-drift` suites passed locally for the wrong reason and would behave differently under CI (which sets `GITHUB_REPOSITORY_OWNER` and starts from an empty `.build-lineage/`). They are reworked to exercise their **stated** path and to pass **deterministically whether the owner env is set or unset** — a prerequisite for widening the `unit-tests` gate to the full suite (the rest of #785).

**Test-only — no production code changed.**

## What changed

- **`dependency-graph.bats` — "list-builds failure → rc=2"**: it set `_DEPGRAPH_CONTAINERS_OVERRIDE`, which routes through the test-no-filter branch so `./make list-builds` was never called; the asserted rc=2 actually came from owner resolution failing. Now leaves the override unset, stubs `./make` so `list` succeeds and `list-builds` fails, pins the owner, and asserts the fail-closed `list-builds` error on stderr — so it genuinely locks the path it names.
- **`detect-base-digest-drift.bats` — dep-graph failure → error record**: the failure hinged on the owner being unset (true locally, false in CI). Now clears the owner env explicitly so the failure is deterministic in both, and the test is renamed to its real trigger ("owner unresolvable").
- **`detect-base-digest-drift.bats` — "default LINEAGE_DIR"**: read the *real* repo's `.build-lineage/` because the script recomputes `PROJECT_ROOT` from `BASH_SOURCE`. Now copies the script + helpers under the temp root so the default lineage dir resolves into the test fixture.

## Verification

`bats --jobs 4 tests/unit/detect-base-digest-drift.bats tests/unit/dependency-graph.bats`, run twice:
- with `GITHUB_REPOSITORY_OWNER=oorabona` (CI-like) → **180/180**
- with the owner unset (local-like) → **180/180**

Identical, deterministic across both environments.

## Scope

This is **Lot A** of #785 (make the blocking tests honest). Remaining before the gate can widen to the full suite:
- **Lot B** — isolate the load-flaky parallel tests (`variant-utils.bats`, `liveness-url-coherence.bats`) on the 2-core runner.
- **Lot C** — flip `unit-tests.yaml` to the full `run-tests.sh`, tune `--jobs` / job timeout, confirm green over several runs.

Part of #785 (does not close it).
