### PR TITLE
fix(build): copy the entrypoint into an image, not every script beside it

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -60,7 +60,12 @@ RUN useradd -ms /bin/bash -G sudo ansible \
     && echo "ansible ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && chown -R ansible:ansible $VIRTUAL_ENV
 
-COPY --chmod=755 *.sh /
+# Named rather than globbed. This directory also holds test.sh, which the e2e
+# harness runs from the host against a running container, and version.sh, which
+# the build system runs to discover the upstream release. Neither has a role
+# inside the image, and the glob shipped both — putting test code in a published
+# image, and making every edit to either one rebuild that image.
+COPY --chmod=755 docker-entrypoint.sh addon.sh /
 
 LABEL org.opencontainers.image.title="Ansible" \
       org.opencontainers.image.description="Ansible automation platform with Python venv isolation" \

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -120,7 +120,7 @@ docker build \
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ADDONSCRIPT` | Path to custom initialization script | `/default-addon.sh` |
+| `ADDONSCRIPT` | Path to custom initialization script | (unset — no script runs) |
 | `WAIT_BEFORE_EXIT` | Wait for keypress before container exits | (unset) |
 | `VIRTUAL_ENV` | Python virtual environment path | `/opt/ansible-venv` |
 | `PATH` | Updated to include venv binaries | `/opt/ansible-venv/bin:$PATH` |
@@ -138,10 +138,12 @@ services:
       - ./scripts:/scripts:ro
 ```
 
