### PR TITLE
ci(e2e): run container smoke tests on pull requests

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -89,6 +89,9 @@ outputs:
   matrix_builds:
     description: 'JSON array of builds routed to the flat matrix engine (all non-bake containers)'
     value: ${{ steps.split-build-engine.outputs.matrix_builds }}
+  e2e_builds:
+    description: 'JSON array of changed latest Linux builds eligible for e2e tests'
+    value: ${{ steps.split-build-engine.outputs.e2e_builds }}
   extension_builds:
     description: 'JSON array of distinct detected containers that have extensions/config.yaml'
     value: ${{ steps.split-build-engine.outputs.extension_builds }}
@@ -707,13 +710,37 @@ runs:
         extension_builds=$(extension_containers_in "$builds_input" "any")
         bake_final_builds=$(extension_containers_in "$bake_builds" "final")
         postgres_matrix_builds=$(echo "$matrix_builds" | jq -c '[.[] | select(.container == "postgres")]')
+        e2e_builds='[]'
+
+        while IFS= read -r build; do
+          [[ -z "$build" ]] && continue
+
+          container=$(echo "$build" | jq -r '.container // ""')
+          is_latest_version=$(echo "$build" | jq -r '.is_latest_version // false')
+          os=$(echo "$build" | jq -r '.os // "linux"')
+
+          if [[ -z "$container" || "$is_latest_version" != "true" || "$os" == "windows" ]]; then
+            continue
+          fi
+
+          e2e_enabled=false
+          if [[ -f "$container/variants.yaml" ]]; then
+            e2e_enabled=$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null || echo "false")
+          fi
+
+          if [[ "$e2e_enabled" == "true" ]]; then
+            e2e_builds=$(jq -c --argjson build "$build" '. + [$build]' <<< "$e2e_builds")
+          fi
+        done < <(echo "$builds_input" | jq -c '.[]')
 
         bake_count=$(echo "$bake_builds" | jq 'length')
         matrix_count=$(echo "$matrix_builds" | jq 'length')
+        e2e_count=$(echo "$e2e_builds" | jq 'length')
 
         echo "bake_builds=$bake_builds" >> "$GITHUB_OUTPUT"
         echo "matrix_builds=$matrix_builds" >> "$GITHUB_OUTPUT"
+        echo "e2e_builds=$e2e_builds" >> "$GITHUB_OUTPUT"
         echo "extension_builds=$extension_builds" >> "$GITHUB_OUTPUT"
         echo "bake_final_builds=$bake_final_builds" >> "$GITHUB_OUTPUT"
         echo "postgres_matrix_builds=$postgres_matrix_builds" >> "$GITHUB_OUTPUT"
-        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count (force_matrix=${force_matrix} event=${EVENT_NAME})"
+        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count e2e=$e2e_count (force_matrix=${force_matrix} event=${EVENT_NAME})"

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -282,13 +282,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Least privilege: this job checks out and runs branch-controlled build/test
-    # code. It needs the tree (read) and packages:write only so the build's
-    # registry buildcache (--cache-to) can write the owner's own cache; it does
-    # NOT need the workflow's global id-token / attestations / security-events /
-    # issues grants.
+    # code. It reads the tree and the shared registry cache/base mirror only —
+    # it never writes the cache or pushes an image (see BUILD_CACHE_EXPORT below),
+    # so packages:read is enough and none of the workflow's global id-token /
+    # attestations / security-events / issues grants are needed.
     permissions:
       contents: read
-      packages: write
+      packages: read
+    env:
+      # Throwaway PR build: read the shared registry cache but never export it,
+      # so PR-built layers can't land in the canonical <ref>:buildcache
+      # (mirrors the bake engine's PR guard).
+      BUILD_CACHE_EXPORT: 'false'
     strategy:
       fail-fast: false
       matrix:
@@ -317,11 +322,11 @@ jobs:
           variant: ${{ matrix.build.variant }}
           dockerfile: ${{ matrix.build.dockerfile }}
           platform: linux/amd64
