### PR TITLE
fix(dashboard): split stats snapshot into credential-free collect and authenticated persist jobs

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,6 +3,12 @@ name: Unit Tests
 on:
   pull_request:
   push:
+    # stats/** is a pure data file (Docker Hub pull-count history) with no
+    # code implications — excluded so the daily App-token-authenticated
+    # stats commit (which, unlike GITHUB_TOKEN, DOES retrigger workflow push
+    # events) doesn't fan out into a full unit-test run for no reason.
+    paths-ignore:
+      - "stats/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -32,8 +32,12 @@ on:
       - "*/README.md"
       - "generate-dashboard.sh"
       - "scripts/snapshot-stats.sh"
+      - "scripts/collect-stats-snapshot.sh"
       - "scripts/commit-stats-snapshot.sh"
-      # Bot stats commits use GITHUB_TOKEN and cannot retrigger workflows.
+      # Bot stats commits are authenticated with a GitHub App token (needed
+      # to satisfy master's branch protection), which — unlike GITHUB_TOKEN —
+      # DOES retrigger workflow push events, so this path naturally covers
+      # the daily stats commit too.
       - "stats/**"
       - ".github/workflows/update-dashboard.yaml"
 
@@ -682,43 +686,25 @@ jobs:
         with:
           path: ./_site
 
-  commit-stats-snapshot:
+  collect-stats-snapshot:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Own concurrency group, with a name that can never collide with the
-    # `pages` group used by `build`/`deploy` (GitHub Actions concurrency
-    # groups are scoped by name across the whole repo, not per job or per
-    # workflow file — a shared name would let an unrelated Pages run cancel
-    # this job mid-flight even on triggers that can't themselves run it).
-    # cancel-in-progress: false means an in-progress run of THIS job is never
-    # killed by a newer trigger — it queues instead. GitHub keeps at most one
-    # PENDING run per group by default (not `queue: max`): if several
-    # triggers arrive in a burst while one run is executing, only the LATEST
-    # pending one survives to actually run once the current run finishes,
-    # not all of them in sequence. That's fine here — the script is fully
-    # idempotent (skips containers already recorded today) and retries
-    # internally, so a coalesced run reconciles the same "what's still
-    # missing today" state any of the superseded ones would have. The
-    # trade-off is fewer independent retry attempts across a burst, not a
-    # correctness gap — this design already accepts same-day recovery isn't
-    # guaranteed (see the header comment in commit-stats-snapshot.sh).
+    outputs:
+      still_missing: ${{ steps.collect.outputs.still_missing }}
+    # Serialize only collection. GitHub Actions keeps at most one pending job
+    # per group; if a newer trigger drops an older pending collect job, that
+    # dropped job has not fetched Docker Hub or uploaded an artifact yet, so
+    # there is no collected data to orphan. Completed collect jobs hand real
+    # candidate artifacts to commit-stats-snapshot, which is intentionally not
+    # serialized below.
     concurrency:
-      group: commit-stats-snapshot
+      group: collect-stats-snapshot
       cancel-in-progress: false
     # Deliberately excludes workflow_call — recreate-manifests.yaml (the only
     # current workflow_call caller) grants only contents: read and cannot safely
-    # be assumed to propagate contents: write through a reusable-workflow call.
-    # Direct invocations are the best-effort persistence attempts for this job:
-    # schedule, push, workflow_dispatch on master, and filtered workflow_run. A
-    # missed cron attempt is commonly recovered by the same day's post-build
-    # workflow_run with a fresh checkout and retry loop. The narrow irrecoverable
-    # data-loss case is a UTC day with zero container builds, where the schedule
-    # is the only invocation and all 3 persistence attempts are exhausted before
-    # midnight — and now visible: the script exits non-zero when it ends with
-    # anything still missing, rather than always reporting success.
-    # A successful push also self-triggers a follow-up dashboard build (see the
-    # script's own `gh workflow run` call) so the deployed trend does not have
-    # to wait for the next independent trigger — needs `actions: write` below.
+    # be assumed to propagate stats-persist permissions through a reusable-
+    # workflow call. Direct invocations are the best-effort persistence attempts:
+    # schedule, push, workflow_dispatch on master, and filtered workflow_run.
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
@@ -728,8 +714,72 @@ jobs:
        github.event.workflow_run.event != 'pull_request' &&
        github.event.workflow_run.head_branch == 'master')
     permissions:
-      contents: write
-      actions: write
+      actions: read           # Required by actions/upload-artifact and actions/cache (artifact + cache restore steps below)
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: 'refs/heads/master'
+          persist-credentials: false
+
+      - name: Restore build lineage cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .build-lineage
+          key: build-lineage-never-exact-match
+          restore-keys: build-lineage-
+
+      - name: Collect stats snapshot (non-blocking)
+        id: collect
+        run: |
+          chmod +x scripts/collect-stats-snapshot.sh
+          ./scripts/collect-stats-snapshot.sh
+
+      - name: Upload stats candidate artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: dockerhub-stats-candidate
+          path: stats/dockerhub-pull-history.jsonl
+          if-no-files-found: error
+          overwrite: true
+
+  commit-stats-snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: collect-stats-snapshot
+    # Deliberately no job-level concurrency block here. Once collection has
+    # succeeded, this run owns a real stats candidate artifact; allowing
+    # GitHub Actions to drop a queued commit job would orphan fetched data.
+    # Parallel commit jobs are expected: scripts/commit-stats-snapshot.sh
+    # merges each candidate into a fresh origin/master checkout and retries
+    # lost push races without clobbering concurrent rows.
+    # Mirrors collect-stats-snapshot's trigger filter and explicitly checks the
+    # needed job result because a job-level `if:` overrides Actions' implicit
+    # "all needs succeeded" guard. A missed cron attempt is commonly recovered
+    # by the same day's post-build workflow_run with a fresh checkout and retry
+    # loop. The narrow irrecoverable data-loss case is a UTC day with zero
+    # container builds, where the schedule is the only invocation and all 3
+    # persistence attempts are exhausted before midnight — and now visible: the
+    # script exits non-zero when it ends with anything still missing, rather
+    # than always reporting success.
+    # A successful push here is authored by the App token below, not
+    # GITHUB_TOKEN — unlike GITHUB_TOKEN, an App-token push DOES trigger
+    # downstream workflow events, and `stats/**` is already in this
+    # workflow's own push path filter, so it naturally retriggers a fresh
+    # dashboard build with no explicit dispatch needed.
+    if: |
+      needs.collect-stats-snapshot.result == 'success' &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+       (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_branch == 'master'))
+    permissions:
+      actions: read           # Required by actions/download-artifact (stats candidate artifact below)
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -737,20 +787,74 @@ jobs:
           ref: 'refs/heads/master'
           persist-credentials: false
 
-      - name: Restore build lineage cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download stats candidate artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4
         with:
-          path: .build-lineage
-          key: build-lineage-never-exact-match
-          restore-keys: build-lineage-
+          name: dockerhub-stats-candidate
+          path: .dockerhub-stats-candidate
+
+      - name: Restore downloaded stats candidate
+        id: stats-candidate
+        run: |
+          set -euo pipefail
+          candidate_file=".dockerhub-stats-candidate/dockerhub-pull-history.jsonl"
+          if [[ ! -f "$candidate_file" ]]; then
+            candidate_file=".dockerhub-stats-candidate/stats/dockerhub-pull-history.jsonl"
+          fi
+          if [[ ! -f "$candidate_file" ]]; then
+            echo "::error::Downloaded stats candidate artifact did not contain dockerhub-pull-history.jsonl"
+            exit 1
+          fi
+          printf 'candidate_source_file=%s\n' "$candidate_file" >> "$GITHUB_OUTPUT"
+
+      # master requires: PR-only changes, verified commit signatures, and the
+      # unit-tests status check — none of which a direct GITHUB_TOKEN push can
+      # satisfy. The existing bot App (already used for the same reason in
+      # upstream-monitor.yaml) is registered as a ruleset bypass actor for
+      # this repo specifically; its token plus a GPG-signed commit is what
+      # actually lets this job land on master directly. Deliberate deferral:
+      # a no-op candidate still mints this short-lived, contents:write token
+      # inside the isolated commit job. Earlier hardening keeps the token
+      # unreachable by unrelated code, so splitting "needs commit?" across an
+      # extra pre-auth boundary is not justified by the residual exposure.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          # Scoped down to exactly what this job needs — without this, the
+          # token defaults to every permission the App is installed with
+          # (used more broadly by upstream-monitor.yaml), which is an
+          # unnecessarily large grant for a job that only pushes one file,
+          # especially since this App is also a ruleset-bypass actor.
+          permission-contents: write
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: Olivier ORABONA
+          git_committer_email: oorabona@users.noreply.github.com
 
       - name: Commit stats snapshot (non-blocking)
+        id: persist
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          CANDIDATE_SOURCE_FILE: ${{ steps.stats-candidate.outputs.candidate_source_file }}
+          STATS_PUSH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           chmod +x scripts/commit-stats-snapshot.sh
           ./scripts/commit-stats-snapshot.sh
+
+      - name: Fail if stats snapshot did not fully persist
+        if: steps.persist.outputs.still_missing_after_reconcile == 'true' || steps.persist.outputs.persisted != 'true'
+        run: |
+          echo "::error::Stats snapshot did not fully persist this run (collection still_missing=${{ needs.collect-stats-snapshot.outputs.still_missing }}, reconciled still_missing=${{ steps.persist.outputs.still_missing_after_reconcile }}, persist persisted=${{ steps.persist.outputs.persisted }}) — another same-day direct trigger may still cover it"
+          exit 1
 
   # Deployment job - only deploy from main/master branch or manual dispatch
   deploy:

--- a/scripts/collect-stats-snapshot.sh
+++ b/scripts/collect-stats-snapshot.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  echo "::error::scripts/collect-stats-snapshot.sh is CI-only" >&2
+  exit 2
+fi
+
+# Pure data collection — no git operations, no push credentials in scope at
+# all (this step in the calling workflow runs BEFORE the App token is minted
+# and the GPG key is imported), so a compromised snapshot-stats.sh (or a
+# malicious Docker Hub response) has nothing here that could push a signed,
+# branch-protection-bypassing change to master. Only
+# scripts/commit-stats-snapshot.sh, run later with those credentials in scope,
+# does that.
+#
+# Pinned once, before the first attempt, so all 3 retries stay focused on
+# the day this run started for, not whatever the clock says by the time a
+# later attempt fires.
+export SNAPSHOT_DATE_OVERRIDE
+SNAPSHOT_DATE_OVERRIDE="$(date -u +%Y-%m-%d)"
+
+still_missing=true
+for attempt in 1 2 3; do
+  if ./scripts/snapshot-stats.sh; then
+    still_missing=false
+    break
+  fi
+  echo "::warning::Stats snapshot collection failed on attempt $attempt; some containers failed, but valid rows from successful containers are still kept"
+  if [[ "$attempt" -lt 3 ]]; then
+    if ! sleep $((attempt * 5)); then
+      echo "::warning::Stats snapshot collection retry sleep failed after attempt $attempt"
+    fi
+  fi
+done
+
+if [[ "$still_missing" == "true" ]]; then
+  echo "::warning::Stats snapshot collection ended with some containers still missing after 3 attempts"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "still_missing=$still_missing" >> "$GITHUB_OUTPUT"
+fi
+
+exit 0

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -6,70 +6,391 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   exit 2
 fi
 
-# This job deliberately re-fetches Docker Hub stats instead of consuming build artifacts; the duplicate read is cheap and avoids cross-job coupling.
-# Hardcoded origin/master targets are safe because update-dashboard.yaml pins this job's checkout to refs/heads/master.
+# Persist-only: scripts/collect-stats-snapshot.sh already ran in a separate
+# workflow job and handed this job only stats/dockerhub-pull-history.jsonl via
+# an artifact. This script never re-fetches Docker Hub — it only commits and
+# pushes that inert candidate data, so it never needs the collection script's
+# network access at all, and the reverse holds too: collection never has these
+# push credentials in scope.
 #
-# Snapshot persistence is attempted best-effort by every direct update-dashboard
-# invocation (schedule, push, workflow_dispatch on master, and filtered
-# workflow_run), not only by the 07:00 UTC cron. A missed schedule attempt is
-# usually recovered by a same-day post-build workflow_run with a fresh checkout
-# and retry loop. The genuinely irrecoverable data-loss case is narrower: a UTC
-# day with zero container builds, where the schedule run is the only invocation
-# and all 3 persistence attempts are exhausted before midnight. A successful bot
-# commit also does not retrigger the Pages deploy by itself, so the deployed UI
-# can lag the committed snapshot until a later normal dashboard trigger; this is
-# a freshness lag, not a data-loss path.
+# Hardcoded origin/master targets are safe because update-dashboard.yaml
+# pins this job's checkout to refs/heads/master.
 #
