### PR TITLE
test(containers): give seven more containers an e2e that can fail, and run it

### DIFF
--- a/ansible/test.sh
+++ b/ansible/test.sh
@@ -1,33 +1,37 @@
 #!/bin/bash
-# E2E test for ansible container
+# E2E test for the ansible container.
+#
+# Uses the repository's test harness so the exit code is the verdict: every check
+# is recorded, the run continues past a failure so all of them are reported, and
+# th_summary returns non-zero if any failed. The previous version printed
+# "All Ansible tests passed" unconditionally.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-ansible}"
 
-echo "  Testing Ansible..."
+th_init --name "Ansible E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test ansible version
-echo "  Checking Ansible version..."
-docker exec "$CONTAINER_NAME" ansible --version | head -1
+th_group "Interpreter and tooling"
 
-# Test ansible-playbook exists
-echo "  Checking ansible-playbook..."
-if docker exec "$CONTAINER_NAME" ansible-playbook --version &>/dev/null; then
-    echo "  ✅ ansible-playbook available"
-else
-    echo "  ❌ ansible-playbook not found"
-    exit 1
-fi
+# The version banner used to be printed and never read, so an image with no
+# ansible at all still reached the end of the script.
+version=$(docker exec "$CONTAINER_NAME" ansible --version 2>/dev/null | head -1)
+th_assert_contains "ansible reports its version" "$version" "ansible"
 
-# Test basic module execution
-echo "  Testing ping module..."
-result=$(docker exec "$CONTAINER_NAME" ansible localhost -m ping -c local 2>/dev/null | grep -c SUCCESS)
-if [ "$result" -ge 1 ]; then
-    echo "  ✅ Ansible ping module works"
-else
-    echo "  ❌ Ansible ping module failed"
-    exit 1
-fi
+playbook=$(docker exec "$CONTAINER_NAME" ansible-playbook --version 2>/dev/null | head -1)
+th_assert_contains "ansible-playbook is installed" "$playbook" "ansible-playbook"
 
-echo "  ✅ All Ansible tests passed"
+th_group "Module execution"
+
+# What the image is for: run a module against localhost over the local
+# connection, which needs the interpreter, the module path and the config to be
+# right at once.
+ping=$(docker exec "$CONTAINER_NAME" ansible localhost -m ping -c local 2>/dev/null | grep -c SUCCESS)
+th_assert_ge "the ping module reports SUCCESS" "${ping:-0}" 1
+
+th_summary

--- a/debian/test.sh
+++ b/debian/test.sh
@@ -1,41 +1,49 @@
 #!/bin/bash
-# E2E test for debian container
+# E2E test for the debian base image.
+#
+# Uses the repository's test harness so the exit code is the verdict. Two checks
+# that were warnings are now assertions: each was measured against the published
+# image and holds, so each is a regression lock rather than a hope.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-debian}"
 
-echo "  Testing Debian base image..."
+th_init --name "Debian base image E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test OS release
-echo "  Checking Debian version..."
-docker exec "$CONTAINER_NAME" cat /etc/debian_version
+th_group "Release"
 
-# Test locale is configured
-echo "  Checking locale..."
-if docker exec "$CONTAINER_NAME" locale 2>/dev/null | grep -q "UTF-8"; then
-    echo "  ✅ UTF-8 locale configured"
+release=$(docker exec "$CONTAINER_NAME" cat /etc/debian_version 2>/dev/null)
+th_assert_not_empty "/etc/debian_version identifies the release" "$release"
+
+th_group "Environment"
+
+# Was a warning reading "may be normal for minimal image". It holds on the
+# published image, and a base image that loses its UTF-8 locale breaks every
+# consumer assuming one, so it is asserted.
+locale_out=$(docker exec "$CONTAINER_NAME" locale 2>/dev/null)
+th_assert_contains "a UTF-8 locale is configured" "$locale_out" "UTF-8"
+
+# Also a warning. The image ships a default unprivileged user; if it stops, every
+# downstream USER directive naming it breaks.
+if docker exec "$CONTAINER_NAME" id debian >/dev/null 2>&1; then
+    th_pass "the default 'debian' user exists"
 else
