### PR TITLE
feat(openvpn): let the operator name the CA and the server certificate

### DIFF
--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
     && make install-exec \
     && apk del .build-deps \
     && cd /usr/local/bin \
-    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://raw.githubusercontent.com/oorabona/scripts/45afb5d9a321980c87f174e92d2c81f53f872b29/openvpn/setup.sh --output ovpn \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://raw.githubusercontent.com/oorabona/scripts/f596677ab2f15da3a88a7b5f1e81b83ba25bf458/openvpn/setup.sh --output ovpn \
     && chmod +x ovpn \
     # Bake EasyRSA at build time so first-run setup is hermetic (#918): fetch the
     # pinned tarball and its GPG signature and verify it against the vendored

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -154,9 +154,24 @@ This file is generated from the script `setup.sh` located in `/usr/local/bin` an
 - SUBNET_IPv6
 - SUBNET_MASKv4
 - SUBNET_MASKv6
-- ENDPOIN
+- ENDPOINT
 
 For details about the meaning of each variable, please refer to the [documentation](https://github.com/oorabona/scripts/tree/main/openvpn).
+
+Two more variables name the PKI. Both are optional; left unset, the installer
+generates a random name as before.
+
+| Variable | Names | Description |
+|----------|-------|-------------|
+| `OPENVPN_SERVER_CN` | the CA | The common name of the certificate authority the install creates. |
+| `OPENVPN_SERVER_NAME` | the server certificate | The name the server's own certificate is issued to. Client profiles pin it with `verify-x509-name`, so it is the name a client checks the server by. It cannot equal `CLIENT` — the server certificate and the first client would collide. |
+
+Both take effect only while the PKI is being built — that is, while
+`/etc/openvpn/easy-rsa` is not yet a directory. A fresh volume qualifies, even
+though `/etc/openvpn` itself already exists as the mount point. Once the PKI is
+there the names are fixed: setting either variable has no effect on it, and
+changing them means building a new PKI on an empty volume. The installer may
+print a note when it ignores one, but do not rely on seeing it.
 
 Three variables control the container's lifecycle:
 
@@ -178,6 +193,37 @@ docker exec -it openvpn cat /etc/openvpn/otp/username.png
 ```
 
 More information can be found on the [wiki](https://github.com/oorabona/scripts/wiki/OpenVPN-OTP).
+
+#### Upgrading an OTP deployment created before this image
+
+`/etc/openvpn/otp` holds one-time password secrets, and the installer checks that
+an existing one is private before writing into it. Earlier images created that
+directory with the default mode, usually `755`, so on a volume carried over from
+one of them adding another OTP client fails with:
+
+```
+Refusing to write one-time password secrets: /etc/openvpn/otp must give its owner rwx and neither group nor other any access (found mode 755).
+```
+
+That directory was created by root, so tightening it needs no capability beyond
+what the container already has. Existing secrets are untouched and no reinstall
+is needed:
+
+```bash
+docker exec openvpn chmod 700 /etc/openvpn/otp &&
+    docker exec openvpn stat -c '%U %a' /etc/openvpn/otp
+```
+
+Expect `root 700`. Anything else means the change did not take, and the cause is
+worth identifying rather than guessing: a read-only or root-squashed mount, a
+filesystem that carries no POSIX modes (some host bind mounts), or a directory
+whose owner is not root. That last case cannot be repaired from inside the
+container — the run command above drops every capability except `NET_ADMIN`,
+`SETUID` and `SETGID`, so `chown` is unavailable. Fix ownership on the host, or
+move `/etc/openvpn` to a named volume.
+
+`/etc/openvpn/clients`, which holds client profiles and their keys, is checked
+the same way and can need the same treatment.
 
 ## Build Arguments
 


### PR DESCRIPTION
Follows #959, which pinned the installer that stopped the CA's name reaching
every certificate. Naming those certificates deliberately is the next step.

## What this gives an operator

Two optional variables that name the PKI, instead of taking whatever random
identifiers the installer generates:

| Variable | Names |
|---|---|
| `OPENVPN_SERVER_CN` | the certificate authority |
| `OPENVPN_SERVER_NAME` | the server's own certificate |

The server name is more than cosmetic: client profiles pin it with
`verify-x509-name`, so it is the name a client checks the server by. Left unset,
both keep generating a random name, so nothing changes for an existing
deployment.

Both apply only while `/etc/openvpn/easy-rsa` is not yet a directory — which a
fresh volume satisfies even though `/etc/openvpn` already exists as the mount
point. That is the installer's own condition, not a paraphrase of it. Once the
PKI is there the names are fixed.

## Why the pin is `f596677` and not `5832ea1`

`5832ea1` is the revision that added the variables. Pinning it alone would have
shipped a regression, because naming the PKI is exactly what makes the installer
read its recorded names back on the ordinary restart path: a container started
with either variable set reads a marker off its own volume with an unqualified
`cat`. A fifo left in that file's place stops the container coming back up.

Measured against `5832ea1` in a container before pinning anything:

```
restart: no openvpn process after 75s
  PID   COMMAND
      1 {ovpn} /bin/bash /usr/local/bin/ovpn
      7 cat /etc/openvpn/easy-rsa/SERVER_CN_GENERATED
```

With `f596677`, on the same volume with the same fifo still in place, the server
is back up in one second. Those reads now take a regular file only, no more of it
than a name can be, and give up rather than block. Upstream: oorabona/scripts#14.

## Verification

The pinned bytes were fetched from the pinned URL and compared byte-for-byte
against the merged upstream tree — identical, sha256
`a1cfb43755aeb0e56d06cdb60be6e6bbf831468414ccbea8cb860729bd8ed451`. All four
build-time assertions this Dockerfile makes about the installer were then
replayed against those exact bytes: the EasyRSA version still resolves from
`EASYRSA_VERSION`, the single GitHub fetch is still rewritten to a copy of the
baked tarball, no EasyRSA download survives that rewrite, and the script parses.

The container build and `openvpn/tests/restart-lifecycle.sh` are left to CI,
which runs them on real Docker. The e2e derives the expected server name from
`server.conf`, so it stays correct under either naming.

## Documentation

`openvpn/README.md` gains the two variables, the boundary where they apply, and
the repair for one upgrade symptom: earlier images created `/etc/openvpn/otp`
with the default mode, and the installer now refuses to write secrets into a
directory that is not private, so adding an OTP client on a carried-over volume
fails until it is tightened. The repair is a `chmod` — that directory is
root-owned, so it needs no capability the recommended run command does not
already grant, and a directory that is genuinely not root-owned cannot be
repaired from inside the container at all, since it drops `CHOWN`.

The refusal is quoted verbatim so an operator can match what they see, which
means the quote had to move with the pin: `f596677` reports the mode it found and
describes what the check enforces, where the previous message named a mode the
check does not actually require.

While there: `ENDPOIN` was a typo for `ENDPOINT`, which the installer does
consume. `ENDPOINT6` is deliberately not listed — in this revision it only
suppresses an interactive IPv6 prompt and never reaches the generated
configuration.

## Known limit, carried from upstream

The installer checks a marker's type and then opens it as two separate steps, so
a writer on the volume can substitute the file in between. Closing that needs a
no-follow open and a read from the same descriptor, which the installer's shell
cannot express. Writing that directory already requires root inside the container
or access to the volume on the host. Tracked upstream at oorabona/scripts#15,
along with the recorded CA name still being trusted on the one-time-password
path.
