### PR TITLE
feat(dashboard): durable Docker Hub pull-count history + trend view

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -86,6 +86,7 @@ on:
       - '!test-harness/**'                      # Test fixtures
       - '!test-logs/**'                         # Generated test logs
       - '!archive/**'                           # Archived containers
+      - '!stats/**'                             # Docker Hub stats snapshots
       - '!**/*.md'                              # Markdown anywhere — READMEs, ADRs, notes (never a build input)
       - '!**/README*'                           # README without .md suffix
       - '!**/LICENSE*'                          # License files
@@ -114,6 +115,7 @@ on:
       - '!test-harness/**'                      # Test fixtures
       - '!test-logs/**'                         # Generated test logs
       - '!archive/**'                           # Archived containers
+      - '!stats/**'                             # Docker Hub stats snapshots
       - '!**/*.md'                              # Markdown anywhere — READMEs, ADRs, notes (never a build input)
       - '!**/README*'                           # README without .md suffix
       - '!**/LICENSE*'                          # License files

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
         default: 'Manual update'
-  # Daily refresh — guarantees stats-history snapshot lands every day,
+  # Daily refresh — attempts a best-effort stats-history snapshot every day,
   # even when upstream-monitor finds no updates (quiet days).
   # Runs after upstream-monitor (06:00 UTC) so any same-day dep updates are reflected.
   schedule:
@@ -31,13 +31,18 @@ on:
       - "*.md"
       - "*/README.md"
       - "generate-dashboard.sh"
+      - "scripts/snapshot-stats.sh"
+      - "scripts/commit-stats-snapshot.sh"
+      # Bot stats commits use GITHUB_TOKEN and cannot retrigger workflows.
+      - "stats/**"
       - ".github/workflows/update-dashboard.yaml"
 
   # Fires once after each Auto Build & Push completion on master.
-  # Combined with `concurrency.cancel-in-progress: true` below, a batch of
-  # parallel auto-builds collapses to a single dashboard deploy: each new
-  # auto-build completion supersedes any in-flight update-dashboard run,
-  # so only the LAST one in the batch actually deploys.
+  # Combined with `build`'s job-level `concurrency.cancel-in-progress: true`
+  # below, a batch of parallel auto-builds collapses to a single dashboard
+  # build: each new auto-build completion supersedes any in-flight build job,
+  # so only the LAST one in the batch actually proceeds to deploy (`deploy`
+  # itself never cancels a peer — see its own concurrency note).
   # The build/deploy `if:` clauses below add per-event filters so that
   # PR-triggered Auto Build runs (smoke builds, no GHCR push) do not
   # cause a stale-data Pages redeploy that could cancel a real one.
@@ -55,15 +60,14 @@ permissions:
   pages: write
   security-events: read   # gh api code-scanning/alerts for trust-strip trivy_summary
 
-# Allow only one concurrent deployment. With cancel-in-progress: true, a batch of parallel
-# auto-build completions collapses to a single dashboard deploy — each successive workflow_run
-# event supersedes any in-flight run so only the last one in the batch actually deploys.
-# Side effect for `workflow_call` callers (`upstream-monitor`, `recreate-manifests`):
-# their dashboard step may be terminated mid-flight by a later auto-build completion.
-# Acceptable by design — the later run redeploys with fresher data.
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+# NOTE: no workflow-level `concurrency` block. GitHub Actions concurrency
+# groups are scoped by NAME across the whole repository, not per workflow
+# file — a workflow-level group here would cancel the ENTIRE run (all jobs,
+# unconditionally) whenever a newer run shares the group, which would also
+# kill commit-stats-snapshot (an unrelated job below) mid-persist even on
+# triggers that can't themselves run that job. The "pages" group is scoped to
+# just the `build` and `deploy` jobs below instead — the collapse-redundant-
+# rebuilds behavior they need — so it can never reach commit-stats-snapshot.
 
 jobs:
   # Build job with integrated dashboard generation
@@ -80,6 +84,23 @@ jobs:
        github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Allow only one concurrent build. With cancel-in-progress: true, a batch of parallel
+    # auto-build completions collapses to a single dashboard build — each successive workflow_run
+    # event supersedes any in-flight build so only the last one in the batch actually proceeds.
+    # Side effect for `workflow_call` callers (`upstream-monitor`, `recreate-manifests`):
+    # this job may be terminated mid-flight by a later auto-build completion.
+    # Acceptable by design — the later run rebuilds with fresher data; a build has no
+    # side effects yet, so cancelling it wastes nothing already published.
+    #
+    # Deliberately a SEPARATE group from `deploy`'s below, not shared: sharing one
+    # "pages" group across build+deploy meant an unrelated newer build starting could
+    # cancel an in-flight DEPLOY (concurrency groups don't distinguish job identity,
+    # only the group string) — killing an already-ready publish and leaving the site
+    # stale until the newer run's own build+deploy fully completes. Job-scoped (not
+    # workflow-level) so it can never reach the unrelated commit-stats-snapshot job.
+    concurrency:
+      group: "pages-build"
+      cancel-in-progress: true
     steps:
 
       - name: Checkout
@@ -485,10 +506,17 @@ jobs:
           chmod +x scripts/enrich-lineage.sh
           ./scripts/enrich-lineage.sh --owner "${{ github.repository_owner }}"
 
-      - name: Snapshot pull/star counts (idempotent per day)
-        run: |
-          chmod +x scripts/snapshot-stats.sh
-          ./scripts/snapshot-stats.sh
+      # No inline stats-snapshot step here (deliberate — see #876 hardening):
+      # the trend sparkline reads stats/dockerhub-pull-history.jsonl straight
+      # from this job's checkout, which already reflects whatever the
+      # separate commit-stats-snapshot job last actually committed — a single
+      # source of truth. An inline local-only fetch here would append a row
+      # this job never commits, letting this build's rendered trend show a
+      # DIFFERENT pull_count for today than what commit-stats-snapshot later
+      # persists to git (two independent Docker Hub fetches, no ordering
+      # guarantee between them) — a real inconsistency, not just staleness.
+      # Current-count display is unaffected: it's a separate live API call
+      # (get_dockerhub_stats), not sourced from this file at all.
 
       - name: Audit base image cache coverage (non-blocking)
         run: |
@@ -511,11 +539,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GHCR_CACHE_DIR: ${{ github.workspace }}/.ghcr-cache
           DASHBOARD_TRACE: ${{ (contains(github.event.inputs.trigger_reason, 'TRACE') || contains(inputs.trigger_reason, 'TRACE')) && '1' || '' }}
+          # Untrusted free-text input (workflow_dispatch/workflow_call caller-supplied) —
+          # passed via env:, never interpolated directly into the run: script, so it
+          # can't break out of quoting and execute commands on the runner.
+          TRIGGER_REASON: ${{ github.event.inputs.trigger_reason || inputs.trigger_reason || 'Automated update' }}
         run: |
           chmod +x generate-dashboard.sh
 
           # Set environment variables for dashboard context
-          export UPDATE_REASON="${{ github.event.inputs.trigger_reason || inputs.trigger_reason || 'Automated update' }}"
+          # Strip control characters (the caller-supplied part of TRIGGER_REASON
+          # is untrusted free text) so it can't spoof extra log lines or GHA
+          # workflow-command annotations via an embedded newline.
+          export UPDATE_REASON="$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]')"
           export GITHUB_EVENT_NAME="${{ github.event_name }}"
 
           echo "🚀 Generating dashboard data with context:"
@@ -621,7 +656,7 @@ jobs:
             gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$id" || true
           done
 
-      - name: Save updated lineage cache (preserves stats history)
+      - name: Save updated lineage cache (best-effort stats history carry-forward)
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -647,6 +682,76 @@ jobs:
         with:
           path: ./_site
 
+  commit-stats-snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Own concurrency group, with a name that can never collide with the
+    # `pages` group used by `build`/`deploy` (GitHub Actions concurrency
+    # groups are scoped by name across the whole repo, not per job or per
+    # workflow file — a shared name would let an unrelated Pages run cancel
+    # this job mid-flight even on triggers that can't themselves run it).
+    # cancel-in-progress: false means an in-progress run of THIS job is never
+    # killed by a newer trigger — it queues instead. GitHub keeps at most one
+    # PENDING run per group by default (not `queue: max`): if several
+    # triggers arrive in a burst while one run is executing, only the LATEST
+    # pending one survives to actually run once the current run finishes,
+    # not all of them in sequence. That's fine here — the script is fully
+    # idempotent (skips containers already recorded today) and retries
+    # internally, so a coalesced run reconciles the same "what's still
+    # missing today" state any of the superseded ones would have. The
+    # trade-off is fewer independent retry attempts across a burst, not a
+    # correctness gap — this design already accepts same-day recovery isn't
+    # guaranteed (see the header comment in commit-stats-snapshot.sh).
+    concurrency:
+      group: commit-stats-snapshot
+      cancel-in-progress: false
+    # Deliberately excludes workflow_call — recreate-manifests.yaml (the only
+    # current workflow_call caller) grants only contents: read and cannot safely
+    # be assumed to propagate contents: write through a reusable-workflow call.
+    # Direct invocations are the best-effort persistence attempts for this job:
+    # schedule, push, workflow_dispatch on master, and filtered workflow_run. A
+    # missed cron attempt is commonly recovered by the same day's post-build
+    # workflow_run with a fresh checkout and retry loop. The narrow irrecoverable
+    # data-loss case is a UTC day with zero container builds, where the schedule
+    # is the only invocation and all 3 persistence attempts are exhausted before
+    # midnight — and now visible: the script exits non-zero when it ends with
+    # anything still missing, rather than always reporting success.
+    # A successful push also self-triggers a follow-up dashboard build (see the
+    # script's own `gh workflow run` call) so the deployed trend does not have
+    # to wait for the next independent trigger — needs `actions: write` below.
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'pull_request' &&
+       github.event.workflow_run.head_branch == 'master')
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: 'refs/heads/master'
+          persist-credentials: false
+
+      - name: Restore build lineage cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build-lineage
+          key: build-lineage-never-exact-match
+          restore-keys: build-lineage-
+
+      - name: Commit stats snapshot (non-blocking)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          chmod +x scripts/commit-stats-snapshot.sh
+          ./scripts/commit-stats-snapshot.sh
+
   # Deployment job - only deploy from main/master branch or manual dispatch
   deploy:
     environment:
@@ -655,12 +760,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
+    # Own group, deliberately separate from `build`'s "pages-build" — see the
+    # note on that job for why they must not share a name. cancel-in-progress:
+    # false here (unlike build) because a deploy in progress has already
+    # started publishing; killing it mid-flight can leave Pages in a partial
+    # state for no benefit. A newer deploy queues behind it instead — deploys
+    # are quick, and GitHub Pages' own environment concurrency additionally
+    # serializes them, so the wait is short and this never piles up under
+    # normal batching (superseded builds get cancelled before their deploy
+    # is even eligible to run, since `needs: build` requires success).
+    concurrency:
+      group: "pages-deploy"
+      cancel-in-progress: false
     # Only deploy if:
     # 1. Triggered by push to master branch, OR
     # 2. Manually dispatched from workflow_dispatch, OR
     # 3. Daily schedule cron (so a 7am cron always reaches Pages and isn't
     #    just a build-and-discard — otherwise it could cancel a real deploy
-    #    via the shared `pages` concurrency group), OR
+    #    via the `pages-build` concurrency group), OR
     # 4. Called from workflow_call but NOT from a pull request context, OR
     # 5. Triggered by a successful Auto Build & Push completion on master,
     #    excluding PR-triggered upstream runs (smoke builds, stale data risk)
@@ -679,26 +796,30 @@ jobs:
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
       - name: Create workflow summary
+        env:
+          TRIGGER_REASON: ${{ github.event.inputs.trigger_reason || inputs.trigger_reason }}
         run: |
-          echo "# 📊 Dashboard & Jekyll Site Deployed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| **Site URL** | [${{ steps.deployment.outputs.page_url }}](${{ steps.deployment.outputs.page_url }}) |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Dashboard** | [${{ steps.deployment.outputs.page_url }}dashboard/](${{ steps.deployment.outputs.page_url }}dashboard/) |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Trigger** | \`${{ github.event_name }}\` |" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# 📊 Dashboard & Jekyll Site Deployed"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| **Site URL** | [${{ steps.deployment.outputs.page_url }}](${{ steps.deployment.outputs.page_url }}) |"
+            echo "| **Dashboard** | [${{ steps.deployment.outputs.page_url }}dashboard/](${{ steps.deployment.outputs.page_url }}dashboard/) |"
+            echo "| **Trigger** | \`${{ github.event_name }}\` |"
 
