### PR TITLE
feat(tor): Add Tor SOCKS proxy container with relay/exit/bridge modes

### DIFF
--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -41,7 +41,7 @@ source "${_BM_SCRIPT_DIR}/logging.sh"
 # operators and tests to expand the set without code changes.
 # ---------------------------------------------------------------------------
 bake_managed_containers() {
-    echo "${BAKE_MANAGED_CONTAINERS:-github-runner web-shell wordpress debian vector jekyll ansible sslh openvpn php openresty terraform postgres}"
+    echo "${BAKE_MANAGED_CONTAINERS:-github-runner web-shell wordpress debian vector jekyll ansible sslh openvpn php openresty terraform postgres tor}"
 }
 
 # ---------------------------------------------------------------------------

--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -13,7 +13,7 @@
 #
 # The bake-managed set defaults to:
 #   github-runner web-shell wordpress debian vector jekyll ansible
-#   sslh openvpn php openresty terraform postgres
+#   sslh openvpn php openresty terraform postgres tor
 # Override at any time via BAKE_MANAGED_CONTAINERS env (space-separated).
 #
 # Requirements: bash 4+, jq

--- a/helpers/latest-github-release
+++ b/helpers/latest-github-release
@@ -11,6 +11,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./logging.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/logging.sh"
 
 # GitHub API base URL (supports GitHub Enterprise via GITHUB_API_URL)
@@ -151,13 +153,21 @@ latest-github-release() {
     # Apply tag_pattern extraction if specified (custom user pattern wins)
     if [[ -n "$tag_pattern" ]]; then
         local extracted
-        extracted=$(echo "$version" | grep -oP "$tag_pattern" || true)
-        if [[ -n "$extracted" ]]; then
-            version="$extracted"
-        else
-            log_error "Tag pattern '${tag_pattern}' did not match version '${version}'"
-            return 1
-        fi
+        local grep_rc=0
+        extracted=$(printf '%s\n' "$version" | grep -oP -- "$tag_pattern" 2>&1) || grep_rc=$?
+        case "$grep_rc" in
+            0)
+                version="$extracted"
+                ;;
+            1)
+                log_error "Tag pattern '${tag_pattern}' did not match version '${version}'"
+                return 1
+                ;;
+            *)
+                log_error "Tag pattern '${tag_pattern}' failed for version '${version}': ${extracted}"
+                return 1
+                ;;
+        esac
     else
         # Default: strip non-digit prefix (e.g., "jq-", "v") to normalize
         # "jq-1.8.1" → "1.8.1", "v7.5.1" → "7.5.1", "1.7.1" → "1.7.1"

--- a/helpers/latest-github-tag
+++ b/helpers/latest-github-tag
@@ -49,6 +49,13 @@ _gha_escape() {
     printf '%s' "$s"
 }
 