-          use_base_cache: 'false'
+          # Use the production base path (default GHCR mirror + REMOTE_CR) so the
+          # e2e build exercises the same base source as normal builds and avoids
+          # anonymous Docker Hub pulls.
           scan_vulnerabilities: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          REMOTE_CR: docker.io
 
       - name: Run e2e
         shell: bash

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -242,6 +242,7 @@ jobs:
       builds_count: ${{ steps.detect.outputs.builds_count }}
       bake_builds: ${{ steps.detect.outputs.bake_builds }}
       matrix_builds: ${{ steps.detect.outputs.matrix_builds }}
+      e2e_builds: ${{ steps.detect.outputs.e2e_builds }}
       extension_builds: ${{ steps.detect.outputs.extension_builds }}
       bake_final_builds: ${{ steps.detect.outputs.bake_final_builds }}
       postgres_matrix_builds: ${{ steps.detect.outputs.postgres_matrix_builds }}
@@ -270,6 +271,60 @@ jobs:
           event_name: ${{ github.event_name }}
           build_all_retained: ${{ github.event.inputs.build_all_retained || inputs.build_all_retained || false }}
           run_tests: ${{ github.event.inputs.run_tests || inputs.run_tests || 'false' }}
+
+  e2e-test:
+    name: E2E ${{ matrix.build.container }}:${{ matrix.build.tag }}
+    needs: [detect-containers]
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+      && needs.detect-containers.outputs.e2e_builds != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        build: ${{ fromJson(needs.detect-containers.outputs.e2e_builds) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Ensure /dev/net/tun
+        shell: bash
+        run: sudo modprobe tun 2>/dev/null || { sudo mkdir -p /dev/net && sudo mknod /dev/net/tun c 10 200 && sudo chmod 600 /dev/net/tun; }; test -c /dev/net/tun
+
+      - name: Build loadable e2e image
+        uses: ./.github/actions/build-container
+        with:
+          container: ${{ matrix.build.container }}
+          version: ${{ matrix.build.version }}
+          tag: ${{ matrix.build.tag }}
+          platform: linux/amd64
+          use_base_cache: 'false'
+          scan_vulnerabilities: 'false'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REMOTE_CR: docker.io
+
+      - name: Run e2e
+        shell: bash
+        run: |
+          E2E_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.build.container }}:${{ matrix.build.tag }}" \
+            tests/e2e-test.sh "${{ matrix.build.container }}"
+
+  e2e-gate:
+    name: e2e-gate
+    needs: [detect-containers, e2e-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          r='${{ needs.e2e-test.result }}'
+          case "$r" in
+            success|skipped) echo "e2e-gate PASS ($r)" ;;
+            *) echo "e2e-gate FAIL ($r)"; exit 1 ;;
+          esac
 
   # Build and push PostgreSQL extension images if postgres is in the build list.
   # Runs as a two-leg arch matrix (amd64 + arm64) on native runners so each leg

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -281,6 +281,14 @@ jobs:
       && needs.detect-containers.outputs.e2e_builds != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Least privilege: this job checks out and runs branch-controlled build/test
+    # code. It needs the tree (read) and packages:write only so the build's
+    # registry buildcache (--cache-to) can write the owner's own cache; it does
+    # NOT need the workflow's global id-token / attestations / security-events /
+    # issues grants.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -288,6 +296,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Ensure /dev/net/tun
         shell: bash
@@ -299,6 +309,13 @@ jobs:
           container: ${{ matrix.build.container }}
           version: ${{ matrix.build.version }}
           tag: ${{ matrix.build.tag }}
+          # Pass the full build cell through so an e2e-enabled variant / alternate
+          # Dockerfile builds and tests the SAME image the detector selected.
+          # (Current opt-ins are flavor-less, so these are empty today.)
+          flavor: ${{ matrix.build.flavor }}
+          build_flavor: ${{ matrix.build.build_flavor }}
+          variant: ${{ matrix.build.variant }}
+          dockerfile: ${{ matrix.build.dockerfile }}
           platform: linux/amd64
           use_base_cache: 'false'
           scan_vulnerabilities: 'false'
@@ -308,22 +325,33 @@ jobs:
 
       - name: Run e2e
         shell: bash
+        env:
+          OWNER: ${{ github.repository_owner }}
+          CONTAINER: ${{ matrix.build.container }}
+          TAG: ${{ matrix.build.tag }}
         run: |
