### PR TITLE
fix(ci): scope PR container detection to the merge-base diff, not two-dot

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -263,6 +263,8 @@ runs:
         source "${GITHUB_ACTION_PATH}/../../../helpers/coverage-checkpoint-utils.sh"
         # shellcheck disable=SC1091  # path resolved at runtime in the action dir
         source "${GITHUB_ACTION_PATH}/../../../helpers/container-scopes.sh"
+        # shellcheck disable=SC1091  # path resolved at runtime in the action dir
+        source "${GITHUB_ACTION_PATH}/../../../helpers/pr-changed-files.sh"
         diff_rc=0
         changed_files=""
         coverage_fallback=false
@@ -344,12 +346,19 @@ runs:
             set -e
             [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (push/non-master event.before..after)"; changed_files=""; }
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs, compare with base and head SHAs from the event (robust, does not require fetch)
+            # PRs diff merge-base..head: only PR-owned changes, excluding base-only changes.
             set +e
-            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null)
+            changed_files=$(pr_changed_files \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}")
             diff_rc=$?
             set -e
-            [[ $diff_rc -ne 0 ]] && { echo "⚠️ Git diff failed (pull request event)"; changed_files=""; }
+            if [[ $diff_rc -ne 0 ]]; then
+              echo "⚠️  PR diff could not be scoped from merge-base..head; " \
+                "building all containers with retained version expansion"
+              coverage_fallback=true
+              changed_files=""
+            fi
           else
             # For manual triggers (workflow_dispatch)
             # rebuild != none OR force_rebuild=true → build ALL containers