-# A successful push does not end the loop by itself when that attempt's own
-# snapshot was only partial (some containers failed to fetch) — the loop keeps
-# retrying the still-missing containers with its remaining attempts. This is
-# safe against data loss: origin/master already has whatever was pushed, and
-# retry_cleanup's "reset --hard origin/master" only ever discards a LATER
-# attempt's uncommitted work, never data that already made it to origin.
-# `still_missing` tracks confirmed end-of-run state (not just the first
-# success) so the final outcome reflects reality even when an earlier attempt
-# already persisted something.
+# On a lost push race, retry_cleanup resets the worktree to origin/master.
+# The initial persist-job checkout can also be newer than the collect-job
+# checkout that produced the downloaded artifact. In both cases, a candidate
+# copy of what collection produced is merged into the current worktree instead
+# of overwriting it, preserving whatever a concurrent run's own successful
+# push may have already added.
 #
-# The run FAILS (exit 1) whenever it ends with anything still missing —
-# whether nothing was ever pushed or only a partial persist landed. This job
-# has no downstream dependents (deploy only needs build), so failing it is
-# isolated and visible rather than a silent, permanently-green job that
+# The run FAILS (exit 1) whenever it ends without a successful push. This
+# job has no downstream dependents (deploy only needs build), so failing it
+# is isolated and visible rather than a silent, permanently-green job that
 # would otherwise mask a real regression (revoked token scope, branch
-# protection change) behind the same warning text a routine Docker Hub
-# hiccup produces. A day where only external fetches were flaky still
-# self-heals via the next day's idempotent retry; a day where NOTHING can be
-# pushed at all needs a human to notice, which a green job would hide.
+# protection change) behind routine warning text.
 #
-# A genuine change to origin/master's content (not just a same-day idempotent
-# no-op) also best-effort triggers a follow-up dashboard build so the
-# deployed trend doesn't wait for the next independent trigger — a bot
-# commit via GITHUB_TOKEN cannot retrigger the `push` path itself (documented
-# GitHub anti-loop behavior), so this uses an explicit workflow_dispatch
-# instead. Detected via a before/after hash of origin/master's ACTUAL content
-# (remote_stats_hash, a fresh fetch + `git show`), not tracking `git push`'s
-# own exit code or the local worktree: an ambiguous network failure (the
-# remote accepts the push but the client never sees the ack) reports failure
-# locally even though origin DID change, and the local worktree can itself
-# diverge from origin under compound cleanup failures (retry_cleanup's own
-# fetch/reset are warn-and-continue, not hard stops) — querying origin
-# directly at both ends is immune to either misreading. If the hash check
-# itself is degraded (either fetch failed, distinguished from a CONFIRMED
-# empty file via the REMOTE_HASH_UNKNOWN sentinel), the dispatch decision
-# falls back to whether a `git push` command reported success this run
-# (push_confirmed) rather than risk a raw comparison against an unknown
-# baseline in either direction.
+# No explicit follow-up dispatch: the calling workflow authenticates this
+# push with a GitHub App installation token (required to satisfy master's
+# branch protection — PR-only changes, verified signatures, status checks —
+# which GITHUB_TOKEN categorically cannot). Unlike GITHUB_TOKEN, an
+# App-token-authored push DOES trigger downstream workflow events, and
+# `stats/**` is already in update-dashboard.yaml's own push path filter —
+# so a successful push here naturally retriggers the dashboard build.
 
-github_token="${GITHUB_TOKEN:-}"
+STATS_FILE="stats/dockerhub-pull-history.jsonl"
+# Floor predates this JSONL dashboard history and rejects absurdly old
+# candidate rows. Already-committed rows before this floor are still preserved
+# verbatim by merge_candidate_into_worktree's raw-line path.
+STATS_DATE_FLOOR="2020-01-01"
+
+push_token="${STATS_PUSH_TOKEN:-}"
 github_repository="${GITHUB_REPOSITORY:-}"
 safe_origin_url=""
+origin_restore_needed=false
 
 if [[ -n "$github_repository" ]]; then
   safe_origin_url="https://github.com/${github_repository}.git"
 fi
 
