### PR TITLE
refactor: replace pipefail-prone echo|grep -q/head with here-strings

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -211,8 +211,8 @@ _image_registry_probe_3state() {
     # "docker: command not found" or "docker-credential-desktop: executable file
     # not found in PATH", which would mis-classify an infra failure as ABSENT and
     # silently drop retained versions from the artifact.
-    if echo "$_probe_stderr" | grep -qiE \
-        'manifest unknown|name unknown|repository name not known|no such manifest'; then
+    if grep -qiE \
+        'manifest unknown|name unknown|repository name not known|no such manifest' <<< "$_probe_stderr"; then
         if command -v skopeo &>/dev/null; then
             local _skopeo_stderr
             local _skopeo_rc=0
@@ -222,8 +222,8 @@ _image_registry_probe_3state() {
             fi
             # skopeo also non-zero; if skopeo's error is NOT a definitive not-found,
             # escalate to ERROR to avoid discarding the version on ambiguous signal.
-            if ! echo "$_skopeo_stderr" | grep -qiE \
-                'manifest unknown|name unknown|repository name not known|no such manifest|MANIFEST_UNKNOWN'; then
+            if ! grep -qiE \
+                'manifest unknown|name unknown|repository name not known|no such manifest|MANIFEST_UNKNOWN' <<< "$_skopeo_stderr"; then
                 return 2  # ERROR (docker said not-found but skopeo is ambiguous)
             fi
         fi
@@ -1162,7 +1162,7 @@ compute_affected_flavors() {
             [[ -z "$changed_ext" ]] && continue
 
             # Check if this extension is in the flavor
-            if ! echo "$flavor_exts" | grep -qFx "$changed_ext"; then
+            if ! grep -qFx "$changed_ext" <<< "$flavor_exts"; then
                 continue
             fi
 

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -342,7 +342,7 @@ detect_major_version() {
         local full_version
         full_version=$("$version_script" 2>/dev/null | head -1)
         # Extract major version (first number before dot or dash)
-        echo "$full_version" | grep -oE '^[0-9]+' | head -1
+        grep -oE '^[0-9]+' <<< "$full_version" | head -1
     else
         log_error "Cannot detect version. Use --major-version or ensure version.sh exists."
         exit 1
@@ -911,7 +911,7 @@ _reuse_ref_is_multiarch() {
     if [[ "$_rc" -ne 0 ]]; then
         return 2
     fi
-    if echo "$_out" | grep -q "linux/amd64" && echo "$_out" | grep -q "linux/arm64"; then
+    if grep -q "linux/amd64" <<< "$_out" && grep -q "linux/arm64" <<< "$_out"; then
         return 0
     fi
     return 1
@@ -1378,8 +1378,8 @@ _image_present_3state() {
     # "docker: command not found" or "docker-credential-desktop: executable file
     # not found in PATH", which would mis-classify an infra failure as ABSENT and
     # silently drop retained versions from the artifact.
-    if echo "$_probe_stderr" | grep -qiE \
-        'manifest unknown|name unknown|repository name not known|no such manifest'; then
+    if grep -qiE \
+        'manifest unknown|name unknown|repository name not known|no such manifest' <<< "$_probe_stderr"; then
         # docker returned a definitive not-found — check skopeo for a second opinion
         # only when available, to confirm and not flip to ERROR on a skopeo transient.
         if command -v skopeo &>/dev/null; then
@@ -1391,8 +1391,8 @@ _image_present_3state() {
             fi
             # skopeo also returned non-zero; if skopeo's error is transient (not a
             # definitive not-found), escalate to ERROR to avoid discarding the version.
-            if ! echo "$_skopeo_stderr" | grep -qiE \
-                'manifest unknown|name unknown|repository name not known|no such manifest|MANIFEST_UNKNOWN'; then
+            if ! grep -qiE \
+                'manifest unknown|name unknown|repository name not known|no such manifest|MANIFEST_UNKNOWN' <<< "$_skopeo_stderr"; then
                 return 2  # ERROR (docker said not-found but skopeo is ambiguous)
             fi
         fi
@@ -2182,8 +2182,8 @@ finalize_multiarch_manifests() {
                 _ext_failed=true
                 break
             fi
-            if ! echo "$_inspect_out" | grep -q "linux/amd64" || \
-               ! echo "$_inspect_out" | grep -q "linux/arm64"; then
+            if ! grep -q "linux/amd64" <<< "$_inspect_out" || \
+               ! grep -q "linux/arm64" <<< "$_inspect_out"; then
                 if [[ "$ver" == "$ceiling" ]]; then
                     log_error "$ext $ver pg${major_ver} (ceiling): created manifest does not cover both linux/amd64 and linux/arm64 — fatal"
                     _ext_failed=true

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -149,7 +149,7 @@ preflight_check() {
     local missing=0
     while IFS= read -r arg; do
         [[ -z "$arg" ]] && continue
-        if ! echo "$dep_sources" | grep -qx "$arg"; then
+        if ! grep -qx "$arg" <<< "$dep_sources"; then
             log_error "[${container}] build_arg '${arg}' has no dependency_sources entry (INV-05)"
             missing=$((missing + 1))
         fi

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -76,7 +76,7 @@ is_valid_tag() {
   local valid_tags="$2"
 
   # Direct match
-  if echo "$valid_tags" | grep -qxF "$tag"; then
+  if grep -qxF "$tag" <<< "$valid_tags"; then
     return 0
   fi
 
@@ -84,7 +84,7 @@ is_valid_tag() {
   local base_tag
   base_tag="${tag%-amd64}"
   base_tag="${base_tag%-arm64}"
-  if [[ "$base_tag" != "$tag" ]] && echo "$valid_tags" | grep -qxF "$base_tag"; then
+  if [[ "$base_tag" != "$tag" ]] && grep -qxF "$base_tag" <<< "$valid_tags"; then
     return 0
   fi
 
@@ -247,7 +247,7 @@ purge_ghcr() {
     while IFS='|' read -r version_id digest tags; do
       [[ -z "$version_id" ]] && continue
 
-      if [[ -n "$protected_digests" ]] && echo "$protected_digests" | grep -qxF "$digest"; then
+      if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
         echo "  ✓ Keep (tags: $tags) — digest is manifest child" >&2
         kept=$((kept + 1))
       else
@@ -274,7 +274,7 @@ purge_ghcr() {
       [[ -z "$version_id" ]] && continue
       [[ -n "$tags" ]] && continue
 
-      if [[ -n "$protected_digests" ]] && echo "$protected_digests" | grep -qxF "$digest"; then
+      if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
         kept=$((kept + 1))
       else
         echo "  ✗ Orphan (digest: ${digest:0:19}...)" >&2

--- a/scripts/open-dep-failure-issue.sh
+++ b/scripts/open-dep-failure-issue.sh
@@ -104,7 +104,7 @@ detect_dep_bump() {
     # Upstream-monitor label format: automation,<container>,dependencies,<minor|major|patch>-update
     # The container name appears as a bare label (e.g. "sslh"), not "sslh-update".
     if [[ -n "$PR_LABELS" ]]; then
-        if echo "$PR_LABELS" | grep -q "automation"; then
+        if grep -q "automation" <<< "$PR_LABELS"; then
             local label_container=""
             local re_update='^[^-]+-update$'
             while IFS= read -r label; do
@@ -280,7 +280,7 @@ get_log_excerpt() {
             --repo "$GITHUB_REPOSITORY" \
             --job "$job_id" \
             --log-failed 2>&1 | tail -30); then
-        echo "$excerpt" | head -50
+        head -50 <<< "$excerpt"
     else
         local reason="$excerpt"
         echo "(log excerpt unavailable: ${reason:-unknown error})"
@@ -762,7 +762,7 @@ find_or_create_issue() {
         if [[ -n "$candidate" ]]; then
             # Prefer a match that references the same PR if available
             if [[ -n "$PR_NUMBER" ]]; then
-                if echo "$search_output" | grep -q "PR #${PR_NUMBER}\|Refs #${PR_NUMBER}\|(#${PR_NUMBER})"; then
+                if grep -q "PR #${PR_NUMBER}\|Refs #${PR_NUMBER}\|(#${PR_NUMBER})" <<< "$search_output"; then
                     existing_number="$candidate"
                 else
                     existing_number="$candidate"


### PR DESCRIPTION
Closes #825

## Why

Same latent defect class as the timescaledb-resolver bug fixed in #824: a producer (`echo`/`printf` of a shell variable) piped into an **early-exiting** consumer (`grep -q`, `head`) under `set -o pipefail`. The consumer exits at the first match/line and closes the pipe; under scheduler pressure the producer takes a SIGPIPE, and `pipefail` propagates it as a pipeline failure — flipping the branch result even though the data was present. In #824 this mis-routed the resolver's error path ~10% of the time under load; the same shape existed at 16 more sites.

## What

Convert every status-significant `echo "$var" | grep -q…` / `| head` over a shell variable to a here-string (`grep -q PAT <<< "$var"`), which is a single command — no pipe, no SIGPIPE, no `pipefail` interaction. Behaviour is identical (a here-string appends a trailing newline exactly like `echo`).

Covered (16 sites, all in `set -o pipefail` scripts):
- `scripts/cleanup-outdated-tags.sh` — 4 (tag/digest membership checks)
- `scripts/build-extensions.sh` — 6 (multi-arch manifest checks, skopeo/docker not-found classification, major-version extraction)
- `helpers/extension-utils.sh` — 3 (same probe classification + flavor membership)
- `scripts/open-dep-failure-issue.sh` — 3 (label detection, dedup search, log excerpt)
- `scripts/check-dependency-versions.sh` — 1 (dep-source membership)

Deliberately left as-is:
- `scripts/build-container.sh` — no `pipefail` in that script, so the flip cannot happen;
- `$(... | head -1 || true)` command substitutions — the `|| true` already absorbs the pipeline status.

## Verification

- 410 bats tests green across the covering suites (cleanup-outdated-tags, build-extensions ×2, open-dep-failure-issue, version-set-resolver, cascade-resolver).
- `shellcheck` on all five files: no new findings (pre-existing info/style notes untouched).

https://claude.ai/code/session_01Nwzqg8CEw7UvsGT3gymqkG