+_validate_github_token_for_curl_config() {
+    if [[ "${GITHUB_TOKEN:-}" == *\"* || "${GITHUB_TOKEN:-}" == *\\* || "${GITHUB_TOKEN:-}" =~ [[:cntrl:]] ]]; then
+        echo "::error::latest-github-tag: GITHUB_TOKEN must not contain double quotes or control characters; backslashes are also rejected" >&2
+        return 1
+    fi
+}
+
 _gh_api_tags() {
     local repo="$1"
     # Use gh cli with paginate ONLY when targeting api.github.com (the default).
@@ -76,6 +83,7 @@ _gh_api_tags() {
         -H "Accept: application/vnd.github+json")
     local curl_cfg=""
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        _validate_github_token_for_curl_config || return 1
         curl_cfg=$(mktemp)
         chmod 600 "$curl_cfg"
         printf 'header = "Authorization: Bearer %s"\n' "$GITHUB_TOKEN" > "$curl_cfg"
@@ -280,8 +288,9 @@ latest-github-tag() {
     fi
 
     # 3. Extract versions using version_extract (capture group 1)
-    #    Build a sortable list: <extracted_version> <raw_tag>
+    #    Build a sortable list: <extracted_version><TAB><raw_tag>
     local versions_with_tags=""
+    local candidate_separator=$'\t'
     while IFS= read -r tag; do
         [[ -z "$tag" ]] && continue
         # Use bash regex match to extract capture group 1.
@@ -295,7 +304,7 @@ latest-github-tag() {
                 echo "::error::latest-github-tag: version-extract regex matched tag '$(_gha_escape "${tag}")' but produced no capture — verify the regex has exactly one parenthesized capture group" >&2
                 return 1
             fi
-            versions_with_tags="${versions_with_tags}${extracted} ${tag}"$'\n'
+            versions_with_tags="${versions_with_tags}${extracted}${candidate_separator}${tag}"$'\n'
         else
             log_info "version_extract '${version_extract}' did not match tag '${tag}' — skipping" >&2
         fi
@@ -310,12 +319,11 @@ latest-github-tag() {
     #    Use sort -t. -k1,1n -k2,2n -k3,3n on the version part (first field)
     local best_line
     best_line=$(echo "$versions_with_tags" | \
-        sort -t' ' -k1,1 --version-sort | \
+        sort -t "$candidate_separator" -k1,1 --version-sort | \
         tail -1)
 
     local best_version best_raw_tag
-    best_version=$(echo "$best_line" | awk '{print $1}')
-    best_raw_tag=$(echo "$best_line" | awk '{print $2}')
+    IFS=$'\t' read -r best_version best_raw_tag <<< "$best_line"
 
     if [[ -z "$best_version" ]]; then
         log_error "Failed to determine best version for ${repo}" >&2

--- a/helpers/latest-github-tag
+++ b/helpers/latest-github-tag
@@ -28,6 +28,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./logging.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/logging.sh"
 
 # GitHub API base URL (supports GitHub Enterprise via GITHUB_API_URL)
@@ -35,6 +37,7 @@ GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
 
 # Default pre-release exclusion regex (case-insensitive match on tag name)
 PRERELEASE_EXCLUDE_REGEX='-rc|-alpha|-beta|-dev|-pre'
+SAFE_VERSION_REGEX='^[0-9]+(\.([0-9]+|windows|linux|darwin|macos|alpine))*$'
 
 # Escape dynamic strings for GHA workflow-commands (::warning::/::error::).
 # Per GHA spec: % → %25, CR → %0D, LF → %0A.
@@ -250,12 +253,20 @@ latest-github-tag() {
 
     # 1. Apply tag_filter (anchored ERE via grep -E)
     local filtered_tags
-    filtered_tags=$(echo "$all_tags" | grep -E "$tag_filter" || true)
-
-    if [[ -z "$filtered_tags" ]]; then
-        log_error "No tags match tag_filter '${tag_filter}' for ${repo}" >&2
-        return 1
-    fi
+    local grep_rc=0
+    filtered_tags=$(printf '%s\n' "$all_tags" | grep -E -- "$tag_filter" 2>&1) || grep_rc=$?
+    case "$grep_rc" in
+        0)
+            ;;
+        1)
+            log_error "No tags match tag_filter '${tag_filter}' for ${repo}" >&2
+            return 1
+            ;;
+        *)
+            log_error "tag_filter regex '${tag_filter}' failed for ${repo}: ${filtered_tags}" >&2
+            return 1
+            ;;
+    esac
 
     # 2. Exclude pre-releases (unless overridden)
     if [[ "$include_prerelease" != "true" ]]; then
@@ -311,9 +322,9 @@ latest-github-tag() {
         return 1
     fi
 
-    # 5. Validate: must start with a digit
-    if [[ ! "$best_version" =~ ^[0-9] ]]; then
-        log_error "Extracted version '${best_version}' does not start with a digit — aborting" >&2
+    # 5. Validate: emitted versions must remain safe for downstream automation.
+    if [[ ! "$best_version" =~ $SAFE_VERSION_REGEX ]]; then
+        log_error "Extracted version '${best_version}' is not a safe normalized version — expected digits separated by dots with optional windows/linux/darwin/macos/alpine dot labels" >&2
         return 1
     fi
 

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -39,8 +39,17 @@ _gitlab_project_api_path() {
     local project_path="$1"
 
     if [[ "$project_path" == *%2F* || "$project_path" == *%2f* ]]; then
+        if [[ ! "$project_path" =~ ^[A-Za-z0-9._-]+(%2[Ff][A-Za-z0-9._-]+)*$ ]]; then
+            log_error "latest-gitlab-tag: encoded project path may contain only alphanumerics, '.', '_', '-', and '%2F' separators" >&2
+            return 1
+        fi
         printf '%s' "$project_path"
         return
+    fi
+
+    if [[ ! "$project_path" =~ ^[A-Za-z0-9._/-]+$ || "$project_path" == /* || "$project_path" == */ || "$project_path" == *//* ]]; then
+        log_error "latest-gitlab-tag: project path may contain only alphanumerics, '.', '_', '-', and '/' separators" >&2
+        return 1
     fi
 
     jq -rn --arg path "$project_path" '$path | @uri'
@@ -49,7 +58,9 @@ _gitlab_project_api_path() {
 _gitlab_api_tags() {
     local project_path="$1"
     local encoded_project
-    encoded_project=$(_gitlab_project_api_path "$project_path")
+    if ! encoded_project=$(_gitlab_project_api_path "$project_path"); then
+        return 1
+    fi
 
     local curl_args=(--proto '=https' --proto-redir '=https' -fsSL --connect-timeout 10 --max-time 30)
     local curl_cfg=""

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -26,6 +26,7 @@ source "$SCRIPT_DIR/logging.sh"
 
 GITLAB_API_URL="${GITLAB_API_URL:-https://gitlab.torproject.org/api/v4}"
 PRERELEASE_EXCLUDE_REGEX='-rc|-alpha|-beta|-dev|-pre'
+SAFE_VERSION_REGEX='^[0-9]+(\.([0-9]+|windows|linux|darwin|macos|alpine))*$'
 _gitlab_api_curl_cfg=""
 
 _gitlab_api_cleanup_curl_config() {
@@ -298,11 +299,20 @@ latest-gitlab-tag() {
     fi
 
     local filtered_tags
-    filtered_tags=$(echo "$all_tags" | grep -E "$tag_filter" || true)
-    if [[ -z "$filtered_tags" ]]; then
-        log_error "No tags match tag_filter '$(_gha_escape "${tag_filter}")' for $(_gha_escape "${project_path}")" >&2
-        return 1
-    fi
+    local grep_rc=0
+    filtered_tags=$(printf '%s\n' "$all_tags" | grep -E -- "$tag_filter" 2>&1) || grep_rc=$?
+    case "$grep_rc" in
+        0)
+            ;;
+        1)
+            log_error "No tags match tag_filter '$(_gha_escape "${tag_filter}")' for $(_gha_escape "${project_path}")" >&2
+            return 1
+            ;;
+        *)
+            log_error "tag_filter regex '$(_gha_escape "${tag_filter}")' failed for $(_gha_escape "${project_path}"): $(_gha_escape "${filtered_tags}")" >&2
+            return 1
+            ;;
+    esac
 
     if [[ "$include_prerelease" != "true" ]]; then
         local no_prerelease
@@ -345,8 +355,8 @@ latest-gitlab-tag() {
         log_error "Failed to determine best version for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
-    if [[ ! "$best_version" =~ ^[0-9] ]]; then
-        log_error "Extracted version '$(_gha_escape "${best_version}")' does not start with a digit — aborting" >&2
+    if [[ ! "$best_version" =~ $SAFE_VERSION_REGEX ]]; then
+        log_error "Extracted version '$(_gha_escape "${best_version}")' is not a safe normalized version — expected digits separated by dots with optional windows/linux/darwin/macos/alpine dot labels" >&2
         return 1
     fi
 

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -26,6 +26,21 @@ source "$SCRIPT_DIR/logging.sh"
 
 GITLAB_API_URL="${GITLAB_API_URL:-https://gitlab.torproject.org/api/v4}"
 PRERELEASE_EXCLUDE_REGEX='-rc|-alpha|-beta|-dev|-pre'
+_gitlab_api_curl_cfg=""
+
+_gitlab_api_cleanup_curl_config() {
+    if [[ -n "${_gitlab_api_curl_cfg:-}" ]]; then
+        rm -f "$_gitlab_api_curl_cfg"
+        _gitlab_api_curl_cfg=""
+    fi
+}
+
+_gitlab_api_signal_cleanup() {
+    local status="$1"
+
+    _gitlab_api_cleanup_curl_config
+    exit "$status"
+}
 
 _gha_escape() {
     local s="$1"
@@ -119,14 +134,15 @@ _gitlab_api_tags() {
     fi
 
     local curl_args=(--proto '=https' --proto-redir '=https' -fsS --connect-timeout 10 --max-time 30)
-    local curl_cfg=""
     if [[ -n "${GITLAB_TOKEN:-}" ]] && _gitlab_token_host_allowed "$api_host"; then
         _validate_gitlab_token_for_curl_config || return 1
-        curl_cfg=$(mktemp)
-        trap 'rm -f "$curl_cfg"' EXIT
-        chmod 600 "$curl_cfg"
-        printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_TOKEN" > "$curl_cfg"
-        curl_args+=(--config "$curl_cfg")
+        _gitlab_api_curl_cfg=$(mktemp)
+        trap _gitlab_api_cleanup_curl_config EXIT
+        trap '_gitlab_api_signal_cleanup 130' INT
+        trap '_gitlab_api_signal_cleanup 143' TERM
+        chmod 600 "$_gitlab_api_curl_cfg"
+        printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_TOKEN" > "$_gitlab_api_curl_cfg"
+        curl_args+=(--config "$_gitlab_api_curl_cfg")
     fi
 
     local url="${GITLAB_API_URL}/projects/${encoded_project}/repository/tags?order_by=version&sort=desc&per_page=100"
@@ -141,14 +157,16 @@ _gitlab_api_tags() {
 
         local body
         if ! body=$(curl "${curl_args[@]}" -D "$hdr_file" "$url" 2>/dev/null); then
-            rm -f "$hdr_file" "$curl_cfg"
+            rm -f "$hdr_file"
+            _gitlab_api_cleanup_curl_config
             echo "::error::latest-gitlab-tag: GitLab API request failed on page $(_gha_escape "${pages_fetched}") for $(_gha_escape "${project_path}")" >&2
             return 1
         fi
 
         local page_tags
         if ! page_tags=$(printf '%s\n' "$body" | jq -r '.[].name' 2>/dev/null); then
-            rm -f "$hdr_file" "$curl_cfg"
+            rm -f "$hdr_file"
+            _gitlab_api_cleanup_curl_config
             echo "::error::latest-gitlab-tag: invalid JSON on page $(_gha_escape "${pages_fetched}") for $(_gha_escape "${project_path}")" >&2
             return 1
         fi
@@ -166,11 +184,13 @@ _gitlab_api_tags() {
         if [[ -n "$next_url" ]]; then
             local next_origin
             if ! next_origin=$(_url_origin "GitLab pagination URL" "$next_url"); then
-                rm -f "$hdr_file" "$curl_cfg"
+                rm -f "$hdr_file"
+                _gitlab_api_cleanup_curl_config
                 return 1
             fi
             if [[ "$next_origin" != "$allowed_origin" ]]; then
-                rm -f "$hdr_file" "$curl_cfg"
+                rm -f "$hdr_file"
+                _gitlab_api_cleanup_curl_config
                 echo "::error::latest-gitlab-tag: refusing cross-origin GitLab pagination URL for $(_gha_escape "${project_path}") (expected origin $(_gha_escape "${allowed_origin}"), got $(_gha_escape "${next_origin}"))" >&2
                 return 1
             fi
@@ -179,12 +199,14 @@ _gitlab_api_tags() {
     done
 
     if [[ "$pages_fetched" -ge "$max_pages" && -n "$url" ]]; then
-        rm -f "$hdr_file" "$curl_cfg"
+        rm -f "$hdr_file"
+        _gitlab_api_cleanup_curl_config
         echo "::error::latest-gitlab-tag: pagination bound reached (max_pages=$(_gha_escape "${max_pages}")) but more pages exist for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
 
-    rm -f "$hdr_file" "$curl_cfg"
+    rm -f "$hdr_file"
+    _gitlab_api_cleanup_curl_config
 
     if [[ "$tags_emitted" -eq 0 ]]; then
         echo "::error::latest-gitlab-tag: no tags returned for $(_gha_escape "${project_path}")" >&2

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -92,8 +92,8 @@ _gitlab_token_host_allowed() {
 }
 
 _validate_gitlab_token_for_curl_config() {
-    if [[ "${GITLAB_TOKEN:-}" == *\"* || "${GITLAB_TOKEN:-}" =~ [[:cntrl:]] ]]; then
-        echo "::error::latest-gitlab-tag: GITLAB_TOKEN must not contain double quotes or control characters" >&2
+    if [[ "${GITLAB_TOKEN:-}" == *\"* || "${GITLAB_TOKEN:-}" == *\\* || "${GITLAB_TOKEN:-}" =~ [[:cntrl:]] ]]; then
+        echo "::error::latest-gitlab-tag: GITLAB_TOKEN must not contain double quotes or control characters; backslashes are also rejected" >&2
         return 1
     fi
 }
@@ -325,6 +325,7 @@ latest-gitlab-tag() {
     fi
 
     local versions_with_tags=""
+    local candidate_separator=$'\t'
     while IFS= read -r tag; do
         [[ -z "$tag" ]] && continue
         if [[ "$tag" =~ $version_extract ]]; then
@@ -333,7 +334,7 @@ latest-gitlab-tag() {
                 echo "::error::latest-gitlab-tag: version-extract regex matched tag '$(_gha_escape "${tag}")' but produced no capture — verify the regex has exactly one parenthesized capture group" >&2
                 return 1
             fi
-            versions_with_tags="${versions_with_tags}${extracted} ${tag}"$'\n'
+            versions_with_tags="${versions_with_tags}${extracted}${candidate_separator}${tag}"$'\n'
         else
             log_info "version_extract '$(_gha_escape "${version_extract}")' did not match tag '$(_gha_escape "${tag}")' — skipping" >&2
         fi
@@ -345,11 +346,10 @@ latest-gitlab-tag() {
     fi
 
     local best_line
-    best_line=$(echo "$versions_with_tags" | sort -t' ' -k1,1 --version-sort | tail -1)
+    best_line=$(echo "$versions_with_tags" | sort -t "$candidate_separator" -k1,1 --version-sort | tail -1)
 
     local best_version best_raw_tag
-    best_version=$(echo "$best_line" | awk '{print $1}')
-    best_raw_tag=$(echo "$best_line" | awk '{print $2}')
+    IFS=$'\t' read -r best_version best_raw_tag <<< "$best_line"
 
     if [[ -z "$best_version" ]]; then
         log_error "Failed to determine best version for $(_gha_escape "${project_path}")" >&2

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+# Resolve the latest upstream GitLab git tag matching a filter regex, then
+# extract a normalized version string using a capture-group regex.
+#
+# Mirrors helpers/latest-github-tag's CLI contract:
+#   latest-gitlab-tag <project-path> \
+#       --tag-filter REGEX \
+#       --version-extract REGEX \
+#       [--include-prerelease] \
+#       [--output version|raw|both]
+#
+# Output:
+#   version: normalized version string
+#   raw:     matching raw git tag
+#   both:    VERSION<TAB>RAW_TAG
+#
+# Exit 1 on no matching tag, API error, empty result, or extract failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./logging.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/logging.sh"
+
+GITLAB_API_URL="${GITLAB_API_URL:-https://gitlab.torproject.org/api/v4}"
+PRERELEASE_EXCLUDE_REGEX='-rc|-alpha|-beta|-dev|-pre'
+
+_gha_escape() {
+    local s="$1"
+    s="${s//%/%25}"
+    s="${s//$'\r'/%0D}"
+    s="${s//$'\n'/%0A}"
+    printf '%s' "$s"
+}
+
+_gitlab_project_api_path() {
+    local project_path="$1"
+
+    if [[ "$project_path" == *%2F* || "$project_path" == *%2f* ]]; then
+        printf '%s' "$project_path"
+        return
+    fi
+
+    jq -rn --arg path "$project_path" '$path | @uri'
+}
+
+_gitlab_api_tags() {
+    local project_path="$1"
+    local encoded_project
+    encoded_project=$(_gitlab_project_api_path "$project_path")
+
+    local curl_args=(--proto '=https' --proto-redir '=https' -fsSL --connect-timeout 10 --max-time 30)
+    local curl_cfg=""
+    if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+        curl_cfg=$(mktemp)
+        chmod 600 "$curl_cfg"
+        printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_TOKEN" > "$curl_cfg"
+        curl_args+=(--config "$curl_cfg")
+    fi
+
+    local url="${GITLAB_API_URL}/projects/${encoded_project}/repository/tags?order_by=version&sort=desc&per_page=100"
+    local max_pages=20
+    local pages_fetched=0
+    local tags_emitted=0
+    local hdr_file
+    hdr_file=$(mktemp)
+
+    while [[ -n "$url" && "$pages_fetched" -lt "$max_pages" ]]; do
+        pages_fetched=$((pages_fetched + 1))
+
+        local body
+        if ! body=$(curl "${curl_args[@]}" -D "$hdr_file" "$url" 2>/dev/null); then
+            rm -f "$hdr_file" "$curl_cfg"
+            echo "::error::latest-gitlab-tag: GitLab API request failed on page $(_gha_escape "${pages_fetched}") for $(_gha_escape "${project_path}")" >&2
+            return 1
+        fi
+
+        local page_tags
+        if ! page_tags=$(printf '%s\n' "$body" | jq -r '.[].name' 2>/dev/null); then
+            rm -f "$hdr_file" "$curl_cfg"
+            echo "::error::latest-gitlab-tag: invalid JSON on page $(_gha_escape "${pages_fetched}") for $(_gha_escape "${project_path}")" >&2
+            return 1
+        fi
+
+        if [[ -n "$page_tags" ]]; then
+            printf '%s\n' "$page_tags"
+            tags_emitted=$((tags_emitted + 1))
+        fi
+
+        local next_url
+        next_url=$(grep -i '^[Ll]ink:' "$hdr_file" \
+            | grep -o '<[^>]*>; rel="next"' \
+            | sed 's/^<//; s/>; rel="next"//' \
+            | head -1 || true)
+        url="$next_url"
+    done
+
+    if [[ "$pages_fetched" -ge "$max_pages" && -n "$url" ]]; then
+        rm -f "$hdr_file" "$curl_cfg"
+        echo "::error::latest-gitlab-tag: pagination bound reached (max_pages=$(_gha_escape "${max_pages}")) but more pages exist for $(_gha_escape "${project_path}")" >&2
+        return 1
+    fi
+
+    rm -f "$hdr_file" "$curl_cfg"
+
+    if [[ "$tags_emitted" -eq 0 ]]; then
+        echo "::error::latest-gitlab-tag: no tags returned for $(_gha_escape "${project_path}")" >&2
+        return 1
+    fi
+}
+
+latest-gitlab-tag() {
+    local project_path=""
+    local tag_filter=""
+    local version_extract=""
+    local include_prerelease=false
+    local output_mode="version"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --tag-filter)
+                tag_filter="${2:-}"
+                shift 2
+                ;;
+            --version-extract)
+                version_extract="${2:-}"
+                shift 2
+                ;;
+            --include-prerelease)
+                include_prerelease=true
+                shift
+                ;;
+            --output)
+                output_mode="${2:-}"
+                shift 2
+                ;;
+            -*)
+                log_error "Unknown option: $1" >&2
+                log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX [--output version|raw|both]" >&2
+                return 1
+                ;;
+            *)
+                if [[ -z "$project_path" ]]; then
+                    project_path="$1"
+                else
+                    log_error "Unexpected argument: $1" >&2
+                    return 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$project_path" ]]; then
+        log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX" >&2
+        return 1
+    fi
+    if [[ -z "$tag_filter" ]]; then
+        log_error "latest-gitlab-tag: --tag-filter is required" >&2
+        return 1
+    fi
+    if [[ -z "$version_extract" ]]; then
+        log_error "latest-gitlab-tag: --version-extract is required" >&2
+        return 1
+    fi
+
+    log_info "Fetching GitLab tags for ${project_path}..." >&2
+    local all_tags
+    all_tags=$(_gitlab_api_tags "$project_path") || {
+        log_error "Failed to fetch GitLab tags for ${project_path}" >&2
+        return 1
+    }
+
+    if [[ -z "$all_tags" ]]; then
+        log_error "No tags returned for ${project_path}" >&2
+        return 1
+    fi
+
+    local filtered_tags
+    filtered_tags=$(echo "$all_tags" | grep -E "$tag_filter" || true)
+    if [[ -z "$filtered_tags" ]]; then
+        log_error "No tags match tag_filter '${tag_filter}' for ${project_path}" >&2
+        return 1
+    fi
+
+    if [[ "$include_prerelease" != "true" ]]; then
+        local no_prerelease
+        no_prerelease=$(echo "$filtered_tags" | grep -v -i -E -- "$PRERELEASE_EXCLUDE_REGEX" || true)
+        if [[ -z "$no_prerelease" ]]; then
+            log_error "All matching tags for ${project_path} are pre-releases — none passed exclusion filter" >&2
+            return 1
+        fi
+        filtered_tags="$no_prerelease"
+    fi
+
+    local versions_with_tags=""
+    while IFS= read -r tag; do
+        [[ -z "$tag" ]] && continue
+        if [[ "$tag" =~ $version_extract ]]; then
+            local extracted="${BASH_REMATCH[1]-}"
+            if [[ -z "$extracted" ]]; then
+                echo "::error::latest-gitlab-tag: version-extract regex matched tag '$(_gha_escape "${tag}")' but produced no capture — verify the regex has exactly one parenthesized capture group" >&2
+                return 1
+            fi
+            versions_with_tags="${versions_with_tags}${extracted} ${tag}"$'\n'
+        else
+            log_info "version_extract '${version_extract}' did not match tag '${tag}' — skipping" >&2
+        fi
+    done <<< "$filtered_tags"
+
+    if [[ -z "$versions_with_tags" ]]; then
+        log_error "version_extract '${version_extract}' produced no results for ${project_path}" >&2
+        return 1
+    fi
+
+    local best_line
+    best_line=$(echo "$versions_with_tags" | sort -t' ' -k1,1 --version-sort | tail -1)
+
+    local best_version best_raw_tag
+    best_version=$(echo "$best_line" | awk '{print $1}')
+    best_raw_tag=$(echo "$best_line" | awk '{print $2}')
+
+    if [[ -z "$best_version" ]]; then
+        log_error "Failed to determine best version for ${project_path}" >&2
+        return 1
+    fi
+    if [[ ! "$best_version" =~ ^[0-9] ]]; then
+        log_error "Extracted version '${best_version}' does not start with a digit — aborting" >&2
+        return 1
+    fi
+
+    case "$output_mode" in
+        version)
+            echo "$best_version"
+            ;;
+        raw)
+            if [[ -z "$best_raw_tag" ]]; then
+                log_error "No raw tag captured for ${project_path}" >&2
+                return 1
+            fi
+            echo "$best_raw_tag"
+            ;;
+        both)
+            if [[ -z "$best_raw_tag" ]]; then
+                log_error "No raw tag captured for ${project_path}" >&2
+                return 1
+            fi
+            printf '%s\t%s\n' "$best_version" "$best_raw_tag"
+            ;;
+        *)
+            log_error "Unknown --output mode '${output_mode}': use 'version', 'raw', or 'both'" >&2
+            return 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    latest-gitlab-tag "$@"
+fi

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -75,6 +75,13 @@ _gitlab_token_host_allowed() {
     [[ "$host" == "gitlab.torproject.org" ]]
 }
 
+_validate_gitlab_token_for_curl_config() {
+    if [[ "${GITLAB_TOKEN:-}" == *\"* || "${GITLAB_TOKEN:-}" =~ [[:cntrl:]] ]]; then
+        echo "::error::latest-gitlab-tag: GITLAB_TOKEN must not contain double quotes or control characters" >&2
+        return 1
+    fi
+}
+
 _gitlab_project_api_path() {
     local project_path="$1"
 
@@ -114,7 +121,9 @@ _gitlab_api_tags() {
     local curl_args=(--proto '=https' --proto-redir '=https' -fsS --connect-timeout 10 --max-time 30)
     local curl_cfg=""
     if [[ -n "${GITLAB_TOKEN:-}" ]] && _gitlab_token_host_allowed "$api_host"; then
+        _validate_gitlab_token_for_curl_config || return 1
         curl_cfg=$(mktemp)
+        trap 'rm -f "$curl_cfg"' EXIT
         chmod 600 "$curl_cfg"
         printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_TOKEN" > "$curl_cfg"
         curl_args+=(--config "$curl_cfg")

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -35,6 +35,23 @@ _gha_escape() {
     printf '%s' "$s"
 }
 
+_url_origin() {
+    local name="$1"
+    local url="$2"
+
+    if [[ "$url" =~ [[:cntrl:]] ]]; then
+        echo "::error::latest-gitlab-tag: $(_gha_escape "${name}") must not contain control characters" >&2
+        return 1
+    fi
+    if [[ "$url" =~ ^([A-Za-z][A-Za-z0-9+.-]*://[^/?#]+) ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    echo "::error::latest-gitlab-tag: $(_gha_escape "${name}") must be an absolute URL with scheme and host" >&2
+    return 1
+}
+
 _gitlab_project_api_path() {
     local project_path="$1"
 
@@ -57,12 +74,17 @@ _gitlab_project_api_path() {
 
 _gitlab_api_tags() {
     local project_path="$1"
+    local allowed_origin
+    if ! allowed_origin=$(_url_origin "GITLAB_API_URL" "$GITLAB_API_URL"); then
+        return 1
+    fi
+
     local encoded_project
     if ! encoded_project=$(_gitlab_project_api_path "$project_path"); then
         return 1
     fi
 
-    local curl_args=(--proto '=https' --proto-redir '=https' -fsSL --connect-timeout 10 --max-time 30)
+    local curl_args=(--proto '=https' --proto-redir '=https' -fsS --connect-timeout 10 --max-time 30)
     local curl_cfg=""
     if [[ -n "${GITLAB_TOKEN:-}" ]]; then
         curl_cfg=$(mktemp)
@@ -105,6 +127,18 @@ _gitlab_api_tags() {
             | grep -o '<[^>]*>; rel="next"' \
             | sed 's/^<//; s/>; rel="next"//' \
             | head -1 || true)
+        if [[ -n "$next_url" ]]; then
+            local next_origin
+            if ! next_origin=$(_url_origin "GitLab pagination URL" "$next_url"); then
+                rm -f "$hdr_file" "$curl_cfg"
+                return 1
+            fi
+            if [[ "$next_origin" != "$allowed_origin" ]]; then
+                rm -f "$hdr_file" "$curl_cfg"
+                echo "::error::latest-gitlab-tag: refusing cross-origin GitLab pagination URL for $(_gha_escape "${project_path}") (expected origin $(_gha_escape "${allowed_origin}"), got $(_gha_escape "${next_origin}"))" >&2
+                return 1
+            fi
+        fi
         url="$next_url"
     done
 

--- a/helpers/latest-gitlab-tag
+++ b/helpers/latest-gitlab-tag
@@ -52,6 +52,29 @@ _url_origin() {
     return 1
 }
 
+_url_host_from_origin() {
+    local origin="$1"
+    local authority host_port host
+
+    authority="${origin#*://}"
+    host_port="${authority##*@}"
+    if [[ "$host_port" == \[*\]* ]]; then
+        host="${host_port#\[}"
+        host="${host%%\]*}"
+    else
+        host="${host_port%%:*}"
+    fi
+
+    [[ -n "$host" ]] || return 1
+    printf '%s' "${host,,}"
+}
+
+_gitlab_token_host_allowed() {
+    local host="$1"
+
+    [[ "$host" == "gitlab.torproject.org" ]]
+}
+
 _gitlab_project_api_path() {
     local project_path="$1"
 
@@ -74,8 +97,12 @@ _gitlab_project_api_path() {
 
 _gitlab_api_tags() {
     local project_path="$1"
-    local allowed_origin
+    local allowed_origin api_host
     if ! allowed_origin=$(_url_origin "GITLAB_API_URL" "$GITLAB_API_URL"); then
+        return 1
+    fi
+    if ! api_host=$(_url_host_from_origin "$allowed_origin"); then
+        echo "::error::latest-gitlab-tag: GITLAB_API_URL must include a host" >&2
         return 1
     fi
 
@@ -86,7 +113,7 @@ _gitlab_api_tags() {
 
     local curl_args=(--proto '=https' --proto-redir '=https' -fsS --connect-timeout 10 --max-time 30)
     local curl_cfg=""
-    if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+    if [[ -n "${GITLAB_TOKEN:-}" ]] && _gitlab_token_host_allowed "$api_host"; then
         curl_cfg=$(mktemp)
         chmod 600 "$curl_cfg"
         printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_TOKEN" > "$curl_cfg"
@@ -166,10 +193,20 @@ latest-gitlab-tag() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --tag-filter)
+                if [[ $# -lt 2 ]]; then
+                    log_error "latest-gitlab-tag: --tag-filter requires a value" >&2
+                    log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX [--output version|raw|both]" >&2
+                    return 1
+                fi
                 tag_filter="${2:-}"
                 shift 2
                 ;;
             --version-extract)
+                if [[ $# -lt 2 ]]; then
+                    log_error "latest-gitlab-tag: --version-extract requires a value" >&2
+                    log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX [--output version|raw|both]" >&2
+                    return 1
+                fi
                 version_extract="${2:-}"
                 shift 2
                 ;;
@@ -178,11 +215,16 @@ latest-gitlab-tag() {
                 shift
                 ;;
             --output)
+                if [[ $# -lt 2 ]]; then
+                    log_error "latest-gitlab-tag: --output requires a value" >&2
+                    log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX [--output version|raw|both]" >&2
+                    return 1
+                fi
                 output_mode="${2:-}"
                 shift 2
                 ;;
             -*)
-                log_error "Unknown option: $1" >&2
+                log_error "Unknown option: $(_gha_escape "$1")" >&2
                 log_error "Usage: latest-gitlab-tag <project-path> --tag-filter REGEX --version-extract REGEX [--output version|raw|both]" >&2
                 return 1
                 ;;
@@ -190,7 +232,7 @@ latest-gitlab-tag() {
                 if [[ -z "$project_path" ]]; then
                     project_path="$1"
                 else
-                    log_error "Unexpected argument: $1" >&2
+                    log_error "Unexpected argument: $(_gha_escape "$1")" >&2
                     return 1
                 fi
                 shift
@@ -210,23 +252,24 @@ latest-gitlab-tag() {
         log_error "latest-gitlab-tag: --version-extract is required" >&2
         return 1
     fi
+    _gitlab_project_api_path "$project_path" >/dev/null || return 1
 
-    log_info "Fetching GitLab tags for ${project_path}..." >&2
+    log_info "Fetching GitLab tags for $(_gha_escape "${project_path}")..." >&2
     local all_tags
     all_tags=$(_gitlab_api_tags "$project_path") || {
-        log_error "Failed to fetch GitLab tags for ${project_path}" >&2
+        log_error "Failed to fetch GitLab tags for $(_gha_escape "${project_path}")" >&2
         return 1
     }
 
     if [[ -z "$all_tags" ]]; then
-        log_error "No tags returned for ${project_path}" >&2
+        log_error "No tags returned for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
 
     local filtered_tags
     filtered_tags=$(echo "$all_tags" | grep -E "$tag_filter" || true)
     if [[ -z "$filtered_tags" ]]; then
-        log_error "No tags match tag_filter '${tag_filter}' for ${project_path}" >&2
+        log_error "No tags match tag_filter '$(_gha_escape "${tag_filter}")' for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
 
@@ -234,7 +277,7 @@ latest-gitlab-tag() {
         local no_prerelease
         no_prerelease=$(echo "$filtered_tags" | grep -v -i -E -- "$PRERELEASE_EXCLUDE_REGEX" || true)
         if [[ -z "$no_prerelease" ]]; then
-            log_error "All matching tags for ${project_path} are pre-releases — none passed exclusion filter" >&2
+            log_error "All matching tags for $(_gha_escape "${project_path}") are pre-releases — none passed exclusion filter" >&2
             return 1
         fi
         filtered_tags="$no_prerelease"
@@ -251,12 +294,12 @@ latest-gitlab-tag() {
             fi
             versions_with_tags="${versions_with_tags}${extracted} ${tag}"$'\n'
         else
-            log_info "version_extract '${version_extract}' did not match tag '${tag}' — skipping" >&2
+            log_info "version_extract '$(_gha_escape "${version_extract}")' did not match tag '$(_gha_escape "${tag}")' — skipping" >&2
         fi
     done <<< "$filtered_tags"
 
     if [[ -z "$versions_with_tags" ]]; then
-        log_error "version_extract '${version_extract}' produced no results for ${project_path}" >&2
+        log_error "version_extract '$(_gha_escape "${version_extract}")' produced no results for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
 
@@ -268,11 +311,11 @@ latest-gitlab-tag() {
     best_raw_tag=$(echo "$best_line" | awk '{print $2}')
 
     if [[ -z "$best_version" ]]; then
-        log_error "Failed to determine best version for ${project_path}" >&2
+        log_error "Failed to determine best version for $(_gha_escape "${project_path}")" >&2
         return 1
     fi
     if [[ ! "$best_version" =~ ^[0-9] ]]; then
-        log_error "Extracted version '${best_version}' does not start with a digit — aborting" >&2
+        log_error "Extracted version '$(_gha_escape "${best_version}")' does not start with a digit — aborting" >&2
         return 1
     fi
 
@@ -282,20 +325,20 @@ latest-gitlab-tag() {
             ;;
         raw)
             if [[ -z "$best_raw_tag" ]]; then
-                log_error "No raw tag captured for ${project_path}" >&2
+                log_error "No raw tag captured for $(_gha_escape "${project_path}")" >&2
                 return 1
             fi
             echo "$best_raw_tag"
             ;;
         both)
             if [[ -z "$best_raw_tag" ]]; then
-                log_error "No raw tag captured for ${project_path}" >&2
+                log_error "No raw tag captured for $(_gha_escape "${project_path}")" >&2
                 return 1
             fi
             printf '%s\t%s\n' "$best_version" "$best_raw_tag"
             ;;
         *)
-            log_error "Unknown --output mode '${output_mode}': use 'version', 'raw', or 'both'" >&2
+            log_error "Unknown --output mode '$(_gha_escape "${output_mode}")': use 'version', 'raw', or 'both'" >&2
             return 1
             ;;
     esac

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -43,6 +43,24 @@ _gha_escape() {
     printf '%s' "$s"
 }
 
+normalize_gitlab_host() {
+    local host="$1"
+
+    host="${host#https://}"
+    host="${host#http://}"
+    host="${host%/}"
+
+    [[ "$host" =~ ^[A-Za-z0-9.-]+(:[0-9]+)?$ ]] || return 1
+    printf '%s' "$host"
+}
+
+gitlab_api_url_from_host() {
+    local host
+
+    host=$(normalize_gitlab_host "$1") || return 1
+    printf 'https://%s/api/v4' "$host"
+}
+
 # Classify semver change type between two versions
 # Returns: major, minor, patch, or unknown
 classify_version_change() {
@@ -81,6 +99,7 @@ build_source_url() {
     local source="$2"
     local version="$3"
     local raw_tag="${4:-}"
+    local source_host="${5:-}"
 
     case "$type" in
         github-release)
@@ -98,12 +117,17 @@ build_source_url() {
             ;;
         gitlab-tags)
             local project_path_web
+            local web_host
+            web_host=$(normalize_gitlab_host "${source_host:-gitlab.torproject.org}") || {
+                echo ""
+                return
+            }
             project_path_web="${source//%2F/\/}"
             project_path_web="${project_path_web//%2f/\/}"
             if [[ -n "$raw_tag" ]]; then
-                echo "https://gitlab.torproject.org/${project_path_web}/-/tags/${raw_tag}"
+                echo "https://${web_host}/${project_path_web}/-/tags/${raw_tag}"
             else
-                echo "https://gitlab.torproject.org/${project_path_web}/-/tags/v${version}"
+                echo "https://${web_host}/${project_path_web}/-/tags/v${version}"
             fi
             ;;
         pypi)
@@ -293,6 +317,7 @@ check_container_deps() {
         local latest_version=""
         local source_ref=""
         local latest_raw_tag=""  # raw tag for github-tag type (used in URL builder)
+        local source_web_host=""
 
         case "$dep_type" in
             github-release)
@@ -346,10 +371,12 @@ check_container_deps() {
                 unset _gh_both
                 ;;
             gitlab-tags)
-                local project_path tag_filter version_extract
+                local project_path tag_filter version_extract web_host api_host gitlab_api_url
                 project_path=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].project_path // ""' "$config")
                 tag_filter=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].tag_filter // ""' "$config")
                 version_extract=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].version_extract // ""' "$config")
+                web_host=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].web_host // "gitlab.torproject.org"' "$config")
+                api_host=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].api_host // "gitlab.torproject.org"' "$config")
                 source_ref="$project_path"
 
                 if [[ -z "$project_path" ]]; then
@@ -360,8 +387,16 @@ check_container_deps() {
                     errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: gitlab-tags type requires tag_filter and version_extract" '. + [$msg]')
                     continue
                 fi
+                source_web_host=$(normalize_gitlab_host "$web_host") || {
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: gitlab-tags web_host is invalid: ${web_host}" '. + [$msg]')
+                    continue
+                }
+                gitlab_api_url=$(gitlab_api_url_from_host "$api_host") || {
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: gitlab-tags api_host is invalid: ${api_host}" '. + [$msg]')
+                    continue
+                }
 
-                _gl_both=$("$PROJECT_ROOT/helpers/latest-gitlab-tag" "$project_path" \
+                _gl_both=$(GITLAB_API_URL="$gitlab_api_url" "$PROJECT_ROOT/helpers/latest-gitlab-tag" "$project_path" \
                     --tag-filter "$tag_filter" \
                     --version-extract "$version_extract" \
                     --output both 2>/dev/null) || {
@@ -416,7 +451,7 @@ check_container_deps() {
             local change_type
             change_type=$(classify_version_change "$current_version" "$latest_version")
             local source_url
-            source_url=$(build_source_url "$dep_type" "$source_ref" "$latest_version" "$latest_raw_tag")
+            source_url=$(build_source_url "$dep_type" "$source_ref" "$latest_version" "$latest_raw_tag" "$source_web_host")
 
             updates_json=$(echo "$updates_json" | jq \
                 --arg name "$dep_name" \

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -86,14 +86,12 @@ classify_version_change() {
 }
 
 # Build source URL for a dependency update
-# Args: type source version [raw_tag]
-#   raw_tag: optional 4th argument for github-tag type.
+# Args: type source version [raw_tag] [source_host]
+#   raw_tag: optional 4th argument for github-tag and gitlab-tags types.
 #     For github-release: raw_tag unused; v${version} path is always correct.
 #     For github-tag: use /tree/${raw_tag} (the git ref always resolves; no
 #       dependence on a release being published). Falls back to v${version}
 #       when raw_tag is empty.
-#     Assumption: raw_tag values from the upstream API are simple [-.\w]+ shaped
-#       (e.g. "openssl-3.5.6", "pcre2-10.47") — no URL-special chars in practice.
 build_source_url() {
     local type="$1"
     local source="$2"
@@ -117,6 +115,7 @@ build_source_url() {
             ;;
         gitlab-tags)
             local project_path_web
+            local tag_segment
             local web_host
             web_host=$(normalize_gitlab_host "${source_host:-gitlab.torproject.org}") || {
                 echo ""
@@ -125,9 +124,11 @@ build_source_url() {
             project_path_web="${source//%2F/\/}"
             project_path_web="${project_path_web//%2f/\/}"
             if [[ -n "$raw_tag" ]]; then
-                echo "https://${web_host}/${project_path_web}/-/tags/${raw_tag}"
+                tag_segment=$(jq -rn --arg segment "$raw_tag" '$segment | @uri')
+                echo "https://${web_host}/${project_path_web}/-/tags/${tag_segment}"
             else
-                echo "https://${web_host}/${project_path_web}/-/tags/v${version}"
+                tag_segment=$(jq -rn --arg segment "v${version}" '$segment | @uri')
+                echo "https://${web_host}/${project_path_web}/-/tags/${tag_segment}"
             fi
             ;;
         pypi)

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -43,6 +43,17 @@ _gha_escape() {
     printf '%s' "$s"
 }
 
+compact_helper_error() {
+    local message="$1"
+
+    message=$(printf '%s' "$message" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g; s/[[:space:]]+/ /g; s/^ //; s/ $//')
+    if [[ -z "$message" ]]; then
+        message="helper exited without stderr"
+    fi
+
+    printf '%s' "$message"
+}
+
 normalize_gitlab_host() {
     local host="$1"
 
@@ -397,13 +408,22 @@ check_container_deps() {
                     continue
                 }
 
+                local gitlab_helper_stderr
+                gitlab_helper_stderr=$(mktemp)
                 _gl_both=$(GITLAB_API_URL="$gitlab_api_url" "$PROJECT_ROOT/helpers/latest-gitlab-tag" "$project_path" \
                     --tag-filter "$tag_filter" \
                     --version-extract "$version_extract" \
-                    --output both 2>/dev/null) || {
-                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: GitLab tag API error for ${project_path}" '. + [$msg]')
+                    --output both 2>"$gitlab_helper_stderr") || {
+                    local gitlab_helper_error gitlab_helper_stderr_text=""
+                    if [[ -r "$gitlab_helper_stderr" ]]; then
+                        gitlab_helper_stderr_text=$(<"$gitlab_helper_stderr")
+                    fi
+                    gitlab_helper_error=$(compact_helper_error "$gitlab_helper_stderr_text")
+                    rm -f "$gitlab_helper_stderr"
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: GitLab tag API error for ${project_path}: ${gitlab_helper_error}" '. + [$msg]')
                     continue
                 }
+                rm -f "$gitlab_helper_stderr"
                 latest_version="${_gl_both%%$'\t'*}"
                 latest_raw_tag="${_gl_both##*$'\t'}"
                 unset _gl_both

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../helpers/logging.sh
+# shellcheck disable=SC1091
 source "$PROJECT_ROOT/helpers/logging.sh"
 
 # Named constant: days before supported_until to emit a ::warning:: countdown
@@ -92,6 +94,16 @@ build_source_url() {
                 echo "https://github.com/${source}/tree/${raw_tag}"
             else
                 echo "https://github.com/${source}/tree/v${version}"
+            fi
+            ;;
+        gitlab-tags)
+            local project_path_web
+            project_path_web="${source//%2F/\/}"
+            project_path_web="${project_path_web//%2f/\/}"
+            if [[ -n "$raw_tag" ]]; then
+                echo "https://gitlab.torproject.org/${project_path_web}/-/tags/${raw_tag}"
+            else
+                echo "https://gitlab.torproject.org/${project_path_web}/-/tags/v${version}"
             fi
             ;;
         pypi)
@@ -332,6 +344,33 @@ check_container_deps() {
                 latest_version="${_gh_both%%$'\t'*}"
                 latest_raw_tag="${_gh_both##*$'\t'}"
                 unset _gh_both
+                ;;
+            gitlab-tags)
+                local project_path tag_filter version_extract
+                project_path=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].project_path // ""' "$config")
+                tag_filter=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].tag_filter // ""' "$config")
+                version_extract=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].version_extract // ""' "$config")
+                source_ref="$project_path"
+
+                if [[ -z "$project_path" ]]; then
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: gitlab-tags type missing project_path:" '. + [$msg]')
+                    continue
+                fi
+                if [[ -z "$tag_filter" || -z "$version_extract" ]]; then
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: gitlab-tags type requires tag_filter and version_extract" '. + [$msg]')
+                    continue
+                fi
+
+                _gl_both=$("$PROJECT_ROOT/helpers/latest-gitlab-tag" "$project_path" \
+                    --tag-filter "$tag_filter" \
+                    --version-extract "$version_extract" \
+                    --output both 2>/dev/null) || {
+                    errors_json=$(echo "$errors_json" | jq --arg msg "${dep_name}: GitLab tag API error for ${project_path}" '. + [$msg]')
+                    continue
+                }
+                latest_version="${_gl_both%%$'\t'*}"
+                latest_raw_tag="${_gl_both##*$'\t'}"
+                unset _gl_both
                 ;;
             pypi)
                 local package

--- a/tests/unit/bake-matrix-arg-parity.bats
+++ b/tests/unit/bake-matrix-arg-parity.bats
@@ -284,7 +284,7 @@ bake_managed_fleet_list_is_expected_parity_surface() { # @test
     local managed
     managed=$(bake_managed_containers)
     assert_equals \
-        "github-runner web-shell wordpress debian vector jekyll ansible sslh openvpn php openresty terraform postgres" \
+        "github-runner web-shell wordpress debian vector jekyll ansible sslh openvpn php openresty terraform postgres tor" \
         "$managed" \
         "bake-managed containers"
 }

--- a/tests/unit/check-version.bats
+++ b/tests/unit/check-version.bats
@@ -339,7 +339,7 @@ EOF
 set -euo pipefail
 printf 'GITLAB_API_URL=%s\n' "\${GITLAB_API_URL:-}" >> "$TEST_TEMP_DIR/gitlab-helper.log"
 printf 'ARGS=%s\n' "\$*" >> "$TEST_TEMP_DIR/gitlab-helper.log"
-printf '0.8.2\tlyrebird-0.8.2\n'
+printf '0.8.2\tlyrebird/0.8.2+meta\n'
 EOF
     chmod +x "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh" "$TEST_TEMP_DIR/helpers/latest-gitlab-tag"
 
@@ -364,7 +364,7 @@ EOF
     json_output=$(printf '%s\n' "$output" | awk 'found || $0 == "[" { found = 1; print }')
     echo "$json_output" | jq -e '.[0].updates[0].name == "LYREBIRD_VERSION"' >/dev/null
     echo "$json_output" | jq -e '.[0].updates[0].latest == "0.8.2"' >/dev/null
-    echo "$json_output" | jq -e '.[0].updates[0].source_url == "https://gitlab.example/tpo/anti-censorship/pluggable-transports/lyrebird/-/tags/lyrebird-0.8.2"' >/dev/null
+    echo "$json_output" | jq -e '.[0].updates[0].source_url == "https://gitlab.example/tpo/anti-censorship/pluggable-transports/lyrebird/-/tags/lyrebird%2F0.8.2%2Bmeta"' >/dev/null
     grep -qx 'GITLAB_API_URL=https://gitlab-api.example:8443/api/v4' "$TEST_TEMP_DIR/gitlab-helper.log"
     grep -q -- '--output both' "$TEST_TEMP_DIR/gitlab-helper.log"
 }

--- a/tests/unit/check-version.bats
+++ b/tests/unit/check-version.bats
@@ -6,15 +6,17 @@ load "../test_helper"
 
 # Source the script functions in a way that handles $(dirname "$0") issue
 source_version_script() {
-    pushd "$SCRIPTS_DIR" > /dev/null 2>&1
+    pushd "$SCRIPTS_DIR" > /dev/null 2>&1 || return
+    # shellcheck disable=SC1091
     source "./check-version.sh"
-    popd > /dev/null 2>&1
+    popd > /dev/null 2>&1 || return
 }
 
 setup() {
     setup_temp_dir
 
     # Source logging first (dependency)
+    # shellcheck disable=SC1091
     source "$HELPERS_DIR/logging.sh"
 
     # Save original PATH
@@ -260,4 +262,109 @@ EOF
 
     # Should fail since version.sh returned non-zero
     [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# check-dependency-versions gitlab-tags coverage
+# =============================================================================
+
+write_gitlab_url_capture_curl() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+header_file=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -D)
+            header_file="$2"
+            shift 2
+            ;;
+        --connect-timeout|--max-time|--proto|--proto-redir|--config)
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+: "${header_file:?missing -D header file}"
+: "${url:?missing url}"
+
+printf 'HTTP/2 200\n' > "$header_file"
+printf '%s\n' "$url" >> "${GITLAB_URL_LOG:?}"
+printf '[{"name":"tor-0.4.9.10"},{"name":"tor-0.4.9.11"}]\n'
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/curl"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+@test "latest-gitlab-tag builds the same encoded API URL for plain and pre-encoded project paths" {
+    write_gitlab_url_capture_curl
+    export GITLAB_URL_LOG="$TEST_TEMP_DIR/gitlab-urls.log"
+    export GITLAB_API_URL="https://gitlab.example/api/v4"
+
+    run "$HELPERS_DIR/latest-gitlab-tag" "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+
+    run "$HELPERS_DIR/latest-gitlab-tag" "tpo%2Fcore%2Ftor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+
+    mapfile -t urls < "$GITLAB_URL_LOG"
+    [ "${urls[0]}" = "https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?order_by=version&sort=desc&per_page=100" ]
+    [ "${urls[1]}" = "https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?order_by=version&sort=desc&per_page=100" ]
+}
+
+@test "check-dependency-versions dispatches gitlab-tags through latest-gitlab-tag with configured hosts" {
+    mkdir -p "$TEST_TEMP_DIR/scripts" "$TEST_TEMP_DIR/helpers" "$TEST_TEMP_DIR/tor"
+    cp "$SCRIPTS_DIR/check-dependency-versions.sh" "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_TEMP_DIR/helpers/logging.sh"
+
+    cat > "$TEST_TEMP_DIR/helpers/latest-gitlab-tag" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'GITLAB_API_URL=%s\n' "\${GITLAB_API_URL:-}" >> "$TEST_TEMP_DIR/gitlab-helper.log"
+printf 'ARGS=%s\n' "\$*" >> "$TEST_TEMP_DIR/gitlab-helper.log"
+printf '0.8.2\tlyrebird-0.8.2\n'
+EOF
+    chmod +x "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh" "$TEST_TEMP_DIR/helpers/latest-gitlab-tag"
+
+    cat > "$TEST_TEMP_DIR/tor/config.yaml" <<'EOF'
+build_args:
+  LYREBIRD_VERSION: "0.8.1"
+dependency_sources:
+  LYREBIRD_VERSION:
+    lifecycle: tracked
+    type: gitlab-tags
+    web_host: gitlab.example
+    api_host: gitlab-api.example:8443
+    project_path: tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird
+    tag_filter: "^lyrebird-[0-9]+\\.[0-9]+\\.[0-9]+$"
+    version_extract: "^lyrebird-([0-9]+\\.[0-9]+\\.[0-9]+)$"
+EOF
+
+    run "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh" tor --json
+
+    [ "$status" -eq 0 ]
+    local json_output
+    json_output=$(printf '%s\n' "$output" | awk 'found || $0 == "[" { found = 1; print }')
+    echo "$json_output" | jq -e '.[0].updates[0].name == "LYREBIRD_VERSION"' >/dev/null
+    echo "$json_output" | jq -e '.[0].updates[0].latest == "0.8.2"' >/dev/null
+    echo "$json_output" | jq -e '.[0].updates[0].source_url == "https://gitlab.example/tpo/anti-censorship/pluggable-transports/lyrebird/-/tags/lyrebird-0.8.2"' >/dev/null
+    grep -qx 'GITLAB_API_URL=https://gitlab-api.example:8443/api/v4' "$TEST_TEMP_DIR/gitlab-helper.log"
+    grep -q -- '--output both' "$TEST_TEMP_DIR/gitlab-helper.log"
 }

--- a/tests/unit/check-version.bats
+++ b/tests/unit/check-version.bats
@@ -368,3 +368,38 @@ EOF
     grep -qx 'GITLAB_API_URL=https://gitlab-api.example:8443/api/v4' "$TEST_TEMP_DIR/gitlab-helper.log"
     grep -q -- '--output both' "$TEST_TEMP_DIR/gitlab-helper.log"
 }
+
+@test "check-dependency-versions includes latest-gitlab-tag failure reason" {
+    mkdir -p "$TEST_TEMP_DIR/scripts" "$TEST_TEMP_DIR/helpers" "$TEST_TEMP_DIR/tor"
+    cp "$SCRIPTS_DIR/check-dependency-versions.sh" "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_TEMP_DIR/helpers/logging.sh"
+
+    cat > "$TEST_TEMP_DIR/helpers/latest-gitlab-tag" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "latest-gitlab-tag: tag_filter regex '[' failed: grep: Invalid regular expression" >&2
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh" "$TEST_TEMP_DIR/helpers/latest-gitlab-tag"
+
+    cat > "$TEST_TEMP_DIR/tor/config.yaml" <<'EOF'
+build_args:
+  LYREBIRD_VERSION: "0.8.1"
+dependency_sources:
+  LYREBIRD_VERSION:
+    lifecycle: tracked
+    type: gitlab-tags
+    project_path: tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird
+    tag_filter: "["
+    version_extract: "^lyrebird-([0-9]+\\.[0-9]+\\.[0-9]+)$"
+EOF
+
+    run "$TEST_TEMP_DIR/scripts/check-dependency-versions.sh" tor --json
+
+    [ "$status" -eq 0 ]
+    local json_output
+    json_output=$(printf '%s\n' "$output" | awk 'found || $0 == "[" { found = 1; print }')
+    echo "$json_output" | jq -e '.[0].errors[0] | contains("GitLab tag API error for tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird")' >/dev/null
+    echo "$json_output" | jq -e '.[0].errors[0] | contains("tag_filter regex")' >/dev/null
+    echo "$json_output" | jq -e '.[0].errors[0] | contains("Invalid regular expression")' >/dev/null
+}

--- a/tests/unit/latest-github-tag.bats
+++ b/tests/unit/latest-github-tag.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    TEST_TEMP_DIR="$(mktemp -d)"
+    HELPER="${PROJECT_ROOT}/helpers/latest-github-tag"
+    export GITHUB_API_URL="https://github.example/api/v3"
+    unset GITHUB_TOKEN
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+    unset GITHUB_API_URL
+    unset GITHUB_TOKEN
+}
+
+write_fake_curl() {
+    local mode="$1"
+
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${FAKE_CURL_MODE:?}"
+header_file=""
+config_file=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -D)
+            header_file="$2"
+            shift 2
+            ;;
+        --config)
+            config_file="$2"
+            shift 2
+            ;;
+        --connect-timeout|--max-time|--proto|--proto-redir|-H)
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+: "${header_file:?missing -D header file}"
+: "${url:?missing url}"
+
+if [[ -n "${FAKE_CURL_CONFIG_LOG:-}" ]]; then
+    if [[ -n "$config_file" ]]; then
+        printf 'CONFIG:%s\n' "$(tr '\n' ';' < "$config_file")" >> "$FAKE_CURL_CONFIG_LOG"
+    else
+        printf 'CONFIG:\n' >> "$FAKE_CURL_CONFIG_LOG"
+    fi
+fi
+if [[ -n "${FAKE_CURL_CONFIG_PATH_LOG:-}" && -n "$config_file" ]]; then
+    printf '%s\n' "$config_file" >> "$FAKE_CURL_CONFIG_PATH_LOG"
+fi
+
+printf 'HTTP/2 200\n' > "$header_file"
+
+case "$mode" in
+    happy)
+        printf '[{"name":"openssl-3.5.0"},{"name":"openssl-3.5.6"}]\n'
+        ;;
+    space_tag)
+        printf '[{"name":"release v1.9.0 with space"},{"name":"release v1.10.0 with space"}]\n'
+        ;;
+    *)
+        exit 99
+        ;;
+esac
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/curl"
+    export PATH="${TEST_TEMP_DIR}/bin:$PATH"
+    export FAKE_CURL_MODE="$mode"
+}
+
+run_helper() {
+    env PATH="$PATH" GITHUB_API_URL="$GITHUB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_CONFIG_LOG="${FAKE_CURL_CONFIG_LOG:-}" FAKE_CURL_CONFIG_PATH_LOG="${FAKE_CURL_CONFIG_PATH_LOG:-}" \
+        "$HELPER" "$@"
+}
+
+run_api_tags() {
+    env PATH="$PATH" GITHUB_API_URL="$GITHUB_API_URL" GITHUB_TOKEN="${GITHUB_TOKEN:-}" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_CONFIG_LOG="${FAKE_CURL_CONFIG_LOG:-}" FAKE_CURL_CONFIG_PATH_LOG="${FAKE_CURL_CONFIG_PATH_LOG:-}" \
+        bash -c 'source "$1" && _gh_api_tags "$2"' bash "$HELPER" "$1"
+}
+
+last_output_line() {
+    printf '%s' "${lines[$((${#lines[@]} - 1))]}"
+}
+
+@test "tag names with spaces are preserved for raw and both output" {
+    write_fake_curl space_tag
+
+    run run_helper "owner/repo" \
+        --tag-filter '^release v[0-9]+\.[0-9]+\.[0-9]+ with space$' \
+        --version-extract '^release v([0-9]+\.[0-9]+\.[0-9]+) with space$' \
+        --output raw
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "release v1.10.0 with space" ]
+
+    run run_helper "owner/repo" \
+        --tag-filter '^release v[0-9]+\.[0-9]+\.[0-9]+ with space$' \
+        --version-extract '^release v([0-9]+\.[0-9]+\.[0-9]+) with space$' \
+        --output both
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = $'1.10.0\trelease v1.10.0 with space' ]
+}
+
+@test "GitHub token rejects literal backslash escapes before curl config is written" {
+    write_fake_curl happy
+    export GITHUB_TOKEN='bad\ntoken'
+    FAKE_CURL_CONFIG_PATH_LOG="${TEST_TEMP_DIR}/curl-config-path.log"
+    FAKE_CURL_CONFIG_LOG="${TEST_TEMP_DIR}/curl-config.log"
+
+    run run_api_tags "owner/repo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GITHUB_TOKEN must not contain double quotes or control characters; backslashes are also rejected"* ]]
+    [ ! -e "$FAKE_CURL_CONFIG_PATH_LOG" ]
+    [ ! -e "$FAKE_CURL_CONFIG_LOG" ]
+}

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -11,6 +11,7 @@ setup() {
 teardown() {
     rm -rf "$TEST_TEMP_DIR"
     unset GITLAB_API_URL
+    unset GITLAB_TOKEN
 }
 
 write_fake_curl() {
@@ -77,6 +78,11 @@ case "$mode" in
 Link: <https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?page=2>; rel="next"'
             printf '[{"name":"tor-0.5.0.0-alpha-dev"}]\n'
         fi
+        ;;
+    cross_origin_paginate)
+        emit_headers 'HTTP/2 200
+Link: <https://evil.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?page=2>; rel="next"'
+        printf '[{"name":"tor-0.5.0.0-alpha-dev"}]\n'
         ;;
     fail)
         exit 22
@@ -181,6 +187,22 @@ last_output_line() {
 
     [ "$status" -eq 0 ]
     [ "$(last_output_line)" = "0.4.9.11" ]
+}
+
+@test "pagination rejects cross-origin Link header before following it" {
+    write_fake_curl cross_origin_paginate
+    export GITLAB_TOKEN="secret"
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refusing cross-origin GitLab pagination URL"* ]]
+    [ "$(wc -l < "$FAKE_CURL_URL_LOG")" -eq 1 ]
+    run grep -q 'evil.example' "$FAKE_CURL_URL_LOG"
+    [ "$status" -ne 0 ]
 }
 
 @test "missing tag_filter fails closed" {

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -63,6 +63,9 @@ if [[ -n "${FAKE_CURL_CONFIG_LOG:-}" ]]; then
         printf 'CONFIG:\n' >> "$FAKE_CURL_CONFIG_LOG"
     fi
 fi
+if [[ -n "${FAKE_CURL_CONFIG_PATH_LOG:-}" && -n "$config_file" ]]; then
+    printf '%s\n' "$config_file" >> "$FAKE_CURL_CONFIG_PATH_LOG"
+fi
 
 emit_headers() {
     printf '%s\n' "$1" > "$header_file"
@@ -96,6 +99,10 @@ Link: <https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?p
 Link: <https://evil.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?page=2>; rel="next"'
         printf '[{"name":"tor-0.5.0.0-alpha-dev"}]\n'
         ;;
+    terminate)
+        kill -TERM "$PPID"
+        exit 143
+        ;;
     fail)
         exit 22
         ;;
@@ -110,7 +117,7 @@ EOF
 }
 
 run_helper() {
-    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_URL_LOG="${FAKE_CURL_URL_LOG:-}" FAKE_CURL_CONFIG_LOG="${FAKE_CURL_CONFIG_LOG:-}" \
+    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_URL_LOG="${FAKE_CURL_URL_LOG:-}" FAKE_CURL_CONFIG_LOG="${FAKE_CURL_CONFIG_LOG:-}" FAKE_CURL_CONFIG_PATH_LOG="${FAKE_CURL_CONFIG_PATH_LOG:-}" \
         "$HELPER" "$@"
 }
 
@@ -228,11 +235,24 @@ last_output_line() {
         --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
 
     [ "$status" -eq 0 ]
+    [[ "$output" != *"unbound variable"* ]]
     grep -q 'CONFIG:header = "PRIVATE-TOKEN: secret";' "$FAKE_CURL_CONFIG_LOG"
 }
 
-@test "GitLab token curl config has EXIT cleanup trap" {
-    grep -Fq "trap 'rm -f \"\$curl_cfg\"' EXIT" "$HELPER"
+@test "GitLab token curl config is cleaned on interruption" {
+    write_fake_curl terminate
+    export GITLAB_TOKEN="secret"
+    FAKE_CURL_CONFIG_PATH_LOG="${TEST_TEMP_DIR}/curl-config-path.log"
+    GITLAB_API_URL="https://gitlab.torproject.org/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -ne 0 ]
+    config_path="$(head -n 1 "$FAKE_CURL_CONFIG_PATH_LOG")"
+    [ -n "$config_path" ]
+    [ ! -e "$config_path" ]
 }
 
 @test "GitLab token rejects curl config quote injection before curl" {

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -92,6 +92,10 @@ case "$mode" in
         emit_headers "HTTP/2 200"
         printf '[{"name":"tor-0.4.9|11"}]\n'
         ;;
+    space_tag)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"release v1.9.0 with space"},{"name":"release v1.10.0 with space"}]\n'
+        ;;
     paginate)
         if [[ "$url" == *"page=2"* ]]; then
             emit_headers "HTTP/2 200"
@@ -240,6 +244,26 @@ last_output_line() {
     [[ "$output" == *"Extracted version '0.4.9|11' is not a safe normalized version"* ]]
 }
 
+@test "tag names with spaces are preserved for raw and both output" {
+    write_fake_curl space_tag
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^release v[0-9]+\.[0-9]+\.[0-9]+ with space$' \
+        --version-extract '^release v([0-9]+\.[0-9]+\.[0-9]+) with space$' \
+        --output raw
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "release v1.10.0 with space" ]
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^release v[0-9]+\.[0-9]+\.[0-9]+ with space$' \
+        --version-extract '^release v([0-9]+\.[0-9]+\.[0-9]+) with space$' \
+        --output both
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = $'1.10.0\trelease v1.10.0 with space' ]
+}
+
 @test "pagination follows GitLab Link header until a matching stable tag is found" {
     write_fake_curl paginate
 
@@ -325,6 +349,23 @@ last_output_line() {
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"GITLAB_TOKEN must not contain double quotes or control characters"* ]]
+    [ ! -e "$FAKE_CURL_URL_LOG" ]
+}
+
+@test "GitLab token rejects literal backslash escapes before curl config is written" {
+    write_fake_curl happy
+    export GITLAB_TOKEN='bad\ntoken'
+    FAKE_CURL_CONFIG_PATH_LOG="${TEST_TEMP_DIR}/curl-config-path.log"
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+    GITLAB_API_URL="https://gitlab.torproject.org/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GITLAB_TOKEN must not contain double quotes or control characters; backslashes are also rejected"* ]]
+    [ ! -e "$FAKE_CURL_CONFIG_PATH_LOG" ]
     [ ! -e "$FAKE_CURL_URL_LOG" ]
 }
 

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -24,6 +24,7 @@ set -euo pipefail
 
 mode="${FAKE_CURL_MODE:?}"
 header_file=""
+config_file=""
 url=""
 
 while [[ $# -gt 0 ]]; do
@@ -32,7 +33,11 @@ while [[ $# -gt 0 ]]; do
             header_file="$2"
             shift 2
             ;;
-        --connect-timeout|--max-time|--proto|--proto-redir|--config)
+        --config)
+            config_file="$2"
+            shift 2
+            ;;
+        --connect-timeout|--max-time|--proto|--proto-redir)
             shift 2
             ;;
         -*)
@@ -50,6 +55,13 @@ done
 
 if [[ -n "${FAKE_CURL_URL_LOG:-}" ]]; then
     printf '%s\n' "$url" >> "$FAKE_CURL_URL_LOG"
+fi
+if [[ -n "${FAKE_CURL_CONFIG_LOG:-}" ]]; then
+    if [[ -n "$config_file" ]]; then
+        printf 'CONFIG:%s\n' "$(tr '\n' ';' < "$config_file")" >> "$FAKE_CURL_CONFIG_LOG"
+    else
+        printf 'CONFIG:\n' >> "$FAKE_CURL_CONFIG_LOG"
+    fi
 fi
 
 emit_headers() {
@@ -98,7 +110,7 @@ EOF
 }
 
 run_helper() {
-    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_URL_LOG="${FAKE_CURL_URL_LOG:-}" \
+    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_URL_LOG="${FAKE_CURL_URL_LOG:-}" FAKE_CURL_CONFIG_LOG="${FAKE_CURL_CONFIG_LOG:-}" \
         "$HELPER" "$@"
 }
 
@@ -205,6 +217,34 @@ last_output_line() {
     [ "$status" -ne 0 ]
 }
 
+@test "GitLab token is attached only for the default allowed API host" {
+    write_fake_curl happy
+    export GITLAB_TOKEN="secret"
+    FAKE_CURL_CONFIG_LOG="${TEST_TEMP_DIR}/curl-config.log"
+    GITLAB_API_URL="https://gitlab.torproject.org/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+    grep -q 'CONFIG:header = "PRIVATE-TOKEN: secret";' "$FAKE_CURL_CONFIG_LOG"
+}
+
+@test "GitLab token is withheld for custom API hosts" {
+    write_fake_curl happy
+    export GITLAB_TOKEN="secret"
+    FAKE_CURL_CONFIG_LOG="${TEST_TEMP_DIR}/curl-config.log"
+    GITLAB_API_URL="https://gitlab.example/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+    grep -qx 'CONFIG:' "$FAKE_CURL_CONFIG_LOG"
+}
+
 @test "missing tag_filter fails closed" {
     write_fake_curl happy
 
@@ -223,6 +263,35 @@ last_output_line() {
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"--version-extract is required"* ]]
+}
+
+@test "missing option values fail with usage errors" {
+    run "$HELPER" "tpo/core/tor" --tag-filter
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--tag-filter requires a value"* ]]
+    [[ "$output" == *"Usage: latest-gitlab-tag"* ]]
+
+    run "$HELPER" "tpo/core/tor" --tag-filter '^tor-' --version-extract
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--version-extract requires a value"* ]]
+    [[ "$output" == *"Usage: latest-gitlab-tag"* ]]
+
+    run "$HELPER" "tpo/core/tor" --tag-filter '^tor-' --version-extract '^tor-(.*)$' --output
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--output requires a value"* ]]
+    [[ "$output" == *"Usage: latest-gitlab-tag"* ]]
+}
+
+@test "logged dynamic values escape embedded newlines" {
+    write_fake_curl happy
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter $'does-not-match\n::error::forged' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does-not-match%0A::error::forged"* ]]
+    [[ "$output" != *$'does-not-match\n::error::forged'* ]]
 }
 
 @test "GitLab API failure exits 1" {

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -47,6 +47,10 @@ done
 : "${header_file:?missing -D header file}"
 : "${url:?missing url}"
 
+if [[ -n "${FAKE_CURL_URL_LOG:-}" ]]; then
+    printf '%s\n' "$url" >> "$FAKE_CURL_URL_LOG"
+fi
+
 emit_headers() {
     printf '%s\n' "$1" > "$header_file"
 }
@@ -88,7 +92,7 @@ EOF
 }
 
 run_helper() {
-    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" \
+    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" FAKE_CURL_URL_LOG="${FAKE_CURL_URL_LOG:-}" \
         "$HELPER" "$@"
 }
 
@@ -106,6 +110,43 @@ last_output_line() {
 
     [ "$status" -eq 0 ]
     [ "$(last_output_line)" = $'0.4.9.11\ttor-0.4.9.11' ]
+}
+
+@test "plain project path is encoded in the GitLab API URL" {
+    write_fake_curl happy
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+    [ "$(head -n 1 "$FAKE_CURL_URL_LOG")" = "https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?order_by=version&sort=desc&per_page=100" ]
+}
+
+@test "pre-encoded project path is passed through in the GitLab API URL" {
+    write_fake_curl happy
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+
+    run run_helper "tpo%2Fcore%2Ftor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+    [ "$(head -n 1 "$FAKE_CURL_URL_LOG")" = "https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?order_by=version&sort=desc&per_page=100" ]
+}
+
+@test "pre-encoded project path rejects raw slash mixed with %2F" {
+    write_fake_curl happy
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+
+    run run_helper "tpo%2Fcore/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"encoded project path may contain only"* ]]
+    [ ! -s "$FAKE_CURL_URL_LOG" ]
 }
 
 @test "prerelease tags are excluded by default" {

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    TEST_TEMP_DIR="$(mktemp -d)"
+    HELPER="${PROJECT_ROOT}/helpers/latest-gitlab-tag"
+    export GITLAB_API_URL="https://gitlab.example/api/v4"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+    unset GITLAB_API_URL
+}
+
+write_fake_curl() {
+    local mode="$1"
+
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${FAKE_CURL_MODE:?}"
+header_file=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -D)
+            header_file="$2"
+            shift 2
+            ;;
+        --connect-timeout|--max-time|--proto|--proto-redir|--config)
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+: "${header_file:?missing -D header file}"
+: "${url:?missing url}"
+
+emit_headers() {
+    printf '%s\n' "$1" > "$header_file"
+}
+
+case "$mode" in
+    happy)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"tor-0.4.9.10"},{"name":"tor-0.4.9.11"}]\n'
+        ;;
+    prerelease)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"tor-0.5.0.0-alpha-dev"},{"name":"tor-0.4.9.11"}]\n'
+        ;;
+    legacy)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"obfs4proxy-0.0.14"},{"name":"lyrebird-0.8.0"},{"name":"lyrebird-0.8.1"}]\n'
+        ;;
+    paginate)
+        if [[ "$url" == *"page=2"* ]]; then
+            emit_headers "HTTP/2 200"
+            printf '[{"name":"tor-0.4.9.11"}]\n'
+        else
+            emit_headers 'HTTP/2 200
+Link: <https://gitlab.example/api/v4/projects/tpo%2Fcore%2Ftor/repository/tags?page=2>; rel="next"'
+            printf '[{"name":"tor-0.5.0.0-alpha-dev"}]\n'
+        fi
+        ;;
+    fail)
+        exit 22
+        ;;
+    *)
+        exit 99
+        ;;
+esac
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/curl"
+    export PATH="${TEST_TEMP_DIR}/bin:$PATH"
+    export FAKE_CURL_MODE="$mode"
+}
+
+run_helper() {
+    env PATH="$PATH" GITLAB_API_URL="$GITLAB_API_URL" FAKE_CURL_MODE="${FAKE_CURL_MODE:-}" \
+        "$HELPER" "$@"
+}
+
+last_output_line() {
+    printf '%s' "${lines[$((${#lines[@]} - 1))]}"
+}
+
+@test "happy path returns latest normalized version and raw tag" {
+    write_fake_curl happy
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$' \
+        --output both
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = $'0.4.9.11\ttor-0.4.9.11' ]
+}
+
+@test "prerelease tags are excluded by default" {
+    write_fake_curl prerelease
+
+    run run_helper "tpo%2Fcore%2Ftor" \
+        --tag-filter '^tor-.*' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?).*$'
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "0.4.9.11" ]
+}
+
+@test "legacy obfs4proxy-prefixed tags are excluded by lyrebird filter" {
+    write_fake_curl legacy
+
+    run run_helper "tpo/anti-censorship/pluggable-transports/lyrebird" \
+        --tag-filter '^lyrebird-[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^lyrebird-([0-9]+\.[0-9]+\.[0-9]+)$' \
+        --output raw
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "lyrebird-0.8.1" ]
+}
+
+@test "pagination follows GitLab Link header until a matching stable tag is found" {
+    write_fake_curl paginate
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "0.4.9.11" ]
+}
+
+@test "missing tag_filter fails closed" {
+    write_fake_curl happy
+
+    run run_helper "tpo/core/tor" \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--tag-filter is required"* ]]
+}
+
+@test "missing version_extract fails closed" {
+    write_fake_curl happy
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--version-extract is required"* ]]
+}
+
+@test "GitLab API failure exits 1" {
+    write_fake_curl fail
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Failed to fetch GitLab tags"* ]]
+}

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -84,6 +84,14 @@ case "$mode" in
         emit_headers "HTTP/2 200"
         printf '[{"name":"obfs4proxy-0.0.14"},{"name":"lyrebird-0.8.0"},{"name":"lyrebird-0.8.1"}]\n'
         ;;