-          E2E_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.build.container }}:${{ matrix.build.tag }}" \
-            tests/e2e-test.sh "${{ matrix.build.container }}"
+          E2E_IMAGE="ghcr.io/${OWNER}/${CONTAINER}:${TAG}" \
+            tests/e2e-test.sh "${CONTAINER}"
 
   e2e-gate:
     name: e2e-gate
     needs: [detect-containers, e2e-test]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - shell: bash
         run: |
+          d='${{ needs.detect-containers.result }}'
           r='${{ needs.e2e-test.result }}'
+          # A detection failure means we never computed what to test — do not pass.
+          if [ "$d" != "success" ]; then
+            echo "e2e-gate FAIL (detect-containers=$d)"; exit 1
+          fi
           case "$r" in
-            success|skipped) echo "e2e-gate PASS ($r)" ;;
-            *) echo "e2e-gate FAIL ($r)"; exit 1 ;;
+            success|skipped) echo "e2e-gate PASS (detect=$d e2e=$r)" ;;
+            *) echo "e2e-gate FAIL (e2e-test=$r)"; exit 1 ;;
           esac
 
   # Build and push PostgreSQL extension images if postgres is in the build list.

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -3401,7 +3401,7 @@ jobs:
           echo "failed_this_run=${ftr_safe}" >> "$GITHUB_OUTPUT"
 
   summary:
-    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries, publish-coverage-checkpoint, bake-build-amd64, bake-build-arm64, bake-merge, bake-attest]
+    needs: [detect-containers, build-extensions, merge-extension-manifests, build-and-push, create-manifest, sync-registries, publish-coverage-checkpoint, bake-build-amd64, bake-build-arm64, bake-merge, bake-attest, e2e-gate]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -3441,6 +3441,9 @@ jobs:
           # (a dedicated GHCR→DockerHub sync, not a non-blocking by design).
           # A 'skipped' result is NOT a failure (non-postgres builds legitimately
           # skip the extension jobs).
+          # e2e-gate is included: it aggregates the container e2e run and passes
+          # on a legitimate skip (non-PR / no eligible change), so its failure
+          # means a container e2e regression that must surface as a build failure.
           # ---------------------------------------------------------------
           detect_result="${{ needs.detect-containers.result }}"
           bap_result="${{ needs.build-and-push.result }}"
@@ -3450,13 +3453,15 @@ jobs:
           bake_amd64_result="${{ needs.bake-build-amd64.result }}"
           bake_arm64_result="${{ needs.bake-build-arm64.result }}"
           bake_merge_result="${{ needs.bake-merge.result }}"
+          e2egate_result="${{ needs.e2e-gate.result }}"
           dry_run_flag="${{ env.DRY_RUN }}"
 
           # build_failed: any monitored pipeline job failed or cancelled.
           # Includes bake jobs so a bake-only master run surfaces failures correctly.
           build_failed=false
           for _r in "$detect_result" "$bap_result" "$bex_result" "$mem_result" "$cm_result" \
-                    "$bake_amd64_result" "$bake_arm64_result" "$bake_merge_result"; do
+                    "$bake_amd64_result" "$bake_arm64_result" "$bake_merge_result" \
+                    "$e2egate_result"; do
             if [ "$_r" = "failure" ] || [ "$_r" = "cancelled" ]; then
               build_failed=true
             fi

--- a/ansible/variants.yaml
+++ b/ansible/variants.yaml
@@ -1,6 +1,9 @@
 # Ansible Container Variants
 build:
   version_retention: 3
+tests:
+  e2e:
+    enabled: true
 versions:
   - tag: 14.2.0-ubuntu
   - tag: 14.1.0-ubuntu

--- a/debian/variants.yaml
+++ b/debian/variants.yaml
@@ -1,6 +1,9 @@
 # Debian Container Variants
 build:
   version_retention: 3
+tests:
+  e2e:
+    enabled: true
 
 versions:
   - tag: "trixie"

--- a/openvpn/variants.yaml
+++ b/openvpn/variants.yaml
@@ -1,6 +1,9 @@
 # OpenVPN Container Variants
 build:
   version_retention: 3
