### PR TITLE
test(openvpn): assert the non-root privilege drop in the e2e

### DIFF
--- a/openvpn/test.sh
+++ b/openvpn/test.sh
@@ -28,4 +28,144 @@ else
     echo "  ⚠️  iptables not found"
 fi
 
+# Assert EVERY OpenVPN server daemon dropped to the unprivileged nobody/nogroup
+# user and holds no capabilities. The container runs under cap_drop:ALL +
+# NET_ADMIN + SETUID + SETGID with AUTO_INSTALL/AUTO_START (set in
+# tests/e2e-test.sh), so it generates the PKI then starts openvpn, which drops
+# per its server.conf's `user nobody` / `group nogroup`. That drop needs
+# CAP_SETUID/CAP_SETGID under cap_drop:ALL and OpenVPN aborts if it fails, so a
+# root daemon (or a container that exited) means the reduced profile is broken.
+# PKI generation can take ~30-60s, so poll until a daemon reaches its dropped
+# state before asserting the full credential + capability set.
+echo "  Checking OpenVPN daemon(s) dropped to nobody/nogroup with no held caps..."
+
+# Expected ids resolved from the container (the drop is name-based, so read the
+# real ids rather than hard-coding 65534/65533). Unresolvable => hard failure,
+# never a guess: a wrong expected id could false-pass or false-fail the drop.
+nobody_uid=$(docker exec "$CONTAINER_NAME" id -u nobody 2>/dev/null || true)
+nogroup_gid=$(docker exec "$CONTAINER_NAME" sh -c 'getent group nogroup 2>/dev/null | cut -d: -f3' 2>/dev/null || true)
+if [ -z "$nobody_uid" ] || [ -z "$nogroup_gid" ]; then
+    echo "  ❌ could not resolve nobody uid ('$nobody_uid') / nogroup gid ('$nogroup_gid') in the container — cannot verify the drop"
+    exit 1
+fi
+
+# Verify one daemon PID's FULL dropped state. Re-reads /proc/cmdline first so a
+# reused PID is rejected, then requires real+eff+saved+fs UID == nobody,
+# real+eff+saved+fs GID == nogroup, supplementary groups ⊆ {nogroup}, and the
+# held capability sets (Inh/Prm/Eff/Amb) all empty (Bnd is the ceiling, allowed).
+assert_daemon_dropped() {
+    local pid="$1" cmd st uid_line gid_line groups_line want_uid want_gid capname capval fail=0
+    # Re-read the cmdline to reject a reused PID whose args no longer match the
+    # openvpn server. (We can't use /proc/$pid/exe here: once openvpn drops to
+    # nobody its dumpable flag is 0, so /proc/$pid/exe is only readable with
+    # CAP_SYS_PTRACE — which this hardened profile deliberately does not grant.)
+    cmd=$(docker exec "$CONTAINER_NAME" sh -c "tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null" 2>/dev/null || true)
+    case "$cmd" in
+        *openvpn*--config*) : ;;
+        *) echo "    ❌ pid $pid is no longer the openvpn server (cmdline='$cmd')"; return 1 ;;
+    esac
+    st=$(docker exec "$CONTAINER_NAME" cat "/proc/$pid/status" 2>/dev/null)
+    [ -n "$st" ] || { echo "    ❌ pid $pid: /proc status unreadable"; return 1; }
+
+    uid_line=$(printf '%s\n' "$st" | awk '/^Uid:/{print $2, $3, $4, $5}')
+    gid_line=$(printf '%s\n' "$st" | awk '/^Gid:/{print $2, $3, $4, $5}')
+    groups_line=$(printf '%s\n' "$st" | awk '/^Groups:/{$1=""; sub(/^[ \t]+/,""); print}')
+    want_uid="$nobody_uid $nobody_uid $nobody_uid $nobody_uid"
+    want_gid="$nogroup_gid $nogroup_gid $nogroup_gid $nogroup_gid"
+
+    [ "$uid_line" = "$want_uid" ] || { echo "    ❌ pid $pid Uid='$uid_line' (real eff saved fs), expected all $nobody_uid"; fail=1; }
+    [ "$gid_line" = "$want_gid" ] || { echo "    ❌ pid $pid Gid='$gid_line', expected all $nogroup_gid"; fail=1; }
+    case "$groups_line" in
+        ""|"$nogroup_gid") : ;;
+        *) echo "    ❌ pid $pid supplementary Groups='$groups_line', expected empty or $nogroup_gid"; fail=1 ;;
+    esac
+    for capname in CapInh CapPrm CapEff CapAmb; do
+        capval=$(printf '%s\n' "$st" | awk -v k="^${capname}:" '$0 ~ k {print $2}')
+        case "$capval" in
+            0000000000000000) : ;;
+            *) echo "    ❌ pid $pid $capname='$capval', expected 0000000000000000"; fail=1 ;;
+        esac
+    done
+    return "$fail"
+}
+
+# Classify a container that exited before the drop could be verified. A failed
+# privilege drop (missing SETUID/SETGID) is a HARD failure — that is exactly the
+# regression this test exists to catch. A first-run install that could not fetch
+# EasyRSA from GitHub (this image downloads it at runtime) is an infrastructure /
+# network problem, not a privilege regression, so it SKIPs loudly rather than
+# reporting a false red. Anything else fails, so unknown breakage is never hidden.
+classify_exit_and_leave() {
+    if printf '%s\n' "$last_logs" | grep -qiE 'set(gid|uid|groups).*failed|Operation not permitted'; then
+        echo "  ❌ openvpn aborted on its privilege drop — the reduced capability profile is broken"
+        printf '%s\n' "$last_logs" | tail -30
+        exit 1
+    elif printf '%s\n' "$last_logs" | grep -qiE 'Could not download EasyRSA|wget:|curl:|Could not resolve|Temporary failure in name resolution|api\.github\.com'; then
+        echo "  ⚠️  SKIPPED: first-run install could not fetch EasyRSA from GitHub (network / rate-limit)."
+        echo "  ⚠️  The openvpn privilege drop was NOT verified this run — infrastructure issue, not a regression."
+        exit 0
+    else
+        echo "  ❌ container exited before the openvpn daemon started (cause unclear)"
+        printf '%s\n' "$last_logs" | tail -40
+        exit 1
+    fi
+}
+
+drop_deadline=$((SECONDS + 150))
+last_logs=""
+pids=""
+while [ "$SECONDS" -lt "$drop_deadline" ]; do
+    # Snapshot logs while the container still exists (e2e runs it with --rm, so
+    # after an early exit the logs are gone — keep the last good copy).
+    logs=$(docker logs "$CONTAINER_NAME" 2>/dev/null) && [ -n "$logs" ] && last_logs="$logs"
+
+    if ! docker ps --format '{{.Names}}' | grep -Fxq -- "$CONTAINER_NAME"; then
+        classify_exit_and_leave
+    fi
+
+    # ALL server daemons (processes with --config) — not the `openvpn --version`
+    # healthcheck (no --config), not the root ovpn bash wrapper. [o] avoids the
+    # awk process matching itself.
+    pids=$(docker exec "$CONTAINER_NAME" sh -c \
+        "ps -eo pid,args 2>/dev/null | awk '/[o]penvpn.*--config/{print \$1}'" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        # Break only once EVERY current daemon has left the transient root phase,
+        # so a still-starting sibling never triggers a premature false failure.
+        all_dropped=1
+        for p in $pids; do
+            ru=$(docker exec "$CONTAINER_NAME" sh -c "awk '/^Uid:/{print \$2}' /proc/$p/status 2>/dev/null" 2>/dev/null || true)
+            { [ -n "$ru" ] && [ "$ru" != "0" ]; } || all_dropped=0
+        done
+        [ "$all_dropped" = 1 ] && break
+    fi
+    sleep 3
+done
+
+if [ -z "$pids" ]; then
+    # Never saw a server daemon — distinguish a crash (classify) from a hang.
+    docker ps --format '{{.Names}}' | grep -Fxq -- "$CONTAINER_NAME" || classify_exit_and_leave
+    echo "  ❌ no openvpn server daemon (--config) found within timeout"
+    [ -n "$last_logs" ] && printf '%s\n' "$last_logs" | tail -40
+    exit 1
+fi
+
+# EVERY daemon must be fully dropped — one root/capped process fails the test.
+all_ok=1
+count=0
+for p in $pids; do
+    count=$((count + 1))
+    if assert_daemon_dropped "$p"; then
+        echo "    ✅ pid $p: UID/GID all nobody/nogroup, no held caps"
+    else
+        all_ok=0
+    fi
+done
+
+if [ "$all_ok" -ne 1 ]; then
+    echo "  ❌ privilege drop assertion FAILED ($count daemon process(es) checked)"
+    [ -n "$last_logs" ] && printf '%s\n' "$last_logs" | tail -40
+    exit 1
+fi
+echo "  ✅ all $count openvpn server daemon(s) dropped to nobody/nogroup with no held capabilities"
+
 echo "  ✅ All OpenVPN tests passed"

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -116,7 +116,16 @@ test_container() {
             run_opts="$run_opts -e POSTGRES_PASSWORD=test -e POSTGRES_USER=test -e POSTGRES_DB=test"
             ;;
         openvpn)
-            run_opts="$run_opts --cap-add NET_ADMIN --device /dev/net/tun:/dev/net/tun"
+            # Run under the shipped hardened profile so the e2e actually exercises
+            # the privilege drop: cap_drop:ALL + NET_ADMIN (tun/routes) + SETUID/SETGID
+            # (the drop to nobody). AUTO_INSTALL/AUTO_START generate the config and
+            # start the server; ENDPOINT is pinned so the installer never reaches out
+            # for public-IP detection. openvpn/test.sh asserts the daemon runs as nobody.
+            run_opts="$run_opts --cap-drop ALL --cap-add NET_ADMIN --cap-add SETUID --cap-add SETGID"
+            run_opts="$run_opts --security-opt no-new-privileges --device /dev/net/tun:/dev/net/tun"
+            run_opts="$run_opts --sysctl net.ipv4.ip_forward=1 --sysctl net.ipv4.conf.all.forwarding=1"
+            run_opts="$run_opts --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1"
+            run_opts="$run_opts -e AUTO_INSTALL=y -e AUTO_START=y -e ENDPOINT=127.0.0.1"
             ;;
         ansible|debian)
             # These need a command to stay running