+    flag_pattern)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"tor-0.4.9.12-rc"},{"name":"tor-0.4.9.11"}]\n'
+        ;;
+    unsafe_version)
+        emit_headers "HTTP/2 200"
+        printf '[{"name":"tor-0.4.9|11"}]\n'
+        ;;
     paginate)
         if [[ "$url" == *"page=2"* ]]; then
             emit_headers "HTTP/2 200"
@@ -195,6 +203,41 @@ last_output_line() {
 
     [ "$status" -eq 0 ]
     [ "$(last_output_line)" = "lyrebird-0.8.1" ]
+}
+
+@test "tag_filter starting with dash is treated as a regex pattern" {
+    write_fake_curl flag_pattern
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '-rc$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)-rc$' \
+        --include-prerelease
+
+    [ "$status" -eq 0 ]
+    [ "$(last_output_line)" = "0.4.9.12" ]
+}
+
+@test "malformed tag_filter regex fails loudly instead of no-match fallback" {
+    write_fake_curl happy
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '[' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tag_filter regex '[' failed"* ]]
+    [[ "$output" != *"No tags match tag_filter"* ]]
+}
+
+@test "unsafe extracted version is rejected before output" {
+    write_fake_curl unsafe_version
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-' \
+        --version-extract '^tor-(.*)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Extracted version '0.4.9|11' is not a safe normalized version"* ]]
 }
 
 @test "pagination follows GitLab Link header until a matching stable tag is found" {

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -231,6 +231,40 @@ last_output_line() {
     grep -q 'CONFIG:header = "PRIVATE-TOKEN: secret";' "$FAKE_CURL_CONFIG_LOG"
 }
 
+@test "GitLab token curl config has EXIT cleanup trap" {
+    grep -Fq "trap 'rm -f \"\$curl_cfg\"' EXIT" "$HELPER"
+}
+
+@test "GitLab token rejects curl config quote injection before curl" {
+    write_fake_curl happy
+    export GITLAB_TOKEN='bad"token'
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+    GITLAB_API_URL="https://gitlab.torproject.org/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GITLAB_TOKEN must not contain double quotes or control characters"* ]]
+    [ ! -e "$FAKE_CURL_URL_LOG" ]
+}
+
+@test "GitLab token rejects control characters before curl" {
+    write_fake_curl happy
+    export GITLAB_TOKEN=$'bad\ntoken'
+    FAKE_CURL_URL_LOG="${TEST_TEMP_DIR}/urls.log"
+    GITLAB_API_URL="https://gitlab.torproject.org/api/v4"
+
+    run run_helper "tpo/core/tor" \
+        --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+        --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$'
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GITLAB_TOKEN must not contain double quotes or control characters"* ]]
+    [ ! -e "$FAKE_CURL_URL_LOG" ]
+}
+
 @test "GitLab token is withheld for custom API hosts" {
     write_fake_curl happy
     export GITLAB_TOKEN="secret"

--- a/tests/unit/lifecycle-schema.bats
+++ b/tests/unit/lifecycle-schema.bats
@@ -5,7 +5,7 @@
 # AC-1  every dependency_sources entry has a valid lifecycle:
 # AC-2  schema test green (valid lifecycle + required fields per lifecycle)
 # AC-14 lifecycle: REQUIRED on every entry; no implicit default
-# AC-17 type: github-tag requires both tag_filter: and version_extract:
+# AC-17 type: github-tag/gitlab-tags requires tag_filter: and version_extract:
 # AC-18 tracked/stable-pin/eol-migrate require type: + per-type locator
 # AC-19 every stable-pin entry declares supported_until_source:
 #
@@ -264,10 +264,10 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-18: per-type locator check (repo/package/gem)
+# T1 AC-18: per-type locator check (repo/project_path/package/gem)
 # ---------------------------------------------------------------------------
 
-@test "each type has the required locator (github-tag/release=repo, pypi=package, rubygems=gem)" {
+@test "each type has the required locator (github-tag/release=repo, gitlab-tags=project_path, pypi=package, rubygems=gem)" {
     local bad=0
     local bad_list=""
 
@@ -294,6 +294,14 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
                     if [[ -z "$repo" || "$repo" == "null" ]]; then
                         bad=$((bad + 1))
                         bad_list="${bad_list}\n  ${container}/${dep}: type=${t} missing repo:"
+                    fi
+                    ;;
+                gitlab-tags)
+                    local project_path
+                    project_path=$(YQ_DEP="$dep" yq -r '.dependency_sources[strenv(YQ_DEP)].project_path // ""' "$config")
+                    if [[ -z "$project_path" || "$project_path" == "null" ]]; then
+                        bad=$((bad + 1))
+                        bad_list="${bad_list}\n  ${container}/${dep}: type=gitlab-tags missing project_path:"
                     fi
                     ;;
                 pypi)
@@ -323,10 +331,10 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T14 AC-17: github-tag type requires tag_filter: and version_extract:
+# T14 AC-17: github-tag/gitlab-tags types require tag_filter: and version_extract:
 # ---------------------------------------------------------------------------
 
-@test "github-tag entries declare both tag_filter and version_extract" {
+@test "github-tag and gitlab-tags entries declare both tag_filter and version_extract" {
     local missing=0
     local missing_list=""
 
@@ -344,24 +352,24 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
             [[ -z "$dep" ]] && continue
             local t
             t=$(YQ_DEP="$dep" yq -r '.dependency_sources[strenv(YQ_DEP)].type // ""' "$config")
-            if [[ "$t" == "github-tag" ]]; then
+            if [[ "$t" == "github-tag" || "$t" == "gitlab-tags" ]]; then
                 local tf ve
                 tf=$(YQ_DEP="$dep" yq -r '.dependency_sources[strenv(YQ_DEP)].tag_filter // ""' "$config")
                 ve=$(YQ_DEP="$dep" yq -r '.dependency_sources[strenv(YQ_DEP)].version_extract // ""' "$config")
                 if [[ -z "$tf" || "$tf" == "null" ]]; then
                     missing=$((missing + 1))
-                    missing_list="${missing_list}\n  ${container}/${dep}: missing tag_filter"
+                    missing_list="${missing_list}\n  ${container}/${dep}: type=${t} missing tag_filter"
                 fi
                 if [[ -z "$ve" || "$ve" == "null" ]]; then
                     missing=$((missing + 1))
-                    missing_list="${missing_list}\n  ${container}/${dep}: missing version_extract"
+                    missing_list="${missing_list}\n  ${container}/${dep}: type=${t} missing version_extract"
                 fi
             fi
         done <<< "$dep_names"
     done
 
     if [[ "$missing" -gt 0 ]]; then
-        echo "FAIL: $missing github-tag entries missing tag_filter/version_extract:${missing_list}"
+        echo "FAIL: $missing github-tag/gitlab-tags entries missing tag_filter/version_extract:${missing_list}"
         return 1
     fi
 }

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -5,9 +5,26 @@ setup() {
     PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
     TEST_TEMP_DIR="$(mktemp -d)"
     ENTRYPOINT="${PROJECT_ROOT}/tor/entrypoint.sh"
+    INTERNAL_GENERATED_DIR="/tmp/tor"
+    INTERNAL_GENERATED_MARKER="${INTERNAL_GENERATED_DIR}/.tor-entrypoint-bats"
+    SLEEP_PID=""
+
+    if [[ -e "$INTERNAL_GENERATED_DIR" && ! -f "$INTERNAL_GENERATED_MARKER" ]]; then
+        skip "${INTERNAL_GENERATED_DIR} exists and is not owned by this test"
+    fi
+    rm -rf "$INTERNAL_GENERATED_DIR"
+    mkdir -p "$INTERNAL_GENERATED_DIR"
+    touch "$INTERNAL_GENERATED_MARKER"
 }
 
 teardown() {
+    if [[ -n "${SLEEP_PID:-}" ]]; then
+        kill "$SLEEP_PID" 2>/dev/null || true
+        wait "$SLEEP_PID" 2>/dev/null || true
+    fi
+    if [[ -f "${INTERNAL_GENERATED_MARKER:-}" ]]; then
+        rm -rf "$INTERNAL_GENERATED_DIR"
+    fi
     rm -rf "$TEST_TEMP_DIR"
 }
 
@@ -68,10 +85,49 @@ run_entrypoint() {
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
         DATA_DIR="${TEST_TEMP_DIR}/data" \
-        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
-        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
-        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
         "$ENTRYPOINT" "$@"
+}
+
+dockerfile_healthcheck_command() {
+    awk '
+        /^HEALTHCHECK / { capture = 1; next }
+        capture && /^ENTRYPOINT / { exit }
+        capture {
+            sub(/^[[:space:]]*CMD /, "")
+            sub(/[[:space:]]*\\$/, "")
+            print
+        }
+    ' "${PROJECT_ROOT}/tor/Dockerfile" | tr '\n' ' '
+}
+
+write_fake_healthcheck_commands() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+
+    cat > "${TEST_TEMP_DIR}/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'nc %s\n' "$*" >> "${FAKE_NC_LOG:?}"
+exit "${FAKE_NC_STATUS:-0}"
+EOF
+
+    cat > "${TEST_TEMP_DIR}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'curl %s\n' "$*" >> "${FAKE_CURL_LOG:?}"
+printf '{"IsTor":true}\n'
+EOF
+
+    chmod +x "${TEST_TEMP_DIR}/bin/nc" "${TEST_TEMP_DIR}/bin/curl"
+    export PATH="${TEST_TEMP_DIR}/bin:$PATH"
+}
+
+write_healthcheck_pid_file() {
+    mkdir -p "${TEST_TEMP_DIR}/data"
+    sleep 60 &
+    SLEEP_PID="$!"
+    printf '%s\n' "$SLEEP_PID" > "${TEST_TEMP_DIR}/data/tor.pid"
 }
 
 @test "entrypoint rejects exact SOCKS_PORT newline injection payload before torrc generation" {
@@ -86,9 +142,6 @@ run_entrypoint() {
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
         DATA_DIR="${TEST_TEMP_DIR}/data" \
-        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
-        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
-        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
         SOCKS_PORT=$'9050\nControlPort 0.0.0.0:9051\nCookieAuthentication 0' \
         "$ENTRYPOINT"
 
@@ -104,10 +157,10 @@ run_entrypoint() {
     run run_entrypoint
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"TOR_STUB_CONFIG=${TEST_TEMP_DIR}/generated/torrc"* ]]
-    grep -qx 'SocksPort 0.0.0.0:9050' "${TEST_TEMP_DIR}/generated/torrc"
-    grep -qx 'ControlPort 127.0.0.1:9051' "${TEST_TEMP_DIR}/generated/torrc"
-    grep -qx 'CookieAuthentication 1' "${TEST_TEMP_DIR}/generated/torrc"
+    [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+    grep -qx 'SocksPort 0.0.0.0:9050' "${INTERNAL_GENERATED_DIR}/torrc"
+    grep -qx 'ControlPort 127.0.0.1:9051' "${INTERNAL_GENERATED_DIR}/torrc"
+    grep -qx 'CookieAuthentication 1' "${INTERNAL_GENERATED_DIR}/torrc"
 }
 
 @test "custom torrc ignores invalid simple-env SOCKS_PORT" {
@@ -118,28 +171,22 @@ run_entrypoint() {
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
         DATA_DIR="${TEST_TEMP_DIR}/data" \
-        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
-        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
-        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
         SOCKS_PORT="not-a-port" \
         "$ENTRYPOINT"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"custom ${TEST_TEMP_DIR}/torrc is active"* ]]
     [[ "$output" == *"TOR_STUB_CONFIG=${TEST_TEMP_DIR}/torrc"* ]]
-    grep -qx 'DataDirectory '"${TEST_TEMP_DIR}"'/data' "${TEST_TEMP_DIR}/generated/defaults-torrc"
+    grep -qx 'DataDirectory '"${TEST_TEMP_DIR}"'/data' "${INTERNAL_GENERATED_DIR}/defaults-torrc"
 }
 
-@test "runtime path validation rejects filesystem root before directory ownership changes" {
+@test "runtime path validation rejects sensitive DATA_DIR paths before directory ownership changes" {
     write_fake_runtime_commands
 
     run env \
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
         DATA_DIR="/" \
-        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
-        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
-        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
         "$ENTRYPOINT"
 
     [ "$status" -ne 0 ]
@@ -148,12 +195,72 @@ run_entrypoint() {
     run env \
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
-        DATA_DIR="${TEST_TEMP_DIR}/data" \
-        GENERATED_DIR="/" \
-        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
-        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        DATA_DIR="/etc" \
         "$ENTRYPOINT"
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *"GENERATED_DIR must not be the filesystem root"* ]]
+    [[ "$output" == *"DATA_DIR must not be a sensitive system path: /etc"* ]]
+}
+
+@test "generated torrc path is internal and written with restrictive permissions" {
+    write_fake_runtime_commands
+    printf 'secret\n' > "${TEST_TEMP_DIR}/control-password"
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        GENERATED_DIR="/" \
+        GENERATED_TORRC="/etc/torrc" \
+        DEFAULTS_TORRC="/etc/defaults-torrc" \
+        PASSWORD_FILE="${TEST_TEMP_DIR}/control-password" \
+        "$ENTRYPOINT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+    grep -qx 'HashedControlPassword 16:FAKE_HASH' "${INTERNAL_GENERATED_DIR}/torrc"
+    [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}/torrc")" = "600" ]
+    [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}")" = "700" ]
+}
+
+@test "healthcheck accepts custom torrc with SocksPort disabled without probing SOCKS" {
+    write_fake_healthcheck_commands
+    write_healthcheck_pid_file
+    printf 'SocksPort 0\n' > "${TEST_TEMP_DIR}/torrc"
+    local healthcheck
+    healthcheck="$(dockerfile_healthcheck_command)"
+    export FAKE_NC_LOG="${TEST_TEMP_DIR}/nc.log"
+    export FAKE_NC_STATUS=99
+    export FAKE_CURL_LOG="${TEST_TEMP_DIR}/curl.log"
+
+    run env \
+        PATH="$PATH" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        CHECK=false \
+        sh -c "$healthcheck"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_NC_LOG" ]
+}
+
+@test "healthcheck probes SOCKS for simple env-driven configuration" {
+    write_fake_healthcheck_commands
+    write_healthcheck_pid_file
+    local healthcheck
+    healthcheck="$(dockerfile_healthcheck_command)"
+    export FAKE_NC_LOG="${TEST_TEMP_DIR}/nc.log"
+    export FAKE_NC_STATUS=0
+    export FAKE_CURL_LOG="${TEST_TEMP_DIR}/curl.log"
+
+    run env \
+        PATH="$PATH" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        TORRC_PATH="${TEST_TEMP_DIR}/missing-torrc" \
+        SOCKS_PORT=19050 \
+        CHECK=false \
+        sh -c "$healthcheck"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'nc -z 127.0.0.1 19050' "$FAKE_NC_LOG"
 }

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -109,3 +109,51 @@ run_entrypoint() {
     grep -qx 'ControlPort 127.0.0.1:9051' "${TEST_TEMP_DIR}/generated/torrc"
     grep -qx 'CookieAuthentication 1' "${TEST_TEMP_DIR}/generated/torrc"
 }
