### PR TITLE
feat(openvpn): drop the VPN server to the non-root nobody user

### DIFF
--- a/docs/CONTAINER_CONFIG.md
+++ b/docs/CONTAINER_CONFIG.md
@@ -140,6 +140,8 @@ OpenVPN server with easy-rsa PKI management.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OS` | `other` | Client OS type |
+| `AUTO_INSTALL` | `n` | `y` runs a non-interactive install (generates PKI + `server.conf`) when no config exists; unset with a config present opens an interactive menu instead of starting |
+| `AUTO_START` | `n` | `y` starts the OpenVPN server after install (required for the server to run on this Alpine image) |
 
 ### Ports
 
@@ -150,12 +152,28 @@ OpenVPN server with easy-rsa PKI management.
 ### Usage
 
 ```bash
-# Run OpenVPN server
-docker run -d --cap-add=NET_ADMIN \
+# Run OpenVPN server. NET_ADMIN sets up the tunnel; SETUID/SETGID let openvpn
+# drop to the unprivileged nobody user its config specifies (NET_RAW is not
+# needed — the UDP transport uses ordinary sockets). This is a bootstrap-and-run
+# invocation: AUTO_INSTALL=y generates the config on an empty volume, AUTO_START=y
+# starts the server. The installer has no clean unattended restart (AUTO_INSTALL=y
+# re-runs setup; unset opens a management menu) — see openvpn/README.md
+# "Lifecycle" and issue #912 before running it as a persistent service.
+docker run -d \
+  --cap-drop=ALL \
+  --cap-add=NET_ADMIN --cap-add=SETUID --cap-add=SETGID \
+  --security-opt no-new-privileges \
+  --device=/dev/net/tun \
+  -e AUTO_INSTALL=y -e AUTO_START=y \
   -v openvpn-data:/etc/openvpn \
   -p 1194:1194/udp \
   ghcr.io/oorabona/openvpn:latest
 ```
+
+> The capability set above covers the default port (1194). Add `NET_BIND_SERVICE`
+> only if openvpn is configured to bind an **internal** port below 1024 — under
+> `cap_drop: ALL` the initial root bind otherwise lacks the privileged-port
+> capability. Mapping a privileged host port to 1194 needs nothing extra.
 
 ---
 

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -35,9 +35,12 @@ Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, 
 ```bash
 docker run -d --name openvpn \
     -p 1194:1194/udp \
-    -v /path/to/config:/etc/openvpn \
+    -v openvpn-data:/etc/openvpn \
+    --cap-drop=ALL \
     --cap-add=NET_ADMIN \
-    --cap-add=NET_RAW \
+    --cap-add=SETUID \
+    --cap-add=SETGID \
+    --security-opt no-new-privileges \
     --device=/dev/net/tun \
     --sysctl net.ipv6.conf.all.disable_ipv6=0 \
     --sysctl net.ipv6.conf.all.forwarding=1 \
@@ -48,6 +51,15 @@ docker run -d --name openvpn \
     oorabona/openvpn
 ```
 
+> **First-run storage under `cap_drop: ALL`.** The example uses a named volume
+> (`openvpn-data`) because `AUTO_INSTALL` generates the PKI and `server.conf`
+> into `/etc/openvpn` on first start, and `cap_drop: ALL` removes the
+> `DAC_OVERRIDE`/`FOWNER`/`CHOWN` capabilities that let root bypass filesystem
+> permissions. A named volume is created root-owned by the daemon, so that
+> generation always succeeds. If you bind-mount a host directory instead, make
+> sure it is writable by the container's root (uid 0) — otherwise first-run
+> generation fails.
+
 ### Docker Compose
 
 ```yaml
@@ -57,10 +69,21 @@ services:
   openvpn:
     image: oorabona/openvpn
     container_name: openvpn
-    restart: unless-stopped
+    # Bootstrap-and-run (see "Lifecycle" below): AUTO_INSTALL=y generates the PKI
+    # + server.conf into the empty named volume, AUTO_START=y launches the
+    # server. Do NOT combine AUTO_INSTALL=y with restart: unless-stopped — the
+    # installer re-runs setup on every restart. See #912.
+    environment:
+      - AUTO_INSTALL=y
+      - AUTO_START=y
     cap_add:
       - NET_ADMIN
-      - NET_RAW
+      - SETUID
+      - SETGID
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     devices:
         - /dev/net/tun
     sysctls:
@@ -71,8 +94,24 @@ services:
     ports:
       - 1194:1194/udp
     volumes:
-      - /path/to/config:/etc/openvpn
+      - openvpn_config:/etc/openvpn
+
+volumes:
+  openvpn_config:
 ```
+
+### Lifecycle (important)
+
+This image's entrypoint (the `ovpn` installer) is **bootstrap-and-run**, not an
+unattended daemon. On an empty volume, `AUTO_INSTALL=y` + `AUTO_START=y`
+generates the config and starts the server. But once a config exists it has no
+clean restart path: `AUTO_INSTALL=y` **re-runs setup** (can overwrite your
+PKI/config), while leaving it unset opens an **interactive management menu**
+instead of starting. So do not run a `restart: unless-stopped` service with a
+persisted `AUTO_INSTALL=y`, and do not expect a plain `docker compose up -d`
+after bootstrap to start the server. Bootstrap once, then manage/run the server
+via the installer's documented commands (see below). This limitation is tracked
+in [#912](https://github.com/oorabona/docker-containers/issues/912).
 
 ## Configuration
 
@@ -103,6 +142,13 @@ This file is generated from the script `setup.sh` located in `/usr/local/bin` an
 - ENDPOIN
 
 For details about the meaning of each variable, please refer to the [documentation](https://github.com/oorabona/scripts/tree/main/openvpn).
+
+Two variables control the container's first-run lifecycle:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTO_INSTALL` | `n` | `y` runs a **non-interactive** install (generates the PKI + `server.conf`) when no config exists. Left unset with a config already present, the entrypoint opens an interactive management menu instead of starting the server. |
+| `AUTO_START` | `n` | `y` starts the OpenVPN server after install (required for the server to actually run on this Alpine image). |
 
 ### Google Authenticator
 
@@ -158,30 +204,62 @@ This context is configured to allow the container to access the following resour
 
 ### Capabilities
 
-The container is configured to run with the following capabilities:
+Run with `cap_drop: ALL` and only these capabilities added back:
 
-- `NET_ADMIN`
-- `NET_RAW`
+- `NET_ADMIN` — create the tun device and configure routes/firewall rules
+- `SETUID` / `SETGID` — let openvpn drop to `nobody`/`nogroup` after setup
+
+`NET_RAW` is **not** needed — openvpn's UDP transport uses ordinary sockets,
+not raw ones. These caps cover the default port (1194). If you configure
+openvpn to bind an **internal** port below 1024, add `NET_BIND_SERVICE` as well
+(the initial bind happens as root before the drop, and `cap_drop: ALL` removes
+the privileged-port capability). Mapping a privileged **host** port to 1194
+(`-p 443:1194/udp`) needs nothing extra.
 
 ### Privileges
 