-          if [ "${{ github.event_name }}" != "push" ]; then
-            echo "| **Reason** | \`${{ github.event.inputs.trigger_reason || inputs.trigger_reason }}\` |" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [ "${{ github.event_name }}" != "push" ]; then
+              printf '| **Reason** | `%s` |\n' "$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')"
+            fi
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🌟 Live Site Features" >> $GITHUB_STEP_SUMMARY
-          echo "- 📊 **Interactive Dashboard**: Real-time container status" >> $GITHUB_STEP_SUMMARY
-          echo "- 📚 **Documentation Hub**: Complete guides and APIs" >> $GITHUB_STEP_SUMMARY
-          echo "- 🔄 **Workflow Integration**: Direct links to GitHub Actions" >> $GITHUB_STEP_SUMMARY
-          echo "- 📱 **Mobile Friendly**: Responsive Jekyll theme" >> $GITHUB_STEP_SUMMARY
-          echo "- 🎨 **Professional Design**: GitHub's official Minima theme" >> $GITHUB_STEP_SUMMARY
+            echo ""
+            echo "### 🌟 Live Site Features"
+            echo "- 📊 **Interactive Dashboard**: Real-time container status"
+            echo "- 📚 **Documentation Hub**: Complete guides and APIs"
+            echo "- 🔄 **Workflow Integration**: Direct links to GitHub Actions"
+            echo "- 📱 **Mobile Friendly**: Responsive Jekyll theme"
+            echo "- 🎨 **Professional Design**: GitHub's official Minima theme"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Summary for skipped deployments (PR contexts)
   deploy-skipped:
@@ -709,23 +830,27 @@ jobs:
     if: github.event_name == 'workflow_call' && github.ref != 'refs/heads/master'
     steps:
       - name: Create skipped deployment summary
+        env:
+          TRIGGER_REASON: ${{ github.event.inputs.trigger_reason || inputs.trigger_reason }}
         run: |
