### PR TITLE
fix(resolver): avoid pipefail+SIGPIPE flip in timescaledb HA-tag presence check

### DIFF
--- a/scripts/resolvers/timescaledb-ha.sh
+++ b/scripts/resolvers/timescaledb-ha.sh
@@ -88,8 +88,15 @@ main() {
     # and fall through to the ceiling-only degrade path.
     # A non-empty response that has no tags for PG_MAJOR indicates an unknown/
     # unsupported major — that is a configuration error, not a transient outage.
+    # Use a here-string, NOT `echo "$ha_tags" | grep -q`: under `set -o pipefail`,
+    # `grep -q` exits at the first match and closes the pipe, so under scheduler
+    # pressure (e.g. CI `bats --jobs`) `echo` can take a SIGPIPE; pipefail then
+    # propagates that as a pipeline failure, flipping this to false even when tags
+    # ARE present. That mis-routed the resolver to the "empty HA response" branch
+    # ~10% of the time under load (#823). A here-string is a single command — no
+    # pipe, no SIGPIPE, no pipefail interaction.
     local ha_has_any_tags=false
-    if echo "$ha_tags" | grep -qE "^pg[0-9]+\.[0-9]+-ts[0-9]+"; then
+    if grep -qE "^pg[0-9]+\.[0-9]+-ts[0-9]+" <<< "$ha_tags"; then
         ha_has_any_tags=true
     fi
 


### PR DESCRIPTION
Closes #823

## Root cause (empirically confirmed)

`scripts/resolvers/timescaledb-ha.sh` checked whether the HA registry returned any tags with:

```bash
if echo "$ha_tags" | grep -qE "^pg[0-9]+\.[0-9]+-ts[0-9]+"; then
    ha_has_any_tags=true
fi
```

Under `set -o pipefail`, `grep -q` exits at the **first** match and closes the pipe. Under scheduler pressure (CI `bats --jobs`), `echo` can then take a **SIGPIPE**, and `pipefail` propagates that as a pipeline failure — so `ha_has_any_tags` flipped to `false` **even though the tags were present**. The resolver then mis-routed an unknown `PG_MAJOR` (a configuration error) into the *empty/garbled-HA* degrade branch and emitted the wrong error message.

This is what surfaced as the flaky `H-unsupported-pg` test in #823. The resolver — not the test — was the defect; `bats --jobs` didn't *cause* it, it **amplified** it (the SIGPIPE race window widens under load).

### Evidence
500 loaded runs of the test:

| | assertion failures | of those, `ha_has_any_tags=false` while fixture fully read (466 lines) |
|---|---|---|
| **before** | 50/500 (~10%) | **50/50** (100%) |
| **after** | **0/500** | — |

(The 2/500 residual seen post-fix were unrelated bats-harness errors — `setup_file failed` / `bats-gather-tests` — under extreme artificial parallelism, not the resolver and not this assertion. See follow-up below.)

## Fix

A here-string instead of the pipe — a single command, so no writer process, no SIGPIPE, no `pipefail` interaction:

```bash
if grep -qE "^pg[0-9]+\.[0-9]+-ts[0-9]+" <<< "$ha_tags"; then
```

This also hardens the resolver in production: under load it would otherwise emit a misleading error message on an unknown major.

## Verification

- 0 assertion failures in 500 loaded runs after the change (was 50).
- Full `resolver-timescaledb-ha.bats` suite green (36/36).
- `shellcheck` clean; resolver behaviour unchanged for valid majors (PG18 → correct array) and for unknown majors (PG99 → `no HA tags found for PG99`).

## Follow-ups (not in this PR)

- The same `echo "$x" | grep -q` shape exists in ~30 other places under `set -o pipefail`. They run single-shot in production (≈0% manifestation) rather than under `bats --jobs`, so they're latent — to be swept systematically with tests in a separate change.
- The ~0.4% residual bats-infra flakes (`setup_file`/`bats-gather-tests`) under heavy parallelism point at the CI `bats` (installed via `apt`, an older build); pinning a recent bats is a separate hygiene change.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