+
+@test "custom torrc ignores invalid simple-env SOCKS_PORT" {
+    write_fake_runtime_commands
+    printf 'SocksPort 127.0.0.1:19050\n' > "${TEST_TEMP_DIR}/torrc"
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
+        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
+        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        SOCKS_PORT="not-a-port" \
+        "$ENTRYPOINT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"custom ${TEST_TEMP_DIR}/torrc is active"* ]]
+    [[ "$output" == *"TOR_STUB_CONFIG=${TEST_TEMP_DIR}/torrc"* ]]
+    grep -qx 'DataDirectory '"${TEST_TEMP_DIR}"'/data' "${TEST_TEMP_DIR}/generated/defaults-torrc"
+}
+
+@test "runtime path validation rejects filesystem root before directory ownership changes" {
+    write_fake_runtime_commands
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="/" \
+        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
+        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
+        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        "$ENTRYPOINT"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"DATA_DIR must not be the filesystem root"* ]]
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        GENERATED_DIR="/" \
+        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
+        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        "$ENTRYPOINT"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GENERATED_DIR must not be the filesystem root"* ]]
+}

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -3,7 +3,7 @@
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
-    TEST_TEMP_DIR="$(mktemp -d /tmp/tor-entrypoint-bats.XXXXXX)"
+    TEST_TEMP_DIR="$(mktemp -d /var/tmp/tor-entrypoint-bats.XXXXXX)"
     ENTRYPOINT="${PROJECT_ROOT}/tor/entrypoint.sh"
     INTERNAL_GENERATED_DIR="/tmp/tor"
     INTERNAL_GENERATED_MARKER="${INTERNAL_GENERATED_DIR}/.tor-entrypoint-bats"
@@ -208,15 +208,21 @@ write_healthcheck_pid_file() {
 @test "runtime path validation rejects sensitive descendants but allows tor data descendants" {
     local rejected
 
-    for rejected in /etc/ssl /root/.ssh /var/lib; do
+    for rejected in /etc/ssl /root/.ssh /tmp /tmp/tor-data /var/lib /var/lib/other-service; do
         run bash -c 'source "$1"; DATA_DIR="$2"; validate_runtime_paths' _ "$ENTRYPOINT" "$rejected"
         [ "$status" -ne 0 ]
         [[ "$output" == *"DATA_DIR must not be a sensitive system path"* ]]
     done
 
-    run bash -c 'source "$1"; DATA_DIR="/var/lib/tor/custom"; validate_runtime_paths' _ "$ENTRYPOINT"
+    run bash -c 'source "$1"; DATA_DIR="/var"; validate_runtime_paths' _ "$ENTRYPOINT"
 
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"DATA_DIR must not be a parent of sensitive system path: /var/lib"* ]]
+
+    for allowed in /var/lib/tor /var/lib/tor/custom /var/tmp/tor-data; do
+        run bash -c 'source "$1"; DATA_DIR="$2"; validate_runtime_paths' _ "$ENTRYPOINT" "$allowed"
+        [ "$status" -eq 0 ]
+    done
 }
 
 @test "generated torrc path is internal and written with restrictive permissions" {
@@ -340,4 +346,22 @@ write_healthcheck_pid_file() {
 
     [ "$status" -eq 0 ]
     grep -qx 'nc -z ::1 19050' "$FAKE_NC_LOG"
+}
+
+@test "healthcheck nc dependency is explicit or documented" {
+    if awk '
+        /apk add --no-cache/ { capture = 1 }
+        capture && /netcat|nmap-ncat|busybox-extras/ { found = 1 }
+        capture && /;/ { capture = 0 }
+        END { exit found ? 0 : 1 }
+    ' "${PROJECT_ROOT}/tor/Dockerfile"; then
+        return 0
+    fi
+
+    grep -Eq 'BusyBox.*(/usr/bin/nc| nc)' "${PROJECT_ROOT}/tor/Dockerfile"
+}
+
+@test "README documents variant pipeline build for monitoring flavor" {
+    grep -Fq './make build tor' "${PROJECT_ROOT}/tor/README.md"
+    ! grep -Fq './make build tor latest monitoring' "${PROJECT_ROOT}/tor/README.md"
 }

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -3,7 +3,7 @@
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
-    TEST_TEMP_DIR="$(mktemp -d)"
+    TEST_TEMP_DIR="$(mktemp -d /tmp/tor-entrypoint-bats.XXXXXX)"
     ENTRYPOINT="${PROJECT_ROOT}/tor/entrypoint.sh"
     INTERNAL_GENERATED_DIR="/tmp/tor"
     INTERNAL_GENERATED_MARKER="${INTERNAL_GENERATED_DIR}/.tor-entrypoint-bats"
@@ -53,6 +53,9 @@ EOF
 set -euo pipefail
 
 if [[ "${1:-}" == "--hash-password" ]]; then
+    if [[ -n "${FAKE_TOR_HASH_LOG:-}" ]]; then
+        printf '%s\n' "$*" >> "$FAKE_TOR_HASH_LOG"
+    fi
     printf '16:FAKE_HASH\n'
     exit 0
 fi
@@ -202,6 +205,20 @@ write_healthcheck_pid_file() {
     [[ "$output" == *"DATA_DIR must not be a sensitive system path: /etc"* ]]
 }
 
+@test "runtime path validation rejects sensitive descendants but allows tor data descendants" {
+    local rejected
+
+    for rejected in /etc/ssl /root/.ssh /var/lib; do
+        run bash -c 'source "$1"; DATA_DIR="$2"; validate_runtime_paths' _ "$ENTRYPOINT" "$rejected"
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"DATA_DIR must not be a sensitive system path"* ]]
+    done
+
+    run bash -c 'source "$1"; DATA_DIR="/var/lib/tor/custom"; validate_runtime_paths' _ "$ENTRYPOINT"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "generated torrc path is internal and written with restrictive permissions" {
     write_fake_runtime_commands
     printf 'secret\n' > "${TEST_TEMP_DIR}/control-password"
@@ -221,6 +238,44 @@ write_healthcheck_pid_file() {
     grep -qx 'HashedControlPassword 16:FAKE_HASH' "${INTERNAL_GENERATED_DIR}/torrc"
     [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}/torrc")" = "600" ]
     [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}")" = "700" ]