+tests:
+  e2e:
+    enabled: true
 versions:
   - tag: v2.7.5-alpine
   - tag: v2.7.4-alpine

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -97,9 +97,20 @@ _configure_cache() {
     _RUNTIME_INFO=""
 
     if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-        _CACHE_ARGS="--cache-from type=registry,ref=$cache_image --cache-to type=registry,ref=$cache_image,mode=max"
-        _RUNTIME_INFO="GitHub Actions (registry cache)"
-        log_success "Using registry cache: $cache_image"
+        # Always read from the shared registry cache. Exporting (--cache-to)
+        # writes the canonical <ref>:buildcache; throwaway PR builds (e.g. the
+        # e2e job) set BUILD_CACHE_EXPORT=false so PR-built layers never land in
+        # the canonical cache — matching the bake engine's PR guard. Default
+        # keeps export on so normal builds are unchanged.
+        _CACHE_ARGS="--cache-from type=registry,ref=$cache_image"
+        if [[ "${BUILD_CACHE_EXPORT:-true}" == "true" ]]; then
+            _CACHE_ARGS="$_CACHE_ARGS --cache-to type=registry,ref=$cache_image,mode=max"
+            _RUNTIME_INFO="GitHub Actions (registry cache)"
+            log_success "Using registry cache: $cache_image"
+        else
+            _RUNTIME_INFO="GitHub Actions (registry cache, export disabled)"
+            log_success "Using registry cache (read-only, export disabled): $cache_image"
+        fi
     elif docker version 2>/dev/null | grep -q "Docker Engine"; then
         if docker pull "$cache_image" 2>/dev/null; then
             _CACHE_ARGS="--cache-from type=registry,ref=$cache_image"

--- a/sslh/test.sh
+++ b/sslh/test.sh
@@ -13,12 +13,14 @@ docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1 || \
 docker exec "$CONTAINER_NAME" sslh --version 2>&1 | head -1 || \
 echo "  (version check returned error, may be normal)"
 
-# Check process is running
-echo "  Checking SSLH process..."
-if docker exec "$CONTAINER_NAME" pgrep -f "sslh" &>/dev/null; then
-    echo "  ✅ SSLH process running"
+# The image is FROM scratch (no pgrep/shell), so prove sslh is actually
+# multiplexing by connecting to its listen port with the busybox nc applet
+# that ships in the image — the same tool the container HEALTHCHECK uses.
+echo "  Checking SSLH is listening on 443..."
+if docker exec "$CONTAINER_NAME" /bin/busybox nc -z 127.0.0.1 443; then
+    echo "  ✅ SSLH is listening on 443"
 else
-    echo "  ❌ SSLH not running"
+    echo "  ❌ SSLH not listening on 443"
     exit 1
 fi
 

--- a/sslh/variants.yaml
+++ b/sslh/variants.yaml
@@ -1,6 +1,9 @@
 # SSLH Container Variants
 build:
   version_retention: 3
+tests:
+  e2e:
+    enabled: true
 versions:
   - tag: v2.3.1-alpine
   - tag: "v2.3.0-alpine"

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -10,12 +10,14 @@
 #   ./e2e-test.sh --no-build               # Skip build, use existing images
 #
 # For containers with variants, version is required (e.g., postgres:16)
+# Set E2E_IMAGE=<image-ref> to test a preloaded image directly.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/helpers/logging.sh"
-source "$SCRIPT_DIR/helpers/variant-utils.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$REPO_ROOT/helpers/logging.sh"
+source "$REPO_ROOT/helpers/variant-utils.sh"
 
 BUILD=true
 CONTAINERS=""
@@ -60,13 +62,87 @@ echo "🧪 E2E Container Tests"
 echo "======================"
 echo ""
 
+resolve_e2e_image() {
+    local container="$1"
+    local image_tag="${2:-}"
+
+    if [ -n "${E2E_IMAGE:-}" ]; then
+        printf '%s\n' "$E2E_IMAGE"
+        return 0
+    fi
+
+    if [ -n "$image_tag" ]; then
+        printf 'docker.io/%s/%s:%s\n' "$GITHUB_REPOSITORY_OWNER" "$container" "$image_tag"
+        return 0
+    fi
+
+    local images=""
+    images=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
+
+    local ids
+    ids=$(printf '%s\n' "$images" | awk -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
+        function starts_with(value, prefix) {
+            return substr(value, 1, length(prefix)) == prefix
+        }
+        starts_with($2, "ghcr.io/" owner "/" container ":") ||
+        starts_with($2, "docker.io/" owner "/" container ":") ||
+        starts_with($2, container ":") {
+            print $1
+        }
+    ' | sort -u)
+
+    local count
+    if [ -z "$ids" ]; then
+        count=0
+    else
+        count=$(printf '%s\n' "$ids" | grep -c .)
+    fi
+
+    if [ "$count" -eq 0 ]; then
+        log_error "No image found for $container; build it first, pass container:tag, or set E2E_IMAGE"
+        return 1
+    fi
+
+    if [ "$count" -gt 1 ]; then
+        log_error "Ambiguous local images for $container ($count distinct image IDs); set E2E_IMAGE"
+        printf '%s\n' "$images" | awk -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
+            function starts_with(value, prefix) {
+                return substr(value, 1, length(prefix)) == prefix
+            }
+            starts_with($2, "ghcr.io/" owner "/" container ":") ||
+            starts_with($2, "docker.io/" owner "/" container ":") ||
+            starts_with($2, container ":") {
+                print "  " $1 " " $2
+            }
+        ' >&2
+        return 1
+    fi
+
+    local image
+    image=$(printf '%s\n' "$images" | awk -v id="$ids" -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
+        function starts_with(value, prefix) {
+            return substr(value, 1, length(prefix)) == prefix
+        }
+        $1 == id && (
+            starts_with($2, "ghcr.io/" owner "/" container ":") ||
+            starts_with($2, "docker.io/" owner "/" container ":") ||
+            starts_with($2, container ":")
+        ) {
+            print $2
+            exit
+        }
+    ')
+
+    printf '%s\n' "$image"
+}
+
 # Test a single container (or variant)
 # Usage: test_container <container> [image_tag]
 test_container() {
     local container="$1"
     local image_tag="${2:-}"
     local container_name="e2e-$container"
-    local test_script="$SCRIPT_DIR/$container/test.sh"
+    local test_script="$REPO_ROOT/$container/test.sh"
 
     # Build test name for display
     local test_name="$container"
@@ -75,7 +151,7 @@ test_container() {
     log_step "Testing $test_name..."
 
     # Build if requested (only for non-variant tests or when no tag specified)
-    if [ "$BUILD" = true ] && [ -z "$image_tag" ]; then
+    if [ -z "${E2E_IMAGE:-}" ] && [ "$BUILD" = true ] && [ -z "$image_tag" ]; then
         log_info "Building $container..."
         if ! ./make build "$container" 2>&1 | tail -5; then
             log_error "Build failed for $container"
@@ -85,16 +161,8 @@ test_container() {
 
     # Determine image name
     local image
-    if [ -n "$image_tag" ]; then
-        # Use specific tag provided
-        image="docker.io/$GITHUB_REPOSITORY_OWNER/$container:$image_tag"
-    else
-        # Find the most recently built image for this container
-        image=$(docker images --format '{{.Repository}}:{{.Tag}}' --filter "reference=*/$container:*" | head -1) || true
-        if [ -z "$image" ]; then
-            # Fallback: try local name
-            image=$(docker images --format '{{.Repository}}:{{.Tag}}' --filter "reference=$container:*" | head -1) || true
-        fi
+    if ! image=$(resolve_e2e_image "$container" "$image_tag"); then
+        return 1
     fi
     if [ -z "$image" ]; then
         log_error "No image found for $test_name"
@@ -213,11 +281,22 @@ test_container() {
 
 # Run tests
 for arg in $CONTAINERS; do
+    if [ -n "${E2E_IMAGE:-}" ]; then
+        container="${arg%%:*}"
+        echo ""
+        if test_container "$container"; then
+            PASSED+=("$container")
+        else
+            FAILED+=("$container")
+        fi
+        continue
+    fi
+
     # Check if argument contains a tag (container:tag format)
     if [[ "$arg" == *":"* ]]; then
         container="${arg%%:*}"
         tag_part="${arg#*:}"
-        container_dir="$SCRIPT_DIR/$container"
+        container_dir="$REPO_ROOT/$container"
 
         # Determine if tag_part is a version (e.g., "16") or a full tag (e.g., "16-full-alpine")
         if [[ "$tag_part" =~ ^[0-9]+$ ]]; then
@@ -272,7 +351,7 @@ for arg in $CONTAINERS; do
         fi
     else
         container="$arg"
-        container_dir="$SCRIPT_DIR/$container"
+        container_dir="$REPO_ROOT/$container"
 
         # Check if container has variants
         if has_variants "$container_dir"; then

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -200,8 +200,13 @@ test_container() {
             run_cmd="sleep infinity"
             ;;
         sslh)
-            # SSLH needs explicit config to start - use test mode
-            run_cmd="sslh-ev --foreground -p 0.0.0.0:8443 --ssh 127.0.0.1:22 --tls 127.0.0.1:443"
+            # sslh-ev is the image ENTRYPOINT, so pass ARGS ONLY (no binary name,
+            # else it runs "sslh-ev sslh-ev ..." with a bogus first argument).
+            # Listen on 443 to satisfy the image HEALTHCHECK (busybox nc -z 443);
+            # the image runs as nobody, so grant NET_BIND_SERVICE to bind the
+            # privileged port. Backends need not be reachable for sslh to listen.
+            run_opts="$run_opts --cap-add NET_BIND_SERVICE"
+            run_cmd="--foreground -p 0.0.0.0:443 --ssh 127.0.0.1:22 --tls 127.0.0.1:8443"
             ;;
     esac
 

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -288,6 +288,38 @@ EOF
     unset GITHUB_REPOSITORY_OWNER
 }
 
+@test "build_container omits cache export when BUILD_CACHE_EXPORT=false" {
+    export GITHUB_ACTIONS="true"
+    export MULTIPLATFORM_SUPPORTED="false"
+    export GITHUB_REPOSITORY_OWNER="testowner"
+    export BUILD_CACHE_EXPORT="false"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" << 'EOF'
+#!/bin/bash
+echo "ARGS: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    create_mock_container "testcontainer" "1.0.0"
+
+    source_build_script
+
+    cd "$TEST_TEMP_DIR"
+    run build_container "testcontainer" "1.0.0" "1.0.0"
+
+    # Still READS the shared cache (fast builds)...
+    grep -q "cache-from" "$TEST_TEMP_DIR/docker_calls.log"
+    # ...but never WRITES it, so throwaway/PR builds can't poison :buildcache
+    ! grep -q "cache-to" "$TEST_TEMP_DIR/docker_calls.log"
+
+    unset GITHUB_ACTIONS
+    unset GITHUB_REPOSITORY_OWNER
+    unset BUILD_CACHE_EXPORT
+}
+
 # =============================================================================
 # build_container tagging tests
 # =============================================================================

--- a/tests/unit/detect-e2e-builds.bats
+++ b/tests/unit/detect-e2e-builds.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+}
+
+teardown() {
+    unset BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS GITHUB_ACTION_PATH GITHUB_OUTPUT
+    teardown_temp_dir
+}
+
+run_split_build_engine_step() {
+    local builds="$1"
+    local script="$TEST_TEMP_DIR/split-build-engine.sh"
+    yq -r '.runs.steps[] | select(.id == "split-build-engine") | .run' \
+        "$PROJECT_ROOT/.github/actions/detect-containers/action.yaml" > "$script"
+
+    export BUILDS="$builds"
+    export EVENT_NAME="pull_request"
+    export BUILD_ALL_RETAINED="false"
+    export RUN_TESTS="false"
+    export GITHUB_ACTION_PATH="$PROJECT_ROOT/.github/actions/detect-containers"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
+
+    run bash "$script"
+}
+
+output_value() {
+    local name="$1"
+    sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
+}
+
+@test "S4: e2e_builds is filtered from the pre-split builds union for changed sslh only" {
+    builds=$(jq -cn '
+      [
+        {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"},
+        {"container":"sslh","version":"v2.3.0","tag":"v2.3.0-alpine","is_default":false,"is_latest_version":false,"os":"linux","runner":"ubuntu-latest"},
+        {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-windows","is_default":false,"is_latest_version":true,"os":"windows","runner":"windows-latest"}
+      ]')
+
+    run_split_build_engine_step "$builds"
+
+    [ "$status" -eq 0 ]
+    e2e_builds=$(output_value e2e_builds)
+    [ "$(echo "$e2e_builds" | jq 'length')" -eq 1 ]
+    [ "$(echo "$e2e_builds" | jq -r '.[0].container')" = "sslh" ]
+    [ "$(echo "$e2e_builds" | jq -r '.[0].tag')" = "v2.3.1-alpine" ]
+}
+
+@test "S5: non-enabled changed container produces empty e2e_builds" {
+    builds=$(jq -cn '
+      [
+        {"container":"wordpress","version":"6.5.0","tag":"latest-6.5.0","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
+      ]')
+
+    run_split_build_engine_step "$builds"
+
+    [ "$status" -eq 0 ]
+    e2e_builds=$(output_value e2e_builds)
+    [ "$e2e_builds" = "[]" ]
+}

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    ORIG_PATH="$PATH"
+    FIXTURE_REPO="$TEST_TEMP_DIR/repo"
+    mkdir -p "$FIXTURE_REPO/tests" "$FIXTURE_REPO/helpers"
+    cp "$PROJECT_ROOT/tests/e2e-test.sh" "$FIXTURE_REPO/tests/e2e-test.sh"
+    cp "$PROJECT_ROOT/helpers/logging.sh" "$FIXTURE_REPO/helpers/logging.sh"
+    cp "$PROJECT_ROOT/helpers/variant-utils.sh" "$FIXTURE_REPO/helpers/variant-utils.sh"
+    chmod +x "$FIXTURE_REPO/tests/e2e-test.sh"
+}
+
+teardown() {
+    export PATH="$ORIG_PATH"
+    unset E2E_IMAGE DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT TEST_SCRIPT_MARKER
+    teardown_temp_dir
+}
+
+install_docker_stub() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    images)
+        printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}"
+        ;;
+    inspect)
+        printf '%s\n' "none"
+        ;;
+    ps)
+        printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}"
+        ;;
+    rm|run|logs|exec)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+
+    cat > "$TEST_TEMP_DIR/bin/sleep" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+}
+
+add_openvpn_fixture() {
+    mkdir -p "$FIXTURE_REPO/openvpn"
+    cat > "$FIXTURE_REPO/openvpn/variants.yaml" <<'YAML'
+versions:
+  - tag: v2.7.5-alpine
+YAML
+    cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
+#!/bin/bash
+printf '%s\n' "${CONTAINER_NAME:-}" > "${TEST_SCRIPT_MARKER:?}"
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+}
+
+@test "S2: helper sourcing resolves from repo root" {
+    run "$FIXTURE_REPO/tests/e2e-test.sh" --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--no-build"* ]]
+}
+
+@test "S3/AD3: E2E_IMAGE bypasses variant routing but still applies openvpn run profile and test.sh" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_SCRIPT_MARKER")" = "e2e-openvpn" ]
+
+    run_line=$(grep '^run ' "$DOCKER_LOG")
+    [[ "$run_line" == *"--cap-drop ALL"* ]]
+    [[ "$run_line" == *"--cap-add NET_ADMIN"* ]]
+    [[ "$run_line" == *"--cap-add SETUID"* ]]
+    [[ "$run_line" == *"--cap-add SETGID"* ]]
+    [[ "$run_line" == *"--device /dev/net/tun:/dev/net/tun"* ]]
+    [[ "$run_line" == *"-e AUTO_INSTALL=y"* ]]
+    [[ "$run_line" == *"-e AUTO_START=y"* ]]
+    [[ "$run_line" == *"ghcr.io/example/openvpn:e2e"* ]]
+    ! grep -q '^images ' "$DOCKER_LOG"
+}
+
+@test "S6: fallback image discovery errors on zero matches" {
+    mkdir -p "$FIXTURE_REPO/debian"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=""
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" --no-build debian
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"No image found for debian"* ]]
+    ! grep -q '^run ' "$DOCKER_LOG"
+}
+
+@test "S6: fallback image discovery errors on ambiguous image IDs" {
+    mkdir -p "$FIXTURE_REPO/debian"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=$'sha111 ghcr.io/oorabona/debian:trixie\nsha222 docker.io/oorabona/debian:bookworm'
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" --no-build debian
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Ambiguous local images for debian"* ]]
+    ! grep -q '^run ' "$DOCKER_LOG"
+}

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -142,3 +142,10 @@ SH
     # nobody must be able to bind the privileged port
     [[ "$run_line" == *"--cap-add NET_BIND_SERVICE"* ]]
 }