-restore_origin_remote() {
-  [[ -n "$safe_origin_url" ]] || return 0
-  git remote set-url origin "$safe_origin_url" >/dev/null 2>&1 || true
+CANDIDATE_SOURCE_FILE="${CANDIDATE_SOURCE_FILE:-}"
+CANDIDATE_FILE=$(mktemp)
+STATS_DATE_CEILING=""
+CONTAINER_ALLOWLIST=""
+
+load_stats_validation_context() {
+  local -a container_allowlist=()
+
+  # Mirrors helpers/logging.sh:list_containers exactly: top-level directories
+  # containing Dockerfile or Dockerfile.* are the only valid stats containers.
+  mapfile -t container_allowlist < <(
+    find . -maxdepth 2 \( -name "Dockerfile" -o -name "Dockerfile.*" \) | sed 's|^\./||' | cut -d'/' -f1 | sort -u
+  )
+
+  if ((${#container_allowlist[@]} > 0)); then
+    CONTAINER_ALLOWLIST=$(printf '%s\n' "${container_allowlist[@]}")
+  else
+    CONTAINER_ALLOWLIST=""
+  fi
+
+  if ! STATS_DATE_CEILING=$(date -u -d '+1 day' +%Y-%m-%d); then
+    echo "::error::Could not compute Docker stats date validation ceiling" >&2
+    return 1
+  fi
+}
+
+# shellcheck disable=SC2016  # jq program text; $names below are jq variables.
+JQ_STATS_HELPERS='
+    def parsed_json_line:
+      try {ok: true, value: fromjson} catch {ok: false, value: null};
+
+    def sortable_snapshot_ts:
+      if (.ts? | type) == "string"
+          and (.ts | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+      then
+        .ts
+      else
+        null
+      end;
+
+    def known_stats_container:
+      (. as $container | ($container_allowlist | split("\n") | index($container)) != null);
+
+    def valid_stats_date:
+      . as $date
+      | ($date | type) == "string"
+        and ($date | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))
+        and (try (($date | strptime("%Y-%m-%d") | mktime | strftime("%Y-%m-%d")) == $date) catch false)
+        and $date >= $stats_date_floor
+        and $date <= $stats_date_ceiling;
+
+    def nonnegative_integer:
+      type == "number" and . >= 0 and . == floor;
+
+    def parsed_stats_row:
+      parsed_json_line as $parsed
+      | ($parsed.value) as $obj
+      | if $parsed.ok
+          and ($obj | type) == "object"
+          and (($obj | sortable_snapshot_ts) != null)
+          and ($obj.date? | valid_stats_date)
+          and ($obj.container? | known_stats_container)
+          and $obj.source? == "dockerhub"
+          and ($obj.pull_count? | nonnegative_integer)
+          and ($obj.star_count? | nonnegative_integer)
+        then
+          $obj
+        else
+          null
+        end;
+'
+
+emit_persisted_output() {
+  local persisted_value="$1"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "persisted=$persisted_value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+emit_still_missing_after_reconcile_output() {
+  local still_missing_value="$1"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "still_missing_after_reconcile=$still_missing_value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# shellcheck disable=SC2329  # Invoked by the EXIT trap below.
+cleanup() {
+  if [[ "$origin_restore_needed" == "true" && -n "$safe_origin_url" ]]; then
+    if ! git remote set-url origin "$safe_origin_url" >/dev/null 2>&1; then
+      echo "::warning::Could not restore unauthenticated origin remote after stats snapshot"
+    fi
+  fi
+  rm -f "$CANDIDATE_FILE"
+  return 0
+}
+trap cleanup EXIT
+
+if ! load_stats_validation_context; then
+  emit_persisted_output false
+  exit 1
+fi
+
+if [[ -n "$CANDIDATE_SOURCE_FILE" ]]; then
+  if [[ ! -f "$CANDIDATE_SOURCE_FILE" ]]; then
+    echo "::error::CANDIDATE_SOURCE_FILE is set but does not exist: $CANDIDATE_SOURCE_FILE"
+    emit_persisted_output false
+    exit 1
+  fi
+  cp "$CANDIDATE_SOURCE_FILE" "$CANDIDATE_FILE"
+elif [[ -f "$STATS_FILE" ]]; then
+  cp "$STATS_FILE" "$CANDIDATE_FILE"
+else
+  : > "$CANDIDATE_FILE"
+fi
+
+merge_candidate_into_worktree() {
+  # Same key (date, container): later snapshot ts wins when both rows have the
+  # fixed UTC format written by snapshot-stats.sh. Rows without that safely
+  # string-comparable ts are no longer conforming, but if a future bug reaches
+  # this tie-break without comparable timestamps, keep the already-processed
+  # row instead of letting an untrusted candidate win by default. Malformed or
+  # otherwise unrecognized nonblank lines already in committed stats history
+  # are preserved verbatim, but candidate-only raw lines are dropped before
+  # this privileged signed push path can trust them.
+  #
+  # Known accepted limitation: this union merge cannot represent an intentional
+  # manual deletion/correction of a row racing a stale collect artifact with the
+  # same (date, container) key. Tombstones or base-SHA deltas would be a larger
+  # design for a narrow, non-security edge case in an append-only dashboard log.
+  local merged_tmp merge_stderr_tmp
+
+  if ! mkdir -p "$(dirname "$STATS_FILE")"; then
+    echo "::warning::Could not prepare stats directory before stats candidate merge"
+    return 1
+  fi
+  if [[ ! -f "$STATS_FILE" ]]; then
+    : > "$STATS_FILE" || {
+      echo "::warning::Could not create missing stats file before stats candidate merge"
+      return 1
+    }
+  fi
+
+  if ! merged_tmp=$(mktemp); then
+    echo "::warning::Could not create temporary file for stats candidate merge"
+    return 1
+  fi
+  if ! merge_stderr_tmp=$(mktemp); then
+    echo "::warning::Could not create temporary stderr file for stats candidate merge"
+    rm -f "$merged_tmp"
+    return 1
+  fi
+
+  if jq -Rrn \
+    --arg stats_file "$STATS_FILE" \
+    --arg candidate_file "$CANDIDATE_FILE" \
+    --arg container_allowlist "$CONTAINER_ALLOWLIST" \
+    --arg stats_date_floor "$STATS_DATE_FLOOR" \
+    --arg stats_date_ceiling "$STATS_DATE_CEILING" \
+    "${JQ_STATS_HELPERS}"'
+    def winning_keyed_row($current; $incoming):
+      if $current == null then
+        $incoming
+      elif $current.source != $incoming.source then
+        ($current.row | sortable_snapshot_ts) as $current_ts
+        | ($incoming.row | sortable_snapshot_ts) as $incoming_ts
+        | if $current_ts != null and $incoming_ts != null then
+            if $incoming_ts >= $current_ts then
+              $incoming
+            else
+              $current
+            end
+          else
+            $current
+          end
+      else
+        $incoming
+      end;
+
+    (reduce inputs as $line (
+      {
+        candidate_raw_counts: {},
+        entries: [],
+        keyed: {},
+        next_id: 0,
+        stats_raw_counts: {}
+      };
+      input_filename as $file
+      | if $line == "" then
+          .
+        else
+          ($line | parsed_stats_row) as $row
+          | if $row != null then
+              ($row.date + "\u0000" + $row.container) as $key
+              | {
+                  id: .next_id,
+                  raw: $line,
+                  row: $row,
+                  source: $file
+                } as $incoming
+              | .keyed[$key] = winning_keyed_row((.keyed[$key] // null); $incoming)
+              | .entries += [{id: .next_id, key: $key, kind: "keyed"}]
+              | .next_id += 1
+            elif $file == $stats_file then
+              .stats_raw_counts[$line] = ((.stats_raw_counts[$line] // 0) + 1)
+              | .entries += [{kind: "raw", raw: $line}]
+            else
+              .candidate_raw_counts[$line] = ((.candidate_raw_counts[$line] // 0) + 1)
+              | if .candidate_raw_counts[$line] > (.stats_raw_counts[$line] // 0) then
+                  . as $state
+                  | (
+                      "::warning::Dropping nonconforming candidate-only stats line before signed push"
+                      | stderr
+                    )
+                  | $state
+                else
+                  .
+                end
+            end
+        end
+    )) as $state
+    | $state.entries[]
+    | if .kind == "raw" then
+        .raw
+      else
+        . as $entry
+        | ($state.keyed[$entry.key]) as $winner
+        | select($entry.id == $winner.id)
+        | if $winner.source == $candidate_file then
+            ($winner.row | @json)
+          else
+            $winner.raw
+          end
+      end
+  ' "$STATS_FILE" "$CANDIDATE_FILE" > "$merged_tmp" 2> "$merge_stderr_tmp"; then
+    if [[ -s "$merge_stderr_tmp" ]]; then
+      cat "$merge_stderr_tmp" >&2
+    fi
+    if mv "$merged_tmp" "$STATS_FILE"; then
+      rm -f "$merge_stderr_tmp"
+      return 0
+    fi
+    echo "::warning::Could not replace stats file after stats candidate merge"
+    rm -f "$merged_tmp" "$merge_stderr_tmp"
+    return 1
+  fi
+
+  echo "::warning::Could not merge collected stats candidate into the worktree"
+  rm -f "$merged_tmp" "$merge_stderr_tmp"
+  return 1
+}
+
+validate_stats_file_jsonl() {
+  local invalid_line
+
+  if ! invalid_line=$(jq -Rn \
+    --arg container_allowlist "$CONTAINER_ALLOWLIST" \
+    --arg stats_date_floor "$STATS_DATE_FLOOR" \
+    --arg stats_date_ceiling "$STATS_DATE_CEILING" \
+    "${JQ_STATS_HELPERS}"'
+    reduce inputs as $line (
+      {invalid_line_number: null, line_number: 0};
+      .line_number += 1
+      | if .invalid_line_number != null
+          or $line == ""
+          or (($line | parsed_json_line).ok)
+        then
+          .
+        else
+          .invalid_line_number = .line_number
+        end
+    )
+    | select(.invalid_line_number != null)
+    | .invalid_line_number
+  ' "$STATS_FILE"); then
+    echo "::warning::Could not validate stats snapshot JSONL before commit"
+    return 1
+  fi
+
+  if [[ -n "$invalid_line" ]]; then
+    echo "::warning::Refusing to commit stats snapshot because $STATS_FILE has invalid JSON at line $invalid_line"
+    return 1
+  fi
+
+  return 0
+}
+
+compute_still_missing_after_reconcile() {
+  local today_utc
+  local still_missing
+
+  if ! today_utc=$(date -u +%Y-%m-%d); then
+    echo "::warning::Could not compute Docker stats completion date" >&2
+    return 1
+  fi
+
+  if [[ ! -f "$STATS_FILE" ]]; then
+    printf 'true\n'
+    return 0
+  fi
+
+  if ! still_missing=$(jq -Rrn \
+    --arg today "$today_utc" \
+    --arg container_allowlist "$CONTAINER_ALLOWLIST" \
+    --arg stats_date_floor "$STATS_DATE_FLOOR" \
+    --arg stats_date_ceiling "$STATS_DATE_CEILING" \
+    "${JQ_STATS_HELPERS}"'
+    reduce inputs as $line (
+      {seen: {}};
+      if $line == "" then
+        .
+      else
+        ($line | parsed_stats_row) as $row
+        | if $row != null and $row.date == $today then
+            .seen[$row.container] = true
+          else
+            .
+          end
+      end
+    )
+    | . as $state
+    | ($container_allowlist | split("\n") | map(select(. != ""))) as $containers
+    | ([$containers[] | select(($state.seen[.] // false) | not)] | length > 0)
+  ' "$STATS_FILE"); then
+    echo "::warning::Could not reconcile stats snapshot completion state" >&2
+    return 1
+  fi
+
+  case "$still_missing" in
+    true|false)
+      printf '%s\n' "$still_missing"
+      ;;
+    *)
+      echo "::warning::Unexpected stats snapshot completion state: $still_missing" >&2
+      return 1
+      ;;
+  esac
 }
 
 sleep_before_retry() {
@@ -82,42 +403,15 @@ sleep_before_retry() {
   fi
 }
 
-# Hashes origin/master's ACTUAL current content for the stats file via a
-# fresh fetch + `git show`, never the local worktree. The local file is only
-# a reliable proxy for origin's state when every cleanup fetch/reset in this
-# run has succeeded — retry_cleanup treats those as warnings, not hard
-# failures, so under compound git-operation failures the local worktree can
-# diverge from what's really on origin in either direction (missing a
-# landed-but-ambiguous push, or still holding rows that never actually
-# pushed). Querying origin directly is immune to that assumption.
-#
-# Returns the sentinel REMOTE_HASH_UNKNOWN (never a real sha256sum output —
-# always exactly 64 lowercase hex chars) when the fetch itself fails, kept
-# distinct from a CONFIRMED "the file is empty/absent" hash. Conflating the
-# two would let a lucky-then-unlucky fetch pair (or vice versa) misfire the
-# dispatch decision in either direction — the caller must never compare an
-# UNKNOWN reading against anything, only fall back to a different signal.
-REMOTE_HASH_UNKNOWN="unknown"
-remote_stats_hash() {
-  # Called via command substitution — anything this function writes to
-  # stdout becomes the caller's captured value, so diagnostics MUST go to
-  # stderr or they'd silently corrupt the hash instead of surfacing as a
-  # real warning.
-  if ! git fetch origin master >/dev/null 2>&1; then
-    echo "::warning::Could not fetch origin/master to check remote stats state" >&2
-    printf '%s' "$REMOTE_HASH_UNKNOWN"
-    return
-  fi
-  git show origin/master:stats/dockerhub-pull-history.jsonl 2>/dev/null | sha256sum | awk '{print $1}' || true
-}
-
 retry_cleanup() {
   local attempt="$1"
   local committed="$2"
+  local reset_failed=false
 
   if [[ "$committed" == "true" ]]; then
     if ! git reset --hard HEAD~1; then
       echo "::warning::Could not discard failed stats commit on attempt $attempt"
+      reset_failed=true
     fi
   fi
 
@@ -127,159 +421,101 @@ retry_cleanup() {
 
   if ! git reset --hard origin/master; then
     echo "::warning::Could not reset stats snapshot worktree after attempt $attempt"
+    reset_failed=true
+  fi
+
+  if [[ "$reset_failed" == "true" ]]; then
+    return 1
+  fi
+
+  if ! merge_candidate_into_worktree; then
+    return 1
   fi
 
   sleep_before_retry "$attempt"
 }
 
-trap restore_origin_remote EXIT
-
-if ! git config user.name "github-actions[bot]"; then
-  echo "::warning::Could not configure git user.name for stats snapshot"
-fi
-if ! git config user.email "github-actions[bot]@users.noreply.github.com"; then
-  echo "::warning::Could not configure git user.email for stats snapshot"
-fi
-if [[ -n "$github_token" && -n "$github_repository" ]]; then
-  if ! git remote set-url origin "https://x-access-token:${github_token}@github.com/${github_repository}.git"; then
+# Deliberately no local `git config user.name/email` here — the calling
+# workflow's GPG-import step sets the committer identity globally, matching
+# the identity the signing key is bound to. A local override here (local
+# config wins over global) would silently produce commits attributed to a
+# name the GPG key doesn't sign for, defeating the "required_signatures"
+# branch protection rule this job depends on.
+if [[ -n "$push_token" && -n "$github_repository" ]]; then
+  origin_restore_needed=true
+  if ! git remote set-url origin "https://x-access-token:${push_token}@github.com/${github_repository}.git"; then
     echo "::warning::Could not configure authenticated origin remote for stats snapshot"
   fi
 else
-  echo "::warning::Missing GitHub token or repository; stats snapshot push may not be authenticated"
+  echo "::warning::Missing push token or repository; stats snapshot push may not be authenticated"
 fi
-
-# Pinned once, before the first attempt, so all 3 retries — including any
-# that happen to fire after a UTC midnight rollover mid-run — stay focused on
-# THIS run's day rather than silently switching to a fresh "today" partway
-# through. See snapshot-stats.sh's SNAPSHOT_DATE_OVERRIDE doc comment.
-export SNAPSHOT_DATE_OVERRIDE
-SNAPSHOT_DATE_OVERRIDE="$(date -u +%Y-%m-%d)"
-
-initial_stats_hash="$(remote_stats_hash)"
 
 persisted=false
-# Pessimistic by default: only cleared at the two points below where we have
-# actually CONFIRMED the run ends with nothing outstanding (full fetch AND
-# either nothing new to push or a successful push). Every other path —
-# fetch failure, diff-inspection failure, add/commit/push failure, or even a
-# FULLY successful fetch whose subsequent git operations then fail — leaves
-# this true, so the final outcome reflects reality regardless of which
-# attempt an earlier successful partial push happened on.
-still_missing=true
-# Narrower than `persisted` (which also becomes true via the "nothing new,
-# already done" no-op) — set true ONLY when a `git push` command itself
-# reports success this run. Used solely as the fallback dispatch signal when
-# the remote hash check is degraded (see the final dispatch decision below);
-# the hash comparison remains the primary, more reliable signal whenever
-# both its fetches succeed.
-push_confirmed=false
-for attempt in 1 2 3; do
-  snapshot_failed=false
-  if ! ./scripts/snapshot-stats.sh; then
-    snapshot_failed=true
-    echo "::warning::Stats snapshot collection failed on attempt $attempt; some containers failed, but valid rows from successful containers will still be considered for commit"
-  fi
+if merge_candidate_into_worktree; then
+  for attempt in 1 2 3; do
+    if git diff --quiet HEAD -- "$STATS_FILE"; then
+      persisted=true
+      break
+    else
+      diff_status=$?
+      if [[ "$diff_status" -gt 1 ]]; then
+        echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
+        if ! retry_cleanup "$attempt" "false"; then
+          break
+        fi
+        continue
+      fi
+    fi
 
-  # HEAD (not index) comparison: catches a change staged-but-not-committed by
-  # a prior attempt that failed between `git add` and a successful `git
-  # commit`+cleanup — a plain `git diff` (working tree vs index) would see
-  # that case as "clean" and wrongly skip straight to persisted=true.
-  if git diff --quiet HEAD -- stats/dockerhub-pull-history.jsonl; then
-    if [[ "$snapshot_failed" == "true" ]]; then
-      echo "::warning::Stats snapshot collection made no commit-worthy progress on attempt $attempt"
-      sleep_before_retry "$attempt"
+    if ! validate_stats_file_jsonl; then
+      if ! retry_cleanup "$attempt" "false"; then
+        break
+      fi
       continue
     fi
-    persisted=true  # nothing new this attempt: either already done, or a
-    still_missing=false  # concurrent run already covered it. Either way, not a failure.
-    break
-  else
-    diff_status=$?
-    if [[ "$diff_status" -gt 1 ]]; then
-      echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
-      retry_cleanup "$attempt" "false"
+
+    if ! git add "$STATS_FILE"; then
+      echo "::warning::Could not stage stats snapshot on attempt $attempt"
+      if ! retry_cleanup "$attempt" "false"; then
+        break
+      fi
       continue
     fi
-  fi
 
-  if ! git add stats/dockerhub-pull-history.jsonl; then
-    echo "::warning::Could not stage stats snapshot on attempt $attempt"
-    retry_cleanup "$attempt" "false"
-    continue
-  fi
-
-  if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot"; then
-    echo "::warning::Could not commit stats snapshot on attempt $attempt"
-    retry_cleanup "$attempt" "false"
-    continue
-  fi
-
-  if git push origin master; then
-    persisted=true
-    push_confirmed=true
-    if [[ "$snapshot_failed" == "true" ]]; then
-      echo "::warning::Persisted partial stats snapshot on attempt $attempt; some containers may still be missing — retrying for the rest"
-      sleep_before_retry "$attempt"
+    if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot" -- "$STATS_FILE"; then
+      echo "::warning::Could not commit stats snapshot on attempt $attempt"
+      if ! retry_cleanup "$attempt" "false"; then
+        break
+      fi
       continue
     fi
-    still_missing=false  # confirmed: fetch was fully successful AND this push succeeded
-    break
-  fi
 
-  # Lost the race (or lack permission) — discard this attempt and retry clean.
-  # origin/master already holds any earlier successful push from this run, so
-  # this reset can never discard already-persisted data.
-  retry_cleanup "$attempt" "true"
-done
+    if git push origin master; then
+      persisted=true
+      break
+    fi
 
-final_stats_hash="$(remote_stats_hash)"
-
-should_dispatch=false
-if [[ "$initial_stats_hash" != "$REMOTE_HASH_UNKNOWN" && "$final_stats_hash" != "$REMOTE_HASH_UNKNOWN" ]]; then
-  # Both checkpoints confirmed — the direct origin-content comparison is the
-  # authoritative signal, regardless of any single git push's own exit code.
-  [[ "$final_stats_hash" != "$initial_stats_hash" ]] && should_dispatch=true
-elif [[ "$push_confirmed" == "true" ]]; then
-  # The remote hash check was unavailable at least once this run (a fetch
-  # failure at either checkpoint), so a raw comparison can't be trusted in
-  # either direction. Fall back to the best remaining signal: did a `git
-  # push` command itself report success. This won't catch an ambiguous
-  # push (reported failure, actually landed) in this degraded path — an
-  # acceptable secondary-order gap given we're already short one reliable
-  # signal, and a missed dispatch here just means the usual freshness lag.
-  should_dispatch=true
-  echo "::warning::Remote stats hash check was unavailable this run; falling back to this run's own confirmed push status for the follow-up dispatch decision"
+    # Lost the race (or lack permission) — discard this attempt and retry
+    # clean, re-merging this run's own candidate data back in afterward.
+    if ! retry_cleanup "$attempt" "true"; then
+      break
+    fi
+  done
 fi
 
-if [[ "$should_dispatch" == "true" ]]; then
-  if [[ -n "$github_token" && -n "$github_repository" ]]; then
-    if ! GH_TOKEN="$github_token" gh workflow run update-dashboard.yaml \
-        --repo "$github_repository" \
-        --ref master \
-        -f trigger_reason="Docker Hub stats snapshot committed"; then
-      echo "::warning::Could not trigger a follow-up dashboard build after persisting stats — the deployed trend may lag until the next independent trigger"
-    fi
-  else
-    echo "::warning::Missing GitHub token or repository; could not trigger a follow-up dashboard build after persisting stats"
+emit_persisted_output "$persisted"
+
+still_missing_after_reconcile=true
+if [[ "$persisted" == "true" ]]; then
+  if ! still_missing_after_reconcile=$(compute_still_missing_after_reconcile); then
+    still_missing_after_reconcile=true
   fi
 fi
+emit_still_missing_after_reconcile_output "$still_missing_after_reconcile"
 
-if [[ "$still_missing" == "true" ]]; then
-  if [[ "$persisted" != "true" ]]; then
-    # No extra snapshot-stats.sh call here — nothing downstream reads the
-    # local worktree after this point (the job ends right after), and a 4th
-    # invocation was pushing the worst-case Docker-Hub-outage runtime close
-    # to the job's own timeout budget for no observable benefit.
-    echo "::error::Could not persist stats snapshot this run — another same-day direct trigger may still cover it"
-  else
-    echo "::error::Exhausted retries with some containers still missing after at least one successful persist — another same-day direct trigger may still cover them"
-  fi
-  restore_origin_remote
-  trap - EXIT
+if [[ "$persisted" != "true" ]]; then
+  echo "::error::Could not persist stats snapshot this run — another same-day direct trigger may still cover it"
   exit 1
 fi
-
-restore_origin_remote
-trap - EXIT
 
 exit 0

--- a/tests/unit/dockerhub-stats-collect.bats
+++ b/tests/unit/dockerhub-stats-collect.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    TEST_REPO="$TEST_TEMP_DIR/repo"
+    FAKE_STATE="$TEST_TEMP_DIR/state"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$FAKE_STATE"
+
+    ln -s "$SCRIPTS_DIR/collect-stats-snapshot.sh" "$TEST_REPO/scripts/collect-stats-snapshot.sh"
+
+    cat > "$TEST_REPO/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_STATE:?}/sleep.log"
+EOF
+    chmod +x "$TEST_REPO/bin/sleep"
+
+    export FAKE_STATE
+    export PATH="$TEST_REPO/bin:$PATH"
+    export GITHUB_ACTIONS="true"
+    export GITHUB_OUTPUT="$FAKE_STATE/github_output"
+    : > "$GITHUB_OUTPUT"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+get_output() {
+    local key="$1"
+    grep "^${key}=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
+}
+
+@test "collect-stats-snapshot refuses to run outside GitHub Actions" {
+    unset GITHUB_ACTIONS
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"::error::scripts/collect-stats-snapshot.sh is CI-only"* ]]
+}
+
+@test "collect-stats-snapshot stops early on a fully successful first attempt" {
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "call" >> "${FAKE_STATE:?}/calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    calls=$(wc -l < "$FAKE_STATE/calls.log")
+    [ "$calls" -eq 1 ]
+
+    [ "$(get_output still_missing)" = "false" ]
+    [[ "$output" != *"still missing"* ]]
+}
+
+@test "collect-stats-snapshot recovers on a later attempt and stops early" {
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "call" >> "${FAKE_STATE:?}/calls.log"
+calls=$(wc -l < "${FAKE_STATE:?}/calls.log")
+if [[ "$calls" -eq 1 ]]; then
+  exit 1
+fi
+exit 0
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
+
+    calls=$(wc -l < "$FAKE_STATE/calls.log")
+    [ "$calls" -eq 2 ]
+
+    [ "$(get_output still_missing)" = "false" ]
+}
+
+@test "collect-stats-snapshot exhausts all 3 attempts and reports still_missing when nothing ever fully succeeds" {
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "call" >> "${FAKE_STATE:?}/calls.log"
+exit 1
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    # Non-blocking by design — the calling workflow's own final check step
+    # decides pass/fail from still_missing, not this script's own exit code.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 2"* ]]
+    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 3"* ]]
+    [[ "$output" == *"::warning::Stats snapshot collection ended with some containers still missing after 3 attempts"* ]]
+
+    calls=$(wc -l < "$FAKE_STATE/calls.log")
+    [ "$calls" -eq 3 ]
+
+    [ "$(get_output still_missing)" = "true" ]
+}
+
+@test "collect-stats-snapshot pins SNAPSHOT_DATE_OVERRIDE once and holds it across all retry attempts" {
+    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "${SNAPSHOT_DATE_OVERRIDE:-UNSET}" >> "${FAKE_STATE:?}/date-override.log"
+exit 1
+EOF
+    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+
+    seen_dates=$(sort -u "$FAKE_STATE/date-override.log")
+    line_count=$(wc -l < "$FAKE_STATE/date-override.log")
+    [ "$line_count" -eq 3 ]
+    [ "$(printf '%s\n' "$seen_dates" | wc -l)" -eq 1 ]
+    [ "$seen_dates" != "UNSET" ]
+    [[ "$seen_dates" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+}
+
+@test "collect-stats-snapshot contains no git or token logic at all" {
+    # Regression lock: the real guarantee that collection can't misuse push
+    # credentials isn't anything this script does at runtime — it's that
+    # this script structurally has no git/token code path to misuse, AND
+    # (verified separately in dockerhub-stats-workflow.bats) the calling
+    # workflow doesn't mint the App token or import the GPG key until AFTER
+    # this step has already run. Comment lines are excluded — they're
+    # explanatory prose about the absence of git/token logic, not code.
+    non_comment_lines="$(grep -v '^\s*#' "$SCRIPTS_DIR/collect-stats-snapshot.sh")"
+    [[ "$non_comment_lines" != *'git '* ]]
+    [[ "$non_comment_lines" != *'TOKEN'* ]]
+}

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -6,39 +6,16 @@ setup() {
     setup_temp_dir
     TEST_REPO="$TEST_TEMP_DIR/repo"
     FAKE_GIT_STATE="$TEST_TEMP_DIR/git-state"
-    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$TEST_REPO/helpers" "$FAKE_GIT_STATE"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$FAKE_GIT_STATE"
+    mkdir -p "$TEST_REPO/alpha" "$TEST_REPO/gamma"
+    printf 'FROM scratch\n' > "$TEST_REPO/alpha/Dockerfile"
+    printf 'FROM scratch\n' > "$TEST_REPO/gamma/Dockerfile"
 
     ln -s "$SCRIPTS_DIR/commit-stats-snapshot.sh" "$TEST_REPO/scripts/commit-stats-snapshot.sh"
-    : > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    # Simulates what the (separate, already-run) collect step left behind.
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
     : > "$FAKE_GIT_STATE/head_stats"
-    : > "$FAKE_GIT_STATE/index_stats"
-
-    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-mkdir -p stats
-stats_file="stats/dockerhub-pull-history.jsonl"
-line='{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}'
-if [[ ! -f "$stats_file" ]] || ! grep -qF '"date":"2026-07-12","container":"alpha"' "$stats_file"; then
-  printf '%s\n' "$line" >> "$stats_file"
-fi
-echo "snapshot" >> "${FAKE_GIT_STATE:?}/snapshot.log"
-EOF
-    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
-
-    cat > "$TEST_REPO/bin/gh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-state="${FAKE_GIT_STATE:?}"
-printf '%s\n' "$*" >> "$state/gh.log"
-calls=$(cat "$state/gh_call_count" 2>/dev/null || echo 0)
-echo $((calls + 1)) > "$state/gh_call_count"
-if [[ "${FAKE_GH_FAIL:-}" == "1" ]]; then
-  exit 1
-fi
-exit 0
-EOF
-    chmod +x "$TEST_REPO/bin/gh"
 
     cat > "$TEST_REPO/bin/git" <<'EOF'
 #!/usr/bin/env bash
@@ -46,19 +23,45 @@ set -euo pipefail
 state="${FAKE_GIT_STATE:?}"
 stats_file="stats/dockerhub-pull-history.jsonl"
 head_stats="$state/head_stats"
-index_stats="$state/index_stats"
+local_head_stats="$state/local_head_stats"
+precommit_head_stats="$state/precommit_head_stats"
 commit_stats="$state/commit_stats"
 mkdir -p "$state"
 printf '%s\n' "$*" >> "$state/git.log"
 
-copy_head_to_worktree() {
+ensure_local_head() {
+  if [[ ! -f "$local_head_stats" ]]; then
+    if [[ -f "$head_stats" ]]; then
+      cp "$head_stats" "$local_head_stats"
+    else
+      : > "$local_head_stats"
+    fi
+  fi
+}
+
+reset_worktree_to_local_head() {
+  ensure_local_head
+  mkdir -p stats
+  cp "$local_head_stats" "$stats_file"
+}
+
+reset_worktree_to_origin() {
   mkdir -p stats
   if [[ -f "$head_stats" ]]; then
-    cp "$head_stats" "$stats_file"
-    cp "$head_stats" "$index_stats"
+    cp "$head_stats" "$local_head_stats"
   else
-    : > "$stats_file"
-    : > "$index_stats"
+    : > "$local_head_stats"
+  fi
+  cp "$local_head_stats" "$stats_file"
+}
+
+reset_worktree_to_parent() {
+  mkdir -p stats
+  if [[ -f "$precommit_head_stats" ]]; then
+    cp "$precommit_head_stats" "$local_head_stats"
+    cp "$local_head_stats" "$stats_file"
+  else
+    reset_worktree_to_origin
   fi
 }
 
@@ -68,44 +71,45 @@ case "${1:-}" in
     ;;
   remote)
     if [[ "${2:-}" == "set-url" && "${3:-}" == "origin" ]]; then
+      if [[ "${FAKE_GIT_FAIL_SAFE_REMOTE_RESTORE:-}" == "1" && "${4:-}" == "https://github.com/owner/repo.git" ]]; then
+        exit 1
+      fi
       printf '%s\n' "${4:-}" > "$state/origin_url"
     fi
     exit 0
     ;;
   diff)
-    # `git diff --quiet -- path` (no ref) is worktree-vs-INDEX; `git diff
-    # --quiet HEAD -- path` is worktree-vs-HEAD. The production script always
-    # passes HEAD (compare_against=head_stats below) — the index_stats branch
-    # exists so a dedicated test can demonstrate what the old ref-less form
-    # would have wrongly reported.
-    compare_against="$index_stats"
-    for arg in "$@"; do
-      if [[ "$arg" == "HEAD" ]]; then
-        compare_against="$head_stats"
-        break
-      fi
-    done
-    if cmp -s "$stats_file" "$compare_against"; then
+    # The production script always compares against HEAD. local_head_stats
+    # models that local HEAD; origin/master is head_stats and they coincide
+    # at the start of each checkout/reset.
+    ensure_local_head
+    if [[ "${FAKE_GIT_CORRUPT_ON_DIFF:-}" == "1" ]]; then
+      printf 'not-json-after-merge\n' >> "$stats_file"
+    fi
+    if cmp -s "$stats_file" "$local_head_stats"; then
       exit 0
     fi
     exit 1
     ;;
   add)
-    if [[ "${FAKE_GIT_FAIL_ADD:-}" == "1" ]]; then
+    if [[ "${FAKE_GIT_FAIL_ADD_ONCE:-}" == "1" ]] && [[ ! -f "$state/add_failed_once" ]]; then
+      : > "$state/add_failed_once"
       exit 1
     fi
-    cp "$stats_file" "$index_stats"
+    if [[ "${FAKE_GIT_FAIL_ADD_ALWAYS:-}" == "1" ]]; then
+      exit 1
+    fi
+    cp "$stats_file" "$state/index_stats"
     exit 0
     ;;
   commit)
     if [[ "${FAKE_GIT_FAIL_COMMIT_ALWAYS:-}" == "1" ]]; then
       exit 1
     fi
-    if [[ "${FAKE_GIT_FAIL_COMMIT_ONCE:-}" == "1" ]] && [[ ! -f "$state/commit_failed_once" ]]; then
-      : > "$state/commit_failed_once"
-      exit 1
-    fi
-    cp "$index_stats" "$commit_stats"
+    ensure_local_head
+    cp "$local_head_stats" "$precommit_head_stats"
+    cp "$state/index_stats" "$commit_stats"
+    cp "$commit_stats" "$local_head_stats"
     commits=$(cat "$state/commit_count" 2>/dev/null || echo 0)
     echo $((commits + 1)) > "$state/commit_count"
     exit 0
@@ -114,22 +118,16 @@ case "${1:-}" in
     pushes=$(cat "$state/push_count" 2>/dev/null || echo 0)
     pushes=$((pushes + 1))
     echo "$pushes" > "$state/push_count"
-    mode="${FAKE_GIT_PUSH_MODE:-success_on_retry}"
+    mode="${FAKE_GIT_PUSH_MODE:-always_success}"
     if [[ "$mode" == "always_fail" ]]; then
       exit 1
     fi
-    if [[ "$mode" == "always_success" ]]; then
-      cp "$commit_stats" "$head_stats"
-      cp "$commit_stats" "$index_stats"
-      exit 0
-    fi
-    if [[ "$mode" == "success_once_then_fail" ]]; then
+    if [[ "$mode" == "success_on_retry" ]]; then
       if [[ "$pushes" -eq 1 ]]; then
-        cp "$commit_stats" "$head_stats"
-        cp "$commit_stats" "$index_stats"
-        exit 0
+        exit 1
       fi
-      exit 1
+      cp "$commit_stats" "$head_stats"
+      exit 0
     fi
     if [[ "$mode" == "ambiguous_fail_once" ]]; then
       # Simulates a network partition where the remote accepts the push but
@@ -137,49 +135,54 @@ case "${1:-}" in
       # the command still reports failure to the caller.
       if [[ "$pushes" -eq 1 ]]; then
         cp "$commit_stats" "$head_stats"
-        cp "$commit_stats" "$index_stats"
         exit 1
       fi
       cp "$commit_stats" "$head_stats"
-      cp "$commit_stats" "$index_stats"
       exit 0
     fi
-    if [[ "$pushes" -eq 1 ]]; then
-      exit 1
+    if [[ "$mode" == "concurrent_update_then_success" ]]; then
+      # Simulates another run landing a DIFFERENT container's row on origin
+      # in between this run's first (lost) push attempt and its retry — the
+      # candidate-merge must preserve that concurrent addition, not clobber
+      # it with only this run's own alpha row.
+      if [[ "$pushes" -eq 1 ]]; then
+        printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+          > "$head_stats"
+        cp "$head_stats" "$state/first_failed_head_stats"
+        exit 1
+      fi
+      cp "$commit_stats" "$head_stats"
+      exit 0
+    fi
+    if [[ "$mode" == "concurrent_malformed_then_success" ]]; then
+      if [[ "$pushes" -eq 1 ]]; then
+        printf 'not-json\n{ "ts" : "2026-07-12T08:00:00Z", "date" : "2026-07-12", "container" : "gamma", "pull_count" : 99, "star_count" : 9, "source" : "dockerhub" }\n' \
+          > "$head_stats"
+        exit 1
+      fi
+      cp "$commit_stats" "$head_stats"
+      exit 0
     fi
     cp "$commit_stats" "$head_stats"
-    cp "$commit_stats" "$index_stats"
     exit 0
     ;;
   reset)
-    if [[ "$*" == *"origin/master"* ]] && [[ "${FAKE_GIT_FAIL_RESET_ALWAYS:-}" == "1" ]]; then
+    if [[ "${FAKE_GIT_FAIL_RESET_ALWAYS:-}" == "1" ]]; then
       exit 1
     fi
-    if [[ "$*" == *"origin/master"* ]] && [[ "${FAKE_GIT_FAIL_RESET_ONCE:-}" == "1" ]] && [[ ! -f "$state/reset_failed_once" ]]; then
-      : > "$state/reset_failed_once"
-      exit 1
+    if [[ "$*" == *"HEAD~1"* ]]; then
+      reset_worktree_to_parent
+      exit 0
     fi
-    copy_head_to_worktree
+    if [[ "$*" == *"origin/master"* ]]; then
+      reset_worktree_to_origin
+      exit 0
+    fi
+    reset_worktree_to_local_head
     exit 0
     ;;
   fetch)
-    if [[ "${FAKE_GIT_FAIL_FETCH_FOR_HASH:-}" == "1" ]]; then
-      exit 1
-    fi
     exit 0
-    ;;
-  show)
-    # `git show origin/master:stats/dockerhub-pull-history.jsonl` — models
-    # origin's actual content via head_stats (the mock's stand-in for
-    # origin/master), regardless of whatever the local worktree currently
-    # holds. An absent/empty head_stats prints nothing (real git exits
-    # nonzero for a missing path; remote_stats_hash tolerates that the same
-    # way it tolerates a fetch failure — empty input, not a script error).
-    if [[ -s "$head_stats" ]]; then
-      cat "$head_stats"
-      exit 0
-    fi
-    exit 128
     ;;
   *)
     echo "unsupported fake git command: $*" >&2
@@ -196,15 +199,41 @@ echo "$*" >> "${FAKE_GIT_STATE:?}/sleep.log"
 EOF
     chmod +x "$TEST_REPO/bin/sleep"
 
+    hash -r
+    real_jq="$(command -v jq)"
+cat > "$TEST_REPO/bin/jq" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="\${FAKE_GIT_STATE:?}/jq_count"
+count=\$(cat "\$count_file" 2>/dev/null || echo 0)
+count=\$((count + 1))
+echo "\$count" > "\$count_file"
+if [[ "\${FAKE_JQ_FAIL_MERGE:-}" == "1" ]]; then
+  exit 42
+fi
+if [[ -n "\${FAKE_JQ_FAIL_MERGE_ON_CALL:-}" && "\$count" -eq "\$FAKE_JQ_FAIL_MERGE_ON_CALL" ]]; then
+  exit 42
+fi
+exec "$real_jq" "\$@"
+EOF
+    chmod +x "$TEST_REPO/bin/jq"
+
     export FAKE_GIT_STATE
     export PATH="$TEST_REPO/bin:$PATH"
     export GITHUB_ACTIONS="true"
-    export GITHUB_TOKEN="test-token"
+    export STATS_PUSH_TOKEN="test-app-token"
     export GITHUB_REPOSITORY="owner/repo"
+    export GITHUB_OUTPUT="$FAKE_GIT_STATE/github_output"
+    : > "$GITHUB_OUTPUT"
 }
 
 teardown() {
     teardown_temp_dir
+}
+
+get_output() {
+    local key="$1"
+    grep "^${key}=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
 }
 
 @test "commit-stats-snapshot refuses to run outside GitHub Actions before touching git state" {
@@ -215,368 +244,81 @@ teardown() {
     [[ "$output" == *"::error::scripts/commit-stats-snapshot.sh is CI-only"* ]]
 
     [ ! -e "$FAKE_GIT_STATE/git.log" ]
+}
+
+@test "commit-stats-snapshot treats an already-clean worktree as persisted with no git writes" {
+    # Collection produced nothing new (e.g. everything was already recorded
+    # today) — the worktree already matches origin, so there's nothing to
+    # add/commit/push.
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
     [ ! -e "$FAKE_GIT_STATE/commit_count" ]
-    [ ! -e "$FAKE_GIT_STATE/origin_url" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot falls back to push-confirmed status when the remote hash check is degraded" {
-    # remote_stats_hash does its OWN fetch at both the start and end of the
-    # run, independent of retry_cleanup's. If that fetch fails, it returns
-    # the REMOTE_HASH_UNKNOWN sentinel (distinct from a CONFIRMED-empty
-    # hash) rather than crashing — a raw comparison against an unknown
-    # baseline could misfire in either direction, so the dispatch decision
-    # instead falls back to whether a `git push` itself reported success.
-    # Here it did (always_success), so the fallback correctly dispatches
-    # despite never being able to directly verify origin's content.
-    export FAKE_GIT_PUSH_MODE="always_success"
-    export FAKE_GIT_FAIL_FETCH_FOR_HASH="1"
+@test "commit-stats-snapshot fails closed when configured candidate source is missing" {
+    export CANDIDATE_SOURCE_FILE="$TEST_TEMP_DIR/missing-candidate.jsonl"
 
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::error::CANDIDATE_SOURCE_FILE is set but does not exist:"* ]]
+
+    [ ! -e "$FAKE_GIT_STATE/git.log" ]
+    [ ! -e "$FAKE_GIT_STATE/commit_count" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+}
+
+@test "commit-stats-snapshot commits and pushes new candidate data in one attempt" {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"::warning::Could not fetch origin/master to check remote stats state"* ]]
-    [[ "$output" == *"::warning::Remote stats hash check was unavailable this run; falling back to this run's own confirmed push status"* ]]
-
-    # The push itself still succeeded on the very first attempt (always_success),
-    # so retry_cleanup is never invoked at all here — only remote_stats_hash's
-    # own two fetch calls (before and after the loop) exercise this knob.
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 1 ]
-
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
-}
-
-@test "commit-stats-snapshot does not dispatch on a degraded remote check without a confirmed push" {
-    # Same degraded remote-hash situation as above, but this time NOTHING
-    # was ever pushed (persistent add failure) — the fallback must not
-    # dispatch just because the remote check happened to be unavailable.
-    export FAKE_GIT_FAIL_ADD="1"
-    export FAKE_GIT_FAIL_FETCH_FOR_HASH="1"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::warning::Could not fetch origin/master to check remote stats state"* ]]
-    [[ "$output" != *"Remote stats hash check was unavailable this run; falling back"* ]]
-
-    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
-    [ "$pushes" -eq 0 ]
-
-    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
-}
-
-@test "commit-stats-snapshot dispatches the follow-up build after an ambiguous push that actually landed" {
-    # Regression lock: `git push` can report failure (network drop after the
-    # remote already accepted it) even though origin genuinely advanced. A
-    # push-exit-code flag would miss this — the retry loop's own reset picks
-    # up the already-landed data and exits via the "nothing new" path, which
-    # looks identical to a true no-op run. remote_stats_hash (a fresh fetch +
-    # `git show origin/master:...`, modeled by head_stats in this mock, NOT
-    # the local worktree) catches it regardless: origin's content for this
-    # file DID change during this run, so the follow-up build must still fire.
-    export FAKE_GIT_PUSH_MODE="ambiguous_fail_once"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 0 ]
-
-    # Only one push call was ever attempted by the script itself — the
-    # "second" push in the fake (pushes -eq 1 branch) never actually fires;
-    # the retry loop's own reset-and-recheck is what discovers the landed data.
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 1 ]
-
-    jq -e '
-        select(.date == "2026-07-12" and .container == "alpha" and .pull_count == 42)
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
-
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
-}
-
-@test "commit-stats-snapshot retries after rejected push and persists one idempotent row" {
-    export FAKE_GIT_PUSH_MODE="success_on_retry"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 0 ]
-
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 2 ]
-
-    commits=$(cat "$FAKE_GIT_STATE/commit_count")
-    [ "$commits" -eq 2 ]
-
-    rows=$(jq -s 'length' "$TEST_REPO/stats/dockerhub-pull-history.jsonl")
-    [ "$rows" -eq 1 ]
-
-    duplicate_pairs=$(jq -s '
-        group_by(.date + "/" + .container)
-        | map(select(length > 1))
-        | length
-    ' "$TEST_REPO/stats/dockerhub-pull-history.jsonl")
-    [ "$duplicate_pairs" -eq 0 ]
-
-    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
-    [ "$origin_url" = "https://github.com/owner/repo.git" ]
-    [[ "$origin_url" != *"test-token"* ]]
-
-    grep -q 'reset --hard HEAD~1' "$FAKE_GIT_STATE/git.log"
-    grep -q 'reset --hard origin/master' "$FAKE_GIT_STATE/git.log"
-
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
-    grep -q 'workflow run update-dashboard.yaml' "$FAKE_GIT_STATE/gh.log"
-    grep -q -- '--ref master' "$FAKE_GIT_STATE/gh.log"
-}
-
-@test "commit-stats-snapshot retries cleanly after a fully-failed attempt, one commit once progress exists" {
-    # Contract: the loop only keeps looping past a successful push when THAT
-    # push was itself partial (some containers still missing). Here attempt 1
-    # makes zero progress (every container fails, no diff at all) and attempt 2
-    # is a FULLY successful fetch, so it breaks immediately on attempt 2 same as
-    # a single-attempt success would.
-    export FAKE_GIT_PUSH_MODE="always_success"
-
-    rm "$TEST_REPO/scripts/snapshot-stats.sh"
-    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
-    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
-
-    for container in alpha beta gamma; do
-        mkdir -p "$TEST_REPO/$container"
-        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
-    done
-
-    CURL_LOG="$FAKE_GIT_STATE/curl.log"
-    export CURL_LOG
-    cat > "$TEST_REPO/bin/curl" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-url="${*: -1}"
-container="${url%/}"
-container="${container##*/}"
-echo "$container" >> "$CURL_LOG"
-
-count_file="${FAKE_GIT_STATE:?}/curl-${container}-count"
-count=$(cat "$count_file" 2>/dev/null || echo 0)
-count=$((count + 1))
-echo "$count" > "$count_file"
-
-if [[ "$count" -eq 1 ]]; then
-  exit 22
-fi
-
-case "$container" in
-  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
-  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
-  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
-  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
-esac
-EOF
-    chmod +x "$TEST_REPO/bin/curl"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
-    [[ "$output" == *"::warning::Stats snapshot collection made no commit-worthy progress on attempt 1"* ]]
-
-    fetches=$(cat "$CURL_LOG")
-    [ "$fetches" = $'alpha\nbeta\ngamma\nalpha\nbeta\ngamma' ]
+    [ "$(get_output persisted)" = "true" ]
 
     commits=$(cat "$FAKE_GIT_STATE/commit_count")
     [ "$commits" -eq 1 ]
-
-    today="$(date -u +%Y-%m-%d)"
-    jq -s -e --arg today "$today" '
-        [.[] | select(.date == $today)]
-        | length == 3
-        and (map(.container) | sort == ["alpha", "beta", "gamma"])
-    ' "$TEST_REPO/stats/dockerhub-pull-history.jsonl" >/dev/null
-
-    jq -s -e --arg today "$today" '
-        [.[] | select(.date == $today)]
-        | length == 3
-        and (map(.container) | sort == ["alpha", "beta", "gamma"])
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
-
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
-}
-
-@test "commit-stats-snapshot persists successful rows despite persistent partial snapshot failure" {
-    export FAKE_GIT_PUSH_MODE="always_success"
-
-    rm "$TEST_REPO/scripts/snapshot-stats.sh"
-    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
-    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
-
-    for container in alpha beta gamma; do
-        mkdir -p "$TEST_REPO/$container"
-        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
-    done
-
-    CURL_LOG="$FAKE_GIT_STATE/curl-persistent.log"
-    export CURL_LOG
-    cat > "$TEST_REPO/bin/curl" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-url="${*: -1}"
-container="${url%/}"
-container="${container##*/}"
-echo "$container" >> "$CURL_LOG"
-
-case "$container" in
-  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
-  beta)  exit 22 ;;
-  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
-  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
-esac
-EOF
-    chmod +x "$TEST_REPO/bin/curl"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1; some containers failed"* ]]
-    [[ "$output" == *"::warning::Persisted partial stats snapshot on attempt 1"* ]]
-    [[ "$output" == *"::error::Exhausted retries with some containers still missing"* ]]
-
-    # Contract: a partial success keeps retrying with the remaining attempts to
-    # top up the still-missing container. alpha/gamma are idempotently skipped
-    # (already recorded today) on attempts 2 and 3 — only beta gets re-fetched.
-    fetches=$(cat "$CURL_LOG")
-    [ "$fetches" = $'alpha\nbeta\ngamma\nbeta\nbeta' ]
-
-    commits=$(cat "$FAKE_GIT_STATE/commit_count")
-    [ "$commits" -eq 1 ]
-
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 1 ]
 
-    # Something DID get pushed (alpha+gamma on attempt 1) even though the run
-    # as a whole reports failure — the follow-up dashboard build still fires
-    # so that partial progress isn't stuck behind the next independent trigger.
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
 
-    today="$(date -u +%Y-%m-%d)"
-    jq -s -e --arg today "$today" '
-        [.[] | select(.date == $today)]
-        | length == 2
-        and (map(.container) | sort == ["alpha", "gamma"])
-        and all((.pull_count | type) == "number" and (.star_count | type) == "number")
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
-
-    jq -s -e --arg today "$today" '
-        [.[] | select(.date == $today and .container == "beta")]
-        | length == 0
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+    # origin_url alone reflects the FINAL state, which the cleanup trap
+    # always restores to the safe/unauthenticated URL — check the append-only
+    # git.log for evidence the authenticated URL was actually used to push.
+    grep -qF "https://x-access-token:test-app-token@github.com/owner/repo.git" "$FAKE_GIT_STATE/git.log"
+    grep -qF "commit -m chore(stats): daily Docker Hub pull-count snapshot -- stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/git.log"
 }
 
-@test "commit-stats-snapshot retries instead of misreading a staged-but-uncommitted index as already persisted" {
-    # Regression lock for a double-failure sequence: attempt 1's `git add`
-    # succeeds (index now diverges from HEAD) but `git commit` fails, and the
-    # cleanup's `git reset --hard origin/master` ALSO fails — so neither the
-    # worktree nor the index gets reset back to HEAD. On attempt 2, the
-    # snapshot is idempotently skipped (today's row is already in the
-    # worktree from attempt 1) and the ref-less `git diff` form would see
-    # worktree == index (both still hold the never-committed change) and
-    # wrongly report "clean" — exiting with persisted=true having pushed
-    # nothing. Comparing against HEAD (real fix) correctly sees the worktree
-    # still differs from origin/master's actual state and retries the
-    # add+commit+push to completion.
-    export FAKE_GIT_PUSH_MODE="always_success"
-    export FAKE_GIT_FAIL_COMMIT_ONCE="1"
-    export FAKE_GIT_FAIL_RESET_ONCE="1"
+@test "commit-stats-snapshot does not let failed origin restore abort cleanup" {
+    export FAKE_GIT_FAIL_SAFE_REMOTE_RESTORE="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"::warning::Could not commit stats snapshot on attempt 1"* ]]
-    [[ "$output" == *"::warning::Could not reset stats snapshot worktree after attempt 1"* ]]
-    [[ "$output" != *"Could not persist stats snapshot this run"* ]]
-
-    commits=$(cat "$FAKE_GIT_STATE/commit_count")
-    [ "$commits" -eq 1 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Could not restore unauthenticated origin remote after stats snapshot"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 1 ]
-
-    jq -e '
-        select(.date == "2026-07-12" and .container == "alpha" and .pull_count == 42)
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
-
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
 }
 
-@test "commit-stats-snapshot warns when a later fully-successful fetch never gets pushed" {
-    # Regression lock: attempt 1 fetches alpha+gamma (beta fails) and pushes
-    # that partial progress — persisted=true. Attempt 2's fetch is FULLY
-    # successful (beta recovers), but its push fails, as does attempt 3's.
-    # A `still_missing` that only tracks the FETCH outcome of the most recent
-    # attempt would be wrongly cleared on attempt 2/3 (fetch succeeded) even
-    # though beta's row was never actually confirmed on origin/master — the
-    # final "some containers still missing" warning would then never fire,
-    # silently losing visibility into recoverable data that just needs
-    # another push, not another fetch.
-    export FAKE_GIT_PUSH_MODE="success_once_then_fail"
-
-    rm "$TEST_REPO/scripts/snapshot-stats.sh"
-    ln -s "$SCRIPTS_DIR/snapshot-stats.sh" "$TEST_REPO/scripts/snapshot-stats.sh"
-    cp "$HELPERS_DIR/logging.sh" "$TEST_REPO/helpers/logging.sh"
-
-    for container in alpha beta gamma; do
-        mkdir -p "$TEST_REPO/$container"
-        printf 'FROM alpine:3.21\n' > "$TEST_REPO/$container/Dockerfile"
-    done
-
-    CURL_LOG="$FAKE_GIT_STATE/curl-recover.log"
-    export CURL_LOG
-    cat > "$TEST_REPO/bin/curl" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-url="${*: -1}"
-container="${url%/}"
-container="${container##*/}"
-echo "$container" >> "$CURL_LOG"
-
-if [[ "$container" == "beta" ]]; then
-  count_file="${FAKE_GIT_STATE:?}/curl-beta-count"
-  count=$(cat "$count_file" 2>/dev/null || echo 0)
-  count=$((count + 1))
-  echo "$count" > "$count_file"
-  if [[ "$count" -eq 1 ]]; then
-    exit 22
-  fi
-fi
-
-case "$container" in
-  alpha) printf '{"pull_count":600,"star_count":6}\n' ;;
-  beta)  printf '{"pull_count":700,"star_count":7}\n' ;;
-  gamma) printf '{"pull_count":800,"star_count":8}\n' ;;
-  *)     printf '{"pull_count":0,"star_count":0}\n' ;;
-esac
-EOF
-    chmod +x "$TEST_REPO/bin/curl"
+@test "commit-stats-snapshot merges downloaded candidate into fresh checkout before diff" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::warning::Persisted partial stats snapshot on attempt 1"* ]]
-    [[ "$output" == *"::error::Exhausted retries with some containers still missing"* ]]
-
-    # beta: fails attempt 1, succeeds attempts 2 and 3 (fetch works both times,
-    # but its push never lands) — confirms the fetch DID fully succeed on a
-    # later attempt while still never reaching origin/master.
-    fetches=$(cat "$CURL_LOG")
-    [ "$fetches" = $'alpha\nbeta\ngamma\nbeta\nbeta' ]
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 3 ]
-
-    # attempt 1's push DID land (alpha+gamma) — the follow-up build still fires.
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
-
-    jq -s -e '
-        [.[] | select(.container == "beta")]
-        | length == 0
-    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+    [ "$pushes" -eq 1 ]
 
     jq -s -e '
         length == 2
@@ -584,172 +326,447 @@ EOF
     ' "$FAKE_GIT_STATE/head_stats" >/dev/null
 }
 
-@test "commit-stats-snapshot never dispatches on a worktree-only divergence that survives to the end of the run" {
-    # Regression lock, sharper than the two tests above: commit NEVER
-    # succeeds (so retry_cleanup never even attempts the HEAD~1 reset) AND
-    # the origin/master reset ALWAYS fails too — so copy_head_to_worktree is
-    # never called at all, and the worktree keeps holding alpha's row
-    # (staged on attempt 1, never reset) all the way to the final hash check,
-    # while origin (head_stats) never advances. A local-worktree-based hash
-    # would see initial=empty, final=alpha and WRONGLY dispatch a follow-up
-    # build for data that was never actually persisted anywhere — this is
-    # exactly codex's "push that never landed can still dispatch" scenario.
-    # remote_stats_hash is immune: both ends read origin directly and see
-    # the same untouched empty content.
-    export FAKE_GIT_FAIL_COMMIT_ALWAYS="1"
-    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
+@test "commit-stats-snapshot keeps newer checkout row over stale candidate on same key" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"alpha","pull_count":100,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T09:00:00Z","date":"2026-07-12","container":"alpha","pull_count":200,"star_count":2,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
 
-    commits=$(cat "$FAKE_GIT_STATE/commit_count" 2>/dev/null || echo 0)
-    [ "$commits" -eq 0 ]
-
-    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
-    [ "$pushes" -eq 0 ]
-
-    # The worktree DOES still hold the never-committed row — proving this
-    # test actually exercises the divergence, not a no-op.
-    jq -e 'select(.container == "alpha")' "$TEST_REPO/stats/dockerhub-pull-history.jsonl" >/dev/null
-
-    # origin never advanced — no follow-up dispatch, despite the worktree
-    # divergence above.
-    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+    jq -s -e '
+        length == 1
+        and .[0].container == "alpha"
+        and .[0].ts == "2026-07-12T09:00:00Z"
+        and .[0].pull_count == 200
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
 }
 
-@test "commit-stats-snapshot fails loudly after exhausted push retries" {
-    # Regression lock: a persistence mechanism that NEVER succeeds (e.g. a
-    # revoked token, branch protection change) must not report success —
-    # this job has no downstream dependents (deploy only needs build), so
-    # failing it is isolated and visible rather than silently green forever.
+@test "commit-stats-snapshot lets genuinely newer candidate win on same key" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T09:00:00Z","date":"2026-07-12","container":"alpha","pull_count":200,"star_count":2,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"alpha","pull_count":100,"star_count":1,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    jq -s -e '
+        length == 1
+        and .[0].container == "alpha"
+        and .[0].ts == "2026-07-12T09:00:00Z"
+        and .[0].pull_count == 200
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot drops candidate rows missing ts instead of replacing committed data" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    committed_line='{"ts":"2026-07-12T09:00:00Z","date":"2026-07-12","container":"alpha","pull_count":200,"star_count":2,"source":"dockerhub"}'
+    printf '{"date":"2026-07-12","container":"alpha","pull_count":999,"star_count":9,"source":"dockerhub"}\n{"date":"2026-07-12","container":"gamma","pull_count":777,"star_count":7,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '%s\n' "$committed_line" > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+
+    mapfile -t merged_lines < "$FAKE_GIT_STATE/head_stats"
+    [ "${#merged_lines[@]}" -eq 1 ]
+    [ "${merged_lines[0]}" = "$committed_line" ]
+    ! grep -qF '"container":"gamma"' "$FAKE_GIT_STATE/head_stats"
+}
+
+@test "commit-stats-snapshot drops candidate rows with malformed ts instead of replacing committed data" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    committed_line='{"ts":"2026-07-12T09:00:00Z","date":"2026-07-12","container":"alpha","pull_count":200,"star_count":2,"source":"dockerhub"}'
+    printf '{"ts":"2026-07-12 10:00:00Z","date":"2026-07-12","container":"alpha","pull_count":999,"star_count":9,"source":"dockerhub"}\n{"ts":"not-a-snapshot-ts","date":"2026-07-12","container":"gamma","pull_count":777,"star_count":7,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '%s\n' "$committed_line" > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+
+    mapfile -t merged_lines < "$FAKE_GIT_STATE/head_stats"
+    [ "${#merged_lines[@]}" -eq 1 ]
+    [ "${merged_lines[0]}" = "$committed_line" ]
+    ! grep -qF '"container":"gamma"' "$FAKE_GIT_STATE/head_stats"
+}
+
+@test "commit-stats-snapshot drops candidate-only malformed raw lines but still commits valid candidate rows" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf 'not-json-from-candidate\n{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    ! grep -qF 'not-json-from-candidate' "$FAKE_GIT_STATE/head_stats"
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot drops candidate row with unknown container but still commits valid candidate rows" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"fabricated","pull_count":777,"star_count":7,"source":"dockerhub"}\n{"ts":"2026-07-12T07:01:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+
+    ! grep -qF '"container":"fabricated"' "$FAKE_GIT_STATE/head_stats"
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot drops candidate row with future date beyond grace window" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    future_date="$(date -u -d '+2 days' +%Y-%m-%d)"
+    printf '{"ts":"%sT07:00:00Z","date":"%s","container":"alpha","pull_count":777,"star_count":7,"source":"dockerhub"}\n{"ts":"2026-07-12T07:01:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' "$future_date" "$future_date" \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+
+    ! grep -qF "\"date\":\"$future_date\"" "$FAKE_GIT_STATE/head_stats"
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot drops candidate row with non-dockerhub source" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":777,"star_count":7,"source":"ghcr"}\n{"ts":"2026-07-12T07:01:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+
+    ! grep -qF '"source":"ghcr"' "$FAKE_GIT_STATE/head_stats"
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot drops candidate rows with negative or fractional counts" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":-1,"star_count":7,"source":"dockerhub"}\n{"ts":"2026-07-13T07:00:00Z","date":"2026-07-13","container":"alpha","pull_count":777,"star_count":-1,"source":"dockerhub"}\n{"ts":"2026-07-14T07:00:00Z","date":"2026-07-14","container":"alpha","pull_count":1.5,"star_count":7,"source":"dockerhub"}\n{"ts":"2026-07-12T07:01:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+
+    ! grep -qF '"pull_count":-1' "$FAKE_GIT_STATE/head_stats"
+    ! grep -qF '"star_count":-1' "$FAKE_GIT_STATE/head_stats"
+    ! grep -qF '"pull_count":1.5' "$FAKE_GIT_STATE/head_stats"
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot preserves committed history row that fails new semantic checks" {
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    committed_line='{ "date" : "2019-12-31", "container" : "fabricated", "pull_count" : -5, "star_count" : -1, "source" : "ghcr" }'
+    printf '%s\n' "$committed_line" > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
+        > "$candidate_file"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
+    mapfile -t merged_lines < "$FAKE_GIT_STATE/head_stats"
+    [ "${#merged_lines[@]}" -eq 2 ]
+    [ "${merged_lines[0]}" = "$committed_line" ]
+    [ "${merged_lines[1]}" = '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}' ]
+}
+
+@test "commit-stats-snapshot retries after a lost push race and persists cleanly" {
+    export FAKE_GIT_PUSH_MODE="success_on_retry"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 2 ]
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 2 ]
+
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot re-merges its candidate after a reset, preserving a concurrent run's own addition" {
+    # Regression lock for the whole point of the candidate-file design: this
+    # run's own collected row (alpha) must survive a reset-and-retry, AND a
+    # different row a concurrent run pushed in the meantime (gamma) must NOT
+    # be clobbered by blindly restoring the pre-reset candidate wholesale.
+    export FAKE_GIT_PUSH_MODE="concurrent_update_then_success"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
+    # Origin only gained gamma on the lost first attempt, so the reset+merge
+    # reconstructs alpha+gamma and a second real push is required.
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 2 ]
+
+    jq -s -e '
+        length == 1
+        and .[0].container == "gamma"
+    ' "$FAKE_GIT_STATE/first_failed_head_stats" >/dev/null
+
+    jq -s -e '
+        length == 2
+        and (map(.container) | sort == ["alpha", "gamma"])
+    ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot retry merge preserves malformed and raw formatted origin lines" {
+    export FAKE_GIT_PUSH_MODE="concurrent_malformed_then_success"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Refusing to commit stats snapshot because stats/dockerhub-pull-history.jsonl has invalid JSON at line 1"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    mapfile -t merged_lines < "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    [ "${#merged_lines[@]}" -eq 3 ]
+    [ "${merged_lines[0]}" = "not-json" ]
+    [ "${merged_lines[1]}" = '{ "ts" : "2026-07-12T08:00:00Z", "date" : "2026-07-12", "container" : "gamma", "pull_count" : 99, "star_count" : 9, "source" : "dockerhub" }' ]
+    [ "${merged_lines[2]}" = '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}' ]
+}
+
+@test "commit-stats-snapshot recovers from an ambiguous push that actually landed" {
+    # `git push` can report failure (network drop after the remote already
+    # accepted it) even though origin genuinely advanced. The next attempt's
+    # HEAD diff check goes clean (worktree now matches the already-landed
+    # data after the reset), correctly converging without a real 2nd push.
+    export FAKE_GIT_PUSH_MODE="ambiguous_fail_once"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot reports no reconciled missing rows when current stats is complete despite incomplete candidate" {
+    today="$(date -u +%Y-%m-%d)"
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"%sT06:00:00Z","date":"%s","container":"alpha","pull_count":41,"star_count":1,"source":"dockerhub"}\n' "$today" "$today" \
+        > "$candidate_file"
+    printf '{"ts":"%sT07:00:00Z","date":"%s","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n{"ts":"%sT08:00:00Z","date":"%s","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' "$today" "$today" "$today" "$today" \
+        > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [ "$(get_output still_missing_after_reconcile)" = "false" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+}
+
+@test "commit-stats-snapshot reports reconciled missing rows when an allowlisted container is absent today" {
+    today="$(date -u +%Y-%m-%d)"
+    candidate_file="$TEST_TEMP_DIR/candidate.jsonl"
+    printf '{"ts":"%sT07:00:00Z","date":"%s","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' "$today" "$today" \
+        > "$candidate_file"
+    cp "$candidate_file" "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
+    cp "$TEST_REPO/stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/head_stats"
+    export CANDIDATE_SOURCE_FILE="$candidate_file"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [ "$(get_output still_missing_after_reconcile)" = "true" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+}
+
+@test "commit-stats-snapshot reports not persisted after exhausted push retries" {
     export FAKE_GIT_PUSH_MODE="always_fail"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 3 ]
-
-    # 3 loop attempts, no extra repopulate call (removed — nothing downstream
-    # ever consumed it, the local worktree is thrown away with the ephemeral
-    # runner once the job ends, and the call pushed the worst-case runtime
-    # too close to the job timeout during a sustained Docker Hub outage).
-    # The local file is correctly left EMPTY here (every retry_cleanup resets
-    # it to origin/master's actual, never-pushed-to state) — origin/master,
-    # not this ephemeral worktree, is the real source of truth.
-    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
-    [ "$snapshots" -eq 3 ]
-
-    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
-    [ "$origin_url" = "https://github.com/owner/repo.git" ]
-    [[ "$origin_url" != *"test-token"* ]]
-
-    # Nothing was ever pushed — no follow-up dashboard build to trigger.
-    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+    [ ! -s "$FAKE_GIT_STATE/head_stats" ]
 }
 
