### PR TITLE
fix(dashboard): persist daily stats via a PR instead of a direct push to master

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,12 +1,12 @@
 name: Unit Tests
 
 on:
+  # Stats-only bot PRs still need a real unit-tests check because master
+  # requires this status before auto-merge can complete.
   pull_request:
   push:
-    # stats/** is a pure data file (Docker Hub pull-count history) with no
-    # code implications — excluded so the daily App-token-authenticated
-    # stats commit (which, unlike GITHUB_TOKEN, DOES retrigger workflow push
-    # events) doesn't fan out into a full unit-test run for no reason.
+    # The stats PR already ran the required unit-tests check before merge.
+    # Skip the redundant post-merge push run for stats-only squash commits.
     paths-ignore:
       - "stats/**"
   workflow_dispatch:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -554,8 +554,10 @@ jobs:
           # Strip control characters (the caller-supplied part of TRIGGER_REASON
           # is untrusted free text) so it can't spoof extra log lines or GHA
           # workflow-command annotations via an embedded newline.
-          export UPDATE_REASON="$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]')"
-          export GITHUB_EVENT_NAME="${{ github.event_name }}"
+          UPDATE_REASON="$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]')"
+          export UPDATE_REASON
+          GITHUB_EVENT_NAME="${{ github.event_name }}"
+          export GITHUB_EVENT_NAME
 
           echo "🚀 Generating dashboard data with context:"
           echo "  - Trigger: $GITHUB_EVENT_NAME"
@@ -746,7 +748,11 @@ jobs:
 
   commit-stats-snapshot:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # This job's 45-minute timeout is the hard ceiling. The persist script keeps
+    # its own single shared PR budget to 35 minutes total across all retries,
+    # leaving roughly 10 minutes for checkout, artifact download, GPG/App-token
+    # setup, final output handling, and the explicit failure step below.
+    timeout-minutes: 45
     needs: collect-stats-snapshot
     # Deliberately no job-level concurrency block here. Once collection has
     # succeeded, this run owns a real stats candidate artifact; allowing
@@ -807,28 +813,25 @@ jobs:
           fi
           printf 'candidate_source_file=%s\n' "$candidate_file" >> "$GITHUB_OUTPUT"
 
-      # master requires: PR-only changes, verified commit signatures, and the
-      # unit-tests status check — none of which a direct GITHUB_TOKEN push can
-      # satisfy. The existing bot App (already used for the same reason in
-      # upstream-monitor.yaml) is registered as a ruleset bypass actor for
-      # this repo specifically; its token plus a GPG-signed commit is what
-      # actually lets this job land on master directly. Deliberate deferral:
-      # a no-op candidate still mints this short-lived, contents:write token
-      # inside the isolated commit job. Earlier hardening keeps the token
-      # unreachable by unrelated code, so splitting "needs commit?" across an
-      # extra pre-auth boundary is not justified by the residual exposure.
+      # master requires PR-only changes, verified commit signatures, and the
+      # unit-tests status check. Scope the App token to the two operations this
+      # path needs: pushing the PR branch and creating/updating/merging the PR.
+      # GitHub's PR label endpoint accepts pull-requests:write, so no separate
+      # issues scope is granted for the best-effort automation label.
+      #
+      # Deliberate #876 deferral, raised again in gate round 2: the token is
+      # still minted before commit-stats-snapshot proves there is work to
+      # persist. Splitting the no-op diff check into a separate read-only step
+      # is a larger restructure for a narrow exposure-window reduction on this
+      # already-scoped, short-lived token.
       - name: Generate App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          # Scoped down to exactly what this job needs — without this, the
-          # token defaults to every permission the App is installed with
-          # (used more broadly by upstream-monitor.yaml), which is an
-          # unnecessarily large grant for a job that only pushes one file,
-          # especially since this App is also a ruleset-bypass actor.
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
@@ -845,6 +848,7 @@ jobs:
         env:
           CANDIDATE_SOURCE_FILE: ${{ steps.stats-candidate.outputs.candidate_source_file }}
           STATS_PUSH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STATS_PR_BRANCH: bot/stats-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           chmod +x scripts/commit-stats-snapshot.sh
@@ -852,8 +856,15 @@ jobs:
 
       - name: Fail if stats snapshot did not fully persist
         if: steps.persist.outputs.still_missing_after_reconcile == 'true' || steps.persist.outputs.persisted != 'true'
+        env:
+          COLLECT_STILL_MISSING: ${{ needs.collect-stats-snapshot.outputs.still_missing }}
+          RECONCILED_STILL_MISSING: ${{ steps.persist.outputs.still_missing_after_reconcile }}
+          PERSISTED: ${{ steps.persist.outputs.persisted }}
         run: |
-          echo "::error::Stats snapshot did not fully persist this run (collection still_missing=${{ needs.collect-stats-snapshot.outputs.still_missing }}, reconciled still_missing=${{ steps.persist.outputs.still_missing_after_reconcile }}, persist persisted=${{ steps.persist.outputs.persisted }}) — another same-day direct trigger may still cover it"
+          printf '%s%s%s\n' \
+            "::error::Stats snapshot did not fully persist this run " \
+            "(collection still_missing=${COLLECT_STILL_MISSING}, reconciled still_missing=${RECONCILED_STILL_MISSING}, " \
+            "persist persisted=${PERSISTED}) — another same-day trigger may still cover it"
           exit 1
 
   # Deployment job - only deploy from main/master branch or manual dispatch
@@ -913,7 +924,8 @@ jobs:
             echo "| **Trigger** | \`${{ github.event_name }}\` |"
 
             if [ "${{ github.event_name }}" != "push" ]; then
-              printf '| **Reason** | `%s` |\n' "$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')"
+              reason=$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')
+              printf "| **Reason** | \`%s\` |\n" "$reason"
             fi
 
             echo ""
@@ -945,7 +957,8 @@ jobs:
             echo "| **Trigger** | \`${{ github.event_name }}\` |"
             echo "| **Branch** | \`${{ github.ref_name }}\` |"
             echo "| **Status** | Dashboard built, deployment skipped |"
-            printf '| **Reason** | `%s` |\n' "$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')"
+            reason=$(printf '%s' "$TRIGGER_REASON" | tr -d '[:cntrl:]' | tr '`' "'" | sed 's/|/\\|/g')
+            printf "| **Reason** | \`%s\` |\n" "$reason"
             echo ""
             echo "### ℹ️ Deployment Skipped"
             echo "GitHub Pages deployment only occurs from the \`master\` branch due to environment protection rules."

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
-  echo "::error::scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it resets the worktree and rewrites origin" >&2
+  echo "::error::scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it opens and auto-merges stats PRs" >&2
   exit 2
 fi
 
@@ -13,40 +13,54 @@ fi
 # network access at all, and the reverse holds too: collection never has these
 # push credentials in scope.
 #
-# Hardcoded origin/master targets are safe because update-dashboard.yaml
-# pins this job's checkout to refs/heads/master.
+# Hardcoded origin/master targets are safe because update-dashboard.yaml pins
+# this job's checkout to refs/heads/master and each run pushes a unique PR
+# branch named from the workflow run id, workflow attempt, and local retry
+# attempt.
 #
-# On a lost push race, retry_cleanup resets the worktree to origin/master.
-# The initial persist-job checkout can also be newer than the collect-job
-# checkout that produced the downloaded artifact. In both cases, a candidate
-# copy of what collection produced is merged into the current worktree instead
-# of overwriting it, preserving whatever a concurrent run's own successful
-# push may have already added.
+# On every persist attempt, the worktree is reset to freshly-fetched
+# origin/master before the immutable candidate copy of what collection produced
+# is merged in. That preserves whatever a concurrent run's own successful PR
+# may have already added while still carrying this run's candidate forward after
+# a stale PR, transient git/GitHub failure, or retry.
 #
-# The run FAILS (exit 1) whenever it ends without a successful push. This
+# The run FAILS (exit 1) whenever it ends without a fully merged PR. This
 # job has no downstream dependents (deploy only needs build), so failing it
 # is isolated and visible rather than a silent, permanently-green job that
 # would otherwise mask a real regression (revoked token scope, branch
 # protection change) behind routine warning text.
 #
-# No explicit follow-up dispatch: the calling workflow authenticates this
-# push with a GitHub App installation token (required to satisfy master's
-# branch protection — PR-only changes, verified signatures, status checks —
-# which GITHUB_TOKEN categorically cannot). Unlike GITHUB_TOKEN, an
-# App-token-authored push DOES trigger downstream workflow events, and
-# `stats/**` is already in update-dashboard.yaml's own push path filter —
-# so a successful push here naturally retriggers the dashboard build.
+# No explicit follow-up dispatch: the calling workflow authenticates the PR
+# branch push and PR merge with a GitHub App installation token. Unlike
+# GITHUB_TOKEN, App-token-authored PRs and squash-merge pushes DO trigger
+# downstream workflow events; `stats/**` is already in update-dashboard.yaml's
+# own push path filter, so a successful squash merge naturally retriggers the
+# dashboard build.
 
 STATS_FILE="stats/dockerhub-pull-history.jsonl"
 # Floor predates this JSONL dashboard history and rejects absurdly old
 # candidate rows. Already-committed rows before this floor are still preserved
 # verbatim by merge_candidate_into_worktree's raw-line path.
 STATS_DATE_FLOOR="2020-01-01"
