### PR TITLE
ci: authenticate version.sh GitHub API calls to avoid rate-limit flakes

### DIFF
--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -6,6 +6,14 @@ inputs:
     description: 'Container name to check (optional, checks all if empty)'
     required: false
     default: ''
+  github_token:
+    description: >
+      Token for authenticated GitHub API calls made by version.sh scripts
+      (github-runner/vector/web-shell resolve versions from GitHub — the shared
+      helpers use this only when set). Passing it raises the API limit from
+      60 to 1000+ req/hr and avoids rate-limit "empty version" flakes. Optional.
+    required: false
+    default: ''
 
 outputs:
   containers_with_updates:
@@ -32,6 +40,10 @@ runs:
     - name: Check upstream versions
       id: check-versions
       shell: bash
+      env:
+        # Consumed by version.sh's GitHub helpers (latest-github-release/tag)
+        # only when non-empty; empty = unauthenticated (previous behaviour).
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         set -e
         

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: ./.github/actions/check-upstream-versions
         with:
           container: ${{ github.event.inputs.container }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |
@@ -441,6 +442,8 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
           CONTAINER: ${{ steps.resolve.outputs.container_name }}
+          # Authenticate the `./make version` GitHub API call below (#831).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           source ./helpers/base-cache-utils.sh
@@ -865,6 +868,9 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
           SYNC_MANIFEST_OUT: base-sync-manifest/base-sync-manifest.jsonl
+          # Authenticate the `./make version` GitHub API calls in the loop below
+          # (github-runner/vector/web-shell resolve from GitHub) — see #831.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           source ./helpers/base-cache-utils.sh

--- a/.github/workflows/validate-version-scripts.yaml
+++ b/.github/workflows/validate-version-scripts.yaml
@@ -25,6 +25,20 @@ on:
 
 permissions:
   contents: read
+
+# Authenticate the GitHub API calls that version.sh makes (github-runner/vector/
+# web-shell resolve versions from GitHub). This job tests EVERY version.sh with
+# build_all_retained, so unauthenticated it exhausts the 60 req/hr limit and a
+# GitHub-API version.sh comes back empty (rate-limit flake, #831).
+#
+# SECURITY: this job runs on `pull_request` and executes the PR's own version.sh
+# code, so the token must NOT be exposed to untrusted fork PRs. Provide it only
+# for non-PR events (workflow_dispatch) and SAME-REPO PRs (bot / write-access
+# contributors — where the flake actually occurs); fork PRs get an empty string
+# and stay unauthenticated. Same trust guard the repo uses for use_base_cache.
+env:
+  GITHUB_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.GITHUB_TOKEN || '' }}
+
 jobs:
   validate-version-scripts:
     runs-on: ubuntu-latest
@@ -106,10 +120,16 @@ jobs:
         uses: ./.github/actions/check-upstream-versions
         with:
           container: ${{ steps.test-upstream.outputs.first_container }}
+          # Inherits the fork-guarded value from the workflow-level env above
+          # (empty on untrusted fork PRs).
+          github_token: ${{ env.GITHUB_TOKEN }}
 
       - name: Test upstream monitoring action (all containers)
         if: github.event.inputs.container == '' && steps.detect-containers.outputs.count > 1
         uses: ./.github/actions/check-upstream-versions
+        with:
+          # Inherits the fork-guarded value from the workflow-level env above.
+          github_token: ${{ env.GITHUB_TOKEN }}
 
       - name: Display test results
         run: |


### PR DESCRIPTION
Closes #831

## Why

The `version.sh` scripts for `github-runner`/`vector`/`web-shell` resolve versions from the GitHub API (directly or via `helpers/latest-github-release`/`latest-github-tag`). Those helpers add an `Authorization` header **only when `GITHUB_TOKEN` is set in the environment** — but no workflow wired the token into the steps that run them. So in CI they ran unauthenticated (60 req/hr). `Validate Version Scripts` tests **every** `version.sh` with `build_all_retained`, exhausted the limit, and a GitHub-API script came back empty (the `vector` flake, run 28501090611).

## What

Wire `GITHUB_TOKEN` in at every version-discovery site (env-only; helpers consume it only when set, no script changes):
- `check-upstream-versions` composite gains a `github_token` input, mapped to `GITHUB_TOKEN` for the `./make check-updates` step; passed by `upstream-monitor` and both `validate` invocations.
- `validate-version-scripts.yaml` sets it at workflow level (covers the direct `validate-version-scripts.sh` run).
- `upstream-monitor.yaml` sets it on the two `./make version` loops (sync-base-images, seed-on-PR).

## Security — token exposure boundary (deliberate)

`validate-version-scripts.yaml` runs on `pull_request` and executes the PR's own `version.sh` code, so the token must not reach **untrusted** code. Two guards:

1. **Fork guard.** The token is provided only for non-PR events and **same-repo** PRs (`github.event.pull_request.head.repo.full_name == github.repository`) — the same trust boundary the repo already uses for `use_base_cache`. Fork PRs get an empty string and stay unauthenticated.
2. **Read-only scope.** This workflow declares `permissions: contents: read`, so the token is read-only, on a **public** repo. Exposure is therefore limited to same-repo (write-access / bot) contributors receiving a read-only token to already-public content — the standard GitHub Actions trust model, and the only design that also fixes the flake (which occurs on the bot's same-repo PRs). Accepted deliberately.

`upstream-monitor.yaml` runs only on `schedule`/`workflow_dispatch` (no untrusted PR code), so its token wiring is unconditional.

## Not covered (follow-up)

`./make version` inside the `detect-containers` and `build-container` composites also runs unauthenticated, but those are single-container / low-volume and threading the token through widely-used composites is a larger change — left as follow-up.

## Verification

- `actionlint` (CI severity) clean on the changed workflows.
- This PR triggers `Validate Version Scripts` on itself (same-repo) → the run is now authenticated → confirms the fix live.

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