+
+@test "sslh/test.sh proves liveness without pgrep (scratch image lacks it)" {
+    # The sslh image is FROM scratch: no pgrep. The smoke check must use the
+    # busybox nc applet that ships in the image, not pgrep.
+    ! grep -qE '\bpgrep\b' "$PROJECT_ROOT/sslh/test.sh"
+    grep -q '/bin/busybox nc' "$PROJECT_ROOT/sslh/test.sh"
+}

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -121,3 +121,24 @@ SH
     [[ "$output" == *"Ambiguous local images for debian"* ]]
     ! grep -q '^run ' "$DOCKER_LOG"
 }
+
+@test "sslh run profile: args-only command, port 443, NET_BIND_SERVICE (entrypoint+healthcheck match)" {
+    mkdir -p "$FIXTURE_REPO/sslh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_PS_OUTPUT="e2e-sslh"
+    export E2E_IMAGE="ghcr.io/example/sslh:e2e"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" sslh
+
+    [ "$status" -eq 0 ]
+    run_line=$(grep '^run ' "$DOCKER_LOG")
+    # image ENTRYPOINT is sslh-ev → command is ARGS ONLY (no re-specified binary)
+    [[ "$run_line" == *"--foreground"* ]]
+    [[ "$run_line" != *"sslh-ev --foreground"* ]]
+    # front port 443 to match the image HEALTHCHECK (nc -z 443), not 8443
+    [[ "$run_line" == *"-p 0.0.0.0:443"* ]]
+    [[ "$run_line" != *"0.0.0.0:8443"* ]]
+    # nobody must be able to bind the privileged port
+    [[ "$run_line" == *"--cap-add NET_BIND_SERVICE"* ]]
+}