+}
+
+@test "pre-hashed PASSWORD_FILE is used directly without invoking hash helper" {
+    write_fake_runtime_commands
+    local hashed_password="16:0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    printf '%s\n' "$hashed_password" > "${TEST_TEMP_DIR}/control-password"
+    export FAKE_TOR_HASH_LOG="${TEST_TEMP_DIR}/hash.log"
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        PASSWORD_FILE="${TEST_TEMP_DIR}/control-password" \
+        FAKE_TOR_HASH_LOG="$FAKE_TOR_HASH_LOG" \
+        "$ENTRYPOINT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+    grep -qx "HashedControlPassword ${hashed_password}" "${INTERNAL_GENERATED_DIR}/torrc"
+    [ ! -e "$FAKE_TOR_HASH_LOG" ]
+}
+
+@test "unreadable custom torrc fails loudly instead of falling back to generated defaults" {
+    write_fake_runtime_commands
+    printf 'SocksPort 127.0.0.1:19050\n' > "${TEST_TEMP_DIR}/torrc"
+    chmod 000 "${TEST_TEMP_DIR}/torrc"
+
+    run run_entrypoint
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not read TORRC_PATH: ${TEST_TEMP_DIR}/torrc"* ]]
+    [[ "$output" != *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+}
+
+@test "validate_bind_address accepts IPv4-mapped IPv6 address" {
+    run bash -c 'source "$1"; validate_bind_address SOCKS_BIND "::ffff:192.0.2.1"' _ "$ENTRYPOINT"
+
+    [ "$status" -eq 0 ]
 }
 
 @test "healthcheck accepts custom torrc with SocksPort disabled without probing SOCKS" {
@@ -263,4 +318,26 @@ write_healthcheck_pid_file() {
 
     [ "$status" -eq 0 ]
     grep -qx 'nc -z 127.0.0.1 19050' "$FAKE_NC_LOG"
+}
+
+@test "healthcheck probes IPv6 loopback for IPv6 wildcard SOCKS bind" {
+    write_fake_healthcheck_commands
+    write_healthcheck_pid_file
+    local healthcheck
+    healthcheck="$(dockerfile_healthcheck_command)"
+    export FAKE_NC_LOG="${TEST_TEMP_DIR}/nc.log"
+    export FAKE_NC_STATUS=0
+    export FAKE_CURL_LOG="${TEST_TEMP_DIR}/curl.log"
+
+    run env \
+        PATH="$PATH" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        TORRC_PATH="${TEST_TEMP_DIR}/missing-torrc" \
+        SOCKS_BIND="::" \
+        SOCKS_PORT=19050 \
+        CHECK=false \
+        sh -c "$healthcheck"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'nc -z ::1 19050' "$FAKE_NC_LOG"
 }

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -48,6 +48,31 @@ case "${1:-}" in
 esac
 EOF
 
+    cat > "${TEST_TEMP_DIR}/bin/mkdir" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=()
+for arg in "$@"; do
+    case "$arg" in
+        /var/lib/tor|/var/lib/tor/)
+            ;;
+        *)
+            args+=("$arg")
+            ;;
+    esac
+done
+
+if ((${#args[@]} == 0)); then
+    exit 0
+fi
+if ((${#args[@]} == 1)) && [[ "${args[0]}" == "-p" ]]; then
+    exit 0
+fi
+
+exec /bin/mkdir "${args[@]}"
+EOF
+
     cat > "${TEST_TEMP_DIR}/bin/tor" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -79,7 +104,7 @@ if [[ -n "$torrc" && -f "$torrc" ]] && grep -qx 'CookieAuthentication 0' "$torrc
 fi
 EOF
 
-    chmod +x "${TEST_TEMP_DIR}/bin/id" "${TEST_TEMP_DIR}/bin/tor"
+    chmod +x "${TEST_TEMP_DIR}/bin/id" "${TEST_TEMP_DIR}/bin/mkdir" "${TEST_TEMP_DIR}/bin/tor"
     export PATH="${TEST_TEMP_DIR}/bin:$PATH"
 }
 
@@ -122,7 +147,17 @@ printf 'curl %s\n' "$*" >> "${FAKE_CURL_LOG:?}"
 printf '{"IsTor":true}\n'
 EOF
 
-    chmod +x "${TEST_TEMP_DIR}/bin/nc" "${TEST_TEMP_DIR}/bin/curl"
+    cat > "${TEST_TEMP_DIR}/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${FAKE_PGREP_LOG:-}" ]]; then
+    printf 'pgrep %s\n' "$*" >> "$FAKE_PGREP_LOG"
+fi
+exit "${FAKE_PGREP_STATUS:-0}"
+EOF
+
+    chmod +x "${TEST_TEMP_DIR}/bin/nc" "${TEST_TEMP_DIR}/bin/curl" "${TEST_TEMP_DIR}/bin/pgrep"
     export PATH="${TEST_TEMP_DIR}/bin:$PATH"
 }
 
@@ -180,49 +215,36 @@ write_healthcheck_pid_file() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"custom ${TEST_TEMP_DIR}/torrc is active"* ]]
     [[ "$output" == *"TOR_STUB_CONFIG=${TEST_TEMP_DIR}/torrc"* ]]
-    grep -qx 'DataDirectory '"${TEST_TEMP_DIR}"'/data' "${INTERNAL_GENERATED_DIR}/defaults-torrc"
+    grep -qx 'DataDirectory /var/lib/tor' "${INTERNAL_GENERATED_DIR}/defaults-torrc"
 }
 
-@test "runtime path validation rejects sensitive DATA_DIR paths before directory ownership changes" {
+@test "DATA_DIR environment value is ignored and internal path is retained" {
+    local configured
+
+    for configured in /etc/ssl /root/.ssh /tmp /var/tmp/tor-data /var/lib/tor/custom; do
+        run env DATA_DIR="$configured" bash -c 'source "$1"; printf "%s\n" "$DATA_DIR"' _ "$ENTRYPOINT"
+        [ "$status" -eq 0 ]
+        [ "$output" = "/var/lib/tor" ]
+    done
+}
+
+@test "generated torrc uses internal DATA_DIR even when env var is set" {
     write_fake_runtime_commands
 
     run env \
         PATH="$PATH" \
         TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
-        DATA_DIR="/" \
+        DATA_DIR="/etc/ssl" \
         "$ENTRYPOINT"
 
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"DATA_DIR must not be the filesystem root"* ]]
-
-    run env \
-        PATH="$PATH" \
-        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
-        DATA_DIR="/etc" \
-        "$ENTRYPOINT"
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"DATA_DIR must not be a sensitive system path: /etc"* ]]
-}
-
-@test "runtime path validation rejects sensitive descendants but allows tor data descendants" {
-    local rejected
-
-    for rejected in /etc/ssl /root/.ssh /tmp /tmp/tor-data /var/lib /var/lib/other-service; do
-        run bash -c 'source "$1"; DATA_DIR="$2"; validate_runtime_paths' _ "$ENTRYPOINT" "$rejected"
-        [ "$status" -ne 0 ]
-        [[ "$output" == *"DATA_DIR must not be a sensitive system path"* ]]
-    done
-
-    run bash -c 'source "$1"; DATA_DIR="/var"; validate_runtime_paths' _ "$ENTRYPOINT"
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"DATA_DIR must not be a parent of sensitive system path: /var/lib"* ]]
-
-    for allowed in /var/lib/tor /var/lib/tor/custom /var/tmp/tor-data; do
-        run bash -c 'source "$1"; DATA_DIR="$2"; validate_runtime_paths' _ "$ENTRYPOINT" "$allowed"
-        [ "$status" -eq 0 ]
-    done
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+    grep -qx 'DataDirectory /var/lib/tor' "${INTERNAL_GENERATED_DIR}/torrc"
+    grep -qx 'PidFile /var/lib/tor/tor.pid' "${INTERNAL_GENERATED_DIR}/torrc"
+    grep -qx 'CookieAuthFile /var/lib/tor/control_auth_cookie' "${INTERNAL_GENERATED_DIR}/torrc"
+    if grep -Fq '/etc/ssl' "${INTERNAL_GENERATED_DIR}/torrc"; then
+        return 1
+    fi
 }
 
 @test "generated torrc path is internal and written with restrictive permissions" {
@@ -241,6 +263,7 @@ write_healthcheck_pid_file() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
+    grep -qx 'DataDirectory /var/lib/tor' "${INTERNAL_GENERATED_DIR}/torrc"
     grep -qx 'HashedControlPassword 16:FAKE_HASH' "${INTERNAL_GENERATED_DIR}/torrc"
     [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}/torrc")" = "600" ]
     [ "$(stat -c '%a' "${INTERNAL_GENERATED_DIR}")" = "700" ]
@@ -263,6 +286,23 @@ write_healthcheck_pid_file() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"TOR_STUB_CONFIG=${INTERNAL_GENERATED_DIR}/torrc"* ]]
     grep -qx "HashedControlPassword ${hashed_password}" "${INTERNAL_GENERATED_DIR}/torrc"
+    [ ! -e "$FAKE_TOR_HASH_LOG" ]
+}
+
+@test "invalid pre-hashed PASSWORD_FILE is rejected before invoking hash helper" {
+    write_fake_runtime_commands
+    printf '16:0\n' > "${TEST_TEMP_DIR}/control-password"
+    export FAKE_TOR_HASH_LOG="${TEST_TEMP_DIR}/hash.log"
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        PASSWORD_FILE="${TEST_TEMP_DIR}/control-password" \
+        FAKE_TOR_HASH_LOG="$FAKE_TOR_HASH_LOG" \
+        "$ENTRYPOINT"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"PASSWORD_FILE contains invalid pre-hashed Tor control password; expected 16: followed by 58 hexadecimal digits"* ]]
     [ ! -e "$FAKE_TOR_HASH_LOG" ]
 }
 
@@ -303,6 +343,28 @@ write_healthcheck_pid_file() {
 
     [ "$status" -eq 0 ]
     [ ! -e "$FAKE_NC_LOG" ]
+}
+
+@test "healthcheck ignores DATA_DIR environment for pid file path" {
+    write_fake_healthcheck_commands
+    write_healthcheck_pid_file
+    local healthcheck
+    healthcheck="$(dockerfile_healthcheck_command)"
+    export FAKE_NC_LOG="${TEST_TEMP_DIR}/nc.log"
+    export FAKE_NC_STATUS=0
+    export FAKE_CURL_LOG="${TEST_TEMP_DIR}/curl.log"
+    export FAKE_PGREP_LOG="${TEST_TEMP_DIR}/pgrep.log"
+
+    run env \
+        PATH="$PATH" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        TORRC_PATH="${TEST_TEMP_DIR}/missing-torrc" \
+        CHECK=false \
+        FAKE_PGREP_LOG="$FAKE_PGREP_LOG" \
+        sh -c "$healthcheck"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'pgrep -x tor' "$FAKE_PGREP_LOG"
 }
 
 @test "healthcheck probes SOCKS for simple env-driven configuration" {

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    TEST_TEMP_DIR="$(mktemp -d)"
+    ENTRYPOINT="${PROJECT_ROOT}/tor/entrypoint.sh"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+write_fake_runtime_commands() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+
+    cat > "${TEST_TEMP_DIR}/bin/id" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    -u)
+        printf '1000\n'
+        ;;
+    -un)
+        printf 'bats\n'
+        ;;
+    *)
+        command id "$@"
+        ;;
+esac
+EOF
+
+    cat > "${TEST_TEMP_DIR}/bin/tor" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--hash-password" ]]; then
+    printf '16:FAKE_HASH\n'
+    exit 0
+fi
+
+torrc=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f)
+            torrc="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+printf 'TOR_STUB_CONFIG=%s\n' "$torrc"
+if [[ -n "$torrc" && -f "$torrc" ]] && grep -qx 'CookieAuthentication 0' "$torrc"; then
+    printf 'INJECTION_CANARY_COOKIEAUTH_0\n'
+fi
+EOF
+
+    chmod +x "${TEST_TEMP_DIR}/bin/id" "${TEST_TEMP_DIR}/bin/tor"
+    export PATH="${TEST_TEMP_DIR}/bin:$PATH"
+}
+
+run_entrypoint() {
+    env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
+        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
+        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        "$ENTRYPOINT" "$@"
+}
+
+@test "entrypoint rejects exact SOCKS_PORT newline injection payload before torrc generation" {
+    write_fake_runtime_commands
+
+    # Regression contract:
+    # - Fixed code must fail before execing tor and must name SOCKS_PORT validation.
+    # - Original raw interpolation would write a standalone "CookieAuthentication 0"
+    #   line from this payload; the tor stub would emit INJECTION_CANARY_COOKIEAUTH_0
+    #   and exit 0, making these assertions fail.
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        GENERATED_DIR="${TEST_TEMP_DIR}/generated" \
+        GENERATED_TORRC="${TEST_TEMP_DIR}/generated/torrc" \
+        DEFAULTS_TORRC="${TEST_TEMP_DIR}/generated/defaults-torrc" \
+        SOCKS_PORT=$'9050\nControlPort 0.0.0.0:9051\nCookieAuthentication 0' \
+        "$ENTRYPOINT"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"SOCKS_PORT must not contain control characters"* ]]
+    [[ "$output" != *"INJECTION_CANARY_COOKIEAUTH_0"* ]]
+}
+
+@test "whitespace-only mounted torrc is treated as inactive and secure simple torrc is generated" {
+    write_fake_runtime_commands
+    printf ' \n\t\n  # comment only\n' > "${TEST_TEMP_DIR}/torrc"
+
+    run run_entrypoint
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TOR_STUB_CONFIG=${TEST_TEMP_DIR}/generated/torrc"* ]]
+    grep -qx 'SocksPort 0.0.0.0:9050' "${TEST_TEMP_DIR}/generated/torrc"
+    grep -qx 'ControlPort 127.0.0.1:9051' "${TEST_TEMP_DIR}/generated/torrc"
+    grep -qx 'CookieAuthentication 1' "${TEST_TEMP_DIR}/generated/torrc"
+}

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -7,12 +7,16 @@ setup() {
     ENTRYPOINT="${PROJECT_ROOT}/tor/entrypoint.sh"
     INTERNAL_GENERATED_DIR="/tmp/tor"
     INTERNAL_GENERATED_MARKER="${INTERNAL_GENERATED_DIR}/.tor-entrypoint-bats"
+    INTERNAL_GENERATED_LOCK="/var/tmp/tor-entrypoint-bats.lock"
     SLEEP_PID=""
+
+    exec {INTERNAL_GENERATED_LOCK_FD}>"$INTERNAL_GENERATED_LOCK"
+    flock "$INTERNAL_GENERATED_LOCK_FD"
 
     if [[ -e "$INTERNAL_GENERATED_DIR" && ! -f "$INTERNAL_GENERATED_MARKER" ]]; then
         skip "${INTERNAL_GENERATED_DIR} exists and is not owned by this test"
     fi
-    rm -rf "$INTERNAL_GENERATED_DIR"
+    remove_internal_generated_dir
     mkdir -p "$INTERNAL_GENERATED_DIR"
     touch "$INTERNAL_GENERATED_MARKER"
 }
@@ -23,9 +27,26 @@ teardown() {
         wait "$SLEEP_PID" 2>/dev/null || true
     fi
     if [[ -f "${INTERNAL_GENERATED_MARKER:-}" ]]; then
-        rm -rf "$INTERNAL_GENERATED_DIR"
+        remove_internal_generated_dir
     fi
     rm -rf "$TEST_TEMP_DIR"
+    if [[ -n "${INTERNAL_GENERATED_LOCK_FD:-}" ]]; then
+        flock -u "$INTERNAL_GENERATED_LOCK_FD" 2>/dev/null || true
+        exec {INTERNAL_GENERATED_LOCK_FD}>&-
+    fi
+}
+
+remove_internal_generated_dir() {
+    local attempt
+
+    for attempt in 1 2 3 4 5; do
+        rm -rf "$INTERNAL_GENERATED_DIR"
+        [[ ! -e "$INTERNAL_GENERATED_DIR" ]] && return 0
+        sleep 0.1
+    done
+
+    echo "failed to remove ${INTERNAL_GENERATED_DIR}" >&2
+    return 1
 }
 
 write_fake_runtime_commands() {

--- a/tests/unit/tor-entrypoint.bats
+++ b/tests/unit/tor-entrypoint.bats
@@ -85,6 +85,11 @@ if [[ "${1:-}" == "--hash-password" ]]; then
     exit 0
 fi
 
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Tor version 0.4.9.11.\n'
+    exit 0
+fi
+
 torrc=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -186,6 +191,21 @@ write_healthcheck_pid_file() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"SOCKS_PORT must not contain control characters"* ]]
     [[ "$output" != *"INJECTION_CANARY_COOKIEAUTH_0"* ]]
+}
+
+@test "flag-first invocation passes directly to tor without generated torrc" {
+    write_fake_runtime_commands
+
+    run env \
+        PATH="$PATH" \
+        TORRC_PATH="${TEST_TEMP_DIR}/torrc" \
+        DATA_DIR="${TEST_TEMP_DIR}/data" \
+        SOCKS_PORT="not-a-port" \
+        "$ENTRYPOINT" --version
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "Tor version 0.4.9.11." ]
+    [ ! -e "${INTERNAL_GENERATED_DIR}/torrc" ]
 }
 
 @test "whitespace-only mounted torrc is treated as inactive and secure simple torrc is generated" {
@@ -410,17 +430,18 @@ write_healthcheck_pid_file() {
     grep -qx 'nc -z ::1 19050' "$FAKE_NC_LOG"
 }
 
-@test "healthcheck nc dependency is explicit or documented" {
+@test "healthcheck nc dependency is explicit" {
     if awk '
         /apk add --no-cache/ { capture = 1 }
-        capture && /netcat|nmap-ncat|busybox-extras/ { found = 1 }
+        capture && /(^|[[:space:]])(busybox|netcat|nmap-ncat|busybox-extras)([[:space:]]|\\|$)/ { found = 1 }
         capture && /;/ { capture = 0 }
         END { exit found ? 0 : 1 }
     ' "${PROJECT_ROOT}/tor/Dockerfile"; then
         return 0
     fi
 
-    grep -Eq 'BusyBox.*(/usr/bin/nc| nc)' "${PROJECT_ROOT}/tor/Dockerfile"
+    echo "tor/Dockerfile must explicitly install the package that provides nc"
+    return 1
 }
 
 @test "README documents variant pipeline build for monitoring flavor" {

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -4,6 +4,10 @@ ARG OS_IMAGE_TAG=latest
 FROM ${REMOTE_CR}/library/alpine:${OS_IMAGE_TAG}
 
 ARG FLAVOR=default
+# Discovery-anchor default only: Alpine's installed package version recorded
+# in /usr/local/share/tor/package-versions.env and the image SBOM is the
+# ground truth for what runs. This static value is not auto-refreshed because
+# retained rebuilds install from Alpine's rolling repositories.
 ARG TOR_VERSION
 ARG LYREBIRD_VERSION
 ARG NYX_VERSION
@@ -106,7 +110,7 @@ HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
         if [ -e "$torrc_path" ] && grep -qE '^[[:space:]]*[^#[:space:]]' "$torrc_path"; then simple_torrc=false; fi; \
         if [ "$simple_torrc" = "true" ] || [ "${CHECK:-false}" = "true" ]; then \
             socks_bind="${SOCKS_BIND:-0.0.0.0}"; \
-            if [ "$socks_bind" = "0.0.0.0" ] || [ "$socks_bind" = "::" ]; then socks_host="127.0.0.1"; else socks_host="$socks_bind"; fi; \
+            if [ "$socks_bind" = "0.0.0.0" ]; then socks_host="127.0.0.1"; elif [ "$socks_bind" = "::" ]; then socks_host="::1"; else socks_host="$socks_bind"; fi; \
             case "$socks_host" in *:*) socks_endpoint="[${socks_host}]:${SOCKS_PORT:-9050}" ;; *) socks_endpoint="${socks_host}:${SOCKS_PORT:-9050}" ;; esac; \
             if [ "${CHECK:-false}" = "true" ]; then \
                 curl -fsS --max-time 20 --socks5-hostname "$socks_endpoint" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -98,7 +98,7 @@ EXPOSE 9050 9001
 # Alpine base BusyBox installs /usr/bin/nc via /etc/busybox-paths.d/busybox;
 # the healthcheck uses that applet for the local SOCKS probe.
 HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
-    CMD pid_file="${DATA_DIR:-/var/lib/tor}/tor.pid"; \
+    CMD pid_file="/var/lib/tor/tor.pid"; \
         pid=""; \
         [ -s "$pid_file" ] && pid="$(cat "$pid_file" 2>/dev/null || true)"; \
         case "$pid" in ""|*[!0-9]*) tor_alive=false ;; *) kill -0 "$pid" 2>/dev/null && tor_alive=true || tor_alive=false ;; esac; \

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -70,7 +70,7 @@ RUN set -eu; \
     } > /usr/local/share/tor/package-versions.env; \
     : > /etc/tor/torrc; \
     chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor /usr/local/share/tor; \
-    chmod 0700 /var/lib/tor
+    chmod 0700 /var/lib/tor /tmp/tor
 
 COPY --chown=tor:tor --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
@@ -92,13 +92,27 @@ USER tor
 EXPOSE 9050 9001
 
 HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
