### PR TITLE
ci(bats): install bats via a shared pinned composite (1.13.0, Dependabot-tracked)

### DIFF
--- a/.github/actions/setup-bats/action.yaml
+++ b/.github/actions/setup-bats/action.yaml
@@ -1,0 +1,19 @@
+name: Setup Bats
+description: >
+  Install a pinned bats-core via the official bats-core/bats-action. This is the
+  single source of truth for the bats version across the unit-tests and
+  container-test jobs (previously: apt in unit-tests, an inline 1.11.1 tarball in
+  auto-build). Helper libs (support/assert/detik/file) are intentionally NOT
+  installed — this repo's bats tests are plain (no `load bats-support`). The
+  action pin below is tracked by Dependabot (this dir is listed in
+  .github/dependabot.yml), so version bumps arrive as reviewed PRs.
+runs:
+  using: composite
+  steps:
+    - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+      with:
+        bats-version: "1.13.0"
+        support-install: "false"
+        assert-install: "false"
+        detik-install: "false"
+        file-install: "false"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - "/.github/actions/docker-login"
       - "/.github/actions/preflight-buildkit"
       - "/.github/actions/retry-run"
+      - "/.github/actions/setup-bats"
       - "/.github/actions/setup-github-cli"
     schedule:
       interval: "weekly"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1198,6 +1198,14 @@ jobs:
             }
           }
 
+      - name: Setup bats
+        if: steps.build.outcome == 'success' && matrix.build.os != 'windows' && matrix.build.build_flavor == 'base' && matrix.arch == 'amd64' && inputs.run_tests == true
+        # Advisory like the test step it feeds: a bats-install hiccup must not
+        # hard-fail the build (the inline install it replaced was absorbed by the
+        # test step's own continue-on-error).
+        continue-on-error: true
+        uses: ./.github/actions/setup-bats
+
       - name: Run bats tests (Linux)
         if: steps.build.outcome == 'success' && matrix.build.os != 'windows' && matrix.build.build_flavor == 'base' && matrix.arch == 'amd64' && inputs.run_tests == true
         timeout-minutes: 5
@@ -1205,13 +1213,6 @@ jobs:
         shell: bash
         run: |
           if [[ -f "${{ matrix.build.container }}/tests/test-runner-linux.bats" ]]; then
-            # Install bats from pinned GitHub release
-            if ! command -v bats &>/dev/null; then
-              BATS_VERSION=1.11.1
-              curl -sL "https://github.com/bats-core/bats-core/archive/refs/tags/v${BATS_VERSION}.tar.gz" -o /tmp/bats.tar.gz
-              tar -xzf /tmp/bats.tar.gz -C /tmp
-              sudo "/tmp/bats-core-${BATS_VERSION}/install.sh" /usr/local
-            fi
             bats "${{ matrix.build.container }}/tests/test-runner-linux.bats"
           fi
 
@@ -2497,6 +2498,13 @@ jobs:
           ghcr_login() { printf '%s\n' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin; }
           retry_with_backoff 3 5 ghcr_login
 
+      - name: Setup bats
+        if: matrix.build.build_flavor == 'base' || matrix.build.build_flavor == ''
+        # Advisory like the bake test step it feeds (continue-on-error below):
+        # a bats-install hiccup must not hard-fail the build.
+        continue-on-error: true
+        uses: ./.github/actions/setup-bats
+
       - name: Run bats tests (bake)
         if: matrix.build.build_flavor == 'base' || matrix.build.build_flavor == ''
         # Advisory, matching the legacy flat-matrix bats step: a test result is
@@ -2517,13 +2525,6 @@ jobs:
           if [[ ! -f "${container}/tests/test-runner-linux.bats" ]]; then
             echo "::notice::No Linux bats for ${container}; skipping"
             exit 0
-          fi
-          # Install pinned bats (mirror build-and-push)
-          if ! command -v bats &>/dev/null; then
-            BATS_VERSION=1.11.1
-            curl -sL "https://github.com/bats-core/bats-core/archive/refs/tags/v${BATS_VERSION}.tar.gz" -o /tmp/bats.tar.gz
-            tar -xzf /tmp/bats.tar.gz -C /tmp
-            sudo "/tmp/bats-core-${BATS_VERSION}/install.sh" /usr/local
           fi
           # Point integration tests (openresty) at this run's published per-arch ref.
           # No eager pull: openresty's test `docker run`s it (auto-pull on demand);

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -36,11 +36,11 @@ jobs:
           yq --version
 
       - name: Install bats
-        timeout-minutes: 5
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bats
-          bats --version
+        uses: ./.github/actions/setup-bats
+
+      - name: Show bats version
+        shell: bash
+        run: bats --version
 
       - name: Run unit tests
         shell: bash


### PR DESCRIPTION
## Why

Three divergent bats installs existed:
- `unit-tests.yaml` → `apt-get install bats` (an old, unpinned Ubuntu build; its `--jobs` parallel handling is behind the residual harness flakes seen while fixing #823),
- `auto-build.yaml` → an inline `1.11.1` tarball, duplicated in **two** steps.

Local dev is on `1.13.0`, so CI and local also drifted.

## What

One shared composite, `.github/actions/setup-bats`, that installs bats **1.13.0** via the official `bats-core/bats-action` (SHA-pinned to v4.0.0). Helper libs (support/assert/detik/file) are disabled — this repo's bats tests are plain (no `load bats-support`). All three call sites now use it:
- `unit-tests.yaml` — replaces the `apt` install.
- `auto-build.yaml` — replaces both inline `1.11.1` installs (as gated `Setup bats` steps).

The composite directory is added to `.github/dependabot.yml`'s `github-actions` `directories`, so the action pin is tracked and bumped by Dependabot like every other action — single source of truth for the bats version.

## Advisory-path preservation

The auto-build bats test steps are advisory (`continue-on-error: true`) — a test/install hiccup there must not fail the build. The inline install they replaced was absorbed by the test step's own `continue-on-error`. So the two new `Setup bats` steps in `auto-build.yaml` carry `continue-on-error: true` too. The `unit-tests.yaml` install deliberately does **not** — that job is a required gate and a bats-install failure there *should* fail it.

## Verification

- `actionlint -config-file /dev/null` with CI's `SHELLCHECK_OPTS=--severity=error` → clean.
- All four files YAML-valid; no residual `apt`/`1.11.1`/tarball install remains.
- Action pin is the commit SHA for tag v4.0.0 (`77d6fb6…`), verified via tag dereference.
- The composite is exercised by this PR's own `unit-tests` run (it installs 1.13.0 and runs the suite).

## Note

The `bats-version: "1.13.0"` is an explicit reproducibility pin; Dependabot tracks the **action** wrapper (new `bats-core/bats-action` releases → PRs). Bumping bats itself beyond 1.13.0 is a one-line input change (or arrives with an action bump).

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