-@test "commit-stats-snapshot fails loudly when git add fails mid-loop" {
-    export FAKE_GIT_FAIL_ADD="1"
+@test "commit-stats-snapshot fails closed when upfront candidate merge fails" {
+    export FAKE_JQ_FAIL_MERGE="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::warning::Could not stage stats snapshot on attempt 1"* ]]
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not merge collected stats candidate into the worktree"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
-    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
-    [ "$pushes" -eq 0 ]
-
-    # 3 loop attempts, no extra repopulate call — see the note above.
-    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
-    [ "$snapshots" -eq 3 ]
-
-    origin_url=$(cat "$FAKE_GIT_STATE/origin_url")
-    [ "$origin_url" = "https://github.com/owner/repo.git" ]
-    [[ "$origin_url" != *"test-token"* ]]
-
-    # The default fake snapshot-stats.sh still writes a fresh row into the
-    # local worktree file on every attempt even though `git add` never lets
-    # it get staged — this doubles as a regression lock for remote_stats_hash
-    # reading origin (head_stats), never the local worktree: origin was
-    # never touched here, so no dispatch, despite the worktree differing.
-    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot pins SNAPSHOT_DATE_OVERRIDE once and holds it across all retry attempts" {
-    # Regression lock: without a pinned date, a run whose retries straddle a
-    # UTC midnight rollover would silently start filling a NEW day partway
-    # through, abandoning the original day's still-missing rows while
-    # reporting success. The wrapper must export the SAME date value to
-    # every attempt, not recompute it each time.
-    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-echo "${SNAPSHOT_DATE_OVERRIDE:-UNSET}" >> "${FAKE_GIT_STATE:?}/date-override.log"
-exit 1
-EOF
-    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
+@test "commit-stats-snapshot fails closed when retry merge fails" {
+    export FAKE_GIT_PUSH_MODE="always_fail"
+    export FAKE_JQ_FAIL_MERGE_ON_CALL="3"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-
-    seen_dates=$(sort -u "$FAKE_GIT_STATE/date-override.log")
-    line_count=$(wc -l < "$FAKE_GIT_STATE/date-override.log")
-    [ "$line_count" -eq 3 ]
-    # Exactly one distinct, non-empty value across all 3 attempts.
-    [ "$(printf '%s\n' "$seen_dates" | wc -l)" -eq 1 ]
-    [ "$seen_dates" != "UNSET" ]
-    [[ "$seen_dates" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
-}
-
-@test "commit-stats-snapshot fails loudly when snapshot collection makes no progress" {
-    cat > "$TEST_REPO/scripts/snapshot-stats.sh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-echo "snapshot" >> "${FAKE_GIT_STATE:?}/snapshot.log"
-echo "simulated Docker Hub outage" >&2
-exit 1
-EOF
-    chmod +x "$TEST_REPO/scripts/snapshot-stats.sh"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"::warning::Stats snapshot collection failed on attempt 1"* ]]
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not merge collected stats candidate into the worktree"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
-    commits=$(cat "$FAKE_GIT_STATE/commit_count" 2>/dev/null || echo 0)
-    [ "$commits" -eq 0 ]
-
-    pushes=$(cat "$FAKE_GIT_STATE/push_count" 2>/dev/null || echo 0)
-    [ "$pushes" -eq 0 ]
-
-    # 3 loop attempts, no extra repopulate call (removed — nothing downstream
-    # ever consumed it, and it pushed the worst-case runtime too close to the
-    # job timeout during a sustained Docker Hub outage).
-    snapshots=$(wc -l < "$FAKE_GIT_STATE/snapshot.log")
-    [ "$snapshots" -eq 3 ]
-
-    [ ! -e "$FAKE_GIT_STATE/gh_call_count" ]
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
 }
 
