### PR TITLE
Stop proposing version downgrades as upstream updates

### DIFF
--- a/debian/version.sh
+++ b/debian/version.sh
@@ -8,6 +8,16 @@ if [ "$1" = "--registry-pattern" ]; then
     exit 0
 fi
 
+if [ "$1" = "--numeric-alias-image" ]; then
+    echo "library/debian"
+    exit 0
+fi
+
+if [ "$1" = "--numeric-alias-pattern" ]; then
+    echo "^[0-9]+$"
+    exit 0
+fi
+
 # Debian tags are plain codenames (trixie/bookworm/bullseye) — no suffix.
 if [ "$1" = "--tag-suffix" ]; then
     echo ""

--- a/helpers/dependency-freshness.sh
+++ b/helpers/dependency-freshness.sh
@@ -11,6 +11,10 @@
 set -euo pipefail
 
 _DEPENDENCY_FRESHNESS_HELPER="${BASH_SOURCE[0]}"
+_DEPENDENCY_FRESHNESS_DIR="$(cd "$(dirname "${_DEPENDENCY_FRESHNESS_HELPER}")" && pwd)"
+
+# shellcheck source=./version-utils.sh
+source "${_DEPENDENCY_FRESHNESS_DIR}/version-utils.sh"
 
 _freshness_resolver_for() {
     case "${1:-}" in
@@ -60,61 +64,8 @@ _freshness_normalize_name() {
     esac
 }
 
-_freshness_numeric_tuple() {
-    local version="$1"
-    if [[ "$version" =~ ^([0-9]+([.][0-9]+)*) ]]; then
-        printf '%s\n' "${BASH_REMATCH[1]}"
-        return 0
-    fi
-    return 1
-}
-
-_freshness_normalize_numeric_component() {
-    local component="$1"
-    while [[ "$component" == 0* && "$component" != "0" ]]; do
-        component="${component#0}"
-    done
-    printf '%s\n' "$component"
-}
-
 _freshness_numeric_version_gt() {
-    local candidate="$1"
-    local current="$2"
-    local candidate_tuple current_tuple candidate_part current_part index max_parts
-    local -a candidate_parts current_parts
-
-    [[ -n "$candidate" && -n "$current" ]] || return 2
-    candidate_tuple=$(_freshness_numeric_tuple "$candidate") || return 2
-    current_tuple=$(_freshness_numeric_tuple "$current") || return 2
-
-    local IFS=.
-    read -r -a candidate_parts <<< "$candidate_tuple"
-    read -r -a current_parts <<< "$current_tuple"
-
-    max_parts="${#candidate_parts[@]}"
-    if (( ${#current_parts[@]} > max_parts )); then
-        max_parts="${#current_parts[@]}"
-    fi
-
-    for ((index = 0; index < max_parts; index++)); do
-        candidate_part=$(_freshness_normalize_numeric_component "${candidate_parts[index]:-0}")
-        current_part=$(_freshness_normalize_numeric_component "${current_parts[index]:-0}")
-
-        if (( ${#candidate_part} > ${#current_part} )); then
-            return 0
-        fi
-        if (( ${#candidate_part} < ${#current_part} )); then
-            return 1
-        fi
-        if [[ "$candidate_part" > "$current_part" ]]; then
-            return 0
-        fi
-        if [[ "$candidate_part" < "$current_part" ]]; then
-            return 1
-        fi
-    done
-
-    return 1
+    version_is_greater "$1" "$2"
 }
 
 _freshness_version_gt() {

--- a/helpers/docker-tag
+++ b/helpers/docker-tag
@@ -5,22 +5,87 @@
 # Skopeo container image for consistent behavior
 readonly SKOPEO_IMAGE="quay.io/skopeo/stable:latest"
 
+function docker-tag-registry-url() {
+  local image=$1
+
+  if [[ "$image" == quay.io/* ]] || [[ "$image" == ghcr.io/* ]]; then
+    # External registries - use as-is
+    printf 'docker://%s\n' "$image"
+  elif [[ "$image" == */* ]]; then
+    # Docker Hub with namespace (e.g., "oorabona/php") - use as-is
+    printf 'docker://%s\n' "$image"
+  else
+    # Docker Hub official images (e.g., "php") - needs library/ prefix
+    printf 'docker://library/%s\n' "$image"
+  fi
+}
+
+function docker-tag-list-raw() {
+  local registry_url=$1
+  local timeout_seconds=${2:-120}
+  local raw rc
+
+  raw=$(timeout "$timeout_seconds" docker run --rm "$SKOPEO_IMAGE" list-tags "$registry_url" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$raw"
+}
+
+function docker-tag-matching-tags() {
+  local image=$1
+  local pattern=$2
+  local timeout_seconds=${3:-120}
+  local registry_url raw
+
+  registry_url=$(docker-tag-registry-url "$image")
+  raw=$(docker-tag-list-raw "$registry_url" "$timeout_seconds") || return 1
+
+  printf '%s' "$raw" | \
+    jq -r '.Tags[]? // empty' 2>/dev/null | \
+    grep -E "$pattern" 2>/dev/null | \
+    # Exclude prerelease tags (rc, alpha, beta, dev, pre, snapshot, nightly).
+    # Anchored at end of string to avoid false positives (e.g. "go-alpine" != alpha).
+    grep -viE '\-?(rc|alpha|beta|dev|pre|snapshot|nightly)[0-9.]*$' 2>/dev/null | \
+    sort -V
+}
+
+function docker-tag-digest() {
+  local image=$1
+  local tag=$2
+  local timeout_seconds=${3:-30}
+  local registry_url ref digest raw rc
+
+  registry_url=$(docker-tag-registry-url "$image")
+  ref="${registry_url}:${tag}"
+
+  digest=$(timeout "$timeout_seconds" docker run --rm "$SKOPEO_IMAGE" inspect --format '{{.Digest}}' "$ref" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [[ -n "$digest" && "$digest" != "<no value>" && "$digest" != "null" ]]; then
+    printf '%s\n' "$digest"
+    return 0
+  fi
+
+  raw=$(timeout "$timeout_seconds" docker run --rm "$SKOPEO_IMAGE" inspect "$ref" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 1
+  fi
+
+  digest=$(printf '%s' "$raw" | jq -r '.Digest // empty' 2>/dev/null)
+  if [[ -n "$digest" && "$digest" != "null" ]]; then
+    printf '%s\n' "$digest"
+    return 0
+  fi
+
+  return 1
+}
+
 function latest-docker-tag() {
   local image=$1
   local pattern=$2
-  local registry_url
-  
-  # Determine registry URL format with proper library/ prefix handling
-  if [[ "$image" == quay.io/* ]] || [[ "$image" == ghcr.io/* ]]; then
-    # External registries - use as-is
-    registry_url="docker://$image"
-  elif [[ "$image" == */* ]]; then
-    # Docker Hub with namespace (e.g., "oorabona/php") - use as-is
-    registry_url="docker://$image"
-  else
-    # Docker Hub official images (e.g., "php") - needs library/ prefix
-    registry_url="docker://library/$image"
-  fi
   
   # Get all tags using skopeo and filter with pattern.
   # timeout 120: cold image pull + list-tags can take 30-60s; 120s is generous
@@ -28,22 +93,8 @@ function latest-docker-tag() {
   # Capture raw output and exit code FIRST so a 124 (timeout with partial stdout)
   # deterministically routes to the failure path rather than silently returning
   # whatever partial JSON the pipeline happened to parse before exit.
-  local raw rc
-  raw=$(timeout 120 docker run --rm "$SKOPEO_IMAGE" list-tags "$registry_url" 2>/dev/null)
-  rc=$?
-  if [ "$rc" -ne 0 ]; then
-    return 1
-  fi
-
   local result
-  result=$(printf '%s' "$raw" | \
-    jq -r '.Tags[]? // empty' 2>/dev/null | \
-    grep -E "$pattern" 2>/dev/null | \
-    # Exclude prerelease tags (rc, alpha, beta, dev, pre, snapshot, nightly).
-    # Anchored at end of string to avoid false positives (e.g. "go-alpine" != alpha).
-    grep -viE '\-?(rc|alpha|beta|dev|pre|snapshot|nightly)[0-9.]*$' 2>/dev/null | \
-    sort -V | \
-    tail -n1)
+  result=$(docker-tag-matching-tags "$image" "$pattern" 120 | tail -n1)
 
   if [[ -n "$result" && "$result" != "null" ]]; then
     echo "$result"
@@ -58,17 +109,7 @@ function check-docker-tag() {
   local tag_pattern=$2
   local registry_url
   
-  # Determine registry URL format with proper library/ prefix handling
-  if [[ "$image" == quay.io/* ]] || [[ "$image" == ghcr.io/* ]]; then
-    # External registries - use as-is
-    registry_url="docker://$image"
-  elif [[ "$image" == */* ]]; then
-    # Docker Hub with namespace (e.g., "oorabona/php") - use as-is
-    registry_url="docker://$image"
-  else
-    # Docker Hub official images (e.g., "php") - needs library/ prefix
-    registry_url="docker://library/$image"
-  fi
+  registry_url=$(docker-tag-registry-url "$image")
   
   # Check if specific tag exists with enhanced error handling for CI
   local result
@@ -98,6 +139,28 @@ function check-docker-tag() {
   return 1
 }
 
+function resolve-numeric-alias() {
+  local image=$1
+  local tag=$2
+  local numeric_pattern=$3
+  local target_digest candidates candidate candidate_digest
+
+  target_digest=$(docker-tag-digest "$image" "$tag" 30) || return 1
+  candidates=$(docker-tag-matching-tags "$image" "$numeric_pattern" 120) || return 1
+
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+
+    candidate_digest=$(docker-tag-digest "$image" "$candidate" 30) || return 1
+    if [[ "$candidate_digest" == "$target_digest" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done <<< "$candidates"
+
+  return 1
+}
+
 # Handle execution - all script names containing "docker-tag" will execute
 if [[ "$0" == *"docker-tag"* ]]; then
   script_name="$(basename "$0")"
@@ -107,6 +170,9 @@ if [[ "$0" == *"docker-tag"* ]]; then
       ;;
     "check-docker-tag")
       check-docker-tag "$@"
+      ;;
+    "resolve-numeric-alias")
+      resolve-numeric-alias "$@"
       ;;
     *)
       # Called directly as docker-tag: docker-tag function_name args...

--- a/helpers/docker-tag
+++ b/helpers/docker-tag
@@ -151,7 +151,7 @@ function resolve-numeric-alias() {
   while IFS= read -r candidate; do
     [[ -n "$candidate" ]] || continue
 
-    candidate_digest=$(docker-tag-digest "$image" "$candidate" 30) || return 1
+    candidate_digest=$(docker-tag-digest "$image" "$candidate" 30) || continue
     if [[ "$candidate_digest" == "$target_digest" ]]; then
       printf '%s\n' "$candidate"
       return 0

--- a/helpers/version-utils.sh
+++ b/helpers/version-utils.sh
@@ -5,6 +5,66 @@
 # Default semver pattern when container has no custom --registry-pattern
 DEFAULT_VERSION_PATTERN='^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'
 
+_version_numeric_tuple() {
+    local version="$1"
+    if [[ "$version" =~ ^([0-9]+([.][0-9]+)*) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+_version_normalize_numeric_component() {
+    local component="$1"
+    while [[ "$component" == 0* && "$component" != "0" ]]; do
+        component="${component#0}"
+    done
+    printf '%s\n' "$component"
+}
+
+# Compare leading numeric dotted tuples from version strings.
+# Args: $1 = candidate version, $2 = current version
+# Returns: 0 when candidate is greater, 1 when not greater, 2 when unparseable
+version_is_greater() {
+    local candidate="$1"
+    local current="$2"
+    local candidate_tuple current_tuple candidate_part current_part index max_parts
+    local -a candidate_parts current_parts
+
+    [[ -n "$candidate" && -n "$current" ]] || return 2
+    candidate_tuple=$(_version_numeric_tuple "$candidate") || return 2
+    current_tuple=$(_version_numeric_tuple "$current") || return 2
+
+    local IFS=.
+    read -r -a candidate_parts <<< "$candidate_tuple"
+    read -r -a current_parts <<< "$current_tuple"
+
+    max_parts="${#candidate_parts[@]}"
+    if (( ${#current_parts[@]} > max_parts )); then
+        max_parts="${#current_parts[@]}"
+    fi
+
+    for ((index = 0; index < max_parts; index++)); do
+        candidate_part=$(_version_normalize_numeric_component "${candidate_parts[index]:-0}")
+        current_part=$(_version_normalize_numeric_component "${current_parts[index]:-0}")
+
+        if (( ${#candidate_part} > ${#current_part} )); then
+            return 0
+        fi
+        if (( ${#candidate_part} < ${#current_part} )); then
+            return 1
+        fi
+        if [[ "$candidate_part" > "$current_part" ]]; then
+            return 0
+        fi
+        if [[ "$candidate_part" < "$current_part" ]]; then
+            return 1
+        fi
+    done
+
+    return 1
+}
+
 # Get the registry pattern for a container (must be called from within the container dir)
 # Returns the container-specific pattern or the default semver pattern
 get_registry_pattern() {

--- a/helpers/version-utils.sh
+++ b/helpers/version-utils.sh
@@ -7,7 +7,7 @@ DEFAULT_VERSION_PATTERN='^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-
 
 _version_numeric_tuple() {
     local version="$1"
-    if [[ "$version" =~ ^([0-9]+([.][0-9]+)*) ]]; then
+    if [[ "$version" =~ ^[vV]?([0-9]+([.][0-9]+)*) ]]; then
         printf '%s\n' "${BASH_REMATCH[1]}"
         return 0
     fi

--- a/make
+++ b/make
@@ -88,6 +88,45 @@ list_containers() {
   done
 }
 
+check_updates_current_blocks_latest() {
+  local current_version=$1
+  local latest_version=$2
+  local compare_rc
+
+  version_is_greater "$current_version" "$latest_version"
+  compare_rc=$?
+  if [ "$compare_rc" -eq 0 ]; then
+    return 0
+  fi
+  if [ "$compare_rc" -ne 2 ]; then
+    return 1
+  fi
+
+  local numeric_alias_image numeric_alias_pattern
+  numeric_alias_image=$(./version.sh --numeric-alias-image 2>/dev/null | head -1 | tr -d '\n' || true)
+  numeric_alias_pattern=$(./version.sh --numeric-alias-pattern 2>/dev/null | head -1 | tr -d '\n' || true)
+
+  # Unknown flags in some older version.sh files fall through to the normal
+  # latest-version lookup. Require an explicit image-like source to opt in.
+  if [[ -z "$numeric_alias_image" || -z "$numeric_alias_pattern" || "$numeric_alias_image" != */* ]]; then
+    return 1
+  fi
+
+  local current_numeric_alias latest_numeric_alias
+  current_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$current_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n') || return 1
+  latest_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$latest_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n') || return 1
+
+  if [[ -z "$current_numeric_alias" || -z "$latest_numeric_alias" ]]; then
+    return 1
+  fi
+
+  if version_is_greater "$current_numeric_alias" "$latest_numeric_alias"; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Show project-internal dependency graph for a container
 list_deps() {
   local container="${1:-}"
@@ -524,7 +563,7 @@ check_updates() {
             status="new-container"
           fi
         elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
-          if version_is_greater "$current_version" "$latest_version"; then
+          if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
             :
           else
             update_available="true"
@@ -581,7 +620,7 @@ check_updates() {
         status="new-container"
       fi
     elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
-      if version_is_greater "$current_version" "$latest_version"; then
+      if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
         :
       else
         update_available="true"

--- a/make
+++ b/make
@@ -91,11 +91,25 @@ list_containers() {
 check_updates_current_blocks_latest() {
   local current_version=$1
   local latest_version=$2
-  local compare_current=$current_version
-  local compare_latest=$latest_version
+  local normalized_current=$current_version
+  local normalized_latest=$latest_version
 
   if ! command -v dpkg >/dev/null 2>&1; then
     return 1
+  fi
+
+  case "$normalized_current" in
+    v*) normalized_current=${normalized_current#v} ;;
+    V*) normalized_current=${normalized_current#V} ;;
+  esac
+  case "$normalized_latest" in
+    v*) normalized_latest=${normalized_latest#v} ;;
+    V*) normalized_latest=${normalized_latest#V} ;;
+  esac
+
+  if [[ "$normalized_current" =~ ^[0-9] && "$normalized_latest" =~ ^[0-9] ]]; then
+    dpkg --compare-versions "$normalized_current" gt "$normalized_latest" 2>/dev/null
+    return $?
   fi
 
   local numeric_alias_image numeric_alias_pattern
@@ -113,11 +127,15 @@ check_updates_current_blocks_latest() {
       return 1
     fi
 
-    compare_current=$current_numeric_alias
-    compare_latest=$latest_numeric_alias
+    if [[ ! "$current_numeric_alias" =~ ^[0-9] || ! "$latest_numeric_alias" =~ ^[0-9] ]]; then
+      return 1
+    fi
+
+    dpkg --compare-versions "$current_numeric_alias" gt "$latest_numeric_alias" 2>/dev/null
+    return $?
   fi
 
-  dpkg --compare-versions "$compare_current" gt "$compare_latest" 2>/dev/null
+  return 1
 }
 
 # Show project-internal dependency graph for a container

--- a/make
+++ b/make
@@ -518,14 +518,18 @@ check_updates() {
         local update_available="false"
         local status="up_to_date"
 
-        if [ "$current_version" = "no-published-version" ]; then
+        if [ -z "$current_version" ] || [ "$current_version" = "no-published-version" ]; then
           if [ -n "$latest_version" ]; then
             update_available="true"
             status="new-container"
           fi
-        elif [ -n "$latest_version" ] && version_is_greater "$latest_version" "$current_version"; then
-          update_available="true"
-          status="update-available"
+        elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
+          if version_is_greater "$current_version" "$latest_version"; then
+            :
+          else
+            update_available="true"
+            status="update-available"
+          fi
         fi
 
         # Build per-major JSON entry.
@@ -571,14 +575,18 @@ check_updates() {
     local update_available="false"
     local status="up_to_date"
 
-    if [ "$current_version" = "no-published-version" ]; then
+    if [ -z "$current_version" ] || [ "$current_version" = "no-published-version" ]; then
       if [ -n "$latest_version" ]; then
         update_available="true"
         status="new-container"
       fi
-    elif [ -n "$latest_version" ] && version_is_greater "$latest_version" "$current_version"; then
-      update_available="true"
-      status="update-available"
+    elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
+      if version_is_greater "$current_version" "$latest_version"; then
+        :
+      else
+        update_available="true"
+        status="update-available"
+      fi
     fi
 
     # Build JSON object for this container

--- a/make
+++ b/make
@@ -91,14 +91,10 @@ list_containers() {
 check_updates_current_blocks_latest() {
   local current_version=$1
   local latest_version=$2
-  local compare_rc
+  local compare_current=$current_version
+  local compare_latest=$latest_version
 
-  version_is_greater "$current_version" "$latest_version"
-  compare_rc=$?
-  if [ "$compare_rc" -eq 0 ]; then
-    return 0
-  fi
-  if [ "$compare_rc" -ne 2 ]; then
+  if ! command -v dpkg >/dev/null 2>&1; then
     return 1
   fi
 
@@ -108,23 +104,20 @@ check_updates_current_blocks_latest() {
 
   # Unknown flags in some older version.sh files fall through to the normal
   # latest-version lookup. Require an explicit image-like source to opt in.
-  if [[ -z "$numeric_alias_image" || -z "$numeric_alias_pattern" || "$numeric_alias_image" != */* ]]; then
-    return 1
+  if [[ -n "$numeric_alias_image" && -n "$numeric_alias_pattern" && "$numeric_alias_image" == */* ]]; then
+    local current_numeric_alias latest_numeric_alias
+    current_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$current_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n' || true)
+    latest_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$latest_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n' || true)
+
+    if [[ -z "$current_numeric_alias" || -z "$latest_numeric_alias" ]]; then
+      return 1
+    fi
+
+    compare_current=$current_numeric_alias
+    compare_latest=$latest_numeric_alias
   fi
 
-  local current_numeric_alias latest_numeric_alias
-  current_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$current_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n') || return 1
-  latest_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$latest_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n') || return 1
-
-  if [[ -z "$current_numeric_alias" || -z "$latest_numeric_alias" ]]; then
-    return 1
-  fi
-
-  if version_is_greater "$current_numeric_alias" "$latest_numeric_alias"; then
-    return 0
-  fi
-
-  return 1
+  dpkg --compare-versions "$compare_current" gt "$compare_latest" 2>/dev/null
 }
 
 # Show project-internal dependency graph for a container

--- a/make
+++ b/make
@@ -17,6 +17,7 @@ export DOCKEROPTS="${DOCKEROPTS:-}"
 # Source shared logging utilities
 source "$(dirname "$0")/helpers/logging.sh"
 source "$(dirname "$0")/helpers/registry-utils.sh"
+source "$(dirname "$0")/helpers/version-utils.sh"
 source "$(dirname "$0")/helpers/sbom-utils.sh"
 source "$(dirname "$0")/helpers/dependency-graph.sh"
 
@@ -522,7 +523,7 @@ check_updates() {
             update_available="true"
             status="new-container"
           fi
-        elif [ "$current_version" != "$latest_version" ] && [ -n "$latest_version" ]; then
+        elif [ -n "$latest_version" ] && version_is_greater "$latest_version" "$current_version"; then
           update_available="true"
           status="update-available"
         fi
@@ -575,7 +576,7 @@ check_updates() {
         update_available="true"
         status="new-container"
       fi
-    elif [ "$current_version" != "$latest_version" ] && [ -n "$latest_version" ]; then
+    elif [ -n "$latest_version" ] && version_is_greater "$latest_version" "$current_version"; then
       update_available="true"
       status="update-available"
     fi

--- a/tests/unit/latest-docker-tag.bats
+++ b/tests/unit/latest-docker-tag.bats
@@ -69,6 +69,65 @@ EOF
     chmod +x "${TEST_TEMP_DIR}/bin/docker"
 }
 
+write_fake_digest_docker_with_transient_failure() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "run" ]]; then
+    exit 99
+fi
+shift
+
+if [[ "${1:-}" == "--rm" ]]; then
+    shift
+fi
+
+shift # skopeo image
+command="${1:-}"
+shift
+
+case "$command" in
+    list-tags)
+        ref="${1:-}"
+        if [[ "$ref" != "docker://library/debian" ]]; then
+            exit 41
+        fi
+        printf '{"Repository":"library/debian","Tags":["11","12","13","12.14","bookworm","trixie","bullseye"]}\n'
+        ;;
+    inspect)
+        if [[ "${1:-}" == "--format" ]]; then
+            shift 2
+        fi
+        ref="${1:-}"
+        case "$ref" in
+            docker://library/debian:trixie|docker://library/debian:13)
+                echo "sha256:thirteen"
+                ;;
+            docker://library/debian:11)
+                # Transient failure on an unrelated earlier candidate.
+                exit 1
+                ;;
+            docker://library/debian:bookworm|docker://library/debian:12)
+                echo "sha256:twelve"
+                ;;
+            docker://library/debian:bullseye)
+                echo "sha256:eleven"
+                ;;
+            *)
+                exit 42
+                ;;
+        esac
+        ;;
+    *)
+        exit 98
+        ;;
+esac
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+}
+
 run_resolve_numeric_alias() {
     env PATH="${TEST_TEMP_DIR}/bin:$PATH" bash -c '
         source "$1"
@@ -101,4 +160,13 @@ run_resolve_numeric_alias() {
 
     [ "$status" -eq 1 ]
     [ -z "$output" ]
+}
+
+@test "resolve-numeric-alias skips a candidate whose digest lookup transiently fails" {
+    write_fake_digest_docker_with_transient_failure
+
+    run run_resolve_numeric_alias "library/debian" "trixie" '^[0-9]+$'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "13" ]
 }

--- a/tests/unit/latest-docker-tag.bats
+++ b/tests/unit/latest-docker-tag.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    TEST_TEMP_DIR="$(mktemp -d)"
+    HELPER="${PROJECT_ROOT}/helpers/docker-tag"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+write_fake_digest_docker() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "run" ]]; then
+    exit 99
+fi
+shift
+
+if [[ "${1:-}" == "--rm" ]]; then
+    shift
+fi
+
+shift # skopeo image
+command="${1:-}"
+shift
+
+case "$command" in
+    list-tags)
+        ref="${1:-}"
+        if [[ "$ref" != "docker://library/debian" ]]; then
+            exit 41
+        fi
+        printf '{"Repository":"library/debian","Tags":["11","12","13","12.14","bookworm","trixie","bullseye"]}\n'
+        ;;
+    inspect)
+        if [[ "${1:-}" == "--format" ]]; then
+            shift 2
+        fi
+        ref="${1:-}"
+        case "$ref" in
+            docker://library/debian:trixie|docker://library/debian:13)
+                echo "sha256:thirteen"
+                ;;
+            docker://library/debian:bookworm|docker://library/debian:12)
+                echo "sha256:twelve"
+                ;;
+            docker://library/debian:bullseye|docker://library/debian:11)
+                echo "sha256:eleven"
+                ;;
+            docker://library/debian:orphan)
+                echo "sha256:orphan"
+                ;;
+            *)
+                exit 42
+                ;;
+        esac
+        ;;
+    *)
+        exit 98
+        ;;
+esac
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+}
+
+run_resolve_numeric_alias() {
+    env PATH="${TEST_TEMP_DIR}/bin:$PATH" bash -c '
+        source "$1"
+        resolve-numeric-alias "$2" "$3" "$4"
+    ' _ "$HELPER" "$@"
+}
+
+@test "resolve-numeric-alias returns the numeric tag with a matching digest" {
+    write_fake_digest_docker
+
+    run run_resolve_numeric_alias "library/debian" "trixie" '^[0-9]+$'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "13" ]
+}
+
+@test "resolve-numeric-alias returns 1 and no output when no numeric digest matches" {
+    write_fake_digest_docker
+
+    run run_resolve_numeric_alias "library/debian" "orphan" '^[0-9]+$'
+
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "resolve-numeric-alias returns 1 and no output when a lookup fails" {
+    write_fake_digest_docker
+
+    run run_resolve_numeric_alias "library/debian" "missing" '^[0-9]+$'
+
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -628,10 +628,11 @@ EOF
     [[ "$status_6" == "up_to_date" ]]
 }
 
-@test "check_updates multi-entry: empty published version is a new container" {
+@test "check_updates multi-entry: accepted empty current_version ambiguity reports new-container" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
+    # Accepted pre-existing ambiguity: Docker/GHCR/skopeo/rate-limit helper failures and genuinely unpublished containers both yield empty current_version; status is cosmetic, not a fully reasoned contract.
     create_check_updates_fixture "7.0.0-alpine" "__EMPTY_FAILURE__" "7.0.0-alpine" "6.9.4-alpine"
 
     run run_check_updates wordpress
@@ -660,7 +661,7 @@ EOF
     [[ "$status_value" == "update-available" ]]
 }
 
-@test "check_updates default path: non-numeric-leading versions still flag string changes" {
+@test "check_updates default path: v-prefixed versions flag genuine upgrades" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
@@ -675,10 +676,26 @@ EOF
     [[ "$status_value" == "update-available" ]]
 }
 
-@test "check_updates default path: empty published version is a new container" {
+@test "check_updates default path: v-prefixed downgrades are not updates" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
+    create_default_check_updates_fixture "v2.6.17-alpine" "v2.6.16-alpine" "^v[0-9]+\.[0-9]+\.[0-9]+-alpine$"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "up_to_date" ]]
+}
+
+@test "check_updates default path: accepted empty current_version ambiguity reports new-container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    # Accepted pre-existing ambiguity: Docker/GHCR/skopeo/rate-limit helper failures and genuinely unpublished containers both yield empty current_version; status is cosmetic, not a fully reasoned contract.
     create_default_check_updates_fixture "__EMPTY_FAILURE__" "14.1.0-ubuntu"
 
     run run_check_updates ansible
@@ -696,6 +713,7 @@ EOF
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
+    # Accepted fleet-safe fallback: any non-numeric-tuple-affecting suffix change is an update, not ordered -rN magnitude semantics.
     create_default_check_updates_fixture "1.2.3-r0" "1.2.3-r1" "^[0-9]+\.[0-9]+\.[0-9]+-r[0-9]+$"
 
     run run_check_updates ansible

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -456,6 +456,7 @@ EOF
 EOF
 
     cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+    cp "$ORIG_DIR/helpers/version-utils.sh" helpers/
 
     # Copy make to $TEST_DIR so `./make check-updates` runs with TEST_DIR as $(dirname $0).
     # This ensures `source "$(dirname "$0")/helpers/..."` resolves to the TEST_DIR stubs.
@@ -469,6 +470,73 @@ run_check_updates() {
     local container="${1:-wordpress}"
     # Suppress docker-compose availability check errors from make
     ./make check-updates "$container" 2>/dev/null
+}
+
+create_default_check_updates_fixture() {
+    local mock_current="${1:-1.0.0-ubuntu}"
+    local mock_latest="${2:-2.0.0-ubuntu}"
+    local registry_pattern="${3:-^[0-9]+\.[0-9]+(\.[0-9]+)?-ubuntu$}"
+
+    mkdir -p ansible helpers scripts
+
+    cat > ansible/variants.yaml <<'EOF'
+build:
+  requires_extensions: false
+versions:
+  - tag: 1.0.0-ubuntu
+EOF
+
+    printf '#!/bin/bash\n' > ansible/version.sh
+    printf "REGISTRY_PATTERN='%s'\n" "$registry_pattern" >> ansible/version.sh
+    printf 'if [[ "$1" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi\n' >> ansible/version.sh
+    printf 'echo "%s"\n' "$mock_latest" >> ansible/version.sh
+    chmod +x ansible/version.sh
+
+    printf '#!/bin/bash\n' > helpers/latest-docker-tag
+    if [[ "$mock_current" == "__NO_PUBLISHED__" ]]; then
+        printf 'echo "no-published-version"\n' >> helpers/latest-docker-tag
+        printf 'exit 0\n' >> helpers/latest-docker-tag
+    else
+        printf 'echo "%s"\n' "$mock_current" >> helpers/latest-docker-tag
+        printf 'exit 0\n' >> helpers/latest-docker-tag
+    fi
+    chmod +x helpers/latest-docker-tag
+
+    cat > helpers/logging.sh <<'EOF'
+log_error()   { echo "ERROR: $*" >&2; }
+log_warning() { echo "WARN: $*"  >&2; }
+log_info()    { echo "INFO: $*"  >&2; }
+log_success() { :; }
+log_help()    { :; }
+export DOCKER="${DOCKER:-docker}"
+export SKOPEO="${SKOPEO:-skopeo}"
+EOF
+
+    cat > helpers/registry-utils.sh <<'EOF'
+list_containers() {
+    find "${1:-.}" -maxdepth 1 -mindepth 1 -type d \
+        ! -name '.*' ! -name 'helpers' ! -name 'scripts' ! -name 'bin' \
+        2>/dev/null | xargs -I{} basename {} 2>/dev/null
+}
+has_dockerfile()  { return 0; }
+EOF
+
+    cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    cat > scripts/check-version.sh <<'EOF'
+get_build_version() { echo "${2:-latest}"; return 0; }
+EOF
+
+    cat > scripts/build-container.sh <<'EOF'
+EOF
+    cat > scripts/push-container.sh <<'EOF'
+EOF
+
+    cp "$ORIG_DIR/helpers/version-utils.sh" helpers/
+
+    cp "$ORIG_DIR/make" ./make
+    chmod +x ./make
 }
 
 @test "check_updates multi-entry: emits one entry per retained major for latest_per_major container" {
@@ -528,6 +596,84 @@ run_check_updates() {
     update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
     [[ "$update_7" == "false" ]]
     [[ "$update_6" == "false" ]]
+}
+
+@test "check_updates multi-entry: downgrade in latest_per_major path is not an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    # GHCR already has 6.9.5-alpine, but upstream resolution reports older 6.9.4-alpine.
+    create_check_updates_fixture "7.0.0-alpine" "6.9.5-alpine" "7.0.0-alpine" "6.9.4-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    status_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')
+    [[ "$update_6" == "false" ]]
+    [[ "$status_6" == "up_to_date" ]]
+}
+
+@test "check_updates default path: genuine newer latest is an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: ansible downgrade regression is not an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "14.1.0-ubuntu" "14.0.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "up_to_date" ]]
+}
+
+@test "check_updates default path: equal versions are not an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "14.1.0-ubuntu" "14.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "up_to_date" ]]
+}
+
+@test "check_updates default path: no published version remains a new container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "__NO_PUBLISHED__" "14.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    current_version=$(echo "$output" | jq -r '.[0].current_version')
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$current_version" == "no-published-version" ]]
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "new-container" ]]
 }
 
 # ----------------------------------------------------------------

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -782,6 +782,39 @@ EOF
     [[ "$status_value" == "update-available" ]]
 }
 
+@test "check_updates default path: digit-leading versions skip numeric alias probes" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    call_log="${TEST_DIR}/numeric-alias-calls.log"
+
+    printf '#!/bin/bash\n' > ansible/version.sh
+    printf 'CALL_LOG=%q\n' "$call_log" >> ansible/version.sh
+    cat >> ansible/version.sh <<'EOF'
+REGISTRY_PATTERN='^[0-9]+\.[0-9]+(\.[0-9]+)?-ubuntu$'
+if [[ "${1:-}" == "--registry-pattern" ]]; then echo "$REGISTRY_PATTERN"; exit 0; fi
+if [[ "${1:-}" == "--numeric-alias-image" || "${1:-}" == "--numeric-alias-pattern" ]]; then
+    printf '%s\n' "$1" >> "$CALL_LOG"
+    echo "unexpected numeric alias probe" >&2
+    exit 77
+fi
+echo "1.1.0-ubuntu"
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
+    if [[ -s "$call_log" ]]; then
+        fail "numeric alias flags should not be invoked for digit-leading versions"
+    fi
+}
+
 @test "check_updates default path: v-prefixed versions flag genuine upgrades" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
@@ -914,11 +947,11 @@ EOF
     [[ "$status_value" == "update-available" ]]
 }
 
-@test "check_updates default path: unparseable versions without numeric alias remain permissive" {
+@test "check_updates default path: testing and stable labels without numeric alias remain permissive" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
-    create_default_check_updates_fixture "stable" "testing" "^(stable|testing)$"
+    create_default_check_updates_fixture "testing" "stable" "^(stable|testing)$"
 
     run run_check_updates ansible
     [ "$status" -eq 0 ]

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -414,8 +414,20 @@ EOF
     printf '#!/bin/bash\n' > helpers/latest-docker-tag
     printf '# Args: <image> <pattern>\n' >> helpers/latest-docker-tag
     printf 'pattern="$2"\n' >> helpers/latest-docker-tag
-    printf 'if echo "$pattern" | grep -qE "^\\^7"; then echo "%s"; exit 0; fi\n' "${mock_ghcr_7}" >> helpers/latest-docker-tag
-    printf 'if echo "$pattern" | grep -qE "^\\^6"; then echo "%s"; exit 0; fi\n' "${mock_ghcr_6}" >> helpers/latest-docker-tag
+    printf 'if echo "$pattern" | grep -qE "^\\^7"; then\n' >> helpers/latest-docker-tag
+    if [[ "$mock_ghcr_7" == "__EMPTY_FAILURE__" ]]; then
+        printf '  exit 1\n' >> helpers/latest-docker-tag
+    else
+        printf '  echo "%s"; exit 0\n' "${mock_ghcr_7}" >> helpers/latest-docker-tag
+    fi
+    printf 'fi\n' >> helpers/latest-docker-tag
+    printf 'if echo "$pattern" | grep -qE "^\\^6"; then\n' >> helpers/latest-docker-tag
+    if [[ "$mock_ghcr_6" == "__EMPTY_FAILURE__" ]]; then
+        printf '  exit 1\n' >> helpers/latest-docker-tag
+    else
+        printf '  echo "%s"; exit 0\n' "${mock_ghcr_6}" >> helpers/latest-docker-tag
+    fi
+    printf 'fi\n' >> helpers/latest-docker-tag
     printf 'exit 1\n' >> helpers/latest-docker-tag
     chmod +x helpers/latest-docker-tag
 
@@ -496,6 +508,8 @@ EOF
     if [[ "$mock_current" == "__NO_PUBLISHED__" ]]; then
         printf 'echo "no-published-version"\n' >> helpers/latest-docker-tag
         printf 'exit 0\n' >> helpers/latest-docker-tag
+    elif [[ "$mock_current" == "__EMPTY_FAILURE__" ]]; then
+        printf 'exit 1\n' >> helpers/latest-docker-tag
     else
         printf 'echo "%s"\n' "$mock_current" >> helpers/latest-docker-tag
         printf 'exit 0\n' >> helpers/latest-docker-tag
@@ -614,11 +628,75 @@ EOF
     [[ "$status_6" == "up_to_date" ]]
 }
 
+@test "check_updates multi-entry: empty published version is a new container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "__EMPTY_FAILURE__" "7.0.0-alpine" "6.9.4-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    current_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .current_version')
+    update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    status_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')
+    [[ -z "$current_6" ]]
+    [[ "$update_6" == "true" ]]
+    [[ "$status_6" == "new-container" ]]
+}
+
 @test "check_updates default path: genuine newer latest is an update" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
     create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: non-numeric-leading versions still flag string changes" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "v2.6.17-alpine" "v2.6.18-alpine" "^v[0-9]+\.[0-9]+\.[0-9]+-alpine$"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: empty published version is a new container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "__EMPTY_FAILURE__" "14.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    current_version=$(echo "$output" | jq -r '.[0].current_version')
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ -z "$current_version" ]]
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "new-container" ]]
+}
+
+@test "check_updates default path: same numeric tuple with different suffix is an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.2.3-r0" "1.2.3-r1" "^[0-9]+\.[0-9]+\.[0-9]+-r[0-9]+$"
 
     run run_check_updates ansible
     [ "$status" -eq 0 ]

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -553,6 +553,127 @@ EOF
     chmod +x ./make
 }
 
+create_debian_check_updates_fixture() {
+    local mock_current="${1:-trixie}"
+    local mock_latest="${2:-bookworm}"
+
+    mkdir -p debian helpers scripts bin
+
+    cat > debian/variants.yaml <<'EOF'
+build:
+  requires_extensions: false
+versions:
+  - tag: trixie
+EOF
+
+    printf '#!/bin/bash\n' > debian/version.sh
+    printf 'if [[ "$1" == "--registry-pattern" ]]; then echo "^(trixie|bookworm|bullseye)$"; exit 0; fi\n' >> debian/version.sh
+    printf 'if [[ "$1" == "--numeric-alias-image" ]]; then echo "library/debian"; exit 0; fi\n' >> debian/version.sh
+    printf 'if [[ "$1" == "--numeric-alias-pattern" ]]; then echo "^[0-9]+$"; exit 0; fi\n' >> debian/version.sh
+    printf 'echo "%s"\n' "$mock_latest" >> debian/version.sh
+    chmod +x debian/version.sh
+
+    cp "$ORIG_DIR/helpers/docker-tag" helpers/docker-tag
+    chmod +x helpers/docker-tag
+    ln -sf docker-tag helpers/latest-docker-tag
+
+    printf '#!/bin/bash\n' > bin/docker
+    printf 'set -euo pipefail\n' >> bin/docker
+    printf 'MOCK_CURRENT=%q\n' "$mock_current" >> bin/docker
+    cat >> bin/docker <<'EOF'
+if [[ "${1:-}" != "run" ]]; then
+    exit 99
+fi
+shift
+
+if [[ "${1:-}" == "--rm" ]]; then
+    shift
+fi
+
+shift # skopeo image
+command="${1:-}"
+shift
+
+case "$command" in
+    list-tags)
+        ref="${1:-}"
+        case "$ref" in
+            docker://ghcr.io/oorabona/debian)
+                printf '{"Repository":"ghcr.io/oorabona/debian","Tags":["%s"]}\n' "$MOCK_CURRENT"
+                ;;
+            docker://library/debian)
+                printf '{"Repository":"library/debian","Tags":["11","12","13","12.14","bookworm","trixie","bullseye"]}\n'
+                ;;
+            *)
+                exit 41
+                ;;
+        esac
+        ;;
+    inspect)
+        if [[ "${1:-}" == "--format" ]]; then
+            shift 2
+        fi
+        ref="${1:-}"
+        case "$ref" in
+            docker://library/debian:trixie|docker://library/debian:13)
+                echo "sha256:thirteen"
+                ;;
+            docker://library/debian:bookworm|docker://library/debian:12)
+                echo "sha256:twelve"
+                ;;
+            docker://library/debian:bullseye|docker://library/debian:11)
+                echo "sha256:eleven"
+                ;;
+            *)
+                exit 42
+                ;;
+        esac
+        ;;
+    *)
+        exit 98
+        ;;
+esac
+EOF
+    chmod +x bin/docker
+    export PATH="$TEST_DIR/bin:$PATH"
+
+    cat > helpers/logging.sh <<'EOF'
+log_error()   { echo "ERROR: $*" >&2; }
+log_warning() { echo "WARN: $*"  >&2; }
+log_info()    { echo "INFO: $*"  >&2; }
+log_success() { :; }
+log_help()    { :; }
+export DOCKER="${DOCKER:-docker}"
+export SKOPEO="${SKOPEO:-skopeo}"
+EOF
+
+    cat > helpers/registry-utils.sh <<'EOF'
+list_containers() {
+    find "${1:-.}" -maxdepth 1 -mindepth 1 -type d \
+        ! -name '.*' ! -name 'helpers' ! -name 'scripts' ! -name 'bin' \
+        2>/dev/null | xargs -I{} basename {} 2>/dev/null
+}
+has_dockerfile()  { return 0; }
+EOF
+
+    cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    cat > scripts/check-version.sh <<'EOF'
+get_build_version() { echo "${2:-latest}"; return 0; }
+EOF
+
+    cat > scripts/build-container.sh <<'EOF'
+EOF
+    cat > scripts/push-container.sh <<'EOF'
+EOF
+
+    cp "$ORIG_DIR/helpers/version-utils.sh" helpers/
+
+    cp "$ORIG_DIR/make" ./make
+    chmod +x ./make
+}
+
 @test "check_updates multi-entry: emits one entry per retained major for latest_per_major container" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
@@ -738,6 +859,59 @@ EOF
     status_value=$(echo "$output" | jq -r '.[0].status')
     [[ "$update_available" == "false" ]]
     [[ "$status_value" == "up_to_date" ]]
+}
+
+@test "check_updates default path: debian codename downgrade is blocked through numeric alias digests" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+
+    run run_check_updates debian
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    current_version=$(echo "$output" | jq -r '.[0].current_version')
+    latest_version=$(echo "$output" | jq -r '.[0].latest_version')
+    [[ "$current_version" == "trixie" ]]
+    [[ "$latest_version" == "bookworm" ]]
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "up_to_date" ]]
+}
+
+@test "check_updates default path: debian codename upgrade remains an update through numeric alias digests" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "bookworm" "trixie"
+
+    run run_check_updates debian
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    current_version=$(echo "$output" | jq -r '.[0].current_version')
+    latest_version=$(echo "$output" | jq -r '.[0].latest_version')
+    [[ "$current_version" == "bookworm" ]]
+    [[ "$latest_version" == "trixie" ]]
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: unparseable versions without numeric alias remain permissive" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "stable" "testing" "^(stable|testing)$"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "true" ]]
+    [[ "$status_value" == "update-available" ]]
 }
 
 @test "check_updates default path: equal versions are not an update" {

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -834,7 +834,7 @@ EOF
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
-    # Accepted fleet-safe fallback: any non-numeric-tuple-affecting suffix change is an update, not ordered -rN magnitude semantics.
+    # dpkg compares Debian-style revision suffixes numerically, so r1 is a real update over r0.
     create_default_check_updates_fixture "1.2.3-r0" "1.2.3-r1" "^[0-9]+\.[0-9]+\.[0-9]+-r[0-9]+$"
 
     run run_check_updates ansible
@@ -844,6 +844,21 @@ EOF
     status_value=$(echo "$output" | jq -r '.[0].status')
     [[ "$update_available" == "true" ]]
     [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: revision-suffix downgrade is not an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.2.3-r10" "1.2.3-r2" "^[0-9]+\.[0-9]+\.[0-9]+-r[0-9]+$"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    update_available=$(echo "$output" | jq -r '.[0].update_available')
+    status_value=$(echo "$output" | jq -r '.[0].status')
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "up_to_date" ]]
 }
 
 @test "check_updates default path: ansible downgrade regression is not an update" {

--- a/tests/unit/version-utils.bats
+++ b/tests/unit/version-utils.bats
@@ -15,6 +15,16 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "version_is_greater: v-prefixed version upgrade is greater" {
+    run version_is_greater "v2.6.18-alpine" "v2.6.17-alpine"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_is_greater: v-prefixed version downgrade is not greater" {
+    run version_is_greater "v2.6.17-alpine" "v2.6.18-alpine"
+    [ "$status" -eq 1 ]
+}
+
 @test "version_is_greater: ansible downgrade regression is not greater" {
     run version_is_greater "14.0.0-ubuntu" "14.1.0-ubuntu"
     [ "$status" -eq 1 ]

--- a/tests/unit/version-utils.bats
+++ b/tests/unit/version-utils.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/version-utils.sh
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+
+    # shellcheck source=../../helpers/version-utils.sh
+    source "$PROJECT_ROOT/helpers/version-utils.sh"
+}
+
+@test "version_is_greater: returns true for a normal greater version" {
+    run version_is_greater "2.0.0" "1.0.0"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_is_greater: ansible downgrade regression is not greater" {
+    run version_is_greater "14.0.0-ubuntu" "14.1.0-ubuntu"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_is_greater: equal versions are not greater" {
+    run version_is_greater "1.2.3" "1.2.3"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_is_greater: missing numeric components are padded with zero" {
+    run version_is_greater "1.2" "1.2.0"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_is_greater: unequal segment counts compare numerically" {
+    run version_is_greater "1.2.1" "1.2"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_is_greater: unparseable input does not report greater" {
+    run version_is_greater "release-candidate" "1.0.0"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

An auto-generated PR (#853) proposed downgrading the `ansible` container from `14.1.0-ubuntu` (the genuinely latest PyPI release) to `14.0.0-ubuntu` (an older one), with auto-merge enabled. The root cause: `make`'s upstream-update detection (`check_updates`) decided whether a container needed an update by plain string inequality — any difference between the currently-published and detected-upstream version was treated as "needs an update," with no check that the detected version was actually newer.

This fixes the detection for every real version format used across this fleet:
- Plain numeric versions (ansible, terraform, etc.)
- `v`-prefixed versions (openvpn, sslh)
- Debian's codename releases (`trixie`/`bookworm`/`bullseye`) — resolved to their real numeric release number by matching manifest digests against the same upstream registry (Debian publishes both codename and numeric tags for the same image), so there's no hardcoded codename-to-release-order table to maintain — it keeps working automatically for future Debian releases.

Version comparison itself now uses `dpkg --compare-versions` (already installed on every Debian/Ubuntu CI runner) instead of a hand-rolled parser — it correctly orders revision suffixes (`1.2.3-r10` is newer than `1.2.3-r2`) and handles the formats above natively, closing gaps a custom comparator kept needing patches for.

The disabled auto-merge and the closed #853 already prevented the immediate bad outcome; this is the underlying fix so it can't recur, on this container or any other in the fleet.

## Known, accepted trade-offs (explicitly out of scope for this PR)

- **A confirmed-safe comparison (`up_to_date`) doesn't distinguish "genuinely matches upstream" from "published is ahead of/mismatched with what upstream currently reports."** Both produce the same, correct outcome (no downgrade PR is opened) — this is a log/observability label distinction only, not a behavior difference.
- **Downgrade suppression depends on `dpkg` being available**; on a host without it, the code fails open (falls back to the pre-fix permissive behavior — never silently vetoes an update). This CI always runs on GitHub Actions `ubuntu-latest`, which ships `dpkg` by default, so this only matters for someone running `./make check-updates` locally on a non-Debian machine.
- **Debian codename resolution (digest matching) is not cached** — each comparison re-lists the upstream registry's tags and inspects candidate digests from scratch. This only runs for the rare non-numeric-label case (currently just `debian`, checked once per day by the scheduled monitor), not across the whole fleet.
- **`dpkg`'s ordering isn't SemVer-precise for hyphen-based prerelease markers** (e.g. `1.0.0-alpha` vs `1.0.0`) — no container in this fleet currently publishes such tags. This mirrors the same, already-accepted limitation tracked for the sibling dependency-freshness feature (#852).
- **Numeric-alias resolution returns the first ascending-sorted digest match**, which could pick an imprecise value if a future container's alias pattern admitted both a broad and a specific numeric tag (e.g. `12` and `12.14`) for the same image. Debian's current pattern (bare major versions only) doesn't hit this.

## Test plan

- [x] Full unit suite green: 1912/1912 (`./tests/run-tests.sh`)
- [x] `shellcheck --severity=error` clean on all touched shell files
- [x] Dedicated regression tests for: the original ansible downgrade, `v`-prefixed downgrade/upgrade (openvpn/sslh), Debian codename downgrade/upgrade via digest resolution, revision-suffix ordering (`r10`/`r2`), and the numeric-alias probe being skipped for ordinary numeric comparisons
