### PR TITLE
fix(openvpn): clean unattended restart lifecycle via START_EXISTING (#912)

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -338,6 +338,13 @@ jobs:
           E2E_IMAGE="ghcr.io/${OWNER}/${CONTAINER}:${TAG}" \
             tests/e2e-test.sh "${CONTAINER}"
 
+      - name: openvpn restart lifecycle
+        if: matrix.build.container == 'openvpn'
+        shell: bash
+        env:
+          OPENVPN_IMAGE: ghcr.io/${{ github.repository_owner }}/openvpn:${{ matrix.build.tag }}
+        run: openvpn/tests/restart-lifecycle.sh
+
   e2e-gate:
     name: e2e-gate
     needs: [detect-containers, e2e-test]

--- a/docs/CONTAINER_CONFIG.md
+++ b/docs/CONTAINER_CONFIG.md
@@ -142,6 +142,7 @@ OpenVPN server with easy-rsa PKI management.
 | `OS` | `other` | Client OS type |
 | `AUTO_INSTALL` | `n` | `y` runs a non-interactive install (generates PKI + `server.conf`) when no config exists; unset with a config present opens an interactive menu instead of starting |
 | `AUTO_START` | `n` | `y` starts the OpenVPN server after install (required for the server to run on this Alpine image) |
+| `START_EXISTING` | `n` | `y` starts an already-installed server non-interactively (takes precedence over `AUTO_INSTALL` when a config exists) — makes the container safe under `restart: unless-stopped`; Alpine (`OS=other`), installer-generated foreground configs only |
 
 ### Ports
 
@@ -156,15 +157,15 @@ OpenVPN server with easy-rsa PKI management.
 # drop to the unprivileged nobody user its config specifies (NET_RAW is not
 # needed — the UDP transport uses ordinary sockets). This is a bootstrap-and-run
 # invocation: AUTO_INSTALL=y generates the config on an empty volume, AUTO_START=y
-# starts the server. The installer has no clean unattended restart (AUTO_INSTALL=y
-# re-runs setup; unset opens a management menu) — see openvpn/README.md
-# "Lifecycle" and issue #912 before running it as a persistent service.
+# starts the server. Add START_EXISTING=y (and restart: unless-stopped in Compose)
+# for a clean unattended restart — it starts the existing server non-interactively.
+# See openvpn/README.md "Lifecycle".
 docker run -d \
   --cap-drop=ALL \
   --cap-add=NET_ADMIN --cap-add=SETUID --cap-add=SETGID \
   --security-opt no-new-privileges \
   --device=/dev/net/tun \
-  -e AUTO_INSTALL=y -e AUTO_START=y \
+  -e START_EXISTING=y -e AUTO_INSTALL=y -e AUTO_START=y \
   -v openvpn-data:/etc/openvpn \
   -p 1194:1194/udp \
   ghcr.io/oorabona/openvpn:latest

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
     && make install-exec \
     && apk del .build-deps \
     && cd /usr/local/bin \
-    && curl -sSL https://raw.githubusercontent.com/oorabona/scripts/3be0f6fe14bfe139068257410454fdd9a704d156/openvpn/setup.sh --output ovpn \
+    && curl -sSL https://raw.githubusercontent.com/oorabona/scripts/ee87650be1eae8003eee8795d49423a332326f34/openvpn/setup.sh --output ovpn \
     && chmod +x ovpn \
     # Bake EasyRSA at build time so first-run setup is hermetic (#918): fetch the
     # pinned tarball and its GPG signature and verify it against the vendored

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -46,6 +46,7 @@ docker run -d --name openvpn \
     --sysctl net.ipv6.conf.all.forwarding=1 \
     --sysctl net.ipv4.ip_forward=1 \
     --sysctl net.ipv4.conf.all.forwarding=1 \
+    -e START_EXISTING=y \
     -e AUTO_INSTALL=y \
     -e AUTO_START=y \
     oorabona/openvpn
@@ -69,13 +70,16 @@ services:
   openvpn:
     image: oorabona/openvpn
     container_name: openvpn
-    # Bootstrap-and-run (see "Lifecycle" below): AUTO_INSTALL=y generates the PKI
-    # + server.conf into the empty named volume, AUTO_START=y launches the
-    # server. Do NOT combine AUTO_INSTALL=y with restart: unless-stopped — the
-    # installer re-runs setup on every restart. See #912.
+    # First run bootstraps the PKI + server.conf into the empty named volume
+    # (AUTO_INSTALL=y) and starts the server (AUTO_START=y). START_EXISTING=y makes
+    # every subsequent start bring up the existing server non-interactively, so this
+    # is safe under `restart: unless-stopped` (see "Lifecycle" below). Set
+    # ENDPOINT=<host> for a fully non-interactive first install.
     environment:
+      - START_EXISTING=y
       - AUTO_INSTALL=y
       - AUTO_START=y
+      - ENDPOINT=vpn.example.com # Set to the real public host/IP.
     cap_add:
       - NET_ADMIN
       - SETUID
@@ -95,23 +99,34 @@ services:
       - 1194:1194/udp
     volumes:
       - openvpn_config:/etc/openvpn
+    restart: unless-stopped
 
 volumes:
   openvpn_config:
 ```
 
-### Lifecycle (important)
+### Lifecycle
 
-This image's entrypoint (the `ovpn` installer) is **bootstrap-and-run**, not an
-unattended daemon. On an empty volume, `AUTO_INSTALL=y` + `AUTO_START=y`
-generates the config and starts the server. But once a config exists it has no
-clean restart path: `AUTO_INSTALL=y` **re-runs setup** (can overwrite your
-PKI/config), while leaving it unset opens an **interactive management menu**
-instead of starting. So do not run a `restart: unless-stopped` service with a
-persisted `AUTO_INSTALL=y`, and do not expect a plain `docker compose up -d`
-after bootstrap to start the server. Bootstrap once, then manage/run the server
-via the installer's documented commands (see below). This limitation is tracked
-in [#912](https://github.com/oorabona/docker-containers/issues/912).
+On an empty volume, `AUTO_INSTALL=y` + `AUTO_START=y` generates the PKI +
+`server.conf` and starts the server (set `ENDPOINT=<host>` for a fully
+non-interactive first install). **`START_EXISTING=y`** then makes every
+subsequent start bring up the already-installed server non-interactively — it
+takes precedence over `AUTO_INSTALL` when a config already exists — so the
+container is safe to run as a `restart: unless-stopped` service: a restart brings
+the VPN back up instead of re-running setup or dropping into the management menu.
+To manage clients (add/revoke), open the installer's management menu with a
+**one-shot interactive** Compose run against the deployed config volume while
+clearing `START_EXISTING` and `AUTO_INSTALL` (those would start the server
+instead of the menu): `docker compose run --rm -e START_EXISTING= -e
+AUTO_INSTALL= openvpn`.
+
+`START_EXISTING` applies to this Alpine image and expects the installer-generated
+foreground config; a config carrying a `daemon` directive is rejected up front.
+Restart-safety assumes the **first install completed**: `START_EXISTING` starts
+whatever config exists, so if the initial bootstrap is interrupted after
+`server.conf` is written but before the PKI finishes, reset the config volume and
+bootstrap again rather than looping on a half-installed config. (Resolves
+[#912](https://github.com/oorabona/docker-containers/issues/912).)
 
 ## Configuration
 
@@ -143,12 +158,13 @@ This file is generated from the script `setup.sh` located in `/usr/local/bin` an
 
 For details about the meaning of each variable, please refer to the [documentation](https://github.com/oorabona/scripts/tree/main/openvpn).
 
-Two variables control the container's first-run lifecycle:
+Three variables control the container's lifecycle:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTO_INSTALL` | `n` | `y` runs a **non-interactive** install (generates the PKI + `server.conf`) when no config exists. Left unset with a config already present, the entrypoint opens an interactive management menu instead of starting the server. |
 | `AUTO_START` | `n` | `y` starts the OpenVPN server after install (required for the server to actually run on this Alpine image). |
+| `START_EXISTING` | `n` | `y` starts an already-installed server **non-interactively** on restart, taking precedence over `AUTO_INSTALL` when a config exists — makes the container safe under `restart: unless-stopped`. Alpine (`OS=other`), installer-generated foreground configs only. |
 
 ### Google Authenticator
 

--- a/openvpn/docker-compose.yml
+++ b/openvpn/docker-compose.yml
@@ -38,15 +38,20 @@ services:
       - net.ipv4.conf.all.forwarding=1
       - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv6.conf.all.forwarding=1
-    # Bootstrap the empty volume once: `AUTO_INSTALL=y docker compose up -d`
-    # generates the PKI + server.conf. Heads-up on the entrypoint's lifecycle
-    # (tracked in #912): with a config already present, AUTO_INSTALL=y re-runs
-    # setup and AUTO_INSTALL unset/n opens an interactive management menu instead
-    # of starting — so this installer does not support a clean unattended restart
-    # loop out of the box. See openvpn/README.md "Lifecycle" and #912.
+    # Idempotent lifecycle: START_EXISTING=y starts an already-installed server
+    # non-interactively on restart (it takes precedence over AUTO_INSTALL when a
+    # config already exists), so `restart: unless-stopped` brings the VPN back up
+    # cleanly instead of re-running setup or opening the management menu. For the
+    # FIRST run on an empty volume, bootstrap the PKI + server.conf non-interactively
+    # with `AUTO_INSTALL=y ENDPOINT=<host> docker compose up -d` (or run the
+    # installer once interactively). Restart-safety assumes the first install
+    # finished; if it was interrupted mid-bootstrap, reset the volume. See
+    # openvpn/README.md "Lifecycle".
     environment:
+      - START_EXISTING=${START_EXISTING:-y}
       - AUTO_INSTALL=${AUTO_INSTALL:-n}
       - AUTO_START=${AUTO_START:-y}
+      - ENDPOINT=${ENDPOINT:-}
     volumes:
       - openvpn_config:/etc/openvpn
     restart: unless-stopped

--- a/openvpn/tests/restart-lifecycle.sh
+++ b/openvpn/tests/restart-lifecycle.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -gt 1 ]; then
+    echo "usage: $0 [openvpn-image]" >&2
+    exit 2
+fi
+
+image="${1:-${OPENVPN_IMAGE:-}}"
+if [ -z "$image" ]; then
+    echo "openvpn restart lifecycle: image ref required as argv[1] or OPENVPN_IMAGE" >&2
+    exit 2
+fi
+
+suffix="${GITHUB_RUN_ID:-local}-$$-${RANDOM}"
+volume="openvpn-restart-lifecycle-${suffix}"
+bootstrap_container="openvpn-restart-bootstrap-${suffix}"
+restart_container="openvpn-restart-existing-${suffix}"
+
+cleanup() {
+    local status=$?
+    set +e
+    docker rm -f "$bootstrap_container" "$restart_container" >/dev/null 2>&1
+    docker volume rm -f "$volume" >/dev/null 2>&1
+    return "$status"
+}
+trap cleanup EXIT
+
+run_opts=(
+    --cap-drop ALL
+    --cap-add NET_ADMIN
+    --cap-add SETUID
+    --cap-add SETGID
+    --security-opt no-new-privileges
+    --device /dev/net/tun:/dev/net/tun
+    --sysctl net.ipv4.ip_forward=1
+    --sysctl net.ipv4.conf.all.forwarding=1
+    --sysctl net.ipv6.conf.all.disable_ipv6=0
+    --sysctl net.ipv6.conf.all.forwarding=1
+)
+
+log() {
+    printf 'openvpn restart lifecycle: %s\n' "$*"
+}
+
+fail() {
+    printf 'openvpn restart lifecycle: ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+show_logs_tail() {
+    local container="$1"
+
+    docker logs "$container" 2>&1 | tail -80 >&2 || true
+}
+
+openvpn_server_pids() {
+    local container="$1"
+
+    docker exec "$container" sh -c '
+pids=""
+if command -v pgrep >/dev/null 2>&1; then
+    pids=$(pgrep -x openvpn 2>/dev/null || true)
+else
+    for comm in /proc/[0-9]*/comm; do
+        [ -r "$comm" ] || continue
+        [ "$(cat "$comm" 2>/dev/null)" = openvpn ] || continue
+        pid=${comm#/proc/}
+        pids="${pids} ${pid%/comm}"
+    done
+fi
+
+found=0
+for pid in $pids; do
+    cmdline=$(tr "\000" " " < "/proc/$pid/cmdline" 2>/dev/null || true)
+    case "$cmdline" in
+        *openvpn*--config*) printf "%s\n" "$pid"; found=1 ;;
+    esac
+done
+[ "$found" -eq 1 ]
+' 2>/dev/null
+}
+
+wait_for_openvpn() {
+    local container="$1"
+    local phase="$2"
+    local deadline
+    local pids
+    local status
+
+    deadline=$((SECONDS + 150))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        status="$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null || true)"
+        if [ "$status" != "running" ]; then
+            show_logs_tail "$container"
+            fail "$phase container stopped before the OpenVPN server started (state: ${status:-missing})"
+        fi
+
+        pids="$(openvpn_server_pids "$container" || true)"
+        if [ -n "$pids" ]; then
+            log "$phase OpenVPN server is running"
+            printf 'openvpn restart lifecycle: %s server pid(s):\n%s\n' "$phase" "$pids"
+            return 0
+        fi
+
+        sleep 3
+    done
+
+    show_logs_tail "$container"
+    fail "$phase OpenVPN server did not start within 150s"
+}
+
+assert_no_interactive_prompt() {
+    local container="$1"
+    local logs
+
+    logs="$(docker logs "$container" 2>&1 || true)"
+    if printf '%s\n' "$logs" | grep -Eq 'Select an option|Welcome to the OpenVPN installer'; then
+        printf '%s\n' "openvpn restart lifecycle: ERROR: restart logs show installer/menu prompt" >&2
+        printf '%s\n' "$logs" | tail -80 >&2
+        exit 1
+    fi
+}
+
+assert_nat_masquerade() {
+    local container="$1"
+
+    # The restart path must regenerate and apply the iptables rules, else OpenVPN
+    # runs but client traffic is not NATed. Assert the MASQUERADE rule is present.
+    if ! docker exec "$container" iptables -t nat -S POSTROUTING 2>/dev/null | grep -q MASQUERADE; then
+        show_logs_tail "$container"
+        fail "restart did not apply the NAT MASQUERADE rule (client traffic would not route)"
+    fi
+    log "restart NAT MASQUERADE rule is applied"
+}
+
+pki_ca_hash() {
+    local container="$1"
+    local hash
+
+    if ! hash="$(docker exec "$container" sha256sum /etc/openvpn/easy-rsa/pki/ca.crt 2>/dev/null | awk '{print $1}')"; then
+        show_logs_tail "$container"
+        fail "could not read generated CA certificate from $container"
+    fi
+    if [ -z "$hash" ]; then
+        show_logs_tail "$container"
+        fail "generated CA certificate hash was empty in $container"
+    fi
+
+    printf '%s\n' "$hash"
+}
+
+log "using image $image"
+log "creating volume $volume"
+docker volume create "$volume" >/dev/null
+
+log "bootstrap boot: install and start with persisted /etc/openvpn"
+docker run -d \
+    --name "$bootstrap_container" \
+    "${run_opts[@]}" \
+    -v "$volume:/etc/openvpn" \
+    -e START_EXISTING=y \
+    -e AUTO_INSTALL=y \
+    -e AUTO_START=y \
+    -e ENDPOINT=127.0.0.1 \
+    "$image" >/dev/null
+wait_for_openvpn "$bootstrap_container" "bootstrap"
+
+ca_before="$(pki_ca_hash "$bootstrap_container")"
+log "bootstrap generated CA certificate hash: $ca_before"
+
+log "destroying bootstrap container and keeping volume"
+docker rm -f "$bootstrap_container" >/dev/null
+
+log "restart boot: start existing config non-interactively"
+# AUTO_INSTALL=y is set alongside START_EXISTING=y — matching the shipped Compose
+# config — to prove START_EXISTING takes precedence over AUTO_INSTALL for an
+# existing config (it must start the server, not re-run the installer).
+docker run -d \
+    --name "$restart_container" \
+    "${run_opts[@]}" \
+    -v "$volume:/etc/openvpn" \
+    -e START_EXISTING=y \
+    -e AUTO_INSTALL=y \
+    -e AUTO_START=y \
+    "$image" >/dev/null
+wait_for_openvpn "$restart_container" "restart"
+assert_no_interactive_prompt "$restart_container"
+assert_nat_masquerade "$restart_container"
+ca_after="$(pki_ca_hash "$restart_container")"
+if [ "$ca_before" != "$ca_after" ]; then
+    fail "restart changed the persisted CA certificate hash (before: $ca_before, after: $ca_after)"
+fi
+log "PASS: restart preserved existing CA certificate hash"
+
+# Stability: guard against a start-then-exit restart. The server must still be
+# running after a short settle interval, not merely have existed once.
+sleep 5
+wait_for_openvpn "$restart_container" "restart-stable"
+
+log "PASS: existing /etc/openvpn volume restarts non-interactively with START_EXISTING=y"