-Set to empty string to skip addon script execution:
-```bash
-docker run --rm -e ADDONSCRIPT="" ghcr.io/oorabona/ansible ansible --version
-```
+Nothing runs when it is unset, which is the default. Pointing it at a path that
+is not executable is an error and stops the container, so that a mistyped path
+fails loudly instead of silently skipping your initialization.
+
+The image also carries `/addon.sh`, the example from this repository. It is not
+the default and nothing runs it unless you name it.
 
 ### WAIT_BEFORE_EXIT
 Useful for debugging or interactive sessions. Container will wait for Enter key before exiting:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -138,9 +138,11 @@ services:
       - ./scripts:/scripts:ro
 ```
 
-Nothing runs when it is unset, which is the default. Pointing it at a path that
-is not executable is an error and stops the container, so that a mistyped path
-fails loudly instead of silently skipping your initialization.
+Nothing runs when it is unset or empty, which is the default. A value naming
+something that is not executable stops the container with a message. Anything
+executable is sourced — and note that a directory is executable, so a path that
+points at one is sourced, fails, and the container carries on: the check is a
+guard against a typo, not a validation of the script.
 
 The image also carries `/addon.sh`, the example from this repository. It is not
 the default and nothing runs it unless you name it.

--- a/ansible/addon.sh
+++ b/ansible/addon.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # This is an example addon shell script
 cat << eof
-Hello there, this is the default addon script, you can find it useful to keep
-the docker-entrypoint structure and add your extra configuration setup in here.
+Hello there, this is the example addon script. Nothing runs it unless you point
+ADDONSCRIPT at it — there is no default. Keep the docker-entrypoint structure and
+put your extra configuration setup in a script of your own.
 
 Possible use cases would include :
 - init cloud credentials (AWS, etc.)
@@ -10,8 +11,8 @@ Possible use cases would include :
 - open a connection to a remote vault
 etc.
 
-In case you do not need any, you can easily remove either by setting an empty
-ADDONSCRIPT environment variable or by simply removing the file.
+To stop it running, unset ADDONSCRIPT or set it empty — which is also the state
+you get if you never set it at all.
 
 Sleeping for 5 seconds so that you have a chance to read this intro :)
 eof

--- a/tests/unit/dockerfile-copy-scope.bats
+++ b/tests/unit/dockerfile-copy-scope.bats
@@ -11,8 +11,10 @@
 
 load "../test_helper"
 
-# Any directory holding a Dockerfile, not only those with a variants.yaml — the
-# build helpers support containers without one, and they can carry the glob too.
+# Top-level container directories holding a Dockerfile, whether or not they carry
+# a variants.yaml — the build helpers support both. Deliberately not recursive:
+# what this protects is the published images, and a Dockerfile under examples/ is
+# illustration, not a tag anyone pulls.
 container_dirs() {
     local d
     for d in "$PROJECT_ROOT"/*/; do
@@ -21,12 +23,22 @@ container_dirs() {
     done
 }
 
+# Logical instructions, not physical lines: a continued `COPY --chmod=755 \`
+# followed by `*.sh /` satisfies neither line on its own. Lines whose source is a
+# build stage are dropped — `COPY --from=…` does not reach into the directory
+# holding test.sh, so matching it would be a false alarm.
+copy_instructions() { # dockerfile
+    sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$1" |
+        grep -iE '^[[:space:]]*(COPY|ADD)([[:space:]]|$)' |
+        grep -ivE '^[[:space:]]*(COPY|ADD)([[:space:]]+--[^[:space:]]+)*[[:space:]]+--from=' || true
+}
+
 # What this checks and what it does not: it reads Dockerfile text for a copy whose
 # source is a bare `*.sh` glob. It cannot prove that no host-side script reaches an
 # image — only a built image can show that, and a `.dockerignore`, a directory
 # copy or a multi-stage indirection would all escape a text scan. It exists to stop
 # the one spelling that put test.sh into two published images from coming back.
-@test "no Dockerfile copies a bare *.sh glob out of a directory holding host-side scripts" {
+@test "no container Dockerfile copies a bare *.sh glob out of its own directory" {
     local offenders=""
     local dir name df line
 
@@ -38,13 +50,13 @@ container_dirs() {
 
         for df in "$dir"/Dockerfile*; do
             [ -f "$df" ] || continue
-            # Two steps rather than one expression: first the instructions that
-            # bring files in, then a bare `*.sh` token anywhere among their
-            # arguments. Written as one regex it silently stopped matching the
-            # plainest spelling of all.
+            # Two steps rather than one expression: the instructions that bring
+            # files in, then a bare `*.sh` token anywhere among their arguments.
+            # Written as one regex it silently stopped matching the plainest
+            # spelling of all.
             while IFS= read -r line; do
                 offenders="$offenders  $name/$(basename "$df"): $line"$'\n'
-            done < <(grep -iE '^[[:space:]]*(COPY|ADD)([[:space:]]|$)' "$df" |
+            done < <(copy_instructions "$df" |
                      grep -E '(^|[[:space:]"[])(\./)?\*\.sh([[:space:]",]|$)' || true)
         done
     done < <(container_dirs)
@@ -67,10 +79,10 @@ container_dirs() {
 # stops reporting and the suite stays green. It gets its own table of spellings —
 # written after a "broadening" edit quietly stopped matching `COPY *.sh /`, the
 # plainest form of the defect and the one that shipped.
-matches_glob() { # dockerfile line
-    printf '%s\n' "$1" |
-        grep -iE '^[[:space:]]*(COPY|ADD)([[:space:]]|$)' |
-        grep -qE '(^|[[:space:]"[])(\./)?\*\.sh([[:space:]",]|$)'
+matches_glob() { # dockerfile text, possibly multi-line
+    local f="$BATS_TEST_TMPDIR/df"
+    printf '%s\n' "$1" > "$f"
+    copy_instructions "$f" | grep -qE '(^|[[:space:]"[])(\./)?\*\.sh([[:space:]",]|$)'
 }
 
 @test "the glob matcher catches every spelling that would ship the scripts" {
@@ -82,6 +94,9 @@ matches_glob() { # dockerfile line
     matches_glob 'COPY ["*.sh", "/"]'
     matches_glob 'COPY ./*.sh /'
     matches_glob '    COPY *.sh /'
+    # Continued across lines: neither line satisfies the match on its own.
+    matches_glob 'COPY --chmod=755 \
+    *.sh /'
 }
 
 @test "the glob matcher leaves alone what does not ship them" {
@@ -90,6 +105,10 @@ matches_glob() { # dockerfile line
     ! matches_glob 'COPY --from=builder /out/x.sh /'
     ! matches_glob 'RUN ls x*.sh'
     ! matches_glob 'RUN echo hi'
+    # A build stage is not the directory holding test.sh, so a glob out of one is
+    # not this defect.
+    ! matches_glob 'COPY --from=builder *.sh /usr/local/bin/'
+    ! matches_glob 'COPY --chmod=755 --from=builder *.sh /'
 }
 
 # A further check lived here and was removed rather than repaired: "every

--- a/tests/unit/dockerfile-copy-scope.bats
+++ b/tests/unit/dockerfile-copy-scope.bats
@@ -11,16 +11,22 @@
 
 load "../test_helper"
 
-# Directories holding a Dockerfile that is not generated from a template.
+# Any directory holding a Dockerfile, not only those with a variants.yaml — the
+# build helpers support containers without one, and they can carry the glob too.
 container_dirs() {
     local d
     for d in "$PROJECT_ROOT"/*/; do
-        [ -f "${d}variants.yaml" ] || continue
+        compgen -G "${d}Dockerfile*" > /dev/null || continue
         printf '%s\n' "${d%/}"
     done
 }
 
-@test "no Dockerfile globs *.sh out of a directory that also holds host-side scripts" {
+# What this checks and what it does not: it reads Dockerfile text for a copy whose
+# source is a bare `*.sh` glob. It cannot prove that no host-side script reaches an
+# image — only a built image can show that, and a `.dockerignore`, a directory
+# copy or a multi-stage indirection would all escape a text scan. It exists to stop
+# the one spelling that put test.sh into two published images from coming back.
+@test "no Dockerfile copies a bare *.sh glob out of a directory holding host-side scripts" {
     local offenders=""
     local dir name df line
 
@@ -32,9 +38,14 @@ container_dirs() {
 
         for df in "$dir"/Dockerfile*; do
             [ -f "$df" ] || continue
+            # Two steps rather than one expression: first the instructions that
+            # bring files in, then a bare `*.sh` token anywhere among their
+            # arguments. Written as one regex it silently stopped matching the
+            # plainest spelling of all.
             while IFS= read -r line; do
                 offenders="$offenders  $name/$(basename "$df"): $line"$'\n'
-            done < <(grep -iE '^[[:space:]]*COPY([[:space:]]+--[^[:space:]]+)*[[:space:]]+(\./)?\*\.sh[[:space:]]' "$df" || true)
+            done < <(grep -iE '^[[:space:]]*(COPY|ADD)([[:space:]]|$)' "$df" |
+                     grep -E '(^|[[:space:]"[])(\./)?\*\.sh([[:space:]",]|$)' || true)
         done
     done < <(container_dirs)
 
@@ -52,22 +63,40 @@ container_dirs() {
         "$PROJECT_ROOT/wordpress/Dockerfile"
 }
 
-@test "every container's declared entrypoint script is one the Dockerfile copies" {
-    # The failure this catches is narrowing a COPY past what the image invokes.
-    local dir name df entry
-    while IFS= read -r dir; do
-        name=$(basename "$dir")
-        df="$dir/Dockerfile"
-        [ -f "$df" ] || continue
-        entry=$(grep -oE '^[[:space:]]*ENTRYPOINT[[:space:]]*\[[[:space:]]*"[^"]+"' "$df" 2>/dev/null |
-            grep -oE '"[^"]+"' | tr -d '"' | xargs -r basename 2>/dev/null || true)
-        [ -n "$entry" ] || continue
-        # Only check entrypoints that live in the container directory as a script.
-        [ -f "$dir/$entry" ] || continue
-        if ! grep -qE "^[[:space:]]*COPY.*([[:space:]]|/)${entry}([[:space:]]|$)" "$df" &&
-           ! grep -qE '^[[:space:]]*COPY.*\*\.sh' "$df"; then
-            printf '%s declares ENTRYPOINT %s but no COPY brings it in\n' "$name" "$entry" >&2
-            return 1
-        fi
-    done < <(container_dirs)
+# The matcher above is the part that can fail silently: tightened or loosened, it
+# stops reporting and the suite stays green. It gets its own table of spellings —
+# written after a "broadening" edit quietly stopped matching `COPY *.sh /`, the
+# plainest form of the defect and the one that shipped.
+matches_glob() { # dockerfile line
+    printf '%s\n' "$1" |
+        grep -iE '^[[:space:]]*(COPY|ADD)([[:space:]]|$)' |
+        grep -qE '(^|[[:space:]"[])(\./)?\*\.sh([[:space:]",]|$)'
 }
+
+@test "the glob matcher catches every spelling that would ship the scripts" {
+    matches_glob 'COPY *.sh /'
+    matches_glob 'COPY --chmod=755 *.sh /'
+    matches_glob 'copy *.sh /'
+    matches_glob 'ADD *.sh /'
+    matches_glob 'COPY entrypoint.sh *.sh /'
+    matches_glob 'COPY ["*.sh", "/"]'
+    matches_glob 'COPY ./*.sh /'
+    matches_glob '    COPY *.sh /'
+}
+
+@test "the glob matcher leaves alone what does not ship them" {
+    ! matches_glob 'COPY docker-entrypoint.sh /'
+    ! matches_glob 'COPY scripts/*.sh /'
+    ! matches_glob 'COPY --from=builder /out/x.sh /'
+    ! matches_glob 'RUN ls x*.sh'
+    ! matches_glob 'RUN echo hi'
+}
+
+# A further check lived here and was removed rather than repaired: "every
+# container's declared entrypoint script is one the Dockerfile copies". Deciding
+# that from Dockerfile text needs stage-aware source/destination parsing, and the
+# grep standing in for it mistook a wrapper entrypoint for the script it wraps,
+# read only the canonical Dockerfile while its sibling read every variant, and
+# silently skipped whatever it could not parse. A check that skips what it cannot
+# read reports success for the cases it is least able to judge. What actually
+# proves an image runs is the e2e suite, against a built image.

--- a/tests/unit/dockerfile-copy-scope.bats
+++ b/tests/unit/dockerfile-copy-scope.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+#
+# A container directory holds two kinds of shell script: what the image runs, and
+# what the repository runs *about* the image — `test.sh`, which the e2e harness
+# executes from the host against a running container, and `version.sh`, which the
+# build system executes to discover the upstream release.
+#
+# A `COPY *.sh` glob cannot tell them apart. It ships test code into a published
+# image, and it makes the image a dependant of files that can never change it, so
+# every edit to either one queues a rebuild.
+
+load "../test_helper"
+
+# Directories holding a Dockerfile that is not generated from a template.
+container_dirs() {
+    local d
+    for d in "$PROJECT_ROOT"/*/; do
+        [ -f "${d}variants.yaml" ] || continue
+        printf '%s\n' "${d%/}"
+    done
+}
+
+@test "no Dockerfile globs *.sh out of a directory that also holds host-side scripts" {
+    local offenders=""
+    local dir name df line
+
+    while IFS= read -r dir; do
+        name=$(basename "$dir")
+        # Only a directory that actually holds one of the host-side scripts can
+        # be harmed by the glob.
+        [ -f "$dir/test.sh" ] || [ -f "$dir/version.sh" ] || continue
+
+        for df in "$dir"/Dockerfile*; do
+            [ -f "$df" ] || continue
+            while IFS= read -r line; do
+                offenders="$offenders  $name/$(basename "$df"): $line"$'\n'
+            done < <(grep -iE '^[[:space:]]*COPY([[:space:]]+--[^[:space:]]+)*[[:space:]]+(\./)?\*\.sh[[:space:]]' "$df" || true)
+        done
+    done < <(container_dirs)
+
+    if [ -n "$offenders" ]; then
+        printf 'A COPY glob would ship test.sh or version.sh into an image:\n%s' "$offenders" >&2
+        return 1
+    fi
+}
+
+@test "the two images that carried the glob still copy the entrypoint they run" {
+    # Narrowing the glob must not have dropped the file the image actually needs.
+    grep -qE '^[[:space:]]*COPY.*[[:space:]]docker-entrypoint\.sh([[:space:]]|$)' \
+        "$PROJECT_ROOT/ansible/Dockerfile"
+    grep -qE '^[[:space:]]*COPY.*[[:space:]]docker-entrypoint\.sh([[:space:]]|$)' \
+        "$PROJECT_ROOT/wordpress/Dockerfile"
+}
+
+@test "every container's declared entrypoint script is one the Dockerfile copies" {
+    # The failure this catches is narrowing a COPY past what the image invokes.
+    local dir name df entry
+    while IFS= read -r dir; do
+        name=$(basename "$dir")
+        df="$dir/Dockerfile"
+        [ -f "$df" ] || continue
+        entry=$(grep -oE '^[[:space:]]*ENTRYPOINT[[:space:]]*\[[[:space:]]*"[^"]+"' "$df" 2>/dev/null |
+            grep -oE '"[^"]+"' | tr -d '"' | xargs -r basename 2>/dev/null || true)
+        [ -n "$entry" ] || continue
+        # Only check entrypoints that live in the container directory as a script.
+        [ -f "$dir/$entry" ] || continue
+        if ! grep -qE "^[[:space:]]*COPY.*([[:space:]]|/)${entry}([[:space:]]|$)" "$df" &&
+           ! grep -qE '^[[:space:]]*COPY.*\*\.sh' "$df"; then
+            printf '%s declares ENTRYPOINT %s but no COPY brings it in\n' "$name" "$entry" >&2
+            return 1
+        fi
+    done < <(container_dirs)
+}

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -48,7 +48,12 @@ RUN set -ex; \
     wp --info --allow-root
 
 # Copy entrypoint scripts
-COPY --chmod=755 *.sh /usr/local/bin/
+# Named rather than globbed. This directory also holds test.sh, which the e2e
+# harness runs from the host against a running container, and version.sh, which
+# the build system runs to discover the upstream release. Neither has a role
+# inside the image, and the glob shipped both — putting test code in a published
+# image, and making every edit to either one rebuild that image.
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 
 # Setup directories and download WordPress core + SQLite drop-in
 ARG VERSION


### PR DESCRIPTION
Part of #976, and the step that has to land before `<container>/test.sh` can be
classified as a verification input rather than a build input.

## What was wrong

A container directory holds two kinds of shell script: what the image runs, and
what the repository runs *about* the image. `test.sh` is executed by the e2e
harness from the host against a running container; `version.sh` is executed by
the build system to discover the upstream release.

`COPY *.sh` cannot tell them apart. `ansible` and `wordpress` were the only two
containers using it, and both shipped their own test script and their own
version-discovery script into a published image. And because a file that lands in
an image is a build input, every edit to either one queued a rebuild of an image
it could not possibly change.

The other nine containers that carry a `test.sh` never had the glob.

## What changes

Both Dockerfiles name the file they need. `ansible` keeps `addon.sh` — removing
it would break anyone passing `-e ADDONSCRIPT=/addon.sh`, which is a separate
question from this one.

Both images will rebuild and republish, which is the point: their contents change.

## Verification

Nothing depended on the removed files being inside an image. A repository-wide
search for `/test.sh`, `/version.sh` and `/usr/local/bin/{test,version}.sh`
returns only host-side uses — the `validate-version-scripts` workflow operating on
repository files, and each script's own usage comment.

The e2e is unaffected, checked rather than assumed: both `ansible/test.sh` and
`wordpress/test.sh` run from the host and reach into the container with
`docker exec … ansible|php|wp`. Neither ever invoked the copy that was inside.

The unit suite is at **2180, nothing failing**. Restoring the glob turns the new
guard red, so it protects what its name claims.

## The guard

One check fails if any container Dockerfile copies a bare `*.sh` glob out of its
own directory — the defect class rather than these two instances. It matches
logical instructions rather than physical lines, so a continued `COPY … \` cannot
slip past, and it ignores `--from=` sources because a build stage is not the
directory holding `test.sh`. Thirteen spellings are pinned beside it, positive and
negative, because a matcher is the part that fails quietly: an earlier version of
this guard was "broadened" and silently stopped matching `COPY *.sh /`, the
plainest form and the one that shipped.

What it cannot decide is written in the file: a `.dockerignore`, a directory copy
or a multi-stage indirection all escape a text scan. Proving what an image
contains is the e2e's job, against a built image.

A second check was written, then deleted rather than repaired — "every
container's declared entrypoint script is one the Dockerfile copies". Deciding
that from text needs stage-aware source and destination parsing; the grep standing
in for it mistook a wrapper entrypoint for the script it wraps, read only the
canonical Dockerfile while its sibling read every variant, and skipped whatever it
could not parse, which is to say it reported success for the cases it was least
able to judge.

## Documentation, while there

ansible's README gave `ADDONSCRIPT` a default of `/default-addon.sh`. No such file
is in the image and nothing sets that variable, so the documented default never
existed. The table now says what is true, and the surrounding text records what
the entrypoint actually does: a value that is not executable stops the container,
but a directory *is* executable, so a mistyped path pointing at one is sourced,
fails, and the container carries on — there is no `errexit`. It guards against a
typo; it does not validate a script.

The bundled example no longer calls itself the default, and no longer tells the
reader to clear a variable that was never set.