-          echo "# 📊 Dashboard Generated (Deployment Skipped)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| **Trigger** | \`${{ github.event_name }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Branch** | \`${{ github.ref_name }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Status** | Dashboard built, deployment skipped |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Reason** | \`${{ github.event.inputs.trigger_reason || inputs.trigger_reason }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### ℹ️ Deployment Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "GitHub Pages deployment only occurs from the \`master\` branch due to environment protection rules." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**✅ What was completed:**" >> $GITHUB_STEP_SUMMARY
-          echo "- 📊 Dashboard content generated successfully" >> $GITHUB_STEP_SUMMARY
-          echo "- 🏗️ Jekyll site built and validated" >> $GITHUB_STEP_SUMMARY
-          echo "- 📦 Deployment artifact prepared" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**🚀 Next steps:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Dashboard will be deployed automatically when changes are merged to \`master\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# 📊 Dashboard Generated (Deployment Skipped)"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| **Trigger** | \`${{ github.event_name }}\` |"
+            echo "| **Branch** | \`${{ github.ref_name }}\` |"
+            echo "| **Status** | Dashboard built, deployment skipped |"
+            printf '| **Reason** | `%s` |\n' "$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')"
+            echo ""
+            echo "### ℹ️ Deployment Skipped"
+            echo "GitHub Pages deployment only occurs from the \`master\` branch due to environment protection rules."
+            echo ""
+            echo "**✅ What was completed:**"
+            echo "- 📊 Dashboard content generated successfully"
+            echo "- 🏗️ Jekyll site built and validated"
+            echo "- 📦 Deployment artifact prepared"
+            echo ""
+            echo "**🚀 Next steps:**"
+            echo "- Dashboard will be deployed automatically when changes are merged to \`master\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -210,9 +210,58 @@
           {%- endif -%}
           <section id="container-stats" class="stats-strip" aria-label="Container statistics">
             {%- if page.pull_count_formatted or page.pull_count -%}
+            {%- assign _pull_trend_size = 0 -%}
+            {%- if page.pull_trend -%}
+              {%- assign _pull_trend_size = page.pull_trend.size -%}
+            {%- endif -%}
             <div class="stat">
               <span class="eyebrow">PULLS</span>
-              <span class="value">{{ page.pull_count_formatted | default: page.pull_count | default: "0" }}</span>
+              <span class="value">
+                {{ page.pull_count_formatted | default: page.pull_count | default: "0" }}
+                {%- if _pull_trend_size > 1 -%}
+                  {%- assign _trend_first = page.pull_trend | first -%}
+                  {%- assign _trend_last = page.pull_trend | last -%}
+                  {%- assign _trend_min = _trend_first.pull_count | plus: 0 -%}
+                  {%- assign _trend_max = _trend_first.pull_count | plus: 0 -%}
+                  {%- for _trend_point in page.pull_trend -%}
+                    {%- assign _trend_count = _trend_point.pull_count | plus: 0 -%}
+                    {%- if _trend_count < _trend_min -%}{%- assign _trend_min = _trend_count -%}{%- endif -%}
+                    {%- if _trend_count > _trend_max -%}{%- assign _trend_max = _trend_count -%}{%- endif -%}
+                  {%- endfor -%}
+                  {%- assign _trend_range = _trend_max | minus: _trend_min -%}
+                  {%- assign _trend_denominator = _pull_trend_size | minus: 1 -%}
+                  {%- capture _trend_svg_points -%}
+                    {%- for _trend_point in page.pull_trend -%}
+                      {%- assign _trend_count = _trend_point.pull_count | plus: 0 -%}
+                      {%- assign _trend_x = forloop.index0 | times: 116 | divided_by: _trend_denominator | plus: 2 -%}
+                      {%- if _trend_range == 0 -%}
+                        {%- assign _trend_y = 14 -%}
+                      {%- else -%}
+                        {%- assign _trend_delta = _trend_count | minus: _trend_min -%}
+                        {%- assign _trend_y_offset = _trend_delta | times: 24 | divided_by: _trend_range -%}
+                        {%- assign _trend_y = 26 | minus: _trend_y_offset -%}
+                      {%- endif -%}
+                      {{ _trend_x }},{{ _trend_y }}{% unless forloop.last %} {% endunless %}
+                    {%- endfor -%}
+                  {%- endcapture -%}
+                  <svg class="pull-trend-sparkline"
+                       width="120"
+                       height="28"
+                       viewBox="0 0 120 28"
+                       role="img"
+                       aria-labelledby="pull-trend-title-{{ page.name | slugify }}"
+                       focusable="false"
+                       style="display:inline-block;vertical-align:middle;margin-left:8px;overflow:visible">
+                    <title id="pull-trend-title-{{ page.name | slugify }}">{{ _trend_first.pull_count }} to {{ _trend_last.pull_count }} pulls across {{ _pull_trend_size }} recorded days</title>
+                    <polyline points="{{ _trend_svg_points | strip }}"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round" />
+                  </svg>
+                {%- endif -%}
+              </span>
             </div>
             {%- endif -%}
             {%- if page.star_count -%}

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1186,6 +1186,57 @@ format_number() {
     fi
 }
 
+# Cached Docker Hub pull-count trend data, keyed by container name.
+declare -g DOCKERHUB_PULL_TRENDS_CACHE=""
+
+load_dockerhub_pull_trends() {
+    if [[ -n "${DOCKERHUB_PULL_TRENDS_CACHE:-}" ]]; then
+        echo "$DOCKERHUB_PULL_TRENDS_CACHE"
+        return
+    fi
+
+    local history_file="$SCRIPT_DIR/stats/dockerhub-pull-history.jsonl"
+    if [[ ! -f "$history_file" ]]; then
+        DOCKERHUB_PULL_TRENDS_CACHE="{}"
+        echo "$DOCKERHUB_PULL_TRENDS_CACHE"
+        return
+    fi
+
+    DOCKERHUB_PULL_TRENDS_CACHE=$(jq -Rn '
+        [
+          inputs
+          | (try fromjson catch empty)
+          | select((.date? | type) == "string")
+          | select((.container? | type) == "string")
+          | select(has("pull_count"))
+          | (.pull_count | tonumber?) as $pull_count
+          | select($pull_count != null)
+          | {date: .date, container: .container, pull_count: $pull_count}
+        ] as $rows
+        | reduce $rows[] as $row ({}; .[$row.container + "\u0000" + $row.date] = $row)
+        | [.[]]
+        | sort_by(.container, .date)
+        | group_by(.container)
+        | map({
+            key: .[0].container,
+            value: (.[-30:] | map({date, pull_count}))
+          })
+        | from_entries
+    ' "$history_file" 2>/dev/null || echo "{}")
+
+    echo "$DOCKERHUB_PULL_TRENDS_CACHE"
+}
+
+get_dockerhub_pull_trend() {
+    local container="$1"
+    local trends="${DOCKERHUB_PULL_TRENDS_CACHE:-}"
+    if [[ -z "$trends" ]]; then
+        trends=$(load_dockerhub_pull_trends)
+        DOCKERHUB_PULL_TRENDS_CACHE="$trends"
+    fi
+    jq -c --arg container "$container" '.[$container] // []' <<< "$trends"
+}
+
 # Get GHCR image sizes formatted for dashboard (MB suffix)
 # Usage: get_ghcr_sizes <image> [tag]
 # Output: "amd64:84.0MB arm64:81.5MB"
@@ -1506,6 +1557,7 @@ generate_data() {
 
     # Pre-populate build status cache (once, before the loop)
     populate_container_build_status_cache
+    load_dockerhub_pull_trends >/dev/null
 
     local total=0 up_to_date=0 updates_available=0
     local all_containers_json="[]"
@@ -1556,11 +1608,12 @@ generate_data() {
         esac
 
         # Get Docker Hub stats (pulls and stars)
-        local dockerhub_stats pull_count pull_count_formatted star_count
+        local dockerhub_stats pull_count pull_count_formatted star_count pull_trend_json
         dockerhub_stats=$(get_dockerhub_stats "oorabona" "$container")
         pull_count=$(echo "$dockerhub_stats" | grep -oP 'pulls:\K[0-9]+')
         star_count=$(echo "$dockerhub_stats" | grep -oP 'stars:\K[0-9]+')
         pull_count_formatted=$(format_number "$pull_count")
+        pull_trend_json=$(get_dockerhub_pull_trend "$container")
 
         # Get image sizes (only if published)
         local sizes_amd64="" sizes_arm64=""
@@ -1600,6 +1653,7 @@ generate_data() {
                 .pull_count = strenv(PC) | .pull_count_formatted = strenv(PCF) | .star_count = strenv(SC2) |
                 .size_amd64 = strenv(SA) | .size_arm64 = strenv(SR)
             ')
+        container_json=$(echo "$container_json" | jq --argjson pt "$pull_trend_json" '. + {pull_trend: $pt}')
 
         # Add container-level build args from lineage
         local lineage_args_json

--- a/helpers/logging.sh
+++ b/helpers/logging.sh
@@ -25,24 +25,33 @@ if [[ -z "${SKOPEO:-}" ]]; then
 fi
 
 # Logging functions
+#
+# printf with %b/%s (not echo -e) -- %b interprets backslash escapes ONLY in
+# the fixed color-code literals below (safe, no dynamic content), while %s
+# passes "$*" through with NO escape reinterpretation. echo -e would
+# reinterpret any backslash escape sequence present in "$*" itself -- e.g. a
+# literal six-character "backslash u 0 0 1 b" (the JSON escape spelling of
+# the 0x1B control byte) surviving from an external, untrusted response a
+# caller logs verbatim -- turning it into a real control byte and letting
+# untrusted text inject terminal/log control sequences.
 log_success() {
-    echo -e "${GREEN}✅ $*${NC}" >&2
+    printf '%b%s%b\n' "${GREEN}✅ " "$*" "${NC}" >&2
 }
 
 log_error() {
-    echo -e "${RED}❌ $*${NC}" >&2
+    printf '%b%s%b\n' "${RED}❌ " "$*" "${NC}" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}⚠️  $*${NC}" >&2
+    printf '%b%s%b\n' "${YELLOW}⚠️  " "$*" "${NC}" >&2
 }
 
 log_info() {
-    echo -e "${BLUE}ℹ️  $*${NC}" >&2
+    printf '%b%s%b\n' "${BLUE}ℹ️  " "$*" "${NC}" >&2
 }
 
 log_step() {
-    echo -e "${BLUE}🔵 $*${NC}" >&2
+    printf '%b%s%b\n' "${BLUE}🔵 " "$*" "${NC}" >&2
 }
 
 # Helper for help text formatting (from make script)

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  echo "::error::scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it resets the worktree and rewrites origin" >&2
+  exit 2
+fi
+
+# This job deliberately re-fetches Docker Hub stats instead of consuming build artifacts; the duplicate read is cheap and avoids cross-job coupling.
+# Hardcoded origin/master targets are safe because update-dashboard.yaml pins this job's checkout to refs/heads/master.
+#
+# Snapshot persistence is attempted best-effort by every direct update-dashboard
+# invocation (schedule, push, workflow_dispatch on master, and filtered
+# workflow_run), not only by the 07:00 UTC cron. A missed schedule attempt is
+# usually recovered by a same-day post-build workflow_run with a fresh checkout
+# and retry loop. The genuinely irrecoverable data-loss case is narrower: a UTC
+# day with zero container builds, where the schedule run is the only invocation
+# and all 3 persistence attempts are exhausted before midnight. A successful bot
+# commit also does not retrigger the Pages deploy by itself, so the deployed UI
+# can lag the committed snapshot until a later normal dashboard trigger; this is
+# a freshness lag, not a data-loss path.
+#
+# A successful push does not end the loop by itself when that attempt's own
+# snapshot was only partial (some containers failed to fetch) — the loop keeps
+# retrying the still-missing containers with its remaining attempts. This is
+# safe against data loss: origin/master already has whatever was pushed, and
+# retry_cleanup's "reset --hard origin/master" only ever discards a LATER
+# attempt's uncommitted work, never data that already made it to origin.
+# `still_missing` tracks confirmed end-of-run state (not just the first
+# success) so the final outcome reflects reality even when an earlier attempt
+# already persisted something.
+#
+# The run FAILS (exit 1) whenever it ends with anything still missing —
+# whether nothing was ever pushed or only a partial persist landed. This job
+# has no downstream dependents (deploy only needs build), so failing it is
+# isolated and visible rather than a silent, permanently-green job that
+# would otherwise mask a real regression (revoked token scope, branch
+# protection change) behind the same warning text a routine Docker Hub
+# hiccup produces. A day where only external fetches were flaky still
+# self-heals via the next day's idempotent retry; a day where NOTHING can be
+# pushed at all needs a human to notice, which a green job would hide.
+#
+# A genuine change to origin/master's content (not just a same-day idempotent
+# no-op) also best-effort triggers a follow-up dashboard build so the
+# deployed trend doesn't wait for the next independent trigger — a bot
+# commit via GITHUB_TOKEN cannot retrigger the `push` path itself (documented
+# GitHub anti-loop behavior), so this uses an explicit workflow_dispatch
+# instead. Detected via a before/after hash of origin/master's ACTUAL content
+# (remote_stats_hash, a fresh fetch + `git show`), not tracking `git push`'s
+# own exit code or the local worktree: an ambiguous network failure (the
+# remote accepts the push but the client never sees the ack) reports failure
+# locally even though origin DID change, and the local worktree can itself
+# diverge from origin under compound cleanup failures (retry_cleanup's own
+# fetch/reset are warn-and-continue, not hard stops) — querying origin
+# directly at both ends is immune to either misreading. If the hash check
+# itself is degraded (either fetch failed, distinguished from a CONFIRMED
+# empty file via the REMOTE_HASH_UNKNOWN sentinel), the dispatch decision
+# falls back to whether a `git push` command reported success this run
+# (push_confirmed) rather than risk a raw comparison against an unknown
+# baseline in either direction.
+
+github_token="${GITHUB_TOKEN:-}"
+github_repository="${GITHUB_REPOSITORY:-}"
+safe_origin_url=""
+
+if [[ -n "$github_repository" ]]; then
+  safe_origin_url="https://github.com/${github_repository}.git"
+fi
+
+restore_origin_remote() {
+  [[ -n "$safe_origin_url" ]] || return 0
+  git remote set-url origin "$safe_origin_url" >/dev/null 2>&1 || true
+}
+
+sleep_before_retry() {
+  local attempt="$1"
+
+  if [[ "$attempt" -lt 3 ]]; then
+    if ! sleep $((attempt * 5)); then
+      echo "::warning::Stats snapshot retry sleep failed after attempt $attempt"
+    fi
+  fi
+}
+
+# Hashes origin/master's ACTUAL current content for the stats file via a
+# fresh fetch + `git show`, never the local worktree. The local file is only
+# a reliable proxy for origin's state when every cleanup fetch/reset in this
+# run has succeeded — retry_cleanup treats those as warnings, not hard
+# failures, so under compound git-operation failures the local worktree can
+# diverge from what's really on origin in either direction (missing a
+# landed-but-ambiguous push, or still holding rows that never actually
+# pushed). Querying origin directly is immune to that assumption.
+#
+# Returns the sentinel REMOTE_HASH_UNKNOWN (never a real sha256sum output —
+# always exactly 64 lowercase hex chars) when the fetch itself fails, kept
+# distinct from a CONFIRMED "the file is empty/absent" hash. Conflating the
+# two would let a lucky-then-unlucky fetch pair (or vice versa) misfire the
+# dispatch decision in either direction — the caller must never compare an
+# UNKNOWN reading against anything, only fall back to a different signal.
+REMOTE_HASH_UNKNOWN="unknown"
+remote_stats_hash() {
+  # Called via command substitution — anything this function writes to
+  # stdout becomes the caller's captured value, so diagnostics MUST go to
+  # stderr or they'd silently corrupt the hash instead of surfacing as a
+  # real warning.
+  if ! git fetch origin master >/dev/null 2>&1; then
+    echo "::warning::Could not fetch origin/master to check remote stats state" >&2
+    printf '%s' "$REMOTE_HASH_UNKNOWN"
+    return
+  fi
+  git show origin/master:stats/dockerhub-pull-history.jsonl 2>/dev/null | sha256sum | awk '{print $1}' || true
+}
+
+retry_cleanup() {
+  local attempt="$1"
+  local committed="$2"
+
+  if [[ "$committed" == "true" ]]; then
+    if ! git reset --hard HEAD~1; then
+      echo "::warning::Could not discard failed stats commit on attempt $attempt"
+    fi
+  fi
+
+  if ! git fetch origin master; then
+    echo "::warning::Could not fetch origin/master after stats snapshot attempt $attempt"
+  fi
+
+  if ! git reset --hard origin/master; then
+    echo "::warning::Could not reset stats snapshot worktree after attempt $attempt"
+  fi
+
+  sleep_before_retry "$attempt"
+}
+
+trap restore_origin_remote EXIT
+
+if ! git config user.name "github-actions[bot]"; then
+  echo "::warning::Could not configure git user.name for stats snapshot"
+fi
+if ! git config user.email "github-actions[bot]@users.noreply.github.com"; then
+  echo "::warning::Could not configure git user.email for stats snapshot"
+fi
+if [[ -n "$github_token" && -n "$github_repository" ]]; then
+  if ! git remote set-url origin "https://x-access-token:${github_token}@github.com/${github_repository}.git"; then
+    echo "::warning::Could not configure authenticated origin remote for stats snapshot"
+  fi
+else
+  echo "::warning::Missing GitHub token or repository; stats snapshot push may not be authenticated"
+fi
+
+# Pinned once, before the first attempt, so all 3 retries — including any
+# that happen to fire after a UTC midnight rollover mid-run — stay focused on
+# THIS run's day rather than silently switching to a fresh "today" partway
+# through. See snapshot-stats.sh's SNAPSHOT_DATE_OVERRIDE doc comment.
+export SNAPSHOT_DATE_OVERRIDE
+SNAPSHOT_DATE_OVERRIDE="$(date -u +%Y-%m-%d)"
+
+initial_stats_hash="$(remote_stats_hash)"
+
+persisted=false
+# Pessimistic by default: only cleared at the two points below where we have
+# actually CONFIRMED the run ends with nothing outstanding (full fetch AND
+# either nothing new to push or a successful push). Every other path —
+# fetch failure, diff-inspection failure, add/commit/push failure, or even a
+# FULLY successful fetch whose subsequent git operations then fail — leaves
+# this true, so the final outcome reflects reality regardless of which
+# attempt an earlier successful partial push happened on.
+still_missing=true
+# Narrower than `persisted` (which also becomes true via the "nothing new,
+# already done" no-op) — set true ONLY when a `git push` command itself
+# reports success this run. Used solely as the fallback dispatch signal when
+# the remote hash check is degraded (see the final dispatch decision below);
+# the hash comparison remains the primary, more reliable signal whenever
+# both its fetches succeed.
+push_confirmed=false
+for attempt in 1 2 3; do
+  snapshot_failed=false
+  if ! ./scripts/snapshot-stats.sh; then
+    snapshot_failed=true
+    echo "::warning::Stats snapshot collection failed on attempt $attempt; some containers failed, but valid rows from successful containers will still be considered for commit"
+  fi
+
+  # HEAD (not index) comparison: catches a change staged-but-not-committed by
+  # a prior attempt that failed between `git add` and a successful `git
+  # commit`+cleanup — a plain `git diff` (working tree vs index) would see
+  # that case as "clean" and wrongly skip straight to persisted=true.
+  if git diff --quiet HEAD -- stats/dockerhub-pull-history.jsonl; then
+    if [[ "$snapshot_failed" == "true" ]]; then
+      echo "::warning::Stats snapshot collection made no commit-worthy progress on attempt $attempt"
+      sleep_before_retry "$attempt"
+      continue
+    fi
+    persisted=true  # nothing new this attempt: either already done, or a
+    still_missing=false  # concurrent run already covered it. Either way, not a failure.
+    break
+  else
+    diff_status=$?
+    if [[ "$diff_status" -gt 1 ]]; then
+      echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
+      retry_cleanup "$attempt" "false"
+      continue
+    fi
+  fi
+
+  if ! git add stats/dockerhub-pull-history.jsonl; then
+    echo "::warning::Could not stage stats snapshot on attempt $attempt"
+    retry_cleanup "$attempt" "false"
+    continue
+  fi
+
+  if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot"; then
+    echo "::warning::Could not commit stats snapshot on attempt $attempt"
+    retry_cleanup "$attempt" "false"
+    continue
+  fi
+
+  if git push origin master; then
+    persisted=true
+    push_confirmed=true
+    if [[ "$snapshot_failed" == "true" ]]; then
+      echo "::warning::Persisted partial stats snapshot on attempt $attempt; some containers may still be missing — retrying for the rest"
+      sleep_before_retry "$attempt"
+      continue
+    fi
+    still_missing=false  # confirmed: fetch was fully successful AND this push succeeded
+    break
+  fi
+
+  # Lost the race (or lack permission) — discard this attempt and retry clean.
+  # origin/master already holds any earlier successful push from this run, so
+  # this reset can never discard already-persisted data.
+  retry_cleanup "$attempt" "true"
+done
+
+final_stats_hash="$(remote_stats_hash)"
+
+should_dispatch=false
+if [[ "$initial_stats_hash" != "$REMOTE_HASH_UNKNOWN" && "$final_stats_hash" != "$REMOTE_HASH_UNKNOWN" ]]; then
+  # Both checkpoints confirmed — the direct origin-content comparison is the
+  # authoritative signal, regardless of any single git push's own exit code.
+  [[ "$final_stats_hash" != "$initial_stats_hash" ]] && should_dispatch=true
+elif [[ "$push_confirmed" == "true" ]]; then
+  # The remote hash check was unavailable at least once this run (a fetch
+  # failure at either checkpoint), so a raw comparison can't be trusted in
+  # either direction. Fall back to the best remaining signal: did a `git
+  # push` command itself report success. This won't catch an ambiguous
+  # push (reported failure, actually landed) in this degraded path — an
+  # acceptable secondary-order gap given we're already short one reliable
+  # signal, and a missed dispatch here just means the usual freshness lag.
+  should_dispatch=true
+  echo "::warning::Remote stats hash check was unavailable this run; falling back to this run's own confirmed push status for the follow-up dispatch decision"
+fi
+
+if [[ "$should_dispatch" == "true" ]]; then
+  if [[ -n "$github_token" && -n "$github_repository" ]]; then
+    if ! GH_TOKEN="$github_token" gh workflow run update-dashboard.yaml \
+        --repo "$github_repository" \
+        --ref master \
+        -f trigger_reason="Docker Hub stats snapshot committed"; then
+      echo "::warning::Could not trigger a follow-up dashboard build after persisting stats — the deployed trend may lag until the next independent trigger"
+    fi
+  else
+    echo "::warning::Missing GitHub token or repository; could not trigger a follow-up dashboard build after persisting stats"
+  fi
+fi
+
+if [[ "$still_missing" == "true" ]]; then
+  if [[ "$persisted" != "true" ]]; then
+    # No extra snapshot-stats.sh call here — nothing downstream reads the
+    # local worktree after this point (the job ends right after), and a 4th
+    # invocation was pushing the worst-case Docker-Hub-outage runtime close
+    # to the job's own timeout budget for no observable benefit.
+    echo "::error::Could not persist stats snapshot this run — another same-day direct trigger may still cover it"
+  else
+    echo "::error::Exhausted retries with some containers still missing after at least one successful persist — another same-day direct trigger may still cover them"
+  fi
+  restore_origin_remote
+  trap - EXIT
+  exit 1
+fi
+
+restore_origin_remote
+trap - EXIT
+
+exit 0