### PR DESCRIPTION
## What

The container e2e harness (`tests/e2e-test.sh`) — which boots a built image and runs its
per-container `test.sh` smoke check — was run by **no** CI workflow, so assertions like the
openvpn non-root privilege-drop check were only ever exercised by a manual local run. On top
of that the harness had rotted: after it was moved into `tests/`, it sourced its helpers and
looked for `<container>/test.sh` under the wrong directory, so it errored out before running
anything.

This PR repairs the harness and wires it into CI as a **blocking pull-request gate**, scoped
to changed containers. First increment: **openvpn, ansible, debian, sslh**.

## How it works

- **`tests/e2e-test.sh` repaired** — helper/`test.sh` paths anchored to the repo root; a new
  `E2E_IMAGE` override lets CI point the harness at an already-built image, with fail-closed
  image resolution (errors on no-match / ambiguous instead of silently picking one).
- **Per-container opt-in** — a `tests.e2e.enabled` flag in each container's `variants.yaml`,
  surfaced as an `e2e_builds` output on the `detect-containers` action so the run is scoped
  to *changed AND eligible* containers only.
- **`e2e-test` job** — on non-fork pull requests, builds each eligible changed container into
  a locally loadable image and runs the harness against it (openvpn boots under its hardened
  cap profile so the drop-to-`nobody` assertion is actually exercised).
