### PR TITLE
ci: bump docker/login-action to v4.2.0 + silence terraform InvalidDefaultArgInFrom

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -94,7 +94,7 @@ runs:
   steps:
     - name: Log in to GitHub Container Registry
       if: runner.os != 'Windows'
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -103,7 +103,7 @@ runs:
     - name: Log in to Docker Hub
       if: runner.os != 'Windows' && inputs.dockerhub_username != '' && inputs.dockerhub_token != ''
       id: dockerhub-login
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: docker.io
         username: ${{ inputs.dockerhub_username }}

--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -51,7 +51,7 @@ runs:
     - name: Log in to Docker Hub
       if: inputs.dockerhub_username != '' && inputs.dockerhub_token != ''
       id: dockerhub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: docker.io
         username: ${{ inputs.dockerhub_username }}

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,6 +1,9 @@
 # Multi-stage Dockerfile for modern Terraform with security and DevOps tools
 # Supports multiple flavors: base, aws, azure, gcp, full
-ARG VERSION
+# VERSION defaults to `latest` so the stage-1 FROM ref below resolves to a valid
+# image at parse time (CI always overrides it) — silences BuildKit's
+# InvalidDefaultArgInFrom warning without changing CI behavior.
+ARG VERSION=latest
 ARG UPSTREAM_VERSION
 ARG FLAVOR=full
 


### PR DESCRIPTION
Two log-noise cleanups surfaced while reviewing the 2026-06-23 terraform auto-build run (#811).

## 1. `ci(actions)` — docker/login-action v3 → v4.2.0

Two composite actions still pinned the **v3** SHA (`c94ce9fb…`), which runs on **Node 20** — flagged as deprecated by the GitHub Actions runner. Bumped the 3 occurrences to the **v4.2.0** SHA (`650006c6…`, Node 24) that the workflows already use 8× elsewhere:

- `.github/actions/build-container/action.yaml` (×2)
- `.github/actions/docker-login/action.yaml` (×1)

Pin-only change, no interface difference. Kills the `Node.js 20 is deprecated` warning.

## 2. `build(terraform)` — silence `InvalidDefaultArgInFrom`

`terraform/Dockerfile` stage-1 `FROM` used `${UPSTREAM_VERSION:-${VERSION}}` with both args defaultless → at parse time the ref evaluated to `…terraform:` (empty tag) → BuildKit `InvalidDefaultArgInFrom` warning on every terraform build. Defaulting `VERSION` to `latest` makes the fallback resolve to a valid ref. CI always injects `VERSION`, so build behavior is unchanged — this only affects the parse-time default (and gives raw `docker build` a sane fallback instead of a cryptic empty-tag pull error).

## Verification

- `actionlint` — exit 0, no findings
- composite `action.yaml` files — YAML valid
- no residual v3 pin anywhere under `.github/`

## Test plan

- [ ] CI green (actionlint, detect-containers, unit-tests)
- [ ] Next terraform build log no longer shows `Node.js 20 is deprecated` (login) nor `InvalidDefaultArgInFrom`

---

Trivial mechanical diff (SHA already vetted in-repo + cosmetic ARG default). Orthogonal codex gate waived by operator for this class; Copilot review applies.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
