### PR TITLE
fix(php): install composer from getcomposer.org/GitHub instead of the docker.io image

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,11 +1,24 @@
 ARG REMOTE_CR=ghcr.io/oorabona
 ARG VERSION
-ARG COMPOSER_VERSION
-FROM ${REMOTE_CR}/library/composer:${COMPOSER_VERSION} AS composer
-ARG REMOTE_CR
 FROM ${REMOTE_CR}/library/php:${VERSION} AS php
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+# Composer: install the official phar from its GitHub release (the version
+# SSOT upstream-monitor tracks), cross-verified against the per-version
+# sha256sum published by getcomposer.org. Two independent channels — a
+# tampered artifact on either host fails the check. This previously pulled
+# docker.io's library/composer image just to COPY out /usr/bin/composer, but
+# that image's tags lag GitHub releases, so a bumped COMPOSER_VERSION broke
+# the GHCR base-cache sync (composer 2.10.2 existed upstream but not yet on
+# Docker Hub). Self-updates with the arg: both URLs are versioned.
+ARG COMPOSER_VERSION
+RUN set -eux \
+    && apk add --no-cache ca-certificates \
+    && wget -qO /usr/bin/composer "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" \
+    && wget -qO /tmp/composer.sha256sum "https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar.sha256sum" \
+    && printf '%s  /usr/bin/composer\n' "$(cut -d' ' -f1 /tmp/composer.sha256sum)" | sha256sum -c - \
+    && chmod +x /usr/bin/composer \
+    && rm -f /tmp/composer.sha256sum \
+    && composer --version
 
 ARG APCU_VERSION
 

--- a/php/config.yaml
+++ b/php/config.yaml
@@ -5,8 +5,6 @@ base_image: "${REMOTE_CR}/library/php:${VERSION}"
 base_image_cache:
   - source: library/php
     tags_from_versions: true
-  - source: library/composer
-    tags: ["${COMPOSER_VERSION}"]
 build_args:
   COMPOSER_VERSION: "2.10.2"
   APCU_VERSION: "5.1.28"


### PR DESCRIPTION
## Problem — master Auto Build is red

The bot's #833 bumped `COMPOSER_VERSION` to 2.10.2 (a real composer release, tracked from `composer/composer` GitHub releases — the version SSOT). But the php build pulled `docker.io/library/composer:${COMPOSER_VERSION}` just to `COPY` out `/usr/bin/composer`, and Docker Hub's library image lags GitHub releases by days: `composer:2.10.2` returns 404 on docker.io. The fail-closed base-image sync errored → every master Auto Build since has failed (sync + bake + php cells).

This was a structural split-brain: version tracked from source A (GitHub releases), artifact pulled from source B (docker.io) that publishes on its own schedule. Any bump could break until B catches up — reverting the version would only re-break on the next daily scan.

## Fix — install composer from its own release, not a docker image

Replace the `FROM …/library/composer` stage + `COPY` with a direct install in the php stage:

- **phar from the GitHub release** (`github.com/composer/composer/releases/download/<v>/composer.phar`) — the same source the version is tracked from, so a tracked bump always has its artifact immediately;
- **verified against the per-version `sha256sum` published by getcomposer.org** — a second, independent channel: tampering on either host fails the check;
- both URLs are versioned by `COMPOSER_VERSION` → self-updating with the bot's bumps, no hash to maintain in the Dockerfile.

Drop the `library/composer` entry from `base_image_cache` (one less docker.io image to mirror — egress win). `dependency_sources` tracking is unchanged: composer keeps being bumped automatically.

composer was the **only** tool obtained by pulling a docker image rather than installing from its own release (terraform tools, vector, github-runner all install from releases) — this aligns it with the repo-wide pattern. Scanned all 16 container configs: no other `base_image_cache` tag interpolates a github-release-tracked version; this was the only split-brain instance.

## Verification

- Install layer built green on real alpine (twice: initial + cross-check variant): checksum `OK`, binary executable (3.6 MB).
- GitHub-release phar sha256 == getcomposer.org published checksum (`5ee7125f…`) — channels agree for 2.10.2.
- The php build on this PR exercises the full Dockerfile (`composer --version` runs in-layer).

## Test plan

- [ ] php build cells green on this PR (no more composer sync failure)
- [ ] post-merge master Auto Build returns to green
- [ ] next composer bump by the bot builds without docker.io involvement

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
