### PR TITLE
fix(dashboard): compute pull-trend sparkline coordinates in jq, not Liquid

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -210,40 +210,11 @@
           {%- endif -%}
           <section id="container-stats" class="stats-strip" aria-label="Container statistics">
             {%- if page.pull_count_formatted or page.pull_count -%}
-            {%- assign _pull_trend_size = 0 -%}
-            {%- if page.pull_trend -%}
-              {%- assign _pull_trend_size = page.pull_trend.size -%}
-            {%- endif -%}
             <div class="stat">
               <span class="eyebrow">PULLS</span>
               <span class="value">
                 {{ page.pull_count_formatted | default: page.pull_count | default: "0" }}
-                {%- if _pull_trend_size > 1 -%}
-                  {%- assign _trend_first = page.pull_trend | first -%}
-                  {%- assign _trend_last = page.pull_trend | last -%}
-                  {%- assign _trend_min = _trend_first.pull_count | plus: 0 -%}
-                  {%- assign _trend_max = _trend_first.pull_count | plus: 0 -%}
-                  {%- for _trend_point in page.pull_trend -%}
-                    {%- assign _trend_count = _trend_point.pull_count | plus: 0 -%}
-                    {%- if _trend_count < _trend_min -%}{%- assign _trend_min = _trend_count -%}{%- endif -%}
-                    {%- if _trend_count > _trend_max -%}{%- assign _trend_max = _trend_count -%}{%- endif -%}
-                  {%- endfor -%}
-                  {%- assign _trend_range = _trend_max | minus: _trend_min -%}
-                  {%- assign _trend_denominator = _pull_trend_size | minus: 1 -%}
-                  {%- capture _trend_svg_points -%}
-                    {%- for _trend_point in page.pull_trend -%}
-                      {%- assign _trend_count = _trend_point.pull_count | plus: 0 -%}
-                      {%- assign _trend_x = forloop.index0 | times: 116 | divided_by: _trend_denominator | plus: 2 -%}
-                      {%- if _trend_range == 0 -%}
-                        {%- assign _trend_y = 14 -%}
-                      {%- else -%}
-                        {%- assign _trend_delta = _trend_count | minus: _trend_min -%}
-                        {%- assign _trend_y_offset = _trend_delta | times: 24 | divided_by: _trend_range -%}
-                        {%- assign _trend_y = 26 | minus: _trend_y_offset -%}
-                      {%- endif -%}
-                      {{ _trend_x }},{{ _trend_y }}{% unless forloop.last %} {% endunless %}
-                    {%- endfor -%}
-                  {%- endcapture -%}
+                {%- if page.pull_trend_svg_points -%}
                   <svg class="pull-trend-sparkline"
                        width="120"
                        height="28"
@@ -252,8 +223,8 @@
                        aria-labelledby="pull-trend-title-{{ page.name | slugify }}"
                        focusable="false"
                        style="display:inline-block;vertical-align:middle;margin-left:8px;overflow:visible">
