### PR TITLE
test(containers): make three e2e suites able to fail

### DIFF
--- a/ansible/test.sh
+++ b/ansible/test.sh
@@ -1,33 +1,37 @@
 #!/bin/bash
-# E2E test for ansible container
+# E2E test for the ansible container.
+#
+# Uses the repository's test harness so the exit code is the verdict: every check
+# is recorded, the run continues past a failure so all of them are reported, and
+# th_summary returns non-zero if any failed. The previous version printed
+# "All Ansible tests passed" unconditionally.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-ansible}"
 
-echo "  Testing Ansible..."
+th_init --name "Ansible E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test ansible version
-echo "  Checking Ansible version..."
-docker exec "$CONTAINER_NAME" ansible --version | head -1
+th_group "Interpreter and tooling"
 
-# Test ansible-playbook exists
-echo "  Checking ansible-playbook..."
-if docker exec "$CONTAINER_NAME" ansible-playbook --version &>/dev/null; then
-    echo "  ✅ ansible-playbook available"
-else
-    echo "  ❌ ansible-playbook not found"
-    exit 1
-fi
+# The version banner used to be printed and never read, so an image with no
+# ansible at all still reached the end of the script.
+version=$(docker exec "$CONTAINER_NAME" ansible --version 2>/dev/null | head -1)
+th_assert_contains "ansible reports its version" "$version" "ansible"
 
-# Test basic module execution
-echo "  Testing ping module..."
-result=$(docker exec "$CONTAINER_NAME" ansible localhost -m ping -c local 2>/dev/null | grep -c SUCCESS)
-if [ "$result" -ge 1 ]; then
-    echo "  ✅ Ansible ping module works"
-else
-    echo "  ❌ Ansible ping module failed"
-    exit 1
-fi
+playbook=$(docker exec "$CONTAINER_NAME" ansible-playbook --version 2>/dev/null | head -1)
+th_assert_contains "ansible-playbook is installed" "$playbook" "ansible-playbook"
 
-echo "  ✅ All Ansible tests passed"
+th_group "Module execution"
+
+# What the image is for: run a module against localhost over the local
+# connection, which needs the interpreter, the module path and the config to be
+# right at once.
+ping=$(docker exec "$CONTAINER_NAME" ansible localhost -m ping -c local 2>/dev/null | grep -c SUCCESS)
+th_assert_ge "the ping module reports SUCCESS" "${ping:-0}" 1
+
+th_summary

--- a/debian/test.sh
+++ b/debian/test.sh
@@ -1,41 +1,49 @@
 #!/bin/bash
-# E2E test for debian container
+# E2E test for the debian base image.
+#
+# Uses the repository's test harness so the exit code is the verdict. Two checks
+# that were warnings are now assertions: each was measured against the published
+# image and holds, so each is a regression lock rather than a hope.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-debian}"
 
-echo "  Testing Debian base image..."
+th_init --name "Debian base image E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test OS release
-echo "  Checking Debian version..."
-docker exec "$CONTAINER_NAME" cat /etc/debian_version
+th_group "Release"
 
-# Test locale is configured
-echo "  Checking locale..."
-if docker exec "$CONTAINER_NAME" locale 2>/dev/null | grep -q "UTF-8"; then
-    echo "  ✅ UTF-8 locale configured"
+release=$(docker exec "$CONTAINER_NAME" cat /etc/debian_version 2>/dev/null)
+th_assert_not_empty "/etc/debian_version identifies the release" "$release"
+
+th_group "Environment"
+
+# Was a warning reading "may be normal for minimal image". It holds on the
+# published image, and a base image that loses its UTF-8 locale breaks every
+# consumer assuming one, so it is asserted.
+locale_out=$(docker exec "$CONTAINER_NAME" locale 2>/dev/null)
+th_assert_contains "a UTF-8 locale is configured" "$locale_out" "UTF-8"
+
+# Also a warning. The image ships a default unprivileged user; if it stops, every
+# downstream USER directive naming it breaks.
+if docker exec "$CONTAINER_NAME" id debian >/dev/null 2>&1; then
+    th_pass "the default 'debian' user exists"
 else