### PR DESCRIPTION
## What

Gives the openvpn container a clean unattended restart lifecycle (#912). Previously a
`restart: unless-stopped` container with a persisted `/etc/openvpn` volume could not restart
cleanly: `AUTO_INSTALL=y` re-ran the installer on every restart, and leaving it unset dropped
into the interactive management menu instead of starting the server.

## How

- **Pin the installer** (`openvpn/Dockerfile`) to the upstream `oorabona/scripts` commit that
  adds `START_EXISTING` (oorabona/scripts#2).
- **Enable it** in `openvpn/docker-compose.yml` (`START_EXISTING=y`, `ENDPOINT` passthrough)
  and document the idempotent lifecycle in `openvpn/README.md` + `docs/CONTAINER_CONFIG.md`,
  replacing the previous "no clean unattended restart" limitation.
- With `START_EXISTING=y`, a restart brings the existing server up non-interactively — it takes
  precedence over `AUTO_INSTALL` when a config exists. First-run bootstrap still uses
  `AUTO_INSTALL=y` (+ `ENDPOINT`). Restart-safety assumes the first install completed; an
  interrupted first bootstrap needs the volume reset (documented).

## Verification

- `openvpn/tests/restart-lifecycle.sh` (new, wired into the openvpn e2e job) proves the fix on
  real Docker: bootstrap with a persisted volume → destroy the container → restart with
  `START_EXISTING=y AUTO_INSTALL=y` and assert the server comes back up **without** an
  installer/menu prompt, with the CA certificate hash **unchanged** (no PKI overwrite / no
  re-install), the NAT MASQUERADE rule applied (routing), and the process stable after a settle
  interval.
- Shell scripts `bash -n` + shellcheck clean; compose/workflow YAML parse.

Closes #912
