### PR TITLE
Surface Sigstore/SBOM verification on container READMEs

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,6 +6,16 @@ Production-ready Ansible automation container built from source with Python virt
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fansible-blue)](https://ghcr.io/oorabona/ansible)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/ansible:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/debian/README.md
+++ b/debian/README.md
@@ -24,6 +24,16 @@ A small, opinionated Debian base built `FROM debian:trixie` (Debian 13) with the
 - **Automated Builds**: Integrated with upstream monitoring for version updates
 - **Clean Base**: Perfect starting point for custom applications
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/debian:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Usage
 
 ### With Docker Compose

--- a/github-runner/README.md
+++ b/github-runner/README.md
@@ -24,6 +24,16 @@ This image fills a different gap:
 
 **Use the official image when:** you have a Kubernetes cluster and want to use ARC.
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/github-runner:2.332.0 --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -6,6 +6,16 @@ Lightweight Alpine-based container for building and serving Jekyll static sites 
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fjekyll-blue)](https://ghcr.io/oorabona/jekyll)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/jekyll:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ### Docker Run

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -6,6 +6,16 @@ High-performance web platform combining Nginx with LuaJIT for dynamic, programma
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fopenresty-blue)](https://ghcr.io/oorabona/openresty)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/openresty:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -18,6 +18,16 @@ This is a simple `Alpine` based container with `OpenVPN` built from sources.
 - Dependant library `pkcs11-helper` built from sources
 - Embed `Google Authenticator` support
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/openvpn:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Usage
 
 ### Docker

--- a/php/README.md
+++ b/php/README.md
@@ -6,6 +6,16 @@ Production-ready PHP-FPM container with Composer integration, optimized for mode
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fphp-blue)](https://ghcr.io/oorabona/php)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/php:8.4-fpm-alpine --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -6,6 +6,16 @@
 
 Production-ready PostgreSQL containers with multiple **flavors** optimized for different workloads: AI/RAG, analytics, or general purpose. Built on Alpine Linux with pre-compiled extensions.
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/postgres:17-alpine --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/sslh/README.md
+++ b/sslh/README.md
@@ -16,6 +16,16 @@
 - **Auto-updated** — CI tracks [yrutschle/sslh](https://github.com/yrutschle/sslh) releases
 - **SBOM + attestation** — every image ships with a Sigstore-signed SPDX
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/sslh:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Platforms
 - **amd64** - x86_64 systems
 - **arm64** - ARM 64-bit systems

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,6 +6,16 @@ Enterprise-grade Terraform container with comprehensive DevOps tooling for multi
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fterraform-blue)](https://ghcr.io/oorabona/terraform)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/terraform:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/vector/README.md
+++ b/vector/README.md
@@ -16,6 +16,16 @@ This image packages [Vector](https://vector.dev/) as a minimal, production-harde
 - **Automated upstream tracking.** The upstream-monitor workflow checks the Vector GitHub release feed daily and opens a PR when a new version is available, keeping the image current without manual intervention.
 - **Common sink/source coverage.** Supports Docker log collection, syslog, file tailing, Prometheus scrape, and OpenTelemetry out of the box. Pairs directly with the `oorabona/postgres:<version>-full-alpine` flavor (TimescaleDB + ParadeDB) for a complete vendor-free log/metrics store — see the PostgreSQL sink example below.
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/vector:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/web-shell/README.md
+++ b/web-shell/README.md
@@ -6,6 +6,16 @@
 
 Secure browser-based terminal built on our [Debian](../debian/) base image with [ttyd](https://github.com/tsl0922/ttyd) for web terminal access. Includes common DevOps and hosting tools, optional SSH server, and flexible authentication options.
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/web-shell:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```bash

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -6,6 +6,16 @@ Production-ready WordPress container built on PHP-FPM with WP-CLI, auto-install,
 [![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Fwordpress-blue)](https://ghcr.io/oorabona/wordpress)
 [![Build](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml/badge.svg)](https://github.com/oorabona/docker-containers/actions/workflows/auto-build.yaml)
 
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/wordpress:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
 ## Quick Start
 
 ```yaml


### PR DESCRIPTION
## Summary

Every container already ships a Sigstore-signed SBOM (`actions/attest-sbom`) and a full advisory Trivy scan, and there's already a detailed, canonical walkthrough of how to verify all of this at [docs/site/verify-images.md](https://oorabona.github.io/docker-containers/verify-images/). But the per-container READMEs — the ones that sync to Docker Hub — didn't surface this with anything actionable; e.g. `sslh/README.md` only had a single bullet ("SBOM + attestation — every image ships with a Sigstore-signed SPDX") with no command a reader could actually run.

Adds a `## Verify this image` section to all 13 container READMEs, placed right after the intro badges (before usage instructions) — a runnable `gh attestation verify` command plus a link to the full walkthrough. Each command uses that container's own real image name and its README's existing tag convention (e.g. `postgres:17-alpine`, `php:8.4-fpm-alpine`, everything else `:latest`).

Pure documentation change — no code, no build/test impact. `examples/README.md` and `test-harness/README.md` are untouched (not published containers).

## Test plan

- [x] Exactly 13 README.md files changed, insertion-only (10 lines each, 0 removed)
- [x] Each container's `<name>`/`<tag>` verified against that same README's own existing usage examples
- [x] `git diff --check` clean