-    echo "  ⚠️  UTF-8 locale not detected (may be normal for minimal image)"
+    th_fail "the default 'debian' user exists" "id debian failed"
 fi
 
-# Test user exists
-echo "  Checking user setup..."
-if docker exec "$CONTAINER_NAME" id debian &>/dev/null; then
-    echo "  ✅ Default user 'debian' exists"
-else
-    echo "  ⚠️  Default user 'debian' not found"
-fi
+th_group "Core tools"
 
-# Test basic tools
-echo "  Checking core tools..."
 for tool in bash cat ls; do
-    if docker exec "$CONTAINER_NAME" which "$tool" &>/dev/null; then
-        echo "    ✓ $tool"
+    if docker exec "$CONTAINER_NAME" which "$tool" >/dev/null 2>&1; then
+        th_pass "$tool is on PATH"
     else
-        echo "    ❌ $tool not found"
-        exit 1
+        th_fail "$tool is on PATH" "which $tool failed"
     fi
 done
 
-echo "  ✅ All Debian tests passed"
+th_summary

--- a/sslh/test.sh
+++ b/sslh/test.sh
@@ -1,27 +1,57 @@
 #!/bin/bash
-# E2E test for sslh container
+# E2E test for the sslh container.
+#
+# Uses the repository's test harness so the exit code is the verdict.
+#
+# The image is FROM scratch: no shell, no pgrep, no coreutils. Every check has to
+# go through a binary the image actually ships — sslh-ev itself, and the busybox
+# applet the container's own HEALTHCHECK uses.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-sslh}"
 
-echo "  Testing SSLH multiplexer..."
+th_init --name "SSLH E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test sslh binary exists and version
-echo "  Checking SSLH version..."
-docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1 || \
-docker exec "$CONTAINER_NAME" sslh --version 2>&1 | head -1 || \
-echo "  (version check returned error, may be normal)"
+th_group "Binary"
 
