### PR TITLE
ci: run a container's e2e suite when only its tests change

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -68,6 +68,9 @@ outputs:
   containers:
     description: 'JSON array of containers that need building (converted from CSV for matrix compatibility)'
     value: ${{ steps.find-containers.outputs.containers }}
+  containers_to_verify:
+    description: 'JSON array of verification-only containers (test changes not already queued for a build)'
+    value: ${{ steps.find-containers.outputs.containers_to_verify }}
   count:
     description: 'Number of containers to build'
     value: ${{ steps.find-containers.outputs.count }}
@@ -272,6 +275,7 @@ runs:
         changed_files=""
         coverage_fallback=false
         containers_to_build=()
+        containers_to_verify=()
         normalized_container_scopes=""
 
         if [[ -n "${CONTAINER_SCOPES_INPUT:-}" ]]; then
@@ -422,45 +426,72 @@ runs:
             # is a broader policy; tracked as follow-up to avoid over-engineering here.
           fi
 
-          if [[ -n "$changed_files" ]]; then
-            # Extract container names from changed file paths
-            while IFS= read -r file; do
-              # Skip root-level files (no slash in path)
-              if [[ ! "$file" =~ / ]]; then
-                continue
-              fi
+        if [[ -n "$changed_files" ]]; then
+          # Extract container names from changed file paths
+          while IFS= read -r file; do
+            # Skip root-level files (no slash in path)
+            if [[ ! "$file" =~ / ]]; then
+              continue
+            fi
 
