### PR TITLE
docs: drop ephemeral decomposition labels from comments and test names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,11 +36,8 @@
 ## Completed
 
 - [x] ✅ [Web-Shell] Multi-distro variants — template+generator, debian/alpine/ubuntu/rocky (2026-02-26)
-
-## Review Findings (non-blocking)
-
-- [x] ✅ [Web-Shell] compute_build_digest now runs after template expansion — captures config.yaml data (2026-02-27, F-004)
-- [x] ✅ [Web-Shell] Removed unused flavor_arg from all variants.yaml + dead flavor_arg_name() function (2026-02-27, F-005)
+- [x] ✅ [Web-Shell] compute_build_digest now runs after template expansion — captures config.yaml data (2026-02-27)
+- [x] ✅ [Web-Shell] Removed unused flavor_arg from all variants.yaml + dead flavor_arg_name() function (2026-02-27)
 
 ## Blocked / Deferred
 

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -139,7 +139,7 @@
       {{ content }}
     </main>
 
-    <!-- Live status region for screen readers (F-005) -->
+    <!-- Live status region for screen readers -->
     <div id="status-live" class="sr-only" aria-live="polite" aria-atomic="true"></div>
 
     <!-- Footer -->
@@ -148,7 +148,7 @@
 
   <!-- Vanilla web components (trust-strip, security-scan) — CSP-clean, no framework runtime -->
   <script defer src="{{ '/assets/js/components/trust-strip.js' | relative_url }}"></script>
-  <!-- JavaScript (F-006: addEventListener, F-007: IIFE) -->
+  <!-- JavaScript — listeners are bound with addEventListener, wrapped in an IIFE -->
   <script src="{{ site.baseurl }}/assets/js/theme.js"></script>
   <script src="{{ site.baseurl }}/assets/js/dashboard.js"></script>
 </body>

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -362,16 +362,16 @@
       copyBtn.type = 'button';
       copyBtn.className = 'vab-copy-mini';
       copyBtn.setAttribute('data-vab-mini-copy', 'pull');
-      // S-4: dynamic label set here; _updateCollapsedActionsState keeps it in sync
+      // Dynamic label set here; _updateCollapsedActionsState keeps it in sync
       copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
-      // S-2: explicit classes so _onMiniCopyClick can use stable selectors
+      // Explicit classes so _onMiniCopyClick can use stable selectors
       var icon = document.createElement('span');
       icon.className = 'vab-copy-mini__icon';
       icon.setAttribute('aria-hidden', 'true');
       icon.textContent = '⧉'; // ⧉
       copyBtn.appendChild(icon);
       var label = document.createElement('span');
-      // S-3: no leading space — gap is handled by CSS gap:4px on the parent
+      // No leading space — gap is handled by CSS gap:4px on the parent
       label.className = 'vab-copy-mini__label';
       label.textContent = 'pull';
       copyBtn.appendChild(label);
@@ -474,7 +474,7 @@
         var active = miniBtns[i].getAttribute('data-vab-mini-registry') === this._selectedRegistry;
         miniBtns[i].setAttribute('aria-pressed', active ? 'true' : 'false');
       }
-      // S-4: update mini copy button aria-label to reflect current registry
+      // Update the mini copy button's aria-label to reflect the current registry
       var copyBtn = this.querySelector('[data-vab-mini-copy]');
       if (copyBtn) { copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry)); }
     }
@@ -600,7 +600,7 @@
     // Copy to clipboard
     // -------------------------------------------------------
 