+STATS_PERSIST_MAX_ATTEMPTS=3
+# Three consecutive PR view failures tolerates a brief GitHub API/CLI hiccup
+# across multiple polls while bounding time spent on an unknowable PR state.
+STATS_PR_VIEW_MAX_FAILURES="${STATS_PR_VIEW_MAX_FAILURES:-3}"
+STATS_PR_MIN_MERGE_WAIT_SECONDS="${STATS_PR_MIN_MERGE_WAIT_SECONDS:-30}"
 
 push_token="${STATS_PUSH_TOKEN:-}"
 github_repository="${GITHUB_REPOSITORY:-}"
+stats_pr_branch="${STATS_PR_BRANCH:-}"
 safe_origin_url=""
 origin_restore_needed=false
+
+if [[ -z "$stats_pr_branch" && -n "${GITHUB_RUN_ID:-}" ]]; then
+  if [[ -n "${GITHUB_RUN_ATTEMPT:-}" ]]; then
+    stats_pr_branch="bot/stats-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  else
+    stats_pr_branch="bot/stats-snapshot-${GITHUB_RUN_ID}"
+  fi
+fi
 
 if [[ -n "$github_repository" ]]; then
   safe_origin_url="https://github.com/${github_repository}.git"
@@ -178,7 +192,7 @@ merge_candidate_into_worktree() {
   # row instead of letting an untrusted candidate win by default. Malformed or
   # otherwise unrecognized nonblank lines already in committed stats history
   # are preserved verbatim, but candidate-only raw lines are dropped before
-  # this privileged signed push path can trust them.
+  # this privileged signed PR path can trust them.
   #
   # Known accepted limitation: this union merge cannot represent an intentional
   # manual deletion/correction of a row racing a stale collect artifact with the
@@ -265,7 +279,7 @@ merge_candidate_into_worktree() {
               | if .candidate_raw_counts[$line] > (.stats_raw_counts[$line] // 0) then
                   . as $state
                   | (
-                      "::warning::Dropping nonconforming candidate-only stats line before signed push"
+                      "::warning::Dropping nonconforming candidate-only stats line before signed PR"
                       | stderr
                     )
                   | $state
@@ -393,46 +407,372 @@ compute_still_missing_after_reconcile() {
   esac
 }
 
+delete_remote_pr_branch() {
+  local branch="$1"
+
+  if [[ -z "$branch" ]]; then
+    return 0
+  fi
+
+  if ! git push origin --delete "$branch" >/dev/null 2>&1; then
+    echo "::warning::Could not delete stale stats snapshot branch $branch after failure"
+    return 1
+  fi
+
+  return 0
+}
+
+cleanup_failed_pr() {
+  local pr_number="$1"
+  local pr_branch="$2"
+  local remote_branch_maybe_pushed="$3"
+
+  if [[ -n "$pr_number" ]]; then
+    if ! gh pr close "$pr_number" --delete-branch 2>&1; then
+      echo "::warning::Could not close stale stats snapshot PR #$pr_number or delete branch $pr_branch after failure"
+      if [[ "$remote_branch_maybe_pushed" == "true" ]]; then
+        delete_remote_pr_branch "$pr_branch" || true
+      fi
+    fi
+    return 0
+  fi
+
+  if [[ "$remote_branch_maybe_pushed" == "true" ]]; then
+    delete_remote_pr_branch "$pr_branch" || true
+  fi
+}
+
+parse_created_pr_number() {
+  local pr_branch="$1"
+  local pr_create_output="$2"
+  local parsed_number
+
+  parsed_number=$(printf '%s\n' "$pr_create_output" | sed -nE 's#.*github.com/[^[:space:]]+/pull/([0-9]+).*#\1#p' | tail -1)
+  if [[ "$parsed_number" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$parsed_number"
+    return 0
+  fi
+
+  if parsed_number=$(gh pr view "$pr_branch" --json number --jq '.number' 2>&1) && [[ "$parsed_number" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$parsed_number"
+    return 0
+  fi
+
+  echo "::warning::Could not determine stats snapshot PR number after creation" >&2
+  return 1
+}
+
+wait_for_pr_merge() {
+  local pr_number="$1"
+  local deadline_epoch="$2"
+  local poll_seconds="$3"
+  local max_query_failures="$4"
+  local consecutive_query_failures=0
+  local now_epoch pr_view remaining_seconds sleep_seconds state merged_at
+
+  while true; do
+    if ! now_epoch=$(date +%s); then
+      echo "::warning::Could not read wall-clock time while waiting for stats snapshot PR #$pr_number"
+      return 1
+    fi
+    remaining_seconds=$((deadline_epoch - now_epoch))
+    if ((remaining_seconds <= 0)); then
+      echo "::warning::Timed out waiting for stats snapshot PR #$pr_number to merge"
+      return 1
+    fi
+
+    if ! pr_view=$(gh pr view "$pr_number" --json state,mergedAt --jq '[.state, (.mergedAt // "")] | @tsv' 2>&1); then
+      consecutive_query_failures=$((consecutive_query_failures + 1))
+      printf '%s\n' "$pr_view" >&2
+      if ((consecutive_query_failures >= max_query_failures)); then
+        echo "::warning::Could not inspect stats snapshot PR #$pr_number merge state after $consecutive_query_failures consecutive attempt(s)"
+        return 1
+      fi
+      echo "::warning::Could not inspect stats snapshot PR #$pr_number merge state (attempt $consecutive_query_failures/$max_query_failures); continuing within the remaining wait budget"
+    else
+      consecutive_query_failures=0
+
+      IFS=$'\t' read -r state merged_at <<< "$pr_view"
+      if [[ "$state" == "MERGED" || -n "${merged_at:-}" ]]; then
+        echo "::notice::Stats snapshot PR #$pr_number merged"
+        return 0
+      fi
+
+      if [[ "$state" == "CLOSED" ]]; then
+        echo "::warning::Stats snapshot PR #$pr_number closed without merging"
+        return 1
+      fi
+    fi
+
+    if ! now_epoch=$(date +%s); then
+      echo "::warning::Could not read wall-clock time while waiting for stats snapshot PR #$pr_number"
+      return 1
+    fi
+    remaining_seconds=$((deadline_epoch - now_epoch))
+    if ((remaining_seconds <= 0)); then
+      echo "::warning::Timed out waiting for stats snapshot PR #$pr_number to merge"
+      return 1
+    fi
+
+    sleep_seconds="$poll_seconds"
+    if ((sleep_seconds > remaining_seconds)); then
+      sleep_seconds="$remaining_seconds"
+    fi
+    if ! sleep "$sleep_seconds"; then
+      echo "::warning::Stats snapshot PR merge polling sleep failed"
+      return 1
+    fi
+  done
+}
+
+validate_pr_budget_config() {
+  local total_budget_seconds="$1"
+  local min_wait_seconds="$2"
+  local poll_seconds="$3"
+  local max_query_failures="$4"
+
+  if ! [[ "$total_budget_seconds" =~ ^[0-9]+$ ]] ||
+      ! [[ "$min_wait_seconds" =~ ^[0-9]+$ ]] ||
+      ! [[ "$poll_seconds" =~ ^[0-9]+$ ]] ||
+      ! [[ "$max_query_failures" =~ ^[0-9]+$ ]] ||
+      [[ "$poll_seconds" -eq 0 ]] ||
+      [[ "$max_query_failures" -eq 0 ]]; then
+    echo "::warning::Invalid stats PR merge polling configuration"
+    return 1
+  fi
+}
+
+remaining_pr_budget_seconds() {
+  local deadline_epoch="$1"
+  local now_epoch
+
+  if ! now_epoch=$(date +%s); then
+    echo "::warning::Could not read wall-clock time for stats snapshot PR budget" >&2
+    printf '0\n'
+    return 1
+  fi
+
+  if ((now_epoch >= deadline_epoch)); then
+    printf '0\n'
+  else
+    printf '%s\n' "$((deadline_epoch - now_epoch))"
+  fi
+}
+
 sleep_before_retry() {
   local attempt="$1"
+  local deadline_epoch="$2"
+  local remaining_seconds sleep_seconds
 
-  if [[ "$attempt" -lt 3 ]]; then
-    if ! sleep $((attempt * 5)); then
+  if [[ "$attempt" -lt "$STATS_PERSIST_MAX_ATTEMPTS" ]]; then
+    if ! remaining_seconds=$(remaining_pr_budget_seconds "$deadline_epoch"); then
+      remaining_seconds=0
+    fi
+    if ((remaining_seconds <= 0)); then
+      return 0
+    fi
+
+    sleep_seconds=$((attempt * 5))
+    if ((sleep_seconds > remaining_seconds)); then
+      sleep_seconds="$remaining_seconds"
+    fi
+
+    if ! sleep "$sleep_seconds"; then
       echo "::warning::Stats snapshot retry sleep failed after attempt $attempt"
     fi
   fi
 }
 
-retry_cleanup() {
+reset_worktree_to_fresh_master() {
   local attempt="$1"
-  local committed="$2"
-  local reset_failed=false
 
-  if [[ "$committed" == "true" ]]; then
-    if ! git reset --hard HEAD~1; then
-      echo "::warning::Could not discard failed stats commit on attempt $attempt"
-      reset_failed=true
-    fi
-  fi
-
-  if ! git fetch origin master; then
-    echo "::warning::Could not fetch origin/master after stats snapshot attempt $attempt"
+  if ! git fetch --force origin refs/heads/master:refs/remotes/origin/master; then
+    echo "::warning::Could not fetch origin/master before stats snapshot attempt $attempt"
+    return 1
   fi
 
   if ! git reset --hard origin/master; then
-    echo "::warning::Could not reset stats snapshot worktree after attempt $attempt"
-    reset_failed=true
+    echo "::warning::Could not reset stats snapshot worktree before attempt $attempt"
+    return 1
   fi
+}
 
-  if [[ "$reset_failed" == "true" ]]; then
+ensure_stats_snapshot_pr() {
+  local pr_branch="$1"
+  local pr_create_output
+  local pr_number
+
+  if ! pr_create_output=$(gh pr create \
+      --base master \
+      --head "$pr_branch" \
+      --title "chore(stats): daily Docker Hub pull-count snapshot" \
+      --body "Automated Docker Hub pull-count snapshot for this workflow run." 2>&1); then
+    printf '%s\n' "$pr_create_output" >&2
+    echo "::warning::Could not create stats snapshot PR from $pr_branch" >&2
+    if pr_number=$(parse_created_pr_number "$pr_branch" "$pr_create_output"); then
+      echo "::notice::Using existing stats snapshot PR #$pr_number for $pr_branch" >&2
+      printf '%s\n' "$pr_number"
+      return 0
+    fi
+    return 1
+  fi
+  printf '%s\n' "$pr_create_output" >&2
+
+  if ! pr_number=$(parse_created_pr_number "$pr_branch" "$pr_create_output"); then
+    return 1
+  fi
+  printf '%s\n' "$pr_number"
+}
+
+persist_stats_snapshot_via_pr() {
+  # The surrounding GitHub Actions job has a 45-minute hard timeout. This
+  # function enforces one shared 35-minute wall-clock budget across all retry
+  # attempts (legacy STATS_PR_MERGE_TIMEOUT_SECONDS still overrides the default)
+  # so cleanup and output emission run before the job-level timeout can kill us.
+  local total_budget_seconds="${STATS_PR_TOTAL_BUDGET_SECONDS:-${STATS_PR_MERGE_TIMEOUT_SECONDS:-2100}}"
+  local min_wait_seconds="$STATS_PR_MIN_MERGE_WAIT_SECONDS"
+  local poll_seconds="${STATS_PR_MERGE_POLL_SECONDS:-10}"
+  local max_query_failures="$STATS_PR_VIEW_MAX_FAILURES"
+  local attempt attempt_pr_branch attempt_pr_number attempt_remote_branch_maybe_pushed
+  local deadline_epoch diff_status head_commit remaining_seconds start_epoch
+  local attempts_remaining attempt_wait_epoch now_epoch_for_attempt_cap
+
+  if [[ -z "$stats_pr_branch" ]]; then
+    echo "::warning::GITHUB_RUN_ID or STATS_PR_BRANCH is required to name the stats snapshot PR branch"
     return 1
   fi
 
-  if ! merge_candidate_into_worktree; then
+  if ! validate_pr_budget_config "$total_budget_seconds" "$min_wait_seconds" "$poll_seconds" "$max_query_failures"; then
     return 1
   fi
 
-  sleep_before_retry "$attempt"
+  if ! start_epoch=$(date +%s); then
+    echo "::warning::Could not read wall-clock time before stats snapshot PR attempts"
+    return 1
+  fi
+  deadline_epoch=$((start_epoch + total_budget_seconds))
+
+  for ((attempt = 1; attempt <= STATS_PERSIST_MAX_ATTEMPTS; attempt++)); do
+    if ! remaining_seconds=$(remaining_pr_budget_seconds "$deadline_epoch"); then
+      remaining_seconds=0
+    fi
+    if ((remaining_seconds < min_wait_seconds)); then
+      echo "::warning::Not enough stats PR budget remains before attempt $attempt (${remaining_seconds}s left, need at least ${min_wait_seconds}s)"
+      return 1
+    fi
+
+    attempt_pr_branch="${stats_pr_branch}-attempt-${attempt}"
+    attempt_pr_number=""
+    attempt_remote_branch_maybe_pushed=false
+
+    if ! reset_worktree_to_fresh_master "$attempt"; then
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! merge_candidate_into_worktree; then
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if git diff --quiet HEAD -- "$STATS_FILE"; then
+      return 0
+    else
+      diff_status=$?
+      if [[ "$diff_status" -gt 1 ]]; then
+        echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
+        sleep_before_retry "$attempt" "$deadline_epoch"
+        continue
+      fi
+    fi
+
+    if ! validate_stats_file_jsonl; then
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! git checkout -B "$attempt_pr_branch"; then
+      echo "::warning::Could not create or reset stats snapshot branch $attempt_pr_branch on attempt $attempt"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! git add "$STATS_FILE"; then
+      echo "::warning::Could not stage stats snapshot on attempt $attempt"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot" -- "$STATS_FILE"; then
+      echo "::warning::Could not commit stats snapshot on attempt $attempt"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! head_commit=$(git rev-parse HEAD); then
+      echo "::warning::Could not resolve stats snapshot head commit on attempt $attempt"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! git push --force origin "HEAD:${attempt_pr_branch}"; then
+      echo "::warning::Could not push stats snapshot branch $attempt_pr_branch on attempt $attempt"
+      cleanup_failed_pr "" "$attempt_pr_branch" true
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+    attempt_remote_branch_maybe_pushed=true
+
+    if ! attempt_pr_number=$(ensure_stats_snapshot_pr "$attempt_pr_branch"); then
+      cleanup_failed_pr "" "$attempt_pr_branch" "$attempt_remote_branch_maybe_pushed"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    if ! sleep 2; then
+      echo "::warning::Stats snapshot PR label delay failed on attempt $attempt"
+    elif ! gh pr edit "$attempt_pr_number" --add-label "automation" 2>&1; then
+      echo "::warning::Failed to apply automation label to stats snapshot PR #${attempt_pr_number}; PR created successfully — continuing"
+    fi
+
+    if gh pr merge "$attempt_pr_number" --squash --auto --delete-branch --match-head-commit "$head_commit" 2>&1; then
+      echo "::notice::Auto-merge enabled for stats snapshot PR #$attempt_pr_number"
+    else
+      echo "::warning::Failed to enable auto-merge for stats snapshot PR #$attempt_pr_number on attempt $attempt"
+      cleanup_failed_pr "$attempt_pr_number" "$attempt_pr_branch" "$attempt_remote_branch_maybe_pushed"
+      sleep_before_retry "$attempt" "$deadline_epoch"
+      continue
+    fi
+
+    # Cap THIS attempt's own wait to a fair share of whatever budget remains,
+    # not the full shared deadline — otherwise a single blocked/conflicted PR
+    # (the most likely trigger for a retry at all, since it happens exactly
+    # when a sibling stats PR merges first) can burn the entire budget on one
+    # wait, leaving nothing for the attempts that exist specifically to
+    # recover from that case. Recomputed fresh each attempt (not a fixed
+    # 1/max_attempts of the original total) so an attempt that fails fast
+    # doesn't shrink what's available to the ones after it.
+    attempts_remaining=$((STATS_PERSIST_MAX_ATTEMPTS - attempt + 1))
+    if ! remaining_seconds=$(remaining_pr_budget_seconds "$deadline_epoch"); then
+      remaining_seconds=0
+    fi
+    if ! now_epoch_for_attempt_cap=$(date +%s); then
+      now_epoch_for_attempt_cap="$deadline_epoch"
+    fi
+    attempt_wait_epoch=$((now_epoch_for_attempt_cap + remaining_seconds / attempts_remaining))
+    if ((attempt_wait_epoch > deadline_epoch)); then
+      attempt_wait_epoch="$deadline_epoch"
+    fi
+
+    if wait_for_pr_merge "$attempt_pr_number" "$attempt_wait_epoch" "$poll_seconds" "$max_query_failures"; then
+      return 0
+    fi
+
+    cleanup_failed_pr "$attempt_pr_number" "$attempt_pr_branch" "$attempt_remote_branch_maybe_pushed"
+    sleep_before_retry "$attempt" "$deadline_epoch"
+  done
+
+  return 1
 }
 
 # Deliberately no local `git config user.name/email` here — the calling
@@ -442,6 +782,7 @@ retry_cleanup() {
 # name the GPG key doesn't sign for, defeating the "required_signatures"
 # branch protection rule this job depends on.
 if [[ -n "$push_token" && -n "$github_repository" ]]; then
+  export GH_TOKEN="$push_token"
   origin_restore_needed=true
   if ! git remote set-url origin "https://x-access-token:${push_token}@github.com/${github_repository}.git"; then
     echo "::warning::Could not configure authenticated origin remote for stats snapshot"
@@ -451,56 +792,8 @@ else
 fi
 
 persisted=false
-if merge_candidate_into_worktree; then
-  for attempt in 1 2 3; do
-    if git diff --quiet HEAD -- "$STATS_FILE"; then
-      persisted=true
-      break
-    else
-      diff_status=$?
-      if [[ "$diff_status" -gt 1 ]]; then
-        echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
-        if ! retry_cleanup "$attempt" "false"; then
-          break
-        fi
-        continue
-      fi
-    fi
-
-    if ! validate_stats_file_jsonl; then
-      if ! retry_cleanup "$attempt" "false"; then
-        break
-      fi
-      continue
-    fi
-
-    if ! git add "$STATS_FILE"; then
-      echo "::warning::Could not stage stats snapshot on attempt $attempt"
-      if ! retry_cleanup "$attempt" "false"; then
-        break
-      fi
-      continue
-    fi
-
-    if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot" -- "$STATS_FILE"; then
-      echo "::warning::Could not commit stats snapshot on attempt $attempt"
-      if ! retry_cleanup "$attempt" "false"; then
-        break
-      fi
-      continue
-    fi
-
-    if git push origin master; then
-      persisted=true
-      break
-    fi
-
-    # Lost the race (or lack permission) — discard this attempt and retry
-    # clean, re-merging this run's own candidate data back in afterward.
-    if ! retry_cleanup "$attempt" "true"; then
-      break
-    fi
-  done
+if persist_stats_snapshot_via_pr; then
+  persisted=true
 fi
 
 emit_persisted_output "$persisted"
@@ -514,7 +807,7 @@ fi
 emit_still_missing_after_reconcile_output "$still_missing_after_reconcile"
 
 if [[ "$persisted" != "true" ]]; then
-  echo "::error::Could not persist stats snapshot this run — another same-day direct trigger may still cover it"
+  echo "::error::Could not persist stats snapshot this run — another same-day trigger may still cover it"
   exit 1
 fi
 

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -17,17 +17,31 @@ setup() {
         > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
     : > "$FAKE_GIT_STATE/head_stats"
 
-    cat > "$TEST_REPO/bin/git" <<'EOF'
+cat > "$TEST_REPO/bin/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 state="${FAKE_GIT_STATE:?}"
 stats_file="stats/dockerhub-pull-history.jsonl"
 head_stats="$state/head_stats"
 local_head_stats="$state/local_head_stats"
-precommit_head_stats="$state/precommit_head_stats"
 commit_stats="$state/commit_stats"
+head_oid="$state/head_oid"
 mkdir -p "$state"
 printf '%s\n' "$*" >> "$state/git.log"
+
+branch_state_path() {
+  local branch="$1"
+  local safe_branch
+  safe_branch=$(printf '%s' "$branch" | tr '/:' '__')
+  printf '%s/branch_%s_stats\n' "$state" "$safe_branch"
+}
+
+branch_commit_path() {
+  local branch="$1"
+  local safe_branch
+  safe_branch=$(printf '%s' "$branch" | tr '/:' '__')
+  printf '%s/branch_%s_commit\n' "$state" "$safe_branch"
+}
 
 ensure_local_head() {
   if [[ ! -f "$local_head_stats" ]]; then
@@ -39,12 +53,6 @@ ensure_local_head() {
   fi
 }
 
-reset_worktree_to_local_head() {
-  ensure_local_head
-  mkdir -p stats
-  cp "$local_head_stats" "$stats_file"
-}
-
 reset_worktree_to_origin() {
   mkdir -p stats
   if [[ -f "$head_stats" ]]; then
@@ -53,21 +61,21 @@ reset_worktree_to_origin() {
     : > "$local_head_stats"
   fi
   cp "$local_head_stats" "$stats_file"
-}
-
-reset_worktree_to_parent() {
-  mkdir -p stats
-  if [[ -f "$precommit_head_stats" ]]; then
-    cp "$precommit_head_stats" "$local_head_stats"
-    cp "$local_head_stats" "$stats_file"
-  else
-    reset_worktree_to_origin
-  fi
+  printf '%s\n' "origin-master" > "$head_oid"
 }
 
 case "${1:-}" in
   config)
     exit 0
+    ;;
+  checkout)
+    if { [[ "${2:-}" == "-b" ]] || [[ "${2:-}" == "-B" ]]; } && [[ -n "${3:-}" ]]; then
+      ensure_local_head
+      printf '%s\n' "$3" > "$state/current_branch"
+      exit 0
+    fi
+    echo "unsupported fake git checkout: $*" >&2
+    exit 64
     ;;
   remote)
     if [[ "${2:-}" == "set-url" && "${3:-}" == "origin" ]]; then
@@ -107,82 +115,64 @@ case "${1:-}" in
       exit 1
     fi
     ensure_local_head
-    cp "$local_head_stats" "$precommit_head_stats"
     cp "$state/index_stats" "$commit_stats"
     cp "$commit_stats" "$local_head_stats"
     commits=$(cat "$state/commit_count" 2>/dev/null || echo 0)
-    echo $((commits + 1)) > "$state/commit_count"
+    commits=$((commits + 1))
+    echo "$commits" > "$state/commit_count"
+    printf 'commit-%s\n' "$commits" > "$head_oid"
     exit 0
     ;;
+  rev-parse)
+    if [[ "${2:-}" == "HEAD" ]]; then
+      cat "$head_oid"
+      exit 0
+    fi
+    echo "unsupported fake git rev-parse: $*" >&2
+    exit 64
+    ;;
   push)
-    pushes=$(cat "$state/push_count" 2>/dev/null || echo 0)
-    pushes=$((pushes + 1))
-    echo "$pushes" > "$state/push_count"
-    mode="${FAKE_GIT_PUSH_MODE:-always_success}"
-    if [[ "$mode" == "always_fail" ]]; then
-      exit 1
-    fi
-    if [[ "$mode" == "success_on_retry" ]]; then
-      if [[ "$pushes" -eq 1 ]]; then
+    if [[ "${2:-}" == "origin" && "${3:-}" == "--delete" && -n "${4:-}" ]]; then
+      deletes=$(cat "$state/delete_branch_count" 2>/dev/null || echo 0)
+      echo $((deletes + 1)) > "$state/delete_branch_count"
+      if [[ "${FAKE_GIT_FAIL_DELETE_BRANCH:-}" == "1" ]]; then
         exit 1
       fi
-      cp "$commit_stats" "$head_stats"
+      rm -f "$(branch_state_path "$4")"
+      rm -f "$(branch_commit_path "$4")"
       exit 0
     fi
-    if [[ "$mode" == "ambiguous_fail_once" ]]; then
-      # Simulates a network partition where the remote accepts the push but
-      # the client never sees the ack: origin (head_stats) DOES advance, yet
-      # the command still reports failure to the caller.
-      if [[ "$pushes" -eq 1 ]]; then
-        cp "$commit_stats" "$head_stats"
+
+    if [[ "${2:-}" == "--force" && "${3:-}" == "origin" && "${4:-}" == HEAD:* ]]; then
+      branch="${4#HEAD:}"
+      pushes=$(cat "$state/push_count" 2>/dev/null || echo 0)
+      echo $((pushes + 1)) > "$state/push_count"
+      mode="${FAKE_GIT_PUSH_MODE:-always_success}"
+      if [[ "$mode" == "always_fail" ]]; then
         exit 1
       fi
-      cp "$commit_stats" "$head_stats"
-      exit 0
-    fi
-    if [[ "$mode" == "concurrent_update_then_success" ]]; then
-      # Simulates another run landing a DIFFERENT container's row on origin
-      # in between this run's first (lost) push attempt and its retry — the
-      # candidate-merge must preserve that concurrent addition, not clobber
-      # it with only this run's own alpha row.
-      if [[ "$pushes" -eq 1 ]]; then
-        printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
-          > "$head_stats"
-        cp "$head_stats" "$state/first_failed_head_stats"
+      if [[ "$mode" == "success_on_retry" ]] && [[ "$pushes" -eq 0 ]]; then
         exit 1
       fi
-      cp "$commit_stats" "$head_stats"
+      cp "$commit_stats" "$(branch_state_path "$branch")"
+      cp "$head_oid" "$(branch_commit_path "$branch")"
+      printf '%s\n' "$branch" > "$state/pushed_branch"
       exit 0
     fi
-    if [[ "$mode" == "concurrent_malformed_then_success" ]]; then
-      if [[ "$pushes" -eq 1 ]]; then
-        printf 'not-json\n{ "ts" : "2026-07-12T08:00:00Z", "date" : "2026-07-12", "container" : "gamma", "pull_count" : 99, "star_count" : 9, "source" : "dockerhub" }\n' \
-          > "$head_stats"
-        exit 1
-      fi
-      cp "$commit_stats" "$head_stats"
-      exit 0
-    fi
-    cp "$commit_stats" "$head_stats"
+
+    echo "unsupported fake git push: $*" >&2
+    exit 64
+    ;;
+  fetch)
     exit 0
     ;;
   reset)
-    if [[ "${FAKE_GIT_FAIL_RESET_ALWAYS:-}" == "1" ]]; then
-      exit 1
-    fi
-    if [[ "$*" == *"HEAD~1"* ]]; then
-      reset_worktree_to_parent
-      exit 0
-    fi
     if [[ "$*" == *"origin/master"* ]]; then
       reset_worktree_to_origin
       exit 0
     fi
-    reset_worktree_to_local_head
-    exit 0
-    ;;
-  fetch)
-    exit 0
+    echo "unsupported fake git reset: $*" >&2
+    exit 64
     ;;
   *)
     echo "unsupported fake git command: $*" >&2
@@ -195,12 +185,33 @@ EOF
     cat > "$TEST_REPO/bin/sleep" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-echo "$*" >> "${FAKE_GIT_STATE:?}/sleep.log"
+state="${FAKE_GIT_STATE:?}"
+echo "$*" >> "$state/sleep.log"
+if [[ -f "$state/fake_time_epoch" ]]; then
+  seconds="${1:-0}"
+  if [[ "$seconds" =~ ^[0-9]+$ ]]; then
+    now=$(cat "$state/fake_time_epoch")
+    echo $((now + seconds)) > "$state/fake_time_epoch"
+  fi
+fi
 EOF
     chmod +x "$TEST_REPO/bin/sleep"
 
     hash -r
+    real_date="$(command -v date)"
     real_jq="$(command -v jq)"
+    echo 0 > "$FAKE_GIT_STATE/fake_time_epoch"
+cat > "$TEST_REPO/bin/date" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if { [[ "\$#" -eq 1 && "\${1:-}" == "+%s" ]] || [[ "\$#" -eq 2 && "\${1:-}" == "-u" && "\${2:-}" == "+%s" ]]; } && [[ -f "\${FAKE_GIT_STATE:?}/fake_time_epoch" ]]; then
+  cat "\$FAKE_GIT_STATE/fake_time_epoch"
+  exit 0
+fi
+exec "$real_date" "\$@"
+EOF
+    chmod +x "$TEST_REPO/bin/date"
+
 cat > "$TEST_REPO/bin/jq" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -218,11 +229,284 @@ exec "$real_jq" "\$@"
 EOF
     chmod +x "$TEST_REPO/bin/jq"
 
+    cat > "$TEST_REPO/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${FAKE_GIT_STATE:?}"
+head_stats="$state/head_stats"
+mkdir -p "$state"
+printf '%s\n' "$*" >> "$state/gh.log"
+
+safe_ref() {
+  printf '%s' "$1" | tr '/:' '__'
+}
+
+branch_state_path() {
+  printf '%s/branch_%s_stats\n' "$state" "$(safe_ref "$1")"
+}
+
+branch_commit_path() {
+  printf '%s/branch_%s_commit\n' "$state" "$(safe_ref "$1")"
+}
+
+pr_field_path() {
+  local number="$1"
+  local field="$2"
+  printf '%s/pr_%s_%s\n' "$state" "$number" "$field"
+}
+
+branch_pr_number_path() {
+  printf '%s/pr_branch_%s_number\n' "$state" "$(safe_ref "$1")"
+}
+
+next_pr_number() {
+  local number
+  number=$(cat "$state/pr_next_number" 2>/dev/null || echo 123)
+  echo $((number + 1)) > "$state/pr_next_number"
+  printf '%s\n' "$number"
+}
+
+pr_number_for_ref() {
+  local ref="$1"
+
+  if [[ "$ref" =~ ^[0-9]+$ && -f "$(pr_field_path "$ref" head)" ]]; then
+    printf '%s\n' "$ref"
+    return 0
+  fi
+
+  if [[ -f "$(branch_pr_number_path "$ref")" ]]; then
+    cat "$(branch_pr_number_path "$ref")"
+    return 0
+  fi
+
+  return 1
+}
+
+merge_pr_branch() {
+  local number="$1"
+  local branch
+  branch=$(cat "$(pr_field_path "$number" head)")
+  cp "$(branch_state_path "$branch")" "$head_stats"
+  printf '%s\n' "MERGED" > "$(pr_field_path "$number" state)"
+  printf '%s\n' "2026-07-12T07:05:00Z" > "$(pr_field_path "$number" merged_at)"
+  if [[ -f "$(pr_field_path "$number" delete_branch)" ]]; then
+    rm -f "$(branch_state_path "$branch")" "$(branch_commit_path "$branch")"
+  fi
+}
+
+advance_auto_merge_for_view() {
+  local number="$1"
+  local per_pr_views="$2"
+  local mode="${FAKE_GH_PR_VIEW_MODE:-merged}"
+  local branch
+
+  if [[ "$(cat "$(pr_field_path "$number" state)")" != "OPEN" ]]; then
+    return 0
+  fi
+
+  case "$mode" in
+    closed)
+      printf '%s\n' "CLOSED" > "$(pr_field_path "$number" state)"
+      ;;
+    always_open)
+      ;;
+    open_then_merged)
+      if [[ "$per_pr_views" -ge 2 && -f "$(pr_field_path "$number" auto_merge)" ]]; then
+        merge_pr_branch "$number"
+      fi
+      ;;
+    stale_once_then_closed_then_merged)
+      if [[ ! -f "$state/stale_once_done" ]]; then
+        printf '{"ts":"2026-07-12T08:00:00Z","date":"2026-07-12","container":"gamma","pull_count":99,"star_count":9,"source":"dockerhub"}\n' \
+          > "$head_stats"
+        cp "$head_stats" "$state/first_stale_head_stats"
+        printf '%s\n' "CLOSED" > "$(pr_field_path "$number" state)"
+        : > "$state/stale_once_done"
+      elif [[ -f "$(pr_field_path "$number" auto_merge)" ]]; then
+        merge_pr_branch "$number"
+      fi
+      ;;
+    first_pr_closed_then_merged)
+      if [[ ! -f "$state/first_pr_closed_done" ]]; then
+        printf '%s\n' "CLOSED" > "$(pr_field_path "$number" state)"
+        : > "$state/first_pr_closed_done"
+      elif [[ -f "$(pr_field_path "$number" auto_merge)" ]]; then
+        merge_pr_branch "$number"
+      fi
+      ;;
+    cover_then_closed)
+      if [[ ! -f "$state/cover_then_closed_done" ]]; then
+        branch=$(cat "$(pr_field_path "$number" head)")
+        cp "$(branch_state_path "$branch")" "$head_stats"
+        printf '%s\n' "CLOSED" > "$(pr_field_path "$number" state)"
+        : > "$state/cover_then_closed_done"
+      elif [[ -f "$(pr_field_path "$number" auto_merge)" ]]; then
+        merge_pr_branch "$number"
+      fi
+      ;;
+    fail_once_then_merged|merged)
+      if [[ -f "$(pr_field_path "$number" auto_merge)" ]]; then
+        merge_pr_branch "$number"
+      fi
+      ;;
+    *)
+      echo "unsupported fake gh pr view mode: $mode" >&2
+      exit 64
+      ;;
+  esac
+}
+
+case "${1:-} ${2:-}" in
+  "pr create")
+    if [[ "${FAKE_GH_PR_CREATE_FAIL:-}" == "1" ]]; then
+      echo "simulated gh pr create failure" >&2
+      exit 1
+    fi
+    head_branch=""
+    while (($# > 0)); do
+      case "$1" in
+        --head)
+          head_branch="${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    number=$(next_pr_number)
+    printf '%s\n' "${head_branch:?}" > "$(pr_field_path "$number" head)"
+    printf '%s\n' "OPEN" > "$(pr_field_path "$number" state)"
+    : > "$(pr_field_path "$number" merged_at)"
+    printf '%s\n' "$number" > "$(branch_pr_number_path "$head_branch")"
+    printf '%s\n' "$number" > "$state/pr_number"
+    printf 'https://github.com/owner/repo/pull/%s\n' "$number"
+    exit 0
+    ;;
+  "pr edit")
+    if [[ "${FAKE_GH_PR_EDIT_FAIL:-}" == "1" ]]; then
+      echo "simulated gh pr edit failure" >&2
+      exit 1
+    fi
+    : > "$state/pr_edit_called"
+    exit 0
+    ;;
+  "pr merge")
+    merges=$(cat "$state/pr_merge_count" 2>/dev/null || echo 0)
+    echo $((merges + 1)) > "$state/pr_merge_count"
+    printf '%s\n' "$*" >> "$state/pr_merge_args"
+    if [[ "${FAKE_GH_PR_MERGE_FAIL:-}" == "1" ]]; then
+      echo "simulated gh pr merge failure" >&2
+      exit 1
+    fi
+
+    number="${3:-}"
+    if ! number=$(pr_number_for_ref "$number"); then
+      echo "could not resolve pull request: ${3:-}" >&2
+      exit 1
+    fi
+    if [[ "$(cat "$(pr_field_path "$number" state)")" != "OPEN" ]]; then
+      echo "pull request is not open" >&2
+      exit 1
+    fi
+
+    match_head=""
+    delete_branch=false
+    while (($# > 0)); do
+      case "$1" in
+        --match-head-commit)
+          match_head="${2:-}"
+          shift 2
+          ;;
+        --delete-branch)
+          delete_branch=true
+          shift
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    branch=$(cat "$(pr_field_path "$number" head)")
+    actual_head=$(cat "$(branch_commit_path "$branch")" 2>/dev/null || true)
+    if [[ -z "$match_head" || "$actual_head" != "$match_head" ]]; then
+      echo "head commit mismatch" >&2
+      exit 1
+    fi
+
+    if [[ "$delete_branch" == "true" ]]; then
+      : > "$(pr_field_path "$number" delete_branch)"
+    fi
+    printf '%s\n' "$match_head" >> "$state/pr_merge_head_commits"
+    : > "$(pr_field_path "$number" auto_merge)"
+    : > "$state/pr_merge_called"
+    exit 0
+    ;;
+  "pr view")
+    ref="${3:-}"
+    if ! number=$(pr_number_for_ref "$ref"); then
+      echo "could not resolve pull request: $ref" >&2
+      exit 1
+    fi
+
+    if [[ "$*" == *"--json number"* ]]; then
+      printf '%s\n' "$number"
+      exit 0
+    fi
+
+    mode="${FAKE_GH_PR_VIEW_MODE:-merged}"
+    if [[ "$mode" == "fail_once_then_merged" && ! -f "$state/pr_view_failed_once" ]]; then
+      : > "$state/pr_view_failed_once"
+      echo "simulated transient gh pr view failure" >&2
+      exit 1
+    fi
+
+    views=$(cat "$state/pr_view_count" 2>/dev/null || echo 0)
+    views=$((views + 1))
+    echo "$views" > "$state/pr_view_count"
+    per_pr_views=$(cat "$(pr_field_path "$number" view_count)" 2>/dev/null || echo 0)
+    per_pr_views=$((per_pr_views + 1))
+    echo "$per_pr_views" > "$(pr_field_path "$number" view_count)"
+
+    advance_auto_merge_for_view "$number" "$per_pr_views"
+
+    state_value=$(cat "$(pr_field_path "$number" state)")
+    merged_at=$(cat "$(pr_field_path "$number" merged_at)")
+    printf '%s\t%s\n' "$state_value" "$merged_at"
+    exit 0
+    ;;
+  "pr close")
+    if [[ "${FAKE_GH_PR_CLOSE_FAIL:-}" == "1" ]]; then
+      echo "simulated gh pr close failure" >&2
+      exit 1
+    fi
+    closes=$(cat "$state/pr_close_count" 2>/dev/null || echo 0)
+    echo $((closes + 1)) > "$state/pr_close_count"
+    : > "$state/pr_close_called"
+    number="${3:-}"
+    if number=$(pr_number_for_ref "$number"); then
+      printf '%s\n' "CLOSED" > "$(pr_field_path "$number" state)"
+      branch=$(cat "$(pr_field_path "$number" head)")
+      rm -f "$(branch_state_path "$branch")" "$(branch_commit_path "$branch")"
+    fi
+    exit 0
+    ;;
+  *)
+    echo "unsupported fake gh command: $*" >&2
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "$TEST_REPO/bin/gh"
+
     export FAKE_GIT_STATE
     export PATH="$TEST_REPO/bin:$PATH"
     export GITHUB_ACTIONS="true"
     export STATS_PUSH_TOKEN="test-app-token"
     export GITHUB_REPOSITORY="owner/repo"