-# The image is FROM scratch (no pgrep/shell), so prove sslh is actually
-# multiplexing by connecting to its listen port with the busybox nc applet
-# that ships in the image — the same tool the container HEALTHCHECK uses.
-echo "  Checking SSLH is listening on 443..."
-if docker exec "$CONTAINER_NAME" /bin/busybox nc -z 127.0.0.1 443; then
-    echo "  ✅ SSLH is listening on 443"
+# The old version check tried sslh-ev, fell back to a plain `sslh`, and shrugged
+# if both failed. Only sslh-ev is in the image — `sslh` is not a file there — so
+# the fallback was dead and the shrug hid a real failure.
+version=$(docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1)
+th_assert_contains "sslh-ev reports its version" "$version" "sslh-ev"
+
+# The tag carries the upstream version, so the binary disagreeing with it means
+# the image was assembled from something other than what it claims.
+expected="${SSLH_EXPECTED_VERSION:-}"
+if [ -z "$expected" ] && [ -n "${E2E_IMAGE:-}" ]; then
+    # ghcr.io/owner/sslh:v2.3.1-alpine → 2.3.1
+    expected="${E2E_IMAGE##*:}"
+    expected="${expected%%-*}"
+    expected="${expected#v}"
+fi
+# Only a tag that carries a version can be compared against one. A moving tag
+# such as `latest` says nothing about the binary, and asserting on it would fail
+# for a reason that has nothing to do with the image.
+if [[ "$expected" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    th_assert_contains "the binary version matches the image tag ($expected)" "$version" "$expected"
 else
-    echo "  ❌ SSLH not listening on 443"
-    exit 1
+    th_skip "the binary version matches the image tag" "tag '${expected:-none}' carries no version"
 fi
 
-echo "  ✅ All SSLH tests passed"
+th_group "Multiplexer"
+
+# FROM scratch leaves nothing to inspect a process with, so liveness is proven by
+# connecting to the listen port with the busybox nc applet that ships in the
+# image — the same tool the HEALTHCHECK uses.
+if docker exec "$CONTAINER_NAME" /bin/busybox nc -z 127.0.0.1 443 >/dev/null 2>&1; then
+    th_pass "sslh accepts connections on 443"
+else
+    th_fail "sslh accepts connections on 443" "busybox nc -z 127.0.0.1 443 failed"
+fi
+
+th_summary


### PR DESCRIPTION
Continues #978. Files #982 and #983 along the way.

## What changes

jekyll, openresty, php, terraform, vector, web-shell and wordpress each shipped a
`test.sh` that no mechanism ran. Each ended with an unconditional
"All X tests passed", mixed hard exits with warnings that could fail nothing, and
ran without `errexit` — so the verdict was that the script reached its end.

They are converted to `test-harness/test-harness.sh`, the library
`postgres/test.sh` already uses and whose `th_summary` return code is the verdict,
and opted in through `variants.yaml`.

`postgres` stays opted out deliberately: its suite is the one that was already
written properly, but enabling it imports the heavy postgres build into every
pull request touching it, and #572 records those flaking around 20% in their
post-build phase.

## Nothing was promoted on faith

Every check ran against the published image before being written as an assertion,
so each former warning becomes a regression lock rather than a hope — jekyll's
bundler, openresty's Lua, wordpress's wp-cli and its mysqli, php's extensions.

Two measurements changed what got written:

**terraform's validate check was testing a broken fixture, not terraform.** It
wrote `{}` into `main.tf` — HCL, not JSON — and reported the syntax error as "may
need providers". `{}` fails, an empty file validates, `terraform {}` validates. It
is now an assertion on a valid minimal configuration.

**The php image is missing two extensions its Dockerfile installs.** `zip` and
`apcu` are not loaded and have no ini in `conf.d`. That is #982; the suite records
them as skips so the gap shows in every run without failing this pull request on
a fault it did not introduce.

## terraform needed more than a conversion

It asserted nothing at all — every check warned, and it announced success
unconditionally, so it passed against an empty container. It also exits
immediately: a CLI image whose entrypoint ends in `exec /bin/terraform "$@"`, so
even `sleep infinity` becomes a terraform argument. The harness now starts it with
`--entrypoint sleep`, beside the existing ansible/debian and sslh cases.

## Six assertions I got wrong, fixed before CI saw them

Running the suites locally caught what reading them could not:

- `bundle --version` prints `4.0.17` — Bundler 4 puts no "Bundler" in its output.
- `nginx -v` writes to **stderr**; the line is now selected by content rather
  than taken by position.
- `ttyd --version` writes to stdout, so merging stderr only added noise.
- `php -m` is not a flat list of the names used elsewhere: OPcache appears as
  `Zend OPcache`, invisible to an exact-match grep — and `php --ri opcache` denies
  it exists. `extension_loaded()` is the reliable question and is what the suite
  asks. My earlier claim that OPcache was absent was wrong.
- vector's health check accepted any body containing `ok`, which includes
  `not ok`. The endpoint answers `{"ok":true}`; that is now asserted exactly.
- web-shell's token check accepted any response mentioning the word, including an
  error page. It now asserts the JSON shape — not the value, since ttyd answers an
  empty token with no credential configured.

## Verification

The seven, run locally against their published images with the harness's run
profile: **41 assertions, 2 skips, no failures**. The full unit suite is at
**2187, nothing failing**.

Three unit tests failed first and were fixed rather than weakened: they used
wordpress and php as examples of a container without an e2e, which enabling those
made false. They now use `github-runner`, which has no suite at all, and
`postgres`, whose opt-out is deliberate — chosen so enabling postgres later does
not break them again.

## What these suites still do not assert

Recorded as #983 rather than piled on here: the terraform e2e never exercises the
production entrypoint, the suites are blind to build variants, version checks do
not check the version against the tag, captures discard the command's exit status,
jekyll never requests port 4000, and no probe has a per-command timeout. Each is
real; none is a false green today.