--- a/scripts/snapshot-stats.sh
+++ b/scripts/snapshot-stats.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Daily snapshot of pull/star counts per container from Docker Hub.
-# Appends to .build-lineage/stats-history.jsonl (idempotent per day).
+# Appends to stats/dockerhub-pull-history.jsonl (idempotent per day).
 #
 # Usage: ./scripts/snapshot-stats.sh [namespace]
 #   namespace defaults to "oorabona"
+#
+# SNAPSHOT_DATE_OVERRIDE (env, optional): pins the "today" bucket instead of
+# recomputing it from the current UTC clock. commit-stats-snapshot.sh's retry
+# loop sets this once before its first attempt — without it, a run whose
+# retries straddle UTC midnight would silently switch from filling day D to
+# day D+1 partway through, permanently abandoning day D's still-missing rows
+# while reporting success for D+1.
 #
 # JSONL line shape:
 #   {"ts":"<ISO8601>","date":"YYYY-MM-DD","container":"<name>","pull_count":<n>,"star_count":<n>,"source":"dockerhub"}
@@ -19,11 +26,158 @@ source "$ROOT_DIR/helpers/logging.sh"
 cd "$ROOT_DIR"
 
 NAMESPACE="${1:-oorabona}"
-STATS_FILE=".build-lineage/stats-history.jsonl"
-mkdir -p .build-lineage
+STATS_FILE="stats/dockerhub-pull-history.jsonl"
+LEGACY_STATS_FILE=".build-lineage/stats-history.jsonl"
+mkdir -p "$(dirname "$STATS_FILE")"
 