-              # Docs/metadata never affect build inputs — mirrors this workflow's
-              # own trigger-path exclusions. Without this, a per-container README
-              # bundled into a wider diff (e.g. via the coverage-checkpoint
-              # baseline window) wrongly queues that container for a rebuild.
-              # LAST_REBUILD.md is the one exception: it's an explicit
-              # rebuild-signal marker consumed by the smart-rebuild digest.
-              case "$file" in
-                */LAST_REBUILD.md) ;;
-                *.md|*/README*|*/LICENSE*|*/CHANGELOG*|*/docs/*|*/tests/*)
-                  continue
-                  ;;
-              esac
-
-              # Extract the top-level directory from the file path
-              container="${file%%/*}"
-              
-              # Skip if already processed
-              if [[ " ${containers_to_build[*]} " =~ " ${container} " ]]; then
+            # Verification inputs deliberately do not affect the production build
+            # queue. Container-local tests verify that container; the shared e2e
+            # harness verifies every container that explicitly opts in.
+            case "$file" in
+              */tests/*)
+                container="${file%%/*}"
+                if echo "$valid_containers" | grep -Fxq "$container" \
+                  && [[ ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
+                  echo "🧪 Container needs verification: $container (container test changed)"
+                  containers_to_verify+=("$container")
+                fi
                 continue
-              fi
-              
-              # Verify container is in make's valid list (source of truth)
-              if echo "$valid_containers" | grep -qx "$container"; then
-                echo "📦 Container needs building: $container (changed files detected, validated by make)"
-                containers_to_build+=("$container")
-              fi
-            done <<< "$changed_files"
-          else
-            echo "ℹ️  No git diff available or manual trigger without specific container"
-            echo "ℹ️  Skipping auto-detection (use container input for manual builds)"
-          fi
+                ;;
+              tests/e2e-test.sh)
+                while IFS= read -r container; do
+                  [[ -z "$container" || ! -f "$container/variants.yaml" ]] && continue
+                  e2e_enabled=$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null || echo "false")
+                  if [[ "$e2e_enabled" == "true" \
+                    && ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
+                    echo "🧪 Container needs verification: $container (shared e2e harness changed)"
+                    containers_to_verify+=("$container")
+                  fi
+                done <<< "$valid_containers"
+                continue
+                ;;
+            esac
+
+            # Docs/metadata never affect build inputs — mirrors this workflow's
+            # own trigger-path exclusions. Without this, a per-container README
+            # bundled into a wider diff (e.g. via the coverage-checkpoint
+            # baseline window) wrongly queues that container for a rebuild.
+            # LAST_REBUILD.md is the one exception: it's an explicit
+            # rebuild-signal marker consumed by the smart-rebuild digest.
+            case "$file" in
+              */LAST_REBUILD.md) ;;
+              *.md|*/README*|*/LICENSE*|*/CHANGELOG*|*/docs/*|*/tests/*)
+                continue
+                ;;
+            esac
+
+            # Extract the top-level directory from the file path
+            container="${file%%/*}"
+
+            # Skip if already processed
+            if [[ " ${containers_to_build[*]} " =~ " ${container} " ]]; then
+              continue
+            fi
+
+            # Verify container is in make's valid list (source of truth)
+            if echo "$valid_containers" | grep -qx "$container"; then
+              echo "📦 Container needs building: $container (changed files detected, validated by make)"
+              containers_to_build+=("$container")
+            fi
+          done <<< "$changed_files"
+        else
+          echo "ℹ️  No git diff available or manual trigger without specific container"
+          echo "ℹ️  Skipping auto-detection (use container input for manual builds)"
+        fi
         fi
 
         # Shared build-infra canary: if only shared build/cache logic changed
@@ -514,8 +545,25 @@ runs:
           fi
         fi
 
+        # A container changed in both a build input and a verification input is
+        # built once through the normal path; it must not receive a duplicate
+        # verification expansion. Do this after every build-list augmentation.
+        containers_to_verify_only=()
+        for container in "${containers_to_verify[@]}"; do
+          [[ " ${containers_to_build[*]} " =~ " ${container} " ]] && continue
+          [[ " ${containers_to_verify_only[*]} " =~ " ${container} " ]] && continue
+          containers_to_verify_only+=("$container")
+        done
+
         # Create outputs (CSV first, then JSON for matrix compatibility)
         echo "container_scopes=$normalized_container_scopes" >> $GITHUB_OUTPUT
+        if [ ${#containers_to_verify_only[@]} -eq 0 ]; then
+          echo "containers_to_verify=[]" >> $GITHUB_OUTPUT
+        else
+          containers_to_verify_json=$(printf '%s\n' "${containers_to_verify_only[@]}" | jq -R . | jq -s -c .)
+          echo "containers_to_verify=$containers_to_verify_json" >> $GITHUB_OUTPUT
+          echo "🧪 Found containers to verify without building: ${containers_to_verify_only[*]}"
+        fi
         if [ ${#containers_to_build[@]} -eq 0 ]; then
           echo "containers_list=" >> $GITHUB_OUTPUT
           echo "containers=[]" >> $GITHUB_OUTPUT
@@ -648,11 +696,63 @@ runs:
         echo "📋 Total builds: $builds_count"
         echo "$builds_json" | jq .
 
+    - name: Compute versions for verification-only containers
+      id: compute-verification-versions
+      if: steps.find-containers.outputs.containers_to_verify != '[]'
+      shell: bash
+      run: |
+        set -e
+        containers_json='${{ steps.find-containers.outputs.containers_to_verify }}'
+        versions_json="{}"
+
+        for container in $(echo "$containers_json" | jq -r '.[]'); do
+          echo "🔍 Getting verification version for $container..."
+          version=$(./make version "$container" 2>/dev/null || echo "latest")
+          if [[ -z "$version" || "$version" == "unknown" ]]; then
+            version="latest"
+          fi
+          echo "  → $container: $version"
+          versions_json=$(echo "$versions_json" | jq -c --arg c "$container" --arg v "$version" '. + {($c): $v}')
+        done
+
+        echo "versions=$(echo "$versions_json" | jq -c .)" >> "$GITHUB_OUTPUT"
+
+    - name: Expand verification variants for containers
+      id: expand-verification-variants
+      if: steps.find-containers.outputs.containers_to_verify != '[]'
+      shell: bash
+      env:
+        SCOPE_VERSIONS: ${{ inputs.scope_versions }}
+        SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
+        BUILD_SCOPE: ${{ inputs.scope }}
+      run: |
+        set -e
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../../helpers/container-scopes.sh"
+        containers_json='${{ steps.find-containers.outputs.containers_to_verify }}'
+        versions_json='${{ steps.compute-verification-versions.outputs.versions }}'
+        verification_expand_map=$(echo "$containers_json" | jq -c 'reduce .[] as $container ({}; . + {($container): false})')
+
+        verification_builds=$(expand_variants_for_containers \
+          "$containers_json" \
+          "$versions_json" \
+          "$verification_expand_map" \
+          "" \
+          "$SCOPE_VERSIONS" \
+          "$SCOPE_FLAVORS" \
+          "$BUILD_SCOPE")
+
+        echo "builds=$verification_builds" >> "$GITHUB_OUTPUT"
+        echo "📋 Verification builds: $(echo "$verification_builds" | jq 'length')"
+
     - name: Split builds by engine (bake vs matrix)
       id: split-build-engine
       shell: bash
       env:
         BUILDS: ${{ steps.expand-variants.outputs.builds }}
+        VERIFICATION_BUILDS: ${{ steps.expand-verification-variants.outputs.builds }}
         EVENT_NAME: ${{ github.event_name }}
         BUILD_ALL_RETAINED: ${{ inputs.build_all_retained }}
         RUN_TESTS: ${{ inputs.run_tests }}
@@ -669,6 +769,8 @@ runs:
         # empty — treat as an empty array so consumers always get valid JSON.
         builds_input="${BUILDS:-[]}"
         [[ -z "$builds_input" ]] && builds_input="[]"
+        verification_builds_input="${VERIFICATION_BUILDS:-[]}"
+        [[ -z "$verification_builds_input" ]] && verification_builds_input="[]"
 
         # force_matrix=true disables bake routing — all cells go to the flat matrix.
         # Scope inputs do NOT force the matrix: expand-variants has already filtered
@@ -710,6 +812,12 @@ runs:
         extension_builds=$(extension_containers_in "$builds_input" "any")
         bake_final_builds=$(extension_containers_in "$bake_builds" "final")
         postgres_matrix_builds=$(echo "$matrix_builds" | jq -c '[.[] | select(.container == "postgres")]')
+        # Only e2e sees verification candidates. Production routing and all
+        # checkpoint inputs remain derived from builds_input above.
+        e2e_candidates=$(jq -cn \
+          --argjson builds "$builds_input" \
+          --argjson verification "$verification_builds_input" \
+          '$builds + $verification | unique_by(.container, .tag)')
         e2e_builds='[]'
 
         while IFS= read -r build; do
@@ -731,7 +839,7 @@ runs:
           if [[ "$e2e_enabled" == "true" ]]; then
             e2e_builds=$(jq -c --argjson build "$build" '. + [$build]' <<< "$e2e_builds")
           fi
-        done < <(echo "$builds_input" | jq -c '.[]')
+        done < <(echo "$e2e_candidates" | jq -c '.[]')
 
         bake_count=$(echo "$bake_builds" | jq 'length')
         matrix_count=$(echo "$matrix_builds" | jq 'length')
@@ -743,4 +851,8 @@ runs:
         echo "extension_builds=$extension_builds" >> "$GITHUB_OUTPUT"
         echo "bake_final_builds=$bake_final_builds" >> "$GITHUB_OUTPUT"
         echo "postgres_matrix_builds=$postgres_matrix_builds" >> "$GITHUB_OUTPUT"
-        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count e2e=$e2e_count (force_matrix=${force_matrix} event=${EVENT_NAME})"
+        verification_notice=""
+        if [[ "$bake_count" -eq 0 && "$matrix_count" -eq 0 && "$e2e_count" -gt 0 ]]; then
+          verification_notice=" verification-only: no production build cells scheduled"
+        fi
+        echo "::notice::Build engine split: bake=$bake_count matrix=$matrix_count e2e=$e2e_count (force_matrix=${force_matrix} event=${EVENT_NAME})${verification_notice}"

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -286,10 +286,19 @@ runs:
         echo "🔍 Getting list of valid containers from make script..."
         valid_containers=$(cd "$GITHUB_WORKSPACE" && ./make list)
 
+        # A container opts into e2e in its variants.yaml. An absent file means the
+        # container simply has no suite; a file that will not parse means we
+        # cannot tell, and answering "not enabled" there would silently drop a
+        # suite from verification. So the two cases are separated: absent is a
+        # quiet no, unreadable stops detection rather than guessing.
         container_e2e_enabled() {
-          local container="$1"
-          [[ -f "$container/variants.yaml" ]] \
-            && [[ "$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null)" == "true" ]]
+          local container="$1" enabled
+          [[ -f "$container/variants.yaml" ]] || return 1
+          if ! enabled=$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml"); then
+            echo "::error::Cannot read $container/variants.yaml — refusing to decide e2e eligibility for $container"
+            exit 1
+          fi
+          [[ "$enabled" == "true" ]]
         }
 
         if [[ -z "$valid_containers" ]]; then

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -286,6 +286,12 @@ runs:
         echo "🔍 Getting list of valid containers from make script..."
         valid_containers=$(cd "$GITHUB_WORKSPACE" && ./make list)
 
+        container_e2e_enabled() {
+          local container="$1"
+          [[ -f "$container/variants.yaml" ]] \
+            && [[ "$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null)" == "true" ]]
+        }
+
         if [[ -z "$valid_containers" ]]; then
           echo "⚠️  No valid containers found in make script"
           exit 1
@@ -441,6 +447,7 @@ runs:
               */tests/*)
                 container="${file%%/*}"
                 if echo "$valid_containers" | grep -Fxq "$container" \
+                  && container_e2e_enabled "$container" \
                   && [[ ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
                   echo "🧪 Container needs verification: $container (container test changed)"
                   containers_to_verify+=("$container")
@@ -449,10 +456,9 @@ runs:
                 ;;
               tests/e2e-test.sh)
                 while IFS= read -r container; do
-                  [[ -z "$container" || ! -f "$container/variants.yaml" ]] && continue
-                  e2e_enabled=$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null || echo "false")
-                  if [[ "$e2e_enabled" == "true" \
-                    && ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
+                  [[ -z "$container" ]] && continue
+                  if container_e2e_enabled "$container" \
+                    && [[ ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
                     echo "🧪 Container needs verification: $container (shared e2e harness changed)"
                     containers_to_verify+=("$container")
                   fi
@@ -700,20 +706,27 @@ runs:
       id: compute-verification-versions
       if: steps.find-containers.outputs.containers_to_verify != '[]'
       shell: bash
+      env:
+        CONTAINERS_TO_VERIFY: ${{ steps.find-containers.outputs.containers_to_verify }}
       run: |
         set -e
-        containers_json='${{ steps.find-containers.outputs.containers_to_verify }}'
+        containers_json="${CONTAINERS_TO_VERIFY:-[]}"
         versions_json="{}"
 
-        for container in $(echo "$containers_json" | jq -r '.[]'); do
+        while IFS= read -r container; do
+          [[ -z "$container" ]] && continue
           echo "🔍 Getting verification version for $container..."
-          version=$(./make version "$container" 2>/dev/null || echo "latest")
+          if version=$(./make version "$container" 2>/dev/null); then
+            :
+          else
+            version=""
+          fi
           if [[ -z "$version" || "$version" == "unknown" ]]; then
             version="latest"
           fi
           echo "  → $container: $version"
           versions_json=$(echo "$versions_json" | jq -c --arg c "$container" --arg v "$version" '. + {($c): $v}')
-        done
+        done < <(jq -r '.[]' <<< "$containers_json")
 
         echo "versions=$(echo "$versions_json" | jq -c .)" >> "$GITHUB_OUTPUT"
 
@@ -725,14 +738,16 @@ runs:
         SCOPE_VERSIONS: ${{ inputs.scope_versions }}
         SCOPE_FLAVORS: ${{ inputs.scope_flavors }}
         BUILD_SCOPE: ${{ inputs.scope }}
+        CONTAINERS_TO_VERIFY: ${{ steps.find-containers.outputs.containers_to_verify }}
+        VERIFICATION_VERSIONS: ${{ steps.compute-verification-versions.outputs.versions }}
       run: |
         set -e
         # shellcheck disable=SC1091
         source "${GITHUB_ACTION_PATH}/../../../helpers/variant-utils.sh"
         # shellcheck disable=SC1091
         source "${GITHUB_ACTION_PATH}/../../../helpers/container-scopes.sh"
-        containers_json='${{ steps.find-containers.outputs.containers_to_verify }}'
-        versions_json='${{ steps.compute-verification-versions.outputs.versions }}'
+        containers_json="${CONTAINERS_TO_VERIFY:-[]}"
+        versions_json="${VERIFICATION_VERSIONS:-{}}"
         verification_expand_map=$(echo "$containers_json" | jq -c 'reduce .[] as $container ({}; . + {($container): false})')
 
         verification_builds=$(expand_variants_for_containers \

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -279,7 +279,7 @@ jobs:
     needs: [detect-containers]
     if: >-
       github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.fork == false
+      && github.event.pull_request.head.repo.full_name == github.repository
       && needs.detect-containers.outputs.e2e_builds != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -93,6 +93,8 @@ on:
       - '!**/CHANGELOG*'                        # Changelogs
       - '!**/docs/**'                           # Nested docs subdirs inside container dirs
       - '!**/tests/**'                          # Nested test subdirs inside container dirs
