### PR TITLE
feat(dashboard): per-day hover tooltips on the pull-trend sparkline

### DIFF
--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -230,6 +230,9 @@
                               stroke-width="2"
                               stroke-linecap="round"
                               stroke-linejoin="round" />
+                    {%- if page.pull_trend_svg_dots -%}
+                      <g fill="currentColor">{{ page.pull_trend_svg_dots }}</g>
+                    {%- endif -%}
                   </svg>
                 {%- endif -%}
               </span>

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1656,7 +1656,11 @@ generate_data() {
         container_json=$(echo "$container_json" | jq --argjson pt "$pull_trend_json" '
             . + {pull_trend: $pt} + (
                 (
-                    $pt | map(select((.pull_count | isinfinite or isnan) | not))
+                    $pt
+                    | map(select(
+                        (.pull_count | type) == "number"
+                        and ((.pull_count | isinfinite or isnan) | not)
+                      ))
                 ) as $pt
                 | ($pt | length) as $n
                 | if $n > 1 then
@@ -1677,20 +1681,36 @@ generate_data() {
                           | {x: $x, y: $y, date: $pt[$i].date, pull_count: $pt[$i].pull_count}
                         ]
                       ) as $points
-                    | {
-                        pull_trend_svg_points: ($points | map("\(.x),\(.y)") | join(" ")),
-                        pull_trend_svg_dots: (
-                          $points
-                          | map(
-                              (@html "\(.date): \(.pull_count) pulls") as $label
-                              | "<circle class=\"pull-trend-dot\" cx=\"\(.x)\" cy=\"\(.y)\" r=\"2\"><title>\($label)</title></circle>"
-                            )
-                          | join("")
-                        ),
-                        pull_trend_first: $pt[0].pull_count,
-                        pull_trend_last: $pt[-1].pull_count,
-                        pull_trend_days: $n
-                      }
+                    # Validate the OUTPUT, not just the input: whatever
+                    # combination of extreme-but-individually-finite values
+                    # or intermediate overflow produced a bad coordinate,
+                    # this is the one check that catches all of it. Never
+                    # emit a partially-valid sparkline — fall back to no
+                    # sparkline, same as the existing 0/1-point case.
+                    | (
+                        $points
+                        | all(
+                            ((.x | isinfinite or isnan) | not) and (.x >= 0) and (.x <= 120)
+                            and ((.y | isinfinite or isnan) | not) and (.y >= 0) and (.y <= 28)
+                          )
+                      ) as $points_valid
+                    | if $points_valid then
+                        {
+                            pull_trend_svg_points: ($points | map("\(.x),\(.y)") | join(" ")),
+                            pull_trend_svg_dots: (
+                              $points
+                              | map(
+                                  (@html "\(.date): \(.pull_count) pulls") as $label
+                                  | "<circle class=\"pull-trend-dot\" cx=\"\(.x)\" cy=\"\(.y)\" r=\"2\"><title>\($label)</title></circle>"
+                                )
+                              | join("")
+                            ),
+                            pull_trend_first: $pt[0].pull_count,
+                            pull_trend_last: $pt[-1].pull_count,
+                            pull_trend_days: $n
+                          }
+                      else {}
+                      end
                   else {}
                   end
             )

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1671,11 +1671,19 @@ generate_data() {
                               else 26 - (((($pt[$i].pull_count) - $tmin) * 24 / $trange) | floor)
                               end
                             ) as $y
-                          | "\($x),\($y)"
+                          | {x: $x, y: $y, date: $pt[$i].date, pull_count: $pt[$i].pull_count}
                         ]