--- a/helpers/pr-changed-files.sh
+++ b/helpers/pr-changed-files.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Helpers for PR changed-file detection.
+
+set -euo pipefail
+
+pr_changed_files() {
+    if [[ $# -ne 2 ]]; then
+        echo "usage: pr_changed_files <base_sha> <head_sha>" >&2
+        return 2
+    fi
+
+    local base="$1"
+    local head="$2"
+    local mb
+
+    mb="$(git merge-base "$base" "$head" 2>/dev/null || true)"
+
+    if [[ -z "$mb" ]]; then
+        echo "warning: merge-base unavailable for PR diff; refusing unsafe two-dot fallback" >&2
+        return 3
+    fi
+
+    git diff --name-only --no-renames "$mb" "$head"
+}
+
+export -f pr_changed_files

--- a/tests/unit/pr-changed-files.bats
+++ b/tests/unit/pr-changed-files.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+    ORIG_DIR="$PWD"
+    TEST_DIR=$(mktemp -d)
+    HELPER="$BATS_TEST_DIRNAME/../../helpers/pr-changed-files.sh"
+    # shellcheck source=../../helpers/pr-changed-files.sh
+    source "$HELPER"
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+init_repo() {
+    local repo="$1"
+    mkdir -p "$repo"
+    cd "$repo" || return 1
+    git init -q
+    git symbolic-ref HEAD refs/heads/master
+    mkdir -p "$repo/.git/hooks-disabled"
+    git config core.hooksPath "$repo/.git/hooks-disabled"
+    git config commit.gpgSign false
+    git config tag.gpgSign false
+    git config user.email "test@example.com"
+    git config user.name "Test"
+}
+
+commit_file() {
+    local path="$1"
+    local content="$2"
+    local message="$3"
+
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+    git add "$path"
+    git commit -q -m "$message"
+}
+
+@test "regression: PR diff excludes files changed only on advanced base" {
+    init_repo "$TEST_DIR/regression"
+    commit_file "a" "base" "test: add base"
+    base_sha=$(git rev-parse HEAD)
+
+    git checkout -q -b feat
+    commit_file "pr.txt" "pr" "test: add pr file"
+    feat_head_sha=$(git rev-parse HEAD)
+
+    git checkout -q master
+    git checkout -q -b advanced-base "$base_sha"
+    commit_file "master-only.txt" "master" "test: add base-only file"
+    advanced_base_sha=$(git rev-parse HEAD)
+
+    run pr_changed_files "$advanced_base_sha" "$feat_head_sha"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "pr.txt" ]
+    [[ "$output" != *"master-only.txt"* ]]
+}
+
+@test "happy path: branch adding one file returns that file" {
+    init_repo "$TEST_DIR/happy"
+    commit_file "a" "base" "test: add base"
+    base_sha=$(git rev-parse HEAD)
+
+    git checkout -q -b feat
+    commit_file "one.txt" "one" "test: add one file"
+    head_sha=$(git rev-parse HEAD)
+
+    run pr_changed_files "$base_sha" "$head_sha"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "one.txt" ]
+}
+
+@test "branch with no changes since merge-base returns empty output and exit 0" {
+    init_repo "$TEST_DIR/no-changes"
+    commit_file "a" "base" "test: add base"
+    base_sha=$(git rev-parse HEAD)
+
+    git checkout -q -b feat
+    head_sha=$(git rev-parse HEAD)
+
+    run pr_changed_files "$base_sha" "$head_sha"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "rename emits both old and new paths" {
+    init_repo "$TEST_DIR/rename"
+    commit_file "postgres/foo" "base" "test: add postgres file"
+    base_sha=$(git rev-parse HEAD)
+
+    git checkout -q -b feat
+    mkdir -p openresty
+    git mv postgres/foo openresty/foo
+    git commit -q -m "test: move file between containers"
+    head_sha=$(git rev-parse HEAD)
+
+    run pr_changed_files "$base_sha" "$head_sha"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"postgres/foo"* ]]
+    [[ "$output" == *"openresty/foo"* ]]
+}
+
+@test "misuse: wrong arg count returns non-zero and writes usage to stderr" {
+    run --separate-stderr pr_changed_files "only-one-arg"
+
+    [ "$status" -ne 0 ]
+    [ "$output" = "" ]
+    [[ "$stderr" == *"usage: pr_changed_files <base_sha> <head_sha>"* ]]
+}
+
+@test "merge-base unavailable returns non-zero without unsafe two-dot fallback" {
+    init_repo "$TEST_DIR/unrelated"
+    commit_file "base-only.txt" "base" "test: add base root"
+    base_sha=$(git rev-parse HEAD)
+
+    git checkout -q --orphan other
+    git rm -q -rf .
+    commit_file "head-only.txt" "head" "test: add head root"
+    head_sha=$(git rev-parse HEAD)
+
+    run --separate-stderr pr_changed_files "$base_sha" "$head_sha"
+
+    [ "$status" -eq 3 ]
+    [ "$output" = "" ]
+    [[ "$stderr" == *"merge-base unavailable for PR diff"* ]]
+    [[ "$stderr" == *"refusing unsafe two-dot fallback"* ]]
+}


### PR DESCRIPTION
## What

Scope PR container detection to the **merge-base** diff so a pull request no longer
rebuilds containers that changed on `master` since the PR branch point.

`detect-containers` compared the PR base and head with a two-dot `git diff base head`,
which surfaces files changed on the base branch that the PR branch simply lacks. A
container updated on `master` after a PR was opened (e.g. a `terraform` dep bump) got
rebuilt — with its whole retained matrix — by unrelated PRs. (Broader sibling of #872.)

## How

- New `helpers/pr-changed-files.sh` — `pr_changed_files <base> <head>` diffs
  `merge-base(base, head)..head` (only the PR's own changes), with `--no-renames` to
  match the push paths (so a rename still flags its source container). If the merge-base
  cannot be resolved it returns non-zero rather than silently under-detecting via a
  two-dot diff.
- `detect-containers` PR path uses the helper and, if it can't scope the diff, **fails
  safe** by building all containers (never silently builds nothing).

## Verification

- `tests/unit/pr-changed-files.bats` — regression lock (base-only changes excluded),
  rename detection, empty-diff, misuse, and the merge-base-unavailable fail-closed case;
  the test repos are hermetic (own git identity, signing disabled).
- Full unit suite green; `shellcheck` clean.
- Only the `pull_request` path changes; the push / dispatch / coverage-checkpoint paths
  are untouched.

Closes #926