+      - '*/tests/**'                             # Re-include container tests: verification only, never a production build input
+      - 'tests/e2e-test.sh'                      # Re-include shared e2e harness: verifies all opted-in containers
       - '**/LAST_REBUILD.md'                    # Re-include — upstream-monitor's explicit retained-rebuild trigger marker (overrides !**/*.md)
   # Triggered on merge to master (actual deployment)
   push:

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -363,10 +363,12 @@ jobs:
           DETECT_RESULT: ${{ needs.detect-containers.result }}
           E2E_RESULT: ${{ needs.e2e-test.result }}
           E2E_BUILDS: ${{ needs.detect-containers.outputs.e2e_builds }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           d="$DETECT_RESULT"
           r="$E2E_RESULT"
           b="$E2E_BUILDS"
+          e="$EVENT_NAME"
           # A detection failure means we never computed what to test — do not pass.
           if [ "$d" != "success" ]; then
             echo "e2e-gate FAIL (detect-containers=$d)"; exit 1
@@ -374,12 +376,18 @@ jobs:
           case "$r" in
             success) echo "e2e-gate PASS (detect=$d e2e=$r)" ;;
             skipped)
-              # Skipped is only honest when there was nothing to run. The job is
-              # also skipped for a pull request from a fork, which cannot be given
-              # the registry access e2e needs — and passing there would report a
-              # suite as verified that never executed.
+              # Three ways the job is skipped, and only one of them is a lie.
+              #   nothing eligible          — honest, nothing to run
+              #   not a pull request        — honest, e2e is pull-request-only by
+              #                               design, so a push or a dispatch was
+              #                               never going to run it
+              #   eligible, on a PR         — the fork guard fired, and reporting
+              #                               success would call a suite verified
+              #                               that never executed
               if [ -z "$b" ] || [ "$b" = '[]' ]; then
                 echo "e2e-gate PASS (detect=$d e2e=skipped, nothing eligible)"
