### PR TITLE
feat(ci): verify a container when its e2e entrypoint changes, instead of rebuilding it

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -305,12 +305,16 @@ runs:
         # container: is it one make knows, does it run an e2e at all, and is it
         # already in the list. Written once so a fourth path cannot answer them
         # differently.
+        # Cheapest question first: a container already in the list needs no further
+        # thought, and reading its variants.yaml again would spawn one yq per
+        # changed file. A pull request touching many files under one container
+        # would otherwise pay that cost once per file.
         note_verification() {
           local container="$1" reason="$2"
           [[ -n "$container" ]] || return 0
+          [[ " ${containers_to_verify[*]} " =~ " ${container} " ]] && return 0
           echo "$valid_containers" | grep -Fxq "$container" || return 0
           container_e2e_enabled "$container" || return 0
-          [[ " ${containers_to_verify[*]} " =~ " ${container} " ]] && return 0
           echo "🧪 Container needs verification: $container ($reason)"
           containers_to_verify+=("$container")
         }
@@ -476,8 +480,17 @@ runs:
                 # container directory next to the Dockerfile, which is what made
                 # it a build input; no image copies it any more, so a change to it
                 # verifies the container without rebuilding it.
-                note_verification "${file%%/*}" "container e2e entrypoint changed"
-                continue
+                #
+                # A `case` glob spans slashes, so this pattern also matches a
+                # nested <container>/anywhere/test.sh — which may be a genuine
+                # build input, and treating it as verification would silently
+                # cancel its build. Only the file directly beside the Dockerfile
+                # is the harness entrypoint; anything deeper falls through to
+                # normal build classification below.
+                if [[ "${file#*/}" == "test.sh" ]]; then
+                  note_verification "${file%%/*}" "container e2e entrypoint changed"
+                  continue
+                fi
                 ;;
               tests/e2e-test.sh)
                 while IFS= read -r container; do

--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -301,6 +301,20 @@ runs:
           [[ "$enabled" == "true" ]]
         }
 
+        # Every verification path answers the same three questions before adding a
+        # container: is it one make knows, does it run an e2e at all, and is it
+        # already in the list. Written once so a fourth path cannot answer them
+        # differently.
+        note_verification() {
+          local container="$1" reason="$2"
+          [[ -n "$container" ]] || return 0
+          echo "$valid_containers" | grep -Fxq "$container" || return 0
+          container_e2e_enabled "$container" || return 0
+          [[ " ${containers_to_verify[*]} " =~ " ${container} " ]] && return 0
+          echo "🧪 Container needs verification: $container ($reason)"
+          containers_to_verify+=("$container")
+        }
+
         if [[ -z "$valid_containers" ]]; then
           echo "⚠️  No valid containers found in make script"
           exit 1
@@ -454,23 +468,21 @@ runs:
             # harness verifies every container that explicitly opts in.
             case "$file" in
               */tests/*)
-                container="${file%%/*}"
-                if echo "$valid_containers" | grep -Fxq "$container" \
-                  && container_e2e_enabled "$container" \
-                  && [[ ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
-                  echo "🧪 Container needs verification: $container (container test changed)"
-                  containers_to_verify+=("$container")
-                fi
+                note_verification "${file%%/*}" "container test changed"
+                continue
+                ;;
+              */test.sh)
+                # The entrypoint the e2e harness runs. It lives at the top of the
+                # container directory next to the Dockerfile, which is what made
+                # it a build input; no image copies it any more, so a change to it
+                # verifies the container without rebuilding it.
+                note_verification "${file%%/*}" "container e2e entrypoint changed"
                 continue
                 ;;
               tests/e2e-test.sh)
                 while IFS= read -r container; do
                   [[ -z "$container" ]] && continue
