### PR TITLE
test(ci): widen unit-tests gate to the full suite + fix the last parallel flake (closes #785)

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -46,8 +46,8 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          # Gate on the deterministic `bake` subset for now. Widening to the full
-          # suite is tracked in #785 — blocked on a few green-by-coincidence and
-          # load-flaky tests that must be hardened first. The drift that motivated
-          # widening (#779) is itself covered here via generate-bake-hcl.bats.
-          ./tests/run-tests.sh bake 2>&1 | tee /tmp/unit-tests.log
+          # Gate on the FULL unit suite: any unit test reaching a red state blocks
+          # the merge (the #779 lesson — a drift in an ungated test file was invisible).
+          # run-tests.sh runs all unit/*.bats in one `bats --jobs 4` pass (~9-12 min
+          # on the 2-core runner; see timeout-minutes above).
+          ./tests/run-tests.sh 2>&1 | tee /tmp/unit-tests.log

--- a/tests/unit/liveness-url-coherence.bats
+++ b/tests/unit/liveness-url-coherence.bats
@@ -143,12 +143,17 @@ _dockerfile_urls_for() {
 
     for config in "$REPO_ROOT"/*/config.yaml; do
         [[ -f "$config" ]] || continue
-        if ! yq -e '.dependency_sources' "$config" &>/dev/null; then
-            continue
-        fi
 
         local container
         container=$(basename "$(dirname "$config")")
+        # Skip ephemeral test-fixture dirs that other suites (e.g. lifecycle-behavior)
+        # inject into REPO_ROOT under parallel runs. Real containers never use the
+        # 'bats-' prefix, so this excludes scaffolding without masking real configs.
+        [[ "$container" == bats-* ]] && continue
+
+        if ! yq -e '.dependency_sources' "$config" &>/dev/null; then
+            continue
+        fi
 
         local dep_names
         dep_names=$(yq -r '.dependency_sources // {} | keys | .[]' "$config")
@@ -371,6 +376,9 @@ _dockerfile_urls_for() {
     for config in "$REPO_ROOT"/*/config.yaml; do
         local container
         container=$(basename "$(dirname "$config")")
+        # Skip ephemeral 'bats-*' fixture dirs injected into REPO_ROOT by other
+        # suites (e.g. lifecycle-behavior) during parallel runs — never real containers.
+        [[ "$container" == bats-* ]] && continue
 
         if ! yq -e '.dependency_sources' "$config" &>/dev/null; then
             continue


### PR DESCRIPTION
## Summary

Widens the CI `unit-tests` gate from the `bake` subset to the **full** unit suite, so a broken test in any file can no longer reach `master` undetected (the #779 lesson — a drift in an ungated test file was invisible). Also fixes the one parallel flake that blocked the widening.

Closes #785.

## What changed

- **`.github/workflows/unit-tests.yaml`** — the gate now runs `./tests/run-tests.sh` (all `unit/*.bats`) instead of `./tests/run-tests.sh bake`; job `timeout-minutes` 20 → 30 (the full suite measures ~9–12 min on the 2-core runner via `--jobs 4`).
- **`tests/unit/liveness-url-coherence.bats`** — the two tests that enumerate containers via `"$REPO_ROOT"/*/config.yaml` now skip ephemeral `bats-*` fixture dirs. `lifecycle-behavior.bats` injects fake `bats-*` container symlinks into `REPO_ROOT` while it runs (the script it tests resolves containers relative to the repo root, so the fixtures must live there); those fixtures intentionally omit `liveness_url_template`, so when the two suites overlapped under load the glob picked them up and tripped a genuine assertion. Real containers never use the `bats-` prefix, so the guard excludes only scaffolding.

## How it was found

The "6 flaky variant-utils tests" from the issue turned out to be stale (already deterministic). Pinning the suite to 2 cores under high parallelism (`taskset -c 0,1`, `bats --jobs 8`) reproduced the real flake: `liveness-url-coherence` failed ~33% of runs *only* when `lifecycle-behavior.bats` ran concurrently — a genuine cross-test coupling on the shared `REPO_ROOT`, not OOM/timing.

## Verification

- Repro under 2-core stress: **33% → 0%** failures (30 runs) after the guard.
- `liveness-url-coherence.bats` standalone: **6/6 pass, 0 skips** — the guarded tests still assert against the real container configs (not over-skipped).
- Full suite pinned to 2 cores: **0 failures** over repeated runs, ~9–12 min wall-clock (well under the 30-min job timeout).
- The retry wrapper in `run-tests.sh` re-runs only on bats-core infra aborts (zero `not ok`), never on assertion failures — so genuine reds still block the gate.

This PR's own `unit-tests` run already exercises the new full-suite gate.