+              elif [ "$e" != "pull_request" ]; then
+                echo "e2e-gate PASS (detect=$d e2e=skipped, event=$e runs no e2e)"
               else
                 echo "e2e-gate FAIL: e2e was eligible ($b) but the job did not run."
                 echo "A pull request from a fork cannot run it; a maintainer has to run this branch."

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -356,15 +356,36 @@ jobs:
       contents: read
     steps:
       - shell: bash
+        # Through the environment, not expression interpolation: e2e_builds
+        # carries container names and upstream-derived versions, and expressions
+        # are expanded before bash parses this script.
+        env:
+          DETECT_RESULT: ${{ needs.detect-containers.result }}
+          E2E_RESULT: ${{ needs.e2e-test.result }}
+          E2E_BUILDS: ${{ needs.detect-containers.outputs.e2e_builds }}
         run: |
-          d='${{ needs.detect-containers.result }}'
-          r='${{ needs.e2e-test.result }}'
+          d="$DETECT_RESULT"
+          r="$E2E_RESULT"
+          b="$E2E_BUILDS"
           # A detection failure means we never computed what to test — do not pass.
           if [ "$d" != "success" ]; then
             echo "e2e-gate FAIL (detect-containers=$d)"; exit 1
           fi
           case "$r" in
-            success|skipped) echo "e2e-gate PASS (detect=$d e2e=$r)" ;;
+            success) echo "e2e-gate PASS (detect=$d e2e=$r)" ;;
+            skipped)
+              # Skipped is only honest when there was nothing to run. The job is
+              # also skipped for a pull request from a fork, which cannot be given
+              # the registry access e2e needs — and passing there would report a
+              # suite as verified that never executed.
+              if [ -z "$b" ] || [ "$b" = '[]' ]; then
+                echo "e2e-gate PASS (detect=$d e2e=skipped, nothing eligible)"
+              else
+                echo "e2e-gate FAIL: e2e was eligible ($b) but the job did not run."
+                echo "A pull request from a fork cannot run it; a maintainer has to run this branch."
+                exit 1
+              fi
+              ;;
             *) echo "e2e-gate FAIL (e2e-test=$r)"; exit 1 ;;
           esac
 

