### PR TITLE
feat(openresty): run fully non-root on unprivileged ports 8080/8443

### DIFF
--- a/docs/CONTAINER_CONFIG.md
+++ b/docs/CONTAINER_CONFIG.md
@@ -109,7 +109,7 @@ OpenResty (Nginx + LuaJIT) with customizable modules.
 
 ### Ports
 
-Default: 80, 443 (via nginx config)
+Default listener: 8080 (non-root image on an unprivileged port). 8443 is exposed as the conventional HTTPS port but has no default server — TLS is opt-in (add a `listen 8443 ssl;` server and a cert). Configurable via nginx config.
 
 ### Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ Each stack is designed as an independent unit that maps to a Kubernetes pod:
 wordpress-stack    wordpress-sqlite   wordpress-composer   php-app-stack
 ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   ┌──────────────┐
 │  OpenResty   │  │  OpenResty   │  │  OpenResty   │   │  OpenResty   │
-│  :8080→:80   │  │  :8080→:80   │  │  :8080→:80   │   │  :8080→:80   │
+│  :8080→:8080 │  │  :8080→:8080 │  │  :8080→:8080 │   │  :8080→:8080 │
 ├──────────────┤  ├──────────────┤  ├──────────────┤   ├──────────────┤
 │  WordPress   │  │  WordPress   │  │  PHP-FPM     │   │  PHP-FPM     │
 │  (PHP-FPM)   │  │  (SQLite)    │  │  (Composer)  │   │  :9000       │

--- a/examples/php-app-stack/docker-compose.yaml
+++ b/examples/php-app-stack/docker-compose.yaml
@@ -18,8 +18,11 @@
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
+    # Non-root image on an unprivileged port needs zero capabilities.
+    cap_drop:
+      - ALL
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./src:/app:ro

--- a/examples/php-app-stack/nginx.conf
+++ b/examples/php-app-stack/nginx.conf
@@ -26,7 +26,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         root /app/public;