-    echo "  ⚠️  UTF-8 locale not detected (may be normal for minimal image)"
+    th_fail "the default 'debian' user exists" "id debian failed"
 fi
 
-# Test user exists
-echo "  Checking user setup..."
-if docker exec "$CONTAINER_NAME" id debian &>/dev/null; then
-    echo "  ✅ Default user 'debian' exists"
-else
-    echo "  ⚠️  Default user 'debian' not found"
-fi
+th_group "Core tools"
 
-# Test basic tools
-echo "  Checking core tools..."
 for tool in bash cat ls; do
-    if docker exec "$CONTAINER_NAME" which "$tool" &>/dev/null; then
-        echo "    ✓ $tool"
+    if docker exec "$CONTAINER_NAME" which "$tool" >/dev/null 2>&1; then
+        th_pass "$tool is on PATH"
     else
-        echo "    ❌ $tool not found"
-        exit 1
+        th_fail "$tool is on PATH" "which $tool failed"
     fi
 done
 
-echo "  ✅ All Debian tests passed"
+th_summary

--- a/sslh/test.sh
+++ b/sslh/test.sh
@@ -1,27 +1,57 @@
 #!/bin/bash
-# E2E test for sslh container
+# E2E test for the sslh container.
+#
+# Uses the repository's test harness so the exit code is the verdict.
+#
+# The image is FROM scratch: no shell, no pgrep, no coreutils. Every check has to
+# go through a binary the image actually ships — sslh-ev itself, and the busybox
+# applet the container's own HEALTHCHECK uses.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-sslh}"
 
-echo "  Testing SSLH multiplexer..."
+th_init --name "SSLH E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test sslh binary exists and version
-echo "  Checking SSLH version..."
-docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1 || \
-docker exec "$CONTAINER_NAME" sslh --version 2>&1 | head -1 || \
-echo "  (version check returned error, may be normal)"
+th_group "Binary"
 