--- a/openvpn/tests/restart-lifecycle.sh
+++ b/openvpn/tests/restart-lifecycle.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Run by the e2e job in auto-build.yaml, against an image built for the occasion.
+# A change to this file now queues its container for verification on its own —
+# the e2e runs, and no production build is scheduled for it.
 set -euo pipefail
 
 if [ "$#" -gt 1 ]; then

--- a/tests/unit/detect-e2e-builds.bats
+++ b/tests/unit/detect-e2e-builds.bats
@@ -4,10 +4,11 @@ load "../test_helper"
 
 setup() {
     setup_temp_dir
+    export IS_FORK_PR="false"
 }
 
 teardown() {
-    unset BUILDS VERIFICATION_BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS GITHUB_ACTION_PATH GITHUB_OUTPUT
+    unset BUILDS VERIFICATION_BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS IS_FORK_PR GITHUB_ACTION_PATH GITHUB_OUTPUT
     teardown_temp_dir
 }
 

--- a/tests/unit/detect-e2e-builds.bats
+++ b/tests/unit/detect-e2e-builds.bats
@@ -7,17 +7,19 @@ setup() {
 }
 
 teardown() {
-    unset BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS GITHUB_ACTION_PATH GITHUB_OUTPUT
+    unset BUILDS VERIFICATION_BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS GITHUB_ACTION_PATH GITHUB_OUTPUT
     teardown_temp_dir
 }
 
 run_split_build_engine_step() {
     local builds="$1"
+    local verification_builds="${2:-[]}"
     local script="$TEST_TEMP_DIR/split-build-engine.sh"
     yq -r '.runs.steps[] | select(.id == "split-build-engine") | .run' \
         "$PROJECT_ROOT/.github/actions/detect-containers/action.yaml" > "$script"
 
     export BUILDS="$builds"
+    export VERIFICATION_BUILDS="$verification_builds"
     export EVENT_NAME="pull_request"
     export BUILD_ALL_RETAINED="false"
     export RUN_TESTS="false"
@@ -32,7 +34,7 @@ output_value() {
     sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
 }
 
-@test "S4: e2e_builds is filtered from the pre-split builds union for changed sslh only" {
+@test "S4: deleting e2e filtering would stop an enabled changed container from running its latest Linux suite" {
     builds=$(jq -cn '
       [
         {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"},
@@ -49,7 +51,7 @@ output_value() {
     [ "$(echo "$e2e_builds" | jq -r '.[0].tag')" = "v2.3.1-alpine" ]
 }
 
-@test "S5: non-enabled changed container produces empty e2e_builds" {
+@test "S5: deleting the e2e opt-in check would run a non-enabled container's suite" {
     builds=$(jq -cn '
       [
         {"container":"wordpress","version":"6.5.0","tag":"latest-6.5.0","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
@@ -60,4 +62,46 @@ output_value() {
     [ "$status" -eq 0 ]
     e2e_builds=$(output_value e2e_builds)
     [ "$e2e_builds" = "[]" ]
+}
+
+@test "S6: deleting the cell dedupe would run the same e2e variant twice for mixed source and test changes" {
+    build=$(jq -cn '
+      {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}')
+
+    run_split_build_engine_step "[$build]" "[$build]"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value bake_builds)" != "[]" ]
+    [ "$(output_value matrix_builds)" = "[]" ]
+    e2e_builds=$(output_value e2e_builds)
+    [ "$(echo "$e2e_builds" | jq 'length')" -eq 1 ]
+    [ "$(echo "$e2e_builds" | jq -r '.[0].container + ":" + .[0].tag')" = "sslh:v2.3.1-alpine" ]
+}
+
+@test "S7: deleting production isolation would schedule bake or matrix builds for a verification-only change" {
+    verification_builds=$(jq -cn '
+      [
+        {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
+      ]')
+
+    run_split_build_engine_step "[]" "$verification_builds"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value bake_builds)" = "[]" ]
+    [ "$(output_value matrix_builds)" = "[]" ]
+    [ "$(echo "$(output_value e2e_builds)" | jq 'length')" -eq 1 ]
+}
+
+@test "S8: deleting the e2e opt-in check would run a verification-only non-enabled container" {
+    verification_builds=$(jq -cn '
+      [
+        {"container":"wordpress","version":"6.5.0","tag":"latest-6.5.0","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
+      ]')
+
+    run_split_build_engine_step "[]" "$verification_builds"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value bake_builds)" = "[]" ]
+    [ "$(output_value matrix_builds)" = "[]" ]
+    [ "$(output_value e2e_builds)" = "[]" ]
 }

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+}
+
+teardown() {
+    unset BASELINE_FAILED BASELINE_VALID CONTAINER_SCOPES_INPUT GITHUB_ACTION_PATH GITHUB_OUTPUT GITHUB_WORKSPACE RUNNER_TEMP TEST_CHANGED_FILES
+    teardown_temp_dir
+}
+
+run_find_containers_step() {
+    local changed_files="$1"
+    local script="$TEST_TEMP_DIR/find-containers.sh"
+
+    yq -r '.runs.steps[] | select(.id == "find-containers") | .run' \
+        "$PROJECT_ROOT/.github/actions/detect-containers/action.yaml" > "$script"
+
+    # The extracted composite-action script still contains GitHub expressions.
+    # Render just enough pull-request context to exercise its classifier while
+    # replacing the git helper with the controlled changed-file fixture.
+    perl -0pi -e '
+        s/\$\{\{ github\.event_name \}\}/pull_request/g;
+        s/\$\{\{ github\.event\.pull_request\.base\.sha \}\}/base/g;
+        s/\$\{\{ github\.event\.pull_request\.head\.sha \}\}/head/g;
+        s/\$\{\{ inputs\.container \}\}//g;
+        s|(source "\$\{GITHUB_ACTION_PATH\}/\.\./\.\./\.\./helpers/pr-changed-files\.sh")|$1\npr_changed_files() { printf "%s\\n" "\${TEST_CHANGED_FILES}"; }|;
+    ' "$script"
+
+    export BASELINE_FAILED="[]"
+    export BASELINE_VALID="false"
+    export GITHUB_ACTION_PATH="$PROJECT_ROOT/.github/actions/detect-containers"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
+    export GITHUB_WORKSPACE="$PROJECT_ROOT"
+    export RUNNER_TEMP="$TEST_TEMP_DIR"
+    export TEST_CHANGED_FILES="$changed_files"
+
+    run bash "$script"
+}
+
+output_value() {
+    local name="$1"
+    sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
+}
+
+@test "deleting container-test classification would make a changed e2e script run neither verification nor a build" {
+    run_find_containers_step "sslh/tests/e2e.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = '["sslh"]' ]
+}
+
+@test "deleting shared-harness fanout would leave opted-in e2e suites unverified" {
+    run_find_containers_step "tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    actual=$(output_value containers_to_verify | jq -c 'sort')
+    expected=$(for file in "$PROJECT_ROOT"/*/variants.yaml; do
+        if [[ "$(yq -r '.tests.e2e.enabled // false' "$file")" == "true" ]]; then
+            basename "$(dirname "$file")"
+        fi
+    done | jq -R . | jq -sc 'sort')
+    [ "$actual" = "$expected" ]
+}
+
+@test "deleting verification subtraction would duplicate a container changed in both source and tests" {
+    run_find_containers_step $'sslh/Dockerfile\nsslh/tests/e2e.sh'
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = '["sslh"]' ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}
+
+@test "deleting metadata exclusions would turn markdown and docs edits into builds or verification" {
+    run_find_containers_step $'sslh/README.md\nsslh/docs/usage.md'
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -4,6 +4,7 @@ load "../test_helper"
 
 setup() {
     setup_temp_dir
+    export CONTAINER_SCOPES_INPUT=""
 }
 
 teardown() {
@@ -51,6 +52,14 @@ output_value() {
     [ "$status" -eq 0 ]
     [ "$(output_value containers)" = "[]" ]
     [ "$(output_value containers_to_verify)" = '["sslh"]' ]
+}
+
+@test "deleting nested-test e2e opt-in classification would verify a non-enabled container" {
+    run_find_containers_step "github-runner/tests/unit.bats"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
 }
 
 @test "deleting shared-harness fanout would leave opted-in e2e suites unverified" {

--- a/tests/unit/e2e-gate-eligibility.bats
+++ b/tests/unit/e2e-gate-eligibility.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+#
+# The e2e job's own eligibility expression. It is asserted separately from the
+# gate's decision table because the two are coupled: the gate now fails a pull
+# request whose eligible e2e job was skipped, so an eligibility expression that
+# skips the wrong pull requests turns into a blocked merge rather than a silent
+# omission.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    E2E_IF=$(yq -r '.jobs["e2e-test"]["if"]' \
+        "$PROJECT_ROOT/.github/workflows/auto-build.yaml")
+}
+
+teardown() {
+    unset E2E_IF
+    teardown_temp_dir
+}
+
+@test "deleting the identity check would skip e2e on a repository that is itself a fork" {
+    # `head.repo.fork` is true for every branch of a repository that was forked
+    # from somewhere, including its own. The question this job needs answered is
+    # whether the pull request comes from elsewhere, which is an identity
+    # comparison — the form the rest of this workflow already uses.
+    [[ "$E2E_IF" == *"head.repo.full_name == github.repository"* ]]
+    [[ "$E2E_IF" != *"head.repo.fork"* ]]
+}
+
+@test "deleting the event check would run e2e outside a pull request" {
+    [[ "$E2E_IF" == *"github.event_name == 'pull_request'"* ]]
+}
+
+@test "deleting the eligibility check would start an e2e job with nothing to test" {
+    [[ "$E2E_IF" == *"e2e_builds != '[]'"* ]]
+}
+
+@test "the same identity form is used by the sibling that guards cache writes" {
+    # One workflow, one way of asking. A second spelling is how the two drift.
+    run grep -c "head.repo.full_name == github.repository" \
+        "$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 2 ]
+}

--- a/tests/unit/e2e-gate.bats
+++ b/tests/unit/e2e-gate.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# The e2e gate decides whether a run without an e2e execution may still report
+# success. It gets a decision table of its own because the one thing it must
+# never do — call an unrun suite verified — is invisible from a green check.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    GATE_BODY=$(yq -r '.jobs["e2e-gate"].steps[0].run' \
+        "$PROJECT_ROOT/.github/workflows/auto-build.yaml")
+    ELIGIBLE='[{"container":"openvpn","tag":"v2.7.5-alpine"}]'
+}
+
+teardown() {
+    unset DETECT_RESULT E2E_RESULT E2E_BUILDS EVENT_NAME GATE_BODY ELIGIBLE
+    teardown_temp_dir
+}
+
+run_gate() { # detect, e2e, builds, event
+    DETECT_RESULT="$1" E2E_RESULT="$2" E2E_BUILDS="$3" EVENT_NAME="$4" \
+        run bash -c "$GATE_BODY"
+}
+
+@test "deleting the fork check would report a suite verified that never ran" {
+    # The job is skipped for a pull request from a fork, which cannot be given
+    # the registry access e2e needs. Passing there is the false green.
+    run_gate success skipped "$ELIGIBLE" pull_request
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"did not run"* ]]
+}
+
+@test "deleting the event check would fail every push that touches an e2e container" {
+    # e2e is pull-request-only by design, so a push skips it with eligible
+    # containers as a matter of course — and the images are already published by
+    # the time this gate runs.
+    run_gate success skipped "$ELIGIBLE" push
+    [ "$status" -eq 0 ]
+}
+
+@test "deleting the event check would also fail a manual or called run" {
+    run_gate success skipped "$ELIGIBLE" workflow_dispatch
+    [ "$status" -eq 0 ]
+    run_gate success skipped "$ELIGIBLE" workflow_call
+    [ "$status" -eq 0 ]
+}
+
+@test "deleting the eligibility check would fail a pull request with nothing to test" {
+    run_gate success skipped '[]' pull_request
+    [ "$status" -eq 0 ]
+    run_gate success skipped '' pull_request
+    [ "$status" -eq 0 ]
+}
+
+@test "deleting the result check would pass a pull request whose e2e failed" {
+    run_gate success failure "$ELIGIBLE" pull_request
+    [ "$status" -ne 0 ]
+    run_gate success cancelled "$ELIGIBLE" pull_request
+    [ "$status" -ne 0 ]
+}
+
+@test "a green e2e on a pull request passes" {
+    run_gate success success "$ELIGIBLE" pull_request
+    [ "$status" -eq 0 ]
+}
+
+@test "deleting the detection check would pass a run that never computed what to test" {
+    run_gate failure skipped '[]' pull_request
+    [ "$status" -ne 0 ]
+    run_gate cancelled success "$ELIGIBLE" pull_request
+    [ "$status" -ne 0 ]
+}
+
+@test "reading the build list through the environment keeps a hostile name inert" {
+    # e2e_builds carries container names and upstream-derived versions. Were it
+    # interpolated into the script instead, a quote would end the assignment.
+    local marker="$TEST_TEMP_DIR/executed"
+    run_gate success skipped "[{\"container\":\"x'; touch $marker; #\"}]" pull_request
+    [ ! -e "$marker" ]
+}


### PR DESCRIPTION
Closes #958
Closes #962

## What was wrong

A pull request whose changed files were all under `<container>/tests/**` ran
nothing. The trigger's path filter denied those paths, and the changed-file
classifier discarded them before it could map a path to a container. So an edit
to an e2e script merged without the script ever executing — the same shape as the
harness that once sat dead for months precisely because nothing ran it.

Treating a test change like a source change is not the fix, and #962 records why
it was tried and reverted: it builds without testing, expands the matrix to every
retained version, and reaches production one push later through the coverage
checkpoint.

## What changes

A changed path is either a **build input** or a **verification input**. The
classifier had one bucket and threw the second away; it now keeps both, and only
the e2e matrix reads their union.

`bake_builds`, `matrix_builds`, the extension and manifest sets, and everything
feeding the coverage checkpoint keep deriving from build inputs alone. That is
the safety property: a verification-only change schedules no build and pushes
nothing. A container changed in both a source file and a test file is subtracted
out of the verification set, so it is built and verified exactly once.

Two policies, deliberately separate:

| trigger | verifies |
|---|---|
| `<container>/tests/**` | that container |
| `tests/e2e-test.sh` | every container that opts into e2e |

The trigger re-includes `*/tests/**`, narrower than `**/tests/**`: it wakes the
workflow for container tests without waking it for the repository's own root test
suite, which has its own CI. The push filter is untouched, so a verification-only
merge still runs no workflow — the checkpoint tracks what has been built, not
what has been verified.

Eligibility is decided at classification. A container that does not opt into e2e
never enters the verification set, so a test-only change to it no longer resolves
an upstream version over the network only to discard the result.

## Two things the e2e gate was getting wrong

Re-including test paths wakes this workflow for pull requests from forks, where
the e2e job is deliberately skipped — running untrusted code against registry
access is a different security design, and that guard stays. But the gate treated
`skipped` as success unconditionally, so a fork changing an e2e script would have
received a green check with nothing executed. Skipped now has three readings and
only one of them is a lie: nothing was eligible, or the event never runs e2e at
all, or a pull request had work and the fork guard fired. Only the last fails.

Separately, that guard asked whether the head repository *was a fork of
something*, not whether the pull request came from elsewhere. On a repository
that is itself a fork, every one of its own branches reads as foreign. The
workflow already asks the question correctly in two other places, by comparing
`head.repo.full_name` against the repository; this was the one place that did
not.

## Verification

The full unit suite is green on this branch: **2176 collected, 0 failed**, up
from 2156, and checked through the suite guard rather than by reading a tail.

The safety property is mutation-proven: feeding verification candidates into
`partition_builds` turns red the test named *"deleting production isolation would
schedule bake or matrix builds for a verification-only change"*. It protects what
its name claims.

The e2e gate gets a decision table it did not have — every event that can reach
it, crossed with the job result and both eligibility states, plus an assertion
that a container name carrying a quote executes nothing. It was changed twice
without one, and both times the mistake was a row nobody had written down.

Eligibility resolution reads values through the environment rather than workflow
expressions, which are expanded before bash parses the script; a container name
or an upstream-derived version carrying an apostrophe would otherwise close the
quote.

Every test is named for what breaks if it is deleted.

## Scope, stated plainly

Four containers opt into e2e: ansible, debian, openvpn and sslh. Three drive it
from `<container>/test.sh`, which is a build input and already triggered. The
only container-nested e2e script today is
`openvpn/tests/restart-lifecycle.sh`, so the first policy changes behaviour for
one file right now. The second covers the shared harness — the path that
historically went dead.

`github-runner/tests/*.bats` and `openresty/tests/*` belong to containers that do
not opt into e2e. They are classified and produce no cell, which is intended:
those families are gated on `run_tests=true`, which pull requests do not set, and
building an image to run nothing would be worse than the status quo.

## Left for follow-ups

`<container>/test.sh` — the entrypoint the harness actually runs — is still a
build input, so editing one queues a production build. Nine of the eleven
containers that have one do not ship it in their image at all, and two do only
because a `COPY *.sh` glob sweeps it in alongside their upstream version-discovery
script. Narrowing those two globs comes first; classifying the path is uniform
afterwards and needs no per-container exception.