-                      ) as $pairs
+                      ) as $points
                     | {
-                        pull_trend_svg_points: ($pairs | join(" ")),
+                        pull_trend_svg_points: ($points | map("\(.x),\(.y)") | join(" ")),
+                        pull_trend_svg_dots: (
+                          $points
+                          | map(
+                              (@html "\(.date): \(.pull_count) pulls") as $label
+                              | "<circle class=\"pull-trend-dot\" cx=\"\(.x)\" cy=\"\(.y)\" r=\"2\"><title>\($label)</title></circle>"
+                            )
+                          | join("")
+                        ),
                         pull_trend_first: $pt[0].pull_count,
                         pull_trend_last: $pt[-1].pull_count,
                         pull_trend_days: $n

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -1655,7 +1655,10 @@ generate_data() {
             ')
         container_json=$(echo "$container_json" | jq --argjson pt "$pull_trend_json" '
             . + {pull_trend: $pt} + (
-                ($pt | length) as $n
+                (
+                    $pt | map(select((.pull_count | isinfinite or isnan) | not))
+                ) as $pt
+                | ($pt | length) as $n
                 | if $n > 1 then
                     ($pt | map(.pull_count)) as $counts
                     | ($counts | min) as $tmin

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -335,7 +335,8 @@ EOF
     # content validation), so a hostile/malformed date value CAN reach this
     # jq filter — @html must escape it, never interpolate it raw.
     grep -q '&lt;script&gt;alert(1)&lt;/script&gt;' <<< "$dots"
-    ! grep -q '<script>' <<< "$dots"
+    run grep -q '<script>' <<< "$dots"
+    [ "$status" -ne 0 ]
 }
 
 @test "flat pull trend (all pull_counts identical) produces y=14 for every point" {
@@ -427,8 +428,10 @@ EOF
     # ("60,null" / cy="null"). Assert no literal null anywhere, and that the
     # bounds check passes for the REMAINING finite count (4), not the
     # original row count (5).
-    ! grep -q 'null' <<< "$points"
-    ! grep -q 'null' <<< "$dots"
+    run grep -q 'null' <<< "$points"
+    [ "$status" -ne 0 ]
+    run grep -q 'null' <<< "$dots"
+    [ "$status" -ne 0 ]
     assert_svg_points_in_bounds "$points" 4
     assert_svg_dots_match_points "$dots" "$points" 4
 }
@@ -495,8 +498,10 @@ EOF
     # ran together into garbage numbers. The fix moved ALL coordinate math
     # into jq (join(" ") is reliable); Liquid now only interpolates one
     # pre-computed string. Guard against regressing back to loop-based math.
-    ! grep -qE '\{%-?\s*for ' <<< "$pulls_block"
-    ! grep -q 'forloop' <<< "$pulls_block"
+    run grep -qE '\{%-?\s*for ' <<< "$pulls_block"
+    [ "$status" -ne 0 ]
+    run grep -q 'forloop' <<< "$pulls_block"
+    [ "$status" -ne 0 ]
 
     grep -q '<title id="pull-trend-title-' <<< "$pulls_block"
     grep -q 'polyline points="{{ page.pull_trend_svg_points }}"' <<< "$pulls_block"

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -84,6 +84,36 @@ assert_svg_points_in_bounds() {
     done
 }
 
+# Asserts pull_trend_svg_dots contains exactly $n "<circle .../>" elements
+# and that each circle's cx/cy attributes match the corresponding "x,y" pair
+# (same order) in the pull_trend_svg_points string — i.e. the hover-tooltip
+# dots line up with the polyline they annotate (#884).
+assert_svg_dots_match_points() {
+    local dots="$1" points="$2" n="$3"
+    local circle_count
+    circle_count=$(grep -o '<circle ' <<< "$dots" | wc -l)
+    [ "$circle_count" -eq "$n" ]
+
+    local -a circle_tags point_pairs
+    mapfile -t circle_tags < <(grep -oE '<circle[^>]*>' <<< "$dots")
+    read -r -a point_pairs <<< "$points"
+    [ "${#circle_tags[@]}" -eq "${#point_pairs[@]}" ] || return 1
+
+    local idx pair x y cx cy tag
+    for idx in "${!point_pairs[@]}"; do
+        pair="${point_pairs[$idx]}"
+        x="${pair%,*}"
+        y="${pair#*,}"
+        tag="${circle_tags[$idx]}"
+        [[ "$tag" =~ cx=\"([0-9]+)\" ]] || return 1
+        cx="${BASH_REMATCH[1]}"
+        [[ "$tag" =~ cy=\"([0-9]+)\" ]] || return 1
+        cy="${BASH_REMATCH[1]}"
+        [ "$cx" = "$x" ] || return 1
+        [ "$cy" = "$y" ] || return 1
+    done
+}
+
 # Captures the exact container_json generate_data() builds (after the
 # pull_trend/jq step) instead of letting generate_container_page write it
 # to disk and discard the in-memory value.
@@ -259,6 +289,55 @@ EOF
     assert_svg_points_in_bounds "$points" 5
 }
 
+@test "pull_trend_svg_dots has one <circle> per data point, cx/cy matching pull_trend_svg_points, and correct per-point <title> text (#884 hover tooltips)" {
+    make_fixture_container widget
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-04-01","container":"widget","pull_count":100}
+{"date":"2026-04-02","container":"widget","pull_count":340}
+{"date":"2026-04-03","container":"widget","pull_count":210}
+{"date":"2026-04-04","container":"widget","pull_count":480}
+{"date":"2026-04-05","container":"widget","pull_count":75}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json points dots
+    container_json=$(cat "$TEST_DIR/captured-widget.json")
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots")' >/dev/null
+
+    points=$(echo "$container_json" | jq -r '.pull_trend_svg_points')
+    dots=$(echo "$container_json" | jq -r '.pull_trend_svg_dots')
+    assert_svg_dots_match_points "$dots" "$points" 5
+
+    # Spot check the <title> text on the first and fourth points.
+    grep -q '<title>2026-04-01: 100 pulls</title>' <<< "$dots"
+    grep -q '<title>2026-04-04: 480 pulls</title>' <<< "$dots"
+}
+
+@test "pull_trend_svg_dots HTML-escapes date values in <title>, never passes them through raw" {
+    make_fixture_container leaky
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-07-01<script>alert(1)</script>","container":"leaky","pull_count":10}
+{"date":"2026-07-02","container":"leaky","pull_count":20}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json dots
+    container_json=$(cat "$TEST_DIR/captured-leaky.json")
+    dots=$(echo "$container_json" | jq -r '.pull_trend_svg_dots')
+
+    # load_dockerhub_pull_trends only type-checks .date as a string (no
+    # content validation), so a hostile/malformed date value CAN reach this
+    # jq filter — @html must escape it, never interpolate it raw.
+    grep -q '&lt;script&gt;alert(1)&lt;/script&gt;' <<< "$dots"
+    ! grep -q '<script>' <<< "$dots"
+}
+
 @test "flat pull trend (all pull_counts identical) produces y=14 for every point" {
     make_fixture_container steady
     cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
@@ -297,6 +376,7 @@ EOF
     container_json=$(cat "$TEST_DIR/captured-newcomer.json")
     echo "$container_json" | jq -e '.pull_trend == [{"date":"2026-06-01","pull_count":42}]' >/dev/null
     echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
 }
 
 @test "zero data points (no history) produces no pull_trend_svg_points field" {
@@ -311,6 +391,7 @@ EOF
     container_json=$(cat "$TEST_DIR/captured-ghostly.json")
     echo "$container_json" | jq -e '.pull_trend == []' >/dev/null
     echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
 }
 
 @test "container detail template renders the sparkline from a pre-computed jq string, never a Liquid loop (regression lock for #876)" {
@@ -336,4 +417,11 @@ EOF
     grep -q '<title id="pull-trend-title-' <<< "$pulls_block"
     grep -q 'polyline points="{{ page.pull_trend_svg_points }}"' <<< "$pulls_block"
     grep -q 'recorded days' <<< "$pulls_block"
+
+    # #884 hover tooltips: the pre-computed <circle>/<title> markup must be
+    # gated behind its own presence check and interpolated as a single
+    # pre-computed string, same discipline as pull_trend_svg_points above —
+    # never rebuilt as a Liquid loop.
+    grep -q 'if page.pull_trend_svg_dots' <<< "$pulls_block"
+    grep -q '{{ page.pull_trend_svg_dots }}' <<< "$pulls_block"
 }

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -394,6 +394,90 @@ EOF
     echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
 }
 
+@test "a non-finite pull_count (1e999) is excluded from SVG coordinates but preserved in the raw pull_trend (regression lock)" {
+    make_fixture_container glitchy
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-08-01","container":"glitchy","pull_count":100}
+{"date":"2026-08-02","container":"glitchy","pull_count":1e999}
+{"date":"2026-08-03","container":"glitchy","pull_count":210}
+{"date":"2026-08-04","container":"glitchy","pull_count":480}
+{"date":"2026-08-05","container":"glitchy","pull_count":75}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json points dots
+    container_json=$(cat "$TEST_DIR/captured-glitchy.json")
+
+    # The raw field is untouched: all 5 rows survive, including the
+    # non-finite one, so the page still carries the data for transparency.
+    echo "$container_json" | jq -e '(.pull_trend | length) == 5' >/dev/null
+
+    # But the derived SVG fields only see the 4 finite rows.
+    echo "$container_json" | jq -e '.pull_trend_days == 4' >/dev/null
+    echo "$container_json" | jq -e '.pull_trend_first == 100 and .pull_trend_last == 75' >/dev/null
+
+    points=$(echo "$container_json" | jq -r '.pull_trend_svg_points')
+    dots=$(echo "$container_json" | jq -r '.pull_trend_svg_dots')
+
+    # This is the exact bug this test locks: jq serializes Infinity/NaN to
+    # JSON `null`, so an unfiltered non-finite row produced invalid SVG
+    # ("60,null" / cy="null"). Assert no literal null anywhere, and that the
+    # bounds check passes for the REMAINING finite count (4), not the
+    # original row count (5).
+    ! grep -q 'null' <<< "$points"
+    ! grep -q 'null' <<< "$dots"
+    assert_svg_points_in_bounds "$points" 4
+    assert_svg_dots_match_points "$dots" "$points" 4
+}
+
+@test "all pull_counts non-finite produces no sparkline fields, matching the existing graceful zero/one-point fallback" {
+    make_fixture_container voidy
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-09-01","container":"voidy","pull_count":1e999}
+{"date":"2026-09-02","container":"voidy","pull_count":-1e999}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json
+    container_json=$(cat "$TEST_DIR/captured-voidy.json")
+
+    # Raw data still carries both non-finite rows.
+    echo "$container_json" | jq -e '(.pull_trend | length) == 2' >/dev/null
+
+    # Filtering drops both rows to 0 finite points, so no derived fields —
+    # same graceful fallback as the existing 0/1-point cases.
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_first") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_last") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_days") | not' >/dev/null
+}
+
+@test "one finite point remaining after filtering a non-finite row produces no sparkline fields (single-point fallback)" {
+    make_fixture_container solo
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-10-01","container":"solo","pull_count":50}
+{"date":"2026-10-02","container":"solo","pull_count":1e999}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json
+    container_json=$(cat "$TEST_DIR/captured-solo.json")
+
+    echo "$container_json" | jq -e '(.pull_trend | length) == 2' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
+}
+
 @test "container detail template renders the sparkline from a pre-computed jq string, never a Liquid loop (regression lock for #876)" {
     layout="$ORIG_DIR/docs/site/_layouts/container-detail.html"
     gate_line=$(grep -n 'if page.pull_trend_svg_points' "$layout" | head -1 | cut -d: -f1)

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -481,6 +481,88 @@ EOF
     echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
 }
 
+@test "a string 'nan' pull_count round-trips to JSON null and is excluded by the type check (regression lock for refusal 3a)" {
+    make_fixture_container nanny
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-11-01","container":"nanny","pull_count":100}
+{"date":"2026-11-02","container":"nanny","pull_count":"nan"}
+{"date":"2026-11-03","container":"nanny","pull_count":210}
+{"date":"2026-11-04","container":"nanny","pull_count":480}
+{"date":"2026-11-05","container":"nanny","pull_count":75}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json points dots
+    container_json=$(cat "$TEST_DIR/captured-nanny.json")
+
+    # load_dockerhub_pull_trends' `.pull_count | tonumber?` actually PARSES
+    # the string "nan" into a real IEEE754 NaN double (type "number",
+    # isnan == true) rather than erroring — jq only serializes it to JSON
+    # `null` when the cache round-trips through a bash variable. So the raw
+    # field carries all 5 rows, with the nan one now literally `null`.
+    echo "$container_json" | jq -e '(.pull_trend | length) == 5' >/dev/null
+    echo "$container_json" | jq -e '.pull_trend[1].pull_count == null' >/dev/null
+
+    # The `(.pull_count | type) == "number"` guard excludes that null entry
+    # up front (type "null" != "number") — this is what actually protects
+    # this case, not the output-bounds gate (a null pull_count never reaches
+    # the y-coordinate arithmetic at all).
+    echo "$container_json" | jq -e '.pull_trend_days == 4' >/dev/null
+    echo "$container_json" | jq -e '.pull_trend_first == 100 and .pull_trend_last == 75' >/dev/null
+
+    points=$(echo "$container_json" | jq -r '.pull_trend_svg_points')
+    dots=$(echo "$container_json" | jq -r '.pull_trend_svg_dots')
+
+    run grep -q 'null' <<< "$points"
+    [ "$status" -ne 0 ]
+    run grep -q 'null' <<< "$dots"
+    [ "$status" -ne 0 ]
+    assert_svg_points_in_bounds "$points" 4
+    assert_svg_dots_match_points "$dots" "$points" 4
+}
+
+@test "a finite-but-extreme pull_count (1e308) overflows the y-coordinate arithmetic into an out-of-bounds value, caught by the output validation gate (regression lock for refusal 3b)" {
+    make_fixture_container overflowy
+    cat > "$TEST_DIR/stats/dockerhub-pull-history.jsonl" <<'EOF'
+{"date":"2026-12-01","container":"overflowy","pull_count":100}
+{"date":"2026-12-02","container":"overflowy","pull_count":210}
+{"date":"2026-12-03","container":"overflowy","pull_count":480}
+{"date":"2026-12-04","container":"overflowy","pull_count":75}
+{"date":"2026-12-05","container":"overflowy","pull_count":300}
+{"date":"2026-12-06","container":"overflowy","pull_count":1e308}
+EOF
+    reset_trend_cache
+    capture_container_page
+
+    generate_data >/dev/null
+
+    local container_json
+    container_json=$(cat "$TEST_DIR/captured-overflowy.json")
+
+    # 1e308 is individually finite (not inf/nan) and a real number — it
+    # passes BOTH the type check and the isinfinite/isnan input filter. But
+    # $trange = 1e308 - 75 is still ~1e308, and (pull_count - $tmin) * 24
+    # overflows a float64 to +/-Infinity for the OTHER points while for this
+    # extreme point itself, 26 - floor(...) lands on a huge but technically
+    # FINITE negative number (~-1.7976931348623157e308, i.e. -DBL_MAX) —
+    # neither isinfinite nor isnan, yet wildly outside the [0,28] viewBox.
+    # Only the output-bounds gate (.y >= 0 and .y <= 28) catches this; an
+    # isinfinite/isnan-only check on the input would have let it through.
+    # All 6 raw rows still round-trip untouched.
+    echo "$container_json" | jq -e '(.pull_trend | length) == 6' >/dev/null
+
+    # The whole sparkline is dropped (not partially emitted) because one
+    # point out of six fails the output-bounds check.
+    echo "$container_json" | jq -e 'has("pull_trend_svg_points") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_svg_dots") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_first") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_last") | not' >/dev/null
+    echo "$container_json" | jq -e 'has("pull_trend_days") | not' >/dev/null
+}
+
 @test "container detail template renders the sparkline from a pre-computed jq string, never a Liquid loop (regression lock for #876)" {
     layout="$ORIG_DIR/docs/site/_layouts/container-detail.html"
     gate_line=$(grep -n 'if page.pull_trend_svg_points' "$layout" | head -1 | cut -d: -f1)


### PR DESCRIPTION
## Summary

Adds per-day hover tooltips to the dashboard's pull-trend sparkline
(like npm registry's download graph): hovering a point on the trend
line now shows that day's exact date and pull count. Implemented as a
native SVG `<circle>` with a `<title>` child at each recorded day — no
JavaScript, the browser renders it the same way it already does for
the sparkline's aggregate title.

Computed in the same jq pipeline that builds the polyline points
(`generate-dashboard.sh`), keeping the Liquid template a plain string
interpolator, consistent with the design from the earlier same-day fix
(#884). Date/count values are run through jq's `@html` format before
interpolation, since the upstream history file only type-checks `date`
as a string rather than validating its content.

## Hardening beyond the initial tooltip change

Cross-family review caught two additional real defects while reviewing
this branch, both fixed in follow-up commits:

- Pathological `pull_count` values (a non-finite JSON literal like
  `1e999`, a string like `"nan"` that round-trips through a cache
  boundary as JSON `null`, or individually-finite extreme values near
  `DBL_MAX` that overflow mid-computation) could produce invalid SVG
  coordinates (`null`, or values far outside the viewBox). Fixed by
  validating every *computed* x/y coordinate against the declared
  `[0,120]`/`[0,28]` bounds after the math runs, not just the raw
  input — this catches any numeric pathology regardless of which
  arithmetic step produced it. If any point fails, the whole sparkline
  is omitted (graceful fallback), never partially emitted.
  Adversarially verified against a string `"Infinity"`/`"inf"` case
  that bypasses the input-side finiteness filter entirely but is still
  caught by the output-bounds check.
- Five regression-lock assertions used bare `! grep ...` in bats test
  bodies, which — due to a real bash/bats quirk (negated commands are
  exempt from `errexit`) — don't actually fail the test on a match.
  Fixed with `run grep ...` + explicit `[ "$status" -ne 0 ]`, and
  mutation-verified (reintroduced the guarded regression, confirmed
  the fixed test goes red, restored, confirmed green).

## Test plan

- [x] Full local bats suite green: 2036/2036
- [x] jq filter verified against real jq 1.7 across all new cases
- [x] Regression-locked (revert → red → restore → green) for every fix
      in this branch
- [x] Adversarial testing beyond the cited findings (mixed extreme
      values, string `"Infinity"`, near-DBL_MAX pairs, all-identical
      extreme values) — no input found that produces invalid SVG or a
      partial sparkline
- [x] shellcheck clean on `generate-dashboard.sh`
- [ ] After merge: confirm live that hovering a sparkline point on the
      deployed dashboard shows the per-day tooltip