-# The image is FROM scratch (no pgrep/shell), so prove sslh is actually
-# multiplexing by connecting to its listen port with the busybox nc applet
-# that ships in the image — the same tool the container HEALTHCHECK uses.
-echo "  Checking SSLH is listening on 443..."
-if docker exec "$CONTAINER_NAME" /bin/busybox nc -z 127.0.0.1 443; then
-    echo "  ✅ SSLH is listening on 443"
+# The old version check tried sslh-ev, fell back to a plain `sslh`, and shrugged
+# if both failed. Only sslh-ev is in the image — `sslh` is not a file there — so
+# the fallback was dead and the shrug hid a real failure.
+version=$(docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1)
+th_assert_contains "sslh-ev reports its version" "$version" "sslh-ev"
+
+# The tag carries the upstream version, so the binary disagreeing with it means
+# the image was assembled from something other than what it claims.
+expected="${SSLH_EXPECTED_VERSION:-}"
+if [ -z "$expected" ] && [ -n "${E2E_IMAGE:-}" ]; then
+    # ghcr.io/owner/sslh:v2.3.1-alpine → 2.3.1
+    expected="${E2E_IMAGE##*:}"
+    expected="${expected%%-*}"
+    expected="${expected#v}"
+fi
+# Only a tag that carries a version can be compared against one. A moving tag
+# such as `latest` says nothing about the binary, and asserting on it would fail
+# for a reason that has nothing to do with the image.
+if [[ "$expected" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    th_assert_contains "the binary version matches the image tag ($expected)" "$version" "$expected"
 else
-    echo "  ❌ SSLH not listening on 443"
-    exit 1
+    th_skip "the binary version matches the image tag" "tag '${expected:-none}' carries no version"
 fi
 
-echo "  ✅ All SSLH tests passed"
+th_group "Multiplexer"
+
+# FROM scratch leaves nothing to inspect a process with, so liveness is proven by
+# connecting to the listen port with the busybox nc applet that ships in the
+# image — the same tool the HEALTHCHECK uses.
+if docker exec "$CONTAINER_NAME" /bin/busybox nc -z 127.0.0.1 443 >/dev/null 2>&1; then
+    th_pass "sslh accepts connections on 443"
+else
+    th_fail "sslh accepts connections on 443" "busybox nc -z 127.0.0.1 443 failed"
+fi
+
+th_summary


### PR DESCRIPTION
First step of #978, and it changes what that issue is about.

## What the audit found

#978 was filed as "eight containers ship a `test.sh` that nothing runs". Reading
all twelve suites shows the shape is not specific to the eight:

| | hard assertions | warnings | final line |
|---|---|---|---|
| **terraform** | **0** | 2 | unconditional |
| jekyll · wordpress | 1 | 1–2 | unconditional |
| openresty · php | 2 | 1 | unconditional |
| vector | 3 | 0 | unconditional |
| web-shell | 5 | 0 | unconditional |
| postgres | uses the harness | — | summary is the verdict |
| **[enabled]** openvpn | 4 | 2 | unconditional |
| **[enabled]** ansible | 2 | 0 | unconditional |
| **[enabled]** debian | 1 | 2 | unconditional |
| **[enabled]** sslh | 1 | 0 | unconditional |

Every one of them ends by printing "All X tests passed" whatever happened, mixes
hard exits with `else ⚠️` branches that cannot fail anything, and runs under
`set -uo pipefail` without `errexit` — so an unguarded command can error and the
run still reports success. `terraform` has no failure path at all: it passes on
an empty container.

So enabling the eight as they stand would have bought CI time and a green light
that establishes very little. The suites need to be able to fail first.

## The library was already here

`test-harness/test-harness.sh` provides continue-on-failure assertions,
`th_skip` for what is legitimately optional, and `th_summary`, whose return code
is the verdict. `postgres/test.sh` — the one suite with real structure — has been
using it all along. This uses it rather than adding a second way to do the same
thing.

## This change

`ansible`, `debian` and `sslh` converted. Warnings were not simply promoted: each
was measured against the published image first, and each holds, so each becomes a
regression lock rather than a hope — debian's UTF-8 locale and its default user,
ansible's version banner, which was printed and never read.

sslh gains an assertion it never had. Its version check tried `sslh-ev`, fell
back to a plain `sslh` and shrugged if both failed; only `sslh-ev` is in that
image, so the fallback was dead and the shrug hid the failure. The binary does
report its version, so it is now held against the image tag — a tag saying 2.3.1
over a binary saying otherwise means the image is not what it claims. A moving
tag carries no version, so that comparison is skipped with its reason rather than
failing for something unrelated.

`openvpn` is deliberately untouched. Its privilege-drop assertion is a hundred
lines of careful reasoning about `/proc`, reused PIDs and capability sets;
rewriting it for stylistic uniformity would risk far more than it gains.

## Verification

Run against the published images, all three pass with a real report. Pointed at
an alpine image, the debian suite reports four named failures and exits non-zero.

The honest comparison: the version it replaces *also* failed there, through its
one hard check on `bash`, while reporting the missing locale and the missing user
as warnings. The difference is not that it now fails — it is that it now fails
for an image that is still recognisably debian but has lost something.

Two problems were caught before CI: an image tag of `latest` would have failed
the version comparison for a reason having nothing to do with the image, and
`${E2E_IMAGE##*:}` without a default would have aborted the suite under `set -u`
when the variable is unset rather than empty.

The unit suite is at 2187, nothing failing. This branch touches no CI code, so
the four e2e suites run here against freshly built images — which is the check
that matters for it.

## Next

The eight unrun suites, converted and enabled one at a time. `terraform` asserts
nothing today, so it needs assertions written before enabling means anything.
