### PR TITLE
ci(dependabot): drop the broken+redundant docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,24 +41,9 @@ updates:
           - "minor"
           - "patch"
 
-  # Docker dependencies
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "tuesday" 
-      time: "06:00"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "@me"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "docker"
-      - "automated"
-    ignore:
-      # Ignore patch updates for base images (too frequent)
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+  # NOTE: no `docker` ecosystem entry. Base-image version tracking is handled by
+  # upstream-monitor.yaml (each container's version.sh), which understands the
+  # `FROM ${REMOTE_CR}/...:${VERSION}` ARG-interpolated, GHCR-mirrored pattern.
+  # Dependabot's docker ecosystem can't parse ARG-based FROM refs and found no
+  # Dockerfile at the root anyway ("No Dockerfiles ... found in /") — it failed
+  # every run. Removed as redundant + permanently broken.


### PR DESCRIPTION
## Problem

The Dependabot `docker` ecosystem update has failed on **every** run (2026-06-24, 06-23, 06-16, …), firing a weekly failure notification while producing zero PRs.

Root cause (from the failed run log, job `1433548581`):
```
ERROR Error during file fetching; aborting: No Dockerfiles nor Kubernetes YAML found in /
```

The `docker` entry used `directory: "/"`, but no Dockerfile lives at the repo root — they're all in container subdirs (`postgres/`, `terraform/`, …). And even if `directories` pointed at each subdir, Dependabot can't parse this repo's `FROM ${REMOTE_CR}/...:${VERSION}` ARG-interpolated, GHCR-mirrored base refs — it can't resolve `${REMOTE_CR}` to know what image to look up.

## Fix

Remove the `docker` ecosystem block. Base-image version tracking is already fully handled by `upstream-monitor.yaml` (each container's `version.sh`), which understands the `REMOTE_CR`/GHCR-mirror pattern natively. A comment is left in `dependabot.yml` explaining why there's no docker entry, so it doesn't get "helpfully" re-added later.

**Coverage lost: none** — the docker entry never produced a single PR (failed before file-fetch completed).

## Test plan

- [ ] CI green (actionlint)
- [ ] No more weekly `docker` Dependabot failure notification

---

Config-only change. Orthogonal codex gate waived by operator for this class; Copilot review applies.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
