### PR TITLE
chore: emit dashboard last_build_iso + retry the version-discovery GitHub API

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -886,6 +886,7 @@ collect_variant_json() {
         + (if $multi_arch_digests.manifest_digest_amd64 != null then {manifest_digest_amd64: $multi_arch_digests.manifest_digest_amd64} else {} end)
         + (if $multi_arch_digests.manifest_digest_arm64 != null then {manifest_digest_arm64: $multi_arch_digests.manifest_digest_arm64} else {} end)
         + (if ($attestation_id | length) > 0 then {attestation_id: $attestation_id, attestation_url: $attestation_url} else {} end)
+        + (if ($lineage.built_at // "" | length) > 0 then {last_build_iso: $lineage.built_at} else {} end)
         + (if ($build_args | length) > 0 then {build_args: $build_args} else {} end)
         + (if ($sbom_summary | keys | length) > 0 then {sbom_summary: $sbom_summary} else {} end)
         + (if ($sbom_packages | keys | length) > 0 then {sbom_packages: $sbom_packages} else {} end)

--- a/helpers/latest-github-release
+++ b/helpers/latest-github-release
@@ -22,6 +22,9 @@ _github_api_get() {
         -fsSL
         --connect-timeout 10
         --max-time 10
+        --retry 3
+        --retry-delay 2
+        --retry-all-errors
         -H "Accept: application/vnd.github+json"
     )
 


### PR DESCRIPTION
Two small, independent backlog cleanups (one atomic commit each).

**1. `feat(dashboard)`: emit `last_build_iso`.** `container-detail.html` already references `last_build_iso` in six 'awaiting next build' branches, but `generate-dashboard.sh` never emitted the field, so those branches were dead. Alias it from the lineage's ISO-8601 `built_at` (already passed through `resolve_variant_lineage_json`); emitted only when present (no schema change for variants without lineage). Verified: jq emits `last_build_iso` when `built_at` exists, omits it otherwise.

**2. `fix(ci)`: retry the GitHub release API.** `helpers/latest-github-release` issued single-shot curls (`--max-time 10`, no retry) across its 3 fallback strategies, so one transient API error hard-failed the caller's `version.sh` (and could fail an upstream-monitor / version-check job). Adds `--retry 3 --retry-delay 2 --retry-all-errors` (curl 7.71+). Shared helper → hardens every container's version discovery, not just web-shell.

Resolves the last actionable items from the deferred backlog; `bash -n` + shellcheck clean (no new findings).