-    CMD socks_bind="${SOCKS_BIND:-0.0.0.0}"; \
-        if [ "$socks_bind" = "0.0.0.0" ] || [ "$socks_bind" = "::" ]; then socks_host="127.0.0.1"; else socks_host="$socks_bind"; fi; \
-        case "$socks_host" in *:*) socks_endpoint="[${socks_host}]:${SOCKS_PORT:-9050}" ;; *) socks_endpoint="${socks_host}:${SOCKS_PORT:-9050}" ;; esac; \
-        if [ "${CHECK:-false}" = "true" ]; then \
-            curl -fsS --max-time 20 --socks5-hostname "$socks_endpoint" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \
-        else \
-            nc -z "$socks_host" "${SOCKS_PORT:-9050}"; \
+    CMD pid_file="${DATA_DIR:-/var/lib/tor}/tor.pid"; \
+        pid=""; \
+        [ -s "$pid_file" ] && pid="$(cat "$pid_file" 2>/dev/null || true)"; \
+        case "$pid" in ""|*[!0-9]*) tor_alive=false ;; *) kill -0 "$pid" 2>/dev/null && tor_alive=true || tor_alive=false ;; esac; \
+        if [ "$tor_alive" != "true" ]; then \
+            if command -v pgrep >/dev/null 2>&1; then pgrep -x tor >/dev/null || exit 1; \
+            elif command -v pidof >/dev/null 2>&1; then pidof tor >/dev/null || exit 1; \
+            else exit 1; fi; \
+        fi; \
+        torrc_path="${TORRC_PATH:-/etc/tor/torrc}"; \
+        simple_torrc=true; \
+        if [ -e "$torrc_path" ] && grep -qE '^[[:space:]]*[^#[:space:]]' "$torrc_path"; then simple_torrc=false; fi; \
+        if [ "$simple_torrc" = "true" ] || [ "${CHECK:-false}" = "true" ]; then \
+            socks_bind="${SOCKS_BIND:-0.0.0.0}"; \
+            if [ "$socks_bind" = "0.0.0.0" ] || [ "$socks_bind" = "::" ]; then socks_host="127.0.0.1"; else socks_host="$socks_bind"; fi; \
+            case "$socks_host" in *:*) socks_endpoint="[${socks_host}]:${SOCKS_PORT:-9050}" ;; *) socks_endpoint="${socks_host}:${SOCKS_PORT:-9050}" ;; esac; \
+            if [ "${CHECK:-false}" = "true" ]; then \
+                curl -fsS --max-time 20 --socks5-hostname "$socks_endpoint" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \
+            else \
+                nc -z "$socks_host" "${SOCKS_PORT:-9050}"; \
+            fi; \
         fi
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eu; \
     nyx_installed_version=""; \
     apk add --no-cache \
         bash \
+        busybox \
         ca-certificates \
         curl \
         lyrebird \
@@ -95,8 +96,8 @@ USER tor
 
 EXPOSE 9050 9001
 
-# Alpine base BusyBox installs /usr/bin/nc via /etc/busybox-paths.d/busybox;
-# the healthcheck uses that applet for the local SOCKS probe.
+# The explicit busybox package provides /usr/bin/nc via
+# /etc/busybox-paths.d/busybox for the local SOCKS probe.
 HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
     CMD pid_file="/var/lib/tor/tor.pid"; \
         pid=""; \

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -8,31 +8,53 @@ ARG TOR_VERSION
 ARG LYREBIRD_VERSION
 ARG NYX_VERSION
 
-RUN : "${TOR_VERSION:?required}" "${LYREBIRD_VERSION:?required}" "${NYX_VERSION:?required}" \
-    && apk add --no-cache \
+RUN set -eu; \
+    assert_apk_upstream_version() { \
+        package="$1"; \
+        expected="$2"; \
+        installed="$(apk info -e -v "$package" 2>/dev/null | head -n 1)"; \
+        if [ -z "$installed" ]; then \
+            echo "Package is not installed: ${package}" >&2; \
+            exit 1; \
+        fi; \
+        actual="$(printf '%s\n' "$installed" | sed -n "s/^${package}-\\(.*\\)-r[0-9][0-9]*$/\\1/p" | head -n 1)"; \
+        if [ -z "$actual" ]; then \
+            echo "Could not parse installed package version for ${package}: ${installed}" >&2; \
+            exit 1; \
+        fi; \
+        if [ "$actual" != "$expected" ]; then \
+            echo "Version mismatch for ${package}: installed upstream ${actual}, declared ${expected}" >&2; \
+            exit 1; \
+        fi; \
+    }; \
+    : "${TOR_VERSION:?required}" "${LYREBIRD_VERSION:?required}" "${NYX_VERSION:?required}"; \
+    apk add --no-cache \
         bash \
         ca-certificates \
         curl \
         lyrebird \
         su-exec \
         tini \
-        tor \
-    && case "${FLAVOR}" in \
+        tor; \
+    assert_apk_upstream_version tor "$TOR_VERSION"; \
+    assert_apk_upstream_version lyrebird "$LYREBIRD_VERSION"; \
+    case "${FLAVOR}" in \
         default) \
             ;; \
         monitoring) \
-            apk add --no-cache nyx py3-stem \
+            apk add --no-cache nyx py3-stem; \
+            assert_apk_upstream_version nyx "$NYX_VERSION"; \
             ;; \
         *) \
             echo "Unknown FLAVOR: ${FLAVOR}" >&2; exit 1 \
             ;; \
-    esac \
-    && if ! grep -q '^tor:' /etc/group; then addgroup -S tor; fi \
-    && if ! id -u tor >/dev/null 2>&1; then adduser -S -D -H -h /var/lib/tor -s /sbin/nologin -G tor tor; fi \
-    && mkdir -p /etc/tor /var/lib/tor /tmp/tor \
-    && : > /etc/tor/torrc \
-    && chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor \
-    && chmod 0700 /var/lib/tor
+    esac; \
+    if ! grep -q '^tor:' /etc/group; then addgroup -S tor; fi; \
+    if ! id -u tor >/dev/null 2>&1; then adduser -S -D -H -h /var/lib/tor -s /sbin/nologin -G tor tor; fi; \
+    mkdir -p /etc/tor /var/lib/tor /tmp/tor; \
+    : > /etc/tor/torrc; \
+    chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor; \
+    chmod 0700 /var/lib/tor
 
 COPY --chown=tor:tor --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -9,9 +9,8 @@ ARG LYREBIRD_VERSION
 ARG NYX_VERSION
 
 RUN set -eu; \
-    assert_apk_upstream_version() { \
+    apk_upstream_version() { \
         package="$1"; \
-        expected="$2"; \
         installed="$(apk info -e -v "$package" 2>/dev/null | head -n 1)"; \
         if [ -z "$installed" ]; then \
             echo "Package is not installed: ${package}" >&2; \
@@ -22,12 +21,18 @@ RUN set -eu; \
             echo "Could not parse installed package version for ${package}: ${installed}" >&2; \
             exit 1; \
         fi; \
-        if [ "$actual" != "$expected" ]; then \
-            echo "Version mismatch for ${package}: installed upstream ${actual}, declared ${expected}" >&2; \
-            exit 1; \
+        printf '%s\n' "$actual"; \
+    }; \
+    warn_declared_version_drift() { \
+        package="$1"; \
+        declared="$2"; \
+        actual="$3"; \
+        if [ -n "$declared" ] && [ "$actual" != "$declared" ]; then \
+            echo "WARNING: ${package} installed upstream version ${actual} differs from declared ${declared}; keeping build non-failing and recording installed version" >&2; \
         fi; \
     }; \
-    : "${TOR_VERSION:?required}" "${LYREBIRD_VERSION:?required}" "${NYX_VERSION:?required}"; \
+    : "${TOR_VERSION:?required}" "${LYREBIRD_VERSION:?required}"; \
+    nyx_installed_version=""; \
     apk add --no-cache \
         bash \
         ca-certificates \
@@ -36,14 +41,18 @@ RUN set -eu; \
         su-exec \
         tini \
         tor; \
-    assert_apk_upstream_version tor "$TOR_VERSION"; \
-    assert_apk_upstream_version lyrebird "$LYREBIRD_VERSION"; \
+    tor_installed_version="$(apk_upstream_version tor)"; \
+    lyrebird_installed_version="$(apk_upstream_version lyrebird)"; \
+    warn_declared_version_drift tor "$TOR_VERSION" "$tor_installed_version"; \
+    warn_declared_version_drift lyrebird "$LYREBIRD_VERSION" "$lyrebird_installed_version"; \
     case "${FLAVOR}" in \
         default) \
             ;; \
         monitoring) \
+            : "${NYX_VERSION:?required}"; \
             apk add --no-cache nyx py3-stem; \
-            assert_apk_upstream_version nyx "$NYX_VERSION"; \
+            nyx_installed_version="$(apk_upstream_version nyx)"; \
+            warn_declared_version_drift nyx "$NYX_VERSION" "$nyx_installed_version"; \
             ;; \
         *) \
             echo "Unknown FLAVOR: ${FLAVOR}" >&2; exit 1 \
@@ -51,20 +60,29 @@ RUN set -eu; \
     esac; \
     if ! grep -q '^tor:' /etc/group; then addgroup -S tor; fi; \
     if ! id -u tor >/dev/null 2>&1; then adduser -S -D -H -h /var/lib/tor -s /sbin/nologin -G tor tor; fi; \
-    mkdir -p /etc/tor /var/lib/tor /tmp/tor; \
+    mkdir -p /etc/tor /var/lib/tor /tmp/tor /usr/local/share/tor; \
+    { \
+        printf 'TOR_VERSION=%s\n' "$tor_installed_version"; \
+        printf 'LYREBIRD_VERSION=%s\n' "$lyrebird_installed_version"; \
+        if [ -n "$nyx_installed_version" ]; then \
+            printf 'NYX_VERSION=%s\n' "$nyx_installed_version"; \
+        fi; \
+    } > /usr/local/share/tor/package-versions.env; \
     : > /etc/tor/torrc; \
-    chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor; \
+    chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor /usr/local/share/tor; \
     chmod 0700 /var/lib/tor
 
 COPY --chown=tor:tor --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
+# Retained rebuilds install the current Alpine packages from the rolling base,
+# so do not stamp the declared TOR_VERSION into OCI version metadata here. The
+# actual installed package versions are recorded above in package-versions.env.
 LABEL org.opencontainers.image.title="Tor" \
       org.opencontainers.image.description="Tor SOCKS proxy with relay, bridge, hidden-service, Lyrebird, and optional Nyx monitoring support" \
       org.opencontainers.image.source="https://github.com/oorabona/docker-containers" \
       org.opencontainers.image.documentation="https://oorabona.github.io/docker-containers/container/tor/" \
       org.opencontainers.image.vendor="oorabona" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.version="${TOR_VERSION}" \
       org.opencontainers.image.flavor="${FLAVOR}"
 
 VOLUME ["/var/lib/tor"]
@@ -74,10 +92,13 @@ USER tor
 EXPOSE 9050 9001
 
 HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
-    CMD if [ "${CHECK:-false}" = "true" ]; then \
-            curl -fsS --max-time 20 --socks5-hostname "127.0.0.1:${SOCKS_PORT:-9050}" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \
+    CMD socks_bind="${SOCKS_BIND:-0.0.0.0}"; \
+        if [ "$socks_bind" = "0.0.0.0" ] || [ "$socks_bind" = "::" ]; then socks_host="127.0.0.1"; else socks_host="$socks_bind"; fi; \
+        case "$socks_host" in *:*) socks_endpoint="[${socks_host}]:${SOCKS_PORT:-9050}" ;; *) socks_endpoint="${socks_host}:${SOCKS_PORT:-9050}" ;; esac; \
+        if [ "${CHECK:-false}" = "true" ]; then \
+            curl -fsS --max-time 20 --socks5-hostname "$socks_endpoint" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \
         else \
-            nc -z 127.0.0.1 "${SOCKS_PORT:-9050}"; \
+            nc -z "$socks_host" "${SOCKS_PORT:-9050}"; \
         fi
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,0 +1,62 @@
+ARG REMOTE_CR=ghcr.io/oorabona
+ARG OS_IMAGE_TAG=latest
+
+FROM ${REMOTE_CR}/library/alpine:${OS_IMAGE_TAG}
+
+ARG FLAVOR=default
+ARG TOR_VERSION
+ARG LYREBIRD_VERSION
+ARG NYX_VERSION
+
+RUN : "${TOR_VERSION:?required}" "${LYREBIRD_VERSION:?required}" "${NYX_VERSION:?required}" \
+    && apk add --no-cache \
+        bash \
+        ca-certificates \
+        curl \
+        lyrebird \
+        su-exec \
+        tini \
+        tor \
+    && case "${FLAVOR}" in \
+        default) \
+            ;; \
+        monitoring) \
+            apk add --no-cache nyx py3-stem \
+            ;; \
+        *) \
+            echo "Unknown FLAVOR: ${FLAVOR}" >&2; exit 1 \
+            ;; \
+    esac \
+    && if ! grep -q '^tor:' /etc/group; then addgroup -S tor; fi \
+    && if ! id -u tor >/dev/null 2>&1; then adduser -S -D -H -h /var/lib/tor -s /sbin/nologin -G tor tor; fi \
+    && mkdir -p /etc/tor /var/lib/tor /tmp/tor \
+    && : > /etc/tor/torrc \
+    && chown -R tor:tor /etc/tor /var/lib/tor /tmp/tor \
+    && chmod 0700 /var/lib/tor
+
+COPY --chown=tor:tor --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
+LABEL org.opencontainers.image.title="Tor" \
+      org.opencontainers.image.description="Tor SOCKS proxy with relay, bridge, hidden-service, Lyrebird, and optional Nyx monitoring support" \
+      org.opencontainers.image.source="https://github.com/oorabona/docker-containers" \
+      org.opencontainers.image.documentation="https://oorabona.github.io/docker-containers/container/tor/" \
+      org.opencontainers.image.vendor="oorabona" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${TOR_VERSION}" \
+      org.opencontainers.image.flavor="${FLAVOR}"
+
+VOLUME ["/var/lib/tor"]
+
+USER tor
+
+EXPOSE 9050 9001
+
+HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
+    CMD if [ "${CHECK:-false}" = "true" ]; then \
+            curl -fsS --max-time 20 --socks5-hostname "127.0.0.1:${SOCKS_PORT:-9050}" https://check.torproject.org/api/ip | grep -q '"IsTor":true'; \
+        else \
+            nc -z 127.0.0.1 "${SOCKS_PORT:-9050}"; \
+        fi
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["tor"]

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -95,6 +95,8 @@ USER tor
 
 EXPOSE 9050 9001
 
+# Alpine base BusyBox installs /usr/bin/nc via /etc/busybox-paths.d/busybox;
+# the healthcheck uses that applet for the local SOCKS probe.
 HEALTHCHECK --interval=30s --timeout=20s --start-period=90s --retries=3 \
     CMD pid_file="${DATA_DIR:-/var/lib/tor}/tor.pid"; \
         pid=""; \