### PR DESCRIPTION
Closes #910.

Gives the openvpn e2e real coverage of the runtime privilege drop. It now runs the container under the shipped hardened profile (`cap_drop:ALL` + `NET_ADMIN` + `SETUID` + `SETGID`, forwarding sysctls, `AUTO_INSTALL`/`AUTO_START`, pinned `ENDPOINT`) and asserts that **every** openvpn server daemon runs as `nobody`/`nogroup` — checking real+effective+saved+fs UID and GID plus supplementary groups — and holds **no** capabilities (CapInh/Prm/Eff/Amb all empty). Previously it started openvpn with `NET_ADMIN` only and checked just `openvpn --version`, so a broken drop went completely uncaught.

The daemon is matched by its `--config` argv (not the `openvpn --version` healthcheck, not the root `ovpn` wrapper), and the loop waits until every current daemon has left its transient root phase before asserting. Unresolvable `nobody`/`nogroup` ids are a hard failure, never a guess.

First-run setup pulls the EasyRSA tarball from GitHub releases (the rate-limited API version probe is already avoided by the image's pinned `EASYRSA_VERSION`; see #918 for the remaining offline note). A fetch failure is classified as a **loud skip**, while a failed privilege drop (`setgid`/`setuid` EPERM) is a hard failure — so the test fails on privilege regressions, not on network blips.

## Verification

Validated end-to-end against the real image with a live `/dev/net/tun` (rootless podman on WSL2): the assertion passes on the reduced profile (daemon `nobody:nogroup`, zero caps, confirmed via `/proc/<pid>/status`) and **fails** on `NET_ADMIN`-only (the container aborts on the fatal drop, `setgid('nogroup') failed: Operation not permitted`). Full bats suite green; shellcheck clean.