-today=$(date -u +%Y-%m-%d)
+reconcile_legacy_stats_history() {
+  local today_utc="$1"
+
+  [[ -f "$LEGACY_STATS_FILE" ]] || return 0
+
+  local reconciliation_tmp
+  reconciliation_tmp=$(mktemp)
+
+  local -a jq_files=()
+  [[ -f "$STATS_FILE" ]] && jq_files+=("$STATS_FILE")
+  jq_files+=("$LEGACY_STATS_FILE")
+
+  # Excludes today's date from the migrated set (see call site below) —
+  # this is a one-time HISTORICAL backfill, never a substitute for today's
+  # live fetch. Without the exclusion, a same-day row already present in the
+  # legacy cache (plausible at cutover, since the old mechanism that wrote it
+  # was active up until this migration) gets copied in and then read by
+  # snapshot_exists_for_today as "already done", silently skipping a live
+  # re-fetch and persisting a possibly hours-stale pull_count as if fresh.
+  if ! jq -Rrn --arg stats_file "$STATS_FILE" --arg legacy_file "$LEGACY_STATS_FILE" --arg today "$today_utc" '
+    def parsed_stats_row:
+      (try fromjson catch null) as $obj
+      | if ($obj | type) == "object"
+          and (($obj.date? | type) == "string")
+          and (($obj.container? | type) == "string")
+        then
+          (try ($obj.pull_count | tonumber) catch null) as $pull_count
+          | (try ($obj.star_count | tonumber) catch null) as $star_count
+          | if $pull_count != null and $star_count != null then
+              $obj + {pull_count: $pull_count, star_count: $star_count}
+            else
+              null
+            end
+        else
+          null
+        end;
+
+    reduce inputs as $line (
+      {existing: {}, legacy: {}, malformed: 0};
+      input_filename as $file
+      | if $line == "" then
+          .
+        else
+          ($line | parsed_stats_row) as $row
+          | if $file == $stats_file then
+              if $row != null then
+                .existing[$row.date + "\u0000" + $row.container] = true
+              else
+                .
+              end
+            elif $file == $legacy_file then
+              if $row != null then
+                .legacy[$row.date + "\u0000" + $row.container] = $row
+              else
+                .malformed += 1
+              end
+            else
+              .
+            end
+        end
+    )
+    | "__MALFORMED__\t\(.malformed)",
+      (
+        . as $state
+        | [
+            $state.legacy
+            | to_entries[]
+            | select(.key as $key | (($state.existing[$key] // false) | not))
+            | select(.value.date != $today)
+            | .value
+          ]
+        | sort_by(.date, .container)
+        | .[]
+        | @json
+      )
+  ' "${jq_files[@]}" > "$reconciliation_tmp"; then
+    rm -f "$reconciliation_tmp"
+    log_warning "Could not reconcile legacy Docker Hub stats entries from $LEGACY_STATS_FILE"
+    return 0
+  fi
+
+  local malformed
+  malformed=$(sed -n $'1s/^__MALFORMED__\t//p' "$reconciliation_tmp")
+  malformed="${malformed:-0}"
+
+  local reconciled
+  reconciled=$(awk 'NR > 1 && length($0) > 0 { count++ } END { print count + 0 }' "$reconciliation_tmp")
+  if [[ "$reconciled" -gt 0 ]]; then
+    awk 'NR > 1 && length($0) > 0 { print }' "$reconciliation_tmp" >> "$STATS_FILE"
+  fi
+
+  rm -f "$reconciliation_tmp"
+
+  if [[ "$reconciled" -gt 0 ]]; then
+    log_info "Reconciled $reconciled legacy Docker Hub stats entries into $STATS_FILE"
+  fi
+  if [[ "$malformed" -gt 0 ]]; then
+    log_warning "Skipped $malformed malformed legacy Docker Hub stats entries during migration"
+  fi
+}
+
+today="${SNAPSHOT_DATE_OVERRIDE:-$(date -u +%Y-%m-%d)}"
 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+reconcile_legacy_stats_history "$today"
+
+declare -A SNAPSHOTS_TODAY=()
+
+load_today_snapshot_keys() {
+  [[ -f "$STATS_FILE" ]] || return 0
+
+  local container
+  while IFS= read -r container; do
+    [[ -n "$container" ]] && SNAPSHOTS_TODAY["$container"]=1
+  done < <(
+    jq -Rrn --arg date "$today" '
+      def parsed_stats_row:
+        (try fromjson catch null) as $obj
+        | if ($obj | type) == "object"
+            and (($obj.date? | type) == "string")
+            and (($obj.container? | type) == "string")
+          then
+            (try ($obj.pull_count | tonumber) catch null) as $pull_count
+            | (try ($obj.star_count | tonumber) catch null) as $star_count
+            | if $pull_count != null and $star_count != null then
+                $obj + {pull_count: $pull_count, star_count: $star_count}
+              else
+                null
+              end
+          else
+            null
+          end;
+
+      inputs
+      | select(length > 0)
+      | parsed_stats_row
+      | select(. != null and .date == $date)
+      | .container
+    ' "$STATS_FILE" 2>/dev/null || true
+  )
+}
+
+snapshot_exists_for_today() {
+  local container="$1"
+  [[ -n "${SNAPSHOTS_TODAY[$container]:-}" ]]
+}
+
+load_today_snapshot_keys
 
 snapshotted=0
 skipped=0
@@ -33,10 +187,7 @@ while IFS= read -r container; do
   [[ -z "$container" ]] && continue
 
   # Idempotent: skip if today's snapshot already exists for this container.
-  # Field order in JSONL is not guaranteed, so check both substrings on the same line.
-  if [[ -f "$STATS_FILE" ]] && \
-     grep -F "\"container\":\"$container\"" "$STATS_FILE" 2>/dev/null | \
-     grep -qF "\"date\":\"$today\""; then
+  if snapshot_exists_for_today "$container"; then
     skipped=$((skipped + 1))
     continue
   fi
@@ -48,8 +199,23 @@ while IFS= read -r container; do
     continue
   fi
 
-  pull_count=$(echo "$response" | jq -r '.pull_count // 0')
-  star_count=$(echo "$response" | jq -r '.star_count // 0')
+  if ! counts_tsv=$(printf '%s' "$response" | jq -er '
+    if type == "object"
+      and (.pull_count? | type) == "number"
+      and (.star_count? | type) == "number"
+    then
+      [.pull_count, .star_count] | @tsv
+    else
+      empty
+    end
+  ' 2>/dev/null); then
+    response_snippet=$(printf '%s' "$response" | tr '\r\n\t' '   ' | cut -c1-240)
+    log_warning "Unexpected Docker Hub stats response for $container; expected numeric pull_count and star_count, got: $response_snippet"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  IFS=$'\t' read -r pull_count star_count <<< "$counts_tsv"
 
   jq -nc \
     --arg ts "$ts" \
@@ -60,6 +226,7 @@ while IFS= read -r container; do
     '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
     >> "$STATS_FILE"
 
+  SNAPSHOTS_TODAY["$container"]=1
   snapshotted=$((snapshotted + 1))
 done < <(list_containers)
 
@@ -67,3 +234,7 @@ total=0
 [[ -f "$STATS_FILE" ]] && total=$(wc -l < "$STATS_FILE")
 
 log_info "Stats snapshot: $snapshotted new, $skipped already-today, $failed failed (total entries: $total)"
+
+if [[ "$failed" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    local _saved_exit_trap
+    _saved_exit_trap=$(trap -p EXIT 2>/dev/null) || true
+    source "$ORIG_DIR/helpers/logging.sh" 2>/dev/null || true
+    source "$ORIG_DIR/helpers/variant-utils.sh" 2>/dev/null || true
+    source "$ORIG_DIR/generate-dashboard.sh" 2>/dev/null || true
+    _SOURCED_TRIVY_CACHE="${TRIVY_CACHE_FILE:-}"
+    if [[ -n "$_saved_exit_trap" ]]; then
+        eval "$_saved_exit_trap" 2>/dev/null || true
+    else
+        trap - EXIT 2>/dev/null || true
+    fi
+
+    export SCRIPT_DIR="$TEST_DIR"
+    DOCKERHUB_PULL_TRENDS_CACHE=""
+
+    mkdir -p "$TEST_DIR/stats" "$TEST_DIR/docs/site/_data" "$TEST_DIR/docs/site/_containers"
+    DATA_FILE="$TEST_DIR/docs/site/_data/containers.yml"
+    CONTAINERS_DIR="$TEST_DIR/docs/site/_containers"
+    STATS_FILE="$TEST_DIR/docs/site/_data/stats.yml"
+    TRIVY_CACHE_FILE=$(mktemp)
+    export DATA_FILE CONTAINERS_DIR STATS_FILE TRIVY_CACHE_FILE
+
+    get_container_versions()             { echo "1.0.0|1.0.0|green|Up to date"; }
+    get_container_description()          { echo "Alpha test container"; }
+    get_container_build_status()         { echo "success"; }
+    populate_container_build_status_cache() { :; }
+    get_dockerhub_stats()                { echo "pulls:120 stars:3"; }
+    get_ghcr_sizes()                     { echo ""; }
+    ghcr_get_manifest_sizes()            { echo ""; }
+    get_build_lineage_field()            { echo "unknown"; }
+    get_build_lineage_args_json()        { echo "[]"; }
+    has_variants()                       { return 1; }
+    get_sbom_summary()                   { echo "{}"; }
+    get_sbom_packages()                  { echo "{}"; }
+    get_changelog()                      { echo "{}"; }
+    get_build_history()                  { echo "[]"; }
+    resolve_variant_lineage_file()       { echo ""; }
+    build_trivy_category()               { echo "alpha:1.0.0"; }
+    get_attestation_id()                 { return 1; }
+    get_attestation_url()                { echo ""; }
+    get_trivy_summary()                  { echo "{}"; }
+    generate_container_page()            { :; }
+    fetch_recent_activity()              { echo "recent_activity: []"; }
+    calculate_build_success_rate()       { echo "1:1:100"; }
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -f "${TRIVY_CACHE_FILE:-}" 2>/dev/null || true
+    rm -f "${_SOURCED_TRIVY_CACHE:-}" 2>/dev/null || true
+    rm -rf "$TEST_DIR"
+}
+
+reset_trend_cache() {
+    DOCKERHUB_PULL_TRENDS_CACHE=""
+}
+
+@test "Docker Hub pull trend skips malformed rows, sorts by date, and dedupes with last row winning" {
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+not json
+{"date":"2026-01-03","container":"alpha","pull_count":30}
+{"date":"2026-01-01","container":"alpha","pull_count":10}
+{"date":"2026-01-02","container":"alpha","pull_count":20}
+{"date":"2026-01-02","container":"alpha","pull_count":25}
+{"date":"2026-01-04","container":"alpha"}
+{"date":"2026-01-05","container":"alpha","pull_count":"35"}
+{"date":"2026-01-01","container":"beta","pull_count":5}
+EOF
+    reset_trend_cache
+
+    run get_dockerhub_pull_trend "alpha"
+    [ "$status" -eq 0 ]
+
+    echo "$output" | jq -e '
+        length == 4 and
+        .[0] == {"date":"2026-01-01","pull_count":10} and
+        .[1] == {"date":"2026-01-02","pull_count":25} and
+        .[2] == {"date":"2026-01-03","pull_count":30} and
+        .[3] == {"date":"2026-01-05","pull_count":35}
+    ' >/dev/null
+}
+
+@test "Docker Hub pull trend returns only the last 30 daily points" {
+    : > "$TEST_DIR/stats/dockerhub-pull-history.jsonl"
+    for day in $(seq -w 1 31); do
+        jq -nc \
+            --arg date "2026-01-${day}" \
+            --argjson pull_count "$((10#$day))" \
+            '{date: $date, container: "alpha", pull_count: $pull_count}' \
+            >> "$TEST_DIR/stats/dockerhub-pull-history.jsonl"
+    done
+    reset_trend_cache
+
+    run get_dockerhub_pull_trend "alpha"
+    [ "$status" -eq 0 ]
+
+    echo "$output" | jq -e '
+        length == 30 and
+        .[0].date == "2026-01-02" and
+        .[29].date == "2026-01-31"
+    ' >/dev/null
+}
+
+@test "Docker Hub pull trend loads history once across multiple lookups" {
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-02-01","container":"alpha","pull_count":10}
+{"date":"2026-02-01","container":"beta","pull_count":20}
+EOF
+    reset_trend_cache
+
+    eval "$(declare -f load_dockerhub_pull_trends | sed '1s/load_dockerhub_pull_trends/load_dockerhub_pull_trends_uncounted/')"
+    load_trends_count_file="$TEST_DIR/load-trends-count"
+    echo 0 > "$load_trends_count_file"
+    load_dockerhub_pull_trends() {
+        local calls
+        calls=$(cat "$load_trends_count_file")
+        echo $((calls + 1)) > "$load_trends_count_file"
+        load_dockerhub_pull_trends_uncounted "$@"
+    }
+
+    get_dockerhub_pull_trend "alpha" > "$TEST_DIR/alpha-trend.json"
+    get_dockerhub_pull_trend "beta" > "$TEST_DIR/beta-trend.json"
+    get_dockerhub_pull_trend "alpha" > "$TEST_DIR/alpha-trend-again.json"
+    alpha_trend=$(cat "$TEST_DIR/alpha-trend.json")
+    beta_trend=$(cat "$TEST_DIR/beta-trend.json")
+    alpha_again=$(cat "$TEST_DIR/alpha-trend-again.json")
+
+    [ "$(cat "$load_trends_count_file")" -eq 1 ]
+    echo "$alpha_trend" | jq -e 'map(.pull_count) == [10]' >/dev/null
+    echo "$beta_trend" | jq -e 'map(.pull_count) == [20]' >/dev/null
+    [ "$alpha_again" = "$alpha_trend" ]
+}
+
+@test "Docker Hub pull trend preserves flat and downward values for the renderer" {
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-02-01","container":"flat","pull_count":50}
+{"date":"2026-02-02","container":"flat","pull_count":50}
+{"date":"2026-02-01","container":"drop","pull_count":100}
+{"date":"2026-02-02","container":"drop","pull_count":90}
+EOF
+    reset_trend_cache
+
+    run get_dockerhub_pull_trend "flat"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'map(.pull_count) == [50, 50]' >/dev/null
+
+    run get_dockerhub_pull_trend "drop"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'map(.pull_count) == [100, 90]' >/dev/null
+}
+
+@test "Docker Hub pull trend returns an empty array when history is absent or container is unseen" {
+    rm -f "$TEST_DIR/stats/dockerhub-pull-history.jsonl"
+    reset_trend_cache
+
+    run get_dockerhub_pull_trend "missing"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "generate_data folds pull_trend into each container JSON object" {
+    mkdir -p "$TEST_DIR/alpha"
+    printf '#!/usr/bin/env bash\necho "1.0.0"\n' > "$TEST_DIR/alpha/version.sh"
+    chmod +x "$TEST_DIR/alpha/version.sh"
+    printf 'FROM alpine:3.21\n' > "$TEST_DIR/alpha/Dockerfile"
+
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-03-01","container":"alpha","pull_count":110}
+{"date":"2026-03-02","container":"alpha","pull_count":120}
+EOF
+    reset_trend_cache
+
+    generate_data >/dev/null
+
+    yq -o=json '.' "$DATA_FILE" | jq -e '
+        .[0].name == "alpha" and
+        .[0].pull_trend == [
+          {"date":"2026-03-01","pull_count":110},
+          {"date":"2026-03-02","pull_count":120}
+        ]
+    ' >/dev/null
+}
+
+@test "container detail template gates sparkline and includes accessibility and edge-case math" {
+    layout="$ORIG_DIR/docs/site/_layouts/container-detail.html"
+    gate_line=$(grep -n 'if _pull_trend_size > 1' "$layout" | head -1 | cut -d: -f1)
+    svg_line=$(grep -n '<svg class="pull-trend-sparkline"' "$layout" | head -1 | cut -d: -f1)
+    [ "$gate_line" -lt "$svg_line" ]
+
+    grep -q '<title id="pull-trend-title-' "$layout"
+    grep -q '_trend_range == 0' "$layout"
+    grep -q '_trend_y = 14' "$layout"
+    grep -q '_trend_y_offset = _trend_delta | times: 24 | divided_by: _trend_range' "$layout"
+    grep -q '_trend_y = 26 | minus: _trend_y_offset' "$layout"
+    grep -q 'polyline points="{{ _trend_svg_points | strip }}"' "$layout"
+    grep -q 'recorded days' "$layout"
+    ! grep -q 'pulls over {{ _pull_trend_size }} days' "$layout"
+}

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -1,0 +1,755 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    TEST_REPO="$TEST_TEMP_DIR/repo"
+    FAKE_GIT_STATE="$TEST_TEMP_DIR/git-state"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$TEST_REPO/helpers" "$FAKE_GIT_STATE"
+
+    ln -s "$SCRIPTS_DIR/commit-stats-snapshot.sh" "$TEST_REPO/scripts/commit-stats-snapshot.sh"
+    : > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    : > "$FAKE_GIT_STATE/head_stats"
+    : > "$FAKE_GIT_STATE/index_stats"
+
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p stats
+stats_file="stats/dockerhub-pull-history.jsonl"
+line='{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}'
+if [[ ! -f "$stats_file" ]] || ! grep -qF '"date":"2026-07-12","container":"alpha"' "$stats_file"; then
+  printf '%s\n' "$line" >> "$stats_file"
+fi
+echo "snapshot" >> "${FAKE_GIT_STATE:?}/snapshot.log"
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    cat > "$TEST_REPO/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${FAKE_GIT_STATE:?}"
+printf '%s\n' "$*" >> "$state/gh.log"
+calls=$(cat "$state/gh_call_count" 2>/dev/null || echo 0)
+echo $((calls + 1)) > "$state/gh_call_count"
+if [[ "${FAKE_GH_FAIL:-}" == "1" ]]; then
+  exit 1
+fi
+exit 0
+EOF
+    chmod +x "$TEST_REPO/bin/gh"
+
+    cat > "$TEST_REPO/bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${FAKE_GIT_STATE:?}"
+stats_file="stats/dockerhub-pull-history.jsonl"
+head_stats="$state/head_stats"
+index_stats="$state/index_stats"
+commit_stats="$state/commit_stats"
+mkdir -p "$state"
+printf '%s\n' "$*" >> "$state/git.log"
+
+copy_head_to_worktree() {
+  mkdir -p stats
+  if [[ -f "$head_stats" ]]; then
+    cp "$head_stats" "$stats_file"
+    cp "$head_stats" "$index_stats"
+  else
+    : > "$stats_file"
+    : > "$index_stats"
+  fi
+}
+
+case "${1:-}" in
+  config)
+    exit 0
+    ;;
+  remote)
+    if [[ "${2:-}" == "set-url" && "${3:-}" == "origin" ]]; then
+      printf '%s\n' "${4:-}" > "$state/origin_url"
+    fi
+    exit 0
+    ;;
+  diff)
+    # `git diff --quiet -- path` (no ref) is worktree-vs-INDEX; `git diff
+    # --quiet HEAD -- path` is worktree-vs-HEAD. The production script always
+    # passes HEAD (compare_against=head_stats below) — the index_stats branch
+    # exists so a dedicated test can demonstrate what the old ref-less form
+    # would have wrongly reported.
+    compare_against="$index_stats"
+    for arg in "$@"; do
+      if [[ "$arg" == "HEAD" ]]; then
+        compare_against="$head_stats"
+        break
+      fi
+    done
+    if cmp -s "$stats_file" "$compare_against"; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  add)
+    if [[ "${FAKE_GIT_FAIL_ADD:-}" == "1" ]]; then
+      exit 1
+    fi
+    cp "$stats_file" "$index_stats"
+    exit 0
+    ;;
+  commit)
+    if [[ "${FAKE_GIT_FAIL_COMMIT_ALWAYS:-}" == "1" ]]; then
+      exit 1
+    fi
+    if [[ "${FAKE_GIT_FAIL_COMMIT_ONCE:-}" == "1" ]] && [[ ! -f "$state/commit_failed_once" ]]; then
+      : > "$state/commit_failed_once"
+      exit 1
+    fi
+    cp "$index_stats" "$commit_stats"
+    commits=$(cat "$state/commit_count" 2>/dev/null || echo 0)
+    echo $((commits + 1)) > "$state/commit_count"
+    exit 0
+    ;;
+  push)
+    pushes=$(cat "$state/push_count" 2>/dev/null || echo 0)
+    pushes=$((pushes + 1))
+    echo "$pushes" > "$state/push_count"
+    mode="${FAKE_GIT_PUSH_MODE:-success_on_retry}"
+    if [[ "$mode" == "always_fail" ]]; then
+      exit 1
+    fi
+    if [[ "$mode" == "always_success" ]]; then
+      cp "$commit_stats" "$head_stats"
+      cp "$commit_stats" "$index_stats"
+      exit 0
+    fi
+    if [[ "$mode" == "success_once_then_fail" ]]; then
+      if [[ "$pushes" -eq 1 ]]; then
+        cp "$commit_stats" "$head_stats"
+        cp "$commit_stats" "$index_stats"
+        exit 0
+      fi
+      exit 1
+    fi
+    if [[ "$mode" == "ambiguous_fail_once" ]]; then
+      # Simulates a network partition where the remote accepts the push but
+      # the client never sees the ack: origin (head_stats) DOES advance, yet
+      # the command still reports failure to the caller.
+      if [[ "$pushes" -eq 1 ]]; then
+        cp "$commit_stats" "$head_stats"
+        cp "$commit_stats" "$index_stats"
+        exit 1
+      fi
+      cp "$commit_stats" "$head_stats"
+      cp "$commit_stats" "$index_stats"
+      exit 0
+    fi
+    if [[ "$pushes" -eq 1 ]]; then
+      exit 1
+    fi
+    cp "$commit_stats" "$head_stats"
+    cp "$commit_stats" "$index_stats"
+    exit 0
+    ;;
+  reset)
+    if [[ "$*" == *"origin/master"* ]] && [[ "${FAKE_GIT_FAIL_RESET_ALWAYS:-}" == "1" ]]; then
+      exit 1
+    fi
+    if [[ "$*" == *"origin/master"* ]] && [[ "${FAKE_GIT_FAIL_RESET_ONCE:-}" == "1" ]] && [[ ! -f "$state/reset_failed_once" ]]; then
+      : > "$state/reset_failed_once"
+      exit 1
+    fi
+    copy_head_to_worktree
+    exit 0
+    ;;
+  fetch)
+    if [[ "${FAKE_GIT_FAIL_FETCH_FOR_HASH:-}" == "1" ]]; then
+      exit 1
+    fi
+    exit 0
+    ;;
+  show)
+    # `git show origin/master:stats/dockerhub-pull-history.jsonl` — models
+    # origin's actual content via head_stats (the mock's stand-in for
+    # origin/master), regardless of whatever the local worktree currently
+    # holds. An absent/empty head_stats prints nothing (real git exits
+    # nonzero for a missing path; remote_stats_hash tolerates that the same
+    # way it tolerates a fetch failure — empty input, not a script error).
+    if [[ -s "$head_stats" ]]; then
+      cat "$head_stats"
+      exit 0
+    fi
+    exit 128
+    ;;
+  *)
+    echo "unsupported fake git command: $*" >&2
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/git"
+
+    cat > "$TEST_REPO/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_GIT_STATE:?}/sleep.log"
+EOF
+    chmod +x "$TEST_REPO/bin/sleep"
+
+    export FAKE_GIT_STATE
+    export PATH="$TEST_REPO/bin:$PATH"
+    export GITHUB_ACTIONS="true"
+    export GITHUB_TOKEN="test-token"
+    export GITHUB_REPOSITORY="owner/repo"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+@test "commit-stats-snapshot refuses to run outside GitHub Actions before touching git state" {
+    unset GITHUB_ACTIONS
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"::error::scripts/commit-stats-snapshot.sh is CI-only"* ]]
+
+    [ ! -e "$FAKE_GIT_STATE/git.log" ]
+    [ ! -e "$FAKE_GIT_STATE/commit_count" ]
+    [ ! -e "$FAKE_GIT_STATE/origin_url" ]
+}
+
+@test "commit-stats-snapshot falls back to push-confirmed status when the remote hash check is degraded" {
+    # remote_stats_hash does its OWN fetch at both the start and end of the
+    # run, independent of retry_cleanup's. If that fetch fails, it returns
+    # the REMOTE_HASH_UNKNOWN sentinel (distinct from a CONFIRMED-empty
+    # hash) rather than crashing — a raw comparison against an unknown
+    # baseline could misfire in either direction, so the dispatch decision
+    # instead falls back to whether a `git push` itself reported success.
+    # Here it did (always_success), so the fallback correctly dispatches
+    # despite never being able to directly verify origin's content.
+    export FAKE_GIT_PUSH_MODE="always_success"
+    export FAKE_GIT_FAIL_FETCH_FOR_HASH="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Could not fetch origin/master to check remote stats state"* ]]
+    [[ "$output" == *"::warning::Remote stats hash check was unavailable this run; falling back to this run's own confirmed push status"* ]]
+
+    # The push itself still succeeded on the very first attempt (always_success),
+    # so retry_cleanup is never invoked at all here — only remote_stats_hash's
+    # own two fetch calls (before and after the loop) exercise this knob.
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+}
+
+@test "commit-stats-snapshot does not dispatch on a degraded remote check without a confirmed push" {
+    # Same degraded remote-hash situation as above, but this time NOTHING
+    # was ever pushed (persistent add failure) — the fallback must not
+    # dispatch just because the remote check happened to be unavailable.
+    export FAKE_GIT_FAIL_ADD="1"
+    export FAKE_GIT_FAIL_FETCH_FOR_HASH="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::warning::Could not fetch origin/master to check remote stats state"* ]]
+    [[ "$output" != *"Remote stats hash check was unavailable this run; falling back"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
+    [ "$pushes" -eq 0 ]
+
+    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+}
+
+@test "commit-stats-snapshot dispatches the follow-up build after an ambiguous push that actually landed" {
+    # Regression lock: `git push` can report failure (network drop after the
+    # remote already accepted it) even though origin genuinely advanced. A
+    # push-exit-code flag would miss this — the retry loop's own reset picks
+    # up the already-landed data and exits via the "nothing new" path, which
+    # looks identical to a true no-op run. remote_stats_hash (a fresh fetch +
+    # `git show origin/master:...`, modeled by head_stats in this mock, NOT
+    # the local worktree) catches it regardless: origin's content for this
+    # file DID change during this run, so the follow-up build must still fire.
+    export FAKE_GIT_PUSH_MODE="ambiguous_fail_once"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    # Only one push call was ever attempted by the script itself — the
+    # "second" push in the fake (pushes -eq 1 branch) never actually fires;
+    # the retry loop's own reset-and-recheck is what discovers the landed data.
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    jq -e '
+        select(.date == "2026-07-12" and .container == "alpha" and .pull_count == 42)
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+}
+
+@test "commit-stats-snapshot retries after rejected push and persists one idempotent row" {
+    export FAKE_GIT_PUSH_MODE="success_on_retry"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 2 ]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 2 ]
+
+    rows=$(jq -s 'length' "$TEST_REPO/stats/dockerhub-pull-history.jsonl")
+    [ "$rows" -eq 1 ]
+
+    duplicate_pairs=$(jq -s '
+        group_by(.date + "/" + .container)
+        | map(select(length > 1))
+        | length
+    ' "$TEST_REPO/stats/dockerhub-pull-history.jsonl")
+    [ "$duplicate_pairs" -eq 0 ]
+
+    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
+    [ "$origin_url" = "https://github.com/owner/repo.git" ]
+    [[ "$origin_url" != *"test-token"* ]]
+
+    grep -q 'reset --hard HEAD~1' "$FAKE_GIT_STATE/git.log"
+    grep -q 'reset --hard origin/master' "$FAKE_GIT_STATE/git.log"
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+    grep -q 'workflow run update-dashboard.yaml' "$FAKE_GIT_STATE/gh.log"
+    grep -q -- '--ref master' "$FAKE_GIT_STATE/gh.log"
+}
+
+@test "commit-stats-snapshot retries cleanly after a fully-failed attempt, one commit once progress exists" {
+    # Contract: the loop only keeps looping past a successful push when THAT
+    # push was itself partial (some containers still missing). Here attempt 1
+    # makes zero progress (every container fails, no diff at all) and attempt 2
+    # is a FULLY successful fetch, so it breaks immediately on attempt 2 same as
+    # a single-attempt success would.
+    export FAKE_GIT_PUSH_MODE="always_success"
+
+    rm "$TEST_REPO/scripts/snapshot-stats.sh"
+    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
+
+    for container in alpha beta gamma; do
+        mkdir -p "$TEST_REPO/$container"
+        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
+    done
+
+    CURL_LOG="$FAKE_GIT_STATE/curl.log"
+    export CURL_LOG
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+
+count_file="${FAKE_GIT_STATE:?}/curl-${container}-count"
+count=$(cat "$count_file" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "$count_file"
+
+if [[ "$count" -eq 1 ]]; then
+  exit 22
+fi
+
+case "$container" in
+  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
+  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
+  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
+  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
+    [[ "$output" == *"::warning::Stats snapshot collection made no commit-worthy progress on attempt 1"* ]]
+
+    fetches=$(cat "$CURL_LOG")
+    [ "$fetches" = $'alpha\nbeta\ngamma\nalpha\nbeta\ngamma' ]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 1 ]
+
+    today="$(date -u +%Y-%m-%d)"
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today)]
+        | length == 3
+        and (map(.container) | sort == ["alpha", "beta", "gamma"])
+    ' "$TEST_REPO/stats/dockerhub-pull-history.jsonl" >/dev/null
+
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today)]
+        | length == 3
+        and (map(.container) | sort == ["alpha", "beta", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+}
+
+@test "commit-stats-snapshot persists successful rows despite persistent partial snapshot failure" {
+    export FAKE_GIT_PUSH_MODE="always_success"
+
+    rm "$TEST_REPO/scripts/snapshot-stats.sh"
+    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
+
+    for container in alpha beta gamma; do
+        mkdir -p "$TEST_REPO/$container"
+        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
+    done
+
+    CURL_LOG="$FAKE_GIT_STATE/curl-persistent.log"
+    export CURL_LOG
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+
+case "$container" in
+  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
+  beta)  exit 22 ;;
+  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
+  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1; some containers failed"* ]]
+    [[ "$output" == *"::warning::Persisted partial stats snapshot on attempt 1"* ]]
+    [[ "$output" == *"::error::Exhausted retries with some containers still missing"* ]]
+
+    # Contract: a partial success keeps retrying with the remaining attempts to
+    # top up the still-missing container. alpha/gamma are idempotently skipped
+    # (already recorded today) on attempts 2 and 3 — only beta gets re-fetched.
+    fetches=$(cat "$CURL_LOG")
+    [ "$fetches" = $'alpha\nbeta\ngamma\nbeta\nbeta' ]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 1 ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    # Something DID get pushed (alpha+gamma on attempt 1) even though the run
+    # as a whole reports failure — the follow-up dashboard build still fires
+    # so that partial progress isn't stuck behind the next independent trigger.
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+
+    today="$(date -u +%Y-%m-%d)"
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today)]
+        | length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+        and all((.pull_count | type) == "number" and (.star_count | type) == "number")
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today and .container == "beta")]
+        | length == 0
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot retries instead of misreading a staged-but-uncommitted index as already persisted" {
+    # Regression lock for a double-failure sequence: attempt 1's `git add`
+    # succeeds (index now diverges from HEAD) but `git commit` fails, and the
+    # cleanup's `git reset --hard origin/master` ALSO fails — so neither the
+    # worktree nor the index gets reset back to HEAD. On attempt 2, the
+    # snapshot is idempotently skipped (today's row is already in the
+    # worktree from attempt 1) and the ref-less `git diff` form would see
+    # worktree == index (both still hold the never-committed change) and
+    # wrongly report "clean" — exiting with persisted=true having pushed
+    # nothing. Comparing against HEAD (real fix) correctly sees the worktree
+    # still differs from origin/master's actual state and retries the
+    # add+commit+push to completion.
+    export FAKE_GIT_PUSH_MODE="always_success"
+    export FAKE_GIT_FAIL_COMMIT_ONCE="1"
+    export FAKE_GIT_FAIL_RESET_ONCE="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Could not commit stats snapshot on attempt 1"* ]]
+    [[ "$output" == *"::warning::Could not reset stats snapshot worktree after attempt 1"* ]]
+    [[ "$output" != *"Could not persist stats snapshot this run"* ]]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 1 ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    jq -e '
+        select(.date == "2026-07-12" and .container == "alpha" and .pull_count == 42)
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+}
+
+@test "commit-stats-snapshot warns when a later fully-successful fetch never gets pushed" {
+    # Regression lock: attempt 1 fetches alpha+gamma (beta fails) and pushes
+    # that partial progress — persisted=true. Attempt 2's fetch is FULLY
+    # successful (beta recovers), but its push fails, as does attempt 3's.
+    # A `still_missing` that only tracks the FETCH outcome of the most recent
+    # attempt would be wrongly cleared on attempt 2/3 (fetch succeeded) even
+    # though beta's row was never actually confirmed on origin/master — the
+    # final "some containers still missing" warning would then never fire,
+    # silently losing visibility into recoverable data that just needs
+    # another push, not another fetch.
+    export FAKE_GIT_PUSH_MODE="success_once_then_fail"
+
+    rm "$TEST_REPO/scripts/snapshot-stats.sh"
+    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
+
+    for container in alpha beta gamma; do
+        mkdir -p "$TEST_REPO/$container"
+        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
+    done
+
+    CURL_LOG="$FAKE_GIT_STATE/curl-recover.log"
+    export CURL_LOG
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+
+if [[ "$container" == "beta" ]]; then
+  count_file="${FAKE_GIT_STATE:?}/curl-beta-count"
+  count=$(cat "$count_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$count_file"
+  if [[ "$count" -eq 1 ]]; then
+    exit 22
+  fi
+fi
+
+case "$container" in
+  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
+  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
+  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
+  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::warning::Persisted partial stats snapshot on attempt 1"* ]]
+    [[ "$output" == *"::error::Exhausted retries with some containers still missing"* ]]
+
+    # beta: fails attempt 1, succeeds attempts 2 and 3 (fetch works both times,
+    # but its push never lands) — confirms the fetch DID fully succeed on a
+    # later attempt while still never reaching origin/master.
+    fetches=$(cat "$CURL_LOG")
+    [ "$fetches" = $'alpha\nbeta\ngamma\nbeta\nbeta' ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 3 ]
+
+    # attempt 1's push DID land (alpha+gamma) — the follow-up build still fires.
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+
+    jq -s -e '
+        [.[] | select(.container == "beta")]
+        | length == 0
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot never dispatches on a worktree-only divergence that survives to the end of the run" {
+    # Regression lock, sharper than the two tests above: commit NEVER
+    # succeeds (so retry_cleanup never even attempts the HEAD~1 reset) AND
+    # the origin/master reset ALWAYS fails too — so copy_head_to_worktree is
+    # never called at all, and the worktree keeps holding alpha's row
+    # (staged on attempt 1, never reset) all the way to the final hash check,
+    # while origin (head_stats) never advances. A local-worktree-based hash
+    # would see initial=empty, final=alpha and WRONGLY dispatch a follow-up
+    # build for data that was never actually persisted anywhere — this is
+    # exactly codex's "push that never landed can still dispatch" scenario.
+    # remote_stats_hash is immune: both ends read origin directly and see
+    # the same untouched empty content.
+    export FAKE_GIT_FAIL_COMMIT_ALWAYS="1"
+    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count" 2>/dev/null || echo 0)
+    [ "$commits" -eq 0 ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
+    [ "$pushes" -eq 0 ]
+
+    # The worktree DOES still hold the never-committed row — proving this
+    # test actually exercises the divergence, not a no-op.
+    jq -e 'select(.container == "alpha")' "$TEST_REPO/stats/dockerhub-pull-history.jsonl" >/dev/null
+
+    # origin never advanced — no follow-up dispatch, despite the worktree
+    # divergence above.
+    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+}
+
+@test "commit-stats-snapshot fails loudly after exhausted push retries" {
+    # Regression lock: a persistence mechanism that NEVER succeeds (e.g. a
+    # revoked token, branch protection change) must not report success —
+    # this job has no downstream dependents (deploy only needs build), so
+    # failing it is isolated and visible rather than silently green forever.
+    export FAKE_GIT_PUSH_MODE="always_fail"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 3 ]
+
+    # 3 loop attempts, no extra repopulate call (removed — nothing downstream
+    # ever consumed it, the local worktree is thrown away with the ephemeral
+    # runner once the job ends, and the call pushed the worst-case runtime
+    # too close to the job timeout during a sustained Docker Hub outage).
+    # The local file is correctly left EMPTY here (every retry_cleanup resets
+    # it to origin/master's actual, never-pushed-to state) — origin/master,
+    # not this ephemeral worktree, is the real source of truth.
+    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
+    [ "$snapshots" -eq 3 ]
+
+    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
+    [ "$origin_url" = "https://github.com/owner/repo.git" ]
+    [[ "$origin_url" != *"test-token"* ]]
+
+    # Nothing was ever pushed — no follow-up dashboard build to trigger.
+    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+}
+
+@test "commit-stats-snapshot fails loudly when git add fails mid-loop" {
+    export FAKE_GIT_FAIL_ADD="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::warning::Could not stage stats snapshot on attempt 1"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
+    [ "$pushes" -eq 0 ]
+
+    # 3 loop attempts, no extra repopulate call — see the note above.
+    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
+    [ "$snapshots" -eq 3 ]
+
+    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
+    [ "$origin_url" = "https://github.com/owner/repo.git" ]
+    [[ "$origin_url" != *"test-token"* ]]
+
+    # The default fake snapshot-stats.sh still writes a fresh row into the
+    # local worktree file on every attempt even though `git add` never lets
+    # it get staged — this doubles as a regression lock for remote_stats_hash
+    # reading origin (head_stats), never the local worktree: origin was
+    # never touched here, so no dispatch, despite the worktree differing.
+    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+}
+
+@test "commit-stats-snapshot pins SNAPSHOT_DATE_OVERRIDE once and holds it across all retry attempts" {
+    # Regression lock: without a pinned date, a run whose retries straddle a
+    # UTC midnight rollover would silently start filling a NEW day partway
+    # through, abandoning the original day's still-missing rows while
+    # reporting success. The wrapper must export the SAME date value to
+    # every attempt, not recompute it each time.
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "${SNAPSHOT_DATE_OVERRIDE:-UNSET}" >> "${FAKE_GIT_STATE:?}/date-override.log"
+exit 1
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+
+    seen_dates=$(sort -u "$FAKE_GIT_STATE/date-override.log")
+    line_count=$(wc -l < "$FAKE_GIT_STATE/date-override.log")
+    [ "$line_count" -eq 3 ]
+    # Exactly one distinct, non-empty value across all 3 attempts.
+    [ "$(printf '%s\n' "$seen_dates" | wc -l)" -eq 1 ]
+    [ "$seen_dates" != "UNSET" ]
+    [[ "$seen_dates" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+}
+
+@test "commit-stats-snapshot fails loudly when snapshot collection makes no progress" {
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "snapshot" >> "${FAKE_GIT_STATE:?}/snapshot.log"
+echo "simulated Docker Hub outage" >&2
+exit 1
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    commits=$(cat "$FAKE_GIT_STATE/commit_count" 2>/dev/null || echo 0)
+    [ "$commits" -eq 0 ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
+    [ "$pushes" -eq 0 ]
+
+    # 3 loop attempts, no extra repopulate call (removed — nothing downstream
+    # ever consumed it, and it pushed the worst-case runtime too close to the
+    # job timeout during a sustained Docker Hub outage).
+    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
+    [ "$snapshots" -eq 3 ]
+
+    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+}
+
+@test "commit-stats-snapshot tolerates a failed follow-up dashboard dispatch after a full success" {
+    # The self-dispatch is best-effort: its own failure must not turn an
+    # otherwise fully successful, fully persisted run into a failure — only
+    # the persistence outcome itself (still_missing) governs the exit code.
+    export FAKE_GIT_PUSH_MODE="success_on_retry"
+    export FAKE_GH_FAIL="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Could not trigger a follow-up dashboard build"* ]]
+
+    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
+    [ "$gh_calls" -eq 1 ]
+}
+
+@test "commit-stats-snapshot uses explicit persisted flag, not loop-exit warning shorthand" {
+    grep -q 'persisted=false' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
+    grep -q '\[\[ "$persisted" != "true" \]\]' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
+    ! grep -q 'done[[:space:]]*||' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
+}

--- a/tests/unit/dockerhub-stats-snapshot.bats
+++ b/tests/unit/dockerhub-stats-snapshot.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    TEST_REPO="$TEST_TEMP_DIR/repo"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/helpers" "$TEST_REPO/bin"
+
+    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
+    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
+
+    for container in alpha beta gamma; do
+        mkdir -p "$TEST_REPO/$container"
+        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
+    done
+
+    mkdir -p "$TEST_REPO/.build-lineage"
+    for day in 01 02 03 04 05; do
+        for container in alpha beta gamma; do
+            jq -nc \
+                --arg ts "2026-01-${day}T00:00:00Z" \
+                --arg date "2026-01-${day}" \
+                --arg container "$container" \
+                --argjson pull_count "$((10#$day * 100))" \
+                --argjson star_count 1 \
+                '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
+                >> "$TEST_REPO/.build-lineage/stats-history.jsonl"
+        done
+    done
+
+    CURL_LOG="$TEST_TEMP_DIR/curl.log"
+    export CURL_LOG
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+case "$container" in
+  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
+  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
+  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
+  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+    export PATH="$TEST_REPO/bin:$PATH"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+install_jq_counter() {
+    REAL_JQ=$(command -v jq)
+    JQ_COUNT_FILE="$TEST_TEMP_DIR/jq-count"
+    echo 0 > "$JQ_COUNT_FILE"
+    cat > "$TEST_REPO/bin/jq" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+count=\$(cat "$JQ_COUNT_FILE")
+echo \$((count + 1)) > "$JQ_COUNT_FILE"
+exec "$REAL_JQ" "\$@"
+EOF
+    chmod +x "$TEST_REPO/bin/jq"
+    export REAL_JQ JQ_COUNT_FILE
+}
+
+@test "snapshot-stats migrates legacy history and remains idempotent across two same-day runs" {
+    [ ! -e "$TEST_REPO/stats/dockerhub-pull-history.jsonl" ]
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    [ -f "$stats_file" ]
+
+    total_rows=$(jq -s 'length' "$stats_file")
+    [ "$total_rows" -eq 18 ]
+
+    duplicate_pairs=$(jq -s '
+        group_by(.date + "/" + .container)
+        | map(select(length > 1))
+        | length
+    ' "$stats_file")
+    [ "$duplicate_pairs" -eq 0 ]
+
+    for day in 01 02 03 04 05; do
+        for container in alpha beta gamma; do
+            jq -e \
+                --arg date "2026-01-${day}" \
+                --arg container "$container" \
+                'select(.date == $date and .container == $container)' \
+                "$stats_file" >/dev/null
+        done
+    done
+
+    today="$(date -u +%Y-%m-%d)"
+    today_rows=$(jq -s --arg today "$today" '[.[] | select(.date == $today)] | length' "$stats_file")
+    [ "$today_rows" -eq 3 ]
+
+    curl_calls=$(wc -l < "$CURL_LOG")
+    [ "$curl_calls" -eq 3 ]
+}
+
+@test "snapshot-stats skips malformed legacy rows so today's real fetch is not blocked" {
+    today="$(date -u +%Y-%m-%d)"
+    jq -nc \
+        --arg ts "${today}T00:00:00Z" \
+        --arg date "$today" \
+        --arg container "alpha" \
+        '{ts: $ts, date: $date, container: $container, pull_count: "not-a-number", star_count: 1, source: "dockerhub"}' \
+        >> "$TEST_REPO/.build-lineage/stats-history.jsonl"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped 1 malformed legacy Docker Hub stats entries during migration"* ]]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today and .container == "alpha" and .pull_count == 600)]
+        | length == 1
+    ' "$stats_file" >/dev/null
+
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today and .container == "alpha" and (.pull_count | type) != "number")]
+        | length == 0
+    ' "$stats_file" >/dev/null
+
+    grep -qx "alpha" "$CURL_LOG"
+}
+
+@test "snapshot-stats never migrates a same-day legacy row, always live-fetches today" {
+    # Regression lock (#876 hardening): the old mechanism that wrote
+    # .build-lineage/stats-history.jsonl was still active up until this
+    # migration, so at cutover the legacy cache plausibly already has a
+    # TODAY row (fetched hours earlier, now stale — Docker Hub pull_count
+    # only increases). Migrating it would make snapshot_exists_for_today
+    # wrongly treat that container as "already done", silently skipping a
+    # live re-fetch for the rest of the day. Reconciliation must exclude
+    # today's date — it is a one-time HISTORICAL backfill, never a
+    # substitute for today's fetch.
+    today="$(date -u +%Y-%m-%d)"
+    jq -nc \
+        --arg ts "${today}T00:00:00Z" \
+        --arg date "$today" \
+        --arg container "alpha" \
+        --argjson pull_count 111 \
+        --argjson star_count 1 \
+        '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
+        >> "$TEST_REPO/.build-lineage/stats-history.jsonl"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+
+    # The stale legacy value (111) never made it in; the live fetch (600) did.
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today and .container == "alpha")]
+        | length == 1 and .[0].pull_count == 600
+    ' "$stats_file" >/dev/null
+
+    grep -qx "alpha" "$CURL_LOG"
+}
+
+@test "snapshot-stats SNAPSHOT_DATE_OVERRIDE pins the bucket date regardless of the real clock" {
+    # Regression lock: commit-stats-snapshot.sh's retry loop can span a UTC
+    # midnight rollover across its 3 attempts. Without a pinned date, a later
+    # attempt would silently start filling the NEW day instead of finishing
+    # the one the run actually started for, permanently abandoning the
+    # original day's still-missing rows while reporting success.
+    export SNAPSHOT_DATE_OVERRIDE="2026-05-01"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    jq -s -e '
+        [.[] | select(.date == "2026-05-01")]
+        | length == 3
+        and (map(.container) | sort == ["alpha", "beta", "gamma"])
+    ' "$stats_file" >/dev/null
+
+    real_today="$(date -u +%Y-%m-%d)"
+    jq -s -e --arg real_today "$real_today" '
+        [.[] | select(.date == $real_today)] | length == 0
+    ' "$stats_file" >/dev/null
+}
+
+@test "snapshot-stats migrates duplicate legacy rows with last row winning" {
+    jq -nc \
+        --arg ts "2026-01-02T23:59:00Z" \
+        --arg date "2026-01-02" \
+        --arg container "alpha" \
+        --argjson pull_count 999 \
+        --argjson star_count 9 \
+        '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
+        >> "$TEST_REPO/.build-lineage/stats-history.jsonl"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    jq -s -e '
+        [.[] | select(.date == "2026-01-02" and .container == "alpha")]
+        | length == 1 and .[0].pull_count == 999 and .[0].star_count == 9
+    ' "$stats_file" >/dev/null
+
+    total_rows=$(jq -s 'length' "$stats_file")
+    [ "$total_rows" -eq 18 ]
+}
+
+@test "snapshot-stats exits nonzero when every fetch fails and no container is snapshotted" {
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+exit 22
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Stats snapshot: 0 new, 0 already-today, 3 failed"* ]]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    [ -f "$stats_file" ]
+    total_rows=$(jq -s 'length' "$stats_file")
+    [ "$total_rows" -eq 15 ]
+
+    curl_calls=$(wc -l < "$CURL_LOG")
+    [ "$curl_calls" -eq 3 ]
+}
+
+@test "snapshot-stats exits nonzero for partial malformed Docker Hub response without writing a bad row" {
+    cat > "$TEST_REPO/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${*: -1}"
+container="${url%/}"
+container="${container##*/}"
+echo "$container" >> "$CURL_LOG"
+case "$container" in
+  alpha) printf '{"message":"rate limited","star_count":4}\n' ;;
+  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
+  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
+  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/curl"
+
+    today="$(date -u +%Y-%m-%d)"
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unexpected Docker Hub stats response for alpha"* ]]
+    [[ "$output" == *"rate limited"* ]]
+    [[ "$output" == *"Stats snapshot: 2 new, 0 already-today, 1 failed"* ]]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today and .container == "alpha")]
+        | length == 0
+    ' "$stats_file" >/dev/null
+    jq -s -e --arg today "$today" '
+        [.[] | select(.date == $today)]
+        | map(.container)
+        | sort == ["beta", "gamma"]
+    ' "$stats_file" >/dev/null
+}
+
+@test "snapshot-stats uses bounded jq passes for large reconciliation and idempotency inputs" {
+    today="$(date -u +%Y-%m-%d)"
+    mkdir -p "$TEST_REPO/stats"
+    for i in $(seq -w 1 250); do
+        jq -nc \
+            --arg ts "2025-12-${i}T00:00:00Z" \
+            --arg date "2025-12-${i}" \
+            --arg container "alpha" \
+            --argjson pull_count "$((10#$i))" \
+            --argjson star_count 1 \
+            '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
+            >> "$TEST_REPO/.build-lineage/stats-history.jsonl"
+    done
+    for container in alpha beta gamma; do
+        jq -nc \
+            --arg ts "${today}T00:00:00Z" \
+            --arg date "$today" \
+            --arg container "$container" \
+            --argjson pull_count 42 \
+            --argjson star_count 1 \
+            '{ts: $ts, date: $date, container: $container, pull_count: $pull_count, star_count: $star_count, source: "dockerhub"}' \
+            >> "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    done
+
+    install_jq_counter
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Stats snapshot: 0 new, 3 already-today, 0 failed"* ]]
+    [[ ! -s "$CURL_LOG" ]]
+
+    jq_calls=$(cat "$JQ_COUNT_FILE")
+    [ "$jq_calls" -le 4 ]
+}
+
+@test "snapshot-stats ignores malformed existing today row when checking idempotency" {
+    today="$(date -u +%Y-%m-%d)"
+    mkdir -p "$TEST_REPO/stats"
+    printf '{"date":"%s","container":"alpha","pull_count":\n' "$today" \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+
+    run bash -c 'cd "$1" && ./scripts/snapshot-stats.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    stats_file="$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    jq -s -R -e --arg today "$today" '
+        split("\n")
+        | map(select(length > 0) | try fromjson catch empty)
+        | [.[] | select(.date == $today and .container == "alpha" and .pull_count == 600)]
+        | length == 1
+    ' "$stats_file" >/dev/null
+
+    grep -qx "alpha" "$CURL_LOG"
+}

