### PR TITLE
chore(examples): drop capabilities on web-terminal web-shell service

### DIFF
--- a/examples/web-terminal/docker-compose.yaml
+++ b/examples/web-terminal/docker-compose.yaml
@@ -36,10 +36,34 @@ services:
       SHELL_USER: debian
       SHELL_PASSWORD: shell_secret_change_me
     # No port exposure — only accessible through OpenResty
-    # Note: not read_only — entrypoint needs write access to /etc/shadow (chpasswd)
+    # Note: not read_only — the entrypoint's chpasswd writes /etc/shadow at
+    # startup, which a read-only rootfs would block (can't tmpfs-mask /etc
+    # without losing the base contents). tmpfs for the writable runtime dirs.
     tmpfs:
       - /tmp
       - /run
+    # Drop every capability, add back only the four this ttyd-only stack needs
+    # (each verified empirically against the real image, not guessed):
+    #   SETUID + SETGID — ttyd runs `su - $SHELL_USER` per browser session;
+    #                     root needs both to switch uid/gid under no-new-privileges
+    #   CHOWN           — the startup chpasswd's PAM path writes /etc/shadow via
+    #                     temp-file + rename and sets ownership on it
+    #   KILL            — ttyd stays root but its per-session shell runs as the
+    #                     (different-uid) shell user; on browser close ttyd signals
+    #                     that child to reap it, which root cannot do across uids
+    #                     without CAP_KILL — omitting it leaks an orphaned shell
+    #                     per session
+    # Deliberately omitted because this stack is ttyd-only: DAC_OVERRIDE + FOWNER,
+    # which the SSH_PUBLIC_KEY / ENABLE_SSH paths need (root writes an .ssh dir
+    # into the shell user's own home and chmods it), plus sshd's own SYS_CHROOT /
+    # AUDIT_WRITE. Add those only if you layer SSH onto this example.
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - CHOWN
+      - KILL
     # Compose-level override: on real Docker Engine this is redundant —
     # the image's own HEALTHCHECK resolves fine. On a Podman-backed
     # Compose (podman-compose, or `docker compose` aliased to Podman —


### PR DESCRIPTION
## Summary

Hardens the `web-terminal` example's `web-shell` service by dropping all
Linux capabilities and adding back only the minimal set the ttyd-only
stack actually needs. `web-shell` still runs as root in-image (granting
a shell and running `chpasswd` is its purpose); this constrains what
that root can do at runtime.

The cap set was derived empirically against the real image, not guessed:

| Cap | Why it's needed |
|-----|-----------------|
| `SETUID` + `SETGID` | ttyd runs `su - $SHELL_USER` per browser session; root switches uid/gid under `no-new-privileges` |
| `CHOWN` | the startup `chpasswd` PAM path writes `/etc/shadow` (temp-file + rename + set ownership) |
| `KILL` | ttyd stays root but its per-session shell runs as the (different-uid) shell user; on browser close ttyd must signal that child to reap it, which root can't do across uids without `CAP_KILL` — omitting it leaks one orphaned shell per session |

Confirmed with the full stack: container reaches healthy, `su` to the
shell user works, and root reaps a shell-user child cleanly (verified
`kill: Operation not permitted` without `KILL`, clean reap with it).

`DAC_OVERRIDE` and `FOWNER` are deliberately omitted — the compose
comment documents that layering SSH onto this example (`SSH_PUBLIC_KEY`
/ `ENABLE_SSH`) needs them plus sshd's own `SYS_CHROOT` / `AUDIT_WRITE`.
Granting `DAC_OVERRIDE` (which bypasses all file-permission checks) by
default for a path this ttyd-only example doesn't exercise would defeat
the point of the hardening.

`read_only` stays off because `chpasswd` writes `/etc/shadow` at
startup, which a read-only rootfs would block.

## Notes on scope

- **Network raw-socket tools (e.g. `ping`) are unaffected by this
  change** — they were already non-functional for the browser terminal
  user, verified against the *original* unhardened config: the ttyd
  session runs as the non-root shell user, which cannot use raw-socket
  capabilities regardless of what the container grants (a non-root
  process doesn't inherit container caps into its effective set without
  ambient/file capabilities). Adding `NET_RAW` does not change this.
- SSH key-injection under the tightened caps is a documented,
  intentional limitation of this minimal ttyd profile, not an oversight
  — the compose comment states exactly which caps to add for it.

## Test plan

- [x] Full local bats suite green: 2036/2036
- [x] `yamllint` clean
- [x] Empirically derived the minimal cap set against the real image:
      `cap_drop: ALL` alone breaks `chpasswd` (PAM) and kills the
      container; each added cap verified necessary, `DAC_OVERRIDE` and
      `FOWNER` verified unnecessary for the ttyd-only path
- [x] Full stack verified: healthy + `su` works + root reaps a
      shell-user child (session cleanup) under the final cap set
- [x] Confirmed `ping`-as-terminal-user was already non-functional in
      the original config, so this change introduces no regression there
