### PR TITLE
ci: scan composite actions in Dependabot + clear composite-only stale pins

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -130,7 +130,7 @@ runs:
 
     - name: Set up Docker Buildx
       if: runner.os != 'Windows'
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         # docker-container driver: supports --push and multi-platform builds.
         driver: docker-container
@@ -539,7 +539,7 @@ runs:
     - name: Scan for vulnerabilities (Trivy)
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' }}
       id: trivy-scan
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: 'ghcr.io/${{ steps.check-build.outputs.image_name }}:${{ steps.check-build.outputs.current_tag }}'
         format: 'table'
@@ -554,7 +554,7 @@ runs:
     - name: Generate SARIF report
       id: trivy-sarif
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' }}
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: 'ghcr.io/${{ steps.check-build.outputs.image_name }}:${{ steps.check-build.outputs.current_tag }}'
         format: 'sarif'
@@ -632,7 +632,7 @@ runs:
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' }}
       id: sarif-upload
       continue-on-error: true
-      uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: 'trivy-results.sarif'
         category: 'container-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}-${{ inputs.platform }}'
@@ -647,7 +647,7 @@ runs:
       if: ${{ runner.os != 'Windows' && steps.build.outputs.image_loaded == 'true' && inputs.scan_vulnerabilities == 'true' && steps.trivy-scan.outcome != 'skipped' && steps.sarif-upload.outcome == 'failure' }}
       id: sarif-upload-retry
       continue-on-error: true
-      uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: 'trivy-results.sarif'
         category: 'container-${{ inputs.container }}-${{ steps.check-build.outputs.current_tag }}-${{ inputs.platform }}'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,27 @@
 version: 2
 updates:
-  # GitHub Actions
+  # GitHub Actions — workflows AND composite actions.
+  # The default `directory: "/"` only scans .github/workflows/; composite
+  # actions under .github/actions/*/action.yaml are invisible to it, so their
+  # pins rot silently (e.g. docker/login-action v3 lingered there until #812).
+  # List each composite dir explicitly — `directories` does not support globs.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/build-container"
+      - "/.github/actions/check-dependency-versions"
+      - "/.github/actions/check-upstream-versions"
+      - "/.github/actions/close-duplicate-prs"
+      - "/.github/actions/detect-containers"
+      - "/.github/actions/docker-login"
+      - "/.github/actions/preflight-buildkit"
+      - "/.github/actions/retry-run"
+      - "/.github/actions/setup-github-cli"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     reviewers:
       - "@me"
     commit-message:
@@ -17,6 +31,15 @@ updates:
       - "dependencies"
       - "github-actions"
       - "automated"
+    # Batch minor/patch action bumps into a single PR; majors stay isolated so
+    # each gets its own CI validation (cache v6, checkout v7, upload-artifact v7…).
+    groups:
+      github-actions-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Docker dependencies
   - package-ecosystem: "docker"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -2651,7 +2651,7 @@ jobs:
         id: upload_sarif_bake
         if: steps.trivy-scan.outcome != 'skipped'
         continue-on-error: true  # SARIF upload is advisory — never gates the build
-        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'container-${{ matrix.build.container }}-${{ matrix.build.tag }}-linux/${{ matrix.arch }}'
@@ -2660,7 +2660,7 @@ jobs:
       - name: Upload SARIF to GitHub Security (retry on transient failure)
         if: always() && steps.upload_sarif_bake.outcome == 'failure'
         continue-on-error: true  # SARIF upload is advisory — never gates the build
-        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'container-${{ matrix.build.container }}-${{ matrix.build.tag }}-linux/${{ matrix.arch }}'


### PR DESCRIPTION
Follow-up to #812. Root-causes why stale action pins (e.g. `docker/login-action` v3) keep needing manual bumps, and clears the current composite-only backlog.

## Why Dependabot wasn't catching these

The `github-actions` ecosystem in `.github/dependabot.yml` only declared `directory: "/"`, which scans `.github/workflows/` — it does **not** see composite actions under `.github/actions/*/action.yaml`. So pins inside the composites age silently while the workflow copies get bumped weekly. That's exactly how `login-action` v3 survived in the composites until #812.

## Changes

### 1. `ci(dependabot)` — close the blind spot
- Add every composite dir (`build-container`, `docker-login`, `detect-containers`, …) to `directories` so Dependabot scans them too (`directories` has no glob support — listed explicitly).
- Raise `open-pull-requests-limit` 5 → 10 (more surfaces = more potential PRs).
- Group minor/patch action bumps into one PR; **majors stay isolated** so each gets its own CI validation.

### 2. `ci(actions)` — clear the composite-only stale pins (the Node20 noise source)
All were stale **only** in `build-container/action.yaml`:
- `docker/setup-buildx-action` v4.0.0 → **v4.1.0**
- `aquasecurity/trivy-action` v0.35.0 → **v0.36.0**
- `github/codeql-action/upload-sarif` `# v4` (old tag-object SHA) → **v4.36.2** (proper commit SHA; +2 occurrences in `auto-build.yaml` for consistency)

SHAs verified — setup-buildx/trivy targets already in use elsewhere in the repo; codeql via the GitHub API.

## Deliberately deferred to Dependabot (isolated, CI-validated PRs)

The major bumps — `actions/cache` v5→**v6** (released 2026-06-23), `actions/checkout` v6→**v7**, `actions/upload-artifact` →**v7**, `actions/download-artifact` →**v8** — are left for Dependabot now that it can see all surfaces. Majors can carry breaking changes (e.g. upload-artifact v7's glob `!negation`), so one-PR-per-action with dedicated CI is the safer path than a manual sweep.

## Verification

- `actionlint` — exit 0, no findings
- `dependabot.yml` — YAML valid
- no residual old SHAs under `.github/`

## Test plan

- [ ] CI green (actionlint, detect-containers, unit-tests)
- [ ] Next Dependabot run opens the deferred major-bump PRs from the composites too

---

Trivial mechanical diff (SHA bumps verified in-repo/via API + config). Orthogonal codex gate waived by operator for this class; Copilot review applies.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