-@test "commit-stats-snapshot tolerates a failed follow-up dashboard dispatch after a full success" {
-    # The self-dispatch is best-effort: its own failure must not turn an
-    # otherwise fully successful, fully persisted run into a failure — only
-    # the persistence outcome itself (still_missing) governs the exit code.
-    export FAKE_GIT_PUSH_MODE="success_on_retry"
-    export FAKE_GH_FAIL="1"
+@test "commit-stats-snapshot refuses to stage when final JSONL validation catches post-merge corruption" {
+    export FAKE_GIT_CORRUPT_ON_DIFF="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Refusing to commit stats snapshot because stats/dockerhub-pull-history.jsonl has invalid JSON at line 2"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    [ ! -e "$FAKE_GIT_STATE/index_stats" ]
+    [ ! -e "$FAKE_GIT_STATE/commit_count" ]
+    [ ! -e "$FAKE_GIT_STATE/push_count" ]
+}
+
+@test "commit-stats-snapshot fails closed when cleanup reset fails after an unpushed commit" {
+    export FAKE_GIT_PUSH_MODE="always_fail"
+    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not discard failed stats commit on attempt 1"* ]]
+    [[ "$output" == *"::warning::Could not reset stats snapshot worktree after attempt 1"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+}
+
+@test "commit-stats-snapshot retries after a one-shot git add failure" {
+    export FAKE_GIT_FAIL_ADD_ONCE="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"::warning::Could not trigger a follow-up dashboard build"* ]]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Could not stage stats snapshot on attempt 1"* ]]
 
-    gh_calls=$(cat "$FAKE_GIT_STATE/gh_call_count")
-    [ "$gh_calls" -eq 1 ]
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
 }
 
-@test "commit-stats-snapshot uses explicit persisted flag, not loop-exit warning shorthand" {
-    grep -q 'persisted=false' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
-    grep -q '\[\[ "$persisted" != "true" \]\]' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
-    ! grep -q 'done[[:space:]]*||' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
+@test "commit-stats-snapshot reports not persisted when git add always fails" {
+    export FAKE_GIT_FAIL_ADD_ALWAYS="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    [ ! -e "$FAKE_GIT_STATE/commit_count" ]
+}
+
+@test "commit-stats-snapshot reports not persisted when commit and reset never succeed" {
+    export FAKE_GIT_FAIL_COMMIT_ALWAYS="1"
+    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    [ ! -e "$FAKE_GIT_STATE/commit_count" ]
+    # The worktree still holds the never-committed candidate row — proving
+    # this scenario actually exercised the divergence — while origin
+    # (head_stats) never advanced.
+    jq -e 'select(.container == "alpha")' "$TEST_REPO/stats/dockerhub-pull-history.jsonl" >/dev/null
+    [ ! -s "$FAKE_GIT_STATE/head_stats" ]
+}
+
+@test "commit-stats-snapshot uses STATS_PUSH_TOKEN, not a generic GITHUB_TOKEN name" {
+    # Comment lines are excluded — the script's header prose explains why a
+    # generic GITHUB_TOKEN categorically cannot authenticate this push, which
+    # itself contains the substring being checked for absence in real code.
+    grep -q 'STATS_PUSH_TOKEN' "$SCRIPTS_DIR/commit-stats-snapshot.sh"
+    non_comment_lines="$(grep -v '^\s*#' "$SCRIPTS_DIR/commit-stats-snapshot.sh")"
+    [[ "$non_comment_lines" != *'GITHUB_TOKEN'* ]]
 }

--- a/tests/unit/dockerhub-stats-workflow.bats
+++ b/tests/unit/dockerhub-stats-workflow.bats
@@ -69,6 +69,42 @@ extract_job_if() {
     '
 }
 
+extract_job_permissions() {
+    local job_name="$1"
+
+    extract_job_block "$job_name" | awk '
+        $0 ~ /^    permissions:[[:space:]]*$/ {
+            in_permissions = 1
+            print
+            next
+        }
+        in_permissions && $0 ~ /^    [A-Za-z0-9_-]+:/ {
+            exit
+        }
+        in_permissions {
+            print
+        }
+    '
+}
+
+extract_job_concurrency() {
+    local job_name="$1"
+
+    extract_job_block "$job_name" | awk '
+        $0 ~ /^    concurrency:[[:space:]]*$/ {
+            in_concurrency = 1
+            print
+            next
+        }
+        in_concurrency && $0 ~ /^    [A-Za-z0-9_-]+:/ {
+            exit
+        }
+        in_concurrency {
+            print
+        }
+    '
+}
+
 extract_step_run() {
     local step_name="$1"
 
@@ -113,19 +149,104 @@ extract_step_run() {
     [[ "$step_block" != *"continue-on-error: true"* ]]
 }
 
+@test "update-dashboard passes downloaded stats candidate without overwriting checkout stats file" {
+    restore_run="$(extract_step_run "Restore downloaded stats candidate")"
+    commit_step="$(extract_step_block "Commit stats snapshot (non-blocking)")"
+
+    [[ "$restore_run" == *"candidate_source_file="* ]]
+    [[ "$restore_run" == *'$GITHUB_OUTPUT'* ]]
+    [[ "$restore_run" != *"cp \"$candidate_file\" stats/dockerhub-pull-history.jsonl"* ]]
+    [[ "$restore_run" != *"mkdir -p stats"* ]]
+
+    [[ "$commit_step" == *"CANDIDATE_SOURCE_FILE:"* ]]
+    [[ "$commit_step" == *"steps.stats-candidate.outputs.candidate_source_file"* ]]
+}
+
+@test "collect-stats-snapshot comment points at the real commit wrapper" {
+    collect_script="$(cat "$SCRIPTS_DIR/collect-stats-snapshot.sh")"
+
+    [[ "$collect_script" == *"scripts/commit-stats-snapshot.sh"* ]]
+    [[ "$collect_script" != *"scripts/persist-stats-snapshot.sh"* ]]
+}
+
 @test "update-dashboard commit stats job gates workflow_dispatch to master" {
     job_if="$(extract_job_if "commit-stats-snapshot")"
     normalized_if="$(printf '%s' "$job_if" | tr '\n' ' ' | tr -s ' ')"
 
+    [[ "$normalized_if" == *"needs.collect-stats-snapshot.result == 'success' &&"* ]]
     [[ "$normalized_if" == *"(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')"* ]]
     [[ "$normalized_if" != *"github.event_name == 'workflow_dispatch' ||"* ]]
 }
 
-@test "update-dashboard commit stats job has actions:write for its follow-up dispatch" {
+@test "update-dashboard commit stats job authenticates with a scoped App token and signs commits" {
+    # master's ruleset requires PR-only changes and verified signatures — a
+    # direct GITHUB_TOKEN push can satisfy neither, so this job must mint an
+    # App token (scoped down to just contents:write) and import a GPG key
+    # before the push happens. No actions:write: unlike GITHUB_TOKEN, an
+    # App-token push retriggers this same workflow via its own push path
+    # filter, so there is no explicit follow-up dispatch to authorize.
     job_block="$(extract_job_block "commit-stats-snapshot")"
+    permissions_block="$(extract_job_permissions "commit-stats-snapshot")"
 
-    [[ "$job_block" == *"actions: write"* ]]
-    [[ "$job_block" == *"contents: write"* ]]
+    [[ "$permissions_block" == *"contents: read"* ]]
+    [[ "$permissions_block" != *"contents: write"* ]]
+    [[ "$permissions_block" == *"actions: read"* ]]
+    [[ "$permissions_block" != *"actions: write"* ]]
+    [[ "$job_block" == *"create-github-app-token"* ]]
+    [[ "$job_block" == *"permission-contents: write"* ]]
+    [[ "$job_block" == *"ghaction-import-gpg"* ]]
+    [[ "$job_block" == *"git_commit_gpgsign: true"* ]]
+}
+
+@test "update-dashboard stats collection and persistence are isolated by separate jobs" {
+    # The security boundary is job separation, not step ordering: collect runs
+    # on a different runner with a read-only job token, uploads inert data, and
+    # never has the App token or GPG key material in scope.
+    collect_job="$(extract_job_block "collect-stats-snapshot")"
+    commit_job="$(extract_job_block "commit-stats-snapshot")"
+    collect_permissions="$(extract_job_permissions "collect-stats-snapshot")"
+    commit_permissions="$(extract_job_permissions "commit-stats-snapshot")"
+
+    [[ "$collect_job" == *"collect-stats-snapshot:"* ]]
+    [[ "$commit_job" == *"commit-stats-snapshot:"* ]]
+    [[ "$collect_job" != "$commit_job" ]]
+
+    [[ "$commit_job" == *"needs: collect-stats-snapshot"* ]]
+    [[ "$collect_job" == *"outputs:"* ]]
+    [[ "$collect_job" == *"still_missing: \${{ steps.collect.outputs.still_missing }}"* ]]
+    [[ "$commit_job" == *"steps.persist.outputs.still_missing_after_reconcile"* ]]
+
+    [[ "$collect_job" == *"actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4"* ]]
+    [[ "$commit_job" == *"actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4"* ]]
+    [[ "$collect_job" == *"name: dockerhub-stats-candidate"* ]]
+    [[ "$collect_job" == *"overwrite: true"* ]]
+    [[ "$commit_job" == *"name: dockerhub-stats-candidate"* ]]
+
+    [[ "$collect_job" != *"Generate App token"* ]]
+    [[ "$collect_job" != *"Import GPG key"* ]]
+    [[ "$collect_job" != *"STATS_PUSH_TOKEN"* ]]
+    [[ "$collect_job" != *"GPG_PRIVATE_KEY"* ]]
+
+    [[ "$collect_permissions" == *"contents: read"* ]]
+    [[ "$collect_permissions" != *"contents: write"* ]]
+    [[ "$commit_permissions" == *"contents: read"* ]]
+    [[ "$commit_permissions" != *"contents: write"* ]]
+    [[ "$commit_permissions" != *"actions: write"* ]]
+}
+
+@test "update-dashboard final stats failure gate uses reconciled missing signal" {
+    fail_step="$(extract_step_block "Fail if stats snapshot did not fully persist")"
+    fail_if="$(printf '%s\n' "$fail_step" | awk '
+        $0 ~ /^        if: / {
+            sub(/^        if: /, "")
+            print
+        }
+    ')"
+
+    [[ "$fail_step" == *"steps.persist.outputs.still_missing_after_reconcile"* ]]
+    [[ "$fail_if" == *"steps.persist.outputs.still_missing_after_reconcile == 'true'"* ]]
+    [[ "$fail_if" == *"steps.persist.outputs.persisted != 'true'"* ]]
+    [[ "$fail_if" != *"needs.collect-stats-snapshot.outputs.still_missing == 'true'"* ]]
 }
 
 @test "update-dashboard build and deploy use separate, non-workflow-level concurrency groups" {
@@ -145,8 +266,14 @@ extract_step_run() {
     [[ "$deploy_job" == *'group: "pages-deploy"'* ]]
     [[ "$deploy_job" == *"cancel-in-progress: false"* ]]
 
+    collect_concurrency="$(extract_job_concurrency "collect-stats-snapshot")"
+    [[ "$collect_concurrency" == *"group: collect-stats-snapshot"* ]]
+    [[ "$collect_concurrency" == *"cancel-in-progress: false"* ]]
+
     commit_job="$(extract_job_block "commit-stats-snapshot")"
-    [[ "$commit_job" == *"group: commit-stats-snapshot"* ]]
+    commit_concurrency="$(extract_job_concurrency "commit-stats-snapshot")"
+    [ -z "$commit_concurrency" ]
+    [[ "$commit_job" != *"group: commit-stats-snapshot"* ]]
 }
 
 @test "update-dashboard never interpolates trigger_reason directly into a run: script" {


### PR DESCRIPTION
## Summary

Follow-up to #877/#876: the daily Docker Hub download-stats snapshot job was failing in production because master's branch protection ruleset (PR-only changes, verified signatures, required status checks) rejects a direct `GITHUB_TOKEN` push. Stats collection and persistence now run as two separate GitHub Actions jobs so credential isolation is structural rather than a step-ordering convention:

- `collect-stats-snapshot` runs on its own runner with `contents: read` only, fetches Docker Hub pull counts, and uploads the result as a build artifact. It never has push credentials in scope, and has its own concurrency group so near-simultaneous triggers don't hammer Docker Hub in parallel.
- `commit-stats-snapshot` downloads that artifact on a fresh runner, mints a scoped GitHub App token from the repo's existing bot App (already a branch-protection bypass actor) and signs the commit with the existing GPG key, then merges the candidate into its own checkout and pushes — never re-fetching Docker Hub itself. The commit is scoped to exactly the stats file via a pathspec.
- Same-key merge conflicts are resolved by comparing each row's own fetch timestamp, so a stale candidate can never overwrite fresher data already on master — every conforming row is required to carry that timestamp, closing a bypass where a timestamp-less row could otherwise win by default.
- New candidate rows are held to a strict schema (known container, plausible calendar date, source literally "dockerhub", non-negative integer counts) before they can reach a signed push. Already-committed history is never silently dropped, even when it predates this validation.
- The completion check reconciles against the actual current state of the stats file rather than trusting a single run's own stale collection snapshot, since commit jobs now run unserialized and a concurrent sibling run can complete the same day's data first.

## Known, accepted limitations (documented, not blocking)

- **Midnight-UTC boundary**: the completion-reconcile check and the candidate date-validation ceiling both compute "today" independently rather than using the exact date collection pinned. A trigger firing very close to UTC midnight could misjudge completeness for that one run. Narrow timing window (this workflow's scheduled trigger runs at 07:00 UTC, nowhere near midnight); a misjudged run self-corrects on the next trigger, consistent with this job's existing "another same-day direct trigger may still cover it" design.
- **Diagnostic-message completeness**: when the persist step itself fails (`persisted=false`), GitHub Actions skips the subsequent "Fail if..." step (which normally reports collection/reconcile signal detail) because a step's `if:` implicitly requires `success()`. The job still correctly fails either way — this only affects how much diagnostic detail is visible for that one failure mode, not correctness.
- **Full-file artifact vs. delta**: the collect→commit handoff carries the whole history file, not just newly-collected rows. If a maintainer manually edits/deletes a row via a normal PR while a stale collect artifact is in flight, the union merge could re-add it. Requires a deliberate manual edit racing a stale artifact on a purely cosmetic dashboard file — no security or correctness-critical system depends on this file's freshness.

## Test plan

- [x] Full unit test suite green (`./tests/run-tests.sh`, ~2000 tests)
- [x] `shellcheck`, `yamllint`, `actionlint` clean on all changed files
- [x] Verified against jq 1.7 (this repo's CI runner version) in an isolated container, not just local jq 1.8+
- [x] All checks green; behavior validated end-to-end against the final diff
- [ ] After merge: confirm the `commit-stats-snapshot` job succeeds in production and `stats/dockerhub-pull-history.jsonl` is actually populated on master
- [ ] Confirm the deployed dashboard renders the trend sparkline

Closes #876
