### PR TITLE
fix(ci): exclude docs from detect-containers change mapping

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -417,7 +417,20 @@ runs:
               if [[ ! "$file" =~ / ]]; then
                 continue
               fi
-              
+
+              # Docs/metadata never affect build inputs — mirrors this workflow's
+              # own trigger-path exclusions. Without this, a per-container README
+              # bundled into a wider diff (e.g. via the coverage-checkpoint
+              # baseline window) wrongly queues that container for a rebuild.
+              # LAST_REBUILD.md is the one exception: it's an explicit
+              # rebuild-signal marker consumed by the smart-rebuild digest.
+              case "$file" in
+                */LAST_REBUILD.md) ;;
+                *.md|*/README*|*/LICENSE*|*/CHANGELOG*|*/docs/*|*/tests/*)
+                  continue
+                  ;;
+              esac
+
               # Extract the top-level directory from the file path
               container="${file%%/*}"
               


### PR DESCRIPTION
## Summary

- The per-file→container detection loop in `detect-containers/action.yaml` had no doc/README exclusion of its own, unlike the workflow's trigger `paths:` filter.
- On a master push, the diff basis is the coverage-checkpoint baseline tag, not the immediate before/after — so a doc-only PR that correctly never triggered its own build run can sit unbuilt until the next real push bundles it into the checkpoint diff window, and every container it touched (README, docs/, tests/, LICENSE, CHANGELOG) gets wrongly queued for a full rebuild.
- Observed live: a docs-only PR touching 13 per-container READMEs (correctly excluded from triggering its own run) got bundled into the next real push's checkpoint-diff window, causing all 13 containers to rebuild for no code change. Confirmed via the run's own logs (`baseline_valid=true`, diff spanned both PRs) and `git show --stat` on the docs PR (13 README-only files).
- Fix mirrors the workflow-level exclusion inside the per-file loop: skip `*.md`, `*/README*`, `*/LICENSE*`, `*/CHANGELOG*`, `*/docs/*`, `*/tests/*`, except `LAST_REBUILD.md` (the deliberate rebuild-signal marker already consumed by the smart-rebuild digest).

## Test plan

- [x] Full unit suite green (1957/1957, `tests/run-tests.sh`)
- [x] Empirically simulated the fixed loop against the real diff that caused the incident (13 READMEs + tor's real files + `tor/LAST_REBUILD.md`) — confirms only `tor` is queued, matching intent
- [x] `yamllint` clean (no new syntax issues; pre-existing line-length style warnings only)
- [x] Cross-family gate: clean on first pass