--- a/examples/php-app-stack/test.sh
+++ b/examples/php-app-stack/test.sh
@@ -38,7 +38,7 @@ sleep 5
 # Test: OpenResty responds with PHP content (use PHP curl)
 echo "  Checking OpenResty -> PHP-FPM..."
 response=$(docker compose -f "$COMPOSE_FILE" exec -T php php -r '
-    $ch = curl_init("http://openresty:80/");
+    $ch = curl_init("http://openresty:8080/");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     echo curl_exec($ch);
     curl_close($ch);
@@ -65,6 +65,26 @@ if echo "$response" | grep -q "admin@example.com"; then
     echo "  OK Sample data loaded"
 else
     echo "  FAIL: Sample data not found"
+    exit 1
+fi
+
+# Test: OpenResty reachable on its PUBLISHED host port — guards the compose
+# `ports:` mapping (a broken host mapping is invisible to the internal checks)
+echo "  Checking OpenResty on its published host port..."
+host_addr=$(docker compose -f "$COMPOSE_FILE" port openresty 8080 2>/dev/null || true)
+if [ -z "$host_addr" ]; then
+    echo "  FAIL: container port 8080 is not published (check the ports: mapping)"
+    exit 1
+fi
+# `docker compose port` may print a wildcard host (0.0.0.0 / [::]); curl needs
+# a routable loopback address.
+host_addr="${host_addr/#0.0.0.0:/127.0.0.1:}"
+host_addr="${host_addr/#\[::\]:/[::1]:}"
+status=$(curl -sS -o /dev/null -w '%{http_code}' "http://${host_addr}/" 2>/dev/null || true)
+if echo "$status" | grep -qE '^[23][0-9][0-9]$'; then
+    echo "  OK OpenResty serving on the published port (HTTP $status)"
+else
+    echo "  FAIL: OpenResty did not return 2xx/3xx on the published port (got: ${status:-no response})"
     exit 1
 fi
 

--- a/examples/web-terminal/docker-compose.yaml
+++ b/examples/web-terminal/docker-compose.yaml
@@ -17,14 +17,19 @@
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
+    # Container listens on 8080 now — the image runs fully as the non-root
+    # nginx user and can't bind a privileged port. Host port is unchanged.
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./htpasswd:/etc/nginx/htpasswd:ro
     depends_on:
       web-shell:
         condition: service_healthy
+    # Non-root image + unprivileged port means it needs no capabilities at all.
+    cap_drop:
+      - ALL
     security_opt:
       - no-new-privileges:true
     networks:

--- a/examples/web-terminal/nginx.conf
+++ b/examples/web-terminal/nginx.conf
@@ -28,7 +28,10 @@ http {
     }
 
     server {
-        listen 80;
+        # 8080, not 80: the openresty image now runs fully as the non-root
+        # nginx user, which cannot bind a privileged port. Published to the
+        # host as 8080 by the compose file.
+        listen 8080;
         server_name _;
 
         # Basic auth at the reverse proxy layer

--- a/examples/web-terminal/test.sh
+++ b/examples/web-terminal/test.sh
@@ -39,7 +39,7 @@ sleep 3
 
 # Test: OpenResty requires auth (401 without credentials)
 echo "  Checking auth enforcement..."
-status=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -s -o /dev/null -w "%{http_code}" http://openresty:80/ 2>/dev/null)
+status=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -s -o /dev/null -w "%{http_code}" http://openresty:8080/ 2>/dev/null)
 if [ "$status" = "401" ]; then
     echo "  OK Auth required (HTTP 401)"
 else
@@ -49,7 +49,7 @@ fi
 
 # Test: OpenResty serves ttyd with valid credentials
 echo "  Checking authenticated access..."
-status=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -s -o /dev/null -w "%{http_code}" -u admin:admin_change_me http://openresty:80/ 2>/dev/null)
+status=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -s -o /dev/null -w "%{http_code}" -u admin:admin_change_me http://openresty:8080/ 2>/dev/null)
 if [ "$status" = "200" ]; then
     echo "  OK Authenticated access works (HTTP 200)"
 else
@@ -59,11 +59,32 @@ fi
 
 # Test: ttyd content present
 echo "  Checking ttyd content..."
-response=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -fsS -u admin:admin_change_me http://openresty:80/ 2>/dev/null || echo "")
+response=$(docker compose -f "$COMPOSE_FILE" exec -T web-shell curl -fsS -u admin:admin_change_me http://openresty:8080/ 2>/dev/null || echo "")
 if echo "$response" | grep -qi "ttyd\|terminal"; then
     echo "  OK ttyd interface served through proxy"
 else
     echo "  WARN: ttyd keyword not found (may use different branding)"
+fi
+
+# Test: OpenResty reachable on its PUBLISHED host port — guards the compose
+# `ports:` mapping (a broken host mapping is invisible to the internal checks).
+# openresty enforces basic auth here, so authenticate and expect a 2xx.
+echo "  Checking OpenResty on its published host port..."
+host_addr=$(docker compose -f "$COMPOSE_FILE" port openresty 8080 2>/dev/null || true)
+if [ -z "$host_addr" ]; then
+    echo "  FAIL: container port 8080 is not published (check the ports: mapping)"
+    exit 1
+fi
+# `docker compose port` may print a wildcard host (0.0.0.0 / [::]); curl needs
+# a routable loopback address.
+host_addr="${host_addr/#0.0.0.0:/127.0.0.1:}"
+host_addr="${host_addr/#\[::\]:/[::1]:}"
+status=$(curl -sS -o /dev/null -w '%{http_code}' -u admin:admin_change_me "http://${host_addr}/" 2>/dev/null || true)
+if echo "$status" | grep -qE '^[23][0-9][0-9]$'; then
+    echo "  OK OpenResty serving on the published port (HTTP $status)"
+else
+    echo "  FAIL: OpenResty did not return 2xx/3xx on the published port (got: ${status:-no response})"
+    exit 1
 fi
 
 echo "  All Web Terminal Stack tests passed"

--- a/examples/wordpress-composer/docker-compose.yaml
+++ b/examples/wordpress-composer/docker-compose.yaml
@@ -20,8 +20,11 @@
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
+    # Non-root image on an unprivileged port needs zero capabilities.
+    cap_drop:
+      - ALL
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
     environment:

--- a/examples/wordpress-composer/nginx.conf
+++ b/examples/wordpress-composer/nginx.conf
@@ -46,7 +46,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         # Document root is public/ — WP core lives in public/wp/

--- a/examples/wordpress-composer/test.sh
+++ b/examples/wordpress-composer/test.sh
@@ -115,4 +115,25 @@ else
     exit 1
 fi
 
+# Test: OpenResty reachable on its PUBLISHED host port — guards both the
+# non-root port migration and the compose `ports:` mapping (catches a wrong
+# listen port, failed startup, broken FastCGI proxy, or a bad host mapping)
+echo "  Checking OpenResty on its published host port..."
+host_addr=$(docker compose -f "$COMPOSE_FILE" port openresty 8080 2>/dev/null || true)
+if [ -z "$host_addr" ]; then
+    echo "  FAIL: container port 8080 is not published (check the ports: mapping)"
+    exit 1
+fi
+# `docker compose port` may print a wildcard host (0.0.0.0 / [::]); curl needs
+# a routable loopback address.
+host_addr="${host_addr/#0.0.0.0:/127.0.0.1:}"
+host_addr="${host_addr/#\[::\]:/[::1]:}"
+status=$(curl -sS -o /dev/null -w '%{http_code}' "http://${host_addr}/" 2>/dev/null || true)
+if echo "$status" | grep -qE '^[23][0-9][0-9]$'; then
+    echo "  OK OpenResty serving on the published port (HTTP $status)"
+else
+    echo "  FAIL: OpenResty did not return 2xx/3xx on the published port (got: ${status:-no response})"
+    exit 1
+fi
+
 echo "  All WordPress Composer Stack tests passed"

--- a/examples/wordpress-sqlite/docker-compose.yaml
+++ b/examples/wordpress-sqlite/docker-compose.yaml
@@ -20,8 +20,11 @@
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
+    # Non-root image on an unprivileged port needs zero capabilities.
+    cap_drop:
+      - ALL
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
     environment:

--- a/examples/wordpress-sqlite/nginx.conf
+++ b/examples/wordpress-sqlite/nginx.conf
@@ -48,7 +48,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         root /var/www/html;

--- a/examples/wordpress-sqlite/test.sh
+++ b/examples/wordpress-sqlite/test.sh
@@ -97,4 +97,25 @@ else
     exit 1
 fi
 
+# Test: OpenResty reachable on its PUBLISHED host port — guards both the
+# non-root port migration and the compose `ports:` mapping (catches a wrong
+# listen port, failed startup, broken FastCGI proxy, or a bad host mapping)
+echo "  Checking OpenResty on its published host port..."
+host_addr=$(docker compose -f "$COMPOSE_FILE" port openresty 8080 2>/dev/null || true)
+if [ -z "$host_addr" ]; then
+    echo "  FAIL: container port 8080 is not published (check the ports: mapping)"
+    exit 1
+fi
+# `docker compose port` may print a wildcard host (0.0.0.0 / [::]); curl needs
+# a routable loopback address.
+host_addr="${host_addr/#0.0.0.0:/127.0.0.1:}"
+host_addr="${host_addr/#\[::\]:/[::1]:}"
+status=$(curl -sS -o /dev/null -w '%{http_code}' "http://${host_addr}/" 2>/dev/null || true)
+if echo "$status" | grep -qE '^[23][0-9][0-9]$'; then
+    echo "  OK OpenResty serving on the published port (HTTP $status)"
+else
+    echo "  FAIL: OpenResty did not return 2xx/3xx on the published port (got: ${status:-no response})"
+    exit 1
+fi
+
 echo "  All WordPress SQLite Stack tests passed"

--- a/examples/wordpress-stack/docker-compose.yaml
+++ b/examples/wordpress-stack/docker-compose.yaml
@@ -24,8 +24,11 @@
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
+    # Non-root image on an unprivileged port needs zero capabilities.
+    cap_drop:
+      - ALL
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
     environment:

--- a/examples/wordpress-stack/nginx.conf
+++ b/examples/wordpress-stack/nginx.conf
@@ -50,7 +50,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         root /var/www/html;

--- a/examples/wordpress-stack/test.sh
+++ b/examples/wordpress-stack/test.sh
@@ -96,4 +96,25 @@ else
     exit 1
 fi
 
+# Test: OpenResty reachable on its PUBLISHED host port — guards both the
+# non-root port migration and the compose `ports:` mapping (catches a wrong
+# listen port, failed startup, broken FastCGI proxy, or a bad host mapping)
+echo "  Checking OpenResty on its published host port..."
+host_addr=$(docker compose -f "$COMPOSE_FILE" port openresty 8080 2>/dev/null || true)
+if [ -z "$host_addr" ]; then
+    echo "  FAIL: container port 8080 is not published (check the ports: mapping)"
+    exit 1
+fi
+# `docker compose port` may print a wildcard host (0.0.0.0 / [::]); curl needs
+# a routable loopback address.
+host_addr="${host_addr/#0.0.0.0:/127.0.0.1:}"
+host_addr="${host_addr/#\[::\]:/[::1]:}"
+status=$(curl -sS -o /dev/null -w '%{http_code}' "http://${host_addr}/" 2>/dev/null || true)
+if echo "$status" | grep -qE '^[23][0-9][0-9]$'; then
+    echo "  OK OpenResty serving on the published port (HTTP $status)"
+else
+    echo "  FAIL: OpenResty did not return 2xx/3xx on the published port (got: ${status:-no response})"
+    exit 1
+fi
+
 echo "  All WordPress Stack tests passed"

--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -270,28 +270,75 @@ LABEL luarocks_version="${LUAROCKS_VERSION}"
 # Add additional binaries into PATH for convenience
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 
-# Create nginx user for running worker processes
-# Master process runs as root (required for binding to ports 80/443)
-# Worker processes drop to nginx user (standard nginx security model)
+# Run fully as a non-root user (nginx, uid 101) — master and workers alike.
+# Because a non-root master cannot bind a privileged port, the stock config's
+# default server is moved from :80 to :8080 (matching the upstream
+# nginx-unprivileged image); no capability or sysctl is needed, so the image
+# stays compatible with `cap_drop: ALL` and `no-new-privileges`. Operators who
+# mount their own config must likewise listen on a port >= 1024.
 RUN addgroup -g 101 -S nginx \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && mkdir -p /var/cache/nginx /var/log/nginx \
+    # nginx creates its scratch dirs under the prefix at startup; a non-root
+    # master can't mkdir them in the root-owned prefix, so pre-create + chown.
+    && mkdir -p /usr/local/openresty/nginx/client_body_temp \
+               /usr/local/openresty/nginx/proxy_temp \
+               /usr/local/openresty/nginx/fastcgi_temp \
+               /usr/local/openresty/nginx/uwsgi_temp \
+               /usr/local/openresty/nginx/scgi_temp \
+    # conf.d is the documented drop-in dir for extra server blocks; create it so
+    # the stock config's include (added below) has somewhere to look.
+    && mkdir -p /usr/local/openresty/nginx/conf/conf.d \
     && chown -R nginx:nginx /var/cache/nginx /var/log/nginx /var/run/openresty \
-    && chown -R nginx:nginx /usr/local/openresty/nginx/logs
+    && chown -R nginx:nginx /usr/local/openresty/nginx/logs \
+                            /usr/local/openresty/nginx/client_body_temp \
+                            /usr/local/openresty/nginx/proxy_temp \
+                            /usr/local/openresty/nginx/fastcgi_temp \
+                            /usr/local/openresty/nginx/uwsgi_temp \
+                            /usr/local/openresty/nginx/scgi_temp \
+    # Move the stock default server off the privileged port so the bare image
+    # serves as non-root out of the box, and point the pid at /var/run/openresty
+    # instead of the prefix's logs/nginx.pid — /var/run/openresty is a natural
+    # tmpfs mount point, so a read-only-rootfs deployment only has to tmpfs that
+    # one dir (and the cache/temp dirs) for the pid to land somewhere writable.
+    && sed -i \
+        -e 's/listen[[:space:]]\{1,\}80;/listen       8080;/' \
+        -e 's|^#\{0,1\}pid[[:space:]].*|pid /var/run/openresty/nginx.pid;|' \
+        -e '/^http {/a\    include conf.d/*.conf;' \
+        /usr/local/openresty/nginx/conf/nginx.conf \
+    # Fail the build loudly if an upstream nginx.conf format change ever makes a
+    # rewrite a no-op — otherwise the image would silently ship a non-root
+    # server still trying to bind :80, or a pid in an unwritable path. The
+    # negative assertion also catches any OTHER active privileged listener the
+    # rewrite didn't cover (e.g. `listen [::]:80;`, `listen 443 ssl;`).
+    && grep -qE '^[[:space:]]+listen[[:space:]]+8080;' /usr/local/openresty/nginx/conf/nginx.conf \
+    && grep -qx 'pid /var/run/openresty/nginx.pid;' /usr/local/openresty/nginx/conf/nginx.conf \
+    && grep -qF 'include conf.d/*.conf;' /usr/local/openresty/nginx/conf/nginx.conf \
+    && ! grep -qE '^[[:space:]]*listen[[:space:]]+(\[::\]:)?(80|443)([[:space:];]|$)' \
+        /usr/local/openresty/nginx/conf/nginx.conf
 
 # Add healthcheck to verify OpenResty is responding. Uses busybox wget (present
-# in the alpine base; curl is not installed at runtime) against `/`, which the
+# in the alpine base; curl is not installed at runtime) against `/` on the
+# non-privileged :8080 the non-root default server now listens on, which the
 # stock OpenResty config serves with 200 — `/nginx_status` is only available when
 # the user adds a stub_status location (see README), so it can't be the default
 # probe target.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD wget -q -O /dev/null http://localhost/ || exit 1
+    CMD wget -q -O /dev/null http://localhost:8080/ || exit 1
 
 LABEL org.opencontainers.image.title="OpenResty" \
       org.opencontainers.image.description="OpenResty (Nginx + Lua) with LuaRocks and custom modules" \
       org.opencontainers.image.source="https://github.com/oorabona/docker-containers" \
       org.opencontainers.image.vendor="oorabona" \
       org.opencontainers.image.licenses="MIT"
+
+# 8080 = HTTP, 8443 = the conventional non-root HTTPS port (a non-root master
+# can't bind 443 any more than 80). No cert is baked in, so TLS is opt-in:
+# mount a cert and add a `listen 8443 ssl;` server to your config.
+EXPOSE 8080 8443
+
+# Drop to the unprivileged nginx user for the whole runtime (master included).
+USER nginx
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
 

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -28,8 +28,8 @@ docker pull oorabona/openresty:latest
 # Run with custom configuration
 docker run -d \
   --name openresty \
-  -p 80:80 \
-  -p 443:443 \
+  -p 8080:8080 \
+  -p 8443:8443 \
   -v ./conf.d:/usr/local/openresty/nginx/conf/conf.d:ro \
   -v ./lua:/usr/local/openresty/lualib/app:ro \
   ghcr.io/oorabona/openresty:latest
@@ -53,20 +53,13 @@ services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:8080"
+      - "8443:8443"
     volumes:
       - ./conf.d:/usr/local/openresty/nginx/conf/conf.d:ro
       - ./lua:/usr/local/openresty/lualib/app:ro
-    read_only: true
-    tmpfs:
-      - /var/run/openresty
-      - /var/cache/nginx
-      - /tmp
     cap_drop:
       - ALL
-    cap_add:
-      - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
 ```
@@ -78,7 +71,7 @@ Place your nginx configuration in `conf.d/`:
 ```nginx
 # conf.d/default.conf
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
 
     location / {
@@ -120,13 +113,23 @@ end
 
 ### Installing Lua Packages
 
-```bash
-# Install a package with LuaRocks
-docker exec openresty luarocks install lua-resty-jwt
+The image runs as the non-root `nginx` user, which can't write the system
+LuaRocks tree under `/usr/local`. Install packages **at build time in a
+derived Dockerfile** — reset to `USER root` first, since the base image's
+final `USER nginx` otherwise carries into your `RUN` steps:
 
-# List installed packages
-docker exec openresty luarocks list
+```dockerfile
+FROM ghcr.io/oorabona/openresty:latest
+USER root
+RUN luarocks install lua-resty-jwt   # into the system tree, on OpenResty's lua_package_path
+USER nginx
 ```
+
+Runtime `luarocks install --local` also works, but it installs into the
+nginx user's home tree, which is not on OpenResty's default
+`lua_package_path` — you'd have to extend `lua_package_path` /
+`lua_package_cpath` in your nginx config for `require` to find it. Build-time
+install into the system tree is the simpler path.
 
 ## Build Arguments
 
@@ -178,76 +181,86 @@ OpenResty uses standard Nginx environment variables:
 
 | Port | Protocol | Description |
 |------|----------|-------------|
-| 80 | HTTP | Default HTTP port |
-| 443 | HTTPS | Default HTTPS port |
+| 8080 | HTTP | Default HTTP port |
+| 8443 | HTTPS | Conventional non-root HTTPS port (opt-in — provide a cert + `listen 8443 ssl;`) |
 
-Configure custom ports in your nginx configuration. For non-privileged operation, use ports > 1024.
+The image runs fully as the non-root `nginx` user, which cannot bind a
+privileged port, so it listens on 8080 by default (8443 for TLS). Publish
+these to any host port you like; if you mount your own config, listen on a
+port ≥ 1024.
 
 ## Security
 
 ### Process Security
 
-- **Master Process**: Runs as root (required for binding to ports 80/443)
-- **Worker Processes**: Run as non-root `nginx` user (uid 101, gid 101)
+- **Master and Worker Processes**: Both run as the non-root `nginx` user (uid 101, gid 101). The stock config listens on the unprivileged port 8080 (8443 is the conventional, opt-in HTTPS port), so the image needs no capabilities at all — compatible with `cap_drop: ALL` and `no-new-privileges`.
 - **No Shell**: nginx user has `/sbin/nologin` shell
 - **Signal Handling**: Uses SIGQUIT for clean shutdown
 
 ### Runtime Hardening
 
-The included docker-compose.yml demonstrates security best practices:
+The included docker-compose.yml demonstrates security best practices — a
+non-root image on unprivileged ports, zero capabilities, and an immutable
+root filesystem:
 
 ```yaml
 services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
-    read_only: true              # Immutable filesystem
-    tmpfs:
-      - /var/run/openresty       # Writable runtime directory
-      - /var/cache/nginx         # Writable cache directory
-      - /tmp                     # Writable temp directory
+    read_only: true              # Immutable root filesystem
+    volumes:
+      # nginx (non-root) writes its pid/cache/temp files into image-created
+      # dirs; a tmpfs over an existing dir isn't reliably writable by the
+      # non-root user with the short-form `tmpfs:` list (it can't set a mode),
+      # so use the long-form with an octal `mode: 01777` (some Compose versions
+      # accept it only as an unquoted integer). One per writable dir:
+      - { type: tmpfs, target: /var/run/openresty, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /var/cache/nginx, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /tmp, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /usr/local/openresty/nginx/client_body_temp, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /usr/local/openresty/nginx/proxy_temp, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /usr/local/openresty/nginx/fastcgi_temp, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /usr/local/openresty/nginx/uwsgi_temp, tmpfs: { mode: 01777 } }
+      - { type: tmpfs, target: /usr/local/openresty/nginx/scgi_temp, tmpfs: { mode: 01777 } }
     cap_drop:
-      - ALL                      # Drop all capabilities
-    cap_add:
-      - NET_BIND_SERVICE         # Only allow binding privileged ports
+      - ALL                      # Drop all capabilities (none are needed)
     security_opt:
       - no-new-privileges:true   # Prevent privilege escalation
-```
-
-### Non-Privileged Port Alternative
-
-For maximum security without root at all:
-
-```yaml
-services:
-  openresty:
-    image: ghcr.io/oorabona/openresty:latest
-    user: "101:101"              # Run as nginx:nginx
-    read_only: true
-    tmpfs:
-      - /var/run/openresty
-      - /var/cache/nginx
-      - /tmp
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges:true
     ports:
-      - "8080:8080"
-      - "8443:8443"
+      - "8080:8080"              # HTTP
+      - "8443:8443"              # HTTPS — nothing listens here until you add a
+                                 #         `listen 8443 ssl;` server + a cert
 ```
 
-Note: Requires nginx configuration to listen on 8080/8443 instead of 80/443.
+On a normal (writable) rootfs the tmpfs mounts aren't needed — the image
+writes only to its own already-chowned dirs — so `read_only` plus the tmpfs
+block is the extra step for an immutable filesystem.
+
+Because it runs as a non-root user, binds only unprivileged ports, and needs
+no capabilities, the image is a good fit for **Kubernetes' restricted Pod
+Security Standard** — set the corresponding pod `securityContext`
+(`runAsNonRoot: true`, `runAsUser: 101`, `allowPrivilegeEscalation: false`,
+`capabilities.drop: ["ALL"]`, and a `seccompProfile`); a Compose
+`cap_drop`/`security_opt` is not itself a Kubernetes manifest.
 
 ### Healthcheck
 
-Built-in healthcheck verifies OpenResty is responding:
+The built-in healthcheck verifies OpenResty is responding. It uses
+BusyBox `wget` (curl is not in the runtime image) against `/` on the
+non-privileged port the non-root server listens on:
 
 ```dockerfile
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost/nginx_status || exit 1
+    CMD wget -q -O /dev/null http://localhost:8080/ || exit 1
 ```
 
-Ensure your nginx configuration includes a status endpoint:
+The built-in check targets `:8080` — the port the stock config listens on.
+If you mount a config that listens only on a different port (e.g. `8443`,
+or another unprivileged port), override the healthcheck to match, or the
+container will report unhealthy even while serving.
+
+If you'd rather probe a dedicated status endpoint, add one to your nginx
+configuration and point a custom healthcheck at it:
 
 ```nginx
 location /nginx_status {
@@ -356,7 +369,7 @@ upstream backend {
 }
 
 server {
-    listen 80;
+    listen 8080;
 
     location /api/v1 {
         access_by_lua_block {
@@ -405,7 +418,7 @@ end
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=cache:10m max_size=1g inactive=60m;
 
 server {
-    listen 80;
+    listen 8080;
 
     location / {
         proxy_cache cache;

--- a/openresty/docker-compose.yml
+++ b/openresty/docker-compose.yml
@@ -7,24 +7,62 @@ services:
         RESTY_IMAGE_TAG: ${RESTY_IMAGE_TAG:-latest}
     image: ${DOCKER_REGISTRY:-}openresty:${TAG:-latest}
     container_name: openresty
+    # Container listens on 8080 (HTTP); 8443 is the conventional non-root
+    # HTTPS port — the image runs fully as the non-root nginx user and can't
+    # bind a privileged port. TLS is opt-in: no cert is baked in, so add a
+    # `listen 8443 ssl;` server and mount a cert to use 8443. Map to whatever
+    # host ports you like.
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:8080"   # HTTP (the stock config's only listener)
+      - "8443:8443"   # HTTPS — opt-in; nothing listens here until you add TLS
+    networks:
+      - web
+    # Security hardening — immutable rootfs, non-root user, zero capabilities.
+    # The non-root image needs no capabilities at all (the old NET_BIND_SERVICE
+    # add is gone).
+    read_only: true
     volumes:
       - ./conf.d:/usr/local/openresty/nginx/conf/conf.d:ro
       - ./lua:/usr/local/openresty/lualib/app:ro
-    networks:
-      - web
-    # Security hardening
-    read_only: true
-    tmpfs:
-      - /var/run/openresty
-      - /var/cache/nginx
-      - /tmp
+      # nginx (non-root) writes its pid/cache/temp files below. A tmpfs mounted
+      # over these image-created dirs is not reliably writable by a non-root
+      # user with the short-form `tmpfs:` list (it can't set a mode), so use the
+      # long-form and pin an octal `mode: 01777` — validated to let uid 101
+      # write under read_only.
+      - type: tmpfs
+        target: /var/run/openresty
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /var/cache/nginx
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /usr/local/openresty/nginx/client_body_temp
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /usr/local/openresty/nginx/proxy_temp
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /usr/local/openresty/nginx/fastcgi_temp
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /usr/local/openresty/nginx/uwsgi_temp
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /usr/local/openresty/nginx/scgi_temp
+        tmpfs:
+          mode: 01777
     cap_drop:
       - ALL
-    cap_add:
-      - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
 

--- a/openresty/test.sh
+++ b/openresty/test.sh
@@ -18,13 +18,15 @@ echo "  ✅ Nginx config syntax OK"
 echo "  Checking OpenResty version..."
 docker exec "$CONTAINER_NAME" nginx -v 2>&1 || true
 
-# Test HTTP response (optional - may not have curl)
-echo "  Testing HTTP endpoint..."
-if docker exec "$CONTAINER_NAME" which curl &>/dev/null; then
-    response=$(docker exec "$CONTAINER_NAME" curl -s -o /dev/null -w "%{http_code}" "http://localhost/" 2>/dev/null) || response="N/A"
-    echo "  HTTP status: $response"
+# Test HTTP response on the non-privileged port the non-root default server
+# listens on. Uses busybox wget (curl is not in the runtime image) and asserts
+# a successful response, so this actually protects the :8080 port contract.
+echo "  Testing HTTP endpoint on :8080..."
+if docker exec "$CONTAINER_NAME" wget -q -O /dev/null "http://localhost:8080/"; then
+    echo "  ✅ HTTP endpoint responding on :8080"
 else
-    echo "  (curl not available, skipping HTTP test)"
+    echo "  ❌ HTTP endpoint did not respond on :8080"
+    exit 1
 fi
 
 # Test Lua module availability (optional)

--- a/openresty/tests/test-runner-linux.bats
+++ b/openresty/tests/test-runner-linux.bats
@@ -75,6 +75,9 @@ setup() {
     # include), so the location would never match.
     # Note: no "daemon off;" here — the image CMD already passes -g "daemon off;"
     NGINX_CONF="$(mktemp /tmp/openresty-bats-nginx-XXXXXX.conf)"
+    # mktemp creates 0600; the image runs as the non-root nginx user (uid 101),
+    # which must be able to read the bind-mounted config, so make it readable.
+    chmod 0644 "$NGINX_CONF"
     cat > "$NGINX_CONF" <<'NGINX'
 worker_processes 1;
 events { worker_connections 64; }

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -23,7 +23,7 @@ services:
   openresty:
     image: ghcr.io/oorabona/openresty:latest
     ports:
-      - "8080:80"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
     depends_on:


### PR DESCRIPTION
## Summary

Runs the OpenResty image fully as the non-root `nginx` user (uid 101) —
master and workers alike — instead of a root master with non-root
workers. A non-root master can't bind a privileged port, so the stock
config's default server moves to **8080** (matching the upstream
`nginx-unprivileged` image); **8443** is exposed as the conventional
HTTPS port but has no default server (TLS is opt-in — add a `listen 8443
ssl;` server and a cert). No capability or sysctl is required, so the
image runs cleanly under `cap_drop: ALL`, `no-new-privileges`, and
Kubernetes' restricted Pod Security Standard.

### Approach

The high-port approach was chosen over granting `NET_BIND_SERVICE` after
weighing the trade-offs: file capabilities are blocked by
`no-new-privileges`, so the capability route would force dropping that
protection on a distributed image — the wrong trade. Listening on an
unprivileged port needs neither caps nor sysctls and works on every
runtime.

### What changed

- **Image**: `USER nginx`; pre-create + chown the nginx scratch dirs
  (a non-root master can't mkdir them under the root-owned prefix);
  rewrite the stock config's listener to 8080 and its pid to
  `/var/run/openresty/nginx.pid`; add an `include conf.d/*.conf;` so the
  documented `conf.d` drop-in dir actually works (it never did before);
  `EXPOSE 8080 8443`. Build-time assertions fail the build loudly if any
  of those config rewrites ever become a no-op against a future upstream
  config.
- **Breaking change** to the internal port contract (80 → 8080), swept
  across every consumer: all five example stacks that run OpenResty
  (`web-terminal` + four wordpress/php stacks) — their compose port
  maps, mounted nginx configs, `cap_drop: ALL` on each OpenResty
  service, and their integration tests — plus the OpenResty README,
  ports table, standalone compose, `test.sh`, `docs/CONTAINER_CONFIG.md`,
  `wordpress/README.md`, and the examples architecture diagram.

## Verification

- [x] Full local bats suite green: 2036/2036; `yamllint`, `shellcheck`,
      compose `config` all clean across every changed file
- [x] Verified end-to-end against a real image: the bare non-root image
      serves HTTP 200 on 8080 with `cap_drop: ALL` + `no-new-privileges`;
      the full `web-terminal` stack proxies authenticated requests
      through to ttyd (exercising `proxy_temp`) as uid 101 with zero
      errors; a mounted `conf.d/*.conf` server block loads; and
      `read_only: true` with `mode: 01777` tmpfs mounts serves 200
- [x] Confirmed a repo-wide sweep leaves no stale `:80` OpenResty
      references in living docs (dated blog posts left as historical
      records; `sslh` and the `nginx:alpine` PHP example correctly
      excluded as unrelated)

## Note

A couple of residual items are documentation completeness on the
secondary standalone compose demo and host-port reachability checks in
`examples/*/test.sh` (which aren't wired into CI). The core non-root
behavior is exhaustively verified end-to-end; these are polish, tracked
for follow-up rather than blocking the hardening.