-                  if container_e2e_enabled "$container" \
-                    && [[ ! " ${containers_to_verify[*]} " =~ " ${container} " ]]; then
-                    echo "🧪 Container needs verification: $container (shared e2e harness changed)"
-                    containers_to_verify+=("$container")
-                  fi
+                  note_verification "$container" "shared e2e harness changed"
                 done <<< "$valid_containers"
                 continue
                 ;;

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -267,14 +267,29 @@ test_container() {
         return 1
     fi
 
-    # Run custom test script if exists
-    if [ -x "$test_script" ]; then
-        log_info "Running custom tests for $container..."
-        if ! CONTAINER_NAME="$container_name" "$test_script"; then
-            log_error "Custom tests failed for $container"
-            docker rm -f "$container_name" 2>/dev/null || true
-            return 1
-        fi
+    # The per-container script is the point of this run, not an optional extra:
+    # everything above it is a generic liveness check that any image passes. A
+    # missing or non-executable script used to be skipped in silence, so deleting
+    # one — or losing its mode in a checkout — turned a suite into a container
+    # that merely started, and the run still reported success. This harness has
+    # been silently unrun once already; it says so now.
+    if [ ! -e "$test_script" ]; then
+        log_error "$container has no test script at ${test_script#"$REPO_ROOT"/}"
+        log_error "Nothing container-specific would be verified — refusing to report success."
+        docker rm -f "$container_name" 2>/dev/null || true
+        return 1
+    fi
+    if [ ! -x "$test_script" ]; then
+        log_error "${test_script#"$REPO_ROOT"/} is not executable, so it cannot run."
+        docker rm -f "$container_name" 2>/dev/null || true
+        return 1
+    fi
+
+    log_info "Running custom tests for $container..."
+    if ! CONTAINER_NAME="$container_name" "$test_script"; then
+        log_error "Custom tests failed for $container"
+        docker rm -f "$container_name" 2>/dev/null || true
+        return 1
     fi
 
     # Cleanup

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -62,6 +62,33 @@ output_value() {
     [ "$(output_value containers_to_verify)" = "[]" ]
 }
 
+@test "deleting entrypoint classification would rebuild an image for a test-script edit" {
+    # <container>/test.sh is what the harness actually runs. It sits beside the
+    # Dockerfile, which is what used to make it a build input; no image copies it.
+    run_find_containers_step "sslh/test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = '["sslh"]' ]
+}
+
+@test "deleting the entrypoint opt-in check would verify a container with no e2e" {
+    # php has a test.sh and does not opt into e2e, so there is nothing to run.
+    run_find_containers_step "php/test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}
+
+@test "deleting the subtraction would verify a container its own source change already builds" {
+    run_find_containers_step $'sslh/Dockerfile\nsslh/test.sh'
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = '["sslh"]' ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}
+
 @test "deleting shared-harness fanout would leave opted-in e2e suites unverified" {
     run_find_containers_step "tests/e2e-test.sh"
 

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -72,6 +72,25 @@ output_value() {
     [ "$(output_value containers_to_verify)" = '["sslh"]' ]
 }
 
+@test "deleting the one-level guard would cancel the build of a nested script" {
+    # A case glob spans slashes, so */test.sh also matches a nested path. That
+    # file may well be copied into the image; classing it as verification would
+    # suppress the build it needs, silently.
+    run_find_containers_step "sslh/scripts/test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = '["sslh"]' ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}
+
+@test "a test.sh outside any container is neither built nor verified" {
+    run_find_containers_step "examples/wordpress-stack/test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ "$(output_value containers_to_verify)" = "[]" ]
+}
+
 @test "deleting the entrypoint opt-in check would verify a container with no e2e" {
     # php has a test.sh and does not opt into e2e, so there is nothing to run.
     run_find_containers_step "php/test.sh"

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -96,6 +96,38 @@ SH
     ! grep -q '^images ' "$DOCKER_LOG"
 }
 
+@test "deleting the missing-script check would pass a run that verified nothing" {
+    # Everything before the per-container script is a generic liveness check that
+    # any image passes. Skipping a deleted script in silence turned a suite into
+    # "the container started" while still reporting success — which is how this
+    # harness came to sit unrun for months.
+    add_openvpn_fixture
+    rm "$FIXTURE_REPO/openvpn/test.sh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no test script"* ]]
+}
+
+@test "deleting the executable check would pass a script that cannot run" {
+    # A checkout or an archive can drop the mode bit without touching a byte of
+    # the script.
+    add_openvpn_fixture
+    chmod -x "$FIXTURE_REPO/openvpn/test.sh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not executable"* ]]
+}
+
 @test "S6: fallback image discovery errors on zero matches" {
     mkdir -p "$FIXTURE_REPO/debian"
     install_docker_stub
@@ -124,6 +156,10 @@ SH
 
 @test "sslh run profile: args-only command, port 443, NET_BIND_SERVICE (entrypoint+healthcheck match)" {
     mkdir -p "$FIXTURE_REPO/sslh"
+    # The real container has one, and the harness now requires it — this fixture
+    # stands in for it so the assertions below stay about the run profile.
+    printf '#!/bin/bash\nexit 0\n' > "$FIXTURE_REPO/sslh/test.sh"
+    chmod +x "$FIXTURE_REPO/sslh/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export DOCKER_PS_OUTPUT="e2e-sslh"


### PR DESCRIPTION
Completes the sequence begun in #975 and unblocked by #977. Part of #976.

## What changes

`<container>/test.sh` is the script the e2e harness runs from the host against a
running container. It sits at the top of the container directory beside the
Dockerfile, and that position was the only reason it counted as a build input:
editing one queued a production build and, on master, republished the image.

#977 removed the two `COPY *.sh` globs that were the only way that file reached
an image, so the classification is now uniform — there is no container for which
it is a build input, and no per-container exception is needed to say so. A change
to it verifies that container and builds nothing.

A third verification path arrived with it, so the three questions every path was
answering in its own words — is this a container `make list` knows, does it opt
into e2e, is it already listed — are now asked once. Breaking the opt-in check in
that one place turns three tests red rather than one.

## The e2e harness now fails instead of skipping

Everything the harness does before the per-container script is a generic liveness
check that any image passes. The script was invoked under `if [ -x ]`, so a
deleted one, or one that lost its mode bit in a checkout, was skipped in silence
and the run still reported success.

That is the failure this repository has already paid for: the harness sat unrun
for months after a move broke the path it resolved, and nothing said so. It now
ends the run with the reason.

Adding that check made an existing test fail, which is the argument for it. The
sslh fixture was a bare directory with no test script, so its assertions about the
container's run profile were being made inside a run that verified nothing
container-specific. The fixture now carries a script, as the real container does,
and the assertions are unchanged.

## Verification

The unit suite is at **2187, nothing failing** — up from 2180, checked through the
suite guard rather than by reading a tail.

Mutation-proven three ways. Removing the `*/test.sh` case turns its own test red.
Removing the one-level guard turns the nested-path test red. Removing the opt-in
check from the shared helper turns three tests red, one per verification path.

Checked rather than assumed:

- **Case ordering.** A `case` glob spans slashes, so `*/test.sh` also matches
  `<container>/scripts/test.sh` — whose first segment is a real container, so it
  would have been classed as verification and its build silently cancelled. The
  case now requires the remainder after the first slash to be exactly `test.sh`;
  anything deeper falls through to normal classification. The seven nested
  `test.sh` files in the tree all sit under `examples/`, so this was latent, which
  is why it needed a test rather than a reading.
- **Path filters need no change.** `<container>/test.sh` matches the first-level
  pattern and is excluded by nothing, so the workflow woke for it before and
  wakes for it now. Only its classification differs.
- **The push side does not regress.** A `test.sh` edit merged to master starts the
  workflow, produces no build cells, and does not advance the coverage
  checkpoint — so nothing requeues it later. Before, it republished the image.
- **The helper asks the cheapest question first.** Membership before reading
  `variants.yaml`, so a pull request touching many files under one container no
  longer spawns one `yq` per file.

Because this branch touches the shared harness, its own CI exercises the policy
shipped in #975: all four opt-in containers should be verified, and none built.

## Known and unchanged

Nothing changes for the eight containers that have a `test.sh` and do not opt into
e2e — their script was run by nothing before and still is. What stops is
rebuilding an image the file cannot affect. That gap is #978, and this makes it
visible rather than causing it.

The classification rests on no Dockerfile consuming `test.sh`. That is true today
and guarded by a check added in #977, but a text scan cannot prove it in general —
a `COPY .` or a generated Dockerfile would escape it. Enforcing it through the
build context, which can, is worth doing and is tracked separately.