-    // S-4: builds the dynamic aria-label for the mini copy button.
+    // Builds the dynamic aria-label for the mini copy button.
     _buildCopyAriaLabel(reg) {
       var name = reg === 'dockerhub' ? 'Docker Hub' : 'GHCR';
       return 'Copy ' + name + ' pull command';
@@ -634,7 +634,7 @@
       var btnEl = this.querySelector('[data-vab-copy="' + type + '"]');
       var iconEl = btnEl && btnEl.querySelector('.vab-copy-icon');
 
-      // M-A: confirmation only on success — .catch swallows silently
+      // Confirmation only on success — .catch swallows silently
       var showCopied = function () {
         if (iconEl) { iconEl.textContent = '✓'; } // ✓
         if (btnEl) { btnEl.classList.add('vab-copy-btn--copied'); }
@@ -656,15 +656,15 @@
       if (!codeEl) { return; }
       var text = codeEl.textContent || '';
 
-      // S-2: stable class selectors (not fragile attribute-presence selectors)
+      // Stable class selectors, not fragile attribute-presence selectors
       var miniBtn = this.querySelector('[data-vab-mini-copy]');
       var iconEl = miniBtn && miniBtn.querySelector('.vab-copy-mini__icon');
       var labelEl = miniBtn && miniBtn.querySelector('.vab-copy-mini__label');
 
-      // M-A: confirmation only on success — .catch swallows silently
+      // Confirmation only on success — .catch swallows silently
       var showCopied = function () {
         if (iconEl) { iconEl.textContent = '✓'; }
-        // S-3: no leading space — gap handled by CSS gap:4px on parent
+        // No leading space — gap handled by CSS gap:4px on parent
         if (labelEl) { labelEl.textContent = 'copied'; }
         if (miniBtn) { miniBtn.classList.add('vab-copy-mini--copied'); }
         setTimeout(function () {

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -6,7 +6,7 @@
     var currentSearch = '';
     var currentStatus = 'all';
 
-    // Announce status changes to screen readers (F-005: aria-live)
+    // Announce status changes to screen readers through the aria-live region
     function announceStatus(message) {
       var liveRegion = document.getElementById('status-live');
       if (liveRegion) {
@@ -295,7 +295,7 @@
       }
     }
 
-    // Event delegation (F-006: no inline onclick handlers)
+    // Event delegation — no inline onclick handlers
     document.addEventListener('DOMContentLoaded', function() {
       // Restore registry preference
       setGlobalRegistry(currentRegistry, false);

--- a/github-runner/entrypoint.sh
+++ b/github-runner/entrypoint.sh
@@ -178,7 +178,7 @@ get_registration_token() {
     response_file=$(mktemp)
     headers_file=$(mktemp)
 
-    # F-002: dump headers to a dedicated file so -w '%{http_code}' returns only
+    # Dump headers to a dedicated file so -w '%{http_code}' returns only
     # the numeric status code.  Previously -D - mixed headers into stdout,
     # causing $http_status to contain the full header block and the "201"
     # comparison to never match.
@@ -204,7 +204,7 @@ get_registration_token() {
       fi
       log_warn "Attempt ${attempt}/${max_attempts}: received 201 but token field is empty."
     elif [[ "$http_status" == "429" ]]; then
-      # F-003: read Retry-After from the headers file, not the response body.
+      # Read Retry-After from the headers file, not the response body.
       # The header is part of the HTTP response headers, not the JSON body.
       local retry_after
       retry_after=$(grep -i '^Retry-After:' "${headers_file}" | awk '{print $2}' | tr -d '\r' || true)

--- a/test-harness/test-harness.sh
+++ b/test-harness/test-harness.sh
@@ -244,7 +244,7 @@ th_init() {
         esac
     done
 
-    # Validate reporter (F-001: invalid value silently produced no output)
+    # Validate the reporter — an invalid value used to produce no output at all
     case "$_TH_REPORT" in
         table|tap|json) ;;
         *) printf 'test-harness: unknown reporter "%s", falling back to table\n' "$_TH_REPORT" >&2

--- a/tests/unit/build-cache-utils.bats
+++ b/tests/unit/build-cache-utils.bats
@@ -324,7 +324,7 @@ EOF
 
 # --- Observability ---
 
-# --- yq Fallback Behavior (F-004) ---
+# --- yq Fallback Behavior ---
 
 # Helper: run compute_build_digest with yq hidden from PATH
 _run_without_yq() {
@@ -340,7 +340,7 @@ _run_without_yq() {
     PATH="$fake_bin" run compute_build_digest "$@"
 }
 
-@test "F-004a: yq fallback — postgres flavor uses raw file content instead of extension versions" {
+@test "yq fallback — postgres flavor uses raw file content instead of extension versions" {
     mkdir -p flavors extensions
     cat > flavors/vector.yaml <<'EOF'
 name: vector
@@ -381,7 +381,7 @@ EOF
     [ "$digest_before" == "$digest_after" ]
 }
 
-@test "F-004b: yq fallback — terraform variant uses raw variants.yaml content" {
+@test "yq fallback — terraform variant uses raw variants.yaml content" {
     cat > variants.yaml <<'EOF'
 versions:
   - variants:
@@ -410,7 +410,7 @@ EOF
     [ "$digest_with_yq" != "$digest_without_yq" ]
 }
 
-@test "F-004c: yq fallback — simple container uses raw config.yaml content" {
+@test "yq fallback — simple container uses raw config.yaml content" {
     cat > config.yaml <<'EOF'
 build_args:
   FOO: "1.0"
@@ -429,7 +429,7 @@ EOF
     [ "$digest_with_yq" != "$digest_without_yq" ]
 }
 
-@test "F-004d: yq fallback — still produces valid 12-char hex digest" {
+@test "yq fallback — still produces valid 12-char hex digest" {
     echo "FROM alpine" > Dockerfile
 
     _run_without_yq "Dockerfile" ""
@@ -442,9 +442,9 @@ EOF
     [[ "$digest" =~ ^[0-9a-f]{12}$ ]]
 }
 
-# --- Integration Smoke Tests (F-005) ---
+# --- Integration Smoke Tests ---
 
-@test "F-005a: integration — postgres real flavors produce different digests" {
+@test "integration — postgres real flavors produce different digests" {
     cd "$ORIG_DIR/postgres" || skip "postgres directory not found"
 
     local -A digests
@@ -465,7 +465,7 @@ EOF
     [ "$unique" -eq "${#values[@]}" ]
 }
 
-@test "F-005b: integration — terraform real flavors produce different digests" {
+@test "integration — terraform real flavors produce different digests" {
     cd "$ORIG_DIR/terraform" || skip "terraform directory not found"
     # Note: config.yaml already has build_args on disk — no need to source ./build
 
@@ -485,7 +485,7 @@ EOF
     [ "$unique" -eq "${#values[@]}" ]
 }
 
-@test "F-005c: integration — simple container (ansible) produces valid digest" {
+@test "integration — simple container (ansible) produces valid digest" {
     cd "$ORIG_DIR/ansible" || skip "ansible directory not found"
 
     run compute_build_digest "Dockerfile" ""

--- a/tests/unit/collector-emitter.bats
+++ b/tests/unit/collector-emitter.bats
@@ -229,8 +229,8 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-# (d-2) ceiling absent from available → fail-closed
-@test "(d-2) ceiling absent from non-empty available[] → fail-closed" {
+# ceiling absent from available → fail-closed
+@test "ceiling absent from non-empty available[] → fail-closed" {
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.25.0","2.27.1"],"available":["2.23.0","2.25.0"],"excluded":[{"version":"2.27.1","reason":"not available"}]}
 EOF


### PR DESCRIPTION
Text only. Comments, one backlog section heading and nine test names carried
short letter-and-digit tags minted by whatever local planning step produced them.
No logic, control flow, identifier, or string compared at runtime changes.

## Why they had to go

A tag like that means something only inside the one time-bound context that
created it. Months later nobody can decode it, and the next piece of work mints a
fresh grid whose cells collide with the old meaning. The permanent reference is
the issue number, the file path, or — most often here — simply saying what the
code does.

Each tag is replaced by what it actually said. Every description survives intact:

```diff
-    <!-- Live status region for screen readers (F-XXX) -->
+    <!-- Live status region for screen readers -->

-      // S-N: stable class selectors (not fragile attribute-presence selectors)
+      // Stable class selectors, not fragile attribute-presence selectors
```

Nothing in the tree referenced any of them — checked across the whole repository
before and after.

## Eleven were on published surfaces

The dashboard layout and its JavaScript are served from GitHub Pages, so these
tags were visible to anyone reading the page source of the public site.

## The backlog heading was one too

Its section name was itself a process label, which is why the two entries under it
carried matching suffixes. Both were already complete, so they move into the
existing completed section and the heading goes away rather than being renamed.

## Deliberately kept

The well-known Windows SID for the SYSTEM account, in the github-runner entrypoint
and its Windows test, is a real identifier that happens to share the shape of the
tags being removed. All three occurrences survive, and a check confirms it.

It is worth noting that this is exactly the case the guard against these tags
cannot distinguish on its own: it matched that SID here, in this very
description, and the fix was to describe the identifier rather than quote it.

## Deliberately out of scope

805 bats test names across 31 other files carry prefixes of the same kind, plus
361 section comments. That is a separate mechanical change with its own blast
radius on the TAP output; folding it in here would bury twenty judgement calls
under a thousand renames. It gets its own pull request.

One consequence is visible: `tests/unit/collector-emitter.bats` now mixes both
styles, because only the name matching this sweep's family was changed there.

## Verification

The full unit suite is green. shellcheck is clean under the flags CI uses
(`-x -S warning`) on both changed shell scripts, and both changed JavaScript files
pass `node --check`. The two directly touched bats suites were also run on their
own.
