### PR TITLE
feat(openvpn): write client configs to a persistent /etc/openvpn/clients dir (#911)

### DIFF
--- a/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
+++ b/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
@@ -3,7 +3,7 @@ layout: post
 title: "A Hardened OpenVPN Server in Docker: 15 MB Alpine Image, PKCS11-Ready, Least-Privilege"
 description: "Run OpenVPN in a minimal Alpine container with Easy-RSA and PKCS11 hardware-token support, under cap_drop: ALL with NET_ADMIN + SETUID/SETGID; the server worker drops to nobody. 15 MB compressed."
 date: 2026-05-04 10:00:00 +0000
-updated: 2026-07-17
+updated: 2026-07-19
 tags: [openvpn, docker, security, alpine, networking, pkcs11]
 ---
 
@@ -69,34 +69,39 @@ This runs with fewer privileges than `--privileged` by a wide margin. A containe
 
 ## Initial setup
 
-> **⚠️ Outdated commands.** The `ovpn_genconfig` / `ovpn_initpki` / `easyrsa` /
-> `ovpn_getclient` invocations below are from kylemanna's image and do **not**
-> exist in this one — they will fail with "command not found". This image
-> instead runs a single `ovpn` installer driven by env vars: first run with
-> `-e AUTO_INSTALL=y -e AUTO_START=y` to generate the PKI + `server.conf` and
-> start the server, re-run the container to manage clients, and retrieve the
-> generated client config from the `/etc/openvpn` volume. See the maintained
-> [container README](https://github.com/oorabona/docker-containers/tree/master/openvpn)
-> for the current, tested walkthrough.
+This image does not use kylemanna's `ovpn_genconfig`/`ovpn_getclient` helpers. It runs a single
+`ovpn` installer (from [`oorabona/scripts`](https://github.com/oorabona/scripts/tree/main/openvpn))
+driven by environment variables.
 
-Create a CA and the first client cert:
+**Bootstrap the server** on an empty volume — the installer generates the CA and `server.conf`
+and starts OpenVPN:
 
 ```bash
-# Initialise the server (first run)
-docker compose run --rm openvpn ovpn_genconfig -u udp://vpn.example.com
-docker compose run --rm openvpn ovpn_initpki
-
-# Start the server
-docker compose up -d
-
-# Issue a client cert
-docker compose run --rm openvpn easyrsa build-client-full alice nopass
-
-# Export the client .ovpn file
-docker compose run --rm openvpn ovpn_getclient alice > alice.ovpn
+# AUTO_INSTALL=y generates the PKI + server.conf; AUTO_START=y launches the server;
+# START_EXISTING=y makes later restarts bring the existing server back up non-interactively,
+# so `restart: unless-stopped` is safe. Set ENDPOINT to your public host so the installer
+# does not probe for it.
+AUTO_INSTALL=y ENDPOINT=vpn.example.com docker compose up -d
 ```
 
-The `.ovpn` bundle embeds the CA, client cert, and key. Hand it to the client, they import it into their OpenVPN client, and they're connected.
+**Add a client** through the installer's management menu — a one-shot interactive container
+against the same config volume, with `START_EXISTING`/`AUTO_INSTALL` cleared (either would start
+the server instead of opening the menu):
+
+```bash
+docker compose run --rm -e START_EXISTING= -e AUTO_INSTALL= openvpn
+# → choose "1) Add a new user", then enter the client name (e.g. alice)
+```
+
+The installer writes the client bundle to `/root/<name>.ovpn` inside that container (not the
+`/etc/openvpn` volume) and can optionally serve it once over a temporary download port. The
+`.ovpn` embeds the CA, client cert, and key — plus, if you enabled Google Authenticator at
+install, the client's 2FA enrolment (the per-user secret lives under `/etc/openvpn/otp/`). Hand
+it to the client, who imports it and connects. Revoke a client the same way, via the menu's
+"2) Revoke existing user" option.
+
+The maintained [container README](https://github.com/oorabona/docker-containers/tree/master/openvpn)
+carries the current, tested commands.
 
 ## PKCS11: hardware tokens
 

--- a/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
+++ b/docs/site/_posts/2026-05-04-hardened-openvpn-docker-alpine-pkcs11.md
@@ -3,7 +3,7 @@ layout: post
 title: "A Hardened OpenVPN Server in Docker: 15 MB Alpine Image, PKCS11-Ready, Least-Privilege"
 description: "Run OpenVPN in a minimal Alpine container with Easy-RSA and PKCS11 hardware-token support, under cap_drop: ALL with NET_ADMIN + SETUID/SETGID; the server worker drops to nobody. 15 MB compressed."
 date: 2026-05-04 10:00:00 +0000
-updated: 2026-07-19
+updated: 2026-07-20
 tags: [openvpn, docker, security, alpine, networking, pkcs11]
 ---
 
@@ -27,11 +27,11 @@ Running OpenVPN in Docker is [famously easy to get wrong](https://github.com/kyl
 ## What's in the image
 
 ```bash
-docker pull ghcr.io/oorabona/openvpn:v2.7.2-alpine
+docker pull ghcr.io/oorabona/openvpn:v2.7.5-alpine
 # 15 MB compressed, multi-arch (amd64 + arm64)
 ```
 
-- **OpenVPN 2.7.x** (tracked from [yrutschle's OpenVPN fork is unrelated; we follow OpenVPN/openvpn])
+- **OpenVPN 2.7.x** (tracked from [OpenVPN/openvpn](https://github.com/OpenVPN/openvpn))
 - **Easy-RSA 3.2.x** for certificate generation
 - **pkcs11-helper** for hardware-token-backed keys (YubiKey, OpenSC, etc.)
 - **Alpine base** — static-linking where possible, no shell in the final image layer
@@ -45,7 +45,7 @@ docker pull ghcr.io/oorabona/openvpn:v2.7.2-alpine
 # compose.yml
 services:
   openvpn:
-    image: ghcr.io/oorabona/openvpn:v2.7.2-alpine
+    image: ghcr.io/oorabona/openvpn:v2.7.5-alpine
     cap_drop: [ALL]
     cap_add:
       - NET_ADMIN          # create tun0, manipulate routes
@@ -57,6 +57,16 @@ services:
       - "1194:1194/udp"
     volumes:
       - openvpn-data:/etc/openvpn
+    environment:
+      # This sample sets START_EXISTING=y and AUTO_START=y (AUTO_INSTALL stays n);
+      # the image itself defaults all three to n, so these values live in the
+      # compose file, not the container image. Set AUTO_INSTALL=y (and ENDPOINT)
+      # on the first boot to bootstrap; later `docker compose up -d` brings the
+      # existing server back up non-interactively.
+      - START_EXISTING=${START_EXISTING:-y}
+      - AUTO_INSTALL=${AUTO_INSTALL:-n}
+      - AUTO_START=${AUTO_START:-y}
+      - ENDPOINT=${ENDPOINT:-}
     security_opt:
       - no-new-privileges:true
     restart: unless-stopped
@@ -70,8 +80,9 @@ This runs with fewer privileges than `--privileged` by a wide margin. A containe
 ## Initial setup
 
 This image does not use kylemanna's `ovpn_genconfig`/`ovpn_getclient` helpers. It runs a single
-`ovpn` installer (from [`oorabona/scripts`](https://github.com/oorabona/scripts/tree/main/openvpn))
-driven by environment variables.
+`ovpn` installer (from [`oorabona/scripts`](https://github.com/oorabona/scripts/tree/main/openvpn),
+baked at a pinned commit — see [`openvpn/Dockerfile`](https://github.com/oorabona/docker-containers/blob/master/openvpn/Dockerfile)
+for the exact revision) driven by environment variables.
 
 **Bootstrap the server** on an empty volume — the installer generates the CA and `server.conf`
 and starts OpenVPN:
@@ -93,12 +104,25 @@ docker compose run --rm -e START_EXISTING= -e AUTO_INSTALL= openvpn
 # → choose "1) Add a new user", then enter the client name (e.g. alice)
 ```
 
-The installer writes the client bundle to `/root/<name>.ovpn` inside that container (not the
-`/etc/openvpn` volume) and can optionally serve it once over a temporary download port. The
-`.ovpn` embeds the CA, client cert, and key — plus, if you enabled Google Authenticator at
-install, the client's 2FA enrolment (the per-user secret lives under `/etc/openvpn/otp/`). Hand
-it to the client, who imports it and connects. Revoke a client the same way, via the menu's
-"2) Revoke existing user" option.
+The installer writes the client bundle to `/etc/openvpn/clients/<name>.ovpn` (mode 600,
+root-owned) on the persistent `/etc/openvpn` volume, so it survives the one-shot menu container.
+Retrieve it from the running server:
+
+```bash
+docker compose cp openvpn:/etc/openvpn/clients/alice.ovpn .
+```
+
+This `/etc/openvpn/clients` location is the current behavior; images built earlier wrote client
+configs to the ephemeral `/root` instead, so pull a current image if `docker compose cp` from
+`/etc/openvpn/clients` finds nothing.
+
+The `.ovpn` embeds the CA, client cert, key, and tls-crypt/tls-auth key — but no 2FA material. If
+you enabled Google Authenticator at install, the client's OTP enrolment is a separate per-user
+artifact under `/etc/openvpn/otp/` (the QR/secret to load into an authenticator app); provision it
+to the client out of band. Hand the `.ovpn` to the client, who imports it and connects. Revoke a
+client the same way, via the menu's "2) Revoke existing user" option, then restart the server
+(`docker compose restart openvpn`) so it reloads the regenerated CRL — revocation only takes
+effect after the reload.
 
 The maintained [container README](https://github.com/oorabona/docker-containers/tree/master/openvpn)
 carries the current, tested commands.

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
     && make install-exec \
     && apk del .build-deps \
     && cd /usr/local/bin \
-    && curl -sSL https://raw.githubusercontent.com/oorabona/scripts/ee87650be1eae8003eee8795d49423a332326f34/openvpn/setup.sh --output ovpn \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://raw.githubusercontent.com/oorabona/scripts/8985382fb199cdb502783ba42585da40d481eead/openvpn/setup.sh --output ovpn \
     && chmod +x ovpn \
     # Bake EasyRSA at build time so first-run setup is hermetic (#918): fetch the
     # pinned tarball and its GPG signature and verify it against the vendored


### PR DESCRIPTION
## What

Relocate generated OpenVPN client `.ovpn` files to `/etc/openvpn/clients` on the persistent
`/etc/openvpn` volume, and rewrite the setup walkthrough (#911) to the real `ovpn` installer
interface.

## Changes

- Bump the vendored `ovpn` installer to `oorabona/scripts@8985382`: client configs are written to
  `/etc/openvpn/clients` (mode 600, root-owned) on the persistent volume instead of the ephemeral
  `/root`, and the directory is validated/created mode 700 before the certificate is issued.
  Supersedes the earlier `CLIENT_OUTPUT_DIR` idea (`oorabona/scripts#3` → `#4` → `#5`).
- Harden the installer fetch to match the sibling downloads (`-f`, retries, connect timeout).
- Rewrite the walkthrough: a working Compose `environment:` block, the bootstrap command, client
  retrieval via `docker compose cp` from the volume, revoke → restart to reload the CRL, correct
  OTP/2FA handling (the enrolment is a separate `/etc/openvpn/otp` artifact, not embedded in the
  `.ovpn`), and a current image tag.

## Verification

- The openvpn image smoke-build and `restart-lifecycle` e2e run on this PR (the Dockerfile changed).
- Walkthrough commands checked against the pinned installer's actual interface.

## Follow-ups

- #938 — e2e assertion that generated client configs land in `/etc/openvpn/clients` (mode 600).
- #939 — signature/digest verification for the installer and the OpenVPN/pkcs11-helper source fetches.

Closes #911