- **`e2e-gate` job** — a small aggregator that is safe to make a required check: it passes on
  a real green run or a legitimate skip (fork PR / no eligible change) and fails only on an
  actual container regression, so unrelated and fork PRs are never blocked.

## Verification

- Unit tests (`bats tests/unit/e2e-test.bats tests/unit/detect-e2e-builds.bats`): **6/6 pass**,
  including a check that the `E2E_IMAGE` path still applies openvpn's cap/device profile and
  runs `test.sh`, that image resolution fails closed, and that the `e2e_builds` filter selects
  only the changed, latest, Linux, eligible container.
- `shellcheck -x -S warning tests/e2e-test.sh`: clean.
- **This PR exercises the new job on itself** — it changes the four containers' `variants.yaml`,
  so `detect-containers` marks them changed and the `e2e-test` job runs against openvpn,
  ansible, debian, and sslh on this PR's CI (the real Docker runtime, with `/dev/net/tun`).

## Follow-ups (out of scope here)

- postgres e2e (its build expands variants + extension images — needs extra handling).
- Making `e2e-gate` a branch-protection-*enforced* required check without deadlocking
  docs/tests-only PRs needs a small companion workflow (documented GitHub path-filter
  behavior). This PR delivers the failing-check block; the enforced-required-check wiring is
  a repo-settings + follow-up decision.

Closes #920
