### PR TITLE
ci(upstream-monitor): drop redundant update-dashboard job

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -18,12 +18,8 @@ on:
 permissions:
   contents: write      # Push version bumps and merge PRs
   pull-requests: write # Create and merge PRs
-  actions: write       # Trigger auto-build and update-dashboard workflows
+  actions: write       # Trigger auto-build workflow (gh workflow run)
   packages: write      # Push base images to GHCR (sync-base-images job)
-  pages: write         # Required by update-dashboard reusable workflow (deploy to Pages)
-  id-token: write      # Required by update-dashboard reusable workflow (OIDC for Pages)
-  attestations: read   # Required by update-dashboard reusable workflow (trust-strip attestation_url)
-  security-events: read # Required by update-dashboard reusable workflow (trust-strip trivy_summary)
 
 jobs:
   check-upstream-versions:
@@ -755,14 +751,6 @@ jobs:
           source ./helpers/logging.sh
           source ./helpers/retry.sh
           retry_with_backoff 3 5 gh workflow run auto-build.yaml -f container_scopes="$scopes_json" -f force_rebuild=true -f build_all_retained=true
-
-  # Update dashboard after PRs are merged to reflect new versions
-  update-dashboard:
-    needs: [create-update-prs, create-dependency-update-prs]
-    if: always() && (needs.create-update-prs.result == 'success' || needs.create-dependency-update-prs.result == 'success')
-    uses: ./.github/workflows/update-dashboard.yaml
-    with:
-      trigger_reason: "Post upstream-monitor PR merge"
 
   # Sync base images: daily blind-copy of all containers' base images from Docker
   # Hub to GHCR. Shares the sync_base_images_to_ghcr helper with the push-trigger


### PR DESCRIPTION
Closes #809

## Summary

The `update-dashboard` reusable-workflow invocation ran after PR **creation** (not merge), regenerating an identical dashboard from unchanged `master` state (the comment "after PRs are merged" was inaccurate). The dashboard is already refreshed by `update-dashboard.yaml`'s own triggers:

- the daily `schedule` cron at 07:00 UTC, and
- the `workflow_run` trigger after every `Auto Build & Push` completion — the point at which a merged version-bump PR actually produces new data.

Its collision on the `pages` concurrency group (`cancel-in-progress: true`) was the **sole cause** of the recurring `cancelled` conclusions on the daily upstream-monitor schedule. Those benign cancellations **masked genuine `Sync base images to GHCR` failures** (a failed sync still showed as `cancelled`, not `failure`).

Also drops the 4 permissions the job required — `pages: write`, `id-token: write`, `attestations: read`, `security-events: read` — a least-privilege win. `actions: write` is kept (still needed for `gh workflow run auto-build.yaml`).

### Expected outcome
- upstream-monitor runs end in clean `success`/`failure`; a `failure` now signals a real problem instead of hiding behind `cancelled`.
- No loss of dashboard freshness (covered by the two existing triggers).
- One fewer `pages`-group contender per day.

## Test plan

- [ ] `shellcheck` / workflow-validation CI passes
- [ ] Next daily upstream-monitor run ends `success` (no spurious `cancelled`)
- [ ] Dashboard still refreshes via the 07:00 cron + post-auto-build `workflow_run`

---

Net diff: 1 insertion, 13 deletions. Orthogonal codex gate waived by operator for this CI-config change; Copilot review applies.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