-                    <title id="pull-trend-title-{{ page.name | slugify }}">{{ _trend_first.pull_count }} to {{ _trend_last.pull_count }} pulls across {{ _pull_trend_size }} recorded days</title>
-                    <polyline points="{{ _trend_svg_points | strip }}"
+                    <title id="pull-trend-title-{{ page.name | slugify }}">{{ page.pull_trend_first }} to {{ page.pull_trend_last }} pulls across {{ page.pull_trend_days }} recorded days</title>
+                    <polyline points="{{ page.pull_trend_svg_points }}"
                               fill="none"
                               stroke="currentColor"
                               stroke-width="2"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1653,7 +1653,37 @@ generate_data() {
                 .pull_count = strenv(PC) | .pull_count_formatted = strenv(PCF) | .star_count = strenv(SC2) |
                 .size_amd64 = strenv(SA) | .size_arm64 = strenv(SR)
             ')
-        container_json=$(echo "$container_json" | jq --argjson pt "$pull_trend_json" '. + {pull_trend: $pt}')
+        container_json=$(echo "$container_json" | jq --argjson pt "$pull_trend_json" '
+            . + {pull_trend: $pt} + (
+                ($pt | length) as $n
+                | if $n > 1 then
+                    ($pt | map(.pull_count)) as $counts
+                    | ($counts | min) as $tmin
+                    | ($counts | max) as $tmax
+                    | ($tmax - $tmin) as $trange
+                    | ($n - 1) as $denom
+                    | (
+                        [
+                          range(0; $n) as $i
+                          | (((($i * 116) / $denom) | floor) + 2) as $x
+                          | (
+                              if $trange == 0 then 14
+                              else 26 - (((($pt[$i].pull_count) - $tmin) * 24 / $trange) | floor)
+                              end
+                            ) as $y
+                          | "\($x),\($y)"
+                        ]
+                      ) as $pairs
+                    | {
+                        pull_trend_svg_points: ($pairs | join(" ")),
+                        pull_trend_first: $pt[0].pull_count,
+                        pull_trend_last: $pt[-1].pull_count,
+                        pull_trend_days: $n
+                      }
+                  else {}
+                  end
+            )
+        ')
 
         # Add container-level build args from lineage
         local lineage_args_json

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -62,6 +62,48 @@ reset_trend_cache() {
     DOCKERHUB_PULL_TRENDS_CACHE=""
 }
 
+# Asserts a "x1,y1 x2,y2 ..." points string has exactly $n pairs, real single
+# spaces between every pair (the regression lock for #876 — Liquid silently
+# ate this separator), and every coordinate inside the 120x28 SVG viewBox.
+assert_svg_points_in_bounds() {
+    local points="$1" n="$2"
+    local space_count field_count
+    space_count=$(grep -o ' ' <<< "$points" | wc -l)
+    [ "$space_count" -eq "$((n - 1))" ]
+
+    field_count=$(wc -w <<< "$points")
+    [ "$field_count" -eq "$n" ]
+
+    local pair x y
+    for pair in $points; do
+        [[ "$pair" =~ ^([0-9]+),([0-9]+)$ ]] || return 1
+        x="${BASH_REMATCH[1]}"
+        y="${BASH_REMATCH[2]}"
+        [ "$x" -ge 0 ] && [ "$x" -le 120 ] || return 1
+        [ "$y" -ge 0 ] && [ "$y" -le 28 ] || return 1
+    done
+}
+
+# Captures the exact container_json generate_data() builds (after the
+# pull_trend/jq step) instead of letting generate_container_page write it
+# to disk and discard the in-memory value.
+capture_container_page() {
+    generate_container_page() {
+        local container="$1" container_json="$2"
+        echo "$container_json" > "$TEST_DIR/captured-${container}.json"
+    }
+}
+
+# Creates a minimal container directory that satisfies generate_data()'s
+# discovery loop (is_skip_directory / has_dockerfile / version.sh presence).
+make_fixture_container() {
+    local name="$1"
+    mkdir -p "$TEST_DIR/$name"
+    printf '#!/usr/bin/env bash\necho "1.0.0"\n' > "$TEST_DIR/$name/version.sh"
+    chmod +x "$TEST_DIR/$name/version.sh"
+    printf 'FROM alpine:3.21\n' > "$TEST_DIR/$name/Dockerfile"
+}
+
 @test "Docker Hub pull trend skips malformed rows, sorts by date, and dedupes with last row winning" {
     cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
 not json
@@ -188,18 +230,110 @@ EOF
     ' >/dev/null
 }
 
-@test "container detail template gates sparkline and includes accessibility and edge-case math" {
+@test "pull_trend_svg_points has a real space between every point pair, in-bounds coordinates (regression lock for #876)" {
+    make_fixture_container widget
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-04-01","container":"widget","pull_count":100}
+{"date":"2026-04-02","container":"widget","pull_count":340}
+{"date":"2026-04-03","container":"widget","pull_count":210}
+{"date":"2026-04-04","container":"widget","pull_count":480}
+{"date":"2026-04-05","container":"widget","pull_count":75}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json points
+    container_json=$(cat "$TEST_DIR/captured-widget.json")
+
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points")' >/dev/null
+    echo "$container_json" | jq -e '.pull_trend_days == 5' >/dev/null
+    echo "$container_json" | jq -e '.pull_trend_first == 100 and .pull_trend_last == 75' >/dev/null
+
+    points=$(echo "$container_json" | jq -r '.pull_trend_svg_points')
+    # This is the exact bug: a missing separator collapses "2,26 33,10" into
+    # "2,2633,10" — a garbled, unparseable SVG polyline. Assert the general
+    # invariant (every coordinate is a well-formed, in-bounds pair) rather
+    # than just eyeballing the string, so the whole bug CLASS is covered.
+    assert_svg_points_in_bounds "$points" 5
+}
+
+@test "flat pull trend (all pull_counts identical) produces y=14 for every point" {
+    make_fixture_container steady
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-05-01","container":"steady","pull_count":500}
+{"date":"2026-05-02","container":"steady","pull_count":500}
+{"date":"2026-05-03","container":"steady","pull_count":500}
+{"date":"2026-05-04","container":"steady","pull_count":500}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json points y
+    container_json=$(cat "$TEST_DIR/captured-steady.json")
+    points=$(echo "$container_json" | jq -r '.pull_trend_svg_points')
+    assert_svg_points_in_bounds "$points" 4
+
+    for pair in $points; do
+        y="${pair#*,}"
+        [ "$y" -eq 14 ]
+    done
+}
+
+@test "a single data point produces no pull_trend_svg_points field (sparkline must not render)" {
+    make_fixture_container newcomer
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-06-01","container":"newcomer","pull_count":42}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json
+    container_json=$(cat "$TEST_DIR/captured-newcomer.json")
+    echo "$container_json" | jq -e '.pull_trend == [{"date":"2026-06-01","pull_count":42}]' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+}
+
+@test "zero data points (no history) produces no pull_trend_svg_points field" {
+    make_fixture_container ghostly
+    rm -f "$TEST_DIR/stats/dockerhub-pull-history.jsonl"
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json
+    container_json=$(cat "$TEST_DIR/captured-ghostly.json")
+    echo "$container_json" | jq -e '.pull_trend == []' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+}
+
+@test "container detail template renders the sparkline from a pre-computed jq string, never a Liquid loop (regression lock for #876)" {
     layout="$ORIG_DIR/docs/site/_layouts/container-detail.html"
-    gate_line=$(grep -n 'if _pull_trend_size > 1' "$layout" | head -1 | cut -d: -f1)
+    gate_line=$(grep -n 'if page.pull_trend_svg_points' "$layout" | head -1 | cut -d: -f1)
     svg_line=$(grep -n '<svg class="pull-trend-sparkline"' "$layout" | head -1 | cut -d: -f1)
+    [ -n "$gate_line" ]
     [ "$gate_line" -lt "$svg_line" ]
 
-    grep -q '<title id="pull-trend-title-' "$layout"
-    grep -q '_trend_range == 0' "$layout"
-    grep -q '_trend_y = 14' "$layout"
-    grep -q '_trend_y_offset = _trend_delta | times: 24 | divided_by: _trend_range' "$layout"
-    grep -q '_trend_y = 26 | minus: _trend_y_offset' "$layout"
-    grep -q 'polyline points="{{ _trend_svg_points | strip }}"' "$layout"
-    grep -q 'recorded days' "$layout"
-    ! grep -q 'pulls over {{ _pull_trend_size }} days' "$layout"
+    pulls_block=$(sed -n '/<span class="eyebrow">PULLS<\/span>/,/^\s*<\/div>\s*$/p' "$layout")
+
+    # #876 root cause: SVG point coordinates were computed inside a Liquid
+    # {% for %} loop, using {% unless forloop.last %} to emit a separator
+    # space between points. Liquid's remove_blank_strings optimization
+    # silently deletes whitespace-only String bodies inside control-flow
+    # blocks, so that separator vanished in production and all coordinates
+    # ran together into garbage numbers. The fix moved ALL coordinate math
+    # into jq (join(" ") is reliable); Liquid now only interpolates one
+    # pre-computed string. Guard against regressing back to loop-based math.
+    ! grep -qE '\{%-?\s*for ' <<< "$pulls_block"
+    ! grep -q 'forloop' <<< "$pulls_block"
+
+    grep -q '<title id="pull-trend-title-' <<< "$pulls_block"
+    grep -q 'polyline points="{{ page.pull_trend_svg_points }}"' <<< "$pulls_block"
+    grep -q 'recorded days' <<< "$pulls_block"
 }


### PR DESCRIPTION
## Summary

Every container page's PULLS trend sparkline was rendering as a garbled
scribble across the page in production (visible on e.g.
https://oorabona.github.io/docker-containers/container/ansible/,
overlapping the Build/Manifest Digest/SBOM/Trivy rows below it).

Root cause, confirmed against the real `liquid` gem (v5.13.0): the old
template computed SVG polyline coordinates inside a Liquid `{% for %}`
loop in `docs/site/_layouts/container-detail.html`, using
`{% unless forloop.last %} {% endunless %}` to emit a single space as
the separator between points. Liquid's `remove_blank_strings`
optimization silently deletes whitespace-only String bodies inside
control-flow blocks — so that separator vanished in production, and
adjacent coordinate pairs ran together into unparseable garbage
(`points="2,266,2610,2414,..."` instead of `"2,26 6,24 10,22..."`).

Rather than patch around the Liquid quirk, this moves ALL the
coordinate math out of Liquid and into the `jq` pipeline that already
builds each container's dashboard JSON in `generate-dashboard.sh`,
using `join(" ")` to build the points string correctly and reliably.
The layout now just interpolates one pre-computed
`page.pull_trend_svg_points` string — no loop, no math, no
whitespace-sensitive control flow left in the template.

This also fixes a second, independent bug the redesign surfaced: an
unparenthesized `EXPR + N as $var` jq expression let jq 1.7 (this
repo's CI runner version) bind `as` to just the trailing literal
instead of the full expression, silently corrupting a coordinate on
1.7 while working fine on 1.8+. Fixed by fully parenthesizing the
expression before the `as` binding.

## Test plan

- [x] Full local bats suite green: 2029/2029
- [x] New regression coverage in `tests/unit/dashboard-trends.bats`:
      space-separated + in-bounds coordinates (general invariant, not
      just this one string), flat-trend y=14, no sparkline field for
      1 or 0 data points, template no longer contains any
      `{% for %}`/`forloop` construct
- [x] Regression-locked: reverted the jq change, confirmed the new
      tests go RED, restored, confirmed GREEN
- [x] jq filter verified against real jq 1.7 (not just 1.8+) across 5
      cases: 30-point, 2-point, flat, single-point, empty
- [x] Full local Jekyll build (real `generate-dashboard.sh` +
      `bundle exec jekyll build`) using real production stats history
      confirms clean, in-bounds, space-separated `polyline points=`
      output for multiple containers
- [x] shellcheck clean on `generate-dashboard.sh`
- [ ] After merge: confirm the live dashboard renders the sparkline
      cleanly on `/container/ansible/` (and others) with no visual
      corruption

Fixes the visual regression from #876/#877.