--- a/tor/README.md
+++ b/tor/README.md
@@ -1,0 +1,166 @@
+# Tor — SOCKS Proxy, Relay, Bridge, and Hidden-Service Container
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/oorabona/tor)](https://hub.docker.com/r/oorabona/tor)
+[![Docker Image Size](https://img.shields.io/docker/image-size/oorabona/tor)](https://hub.docker.com/r/oorabona/tor)
+[![GHCR](https://img.shields.io/badge/GHCR-oorabona%2Ftor-blue)](https://ghcr.io/oorabona/tor)
+[![GitHub Stars](https://img.shields.io/github/stars/oorabona/docker-containers?style=social)](https://github.com/oorabona/docker-containers)
+
+Tor with a secure default control-port setup: SOCKS on 9050, cookie authentication for local control, Lyrebird for pluggable transports, and an optional Nyx monitoring flavor.
+
+## Verify this image
+
+Every build ships a Sigstore-signed SBOM and a full Trivy scan — verify them yourself, no login required:
+
+```bash
+gh attestation verify oci://ghcr.io/oorabona/tor:latest --owner oorabona
+```
+
+Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, upstream dependency tracking) → <https://oorabona.github.io/docker-containers/verify-images/>
+
+## Platforms
+
+- **amd64** - x86_64 systems
+- **arm64** - ARM 64-bit systems
+
+## Tags
+
+- `latest`, `0.4.9.11-alpine` - Tor + Lyrebird
+- `latest-monitoring`, `0.4.9.11-alpine-monitoring` - Tor + Lyrebird + Nyx + py3-stem
+
+## Basic SOCKS Proxy
+
+```bash
+docker run -d \
+  --name tor \
+  -p 9050:9050 \
+  -v tor-data:/var/lib/tor \
+  ghcr.io/oorabona/tor:latest
+```
+
+Use `socks5h://`, not plain `socks5://`, when the client supports it:
+
+```bash
+curl --proxy socks5h://127.0.0.1:9050 https://check.torproject.org/api/ip
+```
+
+The `h` means hostname resolution happens through Tor. Many clients using plain `socks5://` resolve DNS locally before connecting to the proxy, which leaks the destination hostname outside the Tor circuit.
+
+## Configuration
+
+### Simple Environment Path
+
+The image generates a minimal torrc when `/etc/tor/torrc` is absent or empty.
+
+| Variable | Default | Effect |
+|---|---:|---|
+| `SOCKS_BIND` | `0.0.0.0` | SOCKS listen address inside the container |
+| `SOCKS_PORT` | `9050` | SOCKS listen port |
+| `EXIT_NODES` | unset | Comma-separated country codes rendered as Tor `{cc}` entries |
+| `EXCLUDE_EXIT_NODES` | unset | Comma-separated country codes to avoid |
+| `PASSWORD_FILE` | unset | Optional Docker-secret file for external control authentication |
+| `CONTROL_PORT_BIND` | `127.0.0.1` | Control port bind address; non-loopback requires `PASSWORD_FILE` |
+| `CHECK` | `false` | When true, healthcheck verifies Tor exit status through check.torproject.org |
+
+Default control access uses `CookieAuthentication 1` and binds `ControlPort 127.0.0.1:9051`. The image does not expose the control port.
+
+### Mounted torrc Path
+
+For relay, bridge, exit, and hidden-service deployments, mount a full torrc:
+
+```bash
+docker run -d \
+  --name tor-relay \
+  -p 9050:9050 \
+  -p 9001:9001 \
+  -v "$PWD/torrc:/etc/tor/torrc:ro" \
+  -v tor-data:/var/lib/tor \
+  ghcr.io/oorabona/tor:latest
+```
+
+When `/etc/tor/torrc` is non-empty, it owns Tor's behavior-affecting configuration. The container supplies only `DataDirectory`, `PidFile`, and `Log` through Tor's defaults file. If simple environment variables are also set, startup logs a warning because those variables have no effect in this mode.
+
+## Relay Example
+
+Minimal relay torrc:
+
+```torrc
+Nickname ExampleRelay
+ContactInfo admin@example.com
+ORPort 9001
+ExitRelay 0
+SocksPort 0
+```
+
+Publish `9001` for relay and bridge mode. Without an inbound ORPort mapping, other Tor nodes cannot reach the relay even if the process starts cleanly.
+
+## Monitoring Flavor
+
+Run the monitoring tag, then attach Nyx from inside the container:
+
+```bash
+docker run -d \
+  --name tor \
+  -p 9050:9050 \
+  -v tor-data:/var/lib/tor \
+  ghcr.io/oorabona/tor:latest-monitoring
+
+docker exec -it tor nyx
+```
+
+Nyx runs as the `tor` user and reads `/var/lib/tor/control_auth_cookie`; no password is generated or printed in the default path.
+
+## Persistence
+
+`/var/lib/tor` is optional for a disposable SOCKS proxy and required for identity-bearing modes:
+
+- relay fingerprint continuity
+- bridge identity continuity
+- hidden-service private keys and `.onion` address continuity
+
+The entrypoint warns when a mounted torrc defines `HiddenServiceDir` or `ORPort` and `/var/lib/tor` does not look like a mounted volume. This is a best-effort heuristic; the absence of the warning is not proof that persistence is configured correctly.
+
+## Security
+
+- Runs as the named `tor` user by default
+- Uses Tor cookie authentication by default
+- Binds the control port to loopback by default
+- Does not declare `EXPOSE 9051`
+- Does not ship a default control password
+
+### Runtime Hardening
+
+```yaml
+services:
+  tor:
+    image: ghcr.io/oorabona/tor:latest
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "9050:9050"
+    volumes:
+      - tor-data:/var/lib/tor
+    restart: unless-stopped
+
+volumes:
+  tor-data:
+```
+
+Relay mode still does not need extra Linux capabilities when using an unprivileged ORPort such as `9001`.
+
+## Building
+
+```bash
+./make build tor
+```
+
+Build the monitoring flavor through the normal variant pipeline:
+
+```bash
+./make build tor latest monitoring
+```
+
+## License
+
+MIT

--- a/tor/README.md
+++ b/tor/README.md
@@ -76,7 +76,7 @@ The default healthcheck first verifies that the Tor process is alive. For the ge
 
 ### Opt-In External Control
 
-For password-authenticated external control, set `PASSWORD_FILE` to a Docker secret and bind `CONTROL_PORT_BIND` deliberately. The recommended secret content is a pre-hashed Tor control password in `16:<hex>` `HashedControlPassword` format, generated outside the container, for example with `tor --hash-password` on a trusted host or a throwaway container. The entrypoint uses that value directly and never handles the plaintext.
+For password-authenticated external control, set `PASSWORD_FILE` to a Docker secret and bind `CONTROL_PORT_BIND` deliberately. The recommended secret content is a pre-hashed Tor control password in `16:<58 hex characters>` `HashedControlPassword` format, generated outside the container, for example with `tor --hash-password` on a trusted host or a throwaway container. The entrypoint uses that value directly and never handles the plaintext.
 
 For compatibility, `PASSWORD_FILE` may also contain a plaintext password. In that path the entrypoint hashes it at startup with `tor --hash-password`; Tor does not provide stdin or file input for this operation, so the plaintext is briefly visible in that helper process's argv inside the container PID namespace.
 
@@ -133,6 +133,8 @@ Nyx runs as the `tor` user and reads `/var/lib/tor/control_auth_cookie`; no pass
 - relay fingerprint continuity
 - bridge identity continuity
 - hidden-service private keys and `.onion` address continuity
+
+The data directory is fixed at `/var/lib/tor`; persist it by mounting a named volume or bind mount at that path.
 
 The entrypoint warns when a mounted torrc defines `HiddenServiceDir` or `ORPort` and `/var/lib/tor` does not look like a mounted volume. This is a best-effort heuristic; the absence of the warning is not proof that persistence is configured correctly.
 

--- a/tor/README.md
+++ b/tor/README.md
@@ -38,10 +38,12 @@ Lyrebird and Nyx remain tracked against upstream releases as an advisory traceab
 ```bash
 docker run -d \
   --name tor \
-  -p 9050:9050 \
+  -p 127.0.0.1:9050:9050 \
   -v tor-data:/var/lib/tor \
   ghcr.io/oorabona/tor:latest
 ```
+
+This publishes SOCKS on host loopback only. Broader host-interface exposure should be an explicit operator choice, paired with appropriate network controls.
 
 Use `socks5h://`, not plain `socks5://`, when the client supports it:
 
@@ -63,7 +65,7 @@ The image generates a minimal torrc when `/etc/tor/torrc` is absent, empty, or c
 | `SOCKS_PORT` | `9050` | SOCKS listen port |
 | `EXIT_NODES` | unset | Comma-separated country codes rendered as Tor `{cc}` entries |
 | `EXCLUDE_EXIT_NODES` | unset | Comma-separated country codes to avoid |
-| `PASSWORD_FILE` | unset | Optional Docker-secret file for external control authentication |
+| `PASSWORD_FILE` | unset | Optional Docker-secret file for external control authentication, pre-hashed or plaintext |
 | `CONTROL_PORT_BIND` | `127.0.0.1` | Control port bind address; non-loopback requires `PASSWORD_FILE` |
 | `CONTROL_PORT` | `9051` | Control port listen port |
 | `CHECK` | `false` | When true, healthcheck verifies Tor exit status through check.torproject.org |
@@ -72,6 +74,12 @@ Default control access uses `CookieAuthentication 1` and binds `ControlPort 127.
 
 The default healthcheck first verifies that the Tor process is alive. For the generated simple torrc path it also confirms the configured SOCKS listener is open; for mounted torrc deployments it does not assume SOCKS exists. Set `CHECK=true` only when readiness must confirm a working SOCKS circuit through check.torproject.org.
 
+### Opt-In External Control
+
+For password-authenticated external control, set `PASSWORD_FILE` to a Docker secret and bind `CONTROL_PORT_BIND` deliberately. The recommended secret content is a pre-hashed Tor control password in `16:<hex>` `HashedControlPassword` format, generated outside the container, for example with `tor --hash-password` on a trusted host or a throwaway container. The entrypoint uses that value directly and never handles the plaintext.
+
+For compatibility, `PASSWORD_FILE` may also contain a plaintext password. In that path the entrypoint hashes it at startup with `tor --hash-password`; Tor does not provide stdin or file input for this operation, so the plaintext is briefly visible in that helper process's argv inside the container PID namespace.
+
 ### Mounted torrc Path
 
 For relay, bridge, exit, and hidden-service deployments, mount a full torrc:
@@ -79,7 +87,7 @@ For relay, bridge, exit, and hidden-service deployments, mount a full torrc:
 ```bash
 docker run -d \
   --name tor-relay \
-  -p 9050:9050 \
+  -p 127.0.0.1:9050:9050 \
   -p 9001:9001 \
   -v "$PWD/torrc:/etc/tor/torrc:ro" \
   -v tor-data:/var/lib/tor \
@@ -109,7 +117,7 @@ Run the monitoring tag, then attach Nyx from inside the container:
 ```bash
 docker run -d \
   --name tor \
-  -p 9050:9050 \
+  -p 127.0.0.1:9050:9050 \
   -v tor-data:/var/lib/tor \
   ghcr.io/oorabona/tor:latest-monitoring
 
@@ -149,7 +157,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "9050:9050"
+      - "127.0.0.1:9050:9050"
     volumes:
       - tor-data:/var/lib/tor
     restart: unless-stopped

--- a/tor/README.md
+++ b/tor/README.md
@@ -49,7 +49,7 @@ The `h` means hostname resolution happens through Tor. Many clients using plain 
 
 ### Simple Environment Path
 
-The image generates a minimal torrc when `/etc/tor/torrc` is absent or empty.
+The image generates a minimal torrc when `/etc/tor/torrc` is absent, empty, or contains only whitespace/comments.
 
 | Variable | Default | Effect |
 |---|---:|---|
@@ -59,9 +59,12 @@ The image generates a minimal torrc when `/etc/tor/torrc` is absent or empty.
 | `EXCLUDE_EXIT_NODES` | unset | Comma-separated country codes to avoid |
 | `PASSWORD_FILE` | unset | Optional Docker-secret file for external control authentication |
 | `CONTROL_PORT_BIND` | `127.0.0.1` | Control port bind address; non-loopback requires `PASSWORD_FILE` |
+| `CONTROL_PORT` | `9051` | Control port listen port |
 | `CHECK` | `false` | When true, healthcheck verifies Tor exit status through check.torproject.org |
 
 Default control access uses `CookieAuthentication 1` and binds `ControlPort 127.0.0.1:9051`. The image does not expose the control port.
+
+The default liveness healthcheck uses `nc -z` and only confirms that the SOCKS listener is open. Set `CHECK=true` when readiness must confirm that Tor has bootstrapped a circuit; otherwise `depends_on: service_healthy` can unblock dependents before Tor can route traffic.
 
 ### Mounted torrc Path
 
@@ -77,7 +80,7 @@ docker run -d \
   ghcr.io/oorabona/tor:latest
 ```
 
-When `/etc/tor/torrc` is non-empty, it owns Tor's behavior-affecting configuration. The container supplies only `DataDirectory`, `PidFile`, and `Log` through Tor's defaults file. If simple environment variables are also set, startup logs a warning because those variables have no effect in this mode.
+When `/etc/tor/torrc` contains at least one non-comment directive, it owns Tor's behavior-affecting configuration. The container supplies only `DataDirectory`, `PidFile`, and `Log` through Tor's defaults file. If simple environment variables are also set, startup logs a warning because those variables have no effect in this mode.
 
 ## Relay Example
 
@@ -118,6 +121,8 @@ Nyx runs as the `tor` user and reads `/var/lib/tor/control_auth_cookie`; no pass
 - hidden-service private keys and `.onion` address continuity
 
 The entrypoint warns when a mounted torrc defines `HiddenServiceDir` or `ORPort` and `/var/lib/tor` does not look like a mounted volume. This is a best-effort heuristic; the absence of the warning is not proof that persistence is configured correctly.
+
+Named Docker volumes are prepared by the root-to-`tor` startup path. If `/var/lib/tor` is a bind mount and the container is not started with `--user 0`, pre-own the host directory as uid `100` so the `tor` user can write it.
 
 ## Security
 

--- a/tor/README.md
+++ b/tor/README.md
@@ -170,14 +170,10 @@ Relay mode still does not need extra Linux capabilities when using an unprivileg
 
 ## Building
 
+Build all variants, including the monitoring flavor, through the normal variant pipeline:
+
 ```bash
 ./make build tor
-```
-
-Build the monitoring flavor through the normal variant pipeline:
-
-```bash
-./make build tor latest monitoring
 ```
 
 ## License

--- a/tor/README.md
+++ b/tor/README.md
@@ -27,6 +27,12 @@ Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, 
 - `latest`, `0.4.9.11-alpine` - Tor + Lyrebird
 - `latest-monitoring`, `0.4.9.11-alpine-monitoring` - Tor + Lyrebird + Nyx + py3-stem
 
+## Versioning
+
+Tor, Lyrebird, and Nyx are installed from Alpine packages. The image records the actual installed package versions in `/usr/local/share/tor/package-versions.env`.
+
+Lyrebird and Nyx remain tracked against upstream releases as an advisory traceability signal. A PR such as `LYREBIRD_VERSION: 0.8.1 -> 0.9.0` means upstream released a new version and Alpine should be checked; merging that PR updates the declared signal, but the running image changes only after Alpine repackages and the image is rebuilt.
+
 ## Basic SOCKS Proxy
 
 ```bash
@@ -64,7 +70,7 @@ The image generates a minimal torrc when `/etc/tor/torrc` is absent, empty, or c
 
 Default control access uses `CookieAuthentication 1` and binds `ControlPort 127.0.0.1:9051`. The image does not expose the control port.
 
-The default liveness healthcheck uses `nc -z` and only confirms that the SOCKS listener is open. Set `CHECK=true` when readiness must confirm that Tor has bootstrapped a circuit; otherwise `depends_on: service_healthy` can unblock dependents before Tor can route traffic.
+The default healthcheck first verifies that the Tor process is alive. For the generated simple torrc path it also confirms the configured SOCKS listener is open; for mounted torrc deployments it does not assume SOCKS exists. Set `CHECK=true` only when readiness must confirm a working SOCKS circuit through check.torproject.org.
 
 ### Mounted torrc Path
 

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -16,17 +16,15 @@ dependency_sources:
     lifecycle: untracked
     reason: "Base image tag fallback, not a version to track"
   TOR_VERSION:
-    monitor: true
-    lifecycle: tracked
-    type: gitlab-tags
-    project_path: tpo%2Fcore%2Ftor
-    tag_filter: "^tor-[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$"
-    version_extract: "^tor-([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)$"
-    reason: "Tor stable tags on gitlab.torproject.org; strips the tor- prefix"
+    monitor: false
+    lifecycle: untracked
+    reason: "Primary image version is resolved by tor/version.sh; this build arg verifies the installed Alpine tor package and OCI label"
   LYREBIRD_VERSION:
     monitor: true
     lifecycle: tracked
     type: gitlab-tags
+    web_host: gitlab.torproject.org
+    api_host: gitlab.torproject.org
     project_path: tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird
     tag_filter: "^lyrebird-[0-9]+\\.[0-9]+\\.[0-9]+$"
     version_extract: "^lyrebird-([0-9]+\\.[0-9]+\\.[0-9]+)$"

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -28,13 +28,13 @@ dependency_sources:
     project_path: tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird
     tag_filter: "^lyrebird-[0-9]+\\.[0-9]+\\.[0-9]+$"
     version_extract: "^lyrebird-([0-9]+\\.[0-9]+\\.[0-9]+)$"
-    reason: "Lyrebird tags on gitlab.torproject.org; excludes legacy obfs4proxy tags"
+    reason: "Advisory upstream-release tracking for Lyrebird on gitlab.torproject.org; the Dockerfile installs Alpine's lyrebird package, so a merged bump PR updates this declared signal for traceability and does not change the built image until Alpine repackages"
   NYX_VERSION:
     monitor: true
     lifecycle: tracked
     type: pypi
     package: nyx
-    reason: "Nyx monitoring flavor dependency from PyPI"
+    reason: "Advisory upstream-release tracking for Nyx on PyPI; the monitoring flavor installs Alpine's nyx package, so a merged bump PR updates this declared signal for traceability and does not change the built image until Alpine repackages"
 value_proposition: >-
   Tor SOCKS proxy with relay, bridge, pluggable transport, hidden-service, and
   optional Nyx monitoring support. Multi-arch, SBOM-attested, daily upstream

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -1,0 +1,43 @@
+# Tor container configuration
+# Base image and third-party dependency versions
+
+base_image: "${REMOTE_CR}/library/alpine:${OS_IMAGE_TAG}"
+base_image_cache:
+  - source: library/alpine
+    tags: ["latest"]
+build_args:
+  OS_IMAGE_TAG: "latest"
+  TOR_VERSION: "0.4.9.11"
+  LYREBIRD_VERSION: "0.8.1"
+  NYX_VERSION: "2.1.0"
+dependency_sources:
+  OS_IMAGE_TAG:
+    monitor: false
+    lifecycle: untracked
+    reason: "Base image tag fallback, not a version to track"
+  TOR_VERSION:
+    monitor: true
+    lifecycle: tracked
+    type: gitlab-tags
+    project_path: tpo%2Fcore%2Ftor
+    tag_filter: "^tor-[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$"
+    version_extract: "^tor-([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)$"
+    reason: "Tor stable tags on gitlab.torproject.org; strips the tor- prefix"
+  LYREBIRD_VERSION:
+    monitor: true
+    lifecycle: tracked
+    type: gitlab-tags
+    project_path: tpo%2Fanti-censorship%2Fpluggable-transports%2Flyrebird
+    tag_filter: "^lyrebird-[0-9]+\\.[0-9]+\\.[0-9]+$"
+    version_extract: "^lyrebird-([0-9]+\\.[0-9]+\\.[0-9]+)$"
+    reason: "Lyrebird tags on gitlab.torproject.org; excludes legacy obfs4proxy tags"
+  NYX_VERSION:
+    monitor: true
+    lifecycle: tracked
+    type: pypi
+    package: nyx
+    reason: "Nyx monitoring flavor dependency from PyPI"
+value_proposition: >-
+  Tor SOCKS proxy with relay, bridge, pluggable transport, hidden-service, and
+  optional Nyx monitoring support. Multi-arch, SBOM-attested, daily upstream
+  monitoring.

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -18,7 +18,7 @@ dependency_sources:
   TOR_VERSION:
     monitor: false
     lifecycle: untracked
-    reason: "Primary image version is resolved by tor/version.sh; this build arg verifies the installed Alpine tor package and OCI label"
+    reason: "Primary image version is resolved by tor/version.sh; this build arg records the declared target while Dockerfile build logs and package-versions.env record the installed Alpine tor package"
   LYREBIRD_VERSION:
     monitor: true
     lifecycle: tracked

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -18,7 +18,7 @@ dependency_sources:
   TOR_VERSION:
     monitor: false
     lifecycle: untracked
-    reason: "Primary image version is resolved by tor/version.sh; this build arg records the declared target while Dockerfile build logs and package-versions.env record the installed Alpine tor package"
+    reason: "Discovery-anchor default only, not automatically kept current. Primary image version discovery is resolved by tor/version.sh, but the discovered, actually installed Alpine tor package in /usr/local/share/tor/package-versions.env and the image SBOM is the ground truth for what runs."
   LYREBIRD_VERSION:
     monitor: true
     lifecycle: tracked

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -57,11 +57,23 @@ is_ipv4_address() {
 }
 
 is_ipv6_address() {
-    [[ "$1" == *:* ]] || return 1
-    [[ "$1" =~ ^[0-9A-Fa-f:.]+$ ]] || return 1
-    [[ "$1" != *:::* ]] || return 1
+    local value="$1"
+    local ipv4_tail ipv6_prefix
 
-    awk -v ip="$1" '
+    [[ "$value" == *:* ]] || return 1
+    [[ "$value" != *:::* ]] || return 1
+
+    if [[ "$value" == *.* ]]; then
+        ipv4_tail="${value##*:}"
+        ipv6_prefix="${value%:*}"
+        [[ "$ipv4_tail" != "$value" ]] || return 1
+        [[ "$ipv6_prefix" =~ ^[0-9A-Fa-f:]+$ ]] || return 1
+        is_ipv4_address "$ipv4_tail" || return 1
+    else
+        [[ "$value" =~ ^[0-9A-Fa-f:]+$ ]] || return 1
+    fi
+
+    awk -v ip="$value" '
         function valid_ipv4(value, parts, n, i) {
             n = split(value, parts, ".")
             if (n != 4) return 0
@@ -133,6 +145,7 @@ validate_tor_path() {
 reject_sensitive_data_dir() {
     local value="${1%/}"
     local denied
+    local allowed_data_dir="/var/lib/tor"
     local -a denied_paths=(
         /
         /etc
@@ -150,8 +163,12 @@ reject_sensitive_data_dir() {
         /home
     )
 
+    if [[ "$value" == "$allowed_data_dir" || "$value" == "$allowed_data_dir"/* ]]; then
+        return 0
+    fi
+
     for denied in "${denied_paths[@]}"; do
-        if [[ "$value" == "$denied" ]]; then
+        if [[ "$value" == "$denied" || "$value" == "$denied"/* ]]; then
             die "DATA_DIR must not be a sensitive system path: ${denied}"
         fi
         if [[ "$denied" == "$value"/* ]]; then
@@ -226,10 +243,11 @@ custom_torrc_active() {
 
     if grep -qE '^[[:space:]]*[^#[:space:]]' "$TORRC_PATH"; then
         return 0
+    else
+        local rc=$?
+        [[ "$rc" -eq 2 ]] && die "could not read TORRC_PATH: ${TORRC_PATH}"
     fi
 
-    local rc=$?
-    [[ "$rc" -eq 2 ]] && die "could not read TORRC_PATH: ${TORRC_PATH}"
     return 1
 }
 
@@ -283,6 +301,12 @@ load_control_password_hash() {
 
     IFS= read -r control_password < "$password_file" || true
     [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
+
+    if [[ "$control_password" =~ ^16:[0-9A-Fa-f]+$ ]]; then
+        CONTROL_PASSWORD_HASH="$control_password"
+        unset control_password
+        return 0
+    fi
 
     # tor(1) documents --hash-password PASSWORD, with no stdin or file input for
     # this operation. The plaintext is briefly visible in the hash helper's argv
@@ -407,4 +431,6 @@ main() {
     exec tor -f "$GENERATED_TORRC" "$@"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 
 TORRC_PATH="${TORRC_PATH:-/etc/tor/torrc}"
 DATA_DIR="${DATA_DIR:-/var/lib/tor}"
-GENERATED_DIR="${GENERATED_DIR:-/tmp/tor}"
-GENERATED_TORRC="${GENERATED_TORRC:-${GENERATED_DIR}/torrc}"
-DEFAULTS_TORRC="${DEFAULTS_TORRC:-${GENERATED_DIR}/defaults-torrc}"
+readonly GENERATED_DIR="/tmp/tor"
+readonly GENERATED_TORRC="${GENERATED_DIR}/torrc"
+readonly DEFAULTS_TORRC="${GENERATED_DIR}/defaults-torrc"
 CONTROL_PORT="${CONTROL_PORT:-9051}"
 
 log() {
@@ -130,6 +130,36 @@ validate_tor_path() {
     done
 }
 
+reject_sensitive_data_dir() {
+    local value="${1%/}"
+    local denied
+    local -a denied_paths=(
+        /
+        /etc
+        /var
+        /usr
+        /bin
+        /sbin
+        /lib
+        /lib64
+        /proc
+        /sys
+        /dev
+        /root
+        /boot
+        /home
+    )
+
+    for denied in "${denied_paths[@]}"; do
+        if [[ "$value" == "$denied" ]]; then
+            die "DATA_DIR must not be a sensitive system path: ${denied}"
+        fi
+        if [[ "$denied" == "$value"/* ]]; then
+            die "DATA_DIR must not be a parent of sensitive system path: ${denied}"
+        fi
+    done
+}
+
 validate_country_list() {
     local name="$1"
     local raw="$2"
@@ -166,7 +196,7 @@ validate_torrc_env() {
 
 validate_runtime_paths() {
     validate_tor_path "DATA_DIR" "$DATA_DIR"
-    validate_tor_path "GENERATED_DIR" "$GENERATED_DIR"
+    reject_sensitive_data_dir "$DATA_DIR"
 }
 
 ensure_runtime_dirs() {
@@ -174,8 +204,14 @@ ensure_runtime_dirs() {
 
     if [[ "$(id -u)" == "0" ]]; then
         chown -R tor:tor "$GENERATED_DIR" "$DATA_DIR"
-        chmod 0700 "$DATA_DIR"
+        chmod 0700 "$GENERATED_DIR" "$DATA_DIR"
         exec su-exec tor "$0" "$@"
+    fi
+
+    if [[ -w "$GENERATED_DIR" ]]; then
+        chmod 0700 "$GENERATED_DIR" 2>/dev/null || warn "could not chmod ${GENERATED_DIR}; generated torrc files may not be private"
+    else
+        warn "${GENERATED_DIR} is not writable by $(id -un); generated torrc cannot be written"
     fi
 
     if [[ -w "$DATA_DIR" ]]; then
@@ -248,6 +284,10 @@ load_control_password_hash() {
     IFS= read -r control_password < "$password_file" || true
     [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
 
+    # tor(1) documents --hash-password PASSWORD, with no stdin or file input for
+    # this operation. The plaintext is briefly visible in the hash helper's argv
+    # to processes sharing the container PID namespace; Docker's default
+    # per-container PID namespace limits that residual exposure.
     if ! hashed_password=$(tor --hash-password "$control_password" | awk '/^16:/ {print; exit}'); then
         unset control_password
         die "failed to hash control password from PASSWORD_FILE"
@@ -270,11 +310,16 @@ format_tor_endpoint() {
 }
 
 write_plumbing_defaults() {
-    cat > "$DEFAULTS_TORRC" <<EOF
+    rm -f "$DEFAULTS_TORRC"
+    (
+        umask 077
+        cat > "$DEFAULTS_TORRC" <<EOF
 DataDirectory ${DATA_DIR}
 PidFile ${DATA_DIR}/tor.pid
 Log notice stdout
 EOF
+    )
+    chmod 0600 "$DEFAULTS_TORRC"
 }
 
 write_simple_torrc() {
@@ -290,31 +335,36 @@ write_simple_torrc() {
     socks_endpoint=$(format_tor_endpoint "$socks_bind" "$socks_port")
     control_endpoint=$(format_tor_endpoint "$control_bind" "$CONTROL_PORT")
 
-    {
-        echo "DataDirectory ${DATA_DIR}"
-        echo "PidFile ${DATA_DIR}/tor.pid"
-        echo "RunAsDaemon 0"
-        echo "Log notice stdout"
-        echo "SocksPort ${socks_endpoint}"
-        echo "ControlPort ${control_endpoint}"
-        echo "CookieAuthentication 1"
-        echo "CookieAuthFile ${DATA_DIR}/control_auth_cookie"
-        if [[ -n "$CONTROL_PASSWORD_HASH" ]]; then
-            echo "HashedControlPassword ${CONTROL_PASSWORD_HASH}"
-        fi
+    rm -f "$GENERATED_TORRC"
+    (
+        umask 077
+        {
+            echo "DataDirectory ${DATA_DIR}"
+            echo "PidFile ${DATA_DIR}/tor.pid"
+            echo "RunAsDaemon 0"
+            echo "Log notice stdout"
+            echo "SocksPort ${socks_endpoint}"
+            echo "ControlPort ${control_endpoint}"
+            echo "CookieAuthentication 1"
+            echo "CookieAuthFile ${DATA_DIR}/control_auth_cookie"
+            if [[ -n "$CONTROL_PASSWORD_HASH" ]]; then
+                echo "HashedControlPassword ${CONTROL_PASSWORD_HASH}"
+            fi
 
-        if [[ -n "${EXIT_NODES:-}" ]]; then
-            local exit_nodes
-            exit_nodes=$(render_country_list "$EXIT_NODES")
-            [[ -n "$exit_nodes" ]] && echo "ExitNodes ${exit_nodes}"
-        fi
+            if [[ -n "${EXIT_NODES:-}" ]]; then
+                local exit_nodes
+                exit_nodes=$(render_country_list "$EXIT_NODES")
+                [[ -n "$exit_nodes" ]] && echo "ExitNodes ${exit_nodes}"
+            fi
 
-        if [[ -n "${EXCLUDE_EXIT_NODES:-}" ]]; then
-            local exclude_exit_nodes
-            exclude_exit_nodes=$(render_country_list "$EXCLUDE_EXIT_NODES")
-            [[ -n "$exclude_exit_nodes" ]] && echo "ExcludeExitNodes ${exclude_exit_nodes}"
-        fi
-    } > "$GENERATED_TORRC"
+            if [[ -n "${EXCLUDE_EXIT_NODES:-}" ]]; then
+                local exclude_exit_nodes
+                exclude_exit_nodes=$(render_country_list "$EXCLUDE_EXIT_NODES")
+                [[ -n "$exclude_exit_nodes" ]] && echo "ExcludeExitNodes ${exclude_exit_nodes}"
+            fi
+        } > "$GENERATED_TORRC"
+    )
+    chmod 0600 "$GENERATED_TORRC"
 }
 
 warn_if_identity_not_persistent() {

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -353,6 +353,10 @@ main() {
         exec "$@"
     fi
 
+    if [[ $# -gt 0 && "${1:0:1}" == "-" ]]; then
+        exec tor "$@"
+    fi
+
     if [[ "${1:-}" == "tor" ]]; then
         shift
     fi

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -21,6 +21,141 @@ die() {
     exit 1
 }
 
+reject_control_chars() {
+    local name="$1"
+    local value="$2"
+
+    if [[ "$value" =~ [[:cntrl:]] ]]; then
+        die "${name} must not contain control characters"
+    fi
+}
+
+validate_port() {
+    local name="$1"
+    local value="$2"
+    local number
+
+    reject_control_chars "$name" "$value"
+    [[ "$value" =~ ^[0-9]+$ ]] || die "${name} must be an integer port from 1 to 65535"
+    [[ "${#value}" -le 5 ]] || die "${name} must be an integer port from 1 to 65535"
+
+    number=$((10#$value))
+    (( number >= 1 && number <= 65535 )) || die "${name} must be an integer port from 1 to 65535"
+}
+
+is_ipv4_address() {
+    awk -v ip="$1" '
+        BEGIN {
+            n = split(ip, parts, ".")
+            if (n != 4) exit 1
+            for (i = 1; i <= n; i++) {
+                if (parts[i] !~ /^[0-9]+$/) exit 1
+                if (parts[i] < 0 || parts[i] > 255) exit 1
+            }
+        }
+    '
+}
+
+is_ipv6_address() {
+    [[ "$1" == *:* ]] || return 1
+    [[ "$1" =~ ^[0-9A-Fa-f:.]+$ ]] || return 1
+    [[ "$1" != *:::* ]] || return 1
+
+    awk -v ip="$1" '
+        function valid_ipv4(value, parts, n, i) {
+            n = split(value, parts, ".")
+            if (n != 4) return 0
+            for (i = 1; i <= n; i++) {
+                if (parts[i] !~ /^[0-9]+$/) return 0
+                if (parts[i] < 0 || parts[i] > 255) return 0
+            }
+            return 1
+        }
+
+        BEGIN {
+            tmp = ip
+            if (gsub(/::/, "::", tmp) > 1) exit 1
+            if (ip ~ /^:[^:]/ || ip ~ /[^:]:$/) exit 1
+
+            compressed = index(ip, "::") > 0
+            n = split(ip, parts, ":")
+            groups = 0
+            for (i = 1; i <= n; i++) {
+                if (parts[i] == "") continue
+                if (parts[i] ~ /\./) {
+                    if (i != n || !valid_ipv4(parts[i])) exit 1
+                    groups += 2
+                    continue
+                }
+                if (parts[i] !~ /^[0-9A-Fa-f]{1,4}$/) exit 1
+                groups++
+            }
+
+            if (compressed) {
+                if (groups >= 8) exit 1
+            } else if (groups != 8) {
+                exit 1
+            }
+        }
+    '
+}
+
+validate_bind_address() {
+    local name="$1"
+    local value="$2"
+
+    reject_control_chars "$name" "$value"
+    if is_ipv4_address "$value" || is_ipv6_address "$value"; then
+        return 0
+    fi
+
+    die "${name} must be a plain IPv4 or IPv6 address"
+}
+
+validate_tor_path() {
+    local name="$1"
+    local value="$2"
+
+    reject_control_chars "$name" "$value"
+    [[ "$value" == /* ]] || die "${name} must be an absolute path"
+    [[ "$value" =~ ^/[A-Za-z0-9._/@:+-]*$ ]] || die "${name} contains unsupported path characters"
+}
+
+validate_country_list() {
+    local name="$1"
+    local raw="$2"
+    local item seen=false
+    local -a parts
+
+    [[ -z "$raw" ]] && return 0
+    reject_control_chars "$name" "$raw"
+
+    IFS=',' read -r -a parts <<< "$raw"
+    for item in "${parts[@]}"; do
+        item="${item//[[:space:]]/}"
+        [[ -z "$item" ]] && continue
+        [[ "$item" =~ ^[A-Za-z]{2}$ ]] || die "${name} must be a comma-separated list of two-letter country codes"
+        seen=true
+    done
+
+    [[ "$seen" == "true" ]] || die "${name} must contain at least one two-letter country code"
+}
+
+validate_torrc_env() {
+    local socks_bind="${SOCKS_BIND:-0.0.0.0}"
+    local socks_port="${SOCKS_PORT:-9050}"
+    local control_bind="${CONTROL_PORT_BIND:-127.0.0.1}"
+    [[ -n "$control_bind" ]] || control_bind="127.0.0.1"
+
+    validate_tor_path "DATA_DIR" "$DATA_DIR"
+    validate_bind_address "SOCKS_BIND" "$socks_bind"
+    validate_port "SOCKS_PORT" "$socks_port"
+    validate_bind_address "CONTROL_PORT_BIND" "$control_bind"
+    validate_port "CONTROL_PORT" "$CONTROL_PORT"
+    validate_country_list "EXIT_NODES" "${EXIT_NODES:-}"
+    validate_country_list "EXCLUDE_EXIT_NODES" "${EXCLUDE_EXIT_NODES:-}"
+}
+
 ensure_runtime_dirs() {
     mkdir -p "$GENERATED_DIR" "$DATA_DIR"
 
@@ -38,7 +173,15 @@ ensure_runtime_dirs() {
 }
 
 custom_torrc_active() {
-    [[ -s "$TORRC_PATH" ]]
+    [[ -e "$TORRC_PATH" ]] || return 1
+
+    if grep -qE '^[[:space:]]*[^#[:space:]]' "$TORRC_PATH"; then
+        return 0
+    fi
+
+    local rc=$?
+    [[ "$rc" -eq 2 ]] && die "could not read TORRC_PATH: ${TORRC_PATH}"
+    return 1
 }
 
 non_default_simple_env_present() {
@@ -48,6 +191,7 @@ non_default_simple_env_present() {
     [[ -n "${EXCLUDE_EXIT_NODES:-}" ]] && return 0
     [[ -n "${PASSWORD_FILE:-}" ]] && return 0
     [[ "${CONTROL_PORT_BIND:-127.0.0.1}" != "127.0.0.1" ]] && return 0
+    [[ "${CONTROL_PORT:-9051}" != "9051" ]] && return 0
     return 1
 }
 
@@ -64,26 +208,51 @@ render_country_list() {
     printf '%s' "$out"
 }
 
-control_password_hash() {
+is_loopback_bind() {
+    [[ "$1" == "127.0.0.1" || "$1" == "::1" ]]
+}
+
+require_control_auth() {
     local bind_addr="$1"
     local password_file="${PASSWORD_FILE:-}"
 
-    if [[ -n "$password_file" ]]; then
-        [[ -r "$password_file" ]] || die "PASSWORD_FILE is set but is not readable: ${password_file}"
-
-        local control_password hashed_password
-        IFS= read -r control_password < "$password_file" || true
-        [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
-
-        hashed_password=$(tor --hash-password "$control_password" | awk '/^16:/ {print; exit}')
-        unset control_password
-        [[ -n "$hashed_password" ]] || die "failed to hash control password from PASSWORD_FILE"
-        printf '%s' "$hashed_password"
-        return
-    fi
-
-    if [[ "$bind_addr" != "127.0.0.1" ]]; then
+    if [[ -z "$password_file" ]] && ! is_loopback_bind "$bind_addr"; then
         die "CONTROL_PORT_BIND=${bind_addr} requires a readable PASSWORD_FILE; refusing unauthenticated non-loopback control port"
+    fi
+}
+
+CONTROL_PASSWORD_HASH=""
+
+load_control_password_hash() {
+    local password_file="${PASSWORD_FILE:-}"
+    local control_password hashed_password
+
+    CONTROL_PASSWORD_HASH=""
+    [[ -n "$password_file" ]] || return 0
+
+    [[ -r "$password_file" ]] || die "PASSWORD_FILE is set but is not readable: ${password_file}"
+
+    IFS= read -r control_password < "$password_file" || true
+    [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
+
+    if ! hashed_password=$(tor --hash-password "$control_password" | awk '/^16:/ {print; exit}'); then
+        unset control_password
+        die "failed to hash control password from PASSWORD_FILE"
+    fi
+    unset control_password
+
+    [[ -n "$hashed_password" ]] || die "failed to hash control password from PASSWORD_FILE"
+    CONTROL_PASSWORD_HASH="$hashed_password"
+}
+
+format_tor_endpoint() {
+    local bind_addr="$1"
+    local port="$2"
+
+    if [[ "$bind_addr" == *:* ]]; then
+        printf '[%s]:%s' "$bind_addr" "$port"
+    else
+        printf '%s:%s' "$bind_addr" "$port"
     fi
 }
 
@@ -101,20 +270,24 @@ write_simple_torrc() {
     local control_bind="${CONTROL_PORT_BIND:-127.0.0.1}"
     [[ -n "$control_bind" ]] || control_bind="127.0.0.1"
 
-    local hashed_password=""
-    hashed_password=$(control_password_hash "$control_bind")
+    require_control_auth "$control_bind"
+    load_control_password_hash
+
+    local socks_endpoint control_endpoint
+    socks_endpoint=$(format_tor_endpoint "$socks_bind" "$socks_port")
+    control_endpoint=$(format_tor_endpoint "$control_bind" "$CONTROL_PORT")
 
     {
         echo "DataDirectory ${DATA_DIR}"
         echo "PidFile ${DATA_DIR}/tor.pid"
         echo "RunAsDaemon 0"
         echo "Log notice stdout"
-        echo "SocksPort ${socks_bind}:${socks_port}"
-        echo "ControlPort ${control_bind}:${CONTROL_PORT}"
+        echo "SocksPort ${socks_endpoint}"
+        echo "ControlPort ${control_endpoint}"
         echo "CookieAuthentication 1"
         echo "CookieAuthFile ${DATA_DIR}/control_auth_cookie"
-        if [[ -n "$hashed_password" ]]; then
-            echo "HashedControlPassword ${hashed_password}"
+        if [[ -n "$CONTROL_PASSWORD_HASH" ]]; then
+            echo "HashedControlPassword ${CONTROL_PASSWORD_HASH}"
         fi
 
         if [[ -n "${EXIT_NODES:-}" ]]; then
@@ -154,6 +327,7 @@ main() {
         shift
     fi
 
+    validate_torrc_env
     ensure_runtime_dirs "$@"
 
     if custom_torrc_active; then

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -149,7 +149,8 @@ reject_sensitive_data_dir() {
     local -a denied_paths=(
         /
         /etc
-        /var
+        /var/lib
+        /tmp
         /usr
         /bin
         /sbin

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TORRC_PATH="${TORRC_PATH:-/etc/tor/torrc}"
+DATA_DIR="${DATA_DIR:-/var/lib/tor}"
+GENERATED_DIR="${GENERATED_DIR:-/tmp/tor}"
+GENERATED_TORRC="${GENERATED_TORRC:-${GENERATED_DIR}/torrc}"
+DEFAULTS_TORRC="${DEFAULTS_TORRC:-${GENERATED_DIR}/defaults-torrc}"
+CONTROL_PORT="${CONTROL_PORT:-9051}"
+
+log() {
+    printf 'tor-entrypoint: %s\n' "$*" >&2
+}
+
+warn() {
+    log "WARNING: $*"
+}
+
+die() {
+    log "ERROR: $*"
+    exit 1
+}
+
+ensure_runtime_dirs() {
+    mkdir -p "$GENERATED_DIR" "$DATA_DIR"
+
+    if [[ "$(id -u)" == "0" ]]; then
+        chown -R tor:tor "$GENERATED_DIR" "$DATA_DIR"
+        chmod 0700 "$DATA_DIR"
+        exec su-exec tor "$0" "$@"
+    fi
+
+    if [[ -w "$DATA_DIR" ]]; then
+        chmod 0700 "$DATA_DIR" 2>/dev/null || warn "could not chmod ${DATA_DIR}; Tor may refuse an insecure data directory"
+    else
+        warn "${DATA_DIR} is not writable by $(id -un); mounted volume ownership may need correction"
+    fi
+}
+
+custom_torrc_active() {
+    [[ -s "$TORRC_PATH" ]]
+}
+
+non_default_simple_env_present() {
+    [[ "${SOCKS_PORT:-9050}" != "9050" ]] && return 0
+    [[ "${SOCKS_BIND:-0.0.0.0}" != "0.0.0.0" ]] && return 0
+    [[ -n "${EXIT_NODES:-}" ]] && return 0
+    [[ -n "${EXCLUDE_EXIT_NODES:-}" ]] && return 0
+    [[ -n "${PASSWORD_FILE:-}" ]] && return 0
+    [[ "${CONTROL_PORT_BIND:-127.0.0.1}" != "127.0.0.1" ]] && return 0
+    return 1
+}
+
+render_country_list() {
+    local raw="$1"
+    local item out=""
+    local -a parts
+    IFS=',' read -r -a parts <<< "$raw"
+    for item in "${parts[@]}"; do
+        item="${item//[[:space:]]/}"
+        [[ -z "$item" ]] && continue
+        out="${out:+${out},}{${item}}"
+    done
+    printf '%s' "$out"
+}
+
+control_password_hash() {
+    local bind_addr="$1"
+    local password_file="${PASSWORD_FILE:-}"
+
+    if [[ -n "$password_file" ]]; then
+        [[ -r "$password_file" ]] || die "PASSWORD_FILE is set but is not readable: ${password_file}"
+
+        local control_password hashed_password
+        IFS= read -r control_password < "$password_file" || true
+        [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
+
+        hashed_password=$(tor --hash-password "$control_password" | awk '/^16:/ {print; exit}')
+        unset control_password
+        [[ -n "$hashed_password" ]] || die "failed to hash control password from PASSWORD_FILE"
+        printf '%s' "$hashed_password"
+        return
+    fi
+
+    if [[ "$bind_addr" != "127.0.0.1" ]]; then
+        die "CONTROL_PORT_BIND=${bind_addr} requires a readable PASSWORD_FILE; refusing unauthenticated non-loopback control port"
+    fi
+}
+
+write_plumbing_defaults() {
+    cat > "$DEFAULTS_TORRC" <<EOF
+DataDirectory ${DATA_DIR}
+PidFile ${DATA_DIR}/tor.pid
+Log notice stdout
+EOF
+}
+
+write_simple_torrc() {
+    local socks_bind="${SOCKS_BIND:-0.0.0.0}"
+    local socks_port="${SOCKS_PORT:-9050}"
+    local control_bind="${CONTROL_PORT_BIND:-127.0.0.1}"
+    [[ -n "$control_bind" ]] || control_bind="127.0.0.1"
+
+    local hashed_password=""
+    hashed_password=$(control_password_hash "$control_bind")
+
+    {
+        echo "DataDirectory ${DATA_DIR}"
+        echo "PidFile ${DATA_DIR}/tor.pid"
+        echo "RunAsDaemon 0"
+        echo "Log notice stdout"
+        echo "SocksPort ${socks_bind}:${socks_port}"
+        echo "ControlPort ${control_bind}:${CONTROL_PORT}"
+        echo "CookieAuthentication 1"
+        echo "CookieAuthFile ${DATA_DIR}/control_auth_cookie"
+        if [[ -n "$hashed_password" ]]; then
+            echo "HashedControlPassword ${hashed_password}"
+        fi
+
+        if [[ -n "${EXIT_NODES:-}" ]]; then
+            local exit_nodes
+            exit_nodes=$(render_country_list "$EXIT_NODES")
+            [[ -n "$exit_nodes" ]] && echo "ExitNodes ${exit_nodes}"
+        fi
+
+        if [[ -n "${EXCLUDE_EXIT_NODES:-}" ]]; then
+            local exclude_exit_nodes
+            exclude_exit_nodes=$(render_country_list "$EXCLUDE_EXIT_NODES")
+            [[ -n "$exclude_exit_nodes" ]] && echo "ExcludeExitNodes ${exclude_exit_nodes}"
+        fi
+    } > "$GENERATED_TORRC"
+}
+
+warn_if_identity_not_persistent() {
+    local active_torrc="$1"
+
+    grep -Eiq '^[[:space:]]*(HiddenServiceDir|ORPort)\b' "$active_torrc" || return 0
+
+    local root_dev data_dev
+    root_dev=$(stat -c '%d' / 2>/dev/null || true)
+    data_dev=$(stat -c '%d' "$DATA_DIR" 2>/dev/null || true)
+
+    if [[ -n "$root_dev" && -n "$data_dev" && "$root_dev" == "$data_dev" ]]; then
+        warn "${DATA_DIR} does not look like a mounted volume (best-effort check). Relay, bridge, or hidden-service identity will not survive container replacement unless this path is persisted."
+    fi
+}
+
+main() {
+    if [[ $# -gt 0 && "${1:-}" != "tor" && "${1:0:1}" != "-" ]]; then
+        exec "$@"
+    fi
+
+    if [[ "${1:-}" == "tor" ]]; then
+        shift
+    fi
+
+    ensure_runtime_dirs "$@"
+
+    if custom_torrc_active; then
+        if non_default_simple_env_present; then
+            warn "custom ${TORRC_PATH} is active; SOCKS/control/exit-node environment variables are ignored"
+        fi
+        write_plumbing_defaults
+        warn_if_identity_not_persistent "$TORRC_PATH"
+        exec tor -f "$TORRC_PATH" --defaults-torrc "$DEFAULTS_TORRC" "$@"
+    fi
+
+    write_simple_torrc
+    exec tor -f "$GENERATED_TORRC" "$@"
+}
+
+main "$@"

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 TORRC_PATH="${TORRC_PATH:-/etc/tor/torrc}"
-DATA_DIR="${DATA_DIR:-/var/lib/tor}"
+readonly DATA_DIR="/var/lib/tor"
 readonly GENERATED_DIR="/tmp/tor"
 readonly GENERATED_TORRC="${GENERATED_DIR}/torrc"
 readonly DEFAULTS_TORRC="${GENERATED_DIR}/defaults-torrc"
@@ -124,60 +124,6 @@ validate_bind_address() {
     die "${name} must be a plain IPv4 or IPv6 address"
 }
 
-validate_tor_path() {
-    local name="$1"
-    local value="$2"
-    local segment trimmed
-    local -a segments
-
-    reject_control_chars "$name" "$value"
-    [[ "$value" == /* ]] || die "${name} must be an absolute path"
-    [[ "$value" != "/" ]] || die "${name} must not be the filesystem root"
-    [[ "$value" =~ ^/[A-Za-z0-9._@:+-]+(/[A-Za-z0-9._@:+-]+)*/?$ ]] || die "${name} contains unsupported path characters"
-
-    trimmed="${value%/}"
-    IFS='/' read -r -a segments <<< "${trimmed#/}"
-    for segment in "${segments[@]}"; do
-        [[ "$segment" != "." && "$segment" != ".." ]] || die "${name} must not contain . or .. path segments"
-    done
-}
-
-reject_sensitive_data_dir() {
-    local value="${1%/}"
-    local denied
-    local allowed_data_dir="/var/lib/tor"
-    local -a denied_paths=(
-        /
-        /etc
-        /var/lib
-        /tmp
-        /usr
-        /bin
-        /sbin
-        /lib
-        /lib64
-        /proc
-        /sys
-        /dev
-        /root
-        /boot
-        /home
-    )
-
-    if [[ "$value" == "$allowed_data_dir" || "$value" == "$allowed_data_dir"/* ]]; then
-        return 0
-    fi
-
-    for denied in "${denied_paths[@]}"; do
-        if [[ "$value" == "$denied" || "$value" == "$denied"/* ]]; then
-            die "DATA_DIR must not be a sensitive system path: ${denied}"
-        fi
-        if [[ "$denied" == "$value"/* ]]; then
-            die "DATA_DIR must not be a parent of sensitive system path: ${denied}"
-        fi
-    done
-}
-
 validate_country_list() {
     local name="$1"
     local raw="$2"
@@ -210,11 +156,6 @@ validate_torrc_env() {
     validate_port "CONTROL_PORT" "$CONTROL_PORT"
     validate_country_list "EXIT_NODES" "${EXIT_NODES:-}"
     validate_country_list "EXCLUDE_EXIT_NODES" "${EXCLUDE_EXIT_NODES:-}"
-}
-
-validate_runtime_paths() {
-    validate_tor_path "DATA_DIR" "$DATA_DIR"
-    reject_sensitive_data_dir "$DATA_DIR"
 }
 
 ensure_runtime_dirs() {
@@ -303,7 +244,8 @@ load_control_password_hash() {
     IFS= read -r control_password < "$password_file" || true
     [[ -n "$control_password" ]] || die "PASSWORD_FILE is empty: ${password_file}"
 
-    if [[ "$control_password" =~ ^16:[0-9A-Fa-f]+$ ]]; then
+    if [[ "$control_password" == 16:* ]]; then
+        [[ "$control_password" =~ ^16:[0-9A-Fa-f]{58}$ ]] || die "PASSWORD_FILE contains invalid pre-hashed Tor control password; expected 16: followed by 58 hexadecimal digits"
         CONTROL_PASSWORD_HASH="$control_password"
         unset control_password
         return 0
@@ -415,7 +357,6 @@ main() {
         shift
     fi
 
-    validate_runtime_paths
     ensure_runtime_dirs "$@"
 
     if custom_torrc_active; then

--- a/tor/entrypoint.sh
+++ b/tor/entrypoint.sh
@@ -115,10 +115,19 @@ validate_bind_address() {
 validate_tor_path() {
     local name="$1"
     local value="$2"
+    local segment trimmed
+    local -a segments
 
     reject_control_chars "$name" "$value"
     [[ "$value" == /* ]] || die "${name} must be an absolute path"
-    [[ "$value" =~ ^/[A-Za-z0-9._/@:+-]*$ ]] || die "${name} contains unsupported path characters"
+    [[ "$value" != "/" ]] || die "${name} must not be the filesystem root"
+    [[ "$value" =~ ^/[A-Za-z0-9._@:+-]+(/[A-Za-z0-9._@:+-]+)*/?$ ]] || die "${name} contains unsupported path characters"
+
+    trimmed="${value%/}"
+    IFS='/' read -r -a segments <<< "${trimmed#/}"
+    for segment in "${segments[@]}"; do
+        [[ "$segment" != "." && "$segment" != ".." ]] || die "${name} must not contain . or .. path segments"
+    done
 }
 
 validate_country_list() {
@@ -147,13 +156,17 @@ validate_torrc_env() {
     local control_bind="${CONTROL_PORT_BIND:-127.0.0.1}"
     [[ -n "$control_bind" ]] || control_bind="127.0.0.1"
 
-    validate_tor_path "DATA_DIR" "$DATA_DIR"
     validate_bind_address "SOCKS_BIND" "$socks_bind"
     validate_port "SOCKS_PORT" "$socks_port"
     validate_bind_address "CONTROL_PORT_BIND" "$control_bind"
     validate_port "CONTROL_PORT" "$CONTROL_PORT"
     validate_country_list "EXIT_NODES" "${EXIT_NODES:-}"
     validate_country_list "EXCLUDE_EXIT_NODES" "${EXCLUDE_EXIT_NODES:-}"
+}
+
+validate_runtime_paths() {
+    validate_tor_path "DATA_DIR" "$DATA_DIR"
+    validate_tor_path "GENERATED_DIR" "$GENERATED_DIR"
 }
 
 ensure_runtime_dirs() {
@@ -327,7 +340,7 @@ main() {
         shift
     fi
 
-    validate_torrc_env
+    validate_runtime_paths
     ensure_runtime_dirs "$@"
 
     if custom_torrc_active; then
@@ -339,6 +352,7 @@ main() {
         exec tor -f "$TORRC_PATH" --defaults-torrc "$DEFAULTS_TORRC" "$@"
     fi
 
+    validate_torrc_env
     write_simple_torrc
     exec tor -f "$GENERATED_TORRC" "$@"
 }

--- a/tor/variants.yaml
+++ b/tor/variants.yaml
@@ -1,0 +1,23 @@
+# Tor Container Variants
+# Defines default and monitoring image variants.
+#
+# Tags:
+#   ghcr.io/oorabona/tor:0.4.9.11-alpine
+#   ghcr.io/oorabona/tor:0.4.9.11-alpine-monitoring
+
+build:
+  requires_extensions: false
+  version_retention: 3
+
+versions:
+  - tag: 0.4.9.11-alpine
+    variants:
+      - name: default
+        suffix: ""
+        flavor: default
+        description: "Tor + Lyrebird SOCKS proxy, relay, bridge, and hidden-service support"
+        default: true
+      - name: monitoring
+        suffix: "-monitoring"
+        flavor: monitoring
+        description: "Default Tor image plus Nyx and py3-stem for in-container monitoring"

--- a/tor/version.sh
+++ b/tor/version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Get latest upstream Tor version.
+#
+#   version.sh --upstream         -> raw upstream version, e.g. 0.4.9.11
+#   version.sh --tag-suffix       -> image tag suffix, e.g. -alpine
+#   version.sh --registry-pattern -> regex for published default tags
+
+set -euo pipefail
+
+TAG_SUFFIX="-alpine"
+
+case "${1:-}" in
+    --registry-pattern)
+        echo "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+${TAG_SUFFIX}$"
+        exit 0
+        ;;
+    --tag-suffix)
+        echo "$TAG_SUFFIX"
+        exit 0
+        ;;
+esac
+
+upstream_version=$("$(dirname "$0")/../helpers/latest-gitlab-tag" "tpo%2Fcore%2Ftor" \
+    --tag-filter '^tor-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+    --version-extract '^tor-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$')
+
+if [[ -z "$upstream_version" ]]; then
+    exit 1
+fi
+
+case "${1:-}" in
+    --upstream)
+        echo "$upstream_version"
+        ;;
+    *)
+        echo "${upstream_version}${TAG_SUFFIX}"
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds a `tor` container: a Tor SOCKS proxy supporting relay, exit, bridge,
and hidden-service modes, with Lyrebird pluggable-transport support and an
optional Nyx monitoring flavor. Wrapped in this project's existing
supply-chain pipeline (SBOM + Sigstore attestation, Trivy scanning,
multi-arch buildx, daily upstream version tracking).

- **Security-by-default control port**: uses Tor's native cookie
  authentication (no password anywhere in the default path); the control
  port is never published and binds to loopback only. Opting into external
  control requires both an explicit credential (plaintext or pre-hashed)
  and an explicit bind-widening flag, and fails startup loudly if only one
  is set.
- **Layered configuration**: simple environment variables for the common
  SOCKS-proxy case, or mount a full `torrc` for relay/bridge/hidden-service
  setups.
- **New GitLab-tags dependency source** (`helpers/latest-gitlab-tag`) for
  tracking Tor and Lyrebird releases on `gitlab.torproject.org`, alongside
  the existing PyPI tracking for Nyx.
- All environment-variable-driven config values are validated before being
  written into the generated Tor configuration.

## Known follow-ups (non-blocking)

An automated review pass flagged a few additional defense-in-depth items
for a follow-up: log-escaping edge cases in the version-lookup helpers,
prerelease-version handling in the GitLab/GitHub tag helpers, expanding
authenticated-token support to self-hosted GitLab hosts, and a couple of
healthcheck edge cases for uncommon custom-torrc configurations. None are
exploitable in this container's documented usage; tracked for follow-up.

## Test plan

- [x] Both image flavors (default, monitoring) build successfully
- [x] Live SOCKS5 request through the published port round-trips through
      the real Tor network
- [x] Cookie authentication active by default; control port never exposed
- [x] Injection/validation regression suite passes (targeted `bats` +
      `shellcheck`, all green)
- [x] Dependency-update check resolves Tor/Lyrebird/Nyx versions through
      the new GitLab-tags source
