### PR TITLE
fix(dashboard): meet WCAG AA in light mode for hero/footer/health/badge text

### DIFF
--- a/docs/site/assets/css/dashboard.css
+++ b/docs/site/assets/css/dashboard.css
@@ -813,6 +813,8 @@
       font-size: 0.875rem;
       color: var(--text-muted);
     }
+    /* Light mode: muted grey misses AA over the glass card; use secondary. */
+    [data-theme="light"] .health-label { color: var(--color-text-secondary); }
 
     .health-value {
       font-weight: 600;
@@ -1081,6 +1083,11 @@
       max-width: 620px;
       margin: 0 auto;
     }
+
+    /* Light mode: the hero sits directly on the page gradient, where muted grey
+       misses AA. Darken hero-internal muted text to secondary. */
+    [data-theme="light"] .dashboard-hero-subtitle,
+    [data-theme="light"] .dashboard-hero-freshness { color: var(--color-text-secondary); }
 
     /* Hero CTA — small inline link below the subtitle, low visual weight. */
     .dashboard-hero-cta {

--- a/docs/site/assets/css/theme.css
+++ b/docs/site/assets/css/theme.css
@@ -392,6 +392,11 @@ body {
   text-decoration: none;
 }
 
+/* Light mode: the footer rides the page gradient (shared across all layouts),
+   where muted text and the blue-600 link miss AA. Darken both. */
+[data-theme="light"] .footer { color: var(--color-text-secondary); }
+[data-theme="light"] .footer a { color: #1e40af; } /* blue-800 — AA on the gradient */
+
 /* ============================================================
    Sticky nav (shared across all layouts)
    ============================================================ */

--- a/docs/site/assets/css/tokens.css
+++ b/docs/site/assets/css/tokens.css
@@ -458,7 +458,7 @@
   --color-variant-tag-bg-hover:     rgba(109, 40, 217, 0.18);
   --color-variant-tag-selected-bg:  rgba(59, 130, 246, 0.14);  /* blue on light-selected */
   --color-variant-tag-selected-shadow: rgba(59, 130, 246, 0.18);
-  --color-variant-badge-default-bg:  rgba(4, 120, 87, 0.14);   /* green-700 alpha on white */
+  --color-variant-badge-default-bg:  #e8f5ef;   /* opaque pale green — keeps green-700 fg above AA on tinted/glass parents (0.14 alpha composited to ~3.9:1) */
   --color-variant-badge-default-fg:  var(--color-green-700);
 
   /* SBOM badges: violet-700 + blue-700 on white */


### PR DESCRIPTION
Six small text elements fell below 4.5:1 in light mode (muted/accent text on the lavender page gradient, or the 'default' badge's translucent green over a tinted parent): hero subtitle + freshness date, footer text + link, System Health labels, and the variant 'default' badge.

- Hero subtitle/freshness + health labels → `--color-text-secondary` in light (≥9:1).
- Footer text → `--color-text-secondary`; footer link → #1e40af (blue-800). Footer is shared chrome, so this lifts it on every page.
- 'default' badge: opaque pale-green light bg token so the green-700 fg passes (4.89:1).

All `[data-theme=light]`-scoped (or the token's light value); dark mode verified unchanged. Browser-measured: all 6 now 4.89–9.86:1 (≥4.5). Follow-up to the blog readability work (#792).