+    export GITHUB_RUN_ID="876123"
+    export GITHUB_RUN_ATTEMPT="1"
     export GITHUB_OUTPUT="$FAKE_GIT_STATE/github_output"
     : > "$GITHUB_OUTPUT"
 }
@@ -273,7 +557,7 @@ get_output() {
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot commits and pushes new candidate data in one attempt" {
+@test "commit-stats-snapshot creates per-run branch, PR, label, auto-merge, and waits for merge" {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
@@ -289,7 +573,16 @@ get_output() {
     # always restores to the safe/unauthenticated URL — check the append-only
     # git.log for evidence the authenticated URL was actually used to push.
     grep -qF "https://x-access-token:test-app-token@github.com/owner/repo.git" "$FAKE_GIT_STATE/git.log"
+    grep -qF "fetch --force origin refs/heads/master:refs/remotes/origin/master" "$FAKE_GIT_STATE/git.log"
+    grep -qF "checkout -B bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/git.log"
+    grep -qF "push --force origin HEAD:bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/git.log"
     grep -qF "commit -m chore(stats): daily Docker Hub pull-count snapshot -- stats/dockerhub-pull-history.jsonl" "$FAKE_GIT_STATE/git.log"
+    grep -qF "rev-parse HEAD" "$FAKE_GIT_STATE/git.log"
+    grep -qF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log"
+    grep -qF "pr edit 123 --add-label automation" "$FAKE_GIT_STATE/gh.log"
+    grep -qF "pr merge 123 --squash --auto --delete-branch --match-head-commit commit-1" "$FAKE_GIT_STATE/gh.log"
+    grep -qF "pr view 123 --json state,mergedAt" "$FAKE_GIT_STATE/gh.log"
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
 }
 
 @test "commit-stats-snapshot does not let failed origin restore abort cleanup" {
@@ -384,7 +677,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 
     mapfile -t merged_lines < "$FAKE_GIT_STATE/head_stats"
@@ -405,7 +698,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 
     mapfile -t merged_lines < "$FAKE_GIT_STATE/head_stats"
@@ -426,7 +719,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 1 ]
@@ -450,7 +743,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
 
     ! grep -qF '"container":"fabricated"' "$FAKE_GIT_STATE/head_stats"
     jq -s -e '
@@ -472,7 +765,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
 
     ! grep -qF "\"date\":\"$future_date\"" "$FAKE_GIT_STATE/head_stats"
     jq -s -e '
@@ -493,7 +786,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
 
     ! grep -qF '"source":"ghcr"' "$FAKE_GIT_STATE/head_stats"
     jq -s -e '
@@ -514,7 +807,7 @@ get_output() {
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
-    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed push"* ]]
+    [[ "$output" == *"::warning::Dropping nonconforming candidate-only stats line before signed PR"* ]]
 
     ! grep -qF '"pull_count":-1' "$FAKE_GIT_STATE/head_stats"
     ! grep -qF '"star_count":-1' "$FAKE_GIT_STATE/head_stats"
@@ -544,82 +837,178 @@ get_output() {
     [ "${merged_lines[1]}" = '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}' ]
 }
 
-@test "commit-stats-snapshot retries after a lost push race and persists cleanly" {
-    export FAKE_GIT_PUSH_MODE="success_on_retry"
+@test "commit-stats-snapshot re-merges candidate after a stale PR base advances" {
+    export FAKE_GH_PR_VIEW_MODE="stale_once_then_closed_then_merged"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Stats snapshot PR #123 closed without merging"* ]]
 
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 2 ]
     commits=$(cat "$FAKE_GIT_STATE/commit_count")
     [ "$commits" -eq 2 ]
-
-    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
-}
-
-@test "commit-stats-snapshot re-merges its candidate after a reset, preserving a concurrent run's own addition" {
-    # Regression lock for the whole point of the candidate-file design: this
-    # run's own collected row (alpha) must survive a reset-and-retry, AND a
-    # different row a concurrent run pushed in the meantime (gamma) must NOT
-    # be clobbered by blindly restoring the pre-reset candidate wholesale.
-    export FAKE_GIT_PUSH_MODE="concurrent_update_then_success"
-
-    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -eq 0 ]
-    [ "$(get_output persisted)" = "true" ]
-
-    # Origin only gained gamma on the lost first attempt, so the reset+merge
-    # reconstructs alpha+gamma and a second real push is required.
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 2 ]
+    [ "$(grep -cF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-2" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr merge 123 --squash --auto --delete-branch --match-head-commit" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr merge 124 --squash --auto --delete-branch --match-head-commit" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
 
     jq -s -e '
         length == 1
         and .[0].container == "gamma"
-    ' "$FAKE_GIT_STATE/first_failed_head_stats" >/dev/null
+    ' "$FAKE_GIT_STATE/first_stale_head_stats" >/dev/null
 
     jq -s -e '
         length == 2
         and (map(.container) | sort == ["alpha", "gamma"])
     ' "$FAKE_GIT_STATE/head_stats" >/dev/null
+
+    mapfile -t merge_heads < "$FAKE_GIT_STATE/pr_merge_head_commits"
+    [ "${#merge_heads[@]}" -eq 2 ]
+    [ "${merge_heads[0]}" = "commit-1" ]
+    [ "${merge_heads[1]}" = "commit-2" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-2_stats" ]
 }
 
-@test "commit-stats-snapshot retry merge preserves malformed and raw formatted origin lines" {
-    export FAKE_GIT_PUSH_MODE="concurrent_malformed_then_success"
+@test "commit-stats-snapshot caps each attempt's wait to a fair share of the shared deadline" {
+    # A PR that never resolves (always OPEN — modeling a blocked/conflicted
+    # PR, the most likely retry trigger since it happens exactly when a
+    # sibling stats PR merges first) must not be allowed to consume the
+    # entire shared budget on a single attempt's wait — that would starve
+    # the remaining attempts that exist specifically to recover from this
+    # case. Each attempt gets a fair, dynamically recomputed share of
+    # whatever budget remains, so multiple attempts genuinely get to run
+    # before the shared deadline is exhausted.
+    export FAKE_GH_PR_VIEW_MODE="always_open"
+    export STATS_PR_MERGE_TIMEOUT_SECONDS="30"
+    export STATS_PR_MERGE_POLL_SECONDS="5"
+    export STATS_PR_MIN_MERGE_WAIT_SECONDS="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -ne 0 ]
     [ "$(get_output persisted)" = "false" ]
-    [[ "$output" == *"::warning::Refusing to commit stats snapshot because stats/dockerhub-pull-history.jsonl has invalid JSON at line 1"* ]]
-    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+    [[ "$output" == *"::warning::Timed out waiting for stats snapshot PR #123 to merge"* ]]
+    [[ "$output" == *"::warning::Not enough stats PR budget remains before attempt 3"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 2 ]
+    [ "$(cat "$FAKE_GIT_STATE/pr_close_count")" -eq 2 ]
+    [ "$(cat "$FAKE_GIT_STATE/fake_time_epoch")" -le 30 ]
+    grep -qF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log"
+    grep -qF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-2" "$FAKE_GIT_STATE/gh.log"
+    ! grep -qF "bot/stats-snapshot-876123-1-attempt-3" "$FAKE_GIT_STATE/gh.log"
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-2_stats" ]
+}
+
+@test "commit-stats-snapshot uses a fresh PR when a prior attempt's PR closes" {
+    export FAKE_GH_PR_VIEW_MODE="first_pr_closed_then_merged"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Stats snapshot PR #123 closed without merging"* ]]
+
+    [ "$(grep -cF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-2" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr merge 123 --squash --auto --delete-branch --match-head-commit" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr merge 124 --squash --auto --delete-branch --match-head-commit" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(cat "$FAKE_GIT_STATE/pr_close_count")" -eq 1 ]
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-2_stats" ]
+}
+
+@test "commit-stats-snapshot cleans a pushed branch when a later attempt converges to no-op" {
+    export FAKE_GH_PR_VIEW_MODE="cover_then_closed"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Stats snapshot PR #123 closed without merging"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 1 ]
-
-    mapfile -t merged_lines < "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
-    [ "${#merged_lines[@]}" -eq 3 ]
-    [ "${merged_lines[0]}" = "not-json" ]
-    [ "${merged_lines[1]}" = '{ "ts" : "2026-07-12T08:00:00Z", "date" : "2026-07-12", "container" : "gamma", "pull_count" : 99, "star_count" : 9, "source" : "dockerhub" }' ]
-    [ "${merged_lines[2]}" = '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}' ]
+    [ "$(cat "$FAKE_GIT_STATE/pr_close_count")" -eq 1 ]
+    grep -qF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log"
+    ! grep -qF "bot/stats-snapshot-876123-1-attempt-2" "$FAKE_GIT_STATE/gh.log"
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
 }
 
-@test "commit-stats-snapshot recovers from an ambiguous push that actually landed" {
-    # `git push` can report failure (network drop after the remote already
-    # accepted it) even though origin genuinely advanced. The next attempt's
-    # HEAD diff check goes clean (worktree now matches the already-landed
-    # data after the reset), correctly converging without a real 2nd push.
-    export FAKE_GIT_PUSH_MODE="ambiguous_fail_once"
+@test "commit-stats-snapshot tolerates a transient PR view failure during a healthy wait" {
+    export FAKE_GH_PR_VIEW_MODE="fail_once_then_merged"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 0 ]
+    [ "$(get_output persisted)" = "true" ]
+    [[ "$output" == *"::warning::Could not inspect stats snapshot PR #123 merge state (attempt 1/3); continuing within the remaining wait budget"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
+    [ "$(grep -cF "pr create --base master --head bot/stats-snapshot-876123-1-attempt-1" "$FAKE_GIT_STATE/gh.log")" -eq 1 ]
+    [ "$(grep -cF "pr view 123 --json state,mergedAt" "$FAKE_GIT_STATE/gh.log")" -eq 2 ]
+    ! grep -qF "bot/stats-snapshot-876123-1-attempt-2" "$FAKE_GIT_STATE/gh.log"
+    jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot waits until the stats PR is actually merged" {
+    export FAKE_GH_PR_VIEW_MODE="open_then_merged"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 0 ]
     [ "$(get_output persisted)" = "true" ]
 
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 1 ]
-
+    [ "$(cat "$FAKE_GIT_STATE/pr_view_count")" -eq 2 ]
+    grep -qF "2" "$FAKE_GIT_STATE/sleep.log"
+    grep -qF "10" "$FAKE_GIT_STATE/sleep.log"
     jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
+}
+
+@test "commit-stats-snapshot fails closed and closes PR when merge polling times out" {
+    export FAKE_GH_PR_VIEW_MODE="always_open"
+    export STATS_PR_MERGE_TIMEOUT_SECONDS="10"
+    export STATS_PR_MERGE_POLL_SECONDS="10"
+    export STATS_PR_MIN_MERGE_WAIT_SECONDS="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Timed out waiting for stats snapshot PR #123 to merge"* ]]
+    [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
+
+    [ -e "$FAKE_GIT_STATE/pr_close_called" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
+    [ ! -s "$FAKE_GIT_STATE/head_stats" ]
+}
+
+@test "commit-stats-snapshot fails closed and closes PR when GitHub reports it closed unmerged" {
+    export FAKE_GH_PR_VIEW_MODE="closed"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Stats snapshot PR #123 closed without merging"* ]]
+
+    [ -e "$FAKE_GIT_STATE/pr_close_called" ]
+    [ ! -s "$FAKE_GIT_STATE/head_stats" ]
+}
+
+@test "commit-stats-snapshot deletes pushed branch when PR creation fails" {
+    export FAKE_GH_PR_CREATE_FAIL="1"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -ne 0 ]
+    [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not create stats snapshot PR from bot/stats-snapshot-876123-1-attempt-1"* ]]
+
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 3 ]
+    [ "$(cat "$FAKE_GIT_STATE/delete_branch_count")" -eq 3 ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
+    [ ! -s "$FAKE_GIT_STATE/head_stats" ]
 }
 
 @test "commit-stats-snapshot reports no reconciled missing rows when current stats is complete despite incomplete candidate" {
@@ -655,16 +1044,18 @@ get_output() {
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot reports not persisted after exhausted push retries" {
+@test "commit-stats-snapshot reports not persisted when the PR branch push fails" {
     export FAKE_GIT_PUSH_MODE="always_fail"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -ne 0 ]
     [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not push stats snapshot branch bot/stats-snapshot-876123-1-attempt-1"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
     [ "$pushes" -eq 3 ]
+    [ ! -e "$FAKE_GIT_STATE/gh.log" ]
     [ ! -s "$FAKE_GIT_STATE/head_stats" ]
 }
 
@@ -680,18 +1071,20 @@ get_output() {
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot fails closed when retry merge fails" {
-    export FAKE_GIT_PUSH_MODE="always_fail"
-    export FAKE_JQ_FAIL_MERGE_ON_CALL="3"
+@test "commit-stats-snapshot fails closed and closes PR when auto-merge setup fails" {
+    export FAKE_GH_PR_MERGE_FAIL="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -ne 0 ]
     [ "$(get_output persisted)" = "false" ]
-    [[ "$output" == *"::warning::Could not merge collected stats candidate into the worktree"* ]]
+    [[ "$output" == *"::warning::Failed to enable auto-merge for stats snapshot PR #123"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
     pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 1 ]
+    [ "$pushes" -eq 3 ]
+    [ "$(cat "$FAKE_GIT_STATE/pr_merge_count")" -eq 3 ]
+    [ -e "$FAKE_GIT_STATE/pr_close_called" ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
 }
 
 @test "commit-stats-snapshot refuses to stage when final JSONL validation catches post-merge corruption" {
@@ -708,19 +1101,18 @@ get_output() {
     [ ! -e "$FAKE_GIT_STATE/push_count" ]
 }
 
-@test "commit-stats-snapshot fails closed when cleanup reset fails after an unpushed commit" {
-    export FAKE_GIT_PUSH_MODE="always_fail"
-    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
+@test "commit-stats-snapshot warns but keeps primary failure when stale PR cleanup fails" {
+    export FAKE_GH_PR_MERGE_FAIL="1"
+    export FAKE_GH_PR_CLOSE_FAIL="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -ne 0 ]
     [ "$(get_output persisted)" = "false" ]
-    [[ "$output" == *"::warning::Could not discard failed stats commit on attempt 1"* ]]
-    [[ "$output" == *"::warning::Could not reset stats snapshot worktree after attempt 1"* ]]
+    [[ "$output" == *"::warning::Could not close stale stats snapshot PR #123 or delete branch bot/stats-snapshot-876123-1-attempt-1 after failure"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
-    pushes=$(cat "$FAKE_GIT_STATE/push_count")
-    [ "$pushes" -eq 1 ]
+    [ "$(cat "$FAKE_GIT_STATE/delete_branch_count")" -eq 3 ]
+    [ ! -e "$FAKE_GIT_STATE/branch_bot_stats-snapshot-876123-1-attempt-1_stats" ]
 }
 
 @test "commit-stats-snapshot retries after a one-shot git add failure" {
@@ -731,6 +1123,10 @@ get_output() {
     [ "$(get_output persisted)" = "true" ]
     [[ "$output" == *"::warning::Could not stage stats snapshot on attempt 1"* ]]
 
+    commits=$(cat "$FAKE_GIT_STATE/commit_count")
+    [ "$commits" -eq 1 ]
+    pushes=$(cat "$FAKE_GIT_STATE/push_count")
+    [ "$pushes" -eq 1 ]
     jq -e 'select(.container == "alpha" and .pull_count == 42)' "$FAKE_GIT_STATE/head_stats" >/dev/null
 }
 
@@ -745,13 +1141,13 @@ get_output() {
     [ ! -e "$FAKE_GIT_STATE/commit_count" ]
 }
 
-@test "commit-stats-snapshot reports not persisted when commit and reset never succeed" {
+@test "commit-stats-snapshot reports not persisted when commit fails" {
     export FAKE_GIT_FAIL_COMMIT_ALWAYS="1"
-    export FAKE_GIT_FAIL_RESET_ALWAYS="1"
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -ne 0 ]
     [ "$(get_output persisted)" = "false" ]
+    [[ "$output" == *"::warning::Could not commit stats snapshot"* ]]
     [[ "$output" == *"::error::Could not persist stats snapshot this run"* ]]
 
     [ ! -e "$FAKE_GIT_STATE/commit_count" ]

--- a/tests/unit/dockerhub-stats-workflow.bats
+++ b/tests/unit/dockerhub-stats-workflow.bats
@@ -178,22 +178,25 @@ extract_step_run() {
     [[ "$normalized_if" != *"github.event_name == 'workflow_dispatch' ||"* ]]
 }
 
-@test "update-dashboard commit stats job authenticates with a scoped App token and signs commits" {
-    # master's ruleset requires PR-only changes and verified signatures — a
-    # direct GITHUB_TOKEN push can satisfy neither, so this job must mint an
-    # App token (scoped down to just contents:write) and import a GPG key
-    # before the push happens. No actions:write: unlike GITHUB_TOKEN, an
-    # App-token push retriggers this same workflow via its own push path
-    # filter, so there is no explicit follow-up dispatch to authorize.
+@test "update-dashboard commit stats job scopes its App token and signs commits" {
     job_block="$(extract_job_block "commit-stats-snapshot")"
     permissions_block="$(extract_job_permissions "commit-stats-snapshot")"
+    token_block="$(extract_step_block "Generate App token")"
+    commit_script="$(cat "$SCRIPTS_DIR/commit-stats-snapshot.sh")"
 
+    [[ "$job_block" == *"timeout-minutes: 45"* ]]
+    [[ "$commit_script" == *'STATS_PR_MERGE_TIMEOUT_SECONDS:-2100'* ]]
     [[ "$permissions_block" == *"contents: read"* ]]
     [[ "$permissions_block" != *"contents: write"* ]]
     [[ "$permissions_block" == *"actions: read"* ]]
     [[ "$permissions_block" != *"actions: write"* ]]
     [[ "$job_block" == *"create-github-app-token"* ]]
-    [[ "$job_block" == *"permission-contents: write"* ]]
+    [[ "$token_block" == *"permission-contents: write"* ]]
+    [[ "$token_block" == *"permission-pull-requests: write"* ]]
+    [[ "$(printf '%s\n' "$token_block" | grep -cF "permission-")" -eq 2 ]]
+    [[ "$token_block" != *"permission-issues:"* ]]
+    [[ "$token_block" != *"permission-administration:"* ]]
+    [[ "$job_block" == *"STATS_PR_BRANCH: bot/stats-snapshot-\${{ github.run_id }}-\${{ github.run_attempt }}"* ]]
     [[ "$job_block" == *"ghaction-import-gpg"* ]]
     [[ "$job_block" == *"git_commit_gpgsign: true"* ]]
 }


### PR DESCRIPTION
## Summary

PR #879 (merged) implemented direct-push persistence for the daily Docker
Hub stats snapshot, authenticated via a GitHub App token registered as a
branch-protection ruleset bypass actor. That design was proven, in live
production, not to work: master's ruleset still rejects the push with
`GH013: Repository rule violations... Changes must be made through a pull
request`, even with the App correctly configured as a bypass actor — a
platform limitation on this personal-account (not organization) repo that
wasn't discoverable without a real production run.

This PR replaces the direct-push design with a PR + auto-merge flow,
mirroring the pattern already proven to work in `upstream-monitor.yaml`
using the same bot App:

- Each retry attempt gets its own uniquely named branch and PR, so no state
  is shared or reused across attempts — a stale or closed PR from an
  earlier attempt is never mistaken for a live one, and each attempt cleans
  up only its own branch/PR on failure.
- Every attempt resets to freshly fetched `origin/master` and re-merges
  this run's own candidate data before pushing, so a losing or stale PR
  never discards valid data — it just retries from a fresh baseline. All
  attempts share one wall-clock budget, and each attempt's own wait is
  further capped to a fair share of what remains, so a single blocked or
  conflicted PR (the most likely retry trigger — it happens exactly when a
  sibling stats PR merges first) can't consume the entire shared budget and
  starve the attempts that exist to recover from that case.
- The job waits for the PR to actually merge, not just for auto-merge to be
  enabled, before reporting success, and merges are pinned to the exact
  commit each attempt produced via `--match-head-commit`.
- The App token is scoped to only `contents` and `pull-requests` write,
  not the App's full installed permission set.
- All prior hardening (per-line tolerant merge, semantic row validation,
  fail-closed behavior, reconciled completion check) carries over unchanged.

## Known, accepted limitations (documented, not blocking)

- **Ambiguous remote-mutation handling**: if a `git push` or `gh pr merge
  --auto` call fails due to a lost network response after the mutation
  actually succeeded server-side, cleanup may close/discard a PR that was
  genuinely fine. Worst case is a wasted retry attempt within the existing
  bounded-retry budget, not data loss — the candidate data itself is never
  discarded, only a specific attempt's PR.
- **Credential exposure window**: the App token is minted before the script
  proves there's a diff to persist, and stays active through the merge-wait
  poll. Narrow exposure on an already-scoped, short-lived token; splitting
  the no-op check into a separate read-only step is a larger restructure
  than this residual risk justifies. Same trade-off already made and
  documented twice earlier in this feature's history.
- **Diagnostic message completeness**: when the persist step itself fails,
  GitHub Actions skips the downstream "Fail if..." step (a step's `if:`
  implicitly requires `success()`), so its fuller diagnostic message never
  shows. The job still correctly fails either way — this only affects how
  much detail is visible for that one failure mode.

## Test plan

- [x] Full unit test suite green (`./tests/run-tests.sh`, ~2000 tests)
- [x] `shellcheck`, `yamllint`, `actionlint` clean
- [x] Verified against jq 1.7 (this repo's CI runner version) in an
      isolated container at every stage
- [x] Regression-locked every new behavior (revert → confirm red → restore
      → confirm green) including the concurrent-data-loss fix and the
      per-attempt budget cap
- [ ] After merge: confirm the `commit-stats-snapshot` job succeeds in
      production and `stats/dockerhub-pull-history.jsonl` is actually
      populated on master
- [ ] Confirm the deployed dashboard renders the trend sparkline

Supersedes the persistence mechanism from #879; #876 remains the tracking
issue.