--- a/tests/unit/dockerhub-stats-workflow.bats
+++ b/tests/unit/dockerhub-stats-workflow.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+UPDATE_DASHBOARD_YAML="${PROJECT_ROOT}/.github/workflows/update-dashboard.yaml"
+
+setup() {
+    setup_temp_dir
+    TEST_REPO="$TEST_TEMP_DIR/repo"
+    mkdir -p "$TEST_REPO/scripts"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+extract_step_block() {
+    local step_name="$1"
+
+    awk -v step_name="$step_name" '
+        $0 == "      - name: " step_name {
+            in_step = 1
+            print
+            next
+        }
+        in_step && $0 ~ /^      - name: / {
+            exit
+        }
+        in_step {
+            print
+        }
+    ' "$UPDATE_DASHBOARD_YAML"
+}
+
+extract_job_block() {
+    local job_name="$1"
+
+    awk -v job_name="$job_name" '
+        $0 == "  " job_name ":" {
+            in_job = 1
+            print
+            next
+        }
+        in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ {
+            exit
+        }
+        in_job {
+            print
+        }
+    ' "$UPDATE_DASHBOARD_YAML"
+}
+
+extract_job_if() {
+    local job_name="$1"
+
+    extract_job_block "$job_name" | awk '
+        $0 ~ /^    if: \|[[:space:]]*$/ {
+            in_if = 1
+            next
+        }
+        in_if && $0 ~ /^      / {
+            sub(/^      /, "")
+            print
+            next
+        }
+        in_if {
+            exit
+        }
+    '
+}
+
+extract_step_run() {
+    local step_name="$1"
+
+    extract_step_block "$step_name" | awk '
+        $0 ~ /^        run: \|[[:space:]]*$/ {
+            in_run = 1
+            next
+        }
+        in_run && $0 ~ /^          / {
+            sub(/^          /, "")
+            print
+            next
+        }
+        in_run {
+            exit
+        }
+    '
+}
+
+@test "update-dashboard build job does not run an inline stats snapshot" {
+    # Regression lock (#876 hardening): the build job used to call
+    # snapshot-stats.sh locally, feeding a NEVER-committed row into that
+    # job's own render of the trend sparkline. Since commit-stats-snapshot
+    # independently re-fetches and pushes the same day's data, the two could
+    # diverge (two independent Docker Hub fetches, no ordering guarantee) —
+    # the deployed trend could show a different pull_count for today than
+    # what actually landed in git. The build job must rely solely on
+    # whatever is already committed as of its checkout.
+    step_block="$(extract_step_block "Snapshot pull/star counts (non-blocking)")"
+    [ -z "$step_block" ]
+
+    build_job="$(extract_job_block "build")"
+    [[ "$build_job" != *"snapshot-stats.sh"* ]]
+}
+
+@test "update-dashboard commit stats job still calls commit wrapper directly" {
+    step_block="$(extract_step_block "Commit stats snapshot (non-blocking)")"
+
+    [[ "$step_block" == *"./scripts/commit-stats-snapshot.sh"* ]]
+    [[ "$step_block" != *"./scripts/snapshot-stats.sh"* ]]
+    [[ "$step_block" != *"|| true"* ]]
+    [[ "$step_block" != *"continue-on-error: true"* ]]
+}
+
+@test "update-dashboard commit stats job gates workflow_dispatch to master" {
+    job_if="$(extract_job_if "commit-stats-snapshot")"
+    normalized_if="$(printf '%s' "$job_if" | tr '\n' ' ' | tr -s ' ')"
+
+    [[ "$normalized_if" == *"(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')"* ]]
+    [[ "$normalized_if" != *"github.event_name == 'workflow_dispatch' ||"* ]]
+}
+
+@test "update-dashboard commit stats job has actions:write for its follow-up dispatch" {
+    job_block="$(extract_job_block "commit-stats-snapshot")"
+
+    [[ "$job_block" == *"actions: write"* ]]
+    [[ "$job_block" == *"contents: write"* ]]
+}
+
+@test "update-dashboard build and deploy use separate, non-workflow-level concurrency groups" {
+    # A single workflow-level "pages" group would cancel commit-stats-snapshot's
+    # whole run whenever an unrelated trigger superseded it. A single
+    # job-level group shared by build+deploy has its own bug — an unrelated
+    # newer build can cancel an already in-flight deploy. Both must be
+    # distinct, job-scoped groups.
+    full_yaml="$(cat "$UPDATE_DASHBOARD_YAML")"
+    [[ "$full_yaml" != *$'\nconcurrency:\n  group: "pages"'* ]]
+
+    build_job="$(extract_job_block "build")"
+    [[ "$build_job" == *'group: "pages-build"'* ]]
+    [[ "$build_job" == *"cancel-in-progress: true"* ]]
+
+    deploy_job="$(extract_job_block "deploy")"
+    [[ "$deploy_job" == *'group: "pages-deploy"'* ]]
+    [[ "$deploy_job" == *"cancel-in-progress: false"* ]]
+
+    commit_job="$(extract_job_block "commit-stats-snapshot")"
+    [[ "$commit_job" == *"group: commit-stats-snapshot"* ]]
+}
+
+@test "update-dashboard never interpolates trigger_reason directly into a run: script" {
+    # trigger_reason is caller-supplied free text (workflow_dispatch /
+    # workflow_call input) — interpolating the raw ${{ }} expression into a
+    # run: block lets it break out of quoting and execute commands on the
+    # runner. It must always cross via env: first.
+    full_yaml="$(cat "$UPDATE_DASHBOARD_YAML")"
+    [[ "$full_yaml" != *'"${{ github.event.inputs.trigger_reason'* ]]
+
+    generate_step="$(extract_step_block "Generate dashboard data")"
+    [[ "$generate_step" == *"TRIGGER_REASON:"* ]]
+    [[ "$generate_step" == *'"$TRIGGER_REASON"'* ]]
+}


### PR DESCRIPTION
## Summary

The daily Docker Hub pull-count snapshot already worked, but its history lived only in a GitHub Actions cache (`.build-lineage/stats-history.jsonl`) — the repo sits close to its total cache quota, a real eviction risk for a log meant to span months. This moves the history to a git-tracked file (`stats/dockerhub-pull-history.jsonl`), migrates the existing accumulated entries on first run, and adds the trend sparkline on each container's page that never got built on top of the data.

- New `scripts/commit-stats-snapshot.sh`: retries collection + commit + push up to 3x, self-heals from a lost git-push race, and fails loudly (non-zero exit) when it ends a run with anything still missing — this job has no downstream dependents, so failing it is isolated and visible rather than silently masking a real regression behind routine-flakiness warning text.
- `scripts/snapshot-stats.sh`: one-time reconciliation pulls in the existing cached history (excluding "today", which always gets a live re-fetch); a pinned per-run date keeps a run whose retries straddle UTC midnight focused on the day it started for.
- New independent `commit-stats-snapshot` job in `update-dashboard.yaml`, with its own concurrency group so it can't be cancelled by unrelated Pages-deploy activity, and a best-effort follow-up `workflow_dispatch` after a confirmed persist so the deployed trend doesn't wait for the next independent trigger.
- `generate-dashboard.sh` + `container-detail.html`: inline SVG sparkline per container, reading only what's actually committed (no speculative same-day data from two independent fetches that could disagree).
- `!stats/**` added to `auto-build.yaml`'s path filters so daily stats commits don't fan out into a fleet-wide rebuild (the #872 class of bug).
- `helpers/logging.sh`: hardened against a log/annotation-injection class where untrusted text logged verbatim could reintroduce control bytes via backslash-escape sequences.

GHCR stays out of scope — it has no pull-count API ([community/discussions#146215](https://github.com/orgs/community/discussions/146215), open since 2023, unanswered).

Closes #876

## Test plan

- [x] Full unit suite green (1995/1995), including new coverage for the reconciliation, retry/dispatch, and trend-rendering logic
- [x] `yamllint` / `actionlint` clean on the modified workflow files
- [x] `shellcheck` clean on the modified/new scripts
- [x] Every fix in the retry/dispatch logic is regression-locked: reverted, confirmed its own test fails, then restored
- [x] All checks green; behavior validated end-to-end against the final diff