-The container is configured to run as `root` user.
-No effort has been (yet) made to run the container as a non-root user.
+openvpn **starts** as root — creating the tun device, routes, and firewall
+rules genuinely requires it — then drops to the unprivileged `nobody`
+user/`nogroup` for the lifetime of the tunnel, **provided the running
+`server.conf` specifies `user nobody` / `group nogroup`** (with `persist-tun`
+/ `persist-key` so the already-open tun survives the drop). The image's own
+`AUTO_INSTALL` generates such a config; if you mount your own `server.conf`,
+add those directives yourself — without them openvpn keeps running as root.
+
+The `SETUID`/`SETGID` capabilities are what let that drop complete under
+`cap_drop: ALL`. They aren't optional for a `user`/`group` config: openvpn
+treats a failed privilege drop as **fatal**, so without these caps the
+container fails to start rather than silently running as root.
+
+This drops the OpenVPN **server worker** to `nobody`; it does not make the whole
+container rootless. The entrypoint wrapper that adds and removes the iptables
+NAT rules around the tunnel stays alive as root for the server's lifetime, and
+OTP/PAM authentication (when enabled) uses a root helper. So the profile removes
+`NET_RAW` and all other capabilities, runs under `no-new-privileges`, and drops
+the server worker to `nobody` — a meaningful reduction, not a fully rootless
+container.
+
+The setuid/setgid capability requirement was verified directly under
+`cap_drop: ALL` (`setuid` to `nobody` fails with only `NET_ADMIN` and succeeds
+once `SETUID`/`SETGID` are added back). Exercising openvpn's full end-to-end
+drop needs a live tunnel with a real tun device, which the image's current CI
+e2e does not stand up — that coverage is tracked in
+[#910](https://github.com/oorabona/docker-containers/issues/910). Treat the
+reduced-capability profile as verified at the capability level, not yet
+exercised end-to-end by CI.
 
 ### Security options
 
-The container is configured to run with the following security options:
+The default hardened profile (the `run`/Compose examples above) sets only
+`no-new-privileges`.
 
-- `no-new-privileges`
-- `seccomp=unconfined`
-- `apparmor=unconfined`
-
-### Security labels
-
-The container is configured to run with the following security labels:
-
-- `label=disable`
-- `label=type:spc_t`
+On an **SELinux-enforcing host** the container additionally needs host-policy-
+specific run options — relaxing seccomp/AppArmor and setting the container's
+SELinux label so it can manage the tun device and iptables under the `spc_t`
+context described above. Those settings depend on your host's policy, are **not**
+part of the image's default profile, and are not general hardening
+recommendations — consult your platform's SELinux + container documentation for
+the exact values.
 
 ## Dependencies
 

--- a/openvpn/docker-compose.yml
+++ b/openvpn/docker-compose.yml
@@ -10,10 +10,23 @@ services:
     image: ${DOCKER_REGISTRY:-}openvpn:${TAG:-latest}
     ports:
       - "1194:1194/udp"
-    # Required capabilities for VPN
+    # Capabilities. NET_ADMIN creates the tun device and configures the routes
+    # and firewall rules (openvpn's UDP transport uses ordinary sockets, so
+    # NET_RAW is not needed — matching this image's own hardening writeup).
+    # SETUID/SETGID let openvpn drop to the unprivileged nobody/nogroup its
+    # server.conf specifies (`user nobody` / `group nogroup`, with persist-tun/
+    # persist-key) once the tunnel is up. Under cap_drop: ALL the drop can't
+    # complete without them, and openvpn treats a failed privilege drop as
+    # fatal — so a config with `user`/`group` won't start at all without these
+    # caps. (Setuid mechanic verified: `su` to nobody under cap_drop: ALL fails
+    # with only NET_ADMIN ["can't set groups"] and succeeds with SETUID/SETGID.
+    # openvpn's own end-to-end drop needs a live tunnel with a real tun device
+    # and a user/group server.conf; the CI e2e only boots the image and checks
+    # `openvpn --version`, so it does not by itself exercise the drop.)
     cap_add:
       - NET_ADMIN
-      - NET_RAW
+      - SETUID
+      - SETGID
     cap_drop:
       - ALL
     security_opt:
@@ -25,6 +38,12 @@ services:
       - net.ipv4.conf.all.forwarding=1
       - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv6.conf.all.forwarding=1
+    # Bootstrap the empty volume once: `AUTO_INSTALL=y docker compose up -d`
+    # generates the PKI + server.conf. Heads-up on the entrypoint's lifecycle
+    # (tracked in #912): with a config already present, AUTO_INSTALL=y re-runs
+    # setup and AUTO_INSTALL unset/n opens an interactive management menu instead
+    # of starting — so this installer does not support a clean unattended restart
+    # loop out of the box. See openvpn/README.md "Lifecycle" and #912.
     environment:
       - AUTO_INSTALL=${AUTO_INSTALL:-n}
       - AUTO_START=${AUTO_START:-y}


### PR DESCRIPTION
## What

Harden the `openvpn` container to run under a reduced Linux capability profile
and let the OpenVPN server worker drop to the unprivileged `nobody`/`nogroup`
user.

- Run under `cap_drop: ALL` with only `NET_ADMIN` (tun device + routes/firewall)
  and `SETUID`/`SETGID` (the privilege drop) added back, plus `no-new-privileges`.
- Remove `NET_RAW` — OpenVPN's UDP transport uses ordinary sockets, so it isn't
  needed.
- Update the run/Compose examples and `docs/CONTAINER_CONFIG.md` to the new
  profile, on a named volume so first-run PKI/config generation succeeds under
  `cap_drop: ALL`.

## Why SETUID/SETGID are required

The image's installer generates a `server.conf` with `user nobody` / `group
nogroup`, so OpenVPN drops privileges after init. Under `cap_drop: ALL` that
drop (`setgroups`/`setgid`/`setuid` to `nobody`) needs `CAP_SETUID` and
`CAP_SETGID` — a root euid does not bypass the capability check — and OpenVPN
treats a failed drop as fatal. So `NET_ADMIN` alone is insufficient; the correct
minimal set is `NET_ADMIN + SETUID + SETGID`. Add `NET_BIND_SERVICE` only if you
configure OpenVPN to bind an internal port below 1024 (the default 1194 does not
need it).

## Scope notes

This documents the OpenVPN **server worker** dropping to `nobody`; it is not a
fully rootless container — the entrypoint's iptables wrapper and PAM/OTP auth
keep a root helper. Three follow-ups are tracked separately:

- #910 — add an e2e that exercises the runtime privilege drop under the reduced
  profile (needs a real tun device the current CI e2e doesn't stand up).
- #911 — the hardened-openvpn blog post still publishes an out-of-date
  `NET_ADMIN`-only capability config.
- #912 — the entrypoint has no clean unattended restart lifecycle; the docs now
  state this explicitly rather than implying one.

## Verification

- Full unit/integration suite green (2036/2036).
- The capability requirement was validated directly — a `setuid` to `nobody`
  under `cap_drop: ALL` fails with only `NET_ADMIN` and succeeds once
  `SETUID`/`SETGID` are added — and cross-checked against the kernel capability
  semantics for `setgroups(2)`/`setgid(2)`/`setuid(2)`.
- Compose/YAML linted; docs render-checked. The real-Docker image build runs in
  CI.
