### PR TITLE
ci(upstream-monitor): seed rotated base image to GHCR at PR creation

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -406,6 +406,54 @@ jobs:
             echo "rotated=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Seed the just-rotated base version into GHCR so the PR smoke build can
+      # resolve `FROM ${REMOTE_CR}/<base>:<new-version>` instead of failing
+      # fail-closed on an unseeded base. rotate-versions.sh has already written
+      # the new tag into <container>/config.yaml base_image_cache on disk; the
+      # daily sync-base-images job runs against master (pre-bump) and never seeds
+      # the new version until merge — so without this a base-image version-bump
+      # PR can never get a green build (the validation gap behind the spurious
+      # "Build failed after dep update" auto-issues). Gated on rotated==true:
+      # only retention / latest_per_major containers reach here.
+      - name: Log in to GitHub Container Registry
+        if: steps.rotate.outputs.rotated == 'true' && steps.env_check.outputs.is_local_test != 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.rotate.outputs.rotated == 'true' && steps.env_check.outputs.is_local_test != 'true'
+        continue-on-error: true
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Seed rotated base image to GHCR
+        if: steps.rotate.outputs.rotated == 'true' && steps.env_check.outputs.is_local_test != 'true'
+        # A transient seed flake must not block PR creation — the post-merge
+        # master sync remains the backstop (build fails as it does today, no worse).
+        continue-on-error: true
+        shell: bash
+        env:
+          OWNER: ${{ github.repository_owner }}
+          CONTAINER: ${{ steps.resolve.outputs.container_name }}
+        run: |
+          set -euo pipefail
+          source ./helpers/base-cache-utils.sh
+          # config.yaml base_image_cache already carries the new tag (rotate step).
+          # skip_present=true → only the genuinely-new tag is pulled from docker.io;
+          # already-mirrored bases are skipped (no extra rate-limit pressure).
+          v=$(./make version "$CONTAINER" 2>/dev/null || echo "latest")
+          [[ -z "$v" || "$v" == "unknown" ]] && v="latest"
+          containers_json=$(jq -nc --arg c "$CONTAINER" '[$c]')
+          versions_json=$(jq -nc --arg c "$CONTAINER" --arg v "$v" '{($c): $v}')
+          images=$(collect_all_cache_images "$containers_json" "$versions_json" "$OWNER")
+          sync_base_images_to_ghcr "$images" docker.io true
+
       - name: Close duplicate PRs
         id: close_duplicates
         uses: ./.github/actions/close-duplicate-prs


### PR DESCRIPTION
## Problem

A PR that bumps a container's **base-image version** (e.g. terraform 1.15.6 → 1.15.7) could never get a green smoke build, so we merged base-image bumps blind on the master build and the failure auto-filed spurious `🚨 Build failed after dep update` issues (e.g. #820). Root cause is a timing + permissions gap:

- The build does `FROM ${REMOTE_CR}/<base>:<new-version>` against the GHCR mirror.
- The daily `sync-base-images` job seeds from **master's** `config.yaml` (still the old version), so the new tag is never mirrored until the PR merges.
- PR events skip the seed sync, and the docker.io fallback is disabled (egress containment, #648) — so the unseeded base made every build cell fail fail-closed.

The PR smoke build's whole purpose — validating that the new version builds — was structurally impossible for this change class.

## Fix

Seed the just-rotated base into GHCR **at PR-creation time**, inside `upstream-monitor`'s `create-update-prs` job (which already holds `packages: write`). Right after `rotate-versions.sh` writes the new tag into `<container>/config.yaml base_image_cache` on disk, three steps run (gated on `rotated == 'true'`):

1. GHCR login, 2. Docker Hub login (continue-on-error), 3. seed — `collect_all_cache_images` + `sync_base_images_to_ghcr "$images" docker.io true`.

`skip_present=true` → only the genuinely-new tag is pulled from docker.io; already-mirrored bases are skipped (no extra rate-limit pressure). `continue-on-error` keeps a transient seed flake from blocking PR creation — the post-merge master sync stays the backstop. **No docker.io egress is reopened in the build path**; the seed runs in the trusted automation context exactly where the daily sync already does.

Result: the new base is in GHCR before the PR's CI fires → the smoke build resolves the base and actually validates the bump.

## Scope / notes

- Gated on `rotated == 'true'` → covers `version_retention` / `latest_per_major` containers (terraform, etc.). Containers that bump a base without rotation (e.g. postgres `always_all_versions`) are **not** covered here; if they show the same symptom they need separate handling — flagged, not silently omitted.
- Reuses the daily `sync-base-images` helpers and login pattern verbatim; no new code paths.

## Verification

- `actionlint -config-file /dev/null` with CI's `SHELLCHECK_OPTS=--severity=error` → clean (exit 0). The added `run:` block introduces no shellcheck findings.
- The seed path itself is exercised on the next real version-bump run (or a `workflow_dispatch` of upstream-monitor) — it can't be unit-tested without a live bump.

## Test plan

- [ ] CI green (actionlint, unit-tests)
- [ ] Next base-image version-bump PR (terraform/etc.) gets a **green** smoke build instead of red + a spurious failure issue

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
