### PR TITLE
fix(postgres): pin paradedb Rust toolchain + ADR-015 (automated extension identity)

### DIFF
--- a/docs/adr/ADR-015-automated-extension-image-identity.md
+++ b/docs/adr/ADR-015-automated-extension-image-identity.md
@@ -1,0 +1,73 @@
+# ADR-015: Automated (content-addressed) postgres extension image identity
+
+- **Status:** Accepted (design); implementation deferred
+- **Date:** 2026-06-22
+- **Tracking:** [#801](https://github.com/oorabona/docker-containers/issues/801)
+- **Relates:** ADR-014 (dependency & supply-chain strategy), ADR-002 (smart rebuild detection)
+
+## Context
+
+The postgres extension build prefilter keys an extension image only on its upstream **version** (`ext-<name>:pg<major>-<version>`). So a same-version change to a build input — the Dockerfile, the Rust toolchain, a build dep — silently reuses the existing image: the change is never rebuilt or validated. The trigger was pinning the paradedb Rust toolchain (so a new stable Rust can't silently break the pgrx build); the pin is correct but inert under the version-keyed prefilter until something forces a rebuild.
+
+The operator's hard requirement: the rebuild decision must be **fully automated and deterministic** — **no manual revision bump, no PR check**. The system must autonomously rebuild when (and only when) a build input changes.
+
+## What we tried, and what was rejected
+
+A first implementation added a manual `build_revision` field to the image identity (`…-r<rev>`) plus a PR check that failed a PR when a build input changed without a revision bump. The **identity mechanism** (threading the suffix through ~23 producer/consumer sites, cleanup completeness, multi-arch composition) is sound and reusable. What the operator rejected is the **human-process parts**: the *manual* bump and the *check* enforcing it — they defeat "fully automated." That PR check also proved to be a persistent source of robustness and security problems: it ran on every pull request, read branch-controlled content, and executed logic on it — yielding failure modes such as self-neutering, fail-open on malformed config, and workflow-command injection.
+
+## The chosen direction: content-addressed identity
+
+Replace the manual `-r<rev>` suffix with an **auto-derived content hash of the build inputs**: `ext-<name>:pg<major>-<version>-h<hash>`. Same tag shape, **same threading reused**; only the suffix *source* changes (manual → computed). Then the prefilter naturally rebuilds when the hash changes and reuses when it doesn't — self-correcting, no bump, no PR check. The PR check, the `build_revision` field, and the numeric-revision retention are deleted.
+
+This was pressure-tested **before any code** via a written spec subjected to three independent design reviews (one adversarial, plus a two-engine consensus). All three converged on the same verdict: **the pure content-addressed design is not implementable as-is**, because the current extension builds are **not reproducible functions of the hashable inputs**.
+
+### The core finding (unanimous across the three reviews)
+
+The hash would cover *declared* inputs (package names, floating refs) while the builds resolve content at build time that the hash never captures:
+- `apk add build-base clang-dev …` — package **names, not versions**; Alpine repos roll, so the compiled `.so` drifts while the hash is unchanged (silent stale reuse), and amd64/arm64 resolve **different** package versions under one shared hash.
+- `curl https://sh.rustup.rs | sh` — unpinned installer/components.
+- `git clone --branch v${VERSION}` — a **mutable tag**, not a commit SHA.
+- `PGRX_VERSION=$(grep … Cargo.toml)` — discovered at build time, not in config.
+- `FROM postgres:N-alpine` — floating base tag (per-arch digests differ).
+- `build_date=$(date)` stamped **into the COPY'd artifact** → two builds, same hash, different content.
+- A **circular hash**: if the generated Dockerfile carries `LABEL input_sha256=<hash>`, its bytes depend on the hash that depends on its bytes.
+
+**The multi-arch contradiction** is structural: a *single shared* hash across arches is incompatible with hashing *per-arch* resolved content (apk versions, base digest). You can have one or the other, not both, silently.
+
+### Two coherent ways to deliver the requirement
+
+- **(A) Full reproducible builds + content-addressing.** Resolve and pin every input once before fan-out into a lock artifact (resolved apk closure **per arch**, source commit SHA, base **per-arch** digest, exact Rust toolchain + pgrx, all `FROM` digests, strip timestamps from the output layer), use **per-arch hashes** combined at the manifest level, hash the resolved/expanded Dockerfile (not the template, no label cycle), forbid unresolved network during build. This is true determinism — and a substantial project (industry-hard; bit-reproducible Docker builds are ~2.7% of images). Note: pinning apk to exact versions is itself infeasible/fragile (distro repos keep only the latest → exact pins 404; cf. ADR-014), so A's apk story must hash the *resolved closure per arch*, which forces per-arch hashes and a resolve-before-skip cost.
+- **(B) Pragmatic automated rebuild.** Hash the **declared intent** (extension version, `rust_version`, resolved/expanded Dockerfile bytes, build-affecting config, source identity) — which catches the **common** build-input changes and triggers an automatic rebuild, no bump, no check. Lean on the **existing base-digest-drift** mechanism (which already rebuilds when the base image — and thus the apk world — changes) plus a **periodic time-bounded rebuild backstop** to sweep residual apk drift. Automated and deterministic *for declared inputs*; honestly not bit-reproducible. Much smaller; reuses the existing identity threading and the base-drift infrastructure (which already records base digests).
+
+## Decision
+
+**Adopt (B)** as the target design; **defer implementation** (capture it here, build it as a focused project).
+
+Rationale: (B) delivers the autonomy the requirement actually needs — no manual bump, no check, automatic rebuild on input change — and its only gap (a pure Alpine-toolchain micro-drift not reflected in the hash) is low-impact (the extension still works; it's just not on the newest toolchain) and is largely covered by the existing base-digest-drift plus a periodic backstop. (A)'s full bit-reproducibility is a large, complex project (per-arch hashing, resolved-closure locks, resolve-before-skip cost) for a marginal gain over (B)+base-drift+periodic. If bit-level reproducibility ever becomes a hard requirement, (A) is documented here and is a strict superset of (B).
+
+**Ship now:** only the Rust toolchain pin (the concrete, correct win). The `build_revision` work is **not merged** (it carries the rejected manual/check model) but is **retained as reference** for (B)'s threading — see Reuse.
+
+## Reuse map (what (B) builds on)
+
+Reuse: the identity-suffix **threading** through `ext_image_name` / `ext_ref_resolve` / the prefilter exact-ref check / `generate_dockerfile` FROM+COPY / manifest finalize / lineage; the cleanup **completeness** check (manifest + amd64 + arm64) and multi-arch composition; the fail-closed patterns. Replace only the suffix **source** (`build_revision` → computed hash). Delete: the PR-check job + `scripts/guard-extension-build-inputs.sh`, the `build_revision` config field + its validation, the numeric-revision retention ordering.
+
+## Implementation plan for (B) (deferred)
+
+1. Define the **declared-input record** (canonical JSON, schema-versioned): extension, pg_major, resolved version, source identity (resolve the upstream tag to a **commit SHA** — mandatory, fail-closed if unresolvable), build-affecting config (`rust_version` exact, normalized `build_deps`/`runtime_deps`, `shared_preload`), and the **resolved/expanded** Dockerfile bytes (not the template).
+2. Resolve mutable inputs **once before fan-out**; the record is the single source of truth.
+3. Hash → `…-h<hash>`; reuse the threading. Avoid the **label↔Dockerfile cycle** (compute the hash from a template with canonical placeholders, add provenance labels in a derived phase).
+4. Cleanup: **mark-and-sweep**, two-phase — a flavor build records its ext-hash dependency **before** publish; cleanup serializes against publish (or a grace window ≥ max build time) and re-checks references immediately before delete; completeness fail-closed.
+5. Move `PGRX_VERSION` into config (a hashed input); strip `build_date`/timestamps from the output layer.
+6. The **periodic rebuild backstop** + the existing base-digest-drift cover residual apk drift.
+
+## Consequences
+
+- No manual bump, no PR check (its whole problem surface is removed).
+- Automatic rebuild on any declared build-input change; reuse otherwise.
+- Honest limitation: pure Alpine package micro-drift is swept periodically / via base-drift, not per-hash. Documented, not silently assumed.
+- The pre-implementation design reviews are the design basis; revisiting (A) starts from this ADR.
+
+## References
+
+- The pre-implementation spec, the adversarial design review, and the two-engine consensus — retained in the project's memory notes for #801.
+- ADR-014 (why distro-package exact-pinning is infeasible — informs A's apk story).

--- a/postgres/extensions/build/paradedb.Dockerfile
+++ b/postgres/extensions/build/paradedb.Dockerfile
@@ -24,9 +24,10 @@ ARG REMOTE_CR
 ARG MAJOR_VERSION
 ARG EXT_VERSION
 ARG EXT_REPO
+ARG RUST_VERSION
 
 # Validate required build args
-RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
+RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}" "${RUST_VERSION:?required}"
 
 # Critical: disable static CRT linking for musl/pgrx compatibility
 ENV RUSTFLAGS="-C target-feature=-crt-static"
@@ -45,7 +46,7 @@ RUN apk add --no-cache \
     llvm-dev
 
 # Install Rust via rustup (required for pgrx)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_VERSION}"
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Download ParadeDB source (before pgrx install to auto-detect version)

--- a/postgres/extensions/config.yaml
+++ b/postgres/extensions/config.yaml
@@ -55,6 +55,7 @@ extensions:
     priority: 2
   paradedb:
     version: "0.24.1"
+    rust_version: "1.96.0" # Pinned Rust toolchain; update manually when adopting new stable Rust (see postgres/version-extension.sh).
     description: "Full-text search with BM25 ranking (Elasticsearch alternative)"
     repo: "paradedb/paradedb"
     license: "AGPL-3.0"

--- a/postgres/version-extension.sh
+++ b/postgres/version-extension.sh
@@ -105,6 +105,9 @@ get_all_versions() {
         local first=true
     fi
 
+    # extensions.paradedb.rust_version is not auto-monitored here: Rust stable is
+    # published at https://static.rust-lang.org/dist/channel-rust-stable.toml,
+    # not as a GitHub release, so bump it manually until a rust-toolchain probe exists.
     for ext in $(list_extensions); do
         local repo
         repo=$(get_ext_repo "$ext")

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -93,6 +93,9 @@ build_ext_image() {
     local pg_major="$4"
     local dockerfile="$5"
     local context_dir="$6"
+    local rust_version="${EXT_RUST_VERSION:-}"
+    local _rust_args=()
+    [[ -n "$rust_version" ]] && _rust_args=(--build-arg "RUST_VERSION=$rust_version")
 
     local local_tag
     local_tag=$(ext_local_image_name "$ext_name" "$pg_major")
@@ -178,6 +181,7 @@ build_ext_image() {
             --build-arg MAJOR_VERSION="$pg_major" \
             --build-arg EXT_VERSION="$ext_version" \
             --build-arg EXT_REPO="$ext_repo" \
+            "${_rust_args[@]}" \
             "$context_dir"; then
             log_error "Docker buildx build (compile) failed for $ext_name $ext_version (pg${pg_major})"
             return 1  # compile failure
@@ -207,6 +211,7 @@ build_ext_image() {
         --build-arg MAJOR_VERSION="$pg_major" \
         --build-arg EXT_VERSION="$ext_version" \
         --build-arg EXT_REPO="$ext_repo" \
+        "${_rust_args[@]}" \
         "$context_dir"; then
         log_error "Docker build failed for $ext_name $ext_version (pg${pg_major})"
         return 1
@@ -406,6 +411,8 @@ build_extension() {
     fi
     local repo
     repo=$(ext_config "$ext_name" "repo" "$config_file")
+    local rust_version
+    rust_version=$(yq -r ".extensions.${ext_name}.rust_version // \"\"" "$config_file")
 
     local dockerfile="$container_dir/extensions/build/${ext_name}.Dockerfile"
     local context_dir="$container_dir/extensions"
@@ -435,7 +442,7 @@ build_extension() {
     while [[ "$_attempt" -lt "$_max_attempts" ]]; do
         _attempt=$(( _attempt + 1 ))
         _build_rc=0
-        build_ext_image "$ext_name" "$ext_version" "$repo" "$major_ver" "$dockerfile" "$context_dir" \
+        EXT_RUST_VERSION="$rust_version" build_ext_image "$ext_name" "$ext_version" "$repo" "$major_ver" "$dockerfile" "$context_dir" \
             || _build_rc=$?
         if [[ "$_build_rc" -eq 0 ]]; then
             return 0


### PR DESCRIPTION
## paradedb Rust toolchain pin + ADR-015 (extension identity decision)

Two things, closing out the #801 extension-identity investigation:

### 1. Pin the paradedb Rust toolchain
`postgres/extensions/build/paradedb.Dockerfile` installed whatever stable Rust existed at build time (`curl sh.rustup.rs | sh`), so a new Rust stable release could silently break the pgrx build. Pin it to `1.96.0`, sourced from `extensions/config.yaml` (`paradedb.rust_version`), threaded as a build-arg only for extensions that declare it. Forward-looking: the next paradedb build is deterministic on a known-good toolchain. (Rust stable is a static channel, not a GitHub release, so the value is bumped via the automated-identity work below, not by hand.)

### 2. ADR-015 — automated content-addressed extension image identity
Records the decision for making extension rebuilds **fully automated** (no manual revision bump, no PR check). A pre-implementation study (a written spec + three independent design reviews) found the naive content-addressed design unimplementable as-is — the extension builds are not reproducible functions of the hashable inputs (unpinned apk, mutable source tags, floating base, build-time-discovered pgrx, a stamped timestamp, and a multi-arch single-hash contradiction). The chosen target is **option B** (hash the declared intent + reuse the existing base-digest-drift + a periodic rebuild backstop); the larger full-reproducible-builds **option A** is documented and deferred. The prior `build_revision` + PR-check implementation is retained as reference (tag `ref-801-content-addressed-design`) for option B's threading reuse.

Relates to #801. Implementation of option B is deferred to a focused follow-up.
