### PR TITLE
docs(tests): drop decomposition labels from test names and their references

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -409,8 +409,9 @@ jobs:
     needs: [detect-containers, sync-base-images]
     # Ordered after sync-base-images so the per-major-version GHCR probe below
     # (docker manifest inspect ghcr.io/<owner>/library/postgres:<ver>-alpine) runs
-    # AFTER sync-base-images has seeded that tag — fulfilling SC-18 (extensions use
-    # GHCR). The always() + result-in-(success,skipped) guard mirrors build-and-push
+    # AFTER sync-base-images has seeded that tag, which is what lets the extension
+    # builds resolve it from GHCR. The always() + result-in-(success,skipped) guard
+    # mirrors build-and-push
     # exactly: a skipped seed (fork PRs) or a failed seed (continue-on-error: true
     # means the job reports 'success' to dependents even on failure — but we guard
     # 'skipped' too for future-proofing) never blocks extensions. When the probe
@@ -541,7 +542,7 @@ jobs:
           # merge-extension-manifests (stage B) fuses them into multi-arch manifests.
           ARCH_SUFFIX: ${{ matrix.arch }}
           BUILD_PLATFORM: ${{ matrix.platform }}
-          # BB-1 supply-chain: same-repo PRs publish PR-scoped tags only so unreviewed
+          # supply-chain: same-repo PRs publish PR-scoped tags only so unreviewed
           # code never overwrites canonical production-consumed refs.  On push/dispatch
           # (master) PR_TAG_SUFFIX is empty → canonical refs published.
           # The shared registry build-cache lets master reuse the PR's compiled layers
@@ -814,17 +815,17 @@ jobs:
           CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
           REPO_OWNER: ${{ github.repository_owner }}
-          # BB-1: must match the suffix used by the build-extensions stage A leg so
+          # must match the suffix used by the build-extensions stage A leg so
           # stage B probes the correct scoped per-arch refs and publishes scoped targets.
           # BE-1: same-repo-only guard mirrors the build-extensions expression.
           PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
-          # BH-2b: thread the same rebuild/force signal as stage A so --finalize-multiarch
+          # thread the same rebuild/force signal as stage A so --finalize-multiarch
           # knows to skip canonical-first reuse and merge from freshly-built PR-scoped tags.
           REBUILD: ${{ env.REBUILD_MODE }}
         run: |
           chmod +x scripts/build-extensions.sh helpers/extension-utils.sh
 
-          # BH-2b: mirror stage A's --force logic so finalize skips canonical-first
+          # mirror stage A's --force logic so finalize skips canonical-first
           # reuse for versions that were explicitly rebuilt by stage A this run.
           force_arg=()
           if [[ "$REBUILD" == "force" || "$REBUILD" == "all" ]]; then
@@ -1101,7 +1102,7 @@ jobs:
     # different-container runs parallelize. Same-container races are rare in practice
     # (upstream-monitor serializes PR merges via concurrency on its own workflow).
     env:
-      # BC-1: export PR_TAG_SUFFIX so generate_dockerfile (called by ./make build postgres)
+      # export PR_TAG_SUFFIX so generate_dockerfile (called by ./make build postgres)
       # PR-scopes the non-resolver/single-version extension FROM refs and self-heal
       # per-version COPY refs.  Must match the expression used by build-extensions and
       # merge-extension-manifests so the postgres smoke consumes the PR's own extension

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -54,7 +54,7 @@ jobs:
   # liveness_url:, HTTP HEAD the URL. Non-2xx → ::warning:: + non-zero exit.
   # This step is intentionally SEPARATE so its failure does not cascade to
   # downstream PR-fanout jobs (non-cascading failure design, AC-12/AC-16).
-  # BOUNDED: --max-time + --retry (AC-14).
+  # BOUNDED: --max-time + --retry.
   #
   # P2: needs check-upstream-versions so that for tracked entries with
   # liveness_url_template, we substitute the DETECTED latest_version (not the
@@ -107,7 +107,7 @@ jobs:
           SCOPE_CONTAINER: ${{ github.event.inputs.container || '' }}
         shell: bash
         run: |
-          # Named constants (AC-14)
+          # Named constants
           LIVENESS_MAX_TIME=30
           LIVENESS_RETRY=2
 
@@ -143,7 +143,7 @@ jobs:
               # Template uses {version} placeholder.
               # P2: for tracked entries, prefer the detected latest_version over
               # the pinned current_version so liveness validates the candidate URL.
-              # P1-SECURITY: dep names from config.yaml are untrusted (a PR author
+              # dep names from config.yaml are untrusted (a PR author
               # controls the key names). yq query expressions must NOT be built via
               # shell "${dep}" interpolation — that allows injection of yq special
               # chars (., [], ", etc.) to reshape the query path.
@@ -1317,13 +1317,13 @@ jobs:
               name=$(echo "$update" | jq -r '.name')
               latest=$(echo "$update" | jq -r '.latest')
               echo "  Updating postgres extension $name to $latest"
-              # P1-SECURITY: pass name/latest via env-vars + strenv() to prevent
+              # pass name/latest via env-vars + strenv() to prevent
               # yq query injection if a dep name contains special chars.
               YQ_EXT="$name" YQ_VER="$latest" yq -i '.extensions[strenv(YQ_EXT)].version = strenv(YQ_VER)' "postgres/extensions/config.yaml" || { echo "::error::Failed to update postgres extension $(_gha_escape "${name}") config"; exit 1; }
             done < <(echo "$UPDATES" | jq -c '.[]')
           else
             # Other containers: apply pre-filtered to_apply set from Prepare step.
-            # P1-SECURITY: pass name/latest via env-vars + strenv() to prevent
+            # pass name/latest via env-vars + strenv() to prevent
             # yq query injection if a dep name contains special chars.
             while IFS= read -r update; do
               name=$(echo "$update" | jq -r '.name')

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -50,7 +50,7 @@ Affected containers (sslh, web-shell, wordpress) currently have v1 lineage files
 
 ### Integration smoke origin
 
-`tests/unit/dashboard-integration-smoke.bats` was added per `feedback_perf_integration_smoke_test.md`: a layer-shifting refactor (base_image written at build time, read at dashboard-regen time) requires an end-to-end mutation guard. Unit tests of each individual function are insufficient because the bug manifests at the seam between the write phase and the read phase. The smoke's SMOKE-01 and SMOKE-07 tests guard Fix A1 specifically: disabling the `_BUILD_ARGS_RESOLVED` substitution loop causes `base_image_ref` to read `${OS_IMAGE_BASE}:${OS_IMAGE_TAG}` in the written lineage file, which SMOKE-01 catches via a concrete-value assertion.
+`tests/unit/dashboard-integration-smoke.bats` was added per `feedback_perf_integration_smoke_test.md`: a layer-shifting refactor (base_image written at build time, read at dashboard-regen time) requires an end-to-end mutation guard. Unit tests of each individual function are insufficient because the bug manifests at the seam between the write phase and the read phase. Two of the smoke's cases guard the build-arg resolution specifically: disabling the `_BUILD_ARGS_RESOLVED` substitution loop causes `base_image_ref` to read `${OS_IMAGE_BASE}:${OS_IMAGE_TAG}` in the written lineage file, which the case asserting a concrete `base_image_ref` catches.
 
 ## #532 — Universal base-image digest drift detection cron
 

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -272,7 +272,7 @@ get_variant_build_args_json() {
         while IFS= read -r ext; do
             [[ -z "$ext" ]] && continue
             local ver
-            # P1-SECURITY: ext name comes from yq output — use strenv() to prevent injection.
+            # ext name comes from yq output — use strenv() to prevent injection.
             ver=$(YQ_EXT="$ext" yq -r '.extensions[strenv(YQ_EXT)].version // ""' "$ext_config" 2>/dev/null)
             [[ -z "$ver" ]] && continue
             $first || result+=","
@@ -1002,7 +1002,7 @@ build_dependency_monitoring_json() {
         [[ -z "$dep_name" ]] && continue
         total=$((total + 1))
 
-        # P1-SECURITY: dep_name comes from yq .dependency_sources keys — a PR author
+        # dep_name comes from yq .dependency_sources keys — a PR author
         # controls config.yaml key names. Never interpolate ${dep_name} into the yq
         # query expression. Pass via env-var + strenv() so yq treats it as a literal.
         # Read lifecycle field (required; backward-compat: empty defaults to "tracked")

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -268,7 +268,8 @@ collect_all_cache_images() {
 #
 # Pure function — no I/O, no docker calls, fully bats-testable.
 # Called by emit_reachable_cache_args as the single source of truth for the
-# REMOTE_CR applicability decision; also directly testable via BCU-16..21.
+# REMOTE_CR applicability decision; also covered directly by the
+# remote_cr_applicable cases in tests/unit/base-cache-utils.bats.
 #
 # Rules:
 #   - No new-style entries → print "n/a" (REMOTE_CR not relevant).

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -877,7 +877,7 @@ generate_dockerfile() {
                 local available_count
                 available_count=$(echo "$_versionset_json" | jq '.available | length' 2>/dev/null || echo 0)
 
-                # AO-4: whenever available has exactly ONE entry, that entry MUST
+                # whenever available has exactly ONE entry, that entry MUST
                 # equal the configured ceiling.  This applies to BOTH the self-heal
                 # path (_versionset_from_selfheal=true) AND the on-disk artifact path.
                 # A stale or corrupt artifact with available:["<older>"] (single entry

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -54,11 +54,11 @@ _arch_suffix_tag() {
 # Appends ${PR_TAG_SUFFIX} to <base_ref> when PR_TAG_SUFFIX is non-empty;
 # returns <base_ref> unchanged when PR_TAG_SUFFIX is empty (push/dispatch path).
 #
-# BD-1 supply-chain policy (operator-confirmed option 2): image tags AND the
+# supply-chain policy (operator-confirmed option 2): image tags AND the
 # registry build-cache are both PR-scoped.  On a same-repo pull_request, the
 # build-extensions leg publishes per-arch images and the stage-B merge publishes
 # multi-arch manifests and the bundle — all carrying the -pr<N> suffix.
-# The build-cache ref also carries the PR suffix (see BD-1 comment in
+# The build-cache ref also carries the PR suffix (see the supply-chain comment in
 # build_ext_image) so an unmerged PR cannot influence master's canonical build
 # via a shared cache entry.  Master recompiles the bumped version on merge;
 # the prefilter skips already-canonical versions so only the newly bumped
@@ -126,7 +126,7 @@ build_ext_image() {
         # Format: <registry>/<owner>/ext-<name>:pg<major>-<ver>-<arch>${PR_TAG_SUFFIX}
         _ver_tag=$(_scoped_tag "$(_arch_suffix_tag "$_ver_image" "${ARCH_SUFFIX:-}")")
 
-        # BC-2: cache ref must ALWAYS use a writable GHCR path, independent of
+        # cache ref must ALWAYS use a writable GHCR path, independent of
         # REMOTE_CR (which is the base-image source mirror, not the cache store).
         # REMOTE_CR defaults to ghcr.io/oorabona (public GHCR postgres mirror);
         # deriving the cache ref from REMOTE_CR would produce the wrong namespace
@@ -134,7 +134,7 @@ build_ext_image() {
         # Fix: derive owner from REPO_OWNER (env, set by CI) or get_repo_owner()
         # and construct the cache ref as ghcr.io/<owner>/ext-<name>-buildcache:...
         #
-        # BD-1 supply-chain policy (operator-confirmed): the cache ref is PR-scoped
+        # supply-chain policy (operator-confirmed): the cache ref is PR-scoped
         # by appending PR_TAG_SUFFIX so an unmerged PR cannot influence master's
         # canonical build via a shared cache entry.  On a same-repo PR the ref ends
         # in pg<N>-<arch>-pr<N>; on push/dispatch (master) PR_TAG_SUFFIX is empty
@@ -154,7 +154,7 @@ build_ext_image() {
 
         # Step 1: compile — always use --load (loads image into the local docker
         # store of the native runner).  rc=1 on failure (compile / musl error).
-        # BD-1: the cache is PR-scoped (see comment above); --cache-from on a PR
+        # the cache is PR-scoped (see comment above); --cache-from on a PR
         # reads ONLY that PR's own scoped cache across re-pushes.  On push/dispatch
         # (master) the ref has no suffix so master reads/writes only its own cache.
         # --cache-to writes when we have GHCR write access (_do_push_ext=true);
@@ -781,7 +781,7 @@ _bundle_and_write_artifact() {
         return 0
     fi
 
-    # AO-1: only one version confirmed available — consumer uses single-version path.
+    # only one version confirmed available — consumer uses single-version path.
     if [[ ${#_confirmed_available[@]} -le 1 ]]; then
         log_info "$ext: only ${#_confirmed_available[@]} version(s) confirmed available — deleting stale artifact (consumer uses single-version path)"
         _delete_stale_versionset_artifact "$ext" "$major_ver"
@@ -1100,7 +1100,7 @@ build_tag_push_extensions() {
             # Write per-version lineage file with this version's own duration.
             # Dry runs must not mutate .build-lineage.
             #
-            # AY-2: When ARCH_SUFFIX is non-empty (CI per-arch leg), write the
+            # When ARCH_SUFFIX is non-empty (CI per-arch leg), write the
             # lineage file as arch-suffixed: ext-<ext>-pg<major>-<ver>-<arch>.json.
             # Both arch artifact directories are downloaded into the SAME .build-lineage/
             # during the finalize step; un-suffixed files from both legs would collide
@@ -1495,7 +1495,7 @@ _should_build_extension() {
     fi
 
     # Multi-version path: return 0 if any version in the set needs building.
-    # BH-2a fix: FORCE=true means every resolved version needs (re)build, same as
+    # fix: FORCE=true means every resolved version needs (re)build, same as
     # the single-version branch above. Skip the per-version presence checks entirely.
     if [[ "$FORCE" == "true" ]]; then
         return 0

--- a/scripts/check-dependency-versions.sh
+++ b/scripts/check-dependency-versions.sh
@@ -233,7 +233,7 @@ check_container_deps() {
         lifecycle=$(YQ_DEP="$dep_name" yq -r '.dependency_sources[strenv(YQ_DEP)].lifecycle // ""' "$config")
 
         # Lifecycle dispatch — replaces the binary monitor:false blanket continue.
-        # AC-3: eol-migrate MUST NOT be silently skipped.
+        # eol-migrate MUST NOT be silently skipped.
         case "$lifecycle" in
             untracked)
                 # Declared skip: genuinely nothing to track (base-image fallback,

--- a/tests/unit/audit-base-image-cache.bats
+++ b/tests/unit/audit-base-image-cache.bats
@@ -8,25 +8,25 @@
 #
 # Tests:
 #   normalize_image_source
-#     NIS-01  <unresolved:REMOTE_CR>/ prefix stripped → library/postgres
-#     NIS-02  docker.io/ prefix stripped              → library/nginx
-#     NIS-03  library/<x> emits bare alias            → ubuntu emitted alongside library/ubuntu
-#     NIS-04  bare name untouched                     → ubuntu stays ubuntu
-#     NIS-05  plain resolved name (no prefix)         → composer:2.9.8 source
+#     <unresolved:REMOTE_CR>/ prefix stripped → library/postgres
+#     docker.io/ prefix stripped              → library/nginx
+#     library/<x> emits bare alias            → ubuntu emitted alongside library/ubuntu
+#     bare name untouched                     → ubuntu stays ubuntu
+#     plain resolved name (no prefix)         → composer:2.9.8 source
 #   is_cached
-#     ABA-01  new-style FROM ${REMOTE_CR}/library/postgres → source: library/postgres = CACHED
-#     ABA-02  old-style FROM ${BASE_IMAGE}:${VERSION}, build_args.BASE_IMAGE=ubuntu → CACHED (no regression)
-#     ABA-03  genuine mismatch (mysql vs library/postgres) → NOT cached
-#     ABA-04  FROM docker.io/library/nginx vs source: library/nginx → CACHED
-#     ABA-05  REMOTE_CR in build_args (resolves to docker.io then stripped) → CACHED
-#     ABA-06  bare source: debian matches FROM ${BASE_IMAGE} resolved to debian → CACHED
+#     new-style FROM ${REMOTE_CR}/library/postgres → source: library/postgres = CACHED
+#     old-style FROM ${BASE_IMAGE}:${VERSION}, build_args.BASE_IMAGE=ubuntu → CACHED (no regression)
+#     genuine mismatch (mysql vs library/postgres) → NOT cached
+#     FROM docker.io/library/nginx vs source: library/nginx → CACHED
+#     REMOTE_CR in build_args (resolves to docker.io then stripped) → CACHED
+#     bare source: debian matches FROM ${BASE_IMAGE} resolved to debian → CACHED
 #   is_expected_uncached
-#     ABA-07  ghcr.io/oorabona/postgres:17-alpine → matches self-ref pattern
-#     ABA-13  <unresolved:REMOTE_CR>/php:latest (single-seg own container) → expected-uncached
+#     ghcr.io/oorabona/postgres:17-alpine → matches self-ref pattern
+#     <unresolved:REMOTE_CR>/php:latest (single-seg own container) → expected-uncached
 #     ABA-13b <unresolved:REMOTE_CR>/library/ubuntu (multi-seg DockerHub mirror) → GAP (NOT exempt)
 #     ABA-13c <unresolved:OTHER_REG>/mysql:8 → GAP (only REMOTE_CR single-seg is exempt)
 #   Full audit run (real repo — integration smoke)
-#     SMOKE-01  postgres has no GAP in full audit run
+#     postgres has no GAP in full audit run
 
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/audit-base-image-cache.sh"
 ORIG_DIR="$BATS_TEST_DIRNAME/../.."
@@ -62,7 +62,7 @@ write_config() {
 
 # ─── normalize_image_source ───────────────────────────────────────────────────
 
-@test "NIS-01: <unresolved:REMOTE_CR>/ prefix is stripped, leaving library/postgres" {
+@test "<unresolved:REMOTE_CR>/ prefix is stripped, leaving library/postgres" {
     run normalize_image_source "<unresolved:REMOTE_CR>/library/postgres"
     [ "$status" -eq 0 ]
     # First line: normalized form
@@ -71,28 +71,28 @@ write_config() {
     [[ "${lines[1]}" == "postgres" ]]
 }
 
-@test "NIS-02: docker.io/ prefix is stripped, leaving library/nginx" {
+@test "docker.io/ prefix is stripped, leaving library/nginx" {
     run normalize_image_source "docker.io/library/nginx"
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "library/nginx" ]]
     [[ "${lines[1]}" == "nginx" ]]
 }
 
-@test "NIS-03: library/<x> emits both library/ubuntu and bare ubuntu" {
+@test "library/<x> emits both library/ubuntu and bare ubuntu" {
     run normalize_image_source "library/ubuntu"
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "library/ubuntu" ]]
     [[ "${lines[1]}" == "ubuntu" ]]
 }
 
-@test "NIS-04: bare name (no prefix) passes through unchanged, no alias emitted" {
+@test "bare name (no prefix) passes through unchanged, no alias emitted" {
     run normalize_image_source "ubuntu"
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "ubuntu" ]]
     [ "${#lines[@]}" -eq 1 ]
 }
 
-@test "NIS-05: namespaced source (hashicorp/terraform) passes through, no alias" {
+@test "namespaced source (hashicorp/terraform) passes through, no alias" {
     run normalize_image_source "hashicorp/terraform"
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" == "hashicorp/terraform" ]]
@@ -101,10 +101,10 @@ write_config() {
 
 # ─── is_cached ────────────────────────────────────────────────────────────────
 
-# ABA-01: new-style — REMOTE_CR not in build_args → resolves to <unresolved:REMOTE_CR>
+# new-style — REMOTE_CR not in build_args → resolves to <unresolved:REMOTE_CR>
 # The resolved FROM is "<unresolved:REMOTE_CR>/library/postgres:<unresolved:VERSION>"
 # After tag strip + normalization it must match source: library/postgres
-@test "ABA-01: new-style REMOTE_CR unresolved matches source: library/postgres" {
+@test "new-style REMOTE_CR unresolved matches source: library/postgres" {
     write_config "mypostgres/config.yaml" \
 'base_image_cache:
   - source: library/postgres
@@ -115,9 +115,9 @@ write_config() {
     [ "$status" -eq 0 ]
 }
 
-# ABA-02: old-style — FROM ${BASE_IMAGE}:${VERSION}, build_args.BASE_IMAGE=ubuntu
+# old-style — FROM ${BASE_IMAGE}:${VERSION}, build_args.BASE_IMAGE=ubuntu
 # resolve_image_ref returns "ubuntu:<unresolved:VERSION>"; is_cached must match source: ubuntu
-@test "ABA-02: old-style ubuntu matches source: ubuntu (no regression)" {
+@test "old-style ubuntu matches source: ubuntu (no regression)" {
     write_config "myubuntu/config.yaml" \
 'base_image_cache:
   - arg: BASE_IMAGE
@@ -131,8 +131,8 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-03: genuine mismatch — mysql resolved from a postgres source cache → NOT cached
-@test "ABA-03: genuine mismatch mysql vs source: library/postgres is NOT cached" {
+# genuine mismatch — mysql resolved from a postgres source cache → NOT cached
+@test "genuine mismatch mysql vs source: library/postgres is NOT cached" {
     write_config "mymysql/config.yaml" \
 'base_image_cache:
   - source: library/postgres
@@ -142,8 +142,8 @@ build_args:
     [ "$status" -ne 0 ]
 }
 
-# ABA-04: docker.io/ explicit prefix — FROM docker.io/library/nginx vs source: library/nginx
-@test "ABA-04: FROM docker.io/library/nginx matches source: library/nginx" {
+# docker.io/ explicit prefix — FROM docker.io/library/nginx vs source: library/nginx
+@test "FROM docker.io/library/nginx matches source: library/nginx" {
     write_config "mynginx/config.yaml" \
 'base_image_cache:
   - source: library/nginx
@@ -153,8 +153,8 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-05: REMOTE_CR resolved to docker.io via build_args
-@test "ABA-05: REMOTE_CR resolved to docker.io, then stripped, matches library/postgres" {
+# REMOTE_CR resolved to docker.io via build_args
+@test "REMOTE_CR resolved to docker.io, then stripped, matches library/postgres" {
     write_config "pgwithargs/config.yaml" \
 'base_image_cache:
   - source: library/postgres
@@ -167,8 +167,8 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-06: bare source: debian matches resolved "debian:<unresolved:VERSION>"
-@test "ABA-06: bare source: debian matches resolved debian image" {
+# bare source: debian matches resolved "debian:<unresolved:VERSION>"
+@test "bare source: debian matches resolved debian image" {
     write_config "mydebian/config.yaml" \
 'base_image_cache:
   - arg: BASE_IMAGE
@@ -182,12 +182,12 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-10: cross-registry NO-FALSE-NEGATIVE guard
+# cross-registry NO-FALSE-NEGATIVE guard
 # A FROM that uses the same path ("library/postgres") but on a non-docker.io
 # registry (ghcr.io, quay.io) must NOT match source: library/postgres.
 # The normalization must only strip docker.io/ and <unresolved:VAR>/ — never
 # an arbitrary third-party registry prefix.
-@test "ABA-10: ghcr.io/library/postgres is NOT cached against source: library/postgres (no false negative)" {
+@test "ghcr.io/library/postgres is NOT cached against source: library/postgres (no false negative)" {
     write_config "nfn/config.yaml" \
 'base_image_cache:
   - source: library/postgres
@@ -202,11 +202,11 @@ build_args:
     [ "$status" -ne 0 ]
 }
 
-# ABA-11: chained-on-own-build marker — source: /php → is_cached returns 0 (CACHED)
+# chained-on-own-build marker — source: /php → is_cached returns 0 (CACHED)
 # Regression lock for gate r4 Bug 1: the yq-read source value retained the leading slash
 # while the candidates list stripped it, so the comparison always failed.  The fix adds
 # cache_source="${cache_source#/}" after the yq read so "/php" == "php" comparison works.
-@test "ABA-11: chained-on-own-build source:/php matches FROM php: — CACHED (gate r4 regression lock)" {
+@test "chained-on-own-build source:/php matches FROM php: — CACHED (gate r4 regression lock)" {
     write_config "mywp/config.yaml" \
 'base_image_cache:
   - source: /php
@@ -218,8 +218,8 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-12: chained-on-own-build marker with REMOTE_CR prefix — same invariant
-@test "ABA-12: chained-on-own-build source:/php matches unresolved REMOTE_CR/php: — CACHED" {
+# chained-on-own-build marker with REMOTE_CR prefix — same invariant
+@test "chained-on-own-build source:/php matches unresolved REMOTE_CR/php: — CACHED" {
     write_config "mywp2/config.yaml" \
 'base_image_cache:
   - source: /php
@@ -231,12 +231,12 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-13: ${REMOTE_CR}/<own-container>:<tag> without REMOTE_CR in build_args — single-segment
+# ${REMOTE_CR}/<own-container>:<tag> without REMOTE_CR in build_args — single-segment
 # path is exempt ONLY when the name is a known project container (top-level dir with config.yaml).
 # Regression lock for #666: removing wordpress base_image_cache must not create a spurious gap.
 # Mutation this test catches: exempting a single-segment REMOTE_CR ref without verifying the
 # name is an actual project container would hide real cache gaps for Docker Hub official images.
-@test "ABA-13: <unresolved:REMOTE_CR>/php:latest (project container with config.yaml) is expected-uncached" {
+@test "<unresolved:REMOTE_CR>/php:latest (project container with config.yaml) is expected-uncached" {
     # php must exist as a project container in ROOT_DIR for the exemption to fire.
     mkdir -p "$TEST_DIR/php"
     touch "$TEST_DIR/php/config.yaml"
@@ -244,33 +244,33 @@ build_args:
     [ "$status" -eq 0 ]
 }
 
-# ABA-13b: ${REMOTE_CR}/library/ubuntu (Docker Hub mirror, multi-segment) must NOT be exempt —
+# ${REMOTE_CR}/library/ubuntu (Docker Hub mirror, multi-segment) must NOT be exempt —
 # if base_image_cache is missing it must surface as a GAP, not be silently suppressed.
-@test "ABA-13b: <unresolved:REMOTE_CR>/library/ubuntu (multi-segment) is NOT expected-uncached" {
+@test "<unresolved:REMOTE_CR>/library/ubuntu (multi-segment) is NOT expected-uncached" {
     run is_expected_uncached "<unresolved:REMOTE_CR>/library/ubuntu:latest"
     [ "$status" -ne 0 ]
 }
 
-# ABA-13c: other unresolved registry vars remain gaps regardless of path
-@test "ABA-13c: <unresolved:OTHER_REG>/mysql:8 is NOT expected-uncached" {
+# other unresolved registry vars remain gaps regardless of path
+@test "<unresolved:OTHER_REG>/mysql:8 is NOT expected-uncached" {
     run is_expected_uncached "<unresolved:OTHER_REG>/mysql:8"
     [ "$status" -ne 0 ]
 }
 
-# ABA-13d: ${REMOTE_CR}/ubuntu:latest — single-segment but NOT a project container (no ubuntu/
+# ${REMOTE_CR}/ubuntu:latest — single-segment but NOT a project container (no ubuntu/
 # config.yaml in repo) — must NOT be exempt; codex-flagged regression: the prior broad
 # single-segment exemption silently suppressed this legitimate cache gap.
 # Mutation this test catches: exempting a single-segment name without checking config.yaml
 # would hide a real cache gap (ubuntu is a Docker Hub official image, not our output).
-@test "ABA-13d: <unresolved:REMOTE_CR>/ubuntu:latest (no ubuntu/config.yaml) is NOT expected-uncached" {
+@test "<unresolved:REMOTE_CR>/ubuntu:latest (no ubuntu/config.yaml) is NOT expected-uncached" {
     # Ensure ubuntu/ has no config.yaml (cleanup any stray fixture from other tests)
     rm -rf "$TEST_DIR/ubuntu"
     run is_expected_uncached "<unresolved:REMOTE_CR>/ubuntu:latest"
     [ "$status" -ne 0 ]
 }
 
-# ABA-13e: ${REMOTE_CR}/mysql:8 — single-segment, not a project container → GAP, not exempt.
-@test "ABA-13e: <unresolved:REMOTE_CR>/mysql:8 (no mysql/config.yaml) is NOT expected-uncached" {
+# ${REMOTE_CR}/mysql:8 — single-segment, not a project container → GAP, not exempt.
+@test "<unresolved:REMOTE_CR>/mysql:8 (no mysql/config.yaml) is NOT expected-uncached" {
     rm -rf "$TEST_DIR/mysql"
     run is_expected_uncached "<unresolved:REMOTE_CR>/mysql:8"
     [ "$status" -ne 0 ]
@@ -278,27 +278,27 @@ build_args:
 
 # ─── is_expected_uncached ─────────────────────────────────────────────────────
 
-@test "ABA-07: ghcr.io/oorabona/* self-ref matches expected-uncached pattern" {
+@test "ghcr.io/oorabona/* self-ref matches expected-uncached pattern" {
     run is_expected_uncached "ghcr.io/oorabona/postgres:17-alpine"
     [ "$status" -eq 0 ]
 }
 
-@test "ABA-08: mcr.microsoft.com/* matches expected-uncached pattern" {
+@test "mcr.microsoft.com/* matches expected-uncached pattern" {
     run is_expected_uncached "mcr.microsoft.com/windows/servercore:ltsc2022"
     [ "$status" -eq 0 ]
 }
 
-@test "ABA-09: random external image does NOT match expected-uncached pattern" {
+@test "random external image does NOT match expected-uncached pattern" {
     run is_expected_uncached "docker.io/library/mysql:8.0"
     [ "$status" -ne 0 ]
 }
 
 # ─── Integration smoke: real audit run ───────────────────────────────────────
 
-# SMOKE-01: run the full audit against the real repo.
+# run the full audit against the real repo.
 # postgres must NOT appear as GAP (new-style FROM ${REMOTE_CR}/library/postgres).
 # Old-style containers must still show as cached (no regression).
-@test "SMOKE-01: full repo audit — postgres has no GAP, old-style containers still cached" {
+@test "full repo audit — postgres has no GAP, old-style containers still cached" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
 

--- a/tests/unit/bake-buildresult.bats
+++ b/tests/unit/bake-buildresult.bats
@@ -2,12 +2,12 @@
 # Unit tests for helpers/bake-buildresult.sh — ADR-013 R2 slice (#595 emission)
 #
 # Mutation guards (named per test):
-#   MB1: Change success condition (e.g. ignore digest) → success count wrong
-#   MB2: Remove fail-closed on absent metadata → absent file yields success
-#   MB3: Use wrong field name (e.g. "status" instead of "result") → shape mismatch
-#   MB4: Use arch from cells instead of arg → arch field wrong
-#   MB5: Omit warning on absent metadata → no ::warning:: annotation
-#   MB6: target_id mismatch → all cells become failure even with valid metadata
+#   Change success condition (e.g. ignore digest) → success count wrong
+#   Remove fail-closed on absent metadata → absent file yields success
+#   Use wrong field name (e.g. "status" instead of "result") → shape mismatch
+#   Use arch from cells instead of arg → arch field wrong
+#   Omit warning on absent metadata → no ::warning:: annotation
+#   target_id mismatch → all cells become failure even with valid metadata
 
 load "../test_helper"
 
@@ -73,7 +73,7 @@ _partial_meta() {
 # MB1 + shape: all-success case — every emitted result is "success";
 #              shape is exactly {container, variant, tag, arch, result}.
 # ---------------------------------------------------------------------------
-@test "BBR-01: all cells success when metadata contains every target_id with digest" {
+@test "all cells success when metadata contains every target_id with digest" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -100,9 +100,9 @@ _partial_meta() {
 }
 
 # ---------------------------------------------------------------------------
-# MB4: arch field in emitted files matches the supplied arch argument
+# arch field in emitted files matches the supplied arch argument
 # ---------------------------------------------------------------------------
-@test "BBR-02: emitted build-result files carry the supplied arch field" {
+@test "emitted build-result files carry the supplied arch field" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -118,7 +118,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # partial: missing target → failure; others → success
 # ---------------------------------------------------------------------------
-@test "BBR-03: partial metadata — cell absent from metadata emits result=failure" {
+@test "partial metadata — cell absent from metadata emits result=failure" {
     local meta_file="$TEST_OUT_DIR/meta_partial.json"
     _partial_meta web-shell > "$meta_file"
 
@@ -146,7 +146,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # MB2 + MB5: absent metadata → fail-closed (all failure) + ::warning::
 # ---------------------------------------------------------------------------
-@test "BBR-04: absent metadata file → all cells failure (fail-closed)" {
+@test "absent metadata file → all cells failure (fail-closed)" {
     run bash "$BBR" "$TEST_OUT_DIR/nonexistent.json" amd64 "$TEST_OUT_DIR/out" web-shell 2>&1
     [ "$status" -eq 0 ]
 
@@ -162,7 +162,7 @@ _partial_meta() {
     [ "$file_count" -gt 0 ]
 }
 
-@test "BBR-05: absent metadata file emits a ::warning:: annotation" {
+@test "absent metadata file emits a ::warning:: annotation" {
     # Run with stderr captured to combined output (bats 'run' merges them)
     run bash "$BBR" "$TEST_OUT_DIR/nonexistent.json" amd64 "$TEST_OUT_DIR/out" web-shell 2>&1
     [ "$status" -eq 0 ]
@@ -173,7 +173,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # File naming: build-result-<container>-<tag>-<arch>.json (parity with auto-build.yaml:1061)
 # ---------------------------------------------------------------------------
-@test "BBR-06: emitted filenames match build-result-<container>-<tag>-<arch>.json pattern" {
+@test "emitted filenames match build-result-<container>-<tag>-<arch>.json pattern" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -197,7 +197,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # Shape: emitted JSON has EXACTLY 5 keys (no extras)
 # ---------------------------------------------------------------------------
-@test "BBR-07: emitted JSON has exactly 5 keys: container variant tag arch result" {
+@test "emitted JSON has exactly 5 keys: container variant tag arch result" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -213,7 +213,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # container field matches the container arg
 # ---------------------------------------------------------------------------
-@test "BBR-08: emitted container field matches the requested container name" {
+@test "emitted container field matches the requested container name" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -229,7 +229,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # Cell count parity: number of emitted files equals number of --cells entries
 # ---------------------------------------------------------------------------
-@test "BBR-09: number of emitted build-result files equals --cells entry count for web-shell" {
+@test "number of emitted build-result files equals --cells entry count for web-shell" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -246,10 +246,10 @@ _partial_meta() {
 }
 
 # ---------------------------------------------------------------------------
-# MB6: target_id key-join correctness — a metadata keyed by ACTUAL target_ids
+# target_id key-join correctness — a metadata keyed by ACTUAL target_ids
 # yields success; swapping to wrong keys yields failure (join is tight).
 # ---------------------------------------------------------------------------
-@test "BBR-10: wrong target_id keys in metadata → all cells failure (join must be tight)" {
+@test "wrong target_id keys in metadata → all cells failure (join must be tight)" {
     # Build a metadata file with wrong keys (e.g. containerids with a bogus prefix)
     jq -cn '{
         "WRONG_KEY_1": {"containerimage.digest":"sha256:aaa","image.name":"ghcr.io/test"},
@@ -269,7 +269,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # tag field in emitted file matches cells tag (not overridden by arch arg)
 # ---------------------------------------------------------------------------
-@test "BBR-11: emitted tag field matches the cell tag (not the arch argument)" {
+@test "emitted tag field matches the cell tag (not the arch argument)" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -292,7 +292,7 @@ _partial_meta() {
 # ---------------------------------------------------------------------------
 # ::notice:: summary always emitted (success path)
 # ---------------------------------------------------------------------------
-@test "BBR-12: ::notice:: summary is emitted on success" {
+@test "::notice:: summary is emitted on success" {
     local meta_file="$TEST_OUT_DIR/meta_all.json"
     _all_success_meta web-shell > "$meta_file"
 
@@ -313,7 +313,7 @@ _retained_cell_count() {
     bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained "$1" | jq 'length'
 }
 
-@test "BBR-13: without BAKE_GENERATE_ALL_RETAINED, emit covers latest-only cells" {
+@test "without BAKE_GENERATE_ALL_RETAINED, emit covers latest-only cells" {
     # terraform has more retained cells than latest-only cells (github-runner is
     # bake_latest_only, so it can't exercise the retained path).
     local latest_count
@@ -344,7 +344,7 @@ _retained_cell_count() {
     [ "$file_count" -eq "$latest_count" ]
 }
 
-@test "BBR-14: with BAKE_GENERATE_ALL_RETAINED=true, emit covers all retained cells" {
+@test "with BAKE_GENERATE_ALL_RETAINED=true, emit covers all retained cells" {
     # terraform has more retained cells than latest-only cells (github-runner is
     # bake_latest_only, so it can't exercise the retained path).
     local retained_count
@@ -370,7 +370,7 @@ _retained_cell_count() {
     [ "$file_count" -eq "$retained_count" ]
 }
 
-@test "BBR-15: scoped build-result enumeration ignores scoped-out terraform flavors" {
+@test "scoped build-result enumeration ignores scoped-out terraform flavors" {
     local scoped_cells
     scoped_cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \
         --cells --scope-flavors aws terraform)
@@ -405,7 +405,7 @@ _retained_cell_count() {
     [ "$actual_tags" = "$expected_tags" ]
 }
 
-@test "BBR-16: container_scopes build-result enumeration ignores scoped-out github-runner flavors" {
+@test "container_scopes build-result enumeration ignores scoped-out github-runner flavors" {
     local container_scopes='{"github-runner":{"flavors":"debian-trixie"}}'
     local scoped_cells
     scoped_cells=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" \

--- a/tests/unit/bake-generator-upstream-version.bats
+++ b/tests/unit/bake-generator-upstream-version.bats
@@ -13,13 +13,13 @@
 # This avoids the ./make list container validation entirely.
 #
 # Mutation each test catches:
-#   MU1: suffix strip reverted to live --upstream call → live drift possible
-#   MU2: v-prefix stripped from upstream → sslh-like containers build wrong source
-#   MU3: empty suffix short-circuit removed → upstream==version, still emits UPSTREAM_VERSION
-#   MU4: garbage-suffix guard removed → mis-strip on containers without --tag-suffix support
-#   MU4b: guard's end-match check removed → mis-strip when suffix present but non-matching
-#   MU5: determinism broken — UPSTREAM_VERSION comes from live query, differs per run
-#   MU6: declared-ARG gate removed → unused UPSTREAM_VERSION emitted for jekyll/wordpress/php
+#   suffix strip reverted to live --upstream call → live drift possible
+#   v-prefix stripped from upstream → sslh-like containers build wrong source
+#   empty suffix short-circuit removed → upstream==version, still emits UPSTREAM_VERSION
+#   garbage-suffix guard removed → mis-strip on containers without --tag-suffix support
+#   guard's end-match check removed → mis-strip when suffix present but non-matching
+#   determinism broken — UPSTREAM_VERSION comes from live query, differs per run
+#   declared-ARG gate removed → unused UPSTREAM_VERSION emitted for jekyll/wordpress/php
 
 bats_require_minimum_version 1.5.0
 
@@ -149,7 +149,7 @@ teardown() {
 # MU2 — v-prefix preserved: sslh-like v2.3.1-alpine → v2.3.1 (NOT 2.3.1)
 # Catches: any code that strips the leading 'v' before or after suffix removal.
 # ---------------------------------------------------------------------------
-@test "MU2: v-prefix preserved — v2.3.1-alpine with -alpine → UPSTREAM_VERSION=v2.3.1" {
+@test "v-prefix preserved — v2.3.1-alpine with -alpine → UPSTREAM_VERSION=v2.3.1" {
     _run_build_args_driver "-alpine" "v2.3.1-alpine"
     [ "$status" -eq 0 ]
 
@@ -164,7 +164,7 @@ teardown() {
 # Catches: removing the upstream==version short-circuit check.
 # web-shell style: version "1.7.7", --tag-suffix returns "".
 # ---------------------------------------------------------------------------
-@test "MU3: empty suffix — UPSTREAM_VERSION absent when version has no suffix" {
+@test "empty suffix — UPSTREAM_VERSION absent when version has no suffix" {
     _run_build_args_driver "" "1.7.7"
     [ "$status" -eq 0 ]
 
@@ -178,7 +178,7 @@ teardown() {
 # Catches: removing the robustness guard that rejects non-'-'-prefixed suffixes.
 # A version.sh without --tag-suffix falls through and returns its full tag.
 # ---------------------------------------------------------------------------
-@test "MU4: garbage suffix (no leading '-') → UPSTREAM_VERSION absent (no mis-strip)" {
+@test "garbage suffix (no leading '-') → UPSTREAM_VERSION absent (no mis-strip)" {
     _run_build_args_driver "8.5.7-fpm-alpine" "8.5.7-fpm-alpine"
     [ "$status" -eq 0 ]
 
@@ -192,7 +192,7 @@ teardown() {
 # Catches: removing the "version ends with suffix" check from the guard.
 # suffix="-fpm" but version="1.2.3-alpine" → no match → treat as no-suffix.
 # ---------------------------------------------------------------------------
-@test "MU4b: suffix '-fpm' but version '1.2.3-alpine' (no tail match) → UPSTREAM_VERSION absent" {
+@test "suffix '-fpm' but version '1.2.3-alpine' (no tail match) → UPSTREAM_VERSION absent" {
     _run_build_args_driver "-fpm" "1.2.3-alpine"
     [ "$status" -eq 0 ]
 
@@ -205,7 +205,7 @@ teardown() {
 # MU5 — determinism: two runs on same static tag produce identical result
 # Catches: live query path that could return different values on different runs.
 # ---------------------------------------------------------------------------
-@test "MU5: determinism — two runs on same static tag produce identical UPSTREAM_VERSION" {
+@test "determinism — two runs on same static tag produce identical UPSTREAM_VERSION" {
     _run_build_args_driver "-alpine" "3.5.0-alpine"
     [ "$status" -eq 0 ]
     local first
@@ -228,7 +228,7 @@ teardown() {
 # unused build-arg for jekyll/wordpress/php-style containers, triggering buildkit
 # "unused build-arg" warnings and diverging from the matrix path.
 # ---------------------------------------------------------------------------
-@test "MU6: undeclared ARG UPSTREAM_VERSION in Dockerfile — UPSTREAM_VERSION omitted even with valid suffix" {
+@test "undeclared ARG UPSTREAM_VERSION in Dockerfile — UPSTREAM_VERSION omitted even with valid suffix" {
     _run_build_args_driver "-alpine" "1.31.1.1-alpine" "fakecontainer" 0
     [ "$status" -eq 0 ]
 

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -2,20 +2,20 @@
 # Unit tests for helpers/bake-managed.sh — ADR-013 bake/matrix partition slice
 #
 # Mutation guards (named per test):
-#   MM1: Remove github-runner from default set → github-runner lands in matrix instead of bake
-#   MM2: Remove web-shell from default set → web-shell lands in matrix instead of bake
-#   MM3: Remove wordpress from default set → wordpress lands in matrix instead of bake
-#   MM3b: Remove debian/vector/jekyll/ansible from default set → they land in matrix instead of bake
-#   MM3c: Remove sslh/openvpn/php/openresty/terraform/postgres from default set → they land in matrix instead of bake
-#   MM4: Ignore BAKE_MANAGED_CONTAINERS override → env override has no effect
-#   MM5: Skip bake partition entirely → all cells end up in matrix (wrong)
-#   MM6: Duplicate cells across partitions → total count exceeds input length
-#   MM7: Drop cells during partition → total count below input length
-#   MM8: Reverse partition logic → bake-managed containers land in matrix
-#   MM9: Change is_bake_managed return codes → 0/1 inverted
-#   MM10: Corrupt cell objects during partition → cell fields lost
-#   MM11: Drop OS guard — windows cell of bake-managed container lands in bake instead of matrix
-#   MM12: Treat absent .os as non-linux — linux cell without .os field excluded from bake
+#   Remove github-runner from default set → github-runner lands in matrix instead of bake
+#   Remove web-shell from default set → web-shell lands in matrix instead of bake
+#   Remove wordpress from default set → wordpress lands in matrix instead of bake
+#   Remove debian/vector/jekyll/ansible from default set → they land in matrix instead of bake
+#   Remove sslh/openvpn/php/openresty/terraform/postgres from default set → they land in matrix instead of bake
+#   Ignore BAKE_MANAGED_CONTAINERS override → env override has no effect
+#   Skip bake partition entirely → all cells end up in matrix (wrong)
+#   Duplicate cells across partitions → total count exceeds input length
+#   Drop cells during partition → total count below input length
+#   Reverse partition logic → bake-managed containers land in matrix
+#   Change is_bake_managed return codes → 0/1 inverted
+#   Corrupt cell objects during partition → cell fields lost
+#   Drop OS guard — windows cell of bake-managed container lands in bake instead of matrix
+#   Treat absent .os as non-linux — linux cell without .os field excluded from bake
 
 load "../test_helper"
 
@@ -130,14 +130,14 @@ _fixture_postgres_all_versions_builds() {
 }
 
 # ---------------------------------------------------------------------------
-# BM-01: Default partition — bake-managed containers (github-runner/web-shell/wordpress)
+# Default partition — bake-managed containers (github-runner/web-shell/wordpress)
 #        land in .bake; debian (no is_latest_version:true in fixture) and terraform
 #        (no is_latest_version:true in fixture) land in .matrix.
 # Both debian and terraform are bake-managed; they stay in .matrix only because their
 # fixture cells lack is_latest_version:true (the is_latest_version gate fires first).
 # Catches: MM1, MM2, MM3, MM5, MM8
 # ---------------------------------------------------------------------------
-@test "BM-01: default partition routes github-runner/web-shell/wordpress to bake, others to matrix" {
+@test "default partition routes github-runner/web-shell/wordpress to bake, others to matrix" {
     # Source the helper
     # shellcheck disable=SC1090
     source "$BM"
@@ -166,10 +166,10 @@ _fixture_postgres_all_versions_builds() {
 }
 
 # ---------------------------------------------------------------------------
-# BM-02: Counts add up — no cell is lost or duplicated.
+# Counts add up — no cell is lost or duplicated.
 # Catches: MM6, MM7
 # ---------------------------------------------------------------------------
-@test "BM-02: partition is lossless — bake+matrix count equals input count" {
+@test "partition is lossless — bake+matrix count equals input count" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -185,11 +185,11 @@ _fixture_postgres_all_versions_builds() {
 }
 
 # ---------------------------------------------------------------------------
-# BM-03: Order preserved — cells appear in the same relative order within each
+# Order preserved — cells appear in the same relative order within each
 #        partition as in the input array.
 # Catches: MM10 (partial — verifies object integrity and ordering)
 # ---------------------------------------------------------------------------
-@test "BM-03: partition preserves cell order within each partition" {
+@test "partition preserves cell order within each partition" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -212,12 +212,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-04: BAKE_MANAGED_CONTAINERS env override — only the overridden container
+# BAKE_MANAGED_CONTAINERS env override — only the overridden container
 #        lands in .bake; the default set (github-runner/web-shell/wordpress)
 #        falls through to .matrix.
 # Catches: MM4
 # ---------------------------------------------------------------------------
-@test "BM-04: BAKE_MANAGED_CONTAINERS env override changes partition" {
+@test "BAKE_MANAGED_CONTAINERS env override changes partition" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -247,9 +247,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-05: Empty input [] → {"bake":[],"matrix":[]}
+# Empty input [] → {"bake":[],"matrix":[]}
 # ---------------------------------------------------------------------------
-@test "BM-05: empty input array returns empty bake and matrix partitions" {
+@test "empty input array returns empty bake and matrix partitions" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -259,10 +259,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-06: is_bake_managed — github-runner returns 0 (in set).
+# is_bake_managed — github-runner returns 0 (in set).
 # Catches: MM9
 # ---------------------------------------------------------------------------
-@test "BM-06: is_bake_managed returns 0 for github-runner (default set)" {
+@test "is_bake_managed returns 0 for github-runner (default set)" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -271,10 +271,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-07: is_bake_managed — debian returns 0 (now in default set, PR-B slice 1).
+# is_bake_managed — debian returns 0 (now in default set, PR-B slice 1).
 # Catches: MM9
 # ---------------------------------------------------------------------------
-@test "BM-07: is_bake_managed returns 0 for debian (now in default set)" {
+@test "is_bake_managed returns 0 for debian (now in default set)" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -283,11 +283,11 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-08: is_bake_managed — web-shell and postgres return 0; a synthetic
+# is_bake_managed — web-shell and postgres return 0; a synthetic
 #         legacy-matrix container returns 1.
 # Catches: MM1, MM2, MM3, MM9 (broader coverage)
 # ---------------------------------------------------------------------------
-@test "BM-08: is_bake_managed covers web-shell/postgres (0) and legacy-matrix (1)" {
+@test "is_bake_managed covers web-shell/postgres (0) and legacy-matrix (1)" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -302,11 +302,11 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-08b: is_bake_managed — PR-B slice 1 containers (debian/vector/jekyll/ansible)
+# is_bake_managed — PR-B slice 1 containers (debian/vector/jekyll/ansible)
 #          return 0 (in default set).  terraform joined the bake-managed set in
 #          PR-B slices 2-4 (see BM-08c).
 # ---------------------------------------------------------------------------
-@test "BM-08b: is_bake_managed returns 0 for debian/vector/jekyll/ansible/postgres" {
+@test "is_bake_managed returns 0 for debian/vector/jekyll/ansible/postgres" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -327,12 +327,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-08c: is_bake_managed — PR-B slices 2-4 new containers (sslh/openvpn/php/
+# is_bake_managed — PR-B slices 2-4 new containers (sslh/openvpn/php/
 #          openresty/terraform) return 0 (now in default set); synthetic
 #          legacy-matrix returns 1.
 # Catches: MM3c
 # ---------------------------------------------------------------------------
-@test "BM-08c: is_bake_managed returns 0 for sslh/openvpn/php/openresty/terraform; 1 for legacy-matrix" {
+@test "is_bake_managed returns 0 for sslh/openvpn/php/openresty/terraform; 1 for legacy-matrix" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -356,11 +356,11 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-08d: Full 13-container bake-managed set — every Linux container that routes
+# Full 13-container bake-managed set — every Linux container that routes
 #          through bake is listed.
 #          Mutation guard for the complete set (MM3c comprehensive coverage).
 # ---------------------------------------------------------------------------
-@test "BM-08d: all 13 bake-managed containers return 0; legacy-matrix returns 1" {
+@test "all 13 bake-managed containers return 0; legacy-matrix returns 1" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -380,10 +380,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-09: Cell objects are preserved intact — all fields survive partition.
+# Cell objects are preserved intact — all fields survive partition.
 # Catches: MM10
 # ---------------------------------------------------------------------------
-@test "BM-09: partition preserves all cell fields (no field loss)" {
+@test "partition preserves all cell fields (no field loss)" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -402,9 +402,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-10: Malformed input (not a JSON array) → exit code 1, ::error:: on stderr.
+# Malformed input (not a JSON array) → exit code 1, ::error:: on stderr.
 # ---------------------------------------------------------------------------
-@test "BM-10: malformed input (not an array) returns non-zero exit and error message" {
+@test "malformed input (not an array) returns non-zero exit and error message" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -417,12 +417,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-11: OS guard — github-runner windows cell stays in .matrix even though
+# OS guard — github-runner windows cell stays in .matrix even though
 #         github-runner is bake-managed. The bake generator is linux-only; a
 #         windows cell in .bake would be orphaned (built by neither path).
 # Catches: MM11
 # ---------------------------------------------------------------------------
-@test "BM-11: github-runner windows cell routes to matrix, not bake" {
+@test "github-runner windows cell routes to matrix, not bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -442,12 +442,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-12: OS guard — github-runner linux cell (explicit .os="linux") goes to .bake;
+# OS guard — github-runner linux cell (explicit .os="linux") goes to .bake;
 #         github-runner cell with absent .os (omitted field) also goes to .bake
 #         (absent .os is treated as linux because linux cells may omit the field).
 # Catches: MM12
 # ---------------------------------------------------------------------------
-@test "BM-12: github-runner linux cell and absent-os cell both route to bake" {
+@test "github-runner linux cell and absent-os cell both route to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -474,12 +474,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-13: bake_latest_only — github-runner retained cell (is_latest_version:false)
+# bake_latest_only — github-runner retained cell (is_latest_version:false)
 #         routes to .matrix; github-runner latest cell (is_latest_version:true)
 #         routes to .bake.  Verifies the per-cell fidelity fix (FIX 1).
 # Catches: new finding — retained github-runner built by neither path without this fix
 # ---------------------------------------------------------------------------
-@test "BM-13: github-runner retained linux cell routes to matrix; latest linux cell routes to bake" {
+@test "github-runner retained linux cell routes to matrix; latest linux cell routes to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -510,14 +510,14 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-14: Retained (non-latest) cells for ANY bake-managed container route to
+# Retained (non-latest) cells for ANY bake-managed container route to
 #         .matrix — bake is latest-only by design.  Tests web-shell (no
 #         variants.yaml bake_latest_only flag) and wordpress to verify the
 #         universal is_latest_version==true gate applies to all bake-managed
 #         containers, not just those that declare bake_latest_only.
 # Catches: retained bake-managed cell falsely recovered/unscanned by a latest-only bake run
 # ---------------------------------------------------------------------------
-@test "BM-14: retained web-shell and wordpress cells (is_latest_version:false) route to matrix" {
+@test "retained web-shell and wordpress cells (is_latest_version:false) route to matrix" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -562,12 +562,12 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-15: scoped runs are filtered before partitioning and no longer force the
+# scoped runs are filtered before partitioning and no longer force the
 #         matrix.  With force_matrix=false, scoped bake-managed latest Linux
 #         cells route to .bake, while retained/windows/non-bake cells stay in
 #         .matrix through the normal partition gates.
 # ---------------------------------------------------------------------------
-@test "BM-15: scoped subset allows bake-managed Linux cells to bake" {
+@test "scoped subset allows bake-managed Linux cells to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -610,13 +610,13 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-17: PR routing no longer forces matrix.  With force_matrix=false, bake-managed
+# PR routing no longer forces matrix.  With force_matrix=false, bake-managed
 #         latest Linux cells route to .bake, while legacy-matrix/windows stay in .matrix
 #         through the normal partition gates.  PR Trivy coverage now runs inline in
 #         bake-build for those bake-managed cells.
 # Catches: PR routing accidentally preserving pull_request in force_matrix
 # ---------------------------------------------------------------------------
-@test "BM-17: PR routing allows bake-managed Linux cells to bake" {
+@test "PR routing allows bake-managed Linux cells to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -655,10 +655,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-16: force_matrix default (absent) applies per-cell logic.
+# force_matrix default (absent) applies per-cell logic.
 #         Confirms that omitting the second arg is equivalent to force_matrix=false.
 # ---------------------------------------------------------------------------
-@test "BM-16: force_matrix absent is equivalent to false (per-cell routing)" {
+@test "force_matrix absent is equivalent to false (per-cell routing)" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -681,9 +681,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-18: _bake_retained_eligible — direct eligibility checks for B1-core.
+# _bake_retained_eligible — direct eligibility checks for B1-core.
 # ---------------------------------------------------------------------------
-@test "BM-18: _bake_retained_eligible accepts standalone eligible containers only" {
+@test "_bake_retained_eligible accepts standalone eligible containers only" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -707,10 +707,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-19: _bake_retained_eligible — missing config.yaml fails closed even when a
+# _bake_retained_eligible — missing config.yaml fails closed even when a
 #         test override places the container in both managed and rollout sets.
 # ---------------------------------------------------------------------------
-@test "BM-19: _bake_retained_eligible fails closed for missing config.yaml" {
+@test "_bake_retained_eligible fails closed for missing config.yaml" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -722,10 +722,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-20: include_retained=true — eligible retained cells route to bake; retained
+# include_retained=true — eligible retained cells route to bake; retained
 #         cells for latest-only, chained, and non-bake containers stay matrix.
 # ---------------------------------------------------------------------------
-@test "BM-20: include_retained=true routes only eligible retained cells to bake" {
+@test "include_retained=true routes only eligible retained cells to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -772,9 +772,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-21: include_retained=false/absent preserves current retained routing.
+# include_retained=false/absent preserves current retained routing.
 # ---------------------------------------------------------------------------
-@test "BM-21: include_retained false or absent leaves all retained cells on matrix" {
+@test "include_retained false or absent leaves all retained cells on matrix" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -794,10 +794,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-22: postgres build.always_all_versions routes every final-image cell to
+# postgres build.always_all_versions routes every final-image cell to
 #         bake, including non-latest PG majors 17/16.
 # ---------------------------------------------------------------------------
-@test "BM-22: postgres always_all_versions routes all 21 cells to bake" {
+@test "postgres always_all_versions routes all 21 cells to bake" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -821,10 +821,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-23: Non-always-all managed containers still keep non-latest cells on the
+# Non-always-all managed containers still keep non-latest cells on the
 #         matrix when include_retained=false.
 # ---------------------------------------------------------------------------
-@test "BM-23: non-always-all managed retained cell stays matrix when include_retained=false" {
+@test "non-always-all managed retained cell stays matrix when include_retained=false" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -847,10 +847,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-24: Vanish-proof invariant — every input cell appears in exactly one
+# Vanish-proof invariant — every input cell appears in exactly one
 #         output partition.
 # ---------------------------------------------------------------------------
-@test "BM-24: partition is lossless and non-overlapping with postgres always-all cells" {
+@test "partition is lossless and non-overlapping with postgres always-all cells" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -876,9 +876,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-25: _has_extension_pipeline detects containers with extensions/config.yaml.
+# _has_extension_pipeline detects containers with extensions/config.yaml.
 # ---------------------------------------------------------------------------
-@test "BM-25: _has_extension_pipeline returns true for postgres and false for debian" {
+@test "_has_extension_pipeline returns true for postgres and false for debian" {
     # shellcheck disable=SC1090
     source "$BM"
 
@@ -890,10 +890,10 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# BM-26: extension_containers_in returns sorted-unique extension/final-build
+# extension_containers_in returns sorted-unique extension/final-build
 #         container lists from build-cell JSON.
 # ---------------------------------------------------------------------------
-@test "BM-26: extension_containers_in returns postgres for mixed builds and empty for postgres-free builds" {
+@test "extension_containers_in returns postgres for mixed builds and empty for postgres-free builds" {
     # shellcheck disable=SC1090
     source "$BM"
 

--- a/tests/unit/bake-matrix-arg-parity.bats
+++ b/tests/unit/bake-matrix-arg-parity.bats
@@ -2,17 +2,17 @@
 # Deterministic bake/matrix build-arg parity harness.
 #
 # Mutation guards:
-#   BMP1: reverting _compute_cell_build_args to live version.sh --upstream would
+#   reverting _compute_cell_build_args to live version.sh --upstream would
 #         let retained cells build a newer source under an older matrix tag.
-#   BMP2: dropping tag-suffix validation would mis-strip containers without a
+#   dropping tag-suffix validation would mis-strip containers without a
 #         real --tag-suffix branch.
-#   BMP3: drifting hook-side strip logic would make matrix and bake builds use
+#   drifting hook-side strip logic would make matrix and bake builds use
 #         different source versions.
-#   BMP4: reintroducing openresty RESTY_VERSION would recreate the latent source
+#   reintroducing openresty RESTY_VERSION would recreate the latent source
 #         tarball 404 regression.
-#   BMP5: adding a default to source-version ARG declarations would weaken the
+#   adding a default to source-version ARG declarations would weaken the
 #         required-arg contract.
-#   BMP6: removing the _df_declares_arg gate from STEP 4 would emit UPSTREAM_VERSION
+#   removing the _df_declares_arg gate from STEP 4 would emit UPSTREAM_VERSION
 #         for jekyll/wordpress/php (no ARG UPSTREAM_VERSION) — unused build-arg
 #         warnings and matrix divergence.
 

--- a/tests/unit/bake-merge-manifests.bats
+++ b/tests/unit/bake-merge-manifests.bats
@@ -2,16 +2,16 @@
 # Unit tests for scripts/bake-merge-manifests.sh — ADR-013 R3 slice
 #
 # Mutation guards:
-#   MM1: Emit only versioned ref (omit :latest) → default variant misses rolling tag
-#   MM2: Include single-arch fallback path → strict guard violated
-#   MM5: Pass only -amd64 or only -arm64 → merge source always lists both arches
-#   MM6: Cell set diverges from generator bake mode → parity assertion fails
-#   MM7: Publish :latest for non-latest retained cell → retained version clobbers :latest (F2)
-#   MM8: Emit a docker.io ref → GHCR-only contract violated (egress-containment ADR-013)
-#   MM9: Route rolling alias by flavor → github-runner debian-trixie-base and -dev collide (FIX F)
-#   MM10: Skip duplicate-ref guard → silent manifest corruption on variant.yaml mistakes (FIX F guard)
-#   MM11: Suppress DRY-RUN stdout → documented dry-run contract unmet (FIX H)
-#   MM12: Allow --all-retained flag in containers input → multi-version bake with single-version artifact (FIX I)
+#   Emit only versioned ref (omit :latest) → default variant misses rolling tag
+#   Include single-arch fallback path → strict guard violated
+#   Pass only -amd64 or only -arm64 → merge source always lists both arches
+#   Cell set diverges from generator bake mode → parity assertion fails
+#   Publish :latest for non-latest retained cell → retained version clobbers :latest (F2)
+#   Emit a docker.io ref → GHCR-only contract violated (egress-containment ADR-013)
+#   Route rolling alias by flavor → github-runner debian-trixie-base and -dev collide (FIX F)
+#   Skip duplicate-ref guard → silent manifest corruption on variant.yaml mistakes (FIX F guard)
+#   Suppress DRY-RUN stdout → documented dry-run contract unmet (FIX H)
+#   Allow --all-retained flag in containers input → multi-version bake with single-version artifact (FIX I)
 
 load "../test_helper"
 
@@ -55,10 +55,10 @@ _run_merge() {
 }
 
 # ---------------------------------------------------------------------------
-# MM1: default variant (is_default=true) → GHCR imagetools create carries
+# default variant (is_default=true) → GHCR imagetools create carries
 # both the versioned ref AND :latest.
 # ---------------------------------------------------------------------------
-@test "BMM-01: default variant GHCR merge includes both versioned and :latest refs" {
+@test "default variant GHCR merge includes both versioned and :latest refs" {
     _run_merge debian
     [ "$status" -eq 0 ]
 
@@ -76,10 +76,10 @@ _run_merge() {
 }
 
 # ---------------------------------------------------------------------------
-# MM2: non-default flavored variant → GHCR line carries :latest-<flavor>
+# non-default flavored variant → GHCR line carries :latest-<flavor>
 # NOT bare :latest.
 # ---------------------------------------------------------------------------
-@test "BMM-02: non-default flavored variant GHCR merge carries :latest-<flavor>, not bare :latest" {
+@test "non-default flavored variant GHCR merge carries :latest-<flavor>, not bare :latest" {
     _run_merge web-shell
     [ "$status" -eq 0 ]
 
@@ -103,11 +103,11 @@ _run_merge() {
 }
 
 # ---------------------------------------------------------------------------
-# MM5: STRICT — both arch sources always present in every GHCR create call.
+# STRICT — both arch sources always present in every GHCR create call.
 # Assert every "imagetools create" line that has a ghcr.io -t ref also
 # passes both -amd64 and -arm64 sources.
 # ---------------------------------------------------------------------------
-@test "BMM-03: strict — every GHCR imagetools create call lists both -amd64 and -arm64 sources" {
+@test "strict — every GHCR imagetools create call lists both -amd64 and -arm64 sources" {
     _run_merge web-shell github-runner debian
     [ "$status" -eq 0 ]
 
@@ -128,7 +128,7 @@ _run_merge() {
 # line that lists ONLY -amd64 or ONLY -arm64 as its sole source for a
 # rolling/latest-tagged publish (the strict guard).
 # ---------------------------------------------------------------------------
-@test "BMM-04: no single-arch-only rolling publish line exists in dry-run output" {
+@test "no single-arch-only rolling publish line exists in dry-run output" {
     _run_merge debian web-shell
     [ "$status" -eq 0 ]
 
@@ -155,11 +155,11 @@ _run_merge() {
 }
 
 # ---------------------------------------------------------------------------
-# MM8: GHCR-only — no docker.io ref ever emitted.
+# GHCR-only — no docker.io ref ever emitted.
 # ADR-013 egress-containment: bake intermediates and final manifests are
 # GHCR-only. DockerHub publish is handled by the existing auto-build.yaml.
 # ---------------------------------------------------------------------------
-@test "BMM-05: GHCR-only — no docker.io ref emitted for any container" {
+@test "GHCR-only — no docker.io ref emitted for any container" {
     _run_merge debian web-shell
     [ "$status" -eq 0 ]
 
@@ -169,10 +169,10 @@ _run_merge() {
 }
 
 # ---------------------------------------------------------------------------
-# MM6: Cell-plan parity — the container/tag set from --cells matches the
+# Cell-plan parity — the container/tag set from --cells matches the
 # set that the merge script iterates (integration smoke).
 # ---------------------------------------------------------------------------
-@test "BMM-07: cell plan from --cells matches cells iterated by merge script for web-shell github-runner debian" {
+@test "cell plan from --cells matches cells iterated by merge script for web-shell github-runner debian" {
     _run_merge web-shell github-runner debian
     [ "$status" -eq 0 ]
 
@@ -227,7 +227,7 @@ CALLER
 # Catches MG7: if the is_latest_version gate is missing, both trixie and
 # bookworm would claim :latest, with the last-merged (older) version winning.
 # ---------------------------------------------------------------------------
-@test "BMM-09: F2 — retained non-latest cell publishes versioned ref only, not :latest" {
+@test "F2 — retained non-latest cell publishes versioned ref only, not :latest" {
     export REMOTE_CR="ghcr.io/oorabona"
 
     _call_merge_cell "debian" "bookworm" "" "true" \
@@ -244,7 +244,7 @@ CALLER
     [[ "$create_line" != *"ghcr.io/oorabona/debian:latest"* ]]
 }
 
-@test "BMM-10: F2 — latest cell (is_latest_version=true) DOES publish :latest" {
+@test "F2 — latest cell (is_latest_version=true) DOES publish :latest" {
     export REMOTE_CR="ghcr.io/oorabona"
 
     _call_merge_cell "debian" "trixie" "" "true" \
@@ -262,7 +262,7 @@ CALLER
 # FIX F / MM9: github-runner dry-run merge emits distinct rolling aliases.
 # debian-trixie-base and debian-trixie-dev must NOT share latest-debian-trixie.
 # ---------------------------------------------------------------------------
-@test "BMM-11: FIX F — github-runner merge emits latest-debian-trixie-base AND latest-debian-trixie-dev (distinct, no collision)" {
+@test "FIX F — github-runner merge emits latest-debian-trixie-base AND latest-debian-trixie-dev (distinct, no collision)" {
     export REMOTE_CR="ghcr.io/oorabona"
     _run_merge github-runner
     [ "$status" -eq 0 ]
@@ -286,7 +286,7 @@ CALLER
 # Provide a mock generate-bake-hcl.sh that outputs a dup-ref cell plan, then
 # invoke the real bake-merge-manifests.sh main() via a sourced caller.
 # ---------------------------------------------------------------------------
-@test "BMM-12: FIX F guard — merge aborts with error when two cells map to the same final ref" {
+@test "FIX F guard — merge aborts with error when two cells map to the same final ref" {
     export REMOTE_CR="ghcr.io/oorabona"
 
     # -----------------------------------------------------------------------
@@ -333,7 +333,7 @@ CALLER
 # Catches MM11: if the dry-run branch is removed, the command is captured
 # into err_output and never shown — the documented contract is broken.
 # ---------------------------------------------------------------------------
-@test "BMM-13: FIX H — DRY_RUN=true emits imagetools create command visibly and exits 0" {
+@test "FIX H — DRY_RUN=true emits imagetools create command visibly and exits 0" {
     export REMOTE_CR="ghcr.io/oorabona"
     export DRY_RUN="true"
 
@@ -376,21 +376,21 @@ _run_containers_guard() {
     run bash "$guard_script"
 }
 
-@test "BMM-14: FIX I/N — containers guard rejects --all-retained flag injection" {
+@test "FIX I/N — containers guard rejects --all-retained flag injection" {
     _run_containers_guard "--all-retained github-runner"
     [ "$status" -ne 0 ]
     [[ "$output" == *"invalid container token"* ]]
     [[ "$output" == *"--all-retained"* ]]
 }
 
-@test "BMM-14b: FIX N — containers guard rejects glob pattern (foo*)" {
+@test "FIX N — containers guard rejects glob pattern (foo*)" {
     _run_containers_guard "foo*"
     [ "$status" -ne 0 ]
     [[ "$output" == *"invalid container token"* ]]
     [[ "$output" == *"foo"* ]]
 }
 
-@test "BMM-15: FIX I/N — containers guard accepts valid bare container names" {
+@test "FIX I/N — containers guard accepts valid bare container names" {
     _run_containers_guard "github-runner debian"
     [ "$status" -eq 0 ]
     [[ "$output" == *"OK"* ]]
@@ -402,7 +402,7 @@ _run_containers_guard() {
 # expected arguments and the merge succeeds (no word-splitting regression).
 # ---------------------------------------------------------------------------
 
-@test "BMM-16: FIX U — quoted \$DOCKER invokes mock correctly with expected imagetools args" {
+@test "FIX U — quoted \$DOCKER invokes mock correctly with expected imagetools args" {
     _run_merge debian
     [ "$status" -eq 0 ]
 

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -27,7 +27,7 @@ teardown() {
 
 # --- distro_uses_base_cache ---
 
-@test "BCU-DISTRO-01: distro_uses_base_cache returns false for explicit opt-out" {
+@test "distro_uses_base_cache returns false for explicit opt-out" {
     cat > config.yaml <<'EOF'
 distros:
   debian:
@@ -38,7 +38,7 @@ EOF
     [ "$status" -eq 1 ]
 }
 
-@test "BCU-DISTRO-02: distro_uses_base_cache returns true when key is absent" {
+@test "distro_uses_base_cache returns true when key is absent" {
     cat > config.yaml <<'EOF'
 distros:
   alpine:
@@ -49,7 +49,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "BCU-DISTRO-03: distro_uses_base_cache returns true without distros block" {
+@test "distro_uses_base_cache returns true without distros block" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - source: library/alpine
@@ -60,7 +60,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "BCU-DISTRO-04: distro_uses_base_cache returns true for empty distro arg" {
+@test "distro_uses_base_cache returns true for empty distro arg" {
     cat > config.yaml <<'EOF'
 distros:
   debian:
@@ -73,9 +73,9 @@ EOF
 
 # --- resolve_cache_check_tag ---
 
-# BCU-01: regression lock for the docker.io 429 bug
+# regression lock for the docker.io 429 bug
 # tags_from_versions: true → must return build_version, NOT "latest"
-@test "BCU-01: tags_from_versions=true returns build_version (regression lock: not 'latest')" {
+@test "tags_from_versions=true returns build_version (regression lock: not 'latest')" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -92,8 +92,8 @@ EOF
     [ "$output" != "latest" ]
 }
 
-# BCU-02: tags_from_versions=true with a different build_version
-@test "BCU-02: tags_from_versions=true returns whatever build_version is passed" {
+# tags_from_versions=true with a different build_version
+@test "tags_from_versions=true returns whatever build_version is passed" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -107,8 +107,8 @@ EOF
     [ "$output" = "17-alpine" ]
 }
 
-# BCU-03: tags[] literal array → returns the literal tag (existing behaviour preserved)
-@test "BCU-03: literal tags[0] entry returns the literal tag" {
+# tags[] literal array → returns the literal tag (existing behaviour preserved)
+@test "literal tags[0] entry returns the literal tag" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -122,8 +122,8 @@ EOF
     [ "$output" = "latest" ]
 }
 
-# BCU-04: tags[] with a template that uses ${VERSION}
-@test "BCU-04: tags[0] template using \${VERSION} is resolved to build_version" {
+# tags[] with a template that uses ${VERSION}
+@test "tags[0] template using \${VERSION} is resolved to build_version" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: TERRAFORM_BASE
@@ -137,8 +137,8 @@ EOF
     [ "$output" = "1.9.5" ]
 }
 
-# BCU-05: no tags key and tags_from_versions absent → falls back to "latest"
-@test "BCU-05: absent tags and no tags_from_versions defaults to 'latest'" {
+# no tags key and tags_from_versions absent → falls back to "latest"
+@test "absent tags and no tags_from_versions defaults to 'latest'" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -151,8 +151,8 @@ EOF
     [ "$output" = "latest" ]
 }
 
-# BCU-06: second entry (index=1) is resolved correctly
-@test "BCU-06: entry at index 1 is resolved independently" {
+# second entry (index=1) is resolved correctly
+@test "entry at index 1 is resolved independently" {
     cat > config.yaml <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -172,9 +172,9 @@ EOF
 
 # --- collect_all_cache_images / _collect_entry_tags: new-style dest path ---
 
-# BCU-11: NEW-style entry → sync_image dest preserves source path (library/postgres)
+# NEW-style entry → sync_image dest preserves source path (library/postgres)
 # sync_image must be ghcr.io/<owner>/library/postgres:<tag> — NOT ghcr.io/<owner>/postgres:<tag>
-@test "BCU-11: NEW-style collect_all_cache_images dest preserves full source path with slash" {
+@test "NEW-style collect_all_cache_images dest preserves full source path with slash" {
     mkdir -p pgcontainer
     cat > pgcontainer/variants.yaml <<'EOF'
 versions:
@@ -199,8 +199,8 @@ EOF
     [[ "$output" != *"ghcr.io/myowner/postgres:"* ]]
 }
 
-# BCU-12: OLD-style entry → sync_image dest uses ghcr_repo (regression lock)
-@test "BCU-12: OLD-style collect_all_cache_images dest uses ghcr_repo (regression lock)" {
+# OLD-style entry → sync_image dest uses ghcr_repo (regression lock)
+@test "OLD-style collect_all_cache_images dest uses ghcr_repo (regression lock)" {
     mkdir -p ubuntucontainer
     cat > ubuntucontainer/config.yaml <<'EOF'
 base_image_cache:
@@ -218,8 +218,8 @@ EOF
     [[ "$output" == *"ghcr.io/myowner/ubuntu-base:latest"* ]]
 }
 
-# BCU-13: MIXED collect_all_cache_images — both old and new sync_image dests correct
-@test "BCU-13: MIXED collect_all_cache_images — old uses ghcr_repo, new uses source path" {
+# MIXED collect_all_cache_images — both old and new sync_image dests correct
+@test "MIXED collect_all_cache_images — old uses ghcr_repo, new uses source path" {
     mkdir -p mixcontainer
     cat > mixcontainer/variants.yaml <<'EOF'
 versions:
@@ -248,8 +248,8 @@ EOF
 
 # --- Leading-slash (chained-on-own-build) source path splitting ---
 
-# BCU-14: leading-slash source → sync_image has library/ prefix, probe_image is leaf-only
-@test "BCU-14: leading-slash source (/php) → sync_image uses library/php, probe_image uses php" {
+# leading-slash source → sync_image has library/ prefix, probe_image is leaf-only
+@test "leading-slash source (/php) → sync_image uses library/php, probe_image uses php" {
     mkdir -p wpcontainer
     cat > wpcontainer/config.yaml <<'EOF'
 base_image_cache:
@@ -270,8 +270,8 @@ EOF
     [[ "$output" != *'"sync_image":"ghcr.io/myowner/php:latest"'* ]]
 }
 
-# BCU-15: normal NEW-style source → sync_image == probe_image
-@test "BCU-15: normal NEW-style source (library/postgres) → sync_image equals probe_image" {
+# normal NEW-style source → sync_image == probe_image
+@test "normal NEW-style source (library/postgres) → sync_image equals probe_image" {
     mkdir -p pgcontainer2
     cat > pgcontainer2/variants.yaml <<'EOF'
 versions:
@@ -293,8 +293,8 @@ EOF
     [[ "$output" == *'"probe_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
 }
 
-# BCU-15b: sync_base_images_to_ghcr with leading-slash source — source_ref has explicit library/ prefix
-@test "BCU-15b: sync_base_images_to_ghcr leading-slash source — source_ref has explicit library/ prefix" {
+# sync_base_images_to_ghcr with leading-slash source — source_ref has explicit library/ prefix
+@test "sync_base_images_to_ghcr leading-slash source — source_ref has explicit library/ prefix" {
     docker() {
         if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
             echo "MOCK_DOCKER_ARGS: $*"
@@ -318,8 +318,8 @@ EOF
     [[ "$output" == *"ghcr.io/myowner/library/php:latest"* ]]
 }
 
-# BCU-15d: mutation guard — single-segment chained source must never produce an alias-only ref
-@test "BCU-15d: sync_base_images_to_ghcr single-segment chained source — no bare alias (library/ always explicit)" {
+# mutation guard — single-segment chained source must never produce an alias-only ref
+@test "sync_base_images_to_ghcr single-segment chained source — no bare alias (library/ always explicit)" {
     docker() { return 0; }
     export -f docker
 
@@ -335,8 +335,8 @@ EOF
     [[ "$output" != *"docker.io//debian:bullseye"* ]]
 }
 
-# BCU-15c: dedup by sync_image — entries with same sync_image path are deduplicated
-@test "BCU-15c: collect_all_cache_images dedup uses sync_image field" {
+# dedup by sync_image — entries with same sync_image path are deduplicated
+@test "collect_all_cache_images dedup uses sync_image field" {
     mkdir -p dedup1 dedup2
     cat > dedup1/config.yaml <<'EOF'
 base_image_cache:
@@ -366,8 +366,8 @@ EOF
 
 # --- remote_cr_applicable: pure decision helper ---
 
-# BCU-16: all new-style entries reachable → "apply"
-@test "BCU-16: remote_cr_applicable — all new-style reachable → apply" {
+# all new-style entries reachable → "apply"
+@test "remote_cr_applicable — all new-style reachable → apply" {
     mkdir -p pgcontainer
     cat > pgcontainer/config.yaml <<'EOF'
 base_image_cache:
@@ -379,11 +379,11 @@ EOF
     [ "$output" = "apply" ]
 }
 
-# BCU-17: mixed old+new config, new-style entry unreachable → "drop"
+# mixed old+new config, new-style entry unreachable → "drop"
 # Locks the always-apply mutation: a single unreachable new-style entry in a mixed
 # config must produce "drop", not "apply". BCU-20 covers the partial-reachability
 # boundary (multiple new-style entries, only some reachable).
-@test "BCU-17: remote_cr_applicable — mixed old+new, new-style unreachable → drop (always-apply mutation lock)" {
+@test "remote_cr_applicable — mixed old+new, new-style unreachable → drop (always-apply mutation lock)" {
     mkdir -p mixcontainer
     cat > mixcontainer/config.yaml <<'EOF'
 base_image_cache:
@@ -402,8 +402,8 @@ EOF
     [ "$output" != "apply" ]
 }
 
-# BCU-18: no new-style entries → "n/a"
-@test "BCU-18: remote_cr_applicable — pure old-style config → n/a" {
+# no new-style entries → "n/a"
+@test "remote_cr_applicable — pure old-style config → n/a" {
     mkdir -p oldcontainer
     cat > oldcontainer/config.yaml <<'EOF'
 base_image_cache:
@@ -417,8 +417,8 @@ EOF
     [ "$output" = "n/a" ]
 }
 
-# BCU-19: multiple new-style entries all reachable → "apply"
-@test "BCU-19: remote_cr_applicable — multiple new-style all reachable → apply" {
+# multiple new-style entries all reachable → "apply"
+@test "remote_cr_applicable — multiple new-style all reachable → apply" {
     mkdir -p multinew
     cat > multinew/config.yaml <<'EOF'
 base_image_cache:
@@ -432,8 +432,8 @@ EOF
     [ "$output" = "apply" ]
 }
 
-# BCU-20: multiple new-style entries with one unreachable → "drop"
-@test "BCU-20: remote_cr_applicable — multiple new-style one unreachable → drop" {
+# multiple new-style entries with one unreachable → "drop"
+@test "remote_cr_applicable — multiple new-style one unreachable → drop" {
     mkdir -p multinew2
     cat > multinew2/config.yaml <<'EOF'
 base_image_cache:
@@ -447,8 +447,8 @@ EOF
     [ "$output" = "drop" ]
 }
 
-# BCU-21: mixed old+new, new reachable → "apply" (old flags are ignored)
-@test "BCU-21: remote_cr_applicable — mixed old+new, new reachable → apply" {
+# mixed old+new, new reachable → "apply" (old flags are ignored)
+@test "remote_cr_applicable — mixed old+new, new reachable → apply" {
     mkdir -p mixok
     cat > mixok/config.yaml <<'EOF'
 base_image_cache:
@@ -468,8 +468,8 @@ EOF
 
 # --- emit_reachable_cache_args: per-entry filtered arg emitter ---
 
-# BCU-22: all old-style entries reachable → all --build-arg flags emitted (regression lock)
-@test "BCU-22: emit_reachable_cache_args — all old-style reachable → all args emitted" {
+# all old-style entries reachable → all --build-arg flags emitted (regression lock)
+@test "emit_reachable_cache_args — all old-style reachable → all args emitted" {
     mkdir -p oldall
     cat > oldall/config.yaml <<'EOF'
 base_image_cache:
@@ -493,7 +493,7 @@ EOF
 # BCU-23 (RED→GREEN for FINDING A): one old-style entry unreachable → that arg omitted
 # This is the class bug: old-style args were previously bulk-applied on any-reachable.
 # Now each arg is gated on its own probe flag.
-@test "BCU-23: emit_reachable_cache_args — one old-style unreachable → only reachable arg emitted (FINDING-A lock)" {
+@test "emit_reachable_cache_args — one old-style unreachable → only reachable arg emitted (FINDING-A lock)" {
     mkdir -p oldpartial
     cat > oldpartial/config.yaml <<'EOF'
 base_image_cache:
@@ -517,8 +517,8 @@ EOF
     [[ "$output" != *"REMOTE_CR"* ]]
 }
 
-# BCU-24: mixed old+new, all reachable → old args + REMOTE_CR present
-@test "BCU-24: emit_reachable_cache_args — mixed old+new all reachable → old args + REMOTE_CR" {
+# mixed old+new, all reachable → old args + REMOTE_CR present
+@test "emit_reachable_cache_args — mixed old+new all reachable → old args + REMOTE_CR" {
     mkdir -p mixall
     cat > mixall/config.yaml <<'EOF'
 base_image_cache:
@@ -535,8 +535,8 @@ EOF
     [[ "$output" == *"--build-arg REMOTE_CR=ghcr.io/myowner"* ]]
 }
 
-# BCU-25: mixed old+new, new-style unreachable → old reachable arg present, REMOTE_CR ABSENT
-@test "BCU-25: emit_reachable_cache_args — mixed old+new, new unreachable → old arg kept, REMOTE_CR absent" {
+# mixed old+new, new-style unreachable → old reachable arg present, REMOTE_CR ABSENT
+@test "emit_reachable_cache_args — mixed old+new, new unreachable → old arg kept, REMOTE_CR absent" {
     mkdir -p mixnewmissing
     cat > mixnewmissing/config.yaml <<'EOF'
 base_image_cache:
@@ -556,8 +556,8 @@ EOF
     [[ "$output" != *"REMOTE_CR"* ]]
 }
 
-# BCU-26: pure new-style, all reachable → REMOTE_CR emitted, no old-style args
-@test "BCU-26: emit_reachable_cache_args — pure new-style all reachable → REMOTE_CR only" {
+# pure new-style, all reachable → REMOTE_CR emitted, no old-style args
+@test "emit_reachable_cache_args — pure new-style all reachable → REMOTE_CR only" {
     mkdir -p newonly
     cat > newonly/config.yaml <<'EOF'
 base_image_cache:
@@ -571,8 +571,8 @@ EOF
     [[ "$output" != *"BASE_IMAGE"* ]]
 }
 
-# BCU-27: pure new-style, unreachable → empty output (no REMOTE_CR)
-@test "BCU-27: emit_reachable_cache_args — pure new-style unreachable → empty output" {
+# pure new-style, unreachable → empty output (no REMOTE_CR)
+@test "emit_reachable_cache_args — pure new-style unreachable → empty output" {
     mkdir -p newmiss
     cat > newmiss/config.yaml <<'EOF'
 base_image_cache:
@@ -586,10 +586,10 @@ EOF
 
 # ─── FIX 2 (RED→GREEN): emit_reachable_cache_args arg validation ─────────────
 
-# BCU-FIX2-01: OLD-style entry with injected shell tokens in arg → non-zero, no flag emitted
+# OLD-style entry with injected shell tokens in arg → non-zero, no flag emitted
 # This is the FINDING: "BASE_IMAGE --network host" would inject extra docker flags.
 # RED before fix (returns 0, emits the bad flag), GREEN after (returns non-zero, emits nothing).
-@test "BCU-FIX2-01: emit_reachable_cache_args — malformed arg with shell token → non-zero + no flag (injection prevention)" {
+@test "emit_reachable_cache_args — malformed arg with shell token → non-zero + no flag (injection prevention)" {
     mkdir -p badarg
     cat > badarg/config.yaml <<'EOF'
 base_image_cache:
@@ -605,8 +605,8 @@ EOF
     [[ "$output" != *"--build-arg"* ]]
 }
 
-# BCU-FIX2-02: OLD-style entry with multi-word arg (spaces) → non-zero
-@test "BCU-FIX2-02: emit_reachable_cache_args — arg with embedded spaces → non-zero" {
+# OLD-style entry with multi-word arg (spaces) → non-zero
+@test "emit_reachable_cache_args — arg with embedded spaces → non-zero" {
     mkdir -p badarg2
     cat > badarg2/config.yaml <<'EOF'
 base_image_cache:
@@ -620,8 +620,8 @@ EOF
     [[ "$output" != *"--build-arg"* ]]
 }
 
-# BCU-FIX2-03: OLD-style entry with hyphen in arg (invalid Docker ARG name) → non-zero
-@test "BCU-FIX2-03: emit_reachable_cache_args — arg with hyphen → non-zero" {
+# OLD-style entry with hyphen in arg (invalid Docker ARG name) → non-zero
+@test "emit_reachable_cache_args — arg with hyphen → non-zero" {
     mkdir -p badarg3
     cat > badarg3/config.yaml <<'EOF'
 base_image_cache:
@@ -635,9 +635,9 @@ EOF
     [[ "$output" != *"--build-arg"* ]]
 }
 
-# BCU-FIX2-PASS: valid arg identifier → clean output (regression lock)
+# valid arg identifier → clean output (regression lock)
 # This must pass before AND after the fix (it was already working; guard against over-rejection).
-@test "BCU-FIX2-PASS: emit_reachable_cache_args — valid identifier arg → emits flag correctly" {
+@test "emit_reachable_cache_args — valid identifier arg → emits flag correctly" {
     mkdir -p validarg
     cat > validarg/config.yaml <<'EOF'
 base_image_cache:
@@ -651,10 +651,10 @@ EOF
     [[ "$output" == *"--build-arg BASE_IMAGE=ghcr.io/myowner/ubuntu-base"* ]]
 }
 
-# BCU-FIX2-05: unreachable old-style entry with bad arg → still non-zero
+# unreachable old-style entry with bad arg → still non-zero
 # The validation must run regardless of the reachability flag — bad config is a config error,
 # not a "suppress it" signal. (Guards against: skip validation if flag==false.)
-@test "BCU-FIX2-05: emit_reachable_cache_args — bad arg in unreachable entry → non-zero (no silent skip)" {
+@test "emit_reachable_cache_args — bad arg in unreachable entry → non-zero (no silent skip)" {
     mkdir -p badarg5
     cat > badarg5/config.yaml <<'EOF'
 base_image_cache:
@@ -675,7 +675,7 @@ EOF
 #   --build-arg BASE_IMAGE=ghcr.io/owner/ubuntu-base --network host
 # which would inject extra docker flags silently.
 # After the fix, emit_reachable_cache_args must return non-zero and emit nothing.
-@test "BCU-GHCR-01: emit_reachable_cache_args — ghcr_repo with space+flag → non-zero + no flag (injection prevention)" {
+@test "emit_reachable_cache_args — ghcr_repo with space+flag → non-zero + no flag (injection prevention)" {
     mkdir -p badrepo
     cat > badrepo/config.yaml <<'EOF'
 base_image_cache:
@@ -691,8 +691,8 @@ EOF
     [[ "$output" != *"--build-arg"* ]]
 }
 
-# BCU-GHCR-02: ghcr_repo with semicolon → non-zero
-@test "BCU-GHCR-02: emit_reachable_cache_args — ghcr_repo with semicolon → non-zero" {
+# ghcr_repo with semicolon → non-zero
+@test "emit_reachable_cache_args — ghcr_repo with semicolon → non-zero" {
     mkdir -p badrepo2
     cat > badrepo2/config.yaml <<'EOF'
 base_image_cache:
@@ -706,9 +706,9 @@ EOF
     [[ "$output" != *"--build-arg"* ]]
 }
 
-# BCU-GHCR-03: malicious ghcr_repo in unreachable entry → still non-zero (no silent skip)
+# malicious ghcr_repo in unreachable entry → still non-zero (no silent skip)
 # Mirrors BCU-FIX2-05: validation runs regardless of the probe flag.
-@test "BCU-GHCR-03: emit_reachable_cache_args — bad ghcr_repo in unreachable entry → non-zero (no silent skip)" {
+@test "emit_reachable_cache_args — bad ghcr_repo in unreachable entry → non-zero (no silent skip)" {
     mkdir -p badrepo3
     cat > badrepo3/config.yaml <<'EOF'
 base_image_cache:
@@ -724,11 +724,11 @@ EOF
 
 # ─── FIX 1 (RED→GREEN): standalone source guard — log_error must be defined ────
 #
-# BCU-STANDALONE-01: source base-cache-utils.sh in a FRESH subshell (no pre-sourcing
+# source base-cache-utils.sh in a FRESH subshell (no pre-sourcing
 # of logging.sh) and trigger emit_reachable_cache_args with a malformed arg.
 # RED before FIX 1: "log_error: command not found" appears on stderr.
 # GREEN after FIX 1: the intended validation message appears; "command not found" absent.
-@test "BCU-STANDALONE-01: standalone source — log_error defined, malformed arg emits validation message not 'command not found'" {
+@test "standalone source — log_error defined, malformed arg emits validation message not 'command not found'" {
     # Build a config with a shell-unsafe arg identifier to trigger the log_error path
     mkdir -p standalone_test
     cat > standalone_test/config.yaml <<'EOF'
@@ -755,7 +755,7 @@ EOF
 }
 
 # BCU-GHCR-PASS: valid ghcr_repo values (all current containers) → exit 0 + correct flag
-@test "BCU-GHCR-PASS: emit_reachable_cache_args — all valid old-style ghcr_repo names → PASS" {
+@test "emit_reachable_cache_args — all valid old-style ghcr_repo names → PASS" {
     local repos="ubuntu-base ruby-base php-base composer-base alpine-base rocky-base debian-base terraform-base postgres-base python-base"
     for repo in $repos; do
         mkdir -p "valrepo-${repo}"
@@ -1090,10 +1090,10 @@ EOF
 
 # --- check_image construction guard (gate r3 fix — action.yaml ${source_path#/} strip) ---
 
-# BCU-ACTIONSTRIP-01: leading-slash source → probe_image has no double slash
+# leading-slash source → probe_image has no double slash
 # Mirrors the action.yaml inline check_image construction: check_image="ghcr.io/${owner}/${source_path#/}:${tag}"
 # Without the #/ strip, source: /php would yield ghcr.io/owner//php:tag.
-@test "BCU-ACTIONSTRIP-01: leading-slash source (/php) → probe_image contains no double slash" {
+@test "leading-slash source (/php) → probe_image contains no double slash" {
     mkdir -p wpstrip
     cat > wpstrip/config.yaml <<'EOF'
 base_image_cache:
@@ -1112,8 +1112,8 @@ EOF
     [[ "$output" == *'"probe_image":"ghcr.io/myowner/php:8.2-fpm-alpine"'* ]]
 }
 
-# BCU-ACTIONSTRIP-02: bash strip pattern sanity — ${source_path#/} is idempotent for non-slash sources
-@test "BCU-ACTIONSTRIP-02: strip pattern \${source_path#/} is idempotent for normal (non-leading-slash) source" {
+# bash strip pattern sanity — ${source_path#/} is idempotent for non-slash sources
+@test "strip pattern \${source_path#/} is idempotent for normal (non-leading-slash) source" {
     # Direct bash expansion check: verifies the fix applied in action.yaml does not
     # mangle normal sources like "library/postgres".
     local source_path="library/postgres"
@@ -1125,8 +1125,8 @@ EOF
     [[ "$check_image" != *'//'* ]]
 }
 
-# BCU-ACTIONSTRIP-03: bash strip pattern — ${source_path#/} strips exactly the leading slash for /php
-@test "BCU-ACTIONSTRIP-03: strip pattern \${source_path#/} produces clean path for leading-slash source /php" {
+# bash strip pattern — ${source_path#/} strips exactly the leading slash for /php
+@test "strip pattern \${source_path#/} produces clean path for leading-slash source /php" {
     local source_path="/php"
     local check_image="ghcr.io/myowner/${source_path#/}:8.2-fpm-alpine"
     [ "$check_image" = "ghcr.io/myowner/php:8.2-fpm-alpine" ]
@@ -1135,11 +1135,11 @@ EOF
 
 # --- gate r4 Bug 2 regression: multi-segment leading-slash source must not double library/ ---
 
-# BCU-MULTISEG-01: source="/library/postgres" → sync_dest_path must be "library/postgres"
+# source="/library/postgres" → sync_dest_path must be "library/postgres"
 # Regression lock for gate r4 Bug 2: the unconditional "library/${leaf}" prepend produced
 # "library/library/postgres" when source="/library/postgres" (leaf="library/postgres").
 # Fix: prepend library/ only when leaf has no slash (single-segment, like "php").
-@test "BCU-MULTISEG-01: source=/library/postgres → sync_image is library/postgres NOT library/library/postgres" {
+@test "source=/library/postgres → sync_image is library/postgres NOT library/library/postgres" {
     mkdir -p pgchained
     cat > pgchained/config.yaml <<'EOF'
 base_image_cache:
@@ -1160,9 +1160,9 @@ EOF
     [[ "$output" == *'"probe_image":"ghcr.io/myowner/library/postgres:18-alpine"'* ]]
 }
 
-# BCU-MULTISEG-02: source="/php" (single-segment) still gets library/ prepend
+# source="/php" (single-segment) still gets library/ prepend
 # Regression guard: the multi-segment fix must NOT break the original /php → library/php behaviour.
-@test "BCU-MULTISEG-02: source=/php (single-segment) still uses library/php for sync_image" {
+@test "source=/php (single-segment) still uses library/php for sync_image" {
     mkdir -p phpchained
     cat > phpchained/config.yaml <<'EOF'
 base_image_cache:
@@ -1183,10 +1183,10 @@ EOF
 
 # --- presence gate (skip_present=true) ---
 
-# BCU-PRESGATE-01: skip_present=true + GHCR already present → copy NOT invoked, rc 0
+# skip_present=true + GHCR already present → copy NOT invoked, rc 0
 # Locks the fast path: when `docker manifest inspect` succeeds (image in GHCR),
 # `buildx imagetools create` must never be called (no docker.io request).
-@test "BCU-PRESGATE-01: skip_present=true + GHCR present → copy skipped, rc 0" {
+@test "skip_present=true + GHCR present → copy skipped, rc 0" {
     # Use a marker file to detect whether buildx imagetools create was ever called.
     # A shell variable cannot survive the command-substitution subshell used by
     # _sync_one_with_backoff, so we use a real tempfile (same pattern as the
@@ -1225,10 +1225,10 @@ EOF
     rm -f "$copy_marker"
 }
 
-# BCU-PRESGATE-02: skip_present=true + GHCR absent → copy IS invoked, rc 0
+# skip_present=true + GHCR absent → copy IS invoked, rc 0
 # When `docker manifest inspect` fails (image not yet in GHCR), the normal copy
 # path must run — ensures the gate doesn't block the initial population.
-@test "BCU-PRESGATE-02: skip_present=true + GHCR absent → copy invoked, rc 0" {
+@test "skip_present=true + GHCR absent → copy invoked, rc 0" {
     local copy_marker
     copy_marker=$(mktemp)
     rm -f "$copy_marker"
@@ -1260,11 +1260,11 @@ EOF
     rm -f "$copy_marker"
 }
 
-# BCU-PRESGATE-03: skip_present=false (default, daily sync) → copy invoked even when GHCR present
+# skip_present=false (default, daily sync) → copy invoked even when GHCR present
 # Regression lock: blind-copy behavior must not be broken by the presence gate.
 # The daily upstream-monitor sync calls sync_base_images_to_ghcr without skip_present
 # (defaults to "false"), so it must always copy regardless of GHCR state.
-@test "BCU-PRESGATE-03: skip_present=false (default) → copy invoked even when GHCR present (blind refresh)" {
+@test "skip_present=false (default) → copy invoked even when GHCR present (blind refresh)" {
     local copy_marker
     copy_marker=$(mktemp)
     rm -f "$copy_marker"

--- a/tests/unit/build-args-utils.bats
+++ b/tests/unit/build-args-utils.bats
@@ -35,7 +35,7 @@ make_container() {
 
 # ─── FIX 1: build_args_flags fail-closed enforcement ─────────────────────────
 
-@test "BAU-01: build_args_flags aborts (non-zero) when REMOTE_CR key present" {
+@test "build_args_flags aborts (non-zero) when REMOTE_CR key present" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu"
@@ -47,7 +47,7 @@ EOF
     [[ "$output" =~ "REMOTE_CR" ]]
 }
 
-@test "BAU-02: build_args_flags aborts on non-identifier key (contains space)" {
+@test "build_args_flags aborts on non-identifier key (contains space)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   "X --network host": "val"
@@ -57,7 +57,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "BAU-03: build_args_flags aborts on key with hyphen (invalid Docker ARG)" {
+@test "build_args_flags aborts on key with hyphen (invalid Docker ARG)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   INVALID-KEY: "value"
@@ -67,7 +67,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "BAU-04: build_args_flags aborts on value with embedded space" {
+@test "build_args_flags aborts on value with embedded space" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "foo --network host"
@@ -77,7 +77,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "BAU-05: build_args_flags aborts on value with embedded newline" {
+@test "build_args_flags aborts on value with embedded newline" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu\n--build-arg\nREMOTE_CR=x"
@@ -87,7 +87,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "BAU-06: build_args_flags aborts on non-scalar value (object)" {
+@test "build_args_flags aborts on non-scalar value (object)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE:
@@ -101,7 +101,7 @@ EOF
 # ─── FIX 1: regression lock — valid config emits identical flags ──────────────
 
 # php pattern: 4 build_args, all clean identifiers + scalar values (no whitespace)
-@test "BAU-PASS-01: php-shaped config (4 valid build_args) → correct flags emitted (regression lock)" {
+@test "php-shaped config (4 valid build_args) → correct flags emitted (regression lock)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "php"
@@ -121,7 +121,7 @@ EOF
     [[ ! "$output" =~ "REMOTE_CR" ]]
 }
 
-@test "BAU-PASS-02: empty build_args section → no flags, zero exit" {
+@test "empty build_args section → no flags, zero exit" {
     make_container "myapp" "$(cat <<'EOF'
 build_args: {}
 EOF
@@ -131,7 +131,7 @@ EOF
     [ -z "$output" ]
 }
 
-@test "BAU-PASS-03: absent build_args section → no flags, zero exit" {
+@test "absent build_args section → no flags, zero exit" {
     make_container "myapp" "$(cat <<'EOF'
 base_image: "ubuntu:latest"
 EOF
@@ -141,7 +141,7 @@ EOF
     [ -z "$output" ]
 }
 
-@test "BAU-PASS-04: ansible-shaped config (7 valid build_args) → correct flags emitted (regression lock)" {
+@test "ansible-shaped config (7 valid build_args) → correct flags emitted (regression lock)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu"
@@ -164,7 +164,7 @@ EOF
     [[ "$output" =~ "--build-arg PYCRYPTODOME_VERSION=3.23.0" ]]
 }
 
-@test "BAU-PASS-05: value with colon+slash (image ref, no whitespace) → PASS" {
+@test "value with colon+slash (image ref, no whitespace) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   WORDPRESS_IMAGE: "ghcr.io/oorabona/php:latest"
@@ -175,7 +175,7 @@ EOF
     [[ "$output" =~ "--build-arg WORDPRESS_IMAGE=ghcr.io/oorabona/php:latest" ]]
 }
 
-@test "BAU-PASS-06: no config.yaml → empty output, zero exit (no-op)" {
+@test "no config.yaml → empty output, zero exit (no-op)" {
     mkdir -p empty_container
     run build_args_flags "empty_container"
     [ "$status" -eq 0 ]
@@ -190,7 +190,7 @@ make_version_stub() {
     chmod +x version.sh
 }
 
-@test "PAB-01: prepare_build_args aborts (non-zero) when config has REMOTE_CR key" {
+@test "prepare_build_args aborts (non-zero) when config has REMOTE_CR key" {
     make_container "." "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu"
@@ -204,7 +204,7 @@ EOF
     [[ "$output" =~ "build_args validation failed" ]] || [[ "$output" =~ "REMOTE_CR" ]]
 }
 
-@test "PAB-02: prepare_build_args aborts (non-zero) when config has whitespace-injecting value" {
+@test "prepare_build_args aborts (non-zero) when config has whitespace-injecting value" {
     make_container "." "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "foo --network host"
@@ -215,7 +215,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "PAB-03: prepare_build_args aborts (non-zero) when config has non-identifier key" {
+@test "prepare_build_args aborts (non-zero) when config has non-identifier key" {
     make_container "." "$(cat <<'EOF'
 build_args:
   "INVALID-KEY": "value"
@@ -227,7 +227,7 @@ EOF
 }
 
 # Regression lock: valid php-shaped config must still succeed end-to-end
-@test "PAB-PASS-01: prepare_build_args succeeds + sets _BUILD_ARGS for php-shaped config" {
+@test "prepare_build_args succeeds + sets _BUILD_ARGS for php-shaped config" {
     make_container "." "$(cat <<'EOF'
 build_args:
   COMPOSER_VERSION: "2.9.8"
@@ -246,7 +246,7 @@ EOF
 }
 
 # Regression lock: no config.yaml → prepare_build_args still succeeds (no abort)
-@test "PAB-PASS-02: prepare_build_args succeeds when no config.yaml present" {
+@test "prepare_build_args succeeds when no config.yaml present" {
     # TEST_DIR has no config.yaml
     mkdir -p noconfig && cd noconfig
     prepare_build_args "2.0"

--- a/tests/unit/build-cache-utils.bats
+++ b/tests/unit/build-cache-utils.bats
@@ -30,7 +30,7 @@ teardown() {
 
 # --- Postgres Flavors ---
 
-@test "SC-01: pgvector bump changes vector digest, not timeseries" {
+@test "pgvector bump changes vector digest, not timeseries" {
     mkdir -p flavors extensions
 
     cat > flavors/vector.yaml <<'EOF'
@@ -83,7 +83,7 @@ EOF
     [ "$digest_timeseries_1" == "$digest_timeseries_2" ]
 }
 
-@test "SC-02: full flavor includes all extension versions" {
+@test "full flavor includes all extension versions" {
     mkdir -p flavors extensions
     cat > flavors/full.yaml <<'EOF'
 name: full
@@ -119,7 +119,7 @@ EOF
     [ "$d1" != "$d2" ]
 }
 
-@test "SC-03: base flavor has no extensions — unaffected by extension bumps" {
+@test "base flavor has no extensions — unaffected by extension bumps" {
     mkdir -p flavors extensions
     cat > flavors/base.yaml <<'EOF'
 name: base
@@ -152,7 +152,7 @@ EOF
 
 # --- Terraform Variants ---
 
-@test "SC-04: AWS CLI bump changes aws digest, not base" {
+@test "AWS CLI bump changes aws digest, not base" {
     cat > variants.yaml <<'EOF'
 versions:
   - variants:
@@ -199,7 +199,7 @@ EOF
     [ "$d_base_1" == "$d_base_2" ]
 }
 
-@test "SC-05: TFLINT bump changes all terraform flavors" {
+@test "TFLINT bump changes all terraform flavors" {
     cat > variants.yaml <<'EOF'
 versions:
   - variants:
@@ -246,7 +246,7 @@ EOF
 
 # --- Simple Containers ---
 
-@test "SC-06: container with config.yaml build_args" {
+@test "container with config.yaml build_args" {
     cat > config.yaml <<'EOF'
 build_args:
   FOO: "1.0"
@@ -268,7 +268,7 @@ EOF
     [ "$d1" != "$d2" ]
 }
 
-@test "SC-07: container with no config.yaml returns valid 12-char hex digest" {
+@test "container with no config.yaml returns valid 12-char hex digest" {
     echo "FROM alpine" > Dockerfile
 
     run compute_build_digest "Dockerfile" ""
@@ -289,7 +289,7 @@ EOF
 
 # --- Edge Cases ---
 
-@test "SC-08: CUSTOM_BUILD_ARGS included in digest" {
+@test "CUSTOM_BUILD_ARGS included in digest" {
     echo "FROM alpine" > Dockerfile
 
     run compute_build_digest "Dockerfile" ""
@@ -304,7 +304,7 @@ EOF
     [ "$d1" != "$d2" ]
 }
 
-@test "SC-09: deterministic output — identical inputs produce identical digest" {
+@test "deterministic output — identical inputs produce identical digest" {
     cat > config.yaml <<'EOF'
 build_args:
   A: "1"
@@ -495,7 +495,7 @@ EOF
 
 # --- Observability ---
 
-@test "SC-10: digest inputs are logged when DIGEST_DEBUG=1" {
+@test "digest inputs are logged when DIGEST_DEBUG=1" {
     echo "FROM alpine" > Dockerfile
     mkdir -p flavors
     cat > flavors/test.yaml <<'EOF'
@@ -527,7 +527,7 @@ EOF
 # Dockerfile ARG default (ARG REMOTE_CR=docker.io) when resolving the base
 # image reference for lineage labels and manifest-inspect.
 
-@test "RBI-01: CUSTOM_BUILD_ARGS REMOTE_CR override wins over Dockerfile ARG default" {
+@test "CUSTOM_BUILD_ARGS REMOTE_CR override wins over Dockerfile ARG default" {
     _setup_resolve_base_image
 
     # Dockerfile that mirrors the postgres pattern: ARG REMOTE_CR with docker.io default
@@ -548,7 +548,7 @@ EOF
     [[ "$_BASE_IMAGE_REF" == "ghcr.io/owner/library/postgres:17-alpine" ]]
 }
 
-@test "RBI-02: without CUSTOM_BUILD_ARGS override, ARG default (docker.io) applies" {
+@test "without CUSTOM_BUILD_ARGS override, ARG default (docker.io) applies" {
     _setup_resolve_base_image
 
     cat > Dockerfile <<'EOF'
@@ -564,7 +564,7 @@ EOF
     [[ "$_BASE_IMAGE_REF" == "docker.io/library/postgres:17-alpine" ]]
 }
 
-@test "RBI-03: last --build-arg REMOTE_CR occurrence wins (docker semantics)" {
+@test "last --build-arg REMOTE_CR occurrence wins (docker semantics)" {
     _setup_resolve_base_image
 
     cat > Dockerfile <<'EOF'
@@ -592,7 +592,7 @@ EOF
 # rebuild, leaving base digest unchanged → infinite drift-PR loop.
 # ---------------------------------------------------------------------------
 
-@test "r10-fix1a: LAST_REBUILD.md absent — digest is stable (baseline)" {
+@test "LAST_REBUILD.md absent — digest is stable (baseline)" {
     echo "FROM alpine:3.21" > Dockerfile
 
     run compute_build_digest "Dockerfile" ""
@@ -606,7 +606,7 @@ EOF
     [ "$output" = "$digest_without" ]
 }
 
-@test "r10-fix1b: LAST_REBUILD.md present changes digest vs absent" {
+@test "LAST_REBUILD.md present changes digest vs absent" {
     echo "FROM alpine:3.21" > Dockerfile
 
     run compute_build_digest "Dockerfile" ""
@@ -628,7 +628,7 @@ EOF
     [ "$digest_with" != "$digest_without" ]
 }
 
-@test "r10-fix1c: modifying LAST_REBUILD.md changes digest (invalidates cache)" {
+@test "modifying LAST_REBUILD.md changes digest (invalidates cache)" {
     echo "FROM alpine:3.21" > Dockerfile
 
     echo "## base-digest-drift v1" > LAST_REBUILD.md
@@ -646,7 +646,7 @@ EOF
     [ "$digest_v2" != "$digest_v1" ]
 }
 
-@test "r10-fix1d: LAST_REBUILD.md included in digest with postgres-style flavor" {
+@test "LAST_REBUILD.md included in digest with postgres-style flavor" {
     mkdir -p flavors extensions
     cat > flavors/vector.yaml <<'EOF'
 name: vector

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -247,7 +247,7 @@ _count_log_lines() {
     push_count=$(_count_log_lines "$TEST_TEMP_DIR/push_calls.log")
     [ "$push_count" -eq 3 ]
 
-    # L1: each version must be tagged and pushed under its OWN version string
+    # each version must be tagged and pushed under its OWN version string
     local tag_log push_log
     tag_log=$(cat "$TEST_TEMP_DIR/tag_calls.log")
     push_log=$(cat "$TEST_TEMP_DIR/push_calls.log")
@@ -413,7 +413,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# FIX1: pushed artifact (do_push=true, no ARCH_SUFFIX) must include version_digests
+# pushed artifact (do_push=true, no ARCH_SUFFIX) must include version_digests
 # for every available version.
 #
 # Invariant: version_digests absent ⟺ artifact was NOT pushed.
@@ -425,7 +425,7 @@ _count_log_lines() {
 # After fix: version_digests is captured and included for every available version.
 # ---------------------------------------------------------------------------
 
-@test "FIX1-push-has-digests: do_push=true artifact includes version_digests for every available version" {
+@test "do_push=true artifact includes version_digests for every available version" {
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
     export -f resolve_version_set
 
@@ -468,7 +468,7 @@ _count_log_lines() {
     [ "$all_valid" = "true" ]
 }
 
-@test "FIX1-no-push-no-digests: do_push=false artifact omits version_digests (local/no-push invariant)" {
+@test "do_push=false artifact omits version_digests (local/no-push invariant)" {
     export LOCAL_ONLY=true
 
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
@@ -499,7 +499,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# M1: resolver call-count — resolve_version_set called AT MOST ONCE per
+# resolver call-count — resolve_version_set called AT MOST ONCE per
 # (ext, pg_major) even though both _should_build_extension and
 # build_tag_push_extensions consume the result.
 # ---------------------------------------------------------------------------
@@ -546,13 +546,13 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# M1: resolver call-count — resolve_version_set called AT MOST ONCE per
+# resolver call-count — resolve_version_set called AT MOST ONCE per
 # (ext, pg_major) even though both _should_build_extension and
 # build_tag_push_extensions consume the result.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# A1: main() pre-filter fail-closed — resolver failure must propagate to exit 1
+# main() pre-filter fail-closed — resolver failure must propagate to exit 1
 # (not silently become "All extensions are up to date" / exit 0).
 # ---------------------------------------------------------------------------
 
@@ -728,7 +728,7 @@ _count_log_lines() {
 # After fix:  tag failure always fatal → exit non-zero; version NOT in excluded.
 # ---------------------------------------------------------------------------
 
-@test "D-tag-fatal: non-ceiling tag failure is fatal (exit non-zero), not musl-excluded" {
+@test "non-ceiling tag failure is fatal (exit non-zero), not musl-excluded" {
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
     export -f resolve_version_set
 
@@ -789,7 +789,7 @@ _count_log_lines() {
 # so even with scheduler jitter no single-version delta should reach 3s.)
 # ---------------------------------------------------------------------------
 
-@test "E-duration-independent: per-version lineage durations are bounded, not cumulative" {
+@test "per-version lineage durations are bounded, not cumulative" {
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
     export -f resolve_version_set
 
@@ -839,7 +839,7 @@ _count_log_lines() {
 # (local recovery path). Without LOCAL_ONLY (publish/CI path), must stay fatal.
 # ---------------------------------------------------------------------------
 
-@test "G-local-degrade: resolver fails + LOCAL_ONLY=true → ceiling built, exit 0" {
+@test "resolver fails + LOCAL_ONLY=true → ceiling built, exit 0" {
     export LOCAL_ONLY=true
 
     resolve_version_set() {
@@ -877,7 +877,7 @@ _count_log_lines() {
     [[ "$(cat "$build_log")" == *"ver=2.27.1"* ]]
 }
 
-@test "G-publish-fatal: resolver fails + LOCAL_ONLY=false → exit non-zero (publish path stays fail-closed)" {
+@test "resolver fails + LOCAL_ONLY=false → exit non-zero (publish path stays fail-closed)" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -915,13 +915,13 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# TT-1: empty-HA resolver failure + LOCAL_ONLY=true → degrade to ceiling, exit 0.
+# empty-HA resolver failure + LOCAL_ONLY=true → degrade to ceiling, exit 0.
 # The mode-gated ceiling degrade lives in the CALLER (build_tag_push_extensions),
 # not in the resolver. The resolver now exits non-zero on empty HA; the caller
 # catches that and degrades to ceiling only when LOCAL_ONLY=true.
 # ---------------------------------------------------------------------------
 
-@test "TT-local-degrade: empty-HA resolver failure + LOCAL_ONLY=true → ceiling built, exit 0" {
+@test "empty-HA resolver failure + LOCAL_ONLY=true → ceiling built, exit 0" {
     export LOCAL_ONLY=true
 
     # Simulate what the resolver now does on empty HA: exits non-zero, no stdout.
@@ -961,12 +961,12 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# TT-2: empty-HA resolver failure + LOCAL_ONLY=false (publish path) → FATAL.
+# empty-HA resolver failure + LOCAL_ONLY=false (publish path) → FATAL.
 # A transient HA-metadata outage on the publish path must exit non-zero so CI
 # does not silently publish a ceiling-only image that drops retained versions.
 # ---------------------------------------------------------------------------
 
-@test "TT-publish-fatal: empty-HA resolver failure + LOCAL_ONLY=false → exit non-zero (fail-closed)" {
+@test "empty-HA resolver failure + LOCAL_ONLY=false → exit non-zero (fail-closed)" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -1013,7 +1013,7 @@ _count_log_lines() {
 # the current run's versions are on disk.
 # ---------------------------------------------------------------------------
 
-@test "K-stale-cleanup: stale lineage file from old version is removed before current run" {
+@test "stale lineage file from old version is removed before current run" {
     # Arrange: pre-create a stale per-version lineage file (2.24.0, not in the
     # current resolved set which is [2.25.0,2.26.0,2.27.1]).
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
@@ -1049,7 +1049,7 @@ _count_log_lines() {
     [ -f "$lineage_dir/ext-timescaledb-pg18-2.27.1.json" ]
 }
 
-@test "K-stale-cleanup: stale versionset artifact from previous run is overwritten by final pass" {
+@test "stale versionset artifact from previous run is overwritten by final pass" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -1124,7 +1124,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# P1: --pull-only resolves full version set and attempts pull for each version
+# --pull-only resolves full version set and attempts pull for each version
 # ---------------------------------------------------------------------------
 
 @test "pull-only-multiversion: resolver-backed ext attempts pull for each resolved version" {
@@ -1173,7 +1173,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# P2: --pull-only: versions already local are skipped (not pulled again)
+# --pull-only: versions already local are skipped (not pulled again)
 # ---------------------------------------------------------------------------
 
 @test "pull-only-skip-local: version already present locally is not pulled" {
@@ -1219,7 +1219,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# DRY1: dry run must not delete existing lineage files
+# dry run must not delete existing lineage files
 # ---------------------------------------------------------------------------
 
 @test "dry-run-no-delete: pre-existing lineage file is not removed under DRY_RUN=true" {
@@ -1254,7 +1254,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# DRY2: dry run must not write any new lineage or versionset artifact
+# dry run must not write any new lineage or versionset artifact
 # ---------------------------------------------------------------------------
 
 @test "dry-run-no-write: no new lineage files created under DRY_RUN=true" {
@@ -1290,7 +1290,7 @@ _count_log_lines() {
 # (fail-closed on publish path), NOT cache the bad value and silently skip builds.
 # ---------------------------------------------------------------------------
 
-@test "P-malformed-json: resolver returns non-JSON → publish path exits non-zero (fail-closed)" {
+@test "resolver returns non-JSON → publish path exits non-zero (fail-closed)" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -1327,7 +1327,7 @@ _count_log_lines() {
     [ "$build_count" -eq 0 ]
 }
 
-@test "P-empty-array: resolver returns [] → publish path exits non-zero (fail-closed)" {
+@test "resolver returns [] → publish path exits non-zero (fail-closed)" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -1368,7 +1368,7 @@ _count_log_lines() {
 # not abort. The pull-only recovery path is equivalent to LOCAL_ONLY for degradation.
 # ---------------------------------------------------------------------------
 
-@test "Q-pull-only-degrade: resolver fails + PULL_ONLY=true → degrades to ceiling, exits 0" {
+@test "resolver fails + PULL_ONLY=true → degrades to ceiling, exits 0" {
     export LOCAL_ONLY=false
     export PULL_ONLY=true
 
@@ -1413,7 +1413,7 @@ _count_log_lines() {
 # The DRY_RUN-honoring pull_extension wrapper must be used instead.
 # ---------------------------------------------------------------------------
 
-@test "R-dry-run-pull: pull-only + DRY_RUN=true does not call pull_ext_image" {
+@test "pull-only + DRY_RUN=true does not call pull_ext_image" {
     export LOCAL_ONLY=false
     export DRY_RUN=true
 
@@ -1452,7 +1452,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# CACHED-1: all versions already in registry → no build, but versionset artifact
+# all versions already in registry → no build, but versionset artifact
 # IS written with available == full resolved set, excluded == [].
 # Before fix: main() hits the "All extensions are up to date" early-exit before
 #   build_tag_push_extensions is ever called → no artifact written (RED).
@@ -1460,7 +1460,7 @@ _count_log_lines() {
 #   is built (GREEN).
 # ---------------------------------------------------------------------------
 
-@test "CACHED-1: all-cached run emits versionset artifact with full available set" {
+@test "all-cached run emits versionset artifact with full available set" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -1549,11 +1549,11 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# CACHED-2: partial-cached run — some versions in registry, one absent (built),
+# partial-cached run — some versions in registry, one absent (built),
 # one absent (build fails / musl) → available = present+built, excluded = failed.
 # ---------------------------------------------------------------------------
 
-@test "CACHED-2: partial-cached run — artifact has correct available/excluded split" {
+@test "partial-cached run — artifact has correct available/excluded split" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -1689,7 +1689,7 @@ _count_log_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# MIXED-1: two extensions in scope — timescaledb (resolver-backed, ALL versions
+# two extensions in scope — timescaledb (resolver-backed, ALL versions
 # already in registry → skipped by build_tag_push) and pgvector (single-version,
 # needs build). main() must NOT take the all-up-to-date early-exit; after
 # build_tag_push completes for pgvector, the timescaledb versionset artifact
@@ -1700,7 +1700,7 @@ _count_log_lines() {
 # After fix:  final pass runs on all success paths → artifact present (GREEN).
 # ---------------------------------------------------------------------------
 
-@test "MIXED-1: mixed run (skipped resolver-backed ext + built single-ver ext) emits versionset artifact" {
+@test "mixed run (skipped resolver-backed ext + built single-ver ext) emits versionset artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -1817,12 +1817,12 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# MIXED-2: resolver-backed ext IS built (not skipped), single-ver ext already
+# resolver-backed ext IS built (not skipped), single-ver ext already
 # cached. After build completes, the versionset artifact reflects what is
 # actually in the registry (presence-based — no regression from the build path).
 # ---------------------------------------------------------------------------
 
-@test "MIXED-2: built resolver-backed ext produces correct versionset artifact" {
+@test "built resolver-backed ext produces correct versionset artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2029,7 +2029,7 @@ EOF
 # DRY_RUN=true must NOT write the timescaledb versionset artifact.
 # ---------------------------------------------------------------------------
 
-@test "MIXED-DRY-RUN: mixed path under DRY_RUN=true writes no versionset artifact" {
+@test "mixed path under DRY_RUN=true writes no versionset artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2248,7 +2248,7 @@ EOF
 #   presence check) → available = built+pushed versions (GREEN).
 # ---------------------------------------------------------------------------
 
-@test "FORCE-AVAILABLE: FORCE=true + successful build+push → available is non-empty" {
+@test "FORCE=true + successful build+push → available is non-empty" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2357,7 +2357,7 @@ EOF
 #   - Run must exit 0; no timescaledb resolver is even called.
 # ---------------------------------------------------------------------------
 
-@test "SCOPED-RETENTION: scoped --extension pgvector run does NOT emit timescaledb artifact (MM fix)" {
+@test "scoped --extension pgvector run does NOT emit timescaledb artifact (MM fix)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2488,7 +2488,7 @@ EOF
 #   → locally-built version is in local store → available (GREEN, available=3).
 # ---------------------------------------------------------------------------
 
-@test "PULL-ONLY-LOCAL-PRESENCE: pull-only + local build → locally-built version in available" {
+@test "pull-only + local build → locally-built version in available" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2620,7 +2620,7 @@ EOF
 # GREEN after fix: built-this-run ∪ probe → version included in available[].
 # ---------------------------------------------------------------------------
 
-@test "AA-probe-lag: built-and-pushed version survives probe-absent (registry lag)" {
+@test "built-and-pushed version survives probe-absent (registry lag)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2732,7 +2732,7 @@ EOF
     [[ "$excluded_versions" == *"2.25.0"* ]]
 }
 
-@test "AA-musl-excluded: musl-failed version is not smuggled into available via built-this-run" {
+@test "musl-failed version is not smuggled into available via built-this-run" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2841,7 +2841,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB-1: final-pass resolver failure on PUBLISH path with a FULL (unscoped) run
+# final-pass resolver failure on PUBLISH path with a FULL (unscoped) run
 # (no --extension, LOCAL_ONLY=false, PULL_ONLY=false) → run must exit NON-ZERO
 # (fail-closed).
 #
@@ -2860,7 +2860,7 @@ EOF
 # unscoped final pass iterates ALL extensions → timescaledb resolver fails →
 # fail-closed.
 # ---------------------------------------------------------------------------
-@test "BB-1-publish-fail-closed: full unscoped run with failing timescaledb resolver → exit non-zero (fail-closed)" {
+@test "full unscoped run with failing timescaledb resolver → exit non-zero (fail-closed)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -2965,14 +2965,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB-2: final-pass resolver failure + LOCAL_ONLY=true → degrade, exit 0.
+# final-pass resolver failure + LOCAL_ONLY=true → degrade, exit 0.
 # The recovery path must not be blocked by a transient resolver outage.
 #
 # RED before fix: N/A — current code already degrades (same warn+continue).
-#   This test locks the degrade behavior so it is not broken by the BB-1 fix.
+#   This test locks the degrade behavior so it is not broken by the PR-scoped-tag fix.
 # GREEN: exit 0, warn logged, no artifact (no resolved set → can't write).
 # ---------------------------------------------------------------------------
-@test "BB-2-local-degrade: final-pass resolver failure + LOCAL_ONLY=true → exit 0 (degrade)" {
+@test "final-pass resolver failure + LOCAL_ONLY=true → exit 0 (degrade)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3061,7 +3061,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# FF-1: stale per-version DURATION lineage files are removed on an all-cached
+# stale per-version DURATION lineage files are removed on an all-cached
 # run (no build occurs). The versionset artifact must survive.
 #
 # Scenario: a previous run built timescaledb 2.20.0 and wrote:
@@ -3073,7 +3073,7 @@ EOF
 # GREEN after fix: stale per-version duration file is cleaned on the all-cached
 #   path while the versionset artifact is preserved.
 # ---------------------------------------------------------------------------
-@test "FF-1-allcached-stale-duration-cleaned: stale per-version duration file removed on all-cached run" {
+@test "stale per-version duration file removed on all-cached run" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3164,11 +3164,11 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# FF-2: stale per-version DURATION lineage files are removed on all success paths.
+# stale per-version DURATION lineage files are removed on all success paths.
 # Verify the same cleanup runs on the build path (build_tag_push_extensions IS called).
 # After cleanup, fresh per-version files are written for actually-built versions.
 # ---------------------------------------------------------------------------
-@test "FF-2-build-path-stale-cleaned: stale per-version duration removed even when build runs" {
+@test "stale per-version duration removed even when build runs" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -3204,10 +3204,10 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# FF-3: the FF cleanup must NEVER delete the versionset artifact even if it
+# the FF cleanup must NEVER delete the versionset artifact even if it
 # exists before an all-cached run.
 # ---------------------------------------------------------------------------
-@test "FF-3-versionset-survives: versionset artifact is never deleted by FF cleanup" {
+@test "versionset artifact is never deleted by FF cleanup" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3287,9 +3287,9 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB-3: final-pass resolver failure + PULL_ONLY=true → degrade, exit 0.
+# final-pass resolver failure + PULL_ONLY=true → degrade, exit 0.
 # ---------------------------------------------------------------------------
-@test "BB-3-pullonly-degrade: final-pass resolver failure + PULL_ONLY=true → exit 0 (degrade)" {
+@test "final-pass resolver failure + PULL_ONLY=true → exit 0 (degrade)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3379,7 +3379,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# HH-1: per-version duration files SURVIVE the _emit_final_versionset_pass.
+# per-version duration files SURVIVE the _emit_final_versionset_pass.
 #
 # Before HH fix: _emit_final_versionset_pass deleted per-version duration files
 #   AFTER build_tag_push_extensions had already written them → sum = 0 even after
@@ -3391,7 +3391,7 @@ EOF
 # Assertion: after a full main() run where builds occurred, at least one
 # per-version duration file exists AND sum_flavor_extension_durations > 0.
 # ---------------------------------------------------------------------------
-@test "HH-1-duration-survives-final-pass: build-path per-version duration files exist after final pass" {
+@test "build-path per-version duration files exist after final pass" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3491,13 +3491,13 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# HH-2: all-cached run cleans stale duration file → sum = 0.
+# all-cached run cleans stale duration file → sum = 0.
 #
 # Confirms the all-cached pre-clean runs before sum_flavor_extension_durations
 # would be called: stale from previous run is gone, nothing built this run,
 # sum = 0.  The versionset artifact is also (re)written.
 # ---------------------------------------------------------------------------
-@test "HH-2-allcached-stale-sum-zero: stale duration cleaned on all-cached run, sum = 0" {
+@test "stale duration cleaned on all-cached run, sum = 0" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3585,7 +3585,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# LL-1: empty-available artifact must NOT be written.
+# empty-available artifact must NOT be written.
 #
 # Tests _emit_versionset_artifact directly: when all versions are absent from
 # the registry (available would be []), the writer must skip writing the
@@ -3596,7 +3596,7 @@ EOF
 # RED before fix: artifact written with available=[].
 # GREEN after fix: writer skips write when available is empty.
 # ---------------------------------------------------------------------------
-@test "LL-1: all-absent ext writes NO versionset artifact (available would be empty)" {
+@test "all-absent ext writes NO versionset artifact (available would be empty)" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     rm -rf "$lineage_dir"
 
@@ -3638,7 +3638,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# LL-2: ceiling-absent from available → artifact NOT written.
+# ceiling-absent from available → artifact NOT written.
 #
 # Some older versions are present in the registry but the ceiling (2.27.1) is
 # NOT in available (registry absent, not in built-this-run). Writing such an
@@ -3648,7 +3648,7 @@ EOF
 # RED before fix: artifact written with ceiling absent from available.
 # GREEN after fix: artifact skipped when ceiling not in available.
 # ---------------------------------------------------------------------------
-@test "LL-2: ceiling-absent from available → NO versionset artifact written" {
+@test "ceiling-absent from available → NO versionset artifact written" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     rm -rf "$lineage_dir"
 
@@ -3693,11 +3693,11 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# LL-3: useful artifact (available non-empty AND contains ceiling) IS written.
+# useful artifact (available non-empty AND contains ceiling) IS written.
 # Regression guard: the LL fix must not prevent writing when the ceiling IS
 # present in available.
 # ---------------------------------------------------------------------------
-@test "LL-3: useful artifact (available non-empty, ceiling present) IS written (regression guard)" {
+@test "useful artifact (available non-empty, ceiling present) IS written (regression guard)" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     rm -rf "$lineage_dir"
 
@@ -3731,7 +3731,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# KK-1: scoped cleanup isolation — a scoped (--extension pgvector) all-cached
+# scoped cleanup isolation — a scoped (--extension pgvector) all-cached
 # run must NOT delete duration files from OTHER extensions (timescaledb).
 #
 # Scenario: a previous scoped run built timescaledb and wrote
@@ -3745,7 +3745,7 @@ EOF
 # GREEN after fix: pre-clean scoped to EXTENSION=pgvector → timescaledb file
 #   survives.
 # ---------------------------------------------------------------------------
-@test "KK-1: scoped all-cached run only cleans own extension's duration files, not others'" {
+@test "scoped all-cached run only cleans own extension's duration files, not others'" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -3863,13 +3863,13 @@ EOF
 # log_success+return-0 swallowed real docker build failures.
 # ---------------------------------------------------------------------------
 
-# DEFECT-A-1: REAL build_ext_image with docker build returning non-zero must
+# REAL build_ext_image with docker build returning non-zero must
 # return non-zero (was: returned 0 + logged success).
 #
 # Before fix: RED — build_ext_image ran "$DOCKER build ..." then unconditionally
 #   called log_success and fell off the function → return 0.
 # After fix: GREEN — "if ! $DOCKER build ...; then return 1; fi" propagates failure.
-@test "DEFECT-A-1: real build_ext_image returns non-zero when docker build fails" {
+@test "real build_ext_image returns non-zero when docker build fails" {
     # Restore the real build_ext_image from build-extensions.sh (setup() installs
     # a mock via _setup_default_mocks; we need the production function here).
     _source_build_extensions
@@ -3907,7 +3907,7 @@ EOF
     [[ "$output" != *"Built:"* ]]
 }
 
-# DEFECT-A-2: integration — REAL build_ext_image + docker build failing for a
+# integration — REAL build_ext_image + docker build failing for a
 # NON-CEILING version → build_tag_push_extensions TOLERATES it (exit 0, version
 # recorded in the failed-set but run continues).
 #
@@ -3916,7 +3916,7 @@ EOF
 #   excluded. The run exited 0 but for the wrong reason (swallowed failure).
 # After fix: GREEN — build_ext_image returns 1, compile_ok=false is set,
 #   non-ceiling tolerance records it as excluded/skipped, run exits 0.
-@test "DEFECT-A-2: real build_ext_image docker-fail on non-ceiling version is tolerated (exit 0)" {
+@test "real build_ext_image docker-fail on non-ceiling version is tolerated (exit 0)" {
     # Restore the real build_ext_image (setup installs a mock; we need production here).
     _source_build_extensions
     export REMOTE_CR="docker.io"
@@ -4027,13 +4027,13 @@ EOF
     fi
 }
 
-# DEFECT-A-3: integration — REAL build_ext_image + docker build failing for the
+# integration — REAL build_ext_image + docker build failing for the
 # CEILING version → build_tag_push_extensions is FATAL (exit non-zero).
 #
 # Before fix: RED — docker build failure swallowed → compile_ok stayed true →
 #   ceiling tag+push proceeded → run exited 0 (silently shipping a broken image).
 # After fix: GREEN — failure propagated → ceiling marked failed → exit 1.
-@test "DEFECT-A-3: real build_ext_image docker-fail on ceiling version is fatal (exit non-zero)" {
+@test "real build_ext_image docker-fail on ceiling version is fatal (exit non-zero)" {
     # Restore the real build_ext_image (setup installs a mock; we need production here).
     _source_build_extensions
     export REMOTE_CR="docker.io"
@@ -4107,7 +4107,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# DEFECT-A-4: pull_ext_image must propagate docker pull exit code.
+# pull_ext_image must propagate docker pull exit code.
 # Exercises the REAL pull_ext_image (NOT mocked) — only $DOCKER/docker is mocked
 # so docker pull returns non-zero.
 #
@@ -4116,7 +4116,7 @@ EOF
 # After fix: GREEN — "if ! $DOCKER pull ...; then return 1; fi" propagates failure.
 # ---------------------------------------------------------------------------
 
-@test "DEFECT-A-4: real pull_ext_image returns non-zero when docker pull fails" {
+@test "real pull_ext_image returns non-zero when docker pull fails" {
     # Restore real pull_ext_image from helpers/extension-utils.sh.
     # setup() only sources build-extensions.sh (which sources extension-utils.sh),
     # so pull_ext_image is already the real one — but _setup_default_mocks defines
@@ -4150,7 +4150,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# MM-1: scoped --extension pgvector run with TimescaleDB resolver FAILING →
+# scoped --extension pgvector run with TimescaleDB resolver FAILING →
 # the run SUCCEEDS (exit 0).
 #
 # Before fix (DEFECT MM): _emit_final_versionset_pass iterates ALL extensions
@@ -4163,7 +4163,7 @@ EOF
 #   is never resolved, never emitted, never aborts the run.
 # ---------------------------------------------------------------------------
 
-@test "MM-1: scoped pgvector run with failing timescaledb resolver exits 0 (timescaledb never resolved)" {
+@test "scoped pgvector run with failing timescaledb resolver exits 0 (timescaledb never resolved)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -4279,7 +4279,7 @@ EOF
 # Confirms BB fail-closed is preserved for full runs.
 # ---------------------------------------------------------------------------
 
-@test "MM-2: full run with failing timescaledb resolver on publish path exits non-zero (fail-closed preserved)" {
+@test "full run with failing timescaledb resolver on publish path exits non-zero (fail-closed preserved)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -4359,7 +4359,7 @@ EOF
 # fails closed (exit non-zero). Scoping to the resolver-backed ext keeps it fatal.
 # ---------------------------------------------------------------------------
 
-@test "MM-3: scoped --extension timescaledb with its resolver failing exits non-zero (scoped fatal preserved)" {
+@test "scoped --extension timescaledb with its resolver failing exits non-zero (scoped fatal preserved)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -4434,7 +4434,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# NN-1: transient probe ERROR on a non-ceiling resolved version → fail closed.
+# transient probe ERROR on a non-ceiling resolved version → fail closed.
 #
 # Scenario: resolver returns ["2.25.0","2.26.0","2.27.1"] (all 3 retained).
 # Ceiling 2.27.1 probes as PRESENT.
@@ -4452,7 +4452,7 @@ EOF
 # The test drives _emit_versionset_artifact via the final pass (main()).
 # _image_present_3state is mocked to return rc=2 for 2.25.0 (transient error signal).
 # ---------------------------------------------------------------------------
-@test "NN-1: transient probe error on non-ceiling version fails closed (no partial artifact)" {
+@test "transient probe error on non-ceiling version fails closed (no partial artifact)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -4551,7 +4551,7 @@ EOF
 # Expected: artifact IS written with available=["2.26.0","2.27.1"], exit 0.
 # Ensures we didn't over-correct (definitively absent is still excluded, not an error).
 # ---------------------------------------------------------------------------
-@test "NN-2: definitively absent non-ceiling version is excluded, run continues (exit 0)" {
+@test "definitively absent non-ceiling version is excluded, run continues (exit 0)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -4702,13 +4702,13 @@ _run_3state_probe() {
     printf '%d' $?
 }
 
-@test "OO-explicit-not-found-manifest-unknown: 'manifest unknown' stderr → ABSENT (rc 1)" {
+@test "state_probe: 'manifest unknown' stderr → ABSENT (rc 1)" {
     local rc
     rc=$(_run_3state_probe "Error response from daemon: manifest unknown: manifest unknown")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-explicit-not-found-404: '404 Not Found' → ERROR (rc 2, fail-closed after UU allow-list tightening)" {
+@test "state_probe: '404 Not Found' → ERROR (rc 2, fail-closed after UU allow-list tightening)" {
     # Before UU fix: bare "404" and "not found" matched → ABSENT (rc 1) — fail-open.
     # After UU fix: "Error: 404 Not Found" is a generic HTTP error from a load-balancer
     # or cred-helper, not a registry-manifest-specific signal → ERROR (rc 2).
@@ -4717,19 +4717,19 @@ _run_3state_probe() {
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-explicit-not-found-name-unknown: 'name unknown' in stderr → ABSENT (rc 1)" {
+@test "state_probe: 'name unknown' in stderr → ABSENT (rc 1)" {
     local rc
     rc=$(_run_3state_probe "Error: name unknown: repository name not known to registry")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-explicit-not-found-no-such-manifest: 'no such manifest' in stderr → ABSENT (rc 1)" {
+@test "state_probe: 'no such manifest' in stderr → ABSENT (rc 1)" {
     local rc
     rc=$(_run_3state_probe "no such manifest: ghcr.io/test/ext-timescaledb:pg18-2.27.1")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-toomanyrequests-is-ERROR-not-ABSENT: 'toomanyrequests' stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: 'toomanyrequests' stderr → ERROR (rc 2, fail-closed)" {
     # RED before fix: fell through to ABSENT (rc 1) → silently dropped published version.
     # GREEN after fix: classified as ERROR (rc 2) → fail-closed.
     local rc
@@ -4737,49 +4737,49 @@ _run_3state_probe() {
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-429-is-ERROR-not-ABSENT: '429' in stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: '429' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_3state_probe "Error: 429 Too Many Requests")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-denied-is-ERROR-not-ABSENT: 'denied' in stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: 'denied' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_3state_probe "denied: access forbidden")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-unauthorized-is-ERROR-not-ABSENT: 'unauthorized' in stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: 'unauthorized' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_3state_probe "unauthorized: authentication required")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-no-such-host-is-ERROR-not-ABSENT: 'no such host' in stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: 'no such host' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_3state_probe "dial tcp: lookup ghcr.io: no such host")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-network-unreachable-is-ERROR-not-ABSENT: 'network is unreachable' stderr → ERROR (rc 2)" {
+@test "state_probe: 'network is unreachable' stderr → ERROR (rc 2)" {
     local rc
     rc=$(_run_3state_probe "dial tcp: connect: network is unreachable")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-EOF-is-ERROR-not-ABSENT: 'EOF' in stderr → ERROR (rc 2, fail-closed)" {
+@test "state_probe: 'EOF' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_3state_probe "unexpected EOF")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-context-deadline-is-ERROR-not-ABSENT: 'context deadline exceeded' → ERROR (rc 2)" {
+@test "state_probe: 'context deadline exceeded' → ERROR (rc 2)" {
     local rc
     rc=$(_run_3state_probe "context deadline exceeded")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-empty-stderr-non-zero-is-ERROR-not-ABSENT: empty stderr + rc≠0 → ERROR (rc 2, fail-closed)" {
+@test "state_probe: empty stderr + rc≠0 → ERROR (rc 2, fail-closed)" {
     # RED before fix: empty stderr → fell through to ABSENT (rc 1).
     # GREEN after fix: empty stderr + non-zero → ERROR (rc 2, fail-closed).
     # Rationale: test mocks with `docker() { return 1; }` (no stderr) represent
@@ -4816,7 +4816,7 @@ _run_3state_probe() {
 # GREEN after fix: stale file removed; in-window files and versionset preserved.
 # ---------------------------------------------------------------------------
 
-@test "QQ-mixed-run-stale-cleanup: timescaledb all-cached + pgvector built → stale timescaledb duration file removed" {
+@test "timescaledb all-cached + pgvector built → stale timescaledb duration file removed" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -4942,12 +4942,12 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# UU-1: _image_present_3state — "docker: command not found" must be ERROR (rc=2),
+# _image_present_3state — "docker: command not found" must be ERROR (rc=2),
 # not ABSENT. Before the allow-list tightening, bare "not found" matched, causing
 # infra errors to be mis-classified as definitive absence.
 # ---------------------------------------------------------------------------
 
-@test "UU-image-present-3state-cmd-not-found: 'docker: command not found' stderr → ERROR (rc=2)" {
+@test "'docker: command not found' stderr → ERROR (rc=2)" {
     # Use the same _run_3state_probe helper — it already handles the subshell/set-e
     # correctly and is already updated to use the tightened skopeo pattern.
     # "docker: command not found" contains "not found" which was in the OLD allow-list
@@ -4958,7 +4958,7 @@ EOF
     [ "$rc" -eq 2 ]
 }
 
-@test "UU-image-present-3state-cred-helper-not-found: cred-helper error → ERROR (rc=2)" {
+@test "cred-helper error → ERROR (rc=2)" {
     # "docker-credential-desktop: executable file not found in PATH" contains "not found"
     # which was in the OLD allow-list (ABSENT before UU fix) → now ERROR (rc=2).
     local rc
@@ -4966,7 +4966,7 @@ EOF
     [ "$rc" -eq 2 ]
 }
 
-@test "UU-image-present-3state-manifest-unknown: 'manifest unknown' stderr → ABSENT (rc=1)" {
+@test "'manifest unknown' stderr → ABSENT (rc=1)" {
     # After the UU tightening, "manifest unknown" is still in the allow-list
     # (it is a genuine registry-manifest-specific not-found signal) → ABSENT (rc=1).
     local rc
@@ -5027,7 +5027,7 @@ _run_emit_versionset() {
     " 2>/dev/null
 }
 
-@test "WW-empty-available-deletes-stale: empty available[] on skip path removes stale versionset artifact" {
+@test "empty available[] on skip path removes stale versionset artifact" {
     # Arrange: stale artifact with available=[2.25.0,2.26.0,2.27.1] from prior run.
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -5066,7 +5066,7 @@ _run_emit_versionset() {
     [ ! -f "$stale" ]
 }
 
-@test "WW-ceiling-missing-deletes-stale: ceiling absent from available[] removes stale versionset artifact" {
+@test "ceiling absent from available[] removes stale versionset artifact" {
     # Arrange: stale artifact pre-exists.
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -5103,7 +5103,7 @@ _run_emit_versionset() {
     [ ! -f "$stale" ]
 }
 
-@test "WW-probe-error-deletes-stale: ambiguous probe ERROR (fail-closed) removes stale versionset artifact" {
+@test "ambiguous probe ERROR (fail-closed) removes stale versionset artifact" {
     # Arrange: stale artifact pre-exists.
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -5140,7 +5140,7 @@ _run_emit_versionset() {
     [ ! -f "$stale" ]
 }
 
-@test "WW-dry-run-preserves: DRY_RUN=true skip path must NOT delete the stale versionset artifact" {
+@test "DRY_RUN=true skip path must NOT delete the stale versionset artifact" {
     # Arrange: stale artifact pre-exists.
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -5168,7 +5168,7 @@ _run_emit_versionset() {
     [ -f "$stale" ]
 }
 
-@test "WW-happy-overwrites: confirmed set writes artifact with current available[]" {
+@test "confirmed set writes artifact with current available[]" {
     # Regression: happy path (all probes PRESENT, ceiling in available) must write
     # the artifact with the CURRENT available list, overwriting any stale content.
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
@@ -5209,7 +5209,7 @@ _run_emit_versionset() {
 }
 
 # ---------------------------------------------------------------------------
-# YY-1: malformed resolver output (injection-y entries) → fail-closed BEFORE
+# malformed resolver output (injection-y entries) → fail-closed BEFORE
 #        any build/tag/push. The malformed version must NEVER reach docker.
 #
 # Before fix: _resolve_cached only checks "non-empty JSON array of strings" —
@@ -5218,7 +5218,7 @@ _run_emit_versionset() {
 #   before the build loop; any non-semver entry → fail-closed (no build).
 # ---------------------------------------------------------------------------
 
-@test "YY-1-malformed-injection: resolver returns injection-y version → fail-closed, never reaches build" {
+@test "resolver returns injection-y version → fail-closed, never reaches build" {
     export LOCAL_ONLY=false
 
     # Resolver returns a set with an injection-y entry (valid-looking + shell metachar).
@@ -5267,7 +5267,7 @@ _run_emit_versionset() {
     fi
 }
 
-@test "YY-2-path-traversal: resolver returns ../evil version → fail-closed, never reaches tag" {
+@test "resolver returns ../evil version → fail-closed, never reaches tag" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -5313,7 +5313,7 @@ _run_emit_versionset() {
     fi
 }
 
-@test "YY-3-valid-set-still-builds: fully valid version set still triggers all builds (regression)" {
+@test "fully valid version set still triggers all builds (regression)" {
     export LOCAL_ONLY=false
 
     # All valid semver entries — must build all 3.
@@ -5352,11 +5352,11 @@ _run_emit_versionset() {
 }
 
 # ---------------------------------------------------------------------------
-# YY-4: shared is_strict_semver validator — unit tests for the shared function
+# shared is_strict_semver validator — unit tests for the shared function
 #        extracted to helpers/extension-utils.sh.
 # ---------------------------------------------------------------------------
 
-@test "YY-4-is-strict-semver-valid: is_strict_semver accepts standard X.Y.Z versions" {
+@test "is_strict_semver accepts standard X.Y.Z versions" {
     # is_strict_semver must return 0 (true) for canonical semver strings.
     _source_build_extensions
 
@@ -5370,7 +5370,7 @@ _run_emit_versionset() {
     done
 }
 
-@test "YY-4-is-strict-semver-invalid: is_strict_semver rejects non-semver and injection strings" {
+@test "is_strict_semver rejects non-semver and injection strings" {
     for ver in "latest" "2.27" "2.27.1-beta" "2.27.1+build" "2.27.0; rm -rf /" "../evil" "" "v2.27.1" "2.27.1.0"; do
         run bash -c "
             source \"$HELPERS_DIR/extension-utils.sh\"
@@ -5393,7 +5393,7 @@ _run_emit_versionset() {
 #   through to build/tag/push normally (GREEN).
 # ---------------------------------------------------------------------------
 
-@test "AB-single-version-nonsemver-builds: non-resolver ext pinned to 1.14 builds successfully" {
+@test "non-resolver ext pinned to 1.14 builds successfully" {
     export LOCAL_ONLY=false
 
     # Config with NO version_set.resolver — single-version, trusted input.
@@ -5474,7 +5474,7 @@ EOCFG
 # so the gate MUST still apply and reject the malformed entry.
 # ---------------------------------------------------------------------------
 
-@test "AB-resolver-backed-still-gated: resolver-backed ext with malformed output still fails closed" {
+@test "resolver-backed ext with malformed output still fails closed" {
     export LOCAL_ONLY=false
 
     # Config has version_set.resolver — this ext IS resolver-backed.
@@ -5527,7 +5527,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AD-1: LOCAL_ONLY=true, resolver unavailable in final pass, ceiling built →
+# LOCAL_ONLY=true, resolver unavailable in final pass, ceiling built →
 # NO reduced version-set artifact is written. Any pre-existing stale artifact
 # for that (ext, major) is DELETED so it cannot be silently consumed.
 #
@@ -5537,7 +5537,7 @@ EOCFG
 # GREEN after fix (AD): artifact is NOT written; stale artifact is removed;
 #   downstream build must use skopeo or a CI-produced artifact.
 # ---------------------------------------------------------------------------
-@test "AD-1: LOCAL_ONLY=true + resolver unavailable in final pass → no artifact, stale deleted" {
+@test "LOCAL_ONLY=true + resolver unavailable in final pass → no artifact, stale deleted" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -5622,11 +5622,11 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AD-2: PULL_ONLY=true, resolver unavailable in final pass → no artifact written.
+# PULL_ONLY=true, resolver unavailable in final pass → no artifact written.
 # Consistent with AD-1: both LOCAL_ONLY and PULL_ONLY recovery paths must be
 # fail-closed on artifact emission.
 # ---------------------------------------------------------------------------
-@test "AD-2: PULL_ONLY=true + resolver unavailable in final pass → no artifact written" {
+@test "PULL_ONLY=true + resolver unavailable in final pass → no artifact written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -5698,12 +5698,12 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AC-2: publish path (LOCAL_ONLY=false, PULL_ONLY=false) + resolver unavailable
+# publish path (LOCAL_ONLY=false, PULL_ONLY=false) + resolver unavailable
 # in final pass → run exits non-zero, and no new ceiling-only artifact is written.
 # Regression guard: our fix must NOT create an artifact on the publish path.
 # Must stay GREEN before AND after the fix (fail-closed behavior intact).
 # ---------------------------------------------------------------------------
-@test "AC-2: publish path + resolver unavailable in final pass → exit non-zero (fail-closed), no new artifact" {
+@test "publish path + resolver unavailable in final pass → exit non-zero (fail-closed), no new artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -5774,10 +5774,10 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AC-3: LOCAL_ONLY=true + DRY_RUN=true + resolver unavailable in final pass →
+# LOCAL_ONLY=true + DRY_RUN=true + resolver unavailable in final pass →
 # no filesystem mutation (no artifact written).
 # ---------------------------------------------------------------------------
-@test "AC-3: LOCAL_ONLY=true + DRY_RUN=true + resolver unavailable → no artifact written" {
+@test "LOCAL_ONLY=true + DRY_RUN=true + resolver unavailable → no artifact written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -5847,7 +5847,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AE-1: embedded-newline bypass — resolver returns a single JSON element that
+# embedded-newline bypass — resolver returns a single JSON element that
 # contains an embedded newline ("2.27.1\n9.9.9"). The old line-based semver
 # gate splits this into two lines and passes both; the fix validates at the
 # JSON-array-element level so the element fails the anchored regex and the
@@ -5861,7 +5861,7 @@ EOCFG
 # Non-vacuous: assert NEITHER 2.27.1 NOR 9.9.9 appears in build/tag logs.
 # ---------------------------------------------------------------------------
 
-@test "AE-1-embedded-newline-bypass: resolver returns element with embedded newline → fail-closed, neither version built" {
+@test "resolver returns element with embedded newline → fail-closed, neither version built" {
     export LOCAL_ONLY=false
 
     # One JSON element containing an embedded newline — a single string that
@@ -5914,7 +5914,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AE-2: above-ceiling rejection — resolver returns a set containing 9.9.9
+# above-ceiling rejection — resolver returns a set containing 9.9.9
 # which exceeds the configured ceiling 2.27.1. The ceiling clamp at the
 # array-validation boundary must reject the whole set → fail-closed.
 #
@@ -5924,7 +5924,7 @@ EOCFG
 # Non-vacuous: assert 9.9.9 never appears in build/tag logs.
 # ---------------------------------------------------------------------------
 
-@test "AE-2-above-ceiling-rejected: resolver returns version above ceiling → set rejected, nothing built" {
+@test "resolver returns version above ceiling → set rejected, nothing built" {
     export LOCAL_ONLY=false
 
     # 2.27.1 is the ceiling; 9.9.9 exceeds it.
@@ -5974,12 +5974,12 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AE-3: clean set still builds — a fully valid set ["2.25.0","2.26.0","2.27.1"]
+# clean set still builds — a fully valid set ["2.25.0","2.26.0","2.27.1"]
 # where all versions are <= ceiling (2.27.1) must pass array-level validation
 # and trigger all three builds (regression guard for AE-1/AE-2 fix).
 # ---------------------------------------------------------------------------
 
-@test "AE-3-clean-set-still-builds: valid set all-at-or-below ceiling → all 3 versions built normally" {
+@test "valid set all-at-or-below ceiling → all 3 versions built normally" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -6019,7 +6019,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AG-1: _should_build_extension — resolver returns element with embedded newline
+# _should_build_extension — resolver returns element with embedded newline
 # ("2.27.1\n9.9.9") -> the all-cached path must reject it fail-closed.
 # Without the chokepoint fix, jq -r '.[]' splits the element into two lines
 # (2.27.1 and 9.9.9); each passes the per-line semver check, and 9.9.9 is
@@ -6030,7 +6030,7 @@ EOCFG
 # GREEN after fix: exits non-zero (fail-closed at _resolve_cached chokepoint).
 # ---------------------------------------------------------------------------
 
-@test "AG-1-should-build-embedded-newline: resolver returns element with embedded newline -> fail-closed in pre-filter" {
+@test "resolver returns element with embedded newline -> fail-closed in pre-filter" {
     export LOCAL_ONLY=false
 
     resolve_version_set() {
@@ -6064,7 +6064,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AG-2: embedded-newline resolver output must never reach the versionset artifact.
+# embedded-newline resolver output must never reach the versionset artifact.
 # Full main() subprocess: poisoned resolver -> exit non-zero, artifact absent or
 # does not contain 9.9.9.
 #
@@ -6072,7 +6072,7 @@ EOCFG
 # GREEN after fix: rejected at chokepoint -> exit non-zero, no 9.9.9 in artifact.
 # ---------------------------------------------------------------------------
 
-@test "AG-2-poisoned-all-cached-never-in-artifact: embedded-newline resolver output never written to versionset artifact" {
+@test "embedded-newline resolver output never written to versionset artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -6143,7 +6143,7 @@ EOCFG
 # Ensures the chokepoint does not break the normal happy path.
 # ---------------------------------------------------------------------------
 
-@test "AH-clean-all-cached-still-skips: valid set all-present -> _should_build_extension returns 1 (skip)" {
+@test "valid set all-present -> _should_build_extension returns 1 (skip)" {
     export LOCAL_ONLY=false
 
     resolve_version_set() { echo '["2.27.1"]'; }
@@ -6172,12 +6172,12 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-5: empty available set → NO bundle is built.
+# empty available set → NO bundle is built.
 # If all per-version builds fail (e.g. ceiling fatal), available is empty
 # and build_tag_push_extensions should exit non-zero without building a bundle.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-5: no available versions → bundle NOT built" {
+@test "no available versions → bundle NOT built" {
     local docker_log="$TEST_TEMP_DIR/bundle5_docker.log"
 
     resolve_version_set() { echo '["2.27.1"]'; }
@@ -6229,7 +6229,7 @@ EOCFG
 #   and the probe disagree.
 # GREEN after fix: both derive from the same confirmed_available set.
 # ---------------------------------------------------------------------------
-@test "AK-force-partial-consistency: --force, non-ceiling build fails → failed version in neither bundle nor artifact" {
+@test "--force, non-ceiling build fails → failed version in neither bundle nor artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -6388,7 +6388,7 @@ EOCFG
 # GREEN after fix: the loop calls _image_present_3state; ERROR → skip bundle
 #   assembly and exit non-zero.
 # ---------------------------------------------------------------------------
-@test "AK-transient-allcached-failclosed: all-cached path with ERROR probe → bundle NOT assembled, exits non-zero" {
+@test "all-cached path with ERROR probe → bundle NOT assembled, exits non-zero" {
     # This test verifies the AK-2 fix: the all-cached bundle refresh must use
     # _image_present_3state (3-state) instead of _image_present (2-state) so that
     # a transient ERROR on one version prevents bundle assembly (fail-closed).
@@ -6509,7 +6509,7 @@ EOCFG
 # GREEN after fix: a fatal failure (ceiling in failed[], or any tag/push error)
 #   prevents bundle assembly and artifact emission; run exits non-zero.
 # ---------------------------------------------------------------------------
-@test "AK-fatal-no-bundle: ceiling build fails → exit non-zero, bundle NOT assembled, NO artifact written" {
+@test "ceiling build fails → exit non-zero, bundle NOT assembled, NO artifact written" {
     # Direct function-call test (not subprocess). Mocks assemble_and_push_bundle
     # to record whether it was called — this is the critical observable: the
     # bundle assembler must NOT be invoked when the ceiling failed.
@@ -6571,7 +6571,7 @@ EOCFG
 # computation: if ANY resolved version returns ERROR from the 3-state probe,
 # the confirmed set is unsafe to use — fail closed on the publish path.
 # ---------------------------------------------------------------------------
-@test "INV-transient-failclosed: 3-state ERROR on one resolved version → no bundle, no artifact, fatal" {
+@test "3-state ERROR on one resolved version → no bundle, no artifact, fatal" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -6669,7 +6669,7 @@ EOCFG
 # This is the existing _bundle_and_write_artifact behaviour (set_size<=1 early
 # return) confirmed as a test so any future code change that breaks it is caught.
 # ---------------------------------------------------------------------------
-@test "AL-single-version-no-bundle: resolver-backed ext set_size==1 → no bundle docker build, no artifact" {
+@test "resolver-backed ext set_size==1 → no bundle docker build, no artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -6759,7 +6759,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AO-1: resolved set > 1 but only the ceiling is confirmed available (other
+# resolved set > 1 but only the ceiling is confirmed available (other
 # versions absent) → producer must NOT assemble/push a bundle and must NOT
 # write a versionset artifact.  The consumer would ignore a 1-version bundle
 # (available_count <= 1 falls through to single-version path), so pushing one
@@ -6779,7 +6779,7 @@ EOCFG
 # GREEN after fix: confirmed_available size == 1 → skip bundle, skip artifact,
 #   delete stale, return 0.
 # ---------------------------------------------------------------------------
-@test "AO1-confirmed-one-no-bundle: resolved>1 but only ceiling confirmed → no bundle, no artifact, exit 0" {
+@test "resolved>1 but only ceiling confirmed → no bundle, no artifact, exit 0" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local artifact="$tmpd/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -6879,7 +6879,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AQ-1: CI PR smoke — all-cached, do_push=false (not LOCAL_ONLY/PULL_ONLY).
+# CI PR smoke — all-cached, do_push=false (not LOCAL_ONLY/PULL_ONLY).
 #
 # Defect: _emit_final_versionset_pass computes _do_push_fp solely from
 # LOCAL_ONLY/PULL_ONLY, defaulting to "true" when neither is set. On a CI PR
@@ -6895,7 +6895,7 @@ EOCFG
 #   LOCAL_ONLY=true (do_push=false): assemble locally, NO push (recovery).
 #   NO_PUSH=true (do_push=false):    skip bundle + skip artifact (CI PR smoke).
 # ---------------------------------------------------------------------------
-@test "AQ1-pr-nopush-allcached-clean: all-cached + NO_PUSH=true (CI PR) → NO bundle push, NO artifact, exit 0" {
+@test "all-cached + NO_PUSH=true (CI PR) → NO bundle push, NO artifact, exit 0" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -6979,7 +6979,7 @@ EOCFG
 # AX4 defensive: NO_PUSH=true still suppresses push (script honors it even
 # though the workflow no longer sets it on same-repo PRs; guards local/manual use).
 # ---------------------------------------------------------------------------
-@test "AX4-nopush-true-still-suppresses: NO_PUSH=true explicit → do_push=false → no push (defensive)" {
+@test "NO_PUSH=true explicit → do_push=false → no push (defensive)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7054,7 +7054,7 @@ EOCFG
     [ ! -f "$artifact" ]
 }
 
-@test "AQ1-localonly-allcached-nopush: all-cached + LOCAL_ONLY=true → NO push (regression guard)" {
+@test "all-cached + LOCAL_ONLY=true → NO push (regression guard)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7120,7 +7120,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AR-1: no-push CI build path must NOT write an artifact for an unpushed bundle.
+# no-push CI build path must NOT write an artifact for an unpushed bundle.
 #
 # Scenario: versions were BUILT in this run (not all-cached), do_push=false via
 # NO_PUSH=true (fork PR), NOT LOCAL_ONLY, NOT PULL_ONLY.
@@ -7130,7 +7130,7 @@ EOCFG
 # After fix: guard inside _bundle_and_write_artifact fires → no bundle push,
 #   no artifact written, any stale artifact deleted, exit 0.
 # ---------------------------------------------------------------------------
-@test "AR1-nopush-build-no-artifact: BUILD path, NO_PUSH=true, not LOCAL_ONLY — no artifact written" {
+@test "BUILD path, NO_PUSH=true, not LOCAL_ONLY — no artifact written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7207,7 +7207,7 @@ EOCFG
     # Must succeed (no-push is not a fatal condition).
     [ "$status" -eq 0 ]
 
-    # AR-1: artifact must NOT be written (and stale must be deleted).
+    # artifact must NOT be written (and stale must be deleted).
     [ ! -f "${tmpd}/.build-lineage/ext-timescaledb-pg18-versionset.json" ]
 }
 
@@ -7215,7 +7215,7 @@ EOCFG
 # AR-1 regression: LOCAL_ONLY=true (do_push=false) still writes an artifact
 # without a digest — existing behavior must be preserved.
 # ---------------------------------------------------------------------------
-@test "AR1-localonly-still-writes: LOCAL_ONLY=true, do_push=false — artifact written without digest" {
+@test "LOCAL_ONLY=true, do_push=false — artifact written without digest" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7287,7 +7287,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AR-2: resolver output containing GHA workflow-command injection bytes must
+# resolver output containing GHA workflow-command injection bytes must
 # be neutralized in the logged diagnostic when validation fails.
 #
 # The resolver returns output with an embedded newline followed by
@@ -7295,7 +7295,7 @@ EOCFG
 # at the validation failure site must NOT emit a raw newline-prefixed
 # ::stop-commands:: sequence in its output (stdout/stderr).
 # ---------------------------------------------------------------------------
-@test "AR2-resolver-output-sanitized: malicious resolver output is defanged in log diagnostic" {
+@test "malicious resolver output is defanged in log diagnostic" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local ar2_stderr="/tmp/ar2_resolver_stderr_$$.txt"
@@ -7348,17 +7348,17 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AS-2: the failure-log site in assemble_and_push_bundle that logs the
+# the failure-log site in assemble_and_push_bundle that logs the
 # captured digest must sanitize the value before logging.
 #
-# AS2-digest-failure-log-sanitized: when the captured digest is a malformed
+# when the captured digest is a malformed
 # multi-line string "sha256:abc\n::add-mask::x", the logged failure message
 # must NOT contain a raw newline followed by ::add-mask:: (the GHA injection
 # form). The function must still fail closed (non-zero exit, no artifact).
 # RED before fix: log_error logs the raw _captured_digest without sanitization.
 # GREEN after fix: log_error wraps _captured_digest in _sanitize_for_log.
 # ---------------------------------------------------------------------------
-@test "AS2-digest-failure-log-sanitized: malformed digest with injection bytes — fail closed, log defanged" {
+@test "malformed digest with injection bytes — fail closed, log defanged" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local as2_stderr="/tmp/as2_digest_stderr_$$.txt"
@@ -7447,7 +7447,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AT-1: _sanitize_for_log must neutralize backslash sequences so that
+# _sanitize_for_log must neutralize backslash sequences so that
 # echo -e cannot expand them after sanitisation.
 #
 # The existing sanitiser neutralises actual CR/LF bytes and literal "::" but
@@ -7462,7 +7462,7 @@ EOCFG
 # sequence "\n" (not a newline) and "\x3a" as the literal four-char
 # sequence "\x3a" (not ":").
 #
-# AT1-sanitizer-backslash-escape: end-to-end proof that echo -e cannot
+# end-to-end proof that echo -e cannot
 #   expand an injected backslash escape after sanitisation.
 #   Input: a value with literal \n and \x3a\x3a sequences.
 #   Test drives the sanitised value through the real log_error logger
@@ -7472,11 +7472,11 @@ EOCFG
 #   RED before fix: echo -e expands \n and \x3a, reconstructing "::add-mask::".
 #   GREEN after fix: backslashes escaped first; echo -e sees \\n -> "\n".
 #
-# AT1-sanitizer-actual-controls: the existing CR/LF/:: neutralisation
+# the existing CR/LF/:: neutralisation
 #   still works after the backslash-first fix (regression guard).
 # ---------------------------------------------------------------------------
 
-@test "AT1-sanitizer-backslash-escape: echo -e cannot expand injected backslash sequences after sanitisation" {
+@test "echo -e cannot expand injected backslash sequences after sanitisation" {
     # Poison value: literal backslash-n and backslash-x3a (two-char sequences,
     # NOT actual control bytes).  When passed to echo -e without sanitisation,
     # \n expands to newline and \x3a to ':', producing:
@@ -7524,7 +7524,7 @@ EOCFG
     fi
 }
 
-@test "AT1-sanitizer-actual-controls: existing CR/LF/percent/double-colon neutralisation still works" {
+@test "existing CR/LF/percent/double-colon neutralisation still works" {
     # Regression guard: the backslash-first fix must not break the existing
     # neutralisation of actual control bytes and literal '::'.
     local actual_cr_lf
@@ -7590,7 +7590,7 @@ EOCFG
 # DRY_RUN path is a separate test (AU-dry-run-single-preserves).
 # ---------------------------------------------------------------------------
 
-@test "AU-multi-to-single-deletes-stale: set_size==1 early return deletes pre-existing stale versionset artifact" {
+@test "set_size==1 early return deletes pre-existing stale versionset artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7677,7 +7677,7 @@ EOCFG
 # GREEN: stale artifact survives intact under DRY_RUN=true.
 # ---------------------------------------------------------------------------
 
-@test "AU-dry-run-single-preserves: DRY_RUN=true + set_size==1 + stale artifact is NOT deleted" {
+@test "DRY_RUN=true + set_size==1 + stale artifact is NOT deleted" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7757,7 +7757,7 @@ EOCFG
 # per-arch bundle build in stage A), and NO versionset artifact is written.
 # ---------------------------------------------------------------------------
 
-@test "A-arch-suffixed-build: ARCH_SUFFIX=amd64 uses buildx --platform and defers bundle to stage B, no artifact" {
+@test "ARCH_SUFFIX=amd64 uses buildx --platform and defers bundle to stage B, no artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7849,11 +7849,11 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# A-arm64-suffix: ARCH_SUFFIX=arm64, BUILD_PLATFORM=linux/arm64 => per-version
+# ARCH_SUFFIX=arm64, BUILD_PLATFORM=linux/arm64 => per-version
 # builds use --platform linux/arm64, bundle is DEFERRED to stage B.
 # ---------------------------------------------------------------------------
 
-@test "A-arm64-suffix: ARCH_SUFFIX=arm64 defers bundle to stage B and uses buildx --platform for per-version builds" {
+@test "ARCH_SUFFIX=arm64 defers bundle to stage B and uses buildx --platform for per-version builds" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -7947,7 +7947,7 @@ EOCFG
 # written (existing behavior regression guard).
 # ---------------------------------------------------------------------------
 
-@test "A-local-unchanged: ARCH_SUFFIX empty (local build) keeps un-suffixed bundle tag and writes artifact" {
+@test "ARCH_SUFFIX empty (local build) keeps un-suffixed bundle tag and writes artifact" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8048,7 +8048,7 @@ EOCFG
 # After fix: final pass skips (ext, major) already bundled on the build path.
 # ---------------------------------------------------------------------------
 
-@test "A-no-double-bundle: build+push of an ext assembles bundle EXACTLY ONCE (AV-2 fix)" {
+@test "build+push of an ext assembles bundle EXACTLY ONCE (AV-2 fix)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8171,7 +8171,7 @@ EOCFG
 # and writes the versionset artifact with version_digests. NO bundle build.
 # ---------------------------------------------------------------------------
 
-@test "B-merge-creates-multiarch: finalize-multiarch calls imagetools create for each version, captures index digests, no bundle build" {
+@test "finalize-multiarch calls imagetools create for each version, captures index digests, no bundle build" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -8291,7 +8291,7 @@ EOCFG
 # version_digests = {"<ver>":"sha256:<64hex>", ...}. Assert artifact content.
 # ---------------------------------------------------------------------------
 
-@test "B-merge-captures-index-digest-and-writes-artifact: artifact written with version_digests map" {
+@test "artifact written with version_digests map" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8390,7 +8390,7 @@ EOCFG
 # exits non-zero, NO artifact written.
 # ---------------------------------------------------------------------------
 
-@test "B-merge-fail-closed: imagetools create failure exits non-zero and no artifact written" {
+@test "imagetools create failure exits non-zero and no artifact written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8473,7 +8473,7 @@ EOCFG
     [ ! -f "$artifact" ]
 }
 
-@test "B-merge-fail-closed: digest capture failure exits non-zero and no artifact written" {
+@test "digest capture failure exits non-zero and no artifact written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8540,7 +8540,7 @@ EOCFG
 }
 
 # ---------------------------------------------------------------------------
-# AW-1: finalize-multiarch must merge ALL in-scope extensions, not only
+# finalize-multiarch must merge ALL in-scope extensions, not only
 # resolver-backed ones. A non-resolver extension (pgvector, single version)
 # must get an un-suffixed multi-arch manifest created from its -amd64 + -arm64
 # suffixed source refs.
@@ -8553,7 +8553,7 @@ EOCFG
 #   (no bundle, no versionset artifact). (GREEN)
 # ---------------------------------------------------------------------------
 
-@test "AW1-nonresolver-merged: finalize-multiarch creates un-suffixed manifest for non-resolver extension" {
+@test "finalize-multiarch creates un-suffixed manifest for non-resolver extension" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8651,7 +8651,7 @@ EOF
     [[ "$create_content" == *"pg18-0.8.0-arm64"* ]]
 }
 
-@test "AW1-all-exts-processed: finalize-multiarch creates manifests for both resolver-backed and non-resolver extensions" {
+@test "finalize-multiarch creates manifests for both resolver-backed and non-resolver extensions" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -8773,7 +8773,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AW-2: per-arch buildx build must honor do_push / NO_PUSH.
+# per-arch buildx build must honor do_push / NO_PUSH.
 # When NO_PUSH=true (do_push=false), build_ext_image must use --load, NOT --push.
 # When do_push=true, --push must still be used (regression guard).
 #
@@ -8782,7 +8782,7 @@ EOF
 # After fix:  --push only when do_push=true; --load when do_push=false. (GREEN)
 # ---------------------------------------------------------------------------
 
-@test "AW2-nopush-uses-load: BUILD_PLATFORM + NO_PUSH=true → buildx uses --load, not --push" {
+@test "BUILD_PLATFORM + NO_PUSH=true → buildx uses --load, not --push" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local aw2_log="$tmpd/aw2_nopush_buildx.log"
@@ -8824,7 +8824,7 @@ EOF
     [[ "$call_content" == *"--load"* ]]
 }
 
-@test "AW2-push-true-regression: BUILD_PLATFORM + NO_PUSH unset → buildx uses --load then docker push" {
+@test "BUILD_PLATFORM + NO_PUSH unset → buildx uses --load then docker push" {
     # BA-2 contract: build (--load) and push (docker push) are separate steps.
     # When do_push=true: buildx build --load compiles, then docker push sends to registry.
     # The buildx build command must use --load (not --push); a separate docker push follows.
@@ -8871,7 +8871,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AW-3: prefilter (_should_build_extension multi-version path) must check
+# prefilter (_should_build_extension multi-version path) must check
 # arch-suffixed refs when ARCH_SUFFIX is set.
 #
 # Scenario: ARCH_SUFFIX=arm64, the un-suffixed ref exists in registry but the
@@ -8885,7 +8885,7 @@ EOF
 #   arch-suffixed ref → skips only when -arm64 is present → builds when absent. (GREEN)
 # ---------------------------------------------------------------------------
 
-@test "AW3-prefilter-arch-suffixed: ARCH_SUFFIX set + un-suffixed present but suffixed absent → extension NOT skipped (builds -arm64)" {
+@test "ARCH_SUFFIX set + un-suffixed present but suffixed absent → extension NOT skipped (builds -arm64)" {
     export ARCH_SUFFIX="arm64"
     export BUILD_PLATFORM="linux/arm64"
 
@@ -8921,7 +8921,7 @@ EOF
     unset ARCH_SUFFIX BUILD_PLATFORM
 }
 
-@test "AW3-prefilter-arch-suffixed-present: ARCH_SUFFIX set + suffixed ref IS present → extension skipped" {
+@test "ARCH_SUFFIX set + suffixed ref IS present → extension skipped" {
     export ARCH_SUFFIX="amd64"
     export BUILD_PLATFORM="linux/amd64"
 
@@ -8949,7 +8949,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AW-4: stage B must merge only AVAILABLE versions and tolerate excluded
+# stage B must merge only AVAILABLE versions and tolerate excluded
 # (non-ceiling versions whose -amd64 or -arm64 source is absent).
 #
 # Before fix: finalize_multiarch_manifests treats every imagetools create
@@ -8960,7 +8960,7 @@ EOF
 #   set produces artifact; exit 0. (GREEN)
 # ---------------------------------------------------------------------------
 
-@test "AW4-excluded-version-not-fatal: non-ceiling source tag definitively absent → excluded, ceiling merged, exit 0" {
+@test "non-ceiling source tag definitively absent → excluded, ceiling merged, exit 0" {
     # BA-3 contract: a definitive ABSENT (not ERROR) on a non-ceiling suffixed
     # source tag → excluded (legitimate per-arch build miss), not fatal.
     # The 3-state probe returns ABSENT (rc=1) for the 2.25.0 -amd64 tag, PRESENT
@@ -9080,7 +9080,7 @@ EOF
     [ "$excl_2250" -eq 1 ]
 }
 
-@test "AW4-ceiling-absent-fatal: ceiling version missing from arch sources → exit non-zero (fail-closed)" {
+@test "ceiling version missing from arch sources → exit non-zero (fail-closed)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -9179,7 +9179,7 @@ EOF
 # AX1 digest-map approach. Stable suffixed tags persist in the registry across
 # runs, so a cached version (not rebuilt this run) is included correctly.
 # ---------------------------------------------------------------------------
-@test "SIMP-merge-from-stable-tags: finalize-multiarch uses stable suffixed tag refs, not digest refs" {
+@test "finalize-multiarch uses stable suffixed tag refs, not digest refs" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_calls_log="${tmpd}/simp_imagetools_calls.log"
@@ -9282,7 +9282,7 @@ EOF
 # used digest maps (dropped approach). The new mechanism uses registry probes
 # of the stable suffixed tags to compute the INTERSECTION.
 # ---------------------------------------------------------------------------
-@test "SIMP-intersection-availability: version missing on arm64 suffixed tag is excluded, not merged" {
+@test "version missing on arm64 suffixed tag is excluded, not merged" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_calls_log="${tmpd}/simp_intersection_imagetools.log"
@@ -9398,7 +9398,7 @@ EOF
     fi
 }
 
-@test "SIMP-intersection-availability-ceiling-fatal: ceiling missing on arm64 suffixed tag → fatal exit" {
+@test "ceiling missing on arm64 suffixed tag → fatal exit" {
     # Replaces the reverted AX1-ceiling-missing-one-arch-fatal test.
     # New mechanism: registry probe of stable suffixed tags.
     # Ceiling's -arm64 tag absent → fatal (fail-closed).
@@ -9492,7 +9492,7 @@ EOF
 # manifest → falls through to CREATE (re-creates from per-arch legs), exit 0.
 # The reused manifest covers only linux/amd64; per-arch legs exist for both arches.
 # ---------------------------------------------------------------------------
-@test "SIMP-reuse-single-arch-falls-through: single-arch reused manifest triggers re-create from per-arch legs" {
+@test "single-arch reused manifest triggers re-create from per-arch legs" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -9617,7 +9617,7 @@ EOF
 # imagetools create produces a single-arch manifest → EXCLUDED (exit 0).
 # Ceiling (both arches) → merged; artifact omits excluded version.
 # ---------------------------------------------------------------------------
-@test "SIMP-nonceil-single-arch-create-excluded: non-ceiling single-arch create is excluded, ceiling merged, exit 0" {
+@test "non-ceiling single-arch create is excluded, ceiling merged, exit 0" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -9742,7 +9742,7 @@ EOF
 # SIMP-ceiling-single-arch-create-fatal: ceiling version whose imagetools create
 # produces a single-arch manifest → fatal (exit non-zero). No artifact written.
 # ---------------------------------------------------------------------------
-@test "SIMP-ceiling-single-arch-create-fatal: ceiling single-arch create is fatal" {
+@test "ceiling single-arch create is fatal" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -9833,11 +9833,11 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AX3-duration-consolidated: per-arch duration files for a version
+# per-arch duration files for a version
 # (amd64=100s, arm64=140s) → canonical artifact gets one duration file with
 # MAX policy (140s); the consolidated duration_seconds is 140.
 # ---------------------------------------------------------------------------
-@test "AX3-duration-consolidated: per-arch duration files consolidated with MAX policy; canonical duration=140" {
+@test "per-arch duration files consolidated with MAX policy; canonical duration=140" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -9929,7 +9929,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AY-2 replacement test: non-resolver finalize uses STABLE SUFFIXED TAG refs.
+# Replacement test: non-resolver finalize uses STABLE SUFFIXED TAG refs.
 # This replaces the reverted AY1 digest-map tests.
 # Non-resolver extensions (single configured version) use imagetools create
 # with stable -amd64/-arm64 suffixed tag refs directly (no registry probe,
@@ -9937,7 +9937,7 @@ EOF
 # un-suffixed multi-arch manifest from the stable per-arch tags.
 # ---------------------------------------------------------------------------
 
-@test "SIMP-nonresolver-merge-stable-tags: non-resolver finalize uses stable suffixed tag refs" {
+@test "non-resolver finalize uses stable suffixed tag refs" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -10035,7 +10035,7 @@ EOF
     }
 }
 
-@test "SIMP-nonresolver-merge-succeeds-no-digest-map: non-resolver finalize succeeds without any digest map files" {
+@test "non-resolver finalize succeeds without any digest map files" {
     # Regression guard: non-resolver branch must work WITHOUT digest-map files present.
     # The reverted AY-1 approach required digest maps; the stable-tag approach does not.
     local tmpd="$TEST_TEMP_DIR"
@@ -10095,7 +10095,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AY-2: per-arch leg must write ARCH-SUFFIXED duration files.
+# per-arch leg must write ARCH-SUFFIXED duration files.
 #
 # Before fix: build_tag_push_extensions always writes:
 #   ext-<ext>-pg<major>-<ver>.json  (un-suffixed)
@@ -10109,7 +10109,7 @@ EOF
 # When ARCH_SUFFIX is empty (local/single-arch), keep the un-suffixed name.
 # ---------------------------------------------------------------------------
 
-@test "AY2-arch-suffixed-duration-no-collision: ARCH_SUFFIX=amd64 writes arch-suffixed duration file" {
+@test "ARCH_SUFFIX=amd64 writes arch-suffixed duration file" {
     export ARCH_SUFFIX="amd64"
     export BUILD_PLATFORM="linux/amd64"
 
@@ -10180,7 +10180,7 @@ EOF
     unset ARCH_SUFFIX BUILD_PLATFORM
 }
 
-@test "AY2-local-unsuffixed: ARCH_SUFFIX empty keeps un-suffixed duration file (local/single-arch path)" {
+@test "ARCH_SUFFIX empty keeps un-suffixed duration file (local/single-arch path)" {
     unset ARCH_SUFFIX
     unset BUILD_PLATFORM
 
@@ -10218,7 +10218,7 @@ EOF
     [ ! -f "$arm64_file" ]
 }
 
-@test "AY2-consolidation-runs: -amd64.json + -arm64.json → consolidation writes canonical file with MAX, removes suffixed" {
+@test "-amd64.json + -arm64.json → consolidation writes canonical file with MAX, removes suffixed" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -10343,7 +10343,7 @@ EOF
 # All -amd64 and -arm64 suffixed tags exist (2.25.0 is "cached", not rebuilt).
 # Expectation: all 3 in available[], bundle built, artifact written.
 # ---------------------------------------------------------------------------
-@test "SIMP-cached-version-merged: cached non-ceiling version (not rebuilt) appears in available via stable-tag probe" {
+@test "cached non-ceiling version (not rebuilt) appears in available via stable-tag probe" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -10450,7 +10450,7 @@ EOF
 # amd64,arm64) from AVAILABLE per-version multi-arch manifests. An excluded
 # version is NOT in the bundle COPY list. (AZ-1 regression guard)
 # ---------------------------------------------------------------------------
-@test "SIMP-bundle-from-available: stage-B uses only available versions in version_digests; excluded version absent" {
+@test "stage-B uses only available versions in version_digests; excluded version absent" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/simp_available_imagetools.log"
@@ -10594,7 +10594,7 @@ EOF
 # imagetools create for the ceiling version must be called even when set_size==1.
 # (AZ-4 regression guard)
 # ---------------------------------------------------------------------------
-@test "SIMP-single-version-manifest: resolver-backed set_size==1 creates un-suffixed per-version manifest" {
+@test "resolver-backed set_size==1 creates un-suffixed per-version manifest" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/simp_single_imagetools.log"
@@ -10706,12 +10706,12 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BA-2: per-arch build (BUILD_PLATFORM set) separates compile (--load) from push.
+# per-arch build (BUILD_PLATFORM set) separates compile (--load) from push.
 # A push/auth/network failure must be FATAL for ALL versions (ceiling AND
 # non-ceiling). It must NOT be tolerated as a musl compile incompatibility.
 # ---------------------------------------------------------------------------
 
-@test "BA2-push-fail-fatal: non-ceiling --load succeeds but push fails → FATAL (not excluded)" {
+@test "non-ceiling --load succeeds but push fails → FATAL (not excluded)" {
     # Tests the REAL build_ext_image with BUILD_PLATFORM set.
     # Before fix: buildx build --push is one op; non-zero = compile failure = tolerated
     #             for non-ceiling → exit 0, version silently excluded.
@@ -10796,7 +10796,7 @@ EOF
     grep -q "DOCKER_PUSH_FAIL" "$push_log"
 }
 
-@test "BA2-compile-fail-nonceiling-tolerated: non-ceiling --load (compile) fails → tolerated (exit 0)" {
+@test "non-ceiling --load (compile) fails → tolerated (exit 0)" {
     # Regression guard: musl compile incompatibility on non-ceiling is still tolerated.
     # Before and after fix: a compile failure (--load fails) for a non-ceiling version
     # must remain tolerated → exit 0.
@@ -10878,7 +10878,7 @@ EOF
     grep -q "PUSH_OK.*pg18-2.27.1-amd64" "$build_log"
 }
 
-@test "BA2-ceiling-compile-fail-fatal: ceiling --load (compile) fails → FATAL (exit non-zero)" {
+@test "ceiling --load (compile) fails → FATAL (exit non-zero)" {
     # Ceiling compile failure must remain fatal regardless of the build/push split.
 
     local tmpd="$TEST_TEMP_DIR"
@@ -10952,13 +10952,13 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BA-3: finalize_multiarch_manifests uses 3-state probe (fail-closed on ERROR).
+# finalize_multiarch_manifests uses 3-state probe (fail-closed on ERROR).
 # Before fix: boolean image_exists_in_registry — a transient probe failure
 #             reads as "missing" → non-ceiling version silently excluded.
 # After fix:  _image_present_3state — ERROR (rc=2) → fail closed (fatal), NOT excluded.
 # ---------------------------------------------------------------------------
 
-@test "BA3-transient-probe-failclosed: finalize, transient 3-state ERROR probe → fail closed (not excluded)" {
+@test "finalize, transient 3-state ERROR probe → fail closed (not excluded)" {
     # The test drives finalize_multiarch_manifests via main --finalize-multiarch.
     # The suffixed-tag probe returns rc=2 (transient ERROR) for a NON-ceiling version.
     # Before fix (boolean): rc≠0 → "missing" → non-ceiling excluded → exit 0 with reduced artifact.
@@ -11073,7 +11073,7 @@ EOF
     fi
 }
 
-@test "BA3-definitive-absent-excluded: definitive ABSENT non-ceiling → excluded; ceiling absent → fatal" {
+@test "definitive ABSENT non-ceiling → excluded; ceiling absent → fatal" {
     # A definitive ABSENT (explicit not-found signal) on a NON-ceiling version is a
     # legitimate per-arch build miss → excluded (unchanged behavior).
     # A definitive ABSENT on the CEILING version → fatal (unchanged behavior).
@@ -11183,7 +11183,7 @@ EOF
     [[ "$avail" == *"2.27.1"* ]]
 }
 
-@test "BA3-imagetools-create-with-both-present-fatal: imagetools create fails when both sources confirmed present → FATAL" {
+@test "imagetools create fails when both sources confirmed present → FATAL" {
     # When both -amd64 and -arm64 suffixed tags are confirmed PRESENT by the probe
     # but imagetools create fails, that is a registry infra error → FATAL.
     # Before fix: non-ceiling imagetools-create failure is tolerated → excluded.
@@ -11293,7 +11293,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB1-pr-scoped-tags: PR_TAG_SUFFIX=-pr42 → per-arch + per-version + bundle
+# PR_TAG_SUFFIX=-pr42 → per-arch + per-version + bundle
 # published refs all carry -pr42; canonical (un-suffixed) refs NEVER created.
 #
 # RED before fix: finalize_multiarch_manifests creates refs with no suffix
@@ -11301,7 +11301,7 @@ EOF
 # GREEN after fix: every published ref carries -pr42 suffix; canonical refs
 #   never appear in the docker calls log.
 # ---------------------------------------------------------------------------
-@test "BB1-pr-scoped-tags: PR_TAG_SUFFIX=-pr42 → all published refs carry -pr42, canonical refs absent" {
+@test "PR_TAG_SUFFIX=-pr42 → all published refs carry -pr42, canonical refs absent" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -11413,10 +11413,10 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB1-push-canonical: PR_TAG_SUFFIX empty (push/dispatch) → canonical refs
+# PR_TAG_SUFFIX empty (push/dispatch) → canonical refs
 # (no suffix) created (regression guard).
 # ---------------------------------------------------------------------------
-@test "BB1-push-canonical: PR_TAG_SUFFIX empty → canonical refs published (regression)" {
+@test "PR_TAG_SUFFIX empty → canonical refs published (regression)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -11523,7 +11523,7 @@ EOF
 # RED before fix: buildx build call has no --cache-from / --cache-to flags.
 # GREEN after fix: both flags present with the deterministic buildcache ref.
 # ---------------------------------------------------------------------------
-@test "CACHE-flags: per-arch buildx build carries --cache-from and --cache-to registry flags" {
+@test "per-arch buildx build carries --cache-from and --cache-to registry flags" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/docker_calls.log"
@@ -11616,7 +11616,7 @@ EOF
 
 # A non-ceiling compile that fails once then succeeds must be INCLUDED (not excluded).
 # Without retry: single failure → excluded. With retry: second attempt succeeds → included.
-@test "BB2-transient-build-retry-succeeds: compile fails once then succeeds → version included" {
+@test "compile fails once then succeeds → version included" {
     export EXT_BUILD_RETRIES=3
 
     resolve_version_set() { echo '["2.25.0","2.27.1"]'; }
@@ -11668,7 +11668,7 @@ EOF
 
 # Non-ceiling build that fails ALL retry attempts → tolerated (genuine incompatibility).
 # Ceiling that fails ALL retry attempts → fatal.
-@test "BB2-persistent-build-fail-tolerated: non-ceiling all-retry-fail → tolerated (exit 0)" {
+@test "non-ceiling all-retry-fail → tolerated (exit 0)" {
     export EXT_BUILD_RETRIES=2
 
     resolve_version_set() { echo '["2.25.0","2.26.0","2.27.1"]'; }
@@ -11714,7 +11714,7 @@ EOF
     unset EXT_BUILD_RETRIES
 }
 
-@test "BB2-ceiling-persistent-fail-fatal: ceiling all-retry-fail → exit non-zero" {
+@test "ceiling all-retry-fail → exit non-zero" {
     export EXT_BUILD_RETRIES=2
 
     resolve_version_set() { echo '["2.25.0","2.27.1"]'; }
@@ -11754,7 +11754,7 @@ EOF
 }
 
 # Push failure (rc=2) fails all retries → fatal.
-@test "BB2-push-retry-then-fatal: push fails all retries → fatal" {
+@test "push fails all retries → fatal" {
     export EXT_BUILD_RETRIES=2
 
     resolve_version_set() { echo '["2.25.0","2.27.1"]'; }
@@ -11799,7 +11799,7 @@ EOF
 # the real non-zero exit code, not 0.
 # Without the fix: `if ! $DOCKER ...; then rc=$?` captures rc=0 (exit of `!`).
 # With the fix: rc is captured from the command directly → real non-zero value.
-@test "BBlow-rc-capture: imagetools create failure logs real rc, not 0" {
+@test "imagetools create failure logs real rc, not 0" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local log_file="$tmpd/bblow_output.log"
@@ -11854,7 +11854,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BC-2: build cache ref must always be a writable GHCR ref, independent of
+# build cache ref must always be a writable GHCR ref, independent of
 # REMOTE_CR (which is the base-image source, not the cache store).
 #
 # The per-arch buildx build derives --cache-to/--cache-from from REMOTE_CR,
@@ -11875,7 +11875,7 @@ EOF
 #   LOCAL_ONLY=true (no push) → --cache-to must NOT appear in the buildx invocation.
 #   --cache-from may still be present (reading cache is always safe).
 # ---------------------------------------------------------------------------
-@test "BC2-cache-ref-ghcr: REMOTE_CR=docker.io → cache ref still uses ghcr.io/<owner>/, NOT docker.io" {
+@test "REMOTE_CR=docker.io → cache ref still uses ghcr.io/<owner>/, NOT docker.io" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bc2_docker_calls.log"
@@ -11964,7 +11964,7 @@ EOF
     [[ "$buildx_line" == *"type=registry"* ]]
 }
 
-@test "BC2-cache-to-only-with-write: --local-only flag → --cache-to absent from buildx invocation" {
+@test "--local-only flag → --cache-to absent from buildx invocation" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bc2_local_docker_calls.log"
@@ -12041,7 +12041,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BD1-cache-pr-scoped: build cache ref must carry PR_TAG_SUFFIX on PR builds,
+# build cache ref must carry PR_TAG_SUFFIX on PR builds,
 # and no suffix on push/dispatch (canonical) builds.
 #
 # Supply-chain policy (operator-confirmed): the build cache is PR-scoped so an
@@ -12056,7 +12056,7 @@ EOF
 #   PR_TAG_SUFFIX=-pr42  → --cache-from/--cache-to ref ends in pg18-amd64-pr42
 #   PR_TAG_SUFFIX empty  → --cache-from/--cache-to ref ends in pg18-amd64 (no suffix)
 # ---------------------------------------------------------------------------
-@test "BD1-cache-pr-scoped: PR_TAG_SUFFIX=-pr42 → cache ref is ...buildcache:pg18-amd64-pr42" {
+@test "PR_TAG_SUFFIX=-pr42 → cache ref is ...buildcache:pg18-amd64-pr42" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bd1_pr_docker_calls.log"
@@ -12142,7 +12142,7 @@ EOF
     [ "$unscoped_count" -eq 0 ]
 }
 
-@test "BD1-cache-pr-scoped: PR_TAG_SUFFIX empty (push) → canonical cache ref (no suffix)" {
+@test "PR_TAG_SUFFIX empty (push) → canonical cache ref (no suffix)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bd1_push_docker_calls.log"
@@ -12242,7 +12242,7 @@ EOF
 #   the canonical arch tag exists (unchanged version).
 # GREEN after fix: canonical present → _should_build_extension returns 1 (skip).
 # ---------------------------------------------------------------------------
-@test "BF-pr-reuses-canonical-skips-unchanged: PR_TAG_SUFFIX=-pr42, canonical arch tag present, PR-scoped absent → SKIPPED" {
+@test "PR_TAG_SUFFIX=-pr42, canonical arch tag present, PR-scoped absent → SKIPPED" {
     export PR_TAG_SUFFIX="-pr42"
     export ARCH_SUFFIX="amd64"
     export BUILD_PLATFORM="linux/amd64"
@@ -12286,7 +12286,7 @@ EOF
 # RED before fix: all N+1 versions are built (canonical check absent).
 # GREEN after fix: exactly 1 build (the new/changed version).
 # ---------------------------------------------------------------------------
-@test "BF-pr-builds-only-changed: PR_TAG_SUFFIX=-pr42, 1 new + 2 unchanged → only 1 build issued" {
+@test "PR_TAG_SUFFIX=-pr42, 1 new + 2 unchanged → only 1 build issued" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local build_calls="${tmpd}/build_calls.log"
@@ -12406,7 +12406,7 @@ EOF
 # GREEN after fix: canonical manifests for unchanged versions reused (no extra
 #   imagetools create); new version gets PR-scoped manifest; PR bundle written.
 # ---------------------------------------------------------------------------
-@test "BF-bundle-mixes-canonical-and-prscoped: unchanged versions reused from canonical, new version is PR-scoped, PR bundle written" {
+@test "unchanged versions reused from canonical, new version is PR-scoped, PR bundle written" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="${tmpd}/docker_calls.log"
@@ -12551,7 +12551,7 @@ EOF
 #
 # GREEN before and after fix: on push, canonical-only probing is unchanged.
 # ---------------------------------------------------------------------------
-@test "BF-push-canonical-only: PR_TAG_SUFFIX empty → canonical arch tags probed, unchanged version skipped" {
+@test "PR_TAG_SUFFIX empty → canonical arch tags probed, unchanged version skipped" {
     export PR_TAG_SUFFIX=""
     export ARCH_SUFFIX="amd64"
     export BUILD_PLATFORM="linux/amd64"
@@ -12584,7 +12584,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BG1-nonresolver-reuse-canonical: PR_TAG_SUFFIX=-pr42, non-resolver ext whose
+# PR_TAG_SUFFIX=-pr42, non-resolver ext whose
 # canonical multi-arch manifest EXISTS (pr-scoped arch tags do NOT exist).
 # finalize_multiarch_manifests must REUSE the canonical manifest (no
 # imagetools create) and exit 0.
@@ -12594,7 +12594,7 @@ EOF
 # GREEN after fix: canonical manifest present → reuse (no imagetools create
 #   called for this ext), exit 0.
 # ---------------------------------------------------------------------------
-@test "BG1-nonresolver-reuse-canonical: PR context, canonical multi-arch manifest present, pr-scoped tags absent → reused, no imagetools create" {
+@test "PR context, canonical multi-arch manifest present, pr-scoped tags absent → reused, no imagetools create" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/bg1_imagetools.log"
@@ -12691,14 +12691,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BG1-nonresolver-create-when-changed: PR context, non-resolver ext NOT in
+# PR context, non-resolver ext NOT in
 # canonical (built this PR, pr-scoped arch tags exist) → creates the
 # PR-scoped multi-arch manifest from the -pr42 arch tags.
 #
 # GREEN before AND after fix: when canonical is absent and pr-scoped arch tags
 # are present, imagetools create is called with the pr-scoped arch source tags.
 # ---------------------------------------------------------------------------
-@test "BG1-nonresolver-create-when-changed: PR context, canonical absent, pr-scoped arch tags present → creates PR-scoped manifest" {
+@test "PR context, canonical absent, pr-scoped arch tags present → creates PR-scoped manifest" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/bg1_changed_imagetools.log"
@@ -12789,11 +12789,11 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BG1-push-nonresolver-canonical: PR_TAG_SUFFIX empty (push/dispatch) →
+# PR_TAG_SUFFIX empty (push/dispatch) →
 # creates canonical manifest from -amd64/-arm64 stable tags (regression guard).
 # GREEN before AND after fix: push path is unchanged.
 # ---------------------------------------------------------------------------
-@test "BG1-push-nonresolver-canonical: PR_TAG_SUFFIX empty → creates canonical manifest from stable arch tags" {
+@test "PR_TAG_SUFFIX empty → creates canonical manifest from stable arch tags" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/bg1_push_imagetools.log"
@@ -12901,7 +12901,7 @@ EOF
 # GREEN after fix: `_reuse_ref_is_multiarch` returns 1 → fall-through to
 # imagetools create.
 # ---------------------------------------------------------------------------
-@test "MG-nonresolver-singlearch-recreate: non-resolver ext with single-arch existing manifest → re-creates from per-arch legs" {
+@test "non-resolver ext with single-arch existing manifest → re-creates from per-arch legs" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/mg_imagetools.log"
@@ -13013,7 +13013,7 @@ EOF
 # MG helper unit tests: _reuse_ref_is_multiarch return codes.
 # ---------------------------------------------------------------------------
 
-@test "MG-helper-multiarch: _reuse_ref_is_multiarch returns 0 when both arches reported" {
+@test "_reuse_ref_is_multiarch returns 0 when both arches reported" {
     docker() {
         if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
             printf 'linux/amd64\nlinux/arm64\n'
@@ -13027,7 +13027,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "MG-helper-singlearch: _reuse_ref_is_multiarch returns 1 when only amd64 reported" {
+@test "_reuse_ref_is_multiarch returns 1 when only amd64 reported" {
     docker() {
         if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
             printf 'linux/amd64\n'
@@ -13041,7 +13041,7 @@ EOF
     [ "$status" -eq 1 ]
 }
 
-@test "MG-helper-inspect-error: _reuse_ref_is_multiarch returns 2 when inspect fails" {
+@test "_reuse_ref_is_multiarch returns 2 when inspect fails" {
     docker() {
         if [[ "$1" == 'buildx' && "$2" == 'imagetools' && "$3" == 'inspect' ]]; then
             printf 'error: transient failure\n' >&2
@@ -13056,7 +13056,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BH-2a: FORCE=true + resolver-backed extension, all tags exist in registry
+# FORCE=true + resolver-backed extension, all tags exist in registry
 # → _should_build_extension must return 0 (needs build), NOT skip.
 # Before fix: the multi-version branch goes straight to presence checks and
 #   returns 1 (skip) when all arch tags exist, ignoring FORCE.
@@ -13064,7 +13064,7 @@ EOF
 #   (same as the single-version branch).
 # ---------------------------------------------------------------------------
 
-@test "BH2a-force-resolver-rebuilds: FORCE=true + resolver-backed ext, all tags exist → returns 0 (needs rebuild)" {
+@test "FORCE=true + resolver-backed ext, all tags exist → returns 0 (needs rebuild)" {
     # All versions present in registry.
     image_exists_in_registry() { return 0; }
     export -f image_exists_in_registry
@@ -13095,7 +13095,7 @@ EOF
     unset FORCE PR_TAG_SUFFIX ARCH_SUFFIX
 }
 
-@test "BH2a-noforce-resolver-skips: FORCE unset + resolver-backed ext, all tags exist → returns 1 (skip, regression)" {
+@test "FORCE unset + resolver-backed ext, all tags exist → returns 1 (skip, regression)" {
     # All versions present in registry — should skip when not forcing.
     image_exists_in_registry() { return 0; }
     export -f image_exists_in_registry
@@ -13126,7 +13126,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BH-2b: FORCE=true on a PR + canonical manifest exists for a resolver-backed
+# FORCE=true on a PR + canonical manifest exists for a resolver-backed
 # version → finalize_multiarch_manifests must NOT reuse canonical for it; it
 # must call imagetools create from the freshly-built PR-scoped arch tags.
 #
@@ -13137,7 +13137,7 @@ EOF
 #   always use the freshly-built scoped sources (PR-scoped arch tags). GREEN.
 # ---------------------------------------------------------------------------
 
-@test "BH2b-force-finalize-uses-fresh: FORCE=true on PR, canonical manifest exists → imagetools create from pr-scoped tags" {
+@test "FORCE=true on PR, canonical manifest exists → imagetools create from pr-scoped tags" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/bh2b_imagetools.log"
@@ -13255,7 +13255,7 @@ EOF
     unset FORCE PR_TAG_SUFFIX ARCH_SUFFIX
 }
 
-@test "BH2b-noforce-finalize-reuses-canonical: FORCE unset on PR, canonical manifest present → canonical reused, no imagetools create (BF regression)" {
+@test "FORCE unset on PR, canonical manifest present → canonical reused, no imagetools create (BF regression)" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local imagetools_log="$tmpd/bh2b_noforce_imagetools.log"
@@ -13371,7 +13371,7 @@ EOF
 # GREEN after fix: canonical-first probe → canonical absent → PR-scoped fallback →
 #   pr42 found → 2.25.0 included → confirmed=[2.25.0,2.27.1] → artifact written.
 # ---------------------------------------------------------------------------
-@test "BI2-pr-rerun-idempotent: PR rerun — version built in earlier run (pr42 only) stays available" {
+@test "PR rerun — version built in earlier run (pr42 only) stays available" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 
@@ -13518,7 +13518,7 @@ EOF
 # Post-fix: digest capture uses _confirmed_refs[ver] (PR-scoped ref) →
 #   digest captured from pr42 ref → artifact written with valid version_digests.
 # ---------------------------------------------------------------------------
-@test "PR-scoped-digest-capture: canonical absent, pr42 only → digest from pr42 ref, artifact has version_digests" {
+@test "canonical absent, pr42 only → digest from pr42 ref, artifact has version_digests" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
 

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -126,7 +126,7 @@ _setup_default_mocks() {
 # ---------------------------------------------------------------------------
 
 # Case 1: LOCAL_ONLY=true, image found locally, FORCE=false  →  skip (return 1)
-@test "1: LOCAL_ONLY=true, image present locally, FORCE=false → skip" {
+@test "LOCAL_ONLY=true, image present locally, FORCE=false → skip" {
     export LOCAL_ONLY=true
     export FORCE=false
     _mock_docker_present
@@ -137,7 +137,7 @@ _setup_default_mocks() {
 }
 
 # Case 2: LOCAL_ONLY=true, image found locally, FORCE=true  →  build (return 0)
-@test "2: LOCAL_ONLY=true, image present locally, FORCE=true → build" {
+@test "LOCAL_ONLY=true, image present locally, FORCE=true → build" {
     export LOCAL_ONLY=true
     export FORCE=true
     _mock_docker_present
@@ -147,7 +147,7 @@ _setup_default_mocks() {
 }
 
 # Case 3: LOCAL_ONLY=true, image absent locally  →  build (return 0)
-@test "3: LOCAL_ONLY=true, image absent locally → build" {
+@test "LOCAL_ONLY=true, image absent locally → build" {
     export LOCAL_ONLY=true
     export FORCE=false
     _mock_docker_absent
@@ -157,7 +157,7 @@ _setup_default_mocks() {
 }
 
 # Case 4: LOCAL_ONLY=false, FORCE=true  →  build regardless (return 0)
-@test "4: LOCAL_ONLY=false, FORCE=true → build regardless" {
+@test "LOCAL_ONLY=false, FORCE=true → build regardless" {
     export LOCAL_ONLY=false
     export FORCE=true
     # registry check is irrelevant when FORCE=true
@@ -168,7 +168,7 @@ _setup_default_mocks() {
 }
 
 # Case 5: LOCAL_ONLY=false, FORCE=false, image in registry  →  skip (return 1)
-@test "5: LOCAL_ONLY=false, FORCE=false, image in registry → skip" {
+@test "LOCAL_ONLY=false, FORCE=false, image in registry → skip" {
     export LOCAL_ONLY=false
     export FORCE=false
     _mock_registry_present
@@ -179,7 +179,7 @@ _setup_default_mocks() {
 }
 
 # Case 6: LOCAL_ONLY=false, FORCE=false, image absent  →  build (return 0)
-@test "6: LOCAL_ONLY=false, FORCE=false, image absent → build" {
+@test "LOCAL_ONLY=false, FORCE=false, image absent → build" {
     export LOCAL_ONLY=false
     export FORCE=false
     _mock_registry_absent
@@ -189,7 +189,7 @@ _setup_default_mocks() {
 }
 
 # Case 7: Dockerfile missing  →  skip with warning (return 1)
-@test "7: Dockerfile missing → skip with warning" {
+@test "Dockerfile missing → skip with warning" {
     export LOCAL_ONLY=false
     export FORCE=false
     rm -f "$EXT_DOCKERFILE"
@@ -203,7 +203,7 @@ _setup_default_mocks() {
 # Differs from case 4 (FORCE=true with registry PRESENT): exercises the
 # FORCE-short-circuit path BEFORE the registry probe so a registry outage
 # during a force rebuild can't accidentally skip.
-@test "8: LOCAL_ONLY=false, FORCE=true, image absent in registry → build (force short-circuits before probe)" {
+@test "LOCAL_ONLY=false, FORCE=true, image absent in registry → build (force short-circuits before probe)" {
     export LOCAL_ONLY=false
     export FORCE=true
     _mock_registry_absent

--- a/tests/unit/cascade-resolver.bats
+++ b/tests/unit/cascade-resolver.bats
@@ -23,10 +23,10 @@
 #   and trigger premature auto-merge.
 #
 # Mutation guards:
-#   MG1: Removing the "remaining > 0" branch → auto-merge fires even with open parents
-#   MG2: Removing the --remove-label step → label never removed, infinite retry
-#   MG3: Skip "continue" on remove failure → broken child silently auto-merges
-#   MG4: || echo "0" on gh pr view → API error silently enables auto-merge (Defect C)
+#   Removing the "remaining > 0" branch → auto-merge fires even with open parents
+#   Removing the --remove-label step → label never removed, infinite retry
+#   Skip "continue" on remove failure → broken child silently auto-merges
+#   || echo "0" on gh pr view → API error silently enables auto-merge (Defect C)
 
 load "../test_helper"
 
@@ -238,7 +238,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 # Scenario 1 — single-parent: debian merges, child has only cascade:waiting-for-debian
 # Expected: label removed, remaining=0, auto-merge enabled
-# MG1: if remaining check removed, auto-merge fires even when other parents open
+# if remaining check removed, auto-merge fires even when other parents open
 # ---------------------------------------------------------------------------
 @test "resolver: single-parent — auto-merge enabled after last wait label removed" {
     _setup_mock_gh "single-parent"
@@ -255,7 +255,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 # Scenario 2 — multi-parent: debian merges, child still has cascade:waiting-for-php
 # Expected: label removed, remaining=1, "still waiting" comment, NO auto-merge
-# MG1: if remaining check removed, auto-merge fires here — wrong cascade order
+# if remaining check removed, auto-merge fires here — wrong cascade order
 # ---------------------------------------------------------------------------
 @test "resolver: multi-parent — NO auto-merge when second wait label remains" {
     _setup_mock_gh "multi-parent"
@@ -272,7 +272,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 # Scenario 3 — remove-label failure: gh pr edit --remove-label exits 1
 # Expected: child is skipped (continue), no auto-merge, ::warning:: emitted
-# MG3: if "continue" removed, broken child could still get auto-merged
+# if "continue" removed, broken child could still get auto-merged
 # ---------------------------------------------------------------------------
 @test "resolver: remove-label failure — child skipped, no auto-merge" {
     _setup_mock_gh "remove-fails"
@@ -307,7 +307,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 # Scenario 5 — gh pr view failure: API returns non-zero (Defect C)
 # Expected: child skipped (continue), no auto-merge, ::error:: emitted
-# MG4: if || echo "0" present, API error silently enables auto-merge
+# if || echo "0" present, API error silently enables auto-merge
 # ---------------------------------------------------------------------------
 @test "resolver: gh pr view failure — child skipped, no auto-merge (Defect C)" {
     _setup_mock_gh "view-fails"
@@ -801,9 +801,9 @@ _run_eval_parent_state() {
 # false-ready.  See ADR-011 §Known Limitations.
 #
 # Mutation guards:
-#   MG-B1: changing the if [[ $_parent_drifting -eq 1 ]] branch to echo "ready"
+#   changing the if [[ $_parent_drifting -eq 1 ]] branch to echo "ready"
 #           → this test gets ready (FAIL)
-#   MG-B2: removing the CURRENT_DRIFT_SET guard entirely → State C fires instead,
+#   removing the CURRENT_DRIFT_SET guard entirely → State C fires instead,
 #           output still in_flux but ::notice:: text differs (secondary assertion catches it)
 # ---------------------------------------------------------------------------
 @test "eval_parent_state: parent in drift set, no open PR → in_flux (conservative State B)" {
@@ -853,12 +853,12 @@ _run_eval_parent_state() {
 # stdout — head would have returned 0, making the old guard pass silently.
 #
 # Mutation guards:
-#   MG-R1: reverting to the piped form `$(gh ... | head -1)` in the if-guard
+#   reverting to the piped form `$(gh ... | head -1)` in the if-guard
 #           makes the test pass (gh rc masked) — failing test catches regression.
-#   MG-R2: removing the rc check entirely → status=0, test catches it.
+#   removing the rc check entirely → status=0, test catches it.
 # ---------------------------------------------------------------------------
 
-@test "DefectR: gh pr list exits non-zero (no stdout) → fail-closed, NOT silent empty open_pr" {
+@test "gh pr list exits non-zero (no stdout) → fail-closed, NOT silent empty open_pr" {
     # This mode exits 1 with no stdout — head would return 0 (empty input is OK
     # for head), masking the failure in the old piped form.
     _setup_three_state_mock "pr-list-error"
@@ -872,7 +872,7 @@ _run_eval_parent_state() {
     [ -z "$state_token" ]
 }
 
-@test "DefectR: gh pr list failure must NOT fall through to State B (capture-then-head structure)" {
+@test "gh pr list failure must NOT fall through to State B (capture-then-head structure)" {
     # Structural invariant: the body must capture gh output into a variable
     # (explicit rc check) BEFORE applying head -1.  The pipe-inside-if-guard
     # anti-pattern is structurally absent.
@@ -1168,11 +1168,11 @@ MOCK_BODY
 # auto-merge (the stranding scenario from the old remove-first order).
 #
 # Key invariants:
-#   IV1: snapshot failure → skip before removal (no stranding)
-#   IV2: snapshot succeeds, removal fails → child skipped; snapshot count irrelevant
+#   snapshot failure → skip before removal (no stranding)
+#   snapshot succeeds, removal fails → child skipped; snapshot count irrelevant
 #         (retry on next event; child still has the wait label so it is not stranded)
-#   IV3: snapshot succeeds, removal succeeds, remaining > 0 → comment only, no auto-merge
-#   IV4: snapshot succeeds, removal succeeds, remaining == 0 → auto-merge enabled
+#   snapshot succeeds, removal succeeds, remaining > 0 → comment only, no auto-merge
+#   snapshot succeeds, removal succeeds, remaining == 0 → auto-merge enabled
 # ---------------------------------------------------------------------------
 
 @test "resolver: Defect B — snapshot failure skips child BEFORE removal (no stranding)" {
@@ -1228,15 +1228,15 @@ MOCK_BODY
 # in_flux regardless of the drift set.
 #
 # Mutation guards:
-#   MG-B0a: removing State B0 → errored parent gets ready (the original defect)
+#   removing State B0 → errored parent gets ready (the original defect)
 #            (test "errored parent in CURRENT_ERROR_SET → in_flux, not ready")
-#   MG-B0b: inverting _parent_errored check → errored parent gets ready
+#   inverting _parent_errored check → errored parent gets ready
 #            (test "errored parent → in_flux even when absent from CURRENT_DRIFT_SET")
-#   MG-B0c: State A must still short-circuit before B0
+#   State A must still short-circuit before B0
 #            (test "errored parent with open PR → in_flux via State A, not B0")
 # ---------------------------------------------------------------------------
 
-@test "StateB0: parent in CURRENT_ERROR_SET → in_flux (probe error treated as unknown)" {
+@test "parent in CURRENT_ERROR_SET → in_flux (probe error treated as unknown)" {
     # Parent probe failed this run; no open PR (State A cleared).
     # State B0 must return in_flux — we do not know if the parent is stable.
     _setup_three_state_mock "ghcr-stale"
@@ -1246,7 +1246,7 @@ MOCK_BODY
     [ "$state_token" = "in_flux" ]
 }
 
-@test "StateB0: errored parent → emits ::notice:: with probe-error message" {
+@test "errored parent → emits ::notice:: with probe-error message" {
     _setup_three_state_mock "ghcr-stale"
     CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="" _run_eval_parent_state "debian"
     [ "$status" -eq 0 ]
@@ -1254,7 +1254,7 @@ MOCK_BODY
     [[ "$output" == *"probe errored"* ]]
 }
 
-@test "StateB0: errored parent not in CURRENT_DRIFT_SET → in_flux (not short-circuited to ready by State B)" {
+@test "errored parent not in CURRENT_DRIFT_SET → in_flux (not short-circuited to ready by State B)" {
     # This is the exact defect: error excluded from drift set → State B saw absent → ready.
     # With State B0, error set is checked BEFORE the drift set, so ready is never reached.
     _setup_three_state_mock "ghcr-stale"
@@ -1266,7 +1266,7 @@ MOCK_BODY
     ! [[ "$output" == *"GHCR image is stable, ready"* ]]
 }
 
-@test "StateB0: parent with open PR → in_flux via State A (not B0)" {
+@test "parent with open PR → in_flux via State A (not B0)" {
     # State A runs before B0: an open PR is caught by State A, B0 is never reached.
     _setup_three_state_mock "open-pr"
     CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="" _run_eval_parent_state "debian"
@@ -1278,7 +1278,7 @@ MOCK_BODY
     ! [[ "$output" == *"probe errored"* ]]
 }
 
-@test "StateB0: empty CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
+@test "empty CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
     # When CURRENT_ERROR_SET is empty/unset, B0 is a no-op.
     # Parent absent from drift set → State B returns ready.
     _setup_three_state_mock "ghcr-stale"
@@ -1288,7 +1288,7 @@ MOCK_BODY
     [ "$state_token" = "ready" ]
 }
 
-@test "StateB0: unset CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
+@test "unset CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
     # Same as above but CURRENT_ERROR_SET is unset (not just empty).
     _setup_three_state_mock "ghcr-stale"
     CURRENT_DRIFT_SET="wordpress" _run_eval_parent_state "php"
@@ -1297,14 +1297,14 @@ MOCK_BODY
     [ "$state_token" = "ready" ]
 }
 
-@test "StateB0: body contains CURRENT_ERROR_SET loop (State B0 is present)" {
+@test "body contains CURRENT_ERROR_SET loop (State B0 is present)" {
     # Structural invariant: State B0 must be present in the function body.
     local body="$EVAL_PARENT_STATE_BODY"
     [[ "$body" == *"CURRENT_ERROR_SET"* ]]
     [[ "$body" == *"_parent_errored"* ]]
 }
 
-@test "StateB0: B0 appears before State B loop in function body (ordering invariant)" {
+@test "B0 appears before State B loop in function body (ordering invariant)" {
     # Structural invariant: CURRENT_ERROR_SET check must precede CURRENT_DRIFT_SET check.
     local body="$EVAL_PARENT_STATE_BODY"
     local b0_pos b_pos
@@ -1406,7 +1406,7 @@ MOCK_BODY
 # the child from auto-merging against the stale php parent image.
 # ---------------------------------------------------------------------------
 
-@test "DefectD: scoped dispatch — parent absent from drift set but has open PR → in_flux" {
+@test "scoped dispatch — parent absent from drift set but has open PR → in_flux" {
     # Simulate scoped workflow_dispatch: CURRENT_DRIFT_SET=wordpress (php excluded).
     # php has an open drift PR (#10) — State A must catch it before State B short-circuits.
     _setup_three_state_mock "open-pr"
@@ -1419,7 +1419,7 @@ MOCK_BODY
     grep -q "pr list" "$TEST_TEMP_DIR/gh_calls.log"
 }
 
-@test "DefectD: scoped dispatch — parent absent from drift set with no open PR → ready" {
+@test "scoped dispatch — parent absent from drift set with no open PR → ready" {
     # No open PR for php → State A returns empty → State B sees php absent from drift set
     # → ready (correct: php was rebuilt in a prior run, no pending work).
     _setup_three_state_mock "no-open-pr"
@@ -1429,7 +1429,7 @@ MOCK_BODY
     [ "$state_token" = "ready" ]
 }
 
-@test "DefectD: State A runs before State B (open-PR check precedes drift-set loop in body)" {
+@test "State A runs before State B (open-PR check precedes drift-set loop in body)" {
     # Structural invariant: the gh pr list call must appear before the CURRENT_DRIFT_SET
     # iteration loop (_parent_drifting loop).
     local body="$EVAL_PARENT_STATE_BODY"
@@ -1453,7 +1453,7 @@ MOCK_BODY
 # when it IS in the repo-wide drift set but has no open PR yet.
 # ---------------------------------------------------------------------------
 
-@test "DefectE: scoped dispatch — parent drifting repo-wide, no open PR → in_flux (conservative State B)" {
+@test "scoped dispatch — parent drifting repo-wide, no open PR → in_flux (conservative State B)" {
     # Scenario: workflow_dispatch for wordpress only.  php is also drifting repo-wide.
     # With the Defect E fix, CURRENT_DRIFT_SET contains BOTH wordpress and php.
     # php has no open PR → State B: drifting + no open PR → conservative in_flux.
@@ -1468,7 +1468,7 @@ MOCK_BODY
     ! grep -q "api users" "$TEST_TEMP_DIR/gh_calls.log"
 }
 
-@test "DefectE: scoped dispatch — parent NOT drifting repo-wide, no open PR → ready (State B)" {
+@test "scoped dispatch — parent NOT drifting repo-wide, no open PR → ready (State B)" {
     # php is NOT in the repo-wide drift set; no open PR → State B short-circuits to ready.
     _setup_three_state_mock "no-open-pr"
     CURRENT_DRIFT_SET="wordpress" _run_eval_parent_state "php"
@@ -1486,7 +1486,7 @@ MOCK_BODY
 # Invariant: GHCR API is NEVER called by _eval_parent_state for any state.
 # ---------------------------------------------------------------------------
 
-@test "DefectF: CURRENT_DRIFT_SET unset → State C fires, GHCR API NOT called" {
+@test "CURRENT_DRIFT_SET unset → State C fires, GHCR API NOT called" {
     # When CURRENT_DRIFT_SET is empty/unset the State B block is skipped entirely.
     # State C fires (conservative in_flux) — no GHCR API call.
     _setup_three_state_mock "no-open-pr"
@@ -1495,7 +1495,7 @@ MOCK_BODY
     ! grep -q "api users" "$TEST_TEMP_DIR/gh_calls.log"
 }
 
-@test "DefectF: packages/container lookup absent from function body (r27 regression-lock)" {
+@test "packages/container lookup absent from function body (r27 regression-lock)" {
     # Architectural regression lock: the GHCR /versions API must NOT be present in
     # the function body.  If someone re-introduces it without per-tag label support,
     # this test catches the regression immediately.
@@ -1555,7 +1555,7 @@ _run_cascade_label_loop() {
     run bash "$script"
 }
 
-@test "DefectP: _eval_parent_state returns malformed output → cascade loop exits 1 (fail-closed)" {
+@test "_eval_parent_state returns malformed output → cascade loop exits 1 (fail-closed)" {
     # Simulate _eval_parent_state emitting a ::warning:: annotation but no state token.
     # The grep -E '^(in_flux|ready)$' filter produces empty output.
     # The fail-closed guard must catch this and exit 1.
@@ -1584,7 +1584,7 @@ EOF
     [[ "$output" == *"Raw output:"* ]]
 }
 
-@test "DefectP: _eval_parent_state returns empty string → cascade loop exits 1 (fail-closed)" {
+@test "_eval_parent_state returns empty string → cascade loop exits 1 (fail-closed)" {
     # Edge case: function returns completely empty output.
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/gh" << 'EOF'
@@ -1609,7 +1609,7 @@ EOF
     [[ "$output" == *"refusing to proceed (fail-closed)"* ]]
 }
 
-@test "DefectP: _eval_parent_state returns 'ready' → cascade loop continues, no label applied (regression-lock)" {
+@test "_eval_parent_state returns 'ready' → cascade loop continues, no label applied (regression-lock)" {
     # Healthy path: ready state must not exit 1 (guard must not fire on valid tokens).
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/gh" << 'EOF'
@@ -1650,13 +1650,13 @@ EOF
 # cannot regress to GITHUB_TOKEN without the test catching it.
 #
 # Mutation guards:
-#   MG-F1a: reverting one GH_TOKEN line to secrets.GITHUB_TOKEN →
+#   reverting one GH_TOKEN line to secrets.GITHUB_TOKEN →
 #            grep for secrets.GITHUB_TOKEN finds a match → test fails.
-#   MG-F1b: removing the app-token step entirely →
+#   removing the app-token step entirely →
 #            grep for create-github-app-token finds nothing → test fails.
 # ---------------------------------------------------------------------------
 
-@test "FIX1: cascade-resolver unblock-children uses App token, not secrets.GITHUB_TOKEN (regression-lock)" {
+@test "cascade-resolver unblock-children uses App token, not secrets.GITHUB_TOKEN (regression-lock)" {
     local workflow=".github/workflows/cascade-resolver.yaml"
     local wf_path="${PROJECT_ROOT}/${workflow}"
 
@@ -1687,14 +1687,14 @@ EOF
 # context to infer the repo), and children are never unblocked.
 #
 # Mutation guards:
-#   MG-GHR1: removing GH_REPO from "Identify parent..." step env →
+#   removing GH_REPO from "Identify parent..." step env →
 #             grep finds only 1 occurrence → test fails.
-#   MG-GHR2: removing GH_REPO from "Unblock children" step env →
+#   removing GH_REPO from "Unblock children" step env →
 #             grep finds only 1 occurrence → test fails.
-#   MG-GHR3: removing both → grep finds 0 occurrences → test fails.
+#   removing both → grep finds 0 occurrences → test fails.
 # ---------------------------------------------------------------------------
 
-@test "FIX1: cascade-resolver unblock-children — GH_REPO set in both step envs (no-checkout repo context)" {
+@test "cascade-resolver unblock-children — GH_REPO set in both step envs (no-checkout repo context)" {
     local workflow=".github/workflows/cascade-resolver.yaml"
     local wf_path="${PROJECT_ROOT}/${workflow}"
 
@@ -1756,7 +1756,7 @@ EOF
 # Mutation guard: removing set -o pipefail from the step → this structural
 # test FAILS, catching the regression before it reaches production.
 # ---------------------------------------------------------------------------
-@test "F4: 'Identify parent' step in cascade-resolver.yaml has set -o pipefail" {
+@test "'Identify parent' step in cascade-resolver.yaml has set -o pipefail" {
     local wf_path="${BATS_TEST_DIRNAME}/../../.github/workflows/cascade-resolver.yaml"
     [[ -f "$wf_path" ]] || skip "cascade-resolver.yaml not found at $wf_path"
 

--- a/tests/unit/check-version-drift.bats
+++ b/tests/unit/check-version-drift.bats
@@ -10,10 +10,10 @@
 # GHCR owner is controlled via _VDRIFT_GHCR_OWNER_OVERRIDE.
 #
 # Mutation guards:
-#   MG1: Remove grace check → in_flight becomes drift (breaks test 3)
-#   MG2: Remove absent→drift branch → drift status never set (breaks test 2)
-#   MG3: Remove probe → absent always → in_sync never set (breaks test 1)
-#   MG4: Remove error propagation → error becomes in_sync (breaks test 6)
+#   Remove grace check → in_flight becomes drift (breaks test 3)
+#   Remove absent→drift branch → drift status never set (breaks test 2)
+#   Remove probe → absent always → in_sync never set (breaks test 1)
+#   Remove error propagation → error becomes in_sync (breaks test 6)
 
 load "../test_helper"
 
@@ -117,7 +117,7 @@ _make_probe_stub() {
 
 # ---------------------------------------------------------------------------
 # Test 1: in_sync — declared version published → no drift row, exit 0
-# MG3: if probe is removed, absent is returned → status would be drift, not in_sync
+# if probe is removed, absent is returned → status would be drift, not in_sync
 # ---------------------------------------------------------------------------
 @test "in_sync: declared version published → no drift row, exit 0" {
     local root
@@ -162,7 +162,7 @@ _make_probe_stub() {
 
 # ---------------------------------------------------------------------------
 # Test 2: drift — declared version absent, bump old → drift row, exit 1
-# MG2: if absent→drift branch is removed, status never becomes "drift" → test fails
+# if absent→drift branch is removed, status never becomes "drift" → test fails
 # ---------------------------------------------------------------------------
 @test "drift: declared-absent + old bump → drift row + exit 1" {
     local root
@@ -202,7 +202,7 @@ _make_probe_stub() {
 
 # ---------------------------------------------------------------------------
 # Test 3: in_flight — declared absent, bump ≤ grace hours → in_flight, exit 0
-# MG1: if grace check is removed, in_flight becomes drift → exit 1 not 0
+# if grace check is removed, in_flight becomes drift → exit 1 not 0
 # ---------------------------------------------------------------------------
 @test "in_flight: declared-absent + bump within grace → in_flight + exit 0" {
     local root
@@ -364,7 +364,7 @@ MAKE_EOF
 
 # ---------------------------------------------------------------------------
 # Test 6: probe error → error row, exit 2
-# MG4: if error propagation is removed, error becomes absent/in_sync → exit != 2
+# if error propagation is removed, error becomes absent/in_sync → exit != 2
 # ---------------------------------------------------------------------------
 @test "probe-error: probe returns error → error row + exit 2" {
     local root
@@ -662,7 +662,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # Test D5-1: auto-build.yaml summary job invokes check-version-drift.sh in
 #            post-build mode.
 # ---------------------------------------------------------------------------
-@test "D5-1: auto-build.yaml summary job invokes check-version-drift.sh --mode post-build" {
+@test "auto-build.yaml summary job invokes check-version-drift.sh --mode post-build" {
     [ -f "$AUTO_BUILD_YAML" ]
     grep -q 'check-version-drift.sh' "$AUTO_BUILD_YAML"
     grep -q -- '--mode post-build' "$AUTO_BUILD_YAML"
@@ -672,7 +672,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # Test D5-2: auto-build.yaml version-drift step is advisory (continue-on-error: true)
 #            and does NOT hard-exit on drift (no bare "exit 1" in advisory block).
 # ---------------------------------------------------------------------------
-@test "D5-2: auto-build.yaml version-drift step is advisory (continue-on-error: true, no hard exit on drift)" {
+@test "auto-build.yaml version-drift step is advisory (continue-on-error: true, no hard exit on drift)" {
     [ -f "$AUTO_BUILD_YAML" ]
     grep -q 'continue-on-error: true' "$AUTO_BUILD_YAML"
     # Extract the advisory step block and assert no unconditional "exit 1" for drift.
@@ -687,7 +687,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # ---------------------------------------------------------------------------
 # Test D5-3: version-drift.yaml exists with schedule + workflow_dispatch triggers.
 # ---------------------------------------------------------------------------
-@test "D5-3: version-drift.yaml exists with schedule and workflow_dispatch triggers" {
+@test "version-drift.yaml exists with schedule and workflow_dispatch triggers" {
     [ -f "$DRIFT_YAML" ]
     grep -q 'schedule:' "$DRIFT_YAML"
     grep -q 'cron:' "$DRIFT_YAML"
@@ -698,7 +698,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # Test D5-4: version-drift.yaml mints the GitHub App token via
 #            actions/create-github-app-token with BOT_APP_ID / BOT_APP_PRIVATE_KEY.
 # ---------------------------------------------------------------------------
-@test "D5-4: version-drift.yaml mints App token with BOT_APP_ID / BOT_APP_PRIVATE_KEY" {
+@test "version-drift.yaml mints App token with BOT_APP_ID / BOT_APP_PRIVATE_KEY" {
     [ -f "$DRIFT_YAML" ]
     grep -q 'create-github-app-token' "$DRIFT_YAML"
     grep -q 'BOT_APP_ID' "$DRIFT_YAML"
@@ -708,7 +708,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # ---------------------------------------------------------------------------
 # Test D5-5: version-drift.yaml invokes check-version-drift.sh --mode sweep.
 # ---------------------------------------------------------------------------
-@test "D5-5: version-drift.yaml runs check-version-drift.sh --mode sweep" {
+@test "version-drift.yaml runs check-version-drift.sh --mode sweep" {
     [ -f "$DRIFT_YAML" ]
     grep -q 'check-version-drift.sh' "$DRIFT_YAML"
     grep -q -- '--mode sweep' "$DRIFT_YAML"
@@ -718,7 +718,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # Test D5-6: auto-build.yaml advisory step uses $CONTAINER env var in the shell
 #            body, not raw ${{ matrix.* }} template expressions (injection-safe).
 # ---------------------------------------------------------------------------
-@test "D5-6: auto-build.yaml advisory step uses \$CONTAINER env var, not \${{ matrix.* }} in shell body" {
+@test "auto-build.yaml advisory step uses \$CONTAINER env var, not \${{ matrix.* }} in shell body" {
     [ -f "$AUTO_BUILD_YAML" ]
     grep -q 'CONTAINER=' "$AUTO_BUILD_YAML"
     # Extract the advisory step block and assert no ${{ matrix.* }} in it.
@@ -733,7 +733,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # Test D5-7: version-drift.yaml sweep has no raw ${{ matrix.* }} in the run shell
 #            body (sweep is non-matrix; no matrix context exists).
 # ---------------------------------------------------------------------------
-@test "D5-7: version-drift.yaml sweep run block has no raw \${{ matrix.* }} in shell body" {
+@test "version-drift.yaml sweep run block has no raw \${{ matrix.* }} in shell body" {
     [ -f "$DRIFT_YAML" ]
     local matrix_interp_count
     matrix_interp_count=$(grep -cE '\$\{\{ *matrix\.' "$DRIFT_YAML" || true)
@@ -743,7 +743,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # ---------------------------------------------------------------------------
 # FIX 1 — structural: advisory step is gated to non-PR events.
 # ---------------------------------------------------------------------------
-@test "FIX1: advisory step has 'if: github.event_name != pull_request' guard" {
+@test "advisory step has 'if: github.event_name != pull_request' guard" {
     [ -f "$AUTO_BUILD_YAML" ]
     # Extract the advisory step using a robust awk that starts at the step name
     # and stops at the NEXT step (line starting with 8+ spaces "- name:") or
@@ -768,7 +768,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # FIX 3 — structural: advisory step validates container name pattern AND/OR
 #          routes through _escape_gha_command before emitting ::warning::.
 # ---------------------------------------------------------------------------
-@test "FIX3: advisory step validates container name with ^[a-z0-9_-]+\$ pattern" {
+@test "advisory step validates container name with ^[a-z0-9_-]+\$ pattern" {
     [ -f "$AUTO_BUILD_YAML" ]
     local advisory_block
     advisory_block=$(awk '
@@ -784,7 +784,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
     [ "$guard_count" -ge 1 ]
 }
 
-@test "FIX3: check-version-drift.sh routes untrusted names through _escape_gha_command" {
+@test "check-version-drift.sh routes untrusted names through _escape_gha_command" {
     # Every ::warning:: / ::notice:: annotation line that includes a user-derived
     # value (name, declared, status from JSON data) must route through _escape_gha_command.
     # In _append_row, annotations use $safe_name, $safe_declared, $safe_status — never
@@ -817,7 +817,7 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
 # ---------------------------------------------------------------------------
 # FIX 4 — structural: summary job installs yq before the advisory step.
 # ---------------------------------------------------------------------------
-@test "FIX4: summary job installs yq before Check version drift step" {
+@test "summary job installs yq before Check version drift step" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # The yq install step must appear BEFORE the advisory drift step in the file.
@@ -863,7 +863,7 @@ SKOPEO_EOF
     printf '%s' "$bin_dir"
 }
 
-@test "FIX2-probe: skopeo exits 0 + OCI index manifest → real probe returns present → in_sync" {
+@test "skopeo exits 0 + OCI index manifest → real probe returns present → in_sync" {
     # Real skopeo inspect --raw always emits the manifest JSON on stdout when exit 0.
     # The stub must faithfully model that: emit a valid multi-arch index manifest.
     local root
@@ -888,7 +888,7 @@ SKOPEO_EOF
     [ "$sync_count" -eq 1 ]
 }
 
-@test "FIX2-probe: skopeo exits 1 + 'manifest unknown' stderr → real probe returns absent → drift" {
+@test "skopeo exits 1 + 'manifest unknown' stderr → real probe returns absent → drift" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -911,7 +911,7 @@ SKOPEO_EOF
     [ "$drift_count" -eq 1 ]
 }
 
-@test "FIX2-probe: skopeo exits 1 + network-error stderr → real probe returns error → exit 2" {
+@test "skopeo exits 1 + network-error stderr → real probe returns error → exit 2" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -933,7 +933,7 @@ SKOPEO_EOF
     [ "$error_count" -eq 1 ]
 }
 
-@test "FIX2-structural: real probe distinguishes absent from error (no collapsed all-null path)" {
+@test "real probe distinguishes absent from error (no collapsed all-null path)" {
     # Confirm the script no longer collapses all-null JSON to 'absent'.
     # The old code had: 'All-null JSON → absent (ghcr_get_multi_arch_digests returns all-null on 404/absent)'
     # That comment / code path must be gone.
@@ -977,9 +977,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-1: OCI image index → present → in_sync, exit 0
+# OCI image index → present → in_sync, exit 0
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-1: skopeo returns OCI index → present → in_sync + exit 0" {
+@test "skopeo returns OCI index → present → in_sync + exit 0" {
     local root
     root=$(_make_temp_project "myapp" "3.1.0")
 
@@ -1010,9 +1010,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-2: single-image manifest for Linux tag → absent → drift, exit 1
+# single-image manifest for Linux tag → absent → drift, exit 1
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-2: skopeo returns single-arch manifest for Linux tag → absent → drift + exit 1" {
+@test "skopeo returns single-arch manifest for Linux tag → absent → drift + exit 1" {
     local root
     root=$(_make_temp_project "myapp" "3.1.0")
 
@@ -1044,9 +1044,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-3: single-image manifest for Windows tag → present → in_sync, exit 0
+# single-image manifest for Windows tag → present → in_sync, exit 0
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-3: skopeo returns single-arch manifest for Windows tag → present → in_sync + exit 0" {
+@test "skopeo returns single-arch manifest for Windows tag → present → in_sync + exit 0" {
     # Windows images are legitimately single-arch; tag contains "windows"
     local root
     root=$(_make_temp_project "github-runner" "2.321.0-windows-ltsc2022")
@@ -1078,9 +1078,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-4: skopeo exits 0 but non-JSON output → error → exit 2
+# skopeo exits 0 but non-JSON output → error → exit 2
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-4: skopeo exits 0 with non-JSON output → error → exit 2" {
+@test "skopeo exits 0 with non-JSON output → error → exit 2" {
     local root
     root=$(_make_temp_project "myapp" "3.1.0")
 
@@ -1111,9 +1111,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-5: existing absent (manifest unknown stderr) stub still works
+# existing absent (manifest unknown stderr) stub still works
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-5: skopeo exits 1 + 'manifest unknown' stderr → absent → drift (unchanged)" {
+@test "skopeo exits 1 + 'manifest unknown' stderr → absent → drift (unchanged)" {
     local root
     root=$(_make_temp_project "myapp" "3.1.0")
 
@@ -1137,9 +1137,9 @@ SKOPEO_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MULTIARCH-PROBE-6: existing network error stub still works
+# existing network error stub still works
 # ---------------------------------------------------------------------------
-@test "MULTIARCH-PROBE-6: skopeo exits 1 + network error stderr → error → exit 2 (unchanged)" {
+@test "skopeo exits 1 + network error stderr → error → exit 2 (unchanged)" {
     local root
     root=$(_make_temp_project "myapp" "3.1.0")
 
@@ -1165,7 +1165,7 @@ SKOPEO_EOF
 # ---------------------------------------------------------------------------
 # FIX 1 — window_empty is fail-closed: resolver returns [] → exit 2
 # ---------------------------------------------------------------------------
-@test "FIX1: resolver returns [] → window_empty → fail-closed exit 2 (not silent exit 0)" {
+@test "resolver returns [] → window_empty → fail-closed exit 2 (not silent exit 0)" {
     local root="${TEST_TEMP_DIR}/tsdb-empty-array"
     mkdir -p "${root}/postgres/extensions"
 
@@ -1218,7 +1218,7 @@ MAKE_EOF
     [ "$window_empty_count" -eq 1 ]
 }
 
-@test "FIX1: window_empty accumulator sets _HAS_ERROR (not _HAS_DRIFT)" {
+@test "window_empty accumulator sets _HAS_ERROR (not _HAS_DRIFT)" {
     # Confirm that window_empty maps to exit 2, not exit 1.
     # This catches a regression where someone makes it set _HAS_DRIFT instead.
     # Use a failing resolver so no probe call is needed.
@@ -1268,7 +1268,7 @@ MAKE_EOF
 # FIX 2 — structural: skopeo is installed in both workflow files before the
 # drift-check step.
 # ---------------------------------------------------------------------------
-@test "FIX2-workflow: version-drift.yaml installs skopeo before Run version-drift sweep" {
+@test "version-drift.yaml installs skopeo before Run version-drift sweep" {
     [ -f "$DRIFT_YAML" ]
 
     local skopeo_line sweep_line
@@ -1283,7 +1283,7 @@ MAKE_EOF
     grep -q 'apt-get install.*skopeo\|apt-get.*install.*skopeo' "$DRIFT_YAML"
 }
 
-@test "FIX2-workflow: auto-build.yaml summary job installs skopeo before Check version drift" {
+@test "auto-build.yaml summary job installs skopeo before Check version drift" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     local skopeo_line drift_line
@@ -1295,7 +1295,7 @@ MAKE_EOF
     [ "$skopeo_line" -lt "$drift_line" ]
 }
 
-@test "FIX2-workflow: auto-build.yaml summary job has GHCR login before skopeo install" {
+@test "auto-build.yaml summary job has GHCR login before skopeo install" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     local login_line skopeo_line
@@ -1310,7 +1310,7 @@ MAKE_EOF
 # ---------------------------------------------------------------------------
 # FIX 3 — structural: version-drift.yaml sweep does NOT suppress stderr.
 # ---------------------------------------------------------------------------
-@test "FIX3-workflow: version-drift.yaml sweep does not pipe drift-check through 2>/dev/null" {
+@test "version-drift.yaml sweep does not pipe drift-check through 2>/dev/null" {
     [ -f "$DRIFT_YAML" ]
 
     # The line that runs check-version-drift.sh in sweep mode must not redirect
@@ -1325,7 +1325,7 @@ MAKE_EOF
 # ---------------------------------------------------------------------------
 # FIX 4 — open_version_drift_issue validates container name before labelling.
 # ---------------------------------------------------------------------------
-@test "FIX4: open_version_drift_issue with invalid container name does not reach dep: label" {
+@test "open_version_drift_issue with invalid container name does not reach dep: label" {
     # Source the script in a controlled env (stub all gh calls and env guards)
     # then call open_version_drift_issue with a bad container name.
     # Assert that gh is never called with a dep: label containing the bad name.
@@ -1387,7 +1387,7 @@ GH_EOF
     fi
 }
 
-@test "FIX4: open_version_drift_issue with valid container name uses dep: label" {
+@test "open_version_drift_issue with valid container name uses dep: label" {
     local gh_log="${TEST_TEMP_DIR}/gh-calls-valid.log"
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-bin-valid-$$"
     mkdir -p "$fake_bin"
@@ -1445,7 +1445,7 @@ GH_EOF
 # value into a ::error:: / ::warning:: annotation.
 # ---------------------------------------------------------------------------
 
-@test "GHA-INJ-1a: version-drift.yaml invalid-GRACE_HOURS branch does not interpolate raw GRACE_HOURS value" {
+@test "version-drift.yaml invalid-GRACE_HOURS branch does not interpolate raw GRACE_HOURS value" {
     [ -f "$DRIFT_YAML" ]
 
     # Extract the GRACE_HOURS validation block — lines between the regex guard
@@ -1468,7 +1468,7 @@ GH_EOF
     [ "$raw_value_count" -eq 0 ]
 }
 
-@test "GHA-INJ-1b: auto-build.yaml invalid-container-name branch does not interpolate raw cname value" {
+@test "auto-build.yaml invalid-container-name branch does not interpolate raw cname value" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # Extract the invalid-name branch — lines between the name-validation guard
@@ -1491,7 +1491,7 @@ GH_EOF
     [ "$raw_value_count" -eq 0 ]
 }
 
-@test "GHA-INJ-1c: open_version_drift_issue validation-failure branch does not interpolate raw container value" {
+@test "open_version_drift_issue validation-failure branch does not interpolate raw container value" {
     local script="${REPO_ROOT}/scripts/open-dep-failure-issue.sh"
     [ -f "$script" ]
 
@@ -1524,7 +1524,7 @@ GH_EOF
 # "set -euo pipefail" does not leak into the step's outer shell.
 # ---------------------------------------------------------------------------
 
-@test "GHA-INJ-2a: version-drift.yaml sweeps open_version_drift_issue inside a subshell" {
+@test "version-drift.yaml sweeps open_version_drift_issue inside a subshell" {
     [ -f "$DRIFT_YAML" ]
 
     # The subshell pattern must appear: a line starting with "( source" or "(" that
@@ -1561,7 +1561,7 @@ GH_EOF
     [ "$source_in_subshell" -ge 1 ]
 }
 
-@test "GHA-INJ-2b: auto-build.yaml advisory step calls open_version_drift_issue inside a subshell" {
+@test "auto-build.yaml advisory step calls open_version_drift_issue inside a subshell" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # Same structural check: find the subshell block containing open_version_drift_issue
@@ -1596,7 +1596,7 @@ GH_EOF
 # NEW-FIX1 — structural: advisory install steps are continue-on-error: true
 # ---------------------------------------------------------------------------
 
-@test "NEW-FIX1: Install skopeo (summary job) step has continue-on-error: true" {
+@test "Install skopeo (summary job) step has continue-on-error: true" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # Extract the block for the "Install skopeo (summary job)" step.
@@ -1615,7 +1615,7 @@ GH_EOF
     [ "$coe_count" -ge 1 ]
 }
 
-@test "NEW-FIX1: Install yq (summary job) step has continue-on-error: true" {
+@test "Install yq (summary job) step has continue-on-error: true" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     local yq_block
@@ -1635,7 +1635,7 @@ GH_EOF
 # NEW-FIX2 — structural: sweep vs per-container label spaces are disjoint
 # ---------------------------------------------------------------------------
 
-@test "NEW-FIX2: sweep dedup uses version-drift-sweep label (structural)" {
+@test "sweep dedup uses version-drift-sweep label (structural)" {
     local script="${REPO_ROOT}/scripts/open-dep-failure-issue.sh"
     [ -f "$script" ]
 
@@ -1645,7 +1645,7 @@ GH_EOF
     [ "$sweep_label_count" -ge 1 ]
 }
 
-@test "NEW-FIX2: per-container path uses dep: label and sweep path uses version-drift-sweep (mutually exclusive)" {
+@test "per-container path uses dep: label and sweep path uses version-drift-sweep (mutually exclusive)" {
     local script="${REPO_ROOT}/scripts/open-dep-failure-issue.sh"
     [ -f "$script" ]
 
@@ -1667,7 +1667,7 @@ GH_EOF
     [ "$bare_dedup_count" -eq 0 ]
 }
 
-@test "NEW-FIX2: sweep gh search uses version-drift-sweep label, not per-container dep: label" {
+@test "sweep gh search uses version-drift-sweep label, not per-container dep: label" {
     # Stub gh: return a fake per-container issue number ONLY when query includes dep:
     # (simulates "a per-container issue exists"); return empty when query includes
     # version-drift-sweep (simulates "no existing sweep issue").
@@ -1755,7 +1755,7 @@ GH_EOF
 # and does not print "created #".
 # ---------------------------------------------------------------------------
 
-@test "FAILOPEN-FIX1: open_version_drift_issue CREATE failure returns non-zero, no 'created #' output" {
+@test "open_version_drift_issue CREATE failure returns non-zero, no 'created #' output" {
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-create-fail-$$"
     mkdir -p "$fake_bin"
 
@@ -1810,7 +1810,7 @@ GH_EOF
 # and does not print "commented #".
 # ---------------------------------------------------------------------------
 
-@test "FAILOPEN-FIX1: open_version_drift_issue COMMENT failure returns non-zero, no 'commented #' output" {
+@test "open_version_drift_issue COMMENT failure returns non-zero, no 'commented #' output" {
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-comment-fail-$$"
     mkdir -p "$fake_bin"
 
@@ -1864,7 +1864,7 @@ GH_EOF
 # FAILOPEN-FIX2 — container enumeration failure exits 2, not 1.
 # ---------------------------------------------------------------------------
 
-@test "FAILOPEN-FIX2: ./make list failure → script exits 2, not 1" {
+@test "./make list failure → script exits 2, not 1" {
     local root="${TEST_TEMP_DIR}/fail-enum-project"
     mkdir -p "$root"
 
@@ -1895,7 +1895,7 @@ MAKE_EOF
 # ::warning:: on issue-open failure (structural grep tests).
 # ---------------------------------------------------------------------------
 
-@test "FAILOPEN-FIX3: version-drift.yaml captures issue_rc and exits non-zero on failure" {
+@test "version-drift.yaml captures issue_rc and exits non-zero on failure" {
     [ -f "$DRIFT_YAML" ]
 
     # Must capture subshell rc into a variable (not bare || true)
@@ -1915,7 +1915,7 @@ MAKE_EOF
     [ "$bare_or_true" -eq 0 ]
 }
 
-@test "FAILOPEN-FIX3: auto-build.yaml advisory emits ::warning:: on issue-open failure, not silent || true" {
+@test "auto-build.yaml advisory emits ::warning:: on issue-open failure, not silent || true" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # Extract the advisory step block
@@ -1985,10 +1985,10 @@ MAKE_EOF
 }
 
 # ---------------------------------------------------------------------------
-# GATE-FIX1-a: --mode post-build --container postgres checks declared extension
+# --mode post-build --container postgres checks declared extension
 #              version; absent extension → drift row, exit 1
 # ---------------------------------------------------------------------------
-@test "GATE-FIX1-a: post-build postgres checks extensions — absent ext version → drift + exit 1" {
+@test "post-build postgres checks extensions — absent ext version → drift + exit 1" {
     local root
     root=$(_make_postgres_project)
 
@@ -2022,9 +2022,9 @@ MAKE_EOF
 }
 
 # ---------------------------------------------------------------------------
-# GATE-FIX1-b: --mode post-build --container postgres, extension in_sync → exit 0
+# --mode post-build --container postgres, extension in_sync → exit 0
 # ---------------------------------------------------------------------------
-@test "GATE-FIX1-b: post-build postgres checks extensions — published ext → in_sync + exit 0" {
+@test "post-build postgres checks extensions — published ext → in_sync + exit 0" {
     local root
     root=$(_make_postgres_project)
 
@@ -2058,9 +2058,9 @@ MAKE_EOF
 }
 
 # ---------------------------------------------------------------------------
-# GATE-FIX1-c: --mode post-build --container <non-postgres> does NOT run extension checks
+# --mode post-build --container <non-postgres> does NOT run extension checks
 # ---------------------------------------------------------------------------
-@test "GATE-FIX1-c: post-build non-postgres container does NOT run extension checks" {
+@test "post-build non-postgres container does NOT run extension checks" {
     local root
     root=$(_make_temp_project "nginx" "1.25.0")
 
@@ -2092,7 +2092,7 @@ MAKE_EOF
 # ---------------------------------------------------------------------------
 # GATE-FIX2 — structural: summary job timeout-minutes >= 15
 # ---------------------------------------------------------------------------
-@test "GATE-FIX2: summary job timeout-minutes is >= 15" {
+@test "summary job timeout-minutes is >= 15" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # Extract the timeout-minutes value from the summary job block.
@@ -2116,7 +2116,7 @@ MAKE_EOF
 # NEW-FIX1 — fail-closed on missing tools
 # ---------------------------------------------------------------------------
 
-@test "NEW-FIX1-yq-missing: yq absent from PATH → script exits 2, not 0 (not silent false-clean)" {
+@test "yq absent from PATH → script exits 2, not 0 (not silent false-clean)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2152,7 +2152,7 @@ MAKE_EOF
     [[ "$stderr" == *"yq"* ]]
 }
 
-@test "NEW-FIX1-jq-missing-structural: script has command -v jq prerequisite check → would exit 2 if absent" {
+@test "script has command -v jq prerequisite check → would exit 2 if absent" {
     # Structural test: verify the script contains the fail-closed jq prerequisite check.
     # (A functional test that removes jq from PATH is not reliably portable across
     # environments where jq shares /bin with bash itself; structural is the right oracle here.)
@@ -2189,7 +2189,7 @@ MAKE_EOF
 # The fix adds a direct yq -e '.versions[].tag' guard BEFORE list_versions.
 # ---------------------------------------------------------------------------
 
-@test "FAILOPEN-FIX4: malformed variants.yaml (invalid YAML) → script exits 2, not 0" {
+@test "malformed variants.yaml (invalid YAML) → script exits 2, not 0" {
     # A container whose variants.yaml is not parseable YAML must not be
     # reported as clean.  The script must fail-closed: exit 2 (_HAS_ERROR).
     local root="${TEST_TEMP_DIR}/malformed-project"
@@ -2232,7 +2232,7 @@ MAKE_EOF
     [ "$sync_for_malformed" -eq 0 ]
 }
 
-@test "FAILOPEN-FIX4: schema-broken variants.yaml (valid YAML, no .versions) → script exits 2, not 0" {
+@test "schema-broken variants.yaml (valid YAML, no .versions) → script exits 2, not 0" {
     # A container whose variants.yaml is valid YAML but lacks .versions[].tag
     # entries must also fail-closed: exit 2 (_HAS_ERROR), not report clean.
     local root="${TEST_TEMP_DIR}/schema-broken-project"
@@ -2271,7 +2271,7 @@ MAKE_EOF
     [ "$sync_for_schema_broken" -eq 0 ]
 }
 
-@test "NEW-FIX1-pg-versions-parse-fail: yq failure reading pg_versions → exit 2, not silent exit 0" {
+@test "yq failure reading pg_versions → exit 2, not silent exit 0" {
     # The pg_versions read in _process_extensions uses a raw yq call (not wrapped
     # in || echo ""), so a yq parse failure there is directly detectable.
     # Verify: a fake yq that exits non-zero causes the extension sweep to exit 2.
@@ -2325,7 +2325,7 @@ YQ_EOF
 # NEW-FIX2 — extension sweep respects disabled/max_pg_version filters
 # ---------------------------------------------------------------------------
 
-@test "NEW-FIX2-disabled: disabled extension is NOT checked for drift" {
+@test "disabled extension is NOT checked for drift" {
     # Config with two extensions: pgvector (enabled) and citus (disabled: true).
     # citus would generate a drift row if enumerated; only pgvector must appear.
     local root="${TEST_TEMP_DIR}/disabled-ext-project-$$"
@@ -2380,7 +2380,7 @@ MAKE_EOF
     [ "$pgvector_status" = "in_sync" ]
 }
 
-@test "NEW-FIX2-max-pg-version: extension with max_pg_version < pg_major is NOT checked for drift" {
+@test "extension with max_pg_version < pg_major is NOT checked for drift" {
     # Config: pgvector (no max_pg_version) and pg_cron (max_pg_version: 16).
     # For pg17, pg_cron is incompatible → must not appear in results.
     local root="${TEST_TEMP_DIR}/maxpg-ext-project-$$"
@@ -2439,7 +2439,7 @@ MAKE_EOF
 # NEW-FIX3 — undeterminable bump epoch defaults to drift, not in_flight
 # ---------------------------------------------------------------------------
 
-@test "NEW-FIX3-no-commit: git log finds no commit for declaring file → absent version is drift (not in_flight)" {
+@test "git log finds no commit for declaring file → absent version is drift (not in_flight)" {
     # When _VDRIFT_BUMP_EPOCH_OVERRIDE is NOT set and git log returns empty
     # (no commit tracked for the file), the fallback must be epoch=0 → drift.
     # We use a fresh temp git repo with no commits touching variants.yaml so
@@ -2496,7 +2496,7 @@ MAKE_EOF
     [ "$in_flight_count" -eq 0 ]
 }
 
-@test "NEW-FIX3-workflow: summary job checkout uses fetch-depth: 0 (full git history)" {
+@test "summary job checkout uses fetch-depth: 0 (full git history)" {
     [ -f "$AUTO_BUILD_YAML" ]
 
     # The summary job checkout must use fetch-depth: 0 so git log
@@ -2525,7 +2525,7 @@ MAKE_EOF
 # skopeo exits non-zero.  The old broad matcher ('not found') mapped this to
 # absent → false drift alert.  The narrow matcher must return error → exit 2.
 # ---------------------------------------------------------------------------
-@test "NARROW-ABSENT-1: skopeo fails with 'credential helper not found' → error → exit 2 (not absent/drift)" {
+@test "skopeo fails with 'credential helper not found' → error → exit 2 (not absent/drift)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2561,7 +2561,7 @@ MAKE_EOF
 # Simulates a PATH/tooling failure on the registry side (the client binary
 # itself is not found, or a helper binary is missing).
 # ---------------------------------------------------------------------------
-@test "NARROW-ABSENT-2: skopeo fails with 'command not found' stderr → error → exit 2 (not absent/drift)" {
+@test "skopeo fails with 'command not found' stderr → error → exit 2 (not absent/drift)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2596,7 +2596,7 @@ MAKE_EOF
 # (e.g. /token) and gets a 404, NOT when the manifest itself is missing.
 # The old broad '404' alternative misclassified this as absent.
 # ---------------------------------------------------------------------------
-@test "NARROW-ABSENT-3: skopeo fails with auth-endpoint 'unexpected http status 404' → error → exit 2 (not absent/drift)" {
+@test "skopeo fails with auth-endpoint 'unexpected http status 404' → error → exit 2 (not absent/drift)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2627,7 +2627,7 @@ MAKE_EOF
 # ---------------------------------------------------------------------------
 # NARROW-ABSENT-4 (regression) — "manifest unknown" → absent → drift (no change)
 # ---------------------------------------------------------------------------
-@test "NARROW-ABSENT-4: skopeo fails with 'manifest unknown' stderr → absent → drift + exit 1 (unchanged)" {
+@test "skopeo fails with 'manifest unknown' stderr → absent → drift + exit 1 (unchanged)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2654,7 +2654,7 @@ MAKE_EOF
 # ---------------------------------------------------------------------------
 # NARROW-ABSENT-5 (regression) — "was deleted or has expired" → absent → drift
 # ---------------------------------------------------------------------------
-@test "NARROW-ABSENT-5: skopeo fails with 'was deleted or has expired' stderr → absent → drift + exit 1 (unchanged)" {
+@test "skopeo fails with 'was deleted or has expired' stderr → absent → drift + exit 1 (unchanged)" {
     local root
     root=$(_make_temp_project "foo" "9.9.9")
 
@@ -2684,7 +2684,7 @@ MAKE_EOF
 # A non-empty but unparseable drift_json must return non-zero (fail loudly),
 # not silently no-op as if there were no drift rows.
 # ---------------------------------------------------------------------------
-@test "DRIFT-JSON-VALID-1: open_version_drift_issue with malformed drift_json returns non-zero" {
+@test "open_version_drift_issue with malformed drift_json returns non-zero" {
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-json-valid-$$"
     mkdir -p "$fake_bin"
 
@@ -2727,7 +2727,7 @@ GH_EOF
 #
 # An empty/whitespace drift_json is a legitimate no-op and must still return 0.
 # ---------------------------------------------------------------------------
-@test "DRIFT-JSON-VALID-2: open_version_drift_issue with empty drift_json returns 0 (no-op)" {
+@test "open_version_drift_issue with empty drift_json returns 0 (no-op)" {
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-empty-json-$$"
     mkdir -p "$fake_bin"
 
@@ -2763,7 +2763,7 @@ GH_EOF
 # ---------------------------------------------------------------------------
 # DRIFT-JSON-VALID-3 — "[]" drift_json → open_version_drift_issue returns 0 (no-op)
 # ---------------------------------------------------------------------------
-@test "DRIFT-JSON-VALID-3: open_version_drift_issue with '[]' drift_json returns 0 (no-op)" {
+@test "open_version_drift_issue with '[]' drift_json returns 0 (no-op)" {
     local fake_bin="${TEST_TEMP_DIR}/fake-gh-empty-array-$$"
     mkdir -p "$fake_bin"
 
@@ -2806,7 +2806,7 @@ GH_EOF
 #   c) exit-2 error message no longer claims "GHCR connectivity" as sole cause
 # ---------------------------------------------------------------------------
 
-@test "SECFIX1a: version-drift.yaml checkout step pins ref to refs/heads/master" {
+@test "version-drift.yaml checkout step pins ref to refs/heads/master" {
     [ -f "$DRIFT_YAML" ]
 
     # Extract the checkout step block.
@@ -2824,7 +2824,7 @@ GH_EOF
     [ "$ref_count" -ge 1 ]
 }
 
-@test "SECFIX1b: version-drift.yaml create-github-app-token step sets permission-issues: write (token is scoped, not unscoped)" {
+@test "version-drift.yaml create-github-app-token step sets permission-issues: write (token is scoped, not unscoped)" {
     [ -f "$DRIFT_YAML" ]
 
     # Extract the Generate App token step block.
@@ -2848,7 +2848,7 @@ GH_EOF
     [ "$permission_key_count" -ge 1 ]
 }
 
-@test "SECFIX1c: version-drift.yaml exit-2 message does not hardcode 'GHCR connectivity' as sole cause" {
+@test "version-drift.yaml exit-2 message does not hardcode 'GHCR connectivity' as sole cause" {
     [ -f "$DRIFT_YAML" ]
 
     # The exit-2 handler message must NOT say "check GHCR connectivity" as the

--- a/tests/unit/collector-emitter.bats
+++ b/tests/unit/collector-emitter.bats
@@ -109,7 +109,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (a) Artifact-present digest-pinned emission
 # ---------------------------------------------------------------------------
-@test "(a) artifact with version_digests → collector stage with digest-pinned per-version COPYs" {
+@test "artifact with version_digests → collector stage with digest-pinned per-version COPYs" {
     _write_versionset_with_digests "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -141,7 +141,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (b) Self-heal tag-resolved emission
 # ---------------------------------------------------------------------------
-@test "(b) self-heal (no artifact) → collector stage with tag-based per-version COPYs" {
+@test "self-heal (no artifact) → collector stage with tag-based per-version COPYs" {
     # No artifact on disk → self-heal triggers
 
     resolve_version_set() {
@@ -177,7 +177,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (c) Single-version unchanged — no collector emitted
 # ---------------------------------------------------------------------------
-@test "(c) single available version → single-version FROM path, no collector" {
+@test "single available version → single-version FROM path, no collector" {
     # Artifact with exactly one version (ceiling only)
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.27.1"],"available":["2.27.1"],"excluded":[]}
@@ -208,7 +208,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (d) Empty available → fail-closed
 # ---------------------------------------------------------------------------
-@test "(d) empty available[] → generate_dockerfile fails closed" {
+@test "empty available[] → generate_dockerfile fails closed" {
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.27.1"],"available":[],"excluded":[]}
 EOF
@@ -247,7 +247,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (e) Version in available but missing from version_digests → fail-closed
 # ---------------------------------------------------------------------------
-@test "(e) version in available[] absent from version_digests → fail-closed" {
+@test "version in available[] absent from version_digests → fail-closed" {
     # Artifact: 3 versions in available but version_digests only has 2
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.25.0","2.27.1"],"available":["2.23.0","2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"sha256:0000000000000000000000000000000000000000000000000000000000000001","2.27.1":"sha256:0000000000000000000000000000000000000000000000000000000000000002"}}
@@ -266,7 +266,7 @@ EOF
 # ---------------------------------------------------------------------------
 # (f) Depth: 30 synthetic versions → exactly ONE final-stage COPY
 # ---------------------------------------------------------------------------
-@test "(f) 30-version set → exactly ONE final-stage COPY (count-independent)" {
+@test "30-version set → exactly ONE final-stage COPY (count-independent)" {
     # Generate artifact with 30 versions
     local arr_json="["
     local vd_json="{"

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -68,7 +68,7 @@ source_dashboard_fns() {
 # Pipeline: _prepare_build_args → _resolve_base_image → _emit_build_lineage
 # Assert: base_image_ref concrete, lineage_schema_version=2
 # ---------------------------------------------------------------------------
-@test "SMOKE-01: Monolithic fixture produces concrete base_image_ref (Fix A1)" {
+@test "Monolithic fixture produces concrete base_image_ref (Fix A1)" {
     local work="$TEST_TEMP_DIR/mono"
     mkdir -p "$work"
     cp "$FIXTURE_MONO/config.yaml"   "$work/"
@@ -104,7 +104,7 @@ source_dashboard_fns() {
     [[ "$base_image_ref" == "alpine:3.21" ]]
 }
 
-@test "SMOKE-02: Monolithic fixture lineage_schema_version equals 2" {
+@test "Monolithic fixture lineage_schema_version equals 2" {
     local work="$TEST_TEMP_DIR/mono2"
     mkdir -p "$work"
     cp "$FIXTURE_MONO/config.yaml"   "$work/"
@@ -137,7 +137,7 @@ source_dashboard_fns() {
 # Pipeline: template generation → _resolve_base_image with from_generated=1
 # Assert: base_image_ref = "alpine:3.21" (from generated Dockerfile, not config)
 # ---------------------------------------------------------------------------
-@test "SMOKE-03: Template fixture (alpine) produces alpine:3.21 (Fix A2)" {
+@test "Template fixture (alpine) produces alpine:3.21 (Fix A2)" {
     local work="$TEST_TEMP_DIR/tpl"
     mkdir -p "$work"
     cp "$FIXTURE_TPL/config.yaml"          "$work/"
@@ -183,7 +183,7 @@ source_dashboard_fns() {
     [[ "$base_image_ref" == "alpine:3.21" ]]
 }
 
-@test "SMOKE-04: Template fixture (debian) produces concrete debian base_image_ref" {
+@test "Template fixture (debian) produces concrete debian base_image_ref" {
     local work="$TEST_TEMP_DIR/tpl-deb"
     mkdir -p "$work"
     cp "$FIXTURE_TPL/config.yaml"          "$work/"
@@ -226,7 +226,7 @@ source_dashboard_fns() {
 # Smoke 5 — Dashboard read fast-path (Fix B)
 # resolve_lineage_file must NOT call any network helpers
 # ---------------------------------------------------------------------------
-@test "SMOKE-05: Dashboard resolve_lineage_file does NOT invoke network helpers" {
+@test "Dashboard resolve_lineage_file does NOT invoke network helpers" {
     local work="$TEST_TEMP_DIR/dash"
     local lineage_dir="$work/.build-lineage"
     local container_dir="$work/test-container"
@@ -260,7 +260,7 @@ source_dashboard_fns() {
     [ "$network_calls" -eq 0 ]
 }
 
-@test "SMOKE-06: Dashboard resolves multi_arch_index_digest enriched field from lineage" {
+@test "Dashboard resolves multi_arch_index_digest enriched field from lineage" {
     local work="$TEST_TEMP_DIR/dash2"
     local lineage_dir="$work/.build-lineage"
     local container_dir="$work/enrich-test"
@@ -289,7 +289,7 @@ source_dashboard_fns() {
 # ---------------------------------------------------------------------------
 # Mutation guard: disabling A1 substitution pass causes ${...} to survive
 # ---------------------------------------------------------------------------
-@test "SMOKE-07: Mutation guard — disabling A1 substitution pass leaks placeholder" {
+@test "Mutation guard — disabling A1 substitution pass leaks placeholder" {
     local work="$TEST_TEMP_DIR/mut"
     mkdir -p "$work"
     cp "$FIXTURE_MONO/config.yaml"   "$work/"
@@ -323,7 +323,7 @@ source_dashboard_fns() {
 # base_image_ref containing ${...} (copilot HIGH finding)
 # Pre-v2 lineage files with leaked placeholders survive in multi-variant path.
 # ---------------------------------------------------------------------------
-@test "SMOKE-08: resolve_variant_lineage_json sanitizes pre-v2 leaked base_image_ref" {
+@test "resolve_variant_lineage_json sanitizes pre-v2 leaked base_image_ref" {
     local work="$TEST_TEMP_DIR/f3"
     local lineage_dir="$work/.build-lineage"
     local container_dir="$work/web-shell"
@@ -366,7 +366,7 @@ source_dashboard_fns() {
 # A v1 lineage file (no lineage_schema_version) with a CONCRETE base_image_ref
 # must be preserved, not blanked to "unknown".
 # ---------------------------------------------------------------------------
-@test "SMOKE-09: v1 lineage file with concrete base_image_ref is preserved, not blanked" {
+@test "v1 lineage file with concrete base_image_ref is preserved, not blanked" {
     local work="$TEST_TEMP_DIR/f1-concrete"
     local lineage_dir="$work/.build-lineage"
     local container_dir="$work/mycontainer"
@@ -415,7 +415,7 @@ source_dashboard_fns() {
 # decision (#648): even local/standalone builds resolve bases through the
 # mirror rather than Docker Hub. So _BASE_IMAGE_REF = "ghcr.io/oorabona/library/alpine:3.21".
 # ---------------------------------------------------------------------------
-@test "SMOKE-10: Template container resolves \${REMOTE_CR} to the GHCR mirror default (no placeholder leak)" {
+@test "Template container resolves \${REMOTE_CR} to the GHCR mirror default (no placeholder leak)" {
     # Simulates web-shell alpine variant local build (no REMOTE_CR in env).
     # The generated Dockerfile declares ARG REMOTE_CR=ghcr.io/oorabona (matching the
     # real web-shell/Dockerfile) and _prepare_build_args defaults REMOTE_CR to the
@@ -475,7 +475,7 @@ DOCKERFILE
 # jq "// default" guards.  A v2 lineage file with the new fields must not
 # cause any consumer to error or silently skip.
 # ---------------------------------------------------------------------------
-@test "SMOKE-11: enrich-lineage and extension-duration consumers do not error on v2 lineage" {
+@test "enrich-lineage and extension-duration consumers do not error on v2 lineage" {
     local work="$TEST_TEMP_DIR/schema-v2-audit"
     local lineage_dir="$work/.build-lineage"
     mkdir -p "$lineage_dir"

--- a/tests/unit/dashboard-rollup-default-variant.bats
+++ b/tests/unit/dashboard-rollup-default-variant.bats
@@ -77,7 +77,7 @@ make_variants_yaml() {
 # Fix B: default_variant selection (NEVER filesystem-first)
 # =============================================================================
 
-@test "DRDV-01: Multi-variant single-version uses default_variant (debian is default)" {
+@test "Multi-variant single-version uses default_variant (debian is default)" {
     # Production web-shell: debian has suffix: "" (no suffix) → lineage file = web-shell-1.7.7.json
     # Non-default variants have explicit suffixes: -alpine, -ubuntu, -rocky
     # Fix B: must return the default variant's suffixless file, not the first filesystem match.
@@ -114,7 +114,7 @@ YAML
     [[ "$output" != *"-alpine.json" && "$output" != *"-ubuntu.json" && "$output" != *"-rocky.json" ]]
 }
 
-@test "DRDV-02: Multi-version multi-flavor returns latest version default flavor" {
+@test "Multi-version multi-flavor returns latest version default flavor" {
     # Postgres-style: versions [18, 17, 16], default flavor = base
     make_lineage "postgres-18-alpine" "ghcr.io/oorabona/library/postgres:18-alpine"
     make_lineage "postgres-17-alpine" "ghcr.io/oorabona/library/postgres:17-alpine"
@@ -142,7 +142,7 @@ YAML
     [[ "$output" == *"postgres-18"* ]]
 }
 
-@test "DRDV-03: Versions-only container returns latest version lineage" {
+@test "Versions-only container returns latest version lineage" {
     # ansible: no variants, just versions
     make_lineage "ansible-13.3.0-ubuntu" "ubuntu:noble"
     make_lineage "ansible-13.4.0-ubuntu" "ubuntu:noble"
@@ -160,7 +160,7 @@ YAML
     [[ "$output" == *"13.4.0"* ]]
 }
 
-@test "DRDV-04: Legacy container-level rollup file preserved" {
+@test "Legacy container-level rollup file preserved" {
     # If container.json exists, return it directly (legacy path)
     make_lineage "foo" "alpine:3.21"
 
@@ -170,7 +170,7 @@ YAML
     [[ "$output" == *"foo.json" ]]
 }
 
-@test "DRDV-05: Malformed variants.yaml returns empty sentinel, never filesystem-first" {
+@test "Malformed variants.yaml returns empty sentinel, never filesystem-first" {
     # Create real lineage files that would be found by filesystem-first
     make_lineage "foo-1.0-alpine" "alpine:3.21"
     make_lineage "foo-1.0-debian" "debian:trixie"
@@ -185,7 +185,7 @@ YAML
     [[ -z "$output" ]]
 }
 
-@test "DRDV-06: Multiple default:true variants returns first match (no ambiguity crash)" {
+@test "Multiple default:true variants returns first match (no ambiguity crash)" {
     make_lineage "bar-1.0-alpine" "alpine:3.21"
     make_lineage "bar-1.0-debian" "debian:trixie"
 
@@ -208,7 +208,7 @@ YAML
     [[ -z "$output" || "$output" == *"bar-1.0"* ]]
 }
 
-@test "DRDV-07: Default variant lineage missing, falls back to any present variant with notice" {
+@test "Default variant lineage missing, falls back to any present variant with notice" {
     # debian is default but its lineage file doesn't exist — fall back to alpine
     make_lineage "web-shell-1.7.7-alpine" "alpine:3.21"
     # No web-shell-1.7.7-debian.json
@@ -229,7 +229,7 @@ YAML
     [[ "$output" == *"web-shell-1.7.7-alpine.json" ]]
 }
 
-@test "DRDV-08: All variant lineage files missing returns empty string" {
+@test "All variant lineage files missing returns empty string" {
     # No .json files exist for baz
     make_variants_yaml "$TEST_TEMP_DIR/baz" "$(cat <<'YAML'
 versions:
@@ -249,7 +249,7 @@ YAML
 # Fix E: sanitize-at-read — base_image_ref with ${ returns empty
 # =============================================================================
 
-@test "DRDV-09: Pre-v2 entry with leaked base_image_ref treated as empty at read" {
+@test "Pre-v2 entry with leaked base_image_ref treated as empty at read" {
     # Create a pre-v2 lineage file with a leaked placeholder
     jq -n '{container:"sslh","base_image_ref":"${OS_IMAGE_BASE}:${OS_IMAGE_TAG}","version":"v2.3.1","tag":"v2.3.1-alpine"}' \
         > "$TEST_TEMP_DIR/.build-lineage/sslh-v2.3.1-alpine.json"
@@ -270,7 +270,7 @@ YAML
 # (orthogonal gate codex MEDIUM finding)
 # =============================================================================
 
-@test "DRDV-10: Postgres default-variant (base) resolves suffixless file, not -base suffixed file" {
+@test "Postgres default-variant (base) resolves suffixless file, not -base suffixed file" {
     # Production postgres tags: base variant → "18-alpine" (NO -base suffix),
     # vector variant → "18-alpine-vector". The current bug: the glob
     # *{default_name}.json = *base.json matches "postgres-18-alpine-base.json"
@@ -315,7 +315,7 @@ YAML
 # Finding #1 (gate r3 codex MEDIUM): Legacy rollup must NOT shadow newer per-tag file
 # =============================================================================
 
-@test "DRDV-11: Per-tag lineage preferred over stale legacy rollup when both exist" {
+@test "Per-tag lineage preferred over stale legacy rollup when both exist" {
     # Scenario: cache contains an OLD {container}.json (legacy rollup from a prior-era build)
     # AND a current {container}-{version}-{variant}.json (per-tag file from the new build).
     # The legacy rollup carries a STALE base_image_ref; the per-tag file has the current truth.
@@ -363,7 +363,7 @@ YAML
 # Finding #2 (gate r3 codex LOW): Sidecar files must not be returned by fallback glob
 # =============================================================================
 
-@test "DRDV-12: Sidecar files excluded from fallback glob — no false-positive match" {
+@test "Sidecar files excluded from fallback glob — no false-positive match" {
     # Scenario: .build-lineage/ contains ONLY sidecar files for a container
     # (e.g. foo-1.0-alpine.sbom.json, foo-1.0-alpine.history.json).
     # No actual lineage file (foo-1.0-alpine.json) exists.
@@ -399,7 +399,7 @@ YAML
 # Post-fix: [[ "$legacy_tag" == "$current_latest" ]]  (exact match)
 # =============================================================================
 
-@test "DRDV-13: Legacy rollup tag 11.0-alpine does NOT match current_latest 1.0 (substring false positive)" {
+@test "Legacy rollup tag 11.0-alpine does NOT match current_latest 1.0 (substring false positive)" {
     # Pre-fix: "11.0-alpine" CONTAINS "1.0" → substring match fires → wrong rollup returned
     # Post-fix: "11.0-alpine" != "1.0" → no match → empty returned (correct)
 
@@ -428,7 +428,7 @@ YAML
     }
 }
 
-@test "DRDV-14: Legacy rollup tag 2.0-debian matches current_latest 2.0 via prefix (version same)" {
+@test "Legacy rollup tag 2.0-debian matches current_latest 2.0 via prefix (version same)" {
     # Finding #2 (gate r5): prefix-match fix: legacy_tag="2.0-debian" starts with "2.0-"
     # → returns the legacy rollup (the version matches, regardless of variant suffix).
     # Note: prior to Finding #2, exact-match was used → empty; prefix-match is the r5 correction.
@@ -456,7 +456,7 @@ YAML
     }
 }
 
-@test "DRDV-15: Legacy rollup exact match — tag equals current_latest exactly (valid use case)" {
+@test "Legacy rollup exact match — tag equals current_latest exactly (valid use case)" {
     # When legacy_tag == current_latest exactly, the legacy rollup SHOULD be returned.
     # (This is the legitimate case: a versions-only container wrote {container}.json
     #  but its per-tag file somehow didn't land in .build-lineage.)
@@ -487,7 +487,7 @@ YAML
 # Post-fix: prefix match allows "1.7.7-debian" to match "1.7.7" (version prefix).
 # =============================================================================
 
-@test "DRDV-16: Legacy rollup with full tag '1.7.7-debian' matches current_latest '1.7.7'" {
+@test "Legacy rollup with full tag '1.7.7-debian' matches current_latest '1.7.7'" {
     # web-shell-style: legacy web-shell.json was written with .tag="1.7.7-debian".
     # variants.yaml has versions[0].tag="1.7.7".
     # Per-tag resolution finds nothing (no web-shell-1.7.7*.json in .build-lineage/).
@@ -523,7 +523,7 @@ YAML
 #           NEVER fall back to legacy rollup when variants.yaml is malformed.
 # =============================================================================
 
-@test "DRDV-17: Malformed variants.yaml with stale legacy rollup present — fails closed, not silent fallback" {
+@test "Malformed variants.yaml with stale legacy rollup present — fails closed, not silent fallback" {
     # Scenario: variants.yaml is malformed AND a stale {container}.json exists.
     # Pre-fix: yq fails → latest_version="" → legacy fallback fires → stale rollup returned silently.
     # Post-fix: detect yq failure → return empty AND emit stderr warning.
@@ -555,7 +555,7 @@ YAML
 #   not "1.0.1-alpine.json".
 # =============================================================================
 
-@test "DRDV-18: Version prefix-collision — '1.0' must NOT match '1.0.1-alpine.json' in fallback glob" {
+@test "Version prefix-collision — '1.0' must NOT match '1.0.1-alpine.json' in fallback glob" {
     # Scenario: latest_version="1.0" in variants.yaml.
     # .build-lineage/ has foo-1.0.1-alpine.json (NEXT major patch, NOT the latest 1.0).
     # Pre-fix glob: "${container}-${latest_version}*.json" matches "1.0.1-alpine.json"
@@ -596,7 +596,7 @@ YAML
 #   so the guard branch runs correctly.
 # =============================================================================
 
-@test "DRDV-19: Guarded yq assignment — malformed YAML does not abort parent shell under set -e" {
+@test "Guarded yq assignment — malformed YAML does not abort parent shell under set -e" {
     # This test asserts that resolve_lineage_file is callable from a set -e
     # context without killing the parent shell on a yq parse failure.
     # Technique: invoke the function from within an explicit set -e subshell,

--- a/tests/unit/dependency-graph.bats
+++ b/tests/unit/dependency-graph.bats
@@ -6,11 +6,11 @@
 # avoid touching the real project containers or .build-lineage directory.
 #
 # Mutation guards:
-#   MG1: Remove internal-ref check → external library/php matches as php
-#   MG2: Remove self-dep check → container A listed as its own dep
-#   MG3: Remove sidecar skip → sidecar .sbom.json parsed as lineage
-#   MG4: Remove cycle detection → _depgraph_validate_no_cycles returns 0 on cycle
-#   MG5: Remove transitive dedup → diamond deps appear twice
+#   Remove internal-ref check → external library/php matches as php
+#   Remove self-dep check → container A listed as its own dep
+#   Remove sidecar skip → sidecar .sbom.json parsed as lineage
+#   Remove cycle detection → _depgraph_validate_no_cycles returns 0 on cycle
+#   Remove transitive dedup → diamond deps appear twice
 
 load "../test_helper"
 
@@ -57,7 +57,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 2: External-only — debian with library/debian:trixie → no internal dep
-# MG1: verifies external library/ is NOT classified as internal
+# verifies external library/ is NOT classified as internal
 # ---------------------------------------------------------------------------
 @test "depgraph: debian lineage with library/debian:trixie → empty deps (external)" {
     _write_lineage "debian" "trixie" "library/debian:trixie"
@@ -120,7 +120,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 6: Cycle detection — A→B→A → validate_no_cycles exits 1
-# MG4: if cycle detection removed, this test would fail
+# if cycle detection removed, this test would fail
 # ---------------------------------------------------------------------------
 @test "depgraph: cycle detection — A→B→A → _depgraph_validate_no_cycles exits 1" {
     _write_lineage "containerA" "1.0" "ghcr.io/oorabona/containerB:latest"
@@ -134,7 +134,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 7: Sidecar skip — .sbom.json not counted as lineage
-# MG3: if sidecar skip removed, the sidecar would be parsed as a dep
+# if sidecar skip removed, the sidecar would be parsed as a dep
 # ---------------------------------------------------------------------------
 @test "depgraph: sidecar skip — .sbom.json not parsed as lineage" {
     # Write a sidecar file that references php — should NOT be read as a lineage
@@ -180,7 +180,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 10: External-namespace overlap — library/php NOT our php
-# MG1: the key case — library/php must NOT match internal container "php"
+# the key case — library/php must NOT match internal container "php"
 # ---------------------------------------------------------------------------
 @test "depgraph: library/php is external, NOT matched to internal php container" {
     _write_lineage "wordpress" "latest" "library/php:8.4-fpm-alpine"
@@ -207,7 +207,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 12: Deduplication — same dep across multiple variant files listed once
-# MG5: if dedup removed, same dep would appear twice
+# if dedup removed, same dep would appear twice
 # ---------------------------------------------------------------------------
 @test "depgraph: dedup — two variant files with same base ref → dep listed once" {
     _write_lineage "wordpress" "6.9.1-alpine" "ghcr.io/oorabona/php:latest"
@@ -223,7 +223,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Scenario 13: Transitive with diamond — A→B, A→C, B→C: transitive(A) = "C B" (C once)
-# MG5: if dedup removed in transitive, C would appear twice
+# if dedup removed in transitive, C would appear twice
 # ---------------------------------------------------------------------------
 @test "depgraph: transitive diamond dedup — A→B, A→C, B→C: C appears once" {
     export _DEPGRAPH_CONTAINERS_OVERRIDE="containerA containerB containerC"
@@ -308,9 +308,9 @@ _write_lineage() {
 # It then asserts the result contains php and debian but NOT any banner token.
 #
 # Mutation guards:
-#   MG-F2a: reverting 2>/dev/null → 2>&1: banner leaks into output; "Found"
+#   reverting 2>/dev/null → 2>&1: banner leaks into output; "Found"
 #            appears in the valid-container set and this test fails.
-#   MG-F2b: removing the grep -E filter: banner tokens on stdout (if any)
+#   removing the grep -E filter: banner tokens on stdout (if any)
 #            would not be stripped; test would catch future regressions.
 # ---------------------------------------------------------------------------
 
@@ -666,9 +666,9 @@ _write_lineage() {
 # for both the lineage-file path and the config.yaml fallback path.
 #
 # Mutation guards:
-#   MG-D2a: checking [[ -n "$parent" ]] only (ignoring _iref_rc) → rc=2 swallowed
+#   checking [[ -n "$parent" ]] only (ignoring _iref_rc) → rc=2 swallowed
 #            (test "owner failure in lineage path → get_deps exits non-zero")
-#   MG-D2b: same for config.yaml fallback path
+#   same for config.yaml fallback path
 #            (test "owner failure in config.yaml fallback path → get_deps exits non-zero")
 # ---------------------------------------------------------------------------
 
@@ -820,10 +820,10 @@ _write_lineage() {
 # that a non-zero rc from _depgraph_get_deps NEVER silently continues.
 #
 # Mutation guards:
-#   MG-S1: restoring `-eq 2` in _depgraph_get_deps_transitive → status=0 on
+#   restoring `-eq 2` in _depgraph_get_deps_transitive → status=0 on
 #           rc=1 input, test fails — catches regression.
-#   MG-S2: restoring `-eq 2` in _depgraph_get_consumers → same.
-#   MG-S3: restoring `-eq 2` in _dfs_cycle → same.
+#   restoring `-eq 2` in _depgraph_get_consumers → same.
+#   restoring `-eq 2` in _dfs_cycle → same.
 # ---------------------------------------------------------------------------
 
 _make_list_ok_listbuilds_fail() {
@@ -849,7 +849,7 @@ EOF
     chmod +x "$mock_root/make"
 }
 
-@test "DefectS: rc=1 from _depgraph_get_deps propagates through _depgraph_get_deps_transitive" {
+@test "rc=1 from _depgraph_get_deps propagates through _depgraph_get_deps_transitive" {
     # _depgraph_get_deps returns rc=2 when list-builds fails (Defect Q path).
     # _depgraph_get_deps_transitive's old guard (-eq 2 only) already catches rc=2,
     # but with the new -ne 0 guard it also catches rc=1 if _depgraph_get_deps ever
@@ -874,7 +874,7 @@ EOF
     [[ "$output" == *"::error::"* ]]
 }
 
-@test "DefectS: rc=1 from _depgraph_get_deps propagates through _depgraph_get_consumers" {
+@test "rc=1 from _depgraph_get_deps propagates through _depgraph_get_consumers" {
     local mock_root="$TEST_TEMP_DIR/defects_consumers"
     _make_list_ok_listbuilds_fail "$mock_root"
     _write_lineage "wordpress" "6.9.4-alpine" "ghcr.io/oorabona/php:latest"
@@ -894,7 +894,7 @@ EOF
     [[ "$output" == *"::error::"* ]]
 }
 
-@test "DefectS: rc=1 from _depgraph_get_deps propagates through _depgraph_validate_no_cycles" {
+@test "rc=1 from _depgraph_get_deps propagates through _depgraph_validate_no_cycles" {
     local mock_root="$TEST_TEMP_DIR/defects_cycles"
     _make_list_ok_listbuilds_fail "$mock_root"
     _write_lineage "wordpress" "6.9.4-alpine" "ghcr.io/oorabona/php:latest"
@@ -981,8 +981,8 @@ EOF
 # that are never resolved.
 #
 # Mutation guards:
-#   MG-N1: removing the active-tag filter → stale-tag test gets dep=php (FAIL)
-#   MG-N2: fail-closed instead of fail-open → fallback test returns empty output (FAIL)
+#   removing the active-tag filter → stale-tag test gets dep=php (FAIL)
+#   fail-closed instead of fail-open → fallback test returns empty output (FAIL)
 # ---------------------------------------------------------------------------
 
 @test "depgraph: stale lineage tag excluded from deps when active filter is set (Defect N)" {
@@ -1074,9 +1074,9 @@ EOF
 # the caller skips this container for this cron run.
 #
 # Mutation guards:
-#   MG-Q1: restoring "return 0" on list-builds failure → test expecting rc=2
+#   restoring "return 0" on list-builds failure → test expecting rc=2
 #           gets rc=0, catching the regression immediately.
-#   MG-Q2: restoring ::warning:: instead of ::error:: → test checking stderr
+#   restoring ::warning:: instead of ::error:: → test checking stderr
 #           for "error" fails, catching the annotation severity regression.
 # ---------------------------------------------------------------------------
 
@@ -1198,9 +1198,9 @@ EOF
 # cascade:waiting-for-<dep> protection.
 #
 # Mutation guards:
-#   MG-P1: reverting found_any=true to before the placeholder check →
+#   reverting found_any=true to before the placeholder check →
 #           test 1 (the bug) returns "" instead of "debian" (FAIL).
-#   MG-P2: treating ${REMOTE_CR}/... as a placeholder →
+#   treating ${REMOTE_CR}/... as a placeholder →
 #           test 2 (REMOTE_CR authoritative) returns "" instead of "debian" (FAIL).
 # ---------------------------------------------------------------------------
 
@@ -1246,7 +1246,7 @@ EOF
     mkdir -p "$isolated_dir/web-shell"
 
     # Lineage file: ${REMOTE_CR}/debian:trixie — authoritative
-    # SC2016: single-quote stores literal ${REMOTE_CR} string intentionally
+    # single-quote stores literal ${REMOTE_CR} string intentionally
     # shellcheck disable=SC2016
     printf '{"container":"web-shell","tag":"1.7.7","base_image_ref":"${REMOTE_CR}/debian:trixie","base_image_digest":"sha256:%064d"}' 0 \
         > "${_DEPGRAPH_LINEAGE_DIR}/web-shell-1.7.7.json"
@@ -1354,11 +1354,11 @@ EOF
 # run as a UNION with any lineage-derived deps → debian recovered.
 #
 # Mutation guards:
-#   MG-R1: reverting _saw_nonauthoritative flag + restoring "found_any==false" guard →
+#   reverting _saw_nonauthoritative flag + restoring "found_any==false" guard →
 #           test 1 (mixed external+placeholder) returns "" instead of "debian" (FAIL).
-#   MG-R2: removing dedup in config.yaml union path →
+#   removing dedup in config.yaml union path →
 #           test 2 (mixed, same parent) returns count>1 instead of "1" (FAIL).
-#   MG-R3: making _saw_nonauthoritative suppress found_any check →
+#   making _saw_nonauthoritative suppress found_any check →
 #           test 3 (all-authoritative no-regression) leaks config.yaml dep (FAIL).
 # ---------------------------------------------------------------------------
 
@@ -1508,10 +1508,10 @@ EOF
 # PROJECT_ROOT plays no role in selecting which code is sourced.
 #
 # Mutation guards:
-#   MG-SH1: reverting to `source "${PROJECT_ROOT}/helpers/lineage-utils.sh"` →
+#   reverting to `source "${PROJECT_ROOT}/helpers/lineage-utils.sh"` →
 #            test 1 (bogus PROJECT_ROOT, source succeeds + function available) FAILS:
 #            source errors out because /tmp/helpers/lineage-utils.sh doesn't exist.
-#   MG-SH2: same revert → test 2 (structural grep) FAILS: pattern not present.
+#   same revert → test 2 (structural grep) FAILS: pattern not present.
 # ---------------------------------------------------------------------------
 
 @test "depgraph: source-hijack prevention — bogus PROJECT_ROOT does not break sourcing of lineage-utils.sh" {
@@ -1567,15 +1567,15 @@ EOF
 # fail-closed list-builds call) when no non-sidecar lineage files exist.
 #
 # Mutation guards:
-#   MG-F2a: removing the no-lineage short-circuit (always running active-tag
+#   removing the no-lineage short-circuit (always running active-tag
 #            filter) → when list-builds returns empty, function returns rc=2
 #            instead of proceeding to config.yaml (test catches it).
-#   MG-F2b: weakening the Defect-N fail-closed (lineage-present + list-builds
+#   weakening the Defect-N fail-closed (lineage-present + list-builds
 #            failure → not rc=2) → stale retired-variant lineage could be
 #            resurrected (second test catches it).
 # ---------------------------------------------------------------------------
 
-@test "F2: no-lineage new container with config.yaml internal dep → returns dep via config fallback (exit 0)" {
+@test "no-lineage new container with config.yaml internal dep → returns dep via config fallback (exit 0)" {
     # Container "newcontainer" has NO lineage files (never built).
     # Its config.yaml references an internal base → dep must be returned via config fallback.
     # Uses ${REMOTE_CR}/debian pattern (matches the config-fallback grep and resolves
@@ -1605,7 +1605,7 @@ CONFIGEOF
     [ "$output" = "debian" ]
 }
 
-@test "F2: no-lineage container with no config.yaml internal dep → empty deps, exit 0 (not rc=2)" {
+@test "no-lineage container with no config.yaml internal dep → empty deps, exit 0 (not rc=2)" {
     # Container has no lineage and no internal dep in config.yaml → empty string, exit 0.
     local fake_root="$TEST_TEMP_DIR/fake-root-f2b"
     mkdir -p "$fake_root/newcontainer"
@@ -1702,9 +1702,9 @@ STUB
 #   separate command.
 #
 # Mutation guards:
-#   MG-INJ1: removing _escape_gha_command wrap on _file_tag at the ::notice::
+#   removing _escape_gha_command wrap on _file_tag at the ::notice::
 #             line → test 1 FAILS (raw newline + injected command on stderr).
-#   MG-INJ2: removing _escape_gha_command wrap on base_ref at the ::error::
+#   removing _escape_gha_command wrap on base_ref at the ::error::
 #             line → test 2 FAILS (raw "::set-env::" appears as own command).
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -7,10 +7,10 @@
 # JSON responses from tests/fixtures/digest-drift/*/responses/.
 #
 # Mutation guards documented per spec §6:
-#   MG1: Remove digest comparison → debian reports drift (false positive)
-#   MG2: Remove sidecar filter → foo's variants array has 3 entries
-#   MG3: Remove per-container grouping → result has 2 records instead of 1
-#   MG4: Remove digest shape validation → invalid digest accepted
+#   Remove digest comparison → debian reports drift (false positive)
+#   Remove sidecar filter → foo's variants array has 3 entries
+#   Remove per-container grouping → result has 2 records instead of 1
+#   Remove digest shape validation → invalid digest accepted
 #
 # BDD scenario covered explicitly: "Per-container grouping (2×2 mutation guard)"
 # per spec §4 Scenario 6 — this test directly implements the 2×2 grouping assertion.
@@ -139,7 +139,7 @@ STUB_EOF
 # Alpine recorded=aaa...→current=ccc... (drift), Debian recorded==current (unchanged)
 # Sidecar foo-1.0-alpine.sbom.json must be excluded
 # ---------------------------------------------------------------------------
-@test "scenario-1: alpine reports drift, debian reports unchanged, sidecar excluded" {
+@test "alpine reports drift, debian reports unchanged, sidecar excluded" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -187,9 +187,9 @@ STUB_EOF
     [[ "$result" != *"sbom"* ]]
 }
 
-# MG3: Per-container grouping — removing it would produce 2 records instead of 1
+# Per-container grouping — removing it would produce 2 records instead of 1
 # This test directly guards against that regression.
-@test "scenario-1: output length is 1 (per-container grouping guard MG3)" {
+@test "output length is 1 (per-container grouping guard MG3)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -201,8 +201,8 @@ STUB_EOF
     [ "$length" -eq 1 ]
 }
 
-# MG1: Digest comparison — if comparison were removed, debian would also report drift
-@test "scenario-1: debian status is unchanged (digest comparison guard MG1)" {
+# Digest comparison — if comparison were removed, debian would also report drift
+@test "debian status is unchanged (digest comparison guard MG1)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -215,8 +215,8 @@ STUB_EOF
     [ "$debian_status" = "unchanged" ]
 }
 
-# MG2: Sidecar filter — removing it would produce 3 variants instead of 2
-@test "scenario-1: foo has exactly 2 variants (sidecar exclusion guard MG2)" {
+# Sidecar filter — removing it would produce 3 variants instead of 2
+@test "foo has exactly 2 variants (sidecar exclusion guard MG2)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -228,8 +228,8 @@ STUB_EOF
     [ "$foo_variants" -eq 2 ]
 }
 
-# MG4: Digest shape validation — valid digests must match ^sha256:[a-f0-9]{64}$
-@test "scenario-1: all digests in output match sha256:[a-f0-9]{64} (shape guard MG4)" {
+# Digest shape validation — valid digests must match ^sha256:[a-f0-9]{64}$
+@test "all digests in output match sha256:[a-f0-9]{64} (shape guard MG4)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-1"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -251,7 +251,7 @@ STUB_EOF
 # foo: 2 variants (alpine + debian), bar: 2 variants (ubuntu + rocky) — all drifted
 # Output must have length 2 (grouped by container, NOT by variant)
 # ---------------------------------------------------------------------------
-@test "scenario-2: 2x2 grouping — output length is 2 (one per container)" {
+@test "2x2 grouping — output length is 2 (one per container)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -265,7 +265,7 @@ STUB_EOF
     [ "$length" -eq 2 ]
 }
 
-@test "scenario-2: foo record contains 2 variants" {
+@test "foo record contains 2 variants" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -278,7 +278,7 @@ STUB_EOF
     [ "$foo_count" -eq 2 ]
 }
 
-@test "scenario-2: bar record contains 2 variants" {
+@test "bar record contains 2 variants" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -937,7 +937,7 @@ STUB
 # returns).  The fixture is the imagetools Manifest descriptor — a flat object
 # with .digest, .mediaType, .size (no .manifests[] wrapper at the outer level).
 # ---------------------------------------------------------------------------
-@test "r5-fix1: probe extracts digest from imagetools Manifest descriptor format" {
+@test "probe extracts digest from imagetools Manifest descriptor format" {
     # Fixture: imagetools --format '{{json .Manifest}}' returns a flat OCI descriptor
     # with .digest at the top level.  This is different from the `docker manifest
     # inspect` format which has .manifests[] and a top-level .digest only in the
@@ -990,7 +990,7 @@ EOF
 # must NOT inject a second GHA workflow command.  The escaped form (%0A) must
 # appear in the ::error:: line instead of a raw newline.
 # ---------------------------------------------------------------------------
-@test "r5-fix2: newline in base_image_ref is escaped in ::error:: output" {
+@test "newline in base_image_ref is escaped in ::error:: output" {
     # Lineage file with a base_image_ref containing an embedded newline (simulates
     # a crafted/corrupted lineage entry).  When the registry probe fails, the error
     # line must escape the newline as %0A to prevent GHA command injection.
@@ -1025,7 +1025,7 @@ EOF
 # baseline migration picks it up), while the same entry must be SKIPPED (result=[])
 # in normal mode (to prevent bogus drift PRs).
 # ---------------------------------------------------------------------------
-@test "r5-fix4: baseline-only mode emits legacy for placeholder-ref + missing-digest entry" {
+@test "baseline-only mode emits legacy for placeholder-ref + missing-digest entry" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
     # Pre-#530 entry: placeholder ref, no digest field at all
@@ -1050,7 +1050,7 @@ EOF
     [ "$status_val" = "legacy" ]
 }
 
-@test "r5-fix4: normal mode still skips placeholder-ref + missing-digest entry (no regression)" {
+@test "normal mode still skips placeholder-ref + missing-digest entry (no regression)" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
     # Same pre-#530 entry
@@ -1078,7 +1078,7 @@ EOF
 # verifies that multi-container drift produces one record per container so
 # each matrix entry (and its own concurrency lane) is distinct.
 # ---------------------------------------------------------------------------
-@test "r6-fix1: two drifted containers produce two separate container records" {
+@test "two drifted containers produce two separate container records" {
     export _VALID_CONTAINERS_OVERRIDE="foo
 bar"
 
@@ -1162,7 +1162,7 @@ STUB_EOF
 # This test verifies the CSV is derivable from the detector output and contains
 # all drifted containers separated by commas (no spaces, no brackets).
 # ---------------------------------------------------------------------------
-@test "r10: drift_containers_csv derivable from detector output — CSV form matches JSON list" {
+@test "drift_containers_csv derivable from detector output — CSV form matches JSON list" {
     export _VALID_CONTAINERS_OVERRIDE="foo
 bar"
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
@@ -1248,7 +1248,7 @@ STUB_EOF
 # is gone — this test guards that the script-level emission (the surviving
 # path) is correctly escaped.
 # ---------------------------------------------------------------------------
-@test "r6-fix2: percent-encoded newline in base_image_ref is escaped in script stderr output" {
+@test "percent-encoded newline in base_image_ref is escaped in script stderr output" {
     # A crafted base_image_ref containing %0A (percent-encoded newline).
     # _sanitize_for_json strips literal \n/\r but NOT %0A, so %0A survives
     # into error_reason.  The script must escape the ::error:: line via
@@ -1279,7 +1279,7 @@ STUB_EOF
 # indirectly: run the script in a restricted TMPDIR with a known prefix and
 # check that no files with that prefix remain after the script exits.
 # ---------------------------------------------------------------------------
-@test "r6-fix3: no temp files left behind after empty-raw probe failure" {
+@test "no temp files left behind after empty-raw probe failure" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     local isolated_tmp="$TEST_TEMP_DIR/probe-tmp"
     mkdir -p "$lineage_dir" "$isolated_tmp"
@@ -1312,7 +1312,7 @@ STUB_EOF
     [ "$leaked" -eq 0 ]
 }
 
-@test "r6-fix3: no temp files left behind after digest-extraction failure" {
+@test "no temp files left behind after digest-extraction failure" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     local isolated_tmp="$TEST_TEMP_DIR/probe-tmp2"
     mkdir -p "$lineage_dir" "$isolated_tmp"
@@ -1350,7 +1350,7 @@ STUB_EOF
 # non-hex chars) must be refused and NOT embedded in label_args.  Only
 # ^sha256:[a-f0-9]{64}$ passes.
 # ---------------------------------------------------------------------------
-@test "r7-fix1a: malformed digest (spaces/injection) is NOT added to label_args" {
+@test "malformed digest (spaces/injection) is NOT added to label_args" {
     # Exercise _resolve_base_image from build-container.sh with a docker stub that
     # returns a malformed digest — verify label_args stays clean.
     local test_container_dir="$TEST_TEMP_DIR/r7fix1a"
@@ -1403,7 +1403,7 @@ MOCK
     }
 }
 
-@test "r7-fix1b: well-formed sha256 digest is embedded in label_args" {
+@test "well-formed sha256 digest is embedded in label_args" {
     # Positive case: ^sha256:[a-f0-9]{64}$ must still be accepted.
     local test_container_dir="$TEST_TEMP_DIR/r7fix1b"
     mkdir -p "$test_container_dir/bin"
@@ -1458,7 +1458,7 @@ MOCK
 # This test verifies the script emits status:error that a downstream
 # error_count check can detect, not that the script itself exits non-zero.
 # ---------------------------------------------------------------------------
-@test "r7-fix2: probe failure emits status:error in JSON (re-detect error_count detectable)" {
+@test "probe failure emits status:error in JSON (re-detect error_count detectable)" {
     local lineage_dir="$TEST_TEMP_DIR/r7fix2/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -1494,7 +1494,7 @@ EOF
 # entries correctly populates only the errored containers in the CSV output,
 # and that the drifting containers are NOT included in error_containers_csv.
 # ---------------------------------------------------------------------------
-@test "DefectL: error_containers_csv jq — error containers appear, drift containers do not" {
+@test "error_containers_csv jq — error containers appear, drift containers do not" {
     # Simulate the drift_json that the workflow step has in memory.
     # foo = all variants errored; bar = drifting; baz = stable.
     local drift_json
@@ -1520,7 +1520,7 @@ EOF
     [[ "$error_csv" != *"baz"* ]]
 }
 
-@test "DefectL: error_containers_csv jq — mixed error+drift container appears in error CSV" {
+@test "error_containers_csv jq — mixed error+drift container appears in error CSV" {
     # A container with both error and drift variants must appear in error_containers_csv.
     local drift_json
     drift_json=$(cat <<'EOF'
@@ -1537,7 +1537,7 @@ EOF
     [[ "$error_csv" == *"php"* ]]
 }
 
-@test "DefectL: error_containers_csv jq — empty when no errors" {
+@test "error_containers_csv jq — empty when no errors" {
     # When all containers are stable or drifting (no errors), error_containers_csv is empty.
     local drift_json
     drift_json=$(cat <<'EOF'
@@ -1562,7 +1562,7 @@ EOF
 # the script must exit 2 — NOT silently treat all containers as invalid and
 # return "[]" (false no-drift).
 # ---------------------------------------------------------------------------
-@test "r7-fix4a: detect script exits 2 when _VALID_CONTAINERS_OVERRIDE unset and make list fails" {
+@test "detect script exits 2 when _VALID_CONTAINERS_OVERRIDE unset and make list fails" {
     local fake_root="$TEST_TEMP_DIR/r7fix4a"
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
@@ -1602,7 +1602,7 @@ STUB
     [ "$rc" -eq 2 ]
 }
 
-@test "r7-fix4b: detect script exits 2 when make list returns empty string" {
+@test "detect script exits 2 when make list returns empty string" {
     # A make list that succeeds but prints nothing (empty output) is equally invalid.
     local fake_root="$TEST_TEMP_DIR/r7fix4b"
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
@@ -1639,7 +1639,7 @@ STUB
     [ "$rc" -eq 2 ]
 }
 
-@test "r7-fix4c: _VALID_CONTAINERS_OVERRIDE non-empty bypasses make list check" {
+@test "_VALID_CONTAINERS_OVERRIDE non-empty bypasses make list check" {
     # Test hook: _VALID_CONTAINERS_OVERRIDE set to a non-empty value must bypass
     # the ./make list call entirely (existing pre-r7 behavior preserved for tests).
     local lineage_dir="$TEST_TEMP_DIR/r7fix4c/.build-lineage"
@@ -1672,7 +1672,7 @@ EOF
 # Regression guard: ./make list returning empty must cause exit 2, not
 # silently skip with exit 0 (which would hide the tooling failure).
 # ---------------------------------------------------------------------------
-@test "r7-fix4d: update-last-rebuild exits 2 when make list returns empty" {
+@test "update-last-rebuild exits 2 when make list returns empty" {
     local fake_root="$TEST_TEMP_DIR/r7fix4d"
     local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
     mkdir -p "$fake_root/scripts"
@@ -1700,7 +1700,7 @@ STUB
 # first line because -R without -n consumes one line before [inputs] runs.
 # Adding -n makes jq use null as its initial input, so [inputs] sees all lines.
 # ---------------------------------------------------------------------------
-@test "r8-fix1: jq -Rnc collects all containers including alphabetically-first" {
+@test "jq -Rnc collects all containers including alphabetically-first" {
     # Simulate ./make list output: 3 containers in alphabetical order.
     # The first one (ansible) was previously dropped by jq -Rc (no -n).
     local make_output
@@ -1730,7 +1730,7 @@ STUB
 # prevent container "foo"'s matrix job from creating its drift PR.
 # The jq filter must restrict error counting to the matrix container only.
 # ---------------------------------------------------------------------------
-@test "r8-fix2: error_count scoped to matrix container — bar error does not block foo" {
+@test "error_count scoped to matrix container — bar error does not block foo" {
     # Synthetic drift JSON: foo has drift (clean), bar has an error variant
     local drift_json
     drift_json=$(cat <<'EOF'
@@ -1782,7 +1782,7 @@ EOF
 # (returned by ./make list-builds) must be silently skipped.  Only active-tag
 # entries should be reported.
 # ---------------------------------------------------------------------------
-@test "r9-fix1a: stale tag in lineage is skipped; active tag is reported" {
+@test "stale tag in lineage is skipped; active tag is reported" {
     local lineage_dir="$TEST_TEMP_DIR/r9fix1a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -1830,7 +1830,7 @@ EOF
     [ "$reported_tag" = "2.0" ]
 }
 
-@test "r9-fix1b: stale tag skip emits ::notice:: to stderr" {
+@test "stale tag skip emits ::notice:: to stderr" {
     local lineage_dir="$TEST_TEMP_DIR/r9fix1b/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -1862,7 +1862,7 @@ EOF
 # Fix r9-2: tag sanitization — backticks and pipes in variant_tag are escaped
 # in GHA ::notice:: output (via _escape_gha_command applied at extraction).
 # ---------------------------------------------------------------------------
-@test "r9-fix2: update-last-rebuild escapes backticks and pipes in variant_tag" {
+@test "update-last-rebuild escapes backticks and pipes in variant_tag" {
     # Regression guard: a poisoned variant_tag containing backticks or pipes in the
     # drift JSON must be escaped before embedding in LAST_REBUILD.md markdown.
     local fake_root="$TEST_TEMP_DIR/r9fix2"
@@ -1906,7 +1906,7 @@ STUB
 # ---------------------------------------------------------------------------
 # Fix r9-3: container name with embedded newline is rejected before grep check
 # ---------------------------------------------------------------------------
-@test "r9-fix3: container name with embedded newline is rejected before grep validation" {
+@test "container name with embedded newline is rejected before grep validation" {
     local lineage_dir="$TEST_TEMP_DIR/r9fix3/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -1941,7 +1941,7 @@ bar" \
 # produce an empty array, and the shell-level check must detect length == 0.
 # This mirrors the fix applied in upstream-monitor.yaml.
 # ---------------------------------------------------------------------------
-@test "r9-fix4: empty make_list_out is detected before jq pipeline" {
+@test "empty make_list_out is detected before jq pipeline" {
     # Simulate the fixed pattern: the guard checks the raw string BEFORE piping
     # into jq -Rnc, because a here-string of "" sends a newline to jq which
     # produces [""] (length 1) — false non-empty.
@@ -1952,7 +1952,7 @@ bar" \
     [ -z "$trimmed" ]
 }
 
-@test "r9-fix4b: jq -Rnc on non-empty make list output is non-zero length" {
+@test "jq -Rnc on non-empty make list output is non-zero length" {
     local make_list_out
     make_list_out=$(printf 'ansible\ndebian\nphp\n')
 
@@ -1974,7 +1974,7 @@ bar" \
 # infinite drift-PR loops.
 # ---------------------------------------------------------------------------
 
-@test "r10-fix2a: list-builds failure → container emits error record (r29 Finding 2)" {
+@test "list-builds failure → container emits error record (r29 Finding 2)" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix2a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2015,7 +2015,7 @@ EOF
     [ "$err_reason" = "active_tags_unavailable" ]
 }
 
-@test "r10-fix2b: script contains fail-closed warning text (code audit)" {
+@test "script contains fail-closed warning text (code audit)" {
     # The production list-builds failure path (without _VALID_CONTAINERS_OVERRIDE)
     # cannot be exercised in tests without a full project context (the detector derives
     # PROJECT_ROOT from BASH_SOURCE[0] at startup, so env-var override is impossible).
@@ -2025,7 +2025,7 @@ EOF
     grep -q 'fail-closed' "${DETECTOR_SCRIPT}"
 }
 
-@test "r10-fix2c: stale tag still skipped when active-tags succeeds (no regression)" {
+@test "stale tag still skipped when active-tags succeeds (no regression)" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix2c/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2076,7 +2076,7 @@ EOF
 # entry without calling the registry.
 # ---------------------------------------------------------------------------
 
-@test "r10-fix3a: poisoned base_image_ref (evil.com) is rejected without probe" {
+@test "poisoned base_image_ref (evil.com) is rejected without probe" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix3a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2129,7 +2129,7 @@ STUB
     [ "$err_reason" = "untrusted_ref" ]
 }
 
-@test "r10-fix3b: valid ghcr.io ref passes validation and is probed normally" {
+@test "valid ghcr.io ref passes validation and is probed normally" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix3b/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2159,7 +2159,7 @@ EOF
     [ "$status" = "drift" ]
 }
 
-@test "r10-fix3c: Docker Hub bare name passes validation and is probed normally" {
+@test "Docker Hub bare name passes validation and is probed normally" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix3c/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2187,7 +2187,7 @@ EOF
     [ "$status" = "drift" ]
 }
 
-@test "r10-fix3d: mcr.microsoft.com ref passes validation" {
+@test "mcr.microsoft.com ref passes validation" {
     local lineage_dir="$TEST_TEMP_DIR/r10fix3d/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2225,7 +2225,7 @@ EOF
 # containers.
 # ---------------------------------------------------------------------------
 
-@test "r17-fix-a: docker.io/library/* ref passes validation and is probed normally" {
+@test "docker.io/library/* ref passes validation and is probed normally" {
     local lineage_dir="$TEST_TEMP_DIR/r17fixa/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2254,7 +2254,7 @@ EOF
     [ "$status" = "drift" ]
 }
 
-@test "r17-fix-b: docker.io/oorabona/* ref passes validation and is probed normally" {
+@test "docker.io/oorabona/* ref passes validation and is probed normally" {
     local lineage_dir="$TEST_TEMP_DIR/r17fixb/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2556,7 +2556,7 @@ EOF
 # called 3 times in sequence; it verifies (a) the script completes without
 # "unbound variable" error and (b) all 3 entries produce drift output.
 # ---------------------------------------------------------------------------
-@test "r18-fix: multi-entry probe sequence completes without unbound-variable crash" {
+@test "multi-entry probe sequence completes without unbound-variable crash" {
     local lineage_dir="$TEST_TEMP_DIR/r18fix/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2611,7 +2611,7 @@ gamma" \
 # The fix adds an explicit leading-slash guard at function entry.
 # ---------------------------------------------------------------------------
 
-@test "s1-fix: leading-slash ref /alpine:3.21 is rejected by _validate_image_ref" {
+@test "leading-slash ref /alpine:3.21 is rejected by _validate_image_ref" {
     local lineage_dir="$TEST_TEMP_DIR/s1fix/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2663,7 +2663,7 @@ STUB
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# r21-A: grep option injection — variant tag '--help'
+# grep option injection — variant tag '--help'
 # A lineage tag value of '--help' must NOT be treated as a grep option.
 # The stale-tag filter must reject/skip the entry (not match as active),
 # not print grep help text and exit 0 (which would accept the tag).
@@ -2671,7 +2671,7 @@ STUB
 # grep treats '--help' as an option → prints help and exits 0 → probe is
 # called → this test fails.
 # ---------------------------------------------------------------------------
-@test "r21-A: variant tag '--help' is treated as literal string, not grep option" {
+@test "variant tag '--help' is treated as literal string, not grep option" {
     local lineage_dir="$TEST_TEMP_DIR/r21a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2710,13 +2710,13 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
-# r21-A2: grep option injection — container name '--help' in lineage JSON
+# grep option injection — container name '--help' in lineage JSON
 # A container field of '--help' in the lineage must be rejected as not in
 # ./make list, not accepted because grep printed help text and exited 0.
 # Mutation guard: removing `--` from `grep -qxF -- "$container"` causes
 # grep to treat '--help' as an option → exits 0 → probe would be called.
 # ---------------------------------------------------------------------------
-@test "r21-A2: container name '--help' in lineage is rejected as invalid (not a grep option)" {
+@test "container name '--help' in lineage is rejected as invalid (not a grep option)" {
     local lineage_dir="$TEST_TEMP_DIR/r21a2/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2754,7 +2754,7 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
-# r21-C: localhost allowlist bypass
+# localhost allowlist bypass
 # 'localhost/foo:1.0' must be rejected by _validate_image_ref: Docker/OCI
 # treats bare 'localhost' as an explicit registry host (not a Docker Hub org),
 # so it must hit the allowlist check and be denied.
@@ -2762,7 +2762,7 @@ STUB
 # to fall through to the "no dot, no colon → Docker Hub org" path → return 0
 # → probe would be called.
 # ---------------------------------------------------------------------------
-@test "r21-C: localhost/foo:1.0 is rejected by _validate_image_ref (not a Docker Hub org)" {
+@test "localhost/foo:1.0 is rejected by _validate_image_ref (not a Docker Hub org)" {
     local lineage_dir="$TEST_TEMP_DIR/r21c/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2801,7 +2801,7 @@ STUB
     [ "$err_reason" = "untrusted_ref" ]
 }
 
-@test "r21-C: localhost:5000/foo:1.0 is rejected by _validate_image_ref (host:port localhost)" {
+@test "localhost:5000/foo:1.0 is rejected by _validate_image_ref (host:port localhost)" {
     local lineage_dir="$TEST_TEMP_DIR/r21c2/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2847,7 +2847,7 @@ STUB
 # so the operator sees the corruption explicitly rather than a bogus drift PR.
 # ---------------------------------------------------------------------------
 
-@test "r23-fix-a: short hex recorded_digest surfaces as error, not drift" {
+@test "short hex recorded_digest surfaces as error, not drift" {
     local lineage_dir="$TEST_TEMP_DIR/r23a/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2902,7 +2902,7 @@ STUB
     [ "$error_reason" = "malformed_recorded_digest" ]
 }
 
-@test "r23-fix-b: non-sha256 recorded_digest string surfaces as error, not drift" {
+@test "non-sha256 recorded_digest string surfaces as error, not drift" {
     local lineage_dir="$TEST_TEMP_DIR/r23b/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -2945,7 +2945,7 @@ STUB
     [ "$error_reason" = "malformed_recorded_digest" ]
 }
 
-@test "r23-fix-c: well-formed recorded_digest still reaches probe and compares normally" {
+@test "well-formed recorded_digest still reaches probe and compares normally" {
     local lineage_dir="$TEST_TEMP_DIR/r23c/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -3001,7 +3001,7 @@ STUB
 # (simulating what `./make list-builds <container> current` returns post-fix).
 # ---------------------------------------------------------------------------
 
-@test "r24-fix1a: upstream-pending scenario — lineage tag matches current published; drift detected" {
+@test "upstream-pending scenario — lineage tag matches current published; drift detected" {
     # Simulate: upstream just released 2.0 (future), but currently published is 1.0.
     # Lineage file records tag 1.0 (currently published).
     # _ACTIVE_TAGS_OVERRIDE_ is set to "1.0" (what `list-builds current` returns).
@@ -3051,7 +3051,7 @@ EOF
     [ "$status" = "drift" ]
 }
 
-@test "r24-fix1b: upstream-pending scenario — pre-fix simulation: tag 2.0 active rejects 1.0 as stale (no false-positive)" {
+@test "upstream-pending scenario — pre-fix simulation: tag 2.0 active rejects 1.0 as stale (no false-positive)" {
     # Validate the opposite: if active tags were set to "2.0" (the future/upstream state,
     # which is what the pre-fix `latest` resolution would have returned), then the 1.0
     # lineage entry is treated as stale and skipped — this is the false-negative the fix
@@ -3086,7 +3086,7 @@ EOF
     echo "$stderr_output" | grep -q "Skipping stale lineage entry"
 }
 
-@test "r24-fix2: empty-override (backward compat) bypasses stale filter — entry reaches probe stage" {
+@test "empty-override (backward compat) bypasses stale filter — entry reaches probe stage" {
     # When _ACTIVE_TAGS_OVERRIDE_myimage is set to an empty string, the filter logic
     # short-circuits (empty _active_tags → -n check fails → condition is false) and the
     # entry is NOT skipped.  This is the backward-compat path documented in the filter code.
@@ -3131,14 +3131,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# r25-A: GHA workflow-command escape — rejected container / tag values
+# GHA workflow-command escape — rejected container / tag values
 # Regression guard for Defect A (gate r25): the rejection-path ::warning::
 # must route poisoned values through _escape_gha_command, NOT printf '%q'.
 # A value containing a literal %0A must appear as %250A in the warning
 # (% → %25 then 0A suffix), not as a raw newline or %0A command separator.
 # A value embedding ::add-mask:: must not reintroduce that command.
 # ---------------------------------------------------------------------------
-@test "r25-A1: container name with literal %0A is not passed raw in ::warning::" {
+@test "container name with literal %0A is not passed raw in ::warning::" {
     # Build a lineage file where container field contains the literal string %0A
     # (percent-zero-A — a GHA encoded newline that would inject a new command).
     local lineage_dir="$TEST_TEMP_DIR/r25a1/.build-lineage"
@@ -3181,7 +3181,7 @@ EOF
     fi
 }
 
-@test "r25-A2: tag with newline cntrl char — ::warning:: must not contain raw newline after rejection" {
+@test "tag with newline cntrl char — ::warning:: must not contain raw newline after rejection" {
     # Build a lineage file with a tag containing an embedded newline (cntrl char).
     # The rejection path at the cntrl-char check must emit the value through
     # _escape_gha_command so the newline becomes %0A (literal percent-zero-A),
@@ -3216,7 +3216,7 @@ pathlib.Path('${lineage_dir}/foo-1.0.json').write_text(json.dumps(d))
 }
 
 # ---------------------------------------------------------------------------
-# r27-B: dash-prefix option injection in _validate_image_ref
+# dash-prefix option injection in _validate_image_ref
 #
 # A base_image_ref starting with '-' must be rejected by _validate_image_ref.
 # Without the guard, refs like '-h', '--config /tmp/x', or '-foo:1.0' flow to
@@ -3244,7 +3244,7 @@ _r27b_lineage_with_ref() {
         '}' > "$lineage_dir/foo-1.0.json"
 }
 
-@test "r27-B1: _validate_image_ref rejects '-h' (short option injection)" {
+@test "_validate_image_ref rejects '-h' (short option injection)" {
     local lineage_dir="$TEST_TEMP_DIR/r27b1/.build-lineage"
     _r27b_lineage_with_ref "$lineage_dir" "-h"
 
@@ -3271,7 +3271,7 @@ _r27b_lineage_with_ref() {
     [ "$err_reason" = "untrusted_ref" ]
 }
 
-@test "r27-B2: _validate_image_ref rejects '--config' (long option injection)" {
+@test "_validate_image_ref rejects '--config' (long option injection)" {
     local lineage_dir="$TEST_TEMP_DIR/r27b2/.build-lineage"
     _r27b_lineage_with_ref "$lineage_dir" "--config"
 
@@ -3297,7 +3297,7 @@ _r27b_lineage_with_ref() {
     [ "$err_reason" = "untrusted_ref" ]
 }
 
-@test "r27-B3: _validate_image_ref rejects '-foo:1.0' (dash-prefix with tag)" {
+@test "_validate_image_ref rejects '-foo:1.0' (dash-prefix with tag)" {
     local lineage_dir="$TEST_TEMP_DIR/r27b3/.build-lineage"
     _r27b_lineage_with_ref "$lineage_dir" "-foo:1.0"
 
@@ -3324,7 +3324,7 @@ _r27b_lineage_with_ref() {
 }
 
 # ---------------------------------------------------------------------------
-# r29-2: error records on list-builds failure (gate r29, Finding 2)
+# error records on list-builds failure (gate r29, Finding 2)
 #
 # When ./make list-builds fails or returns empty for a container, the
 # detector must emit one status:"error" record per known lineage entry
@@ -3332,7 +3332,7 @@ _r27b_lineage_with_ref() {
 # workflow surfaces the gap.
 # ---------------------------------------------------------------------------
 
-@test "r29-2: stub list-builds failure emits error record per lineage entry" {
+@test "stub list-builds failure emits error record per lineage entry" {
     local lineage_dir="$TEST_TEMP_DIR/r29-2/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -3388,7 +3388,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# r29-3: error record on rejected base_image_ref (gate r29, Finding 3)
+# error record on rejected base_image_ref (gate r29, Finding 3)
 #
 # When _validate_image_ref rejects a base_image_ref (untrusted registry,
 # dash-prefix, etc.), the detector must emit a status:"error" record with
@@ -3397,7 +3397,7 @@ EOF
 # → poisoned lineage left the workflow green.
 # ---------------------------------------------------------------------------
 
-@test "r29-3: untrusted registry base_image_ref emits error record with untrusted_ref reason" {
+@test "untrusted registry base_image_ref emits error record with untrusted_ref reason" {
     local lineage_dir="$TEST_TEMP_DIR/r29-3/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -3687,11 +3687,11 @@ EOF
 # the other containers must still appear with their normal records.
 #
 # Invariants:
-#   IV-F2a: overall exit code is 0 (not aborted)
-#   IV-F2b: failing container is surfaced as status:error, error_reason:dep_graph_unavailable
-#   IV-F2c: failing container does NOT have internal_deps field (no unsafe leaf)
-#   IV-F2d: succeeding container still appears with its normal drift/unchanged record
-#   IV-F2e: succeeding container IS NOT emitted as normal record with internal_deps:[]
+#   overall exit code is 0 (not aborted)
+#   failing container is surfaced as status:error, error_reason:dep_graph_unavailable
+#   failing container does NOT have internal_deps field (no unsafe leaf)
+#   succeeding container still appears with its normal drift/unchanged record
+#   succeeding container IS NOT emitted as normal record with internal_deps:[]
 #            (it has internal_deps because dep-graph succeeded for it)
 #
 # Strategy: patch helpers/dependency-graph.sh in a fake root so _depgraph_get_deps
@@ -3701,7 +3701,7 @@ EOF
 # NOT call ./make list-builds.  To force a per-container failure in the output-assembly
 # loop (line 696), we patch _depgraph_get_deps in the copied helper.
 # ---------------------------------------------------------------------------
-@test "F2: multi-container run — one dep-graph failure is isolated, other container proceeds" {
+@test "multi-container run — one dep-graph failure is isolated, other container proceeds" {
     local fake_root="$TEST_TEMP_DIR/depgraph-fail-multi"
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
@@ -3774,7 +3774,7 @@ STUB
         PROBE_CMD="$probe_stub" \
         bash scripts/detect-base-digest-drift.sh ".build-lineage" 2>/dev/null) || rc=$?
 
-    # IV-F2a: overall exit 0 — one container failure must not abort the run
+    # overall exit 0 — one container failure must not abort the run
     [ "$rc" -eq 0 ]
 
     # Output must be valid JSON
@@ -3784,7 +3784,7 @@ STUB
     total=$(printf '%s' "$result" | jq 'length')
     [ "$total" -eq 2 ]
 
-    # IV-F2b: failcontainer surfaced as status:error with dep_graph_unavailable reason
+    # failcontainer surfaced as status:error with dep_graph_unavailable reason
     fail_status=$(printf '%s' "$result" | \
         jq -r '.[] | select(.container == "failcontainer") | .variants[0].status')
     [ "$fail_status" = "error" ]
@@ -3793,17 +3793,17 @@ STUB
         jq -r '.[] | select(.container == "failcontainer") | .variants[0].error_reason')
     [ "$fail_reason" = "dep_graph_unavailable" ]
 
-    # IV-F2c: failcontainer does NOT have internal_deps (no unsafe empty-deps leaf)
+    # failcontainer does NOT have internal_deps (no unsafe empty-deps leaf)
     fail_has_deps=$(printf '%s' "$result" | \
         jq '.[] | select(.container == "failcontainer") | has("internal_deps")')
     [ "$fail_has_deps" = "false" ]
 
-    # IV-F2d: okcontainer appears with a normal drift record
+    # okcontainer appears with a normal drift record
     ok_status=$(printf '%s' "$result" | \
         jq -r '.[] | select(.container == "okcontainer") | .variants[0].status')
     [ "$ok_status" = "drift" ]
 
-    # IV-F2e: okcontainer has internal_deps field (dep-graph succeeded) with empty array (no internal refs)
+    # okcontainer has internal_deps field (dep-graph succeeded) with empty array (no internal refs)
     ok_has_deps=$(printf '%s' "$result" | \
         jq '.[] | select(.container == "okcontainer") | has("internal_deps")')
     [ "$ok_has_deps" = "true" ]
@@ -3900,7 +3900,7 @@ EOF
 # Mutation guard: removing the charset gate causes the metachar container to
 # appear in the output (the test catches the regression).
 # ---------------------------------------------------------------------------
-@test "F1a: container name with semicolon (web;rm) is rejected, excluded from output" {
+@test "container name with semicolon (web;rm) is rejected, excluded from output" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage-f1a"
     mkdir -p "$lineage_dir"
 
@@ -3931,7 +3931,7 @@ EOF
     grep -q '::warning::' "$stderr_log"
 }
 
-@test "F1a: container name with only valid chars (web-shell) passes the charset gate" {
+@test "container name with only valid chars (web-shell) passes the charset gate" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage-f1a-valid"
     mkdir -p "$lineage_dir"
 
@@ -3977,7 +3977,7 @@ EOF
 # Before Fix 3, _DEPGRAPH_LINEAGE_DIR was never set by the detector, so the
 # helper fell back to PROJECT_ROOT/.build-lineage regardless of the CLI arg.
 # ---------------------------------------------------------------------------
-@test "F3: alternate LINEAGE_DIR is propagated to dep-graph — deps reflect alt-dir lineage" {
+@test "alternate LINEAGE_DIR is propagated to dep-graph — deps reflect alt-dir lineage" {
     # Alt lineage dir: contains a wordpress entry whose base is php (internal dep).
     # Uses ghcr.io/oorabona/php:8.3 with GITHUB_REPOSITORY_OWNER=oorabona so
     # _depgraph_is_internal_ref can classify it without a git remote lookup.
@@ -4031,7 +4031,7 @@ php" \
     [ "$php_present" = "true" ]
 }
 
-@test "F3: default LINEAGE_DIR (no alt arg) still works — dep-graph reads default dir" {
+@test "default LINEAGE_DIR (no alt arg) still works — dep-graph reads default dir" {
     # No positional arg → LINEAGE_DIR defaults to PROJECT_ROOT/.build-lineage.
     # Uses ghcr.io/oorabona/php:8.3 with GITHUB_REPOSITORY_OWNER=oorabona.
     local default_lineage="$TEST_TEMP_DIR/.build-lineage"
@@ -4119,7 +4119,7 @@ STUB_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MG5: Probe dedup — same base_image_ref probed at most once per run
+# Probe dedup — same base_image_ref probed at most once per run
 #
 # Scenario-3 has two foo variants (1.0-alpine and 1.0-alpine2) that both use
 # base_image_ref = "alpine:3.21".  With memoization, the real probe runs
@@ -4128,7 +4128,7 @@ STUB_EOF
 # Mutation guard: deleting the _DIGEST_CACHE lookup would make the counter
 # reach 2 (one per variant), failing the [ "$count" -eq 1 ] assertion.
 # ---------------------------------------------------------------------------
-@test "scenario-3: probe dedup — shared base_image_ref probed exactly once (guard MG5)" {
+@test "probe dedup — shared base_image_ref probed exactly once (guard MG5)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-3"
     local counter_dir="$TEST_TEMP_DIR/probe-counters"
     local probe_stub
@@ -4146,7 +4146,7 @@ STUB_EOF
     [ "$count" -eq 1 ]
 }
 
-@test "scenario-3: probe dedup — both variants still receive correct drift status (guard MG5)" {
+@test "probe dedup — both variants still receive correct drift status (guard MG5)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-3"
     local counter_dir="$TEST_TEMP_DIR/probe-counters-b"
     local probe_stub
@@ -4168,7 +4168,7 @@ STUB_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MG6: --container scope filter
+# --container scope filter
 #
 # Scenario-2 has two containers: foo (alpine + debian) and bar (ubuntu + rocky).
 # Running with --container foo must:
@@ -4179,7 +4179,7 @@ STUB_EOF
 # Mutation guard: deleting the `continue` skip would cause bar to appear in
 # output and the ubuntu/rocky counters to be non-zero.
 # ---------------------------------------------------------------------------
-@test "scenario-2: --container foo — output contains only foo (guard MG6)" {
+@test "--container foo — output contains only foo (guard MG6)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local counter_dir="$TEST_TEMP_DIR/mg6-counters"
     local probe_stub
@@ -4199,7 +4199,7 @@ STUB_EOF
     [ "$container_name" = "foo" ]
 }
 
-@test "scenario-2: --container foo — bar is absent from output (guard MG6)" {
+@test "--container foo — bar is absent from output (guard MG6)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -4212,7 +4212,7 @@ STUB_EOF
     [ "$bar_count" -eq 0 ]
 }
 
-@test "scenario-2: --container foo — bar's refs are NOT probed (skip before probe, guard MG6)" {
+@test "--container foo — bar's refs are NOT probed (skip before probe, guard MG6)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local counter_dir="$TEST_TEMP_DIR/mg6-skip-counters"
     local probe_stub
@@ -4227,7 +4227,7 @@ STUB_EOF
     [ ! -f "${counter_dir}/rockylinux-9" ]
 }
 
-@test "scenario-2: --container nonexistent — empty output (fail-safe)" {
+@test "--container nonexistent — empty output (fail-safe)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-2"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")
@@ -4243,7 +4243,7 @@ STUB_EOF
 # filename stem.  Scenario-4 has a file named "wrongname-1.0-alpine.json"
 # whose .container field is "foo".  A filename-based filter would miss it;
 # a field-based filter finds it.
-@test "scenario-4: --container foo finds entry whose filename stem is 'wrongname' (field-not-filename, guard MG6)" {
+@test "--container foo finds entry whose filename stem is 'wrongname' (field-not-filename, guard MG6)" {
     local fixture_dir="${FIXTURES_DIR_DRIFT}/scenario-4"
     local probe_stub
     probe_stub=$(_make_probe_stub "${fixture_dir}/responses")

--- a/tests/unit/detect-e2e-builds.bats
+++ b/tests/unit/detect-e2e-builds.bats
@@ -35,7 +35,7 @@ output_value() {
     sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
 }
 
-@test "S4: deleting e2e filtering would stop an enabled changed container from running its latest Linux suite" {
+@test "deleting e2e filtering would stop an enabled changed container from running its latest Linux suite" {
     builds=$(jq -cn '
       [
         {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"},
@@ -52,7 +52,7 @@ output_value() {
     [ "$(echo "$e2e_builds" | jq -r '.[0].tag')" = "v2.3.1-alpine" ]
 }
 
-@test "S5: deleting the e2e opt-in check would run a non-enabled container's suite" {
+@test "deleting the e2e opt-in check would run a non-enabled container's suite" {
     builds=$(jq -cn '
       [
         {"container":"github-runner","version":"2.330.0","tag":"latest-2.330.0","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
@@ -65,7 +65,7 @@ output_value() {
     [ "$e2e_builds" = "[]" ]
 }
 
-@test "S6: deleting the cell dedupe would run the same e2e variant twice for mixed source and test changes" {
+@test "deleting the cell dedupe would run the same e2e variant twice for mixed source and test changes" {
     build=$(jq -cn '
       {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}')
 
@@ -79,7 +79,7 @@ output_value() {
     [ "$(echo "$e2e_builds" | jq -r '.[0].container + ":" + .[0].tag')" = "sslh:v2.3.1-alpine" ]
 }
 
-@test "S7: deleting production isolation would schedule bake or matrix builds for a verification-only change" {
+@test "deleting production isolation would schedule bake or matrix builds for a verification-only change" {
     verification_builds=$(jq -cn '
       [
         {"container":"sslh","version":"v2.3.1","tag":"v2.3.1-alpine","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}
@@ -93,7 +93,7 @@ output_value() {
     [ "$(echo "$(output_value e2e_builds)" | jq 'length')" -eq 1 ]
 }
 
-@test "S8: deleting the e2e opt-in check would run a verification-only non-enabled container" {
+@test "deleting the e2e opt-in check would run a verification-only non-enabled container" {
     verification_builds=$(jq -cn '
       [
         {"container":"github-runner","version":"2.330.0","tag":"latest-2.330.0","is_default":true,"is_latest_version":true,"os":"linux","runner":"ubuntu-latest"}

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -65,7 +65,7 @@ SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
 }
 
-@test "S2: helper sourcing resolves from repo root" {
+@test "helper sourcing resolves from repo root" {
     run "$FIXTURE_REPO/tests/e2e-test.sh" --help
 
     [ "$status" -eq 0 ]
@@ -128,7 +128,7 @@ SH
     [[ "$output" == *"not executable"* ]]
 }
 
-@test "S6: fallback image discovery errors on zero matches" {
+@test "fallback image discovery errors on zero matches" {
     mkdir -p "$FIXTURE_REPO/debian"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
@@ -141,7 +141,7 @@ SH
     ! grep -q '^run ' "$DOCKER_LOG"
 }
 
-@test "S6: fallback image discovery errors on ambiguous image IDs" {
+@test "fallback image discovery errors on ambiguous image IDs" {
     mkdir -p "$FIXTURE_REPO/debian"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"

--- a/tests/unit/expand-retained-map.bats
+++ b/tests/unit/expand-retained-map.bats
@@ -34,10 +34,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-02: container-dir file (config.yaml) change triggers expansion
+# container-dir file (config.yaml) change triggers expansion
 # ---------------------------------------------------------------------------
 
-@test "SC-02: container-dir file (config.yaml) change for openresty → openresty:true" {
+@test "container-dir file (config.yaml) change for openresty → openresty:true" {
     echo "openresty/config.yaml" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -46,10 +46,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-03: container-dir file (LAST_REBUILD.md) change triggers expansion
+# container-dir file (LAST_REBUILD.md) change triggers expansion
 # ---------------------------------------------------------------------------
 
-@test "SC-03: container-dir file (LAST_REBUILD.md) change for openresty → openresty:true" {
+@test "container-dir file (LAST_REBUILD.md) change for openresty → openresty:true" {
     echo "openresty/LAST_REBUILD.md" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -58,10 +58,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-04: pull_request event → all containers true regardless of diff
+# pull_request event → all containers true regardless of diff
 # ---------------------------------------------------------------------------
 
-@test "SC-04: pull_request event → all containers true regardless of diff" {
+@test "pull_request event → all containers true regardless of diff" {
     # Only Dockerfile changed (not in trigger list), but PR event wins
     echo "openresty/Dockerfile" >> "$CHANGED_FILES"
     run compute_expand_retained_map "pull_request" "false" "$CHANGED_FILES" '["openresty"]'
@@ -71,10 +71,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-05: build_all_retained="true" → all containers true
+# build_all_retained="true" → all containers true
 # ---------------------------------------------------------------------------
 
-@test "SC-05: build_all_retained=true → all containers true" {
+@test "build_all_retained=true → all containers true" {
     # changed_files is empty; operator override must win
     run compute_expand_retained_map "push" "true" "$CHANGED_FILES" '["openresty","postgres"]'
     [ "$status" -eq 0 ]
@@ -85,10 +85,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-11: sibling-name collision — php-fpm/config.yaml must NOT trigger php
+# sibling-name collision — php-fpm/config.yaml must NOT trigger php
 # ---------------------------------------------------------------------------
 
-@test "SC-11: php-fpm/config.yaml change does NOT trigger php expansion (exact-match regression-lock)" {
+@test "php-fpm/config.yaml change does NOT trigger php expansion (exact-match regression-lock)" {
     echo "php-fpm/config.yaml" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["php"]'
     [ "$status" -eq 0 ]
@@ -109,10 +109,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-13: empty changed_files (no sentinel) → all false
+# empty changed_files (no sentinel) → all false
 # ---------------------------------------------------------------------------
 
-@test "SC-13: empty changed_files file (no sentinel) → all containers false" {
+@test "empty changed_files file (no sentinel) → all containers false" {
     # CHANGED_FILES exists but is empty; no .diff_failed sentinel
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty","postgres"]'
     [ "$status" -eq 0 ]
@@ -123,10 +123,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-14: .diff_failed sentinel present → all containers true
+# .diff_failed sentinel present → all containers true
 # ---------------------------------------------------------------------------
 
-@test "SC-14: .diff_failed sentinel present → all containers true" {
+@test ".diff_failed sentinel present → all containers true" {
     # Sentinel file alongside changed_files
     touch "${CHANGED_FILES}.diff_failed"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty","postgres"]'
@@ -190,10 +190,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-16: Dockerfile change in container dir triggers expansion (gate finding regression-lock)
+# Dockerfile change in container dir triggers expansion (gate finding regression-lock)
 # ---------------------------------------------------------------------------
 
-@test "SC-16: Dockerfile change in container dir → openresty:true" {
+@test "Dockerfile change in container dir → openresty:true" {
     echo "openresty/Dockerfile" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -202,10 +202,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-17: variants.yaml change in container dir triggers expansion (gate finding regression-lock)
+# variants.yaml change in container dir triggers expansion (gate finding regression-lock)
 # ---------------------------------------------------------------------------
 
-@test "SC-17: variants.yaml change in container dir → openresty:true" {
+@test "variants.yaml change in container dir → openresty:true" {
     echo "openresty/variants.yaml" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]
@@ -214,10 +214,10 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# SC-18: build script change in container dir triggers expansion (gate finding regression-lock)
+# build script change in container dir triggers expansion (gate finding regression-lock)
 # ---------------------------------------------------------------------------
 
-@test "SC-18: build script change in container dir → openresty:true" {
+@test "build script change in container dir → openresty:true" {
     echo "openresty/build" >> "$CHANGED_FILES"
     run compute_expand_retained_map "push" "false" "$CHANGED_FILES" '["openresty"]'
     [ "$status" -eq 0 ]

--- a/tests/unit/extension-duration-utils.bats
+++ b/tests/unit/extension-duration-utils.bats
@@ -144,7 +144,7 @@ _write_ext_lineage() {
 # ---------------------------------------------------------------------------
 
 # Case 1: all 3 lineage files present → sum = 100 + 200 + 50 = 350
-@test "1: flavor=full, all 3 lineage files present → sum of durations" {
+@test "flavor=full, all 3 lineage files present → sum of durations" {
     _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.8.0"  100
     _write_ext_lineage "paradedb"  "$MAJOR_VER" "0.15.0" 200
     _write_ext_lineage "pg_cron"   "$MAJOR_VER" "1.6.4"  50
@@ -155,7 +155,7 @@ _write_ext_lineage() {
 }
 
 # Case 2: 2 lineage files present, 1 skipped (pg_cron absent) → 100 + 200 = 300
-@test "2: flavor=full, 2 of 3 lineage files present (1 skipped) → sum of 2" {
+@test "flavor=full, 2 of 3 lineage files present (1 skipped) → sum of 2" {
     _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.8.0"  100
     _write_ext_lineage "paradedb"  "$MAJOR_VER" "0.15.0" 200
     # pg_cron lineage NOT written (cached, skipped)
@@ -166,7 +166,7 @@ _write_ext_lineage() {
 }
 
 # Case 3: "base" flavor has no extensions → 0 (flavor exists, just no compiled extensions)
-@test "3: flavor=base with no extensions → 0" {
+@test "flavor=base with no extensions → 0" {
     _mock_flavor_base_empty
 
     run sum_flavor_extension_durations "postgres" "base" "$MAJOR_VER"
@@ -175,7 +175,7 @@ _write_ext_lineage() {
 }
 
 # Case 4: all 3 lineage files absent (all extensions cached/skipped) → 0
-@test "4: flavor=full, 0 lineage files (all skipped) → 0" {
+@test "flavor=full, 0 lineage files (all skipped) → 0" {
     # No lineage files written
 
     run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
@@ -184,7 +184,7 @@ _write_ext_lineage() {
 }
 
 # Case 5: config.yaml missing → "null"
-@test "5: config.yaml missing → null" {
+@test "config.yaml missing → null" {
     rm -f "$EXT_DIR/config.yaml"
 
     run sum_flavor_extension_durations "postgres" "full" "$MAJOR_VER"
@@ -195,7 +195,7 @@ _write_ext_lineage() {
 # Case 7: backfill scenario — ceiling lineage file absent, older-version files present
 # Before the fix: function only looks up ext-<ext>-pg<major>-<ceiling>.json → 0
 # After the fix: function sums all ext-<ext>-pg<major>-*.json present → non-zero
-@test "7: backfill — ceiling absent, two older-version lineage files present → sum of older files" {
+@test "backfill — ceiling absent, two older-version lineage files present → sum of older files" {
     # pgvector's ceiling (0.8.0) was already in registry — no lineage written this run.
     # But two older retained versions were backfilled and DID produce lineage files.
     _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.7.0"  120
@@ -211,7 +211,7 @@ _write_ext_lineage() {
 }
 
 # Case 8: versionset artifact file is excluded from duration sum (no duration_seconds field)
-@test "8: versionset artifact not counted in duration sum" {
+@test "versionset artifact not counted in duration sum" {
     # Write a normal lineage file and also a versionset artifact (no duration_seconds)
     _write_ext_lineage "pgvector"  "$MAJOR_VER" "0.8.0"  150
     # Write a versionset artifact (the kind written by build-extensions.sh for multi-version)
@@ -230,7 +230,7 @@ _write_ext_lineage() {
 
 # Case 6: ext_config returns empty version for all → no lineage files exist → returns 0
 # (get_flavor_extensions still returns the 3 extensions, but no builds ran for them)
-@test "6: ext_config returns empty version → no lineage files → returns 0" {
+@test "ext_config returns empty version → no lineage files → returns 0" {
     _mock_ext_config_no_version
     # No lineage files written — in practice, build-extensions.sh only writes
     # ext-<ext>-pg<major>-<version>.json with a concrete version; empty-version
@@ -375,7 +375,7 @@ _write_arch_lineage() {
 #   calling sum_flavor_extension_durations → no files → sum returns 0.
 # This test asserts the behavior of the utility with no files present (as produced
 # by a fully-cleaned all-cached run).
-@test "FF-dur: no per-version files (cleaned by caller) → sum returns 0 for no-op run" {
+@test "no per-version files (cleaned by caller) → sum returns 0 for no-op run" {
     # Simulate the post-cleanup state: no per-version duration files exist.
     # (build-extensions.sh removed them; sum_flavor_extension_durations should return 0.)
 

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -2,23 +2,23 @@
 # Unit tests for scripts/generate-bake-hcl.sh — ADR-013 R2+R3 slice
 #
 # Mutation guards (named per test, see "catches mutation" comments):
-#   MG1: Remove contexts wiring → consumer targets lose "contexts" key
-#   MG2: Emit docker.io / :latest rolling tag → generator produces non-intermediate refs
-#   MG3: Remove _vbc_validate_build_args_config call → REMOTE_CR build_arg accepted
-#   MG4: Skip template expansion → template cells emit dockerfile path, not dockerfile-inline
-#   MG5: Remove NPROC injection → sslh/openvpn targets lose NPROC arg
-#   MG6: Emit NPROC for non-NPROC container → debian target gains spurious NPROC arg
-#   MG7: Omit NPROC bake variable from document header → bake fails to resolve ${NPROC}
-#   MG8: --cells emits bake document instead of array → type check fails
-#   MG9: intermediate_ref includes ${ARCH_SUFFIX} → merge consumer would double-suffix sources
-#   MG10: Cell set for --cells differs from bake mode → plan drift between generator and merge job
-#   MG11: Allow unflagged extension containers into bake graph -> extension sub-pipeline conflict (F1)
-#   MG12: Omit is_latest_version from --cells output → merge job cannot gate rolling tags (F2)
-#   MG13: Remove absolute-path guard in _resolve_cell_base_ref → doubled path → empty contexts (F3)
-#   MG14: Hardcode include_all_retained=true → default mode emits retained versions (F4)
-#   MG15: --cells iterates full closure → dep container appears in merge publish-set (FIX D)
-#   MG16: --cells uses flavor instead of variant → github-runner cells share rolling alias (FIX F)
-#   MG17: bake_latest_only flag ignored → retained github-runner versions enter bake (security bug)
+#   Remove contexts wiring → consumer targets lose "contexts" key
+#   Emit docker.io / :latest rolling tag → generator produces non-intermediate refs
+#   Remove _vbc_validate_build_args_config call → REMOTE_CR build_arg accepted
+#   Skip template expansion → template cells emit dockerfile path, not dockerfile-inline
+#   Remove NPROC injection → sslh/openvpn targets lose NPROC arg
+#   Emit NPROC for non-NPROC container → debian target gains spurious NPROC arg
+#   Omit NPROC bake variable from document header → bake fails to resolve ${NPROC}
+#   --cells emits bake document instead of array → type check fails
+#   intermediate_ref includes ${ARCH_SUFFIX} → merge consumer would double-suffix sources
+#   Cell set for --cells differs from bake mode → plan drift between generator and merge job
+#   Allow unflagged extension containers into bake graph -> extension sub-pipeline conflict (F1)
+#   Omit is_latest_version from --cells output → merge job cannot gate rolling tags (F2)
+#   Remove absolute-path guard in _resolve_cell_base_ref → doubled path → empty contexts (F3)
+#   Hardcode include_all_retained=true → default mode emits retained versions (F4)
+#   --cells iterates full closure → dep container appears in merge publish-set (FIX D)
+#   --cells uses flavor instead of variant → github-runner cells share rolling alias (FIX F)
+#   bake_latest_only flag ignored → retained github-runner versions enter bake (security bug)
 
 load "../test_helper"
 
@@ -67,10 +67,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-01: Valid bake JSON structure
+# Valid bake JSON structure
 # Catches: any top-level key missing (MG7 partial — NPROC variable absent)
 # ---------------------------------------------------------------------------
-@test "GBH-01: generator produces valid JSON with variable/target/group keys for debian" {
+@test "generator produces valid JSON with variable/target/group keys for debian" {
     _run_generator debian
     [ "$status" -eq 0 ]
     # Must be valid JSON
@@ -82,10 +82,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-02: group.default.targets lists requested containers
+# group.default.targets lists requested containers
 # Catches: default group wiring bug
 # ---------------------------------------------------------------------------
-@test "GBH-02: group.default.targets includes at least one target for requested container" {
+@test "group.default.targets includes at least one target for requested container" {
     _run_generator debian
     [ "$status" -eq 0 ]
     local cnt
@@ -94,10 +94,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-03: NPROC bake variable declared in document header (DEFECT 3 / MG7)
+# NPROC bake variable declared in document header (DEFECT 3 / MG7)
 # Catches: NPROC variable missing → bake cannot resolve ${NPROC} in targets
 # ---------------------------------------------------------------------------
-@test "GBH-03: document header declares NPROC bake variable with default 1" {
+@test "document header declares NPROC bake variable with default 1" {
     _run_generator sslh
     [ "$status" -eq 0 ]
     local nproc_default
@@ -106,10 +106,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-04: NPROC injected into sslh target args (DEFECT 3 / MG5)
+# NPROC injected into sslh target args (DEFECT 3 / MG5)
 # Catches: NPROC omitted → sslh build fails with "required variable not set"
 # ---------------------------------------------------------------------------
-@test "GBH-04: sslh target args contains NPROC bake-variable reference" {
+@test "sslh target args contains NPROC bake-variable reference" {
     _run_generator sslh
     [ "$status" -eq 0 ]
     # At least one sslh target must have NPROC in args
@@ -125,9 +125,9 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-05: NPROC injected into openvpn target args (DEFECT 3 / MG5)
+# NPROC injected into openvpn target args (DEFECT 3 / MG5)
 # ---------------------------------------------------------------------------
-@test "GBH-05: openvpn target args contains NPROC bake-variable reference" {
+@test "openvpn target args contains NPROC bake-variable reference" {
     _run_generator openvpn
     [ "$status" -eq 0 ]
     local nproc_vals
@@ -141,10 +141,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-06: NPROC NOT injected into debian target args (DEFECT 3 / MG6)
+# NPROC NOT injected into debian target args (DEFECT 3 / MG6)
 # Catches: spurious NPROC injection → Docker "unused build-arg" warning
 # ---------------------------------------------------------------------------
-@test "GBH-06: debian target args does NOT contain NPROC (no ARG NPROC in Dockerfile)" {
+@test "debian target args does NOT contain NPROC (no ARG NPROC in Dockerfile)" {
     _run_generator debian
     [ "$status" -eq 0 ]
     local nproc_vals
@@ -159,11 +159,11 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-07: Intermediate-only tags — no docker.io or :latest rolling tags (MG2)
+# Intermediate-only tags — no docker.io or :latest rolling tags (MG2)
 # Catches: generator emitting non-intermediate refs; the R3 merge job handles
 # rolling/latest tags, not the generator.
 # ---------------------------------------------------------------------------
-@test "GBH-07: all target tags are GHCR intermediate-only (no docker.io, no :latest without ARCH_SUFFIX)" {
+@test "all target tags are GHCR intermediate-only (no docker.io, no :latest without ARCH_SUFFIX)" {
     _run_generator debian
     [ "$status" -eq 0 ]
     # No docker.io refs
@@ -187,10 +187,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-08: Tag shape — intermediate ref format (DEFECT 4 guard, per spec)
+# Tag shape — intermediate ref format (DEFECT 4 guard, per spec)
 # Each target has exactly one tag of the form ${REMOTE_CR}/<c>:<tag>${ARCH_SUFFIX}
 # ---------------------------------------------------------------------------
-@test "GBH-08: each target has exactly one tag in intermediate-ref format for sslh" {
+@test "each target has exactly one tag in intermediate-ref format for sslh" {
     _run_generator sslh
     [ "$status" -eq 0 ]
     # Every target has exactly 1 tag
@@ -209,10 +209,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-09: DAG / contexts wiring — github-runner debian-trixie cell references
+# DAG / contexts wiring — github-runner debian-trixie cell references
 # the debian target via contexts, and debian target is present in closure (MG1)
 # ---------------------------------------------------------------------------
-@test "GBH-09: github-runner + debian closure includes debian target and consumer has contexts" {
+@test "github-runner + debian closure includes debian target and consumer has contexts" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -234,10 +234,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-10: web-shell closure — web-shell debian cell contexts points at
+# web-shell closure — web-shell debian cell contexts points at
 # the debian dep target (MG1)
 # ---------------------------------------------------------------------------
-@test "GBH-10: web-shell debian variant contexts points at debian target" {
+@test "web-shell debian variant contexts points at debian target" {
     _run_generator web-shell
     [ "$status" -eq 0 ]
 
@@ -254,10 +254,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-11: Template expansion — github-runner targets emit dockerfile-inline,
+# Template expansion — github-runner targets emit dockerfile-inline,
 # NOT a dockerfile path, and content has no @@ markers (DEFECT 2 / MG4)
 # ---------------------------------------------------------------------------
-@test "GBH-11: github-runner linux targets use dockerfile-inline with no @@ markers" {
+@test "github-runner linux targets use dockerfile-inline with no @@ markers" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -293,10 +293,10 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-12: Template expansion — github-runner inline content has a real FROM
+# Template expansion — github-runner inline content has a real FROM
 # (DEFECT 2 — without expansion, the template FROM line wouldn't exist) (MG4)
 # ---------------------------------------------------------------------------
-@test "GBH-12: github-runner dockerfile-inline contains a real FROM instruction" {
+@test "github-runner dockerfile-inline contains a real FROM instruction" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -312,9 +312,9 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-13: Template expansion — web-shell targets emit dockerfile-inline (MG4)
+# Template expansion — web-shell targets emit dockerfile-inline (MG4)
 # ---------------------------------------------------------------------------
-@test "GBH-13: web-shell targets use dockerfile-inline with no @@ markers" {
+@test "web-shell targets use dockerfile-inline with no @@ markers" {
     _run_generator web-shell
     [ "$status" -eq 0 ]
 
@@ -340,14 +340,14 @@ _make_timescaledb_lineage_root() {
 }
 
 # ---------------------------------------------------------------------------
-# GBH-14: Validation fail-closed — REMOTE_CR in config.yaml build_args causes
+# Validation fail-closed — REMOTE_CR in config.yaml build_args causes
 # non-zero exit when _vbc_validate_build_args_config is called (DEFECT 1 / MG3)
 #
 # Tests the validator directly (same function called by _config_build_args).
 # Catches: removing the _vbc_validate_build_args_config call from _config_build_args
 # would allow REMOTE_CR build_args to pass through unchecked.
 # ---------------------------------------------------------------------------
-@test "GBH-14: _vbc_validate_build_args_config rejects REMOTE_CR key in build_args" {
+@test "_vbc_validate_build_args_config rejects REMOTE_CR key in build_args" {
     local tmpdir
     tmpdir=$(mktemp -d)
 
@@ -373,9 +373,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-15: Validation fail-closed — shell-unsafe value rejected (DEFECT 1)
+# Validation fail-closed — shell-unsafe value rejected (DEFECT 1)
 # ---------------------------------------------------------------------------
-@test "GBH-15: _vbc_validate_build_args_config rejects shell-unsafe value in build_args" {
+@test "_vbc_validate_build_args_config rejects shell-unsafe value in build_args" {
     local tmpdir
     tmpdir=$(mktemp -d)
 
@@ -397,9 +397,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-16: Windows cells filtered — no windows/amd64 platform in output
+# Windows cells filtered — no windows/amd64 platform in output
 # ---------------------------------------------------------------------------
-@test "GBH-16: no windows platform targets emitted for github-runner" {
+@test "no windows platform targets emitted for github-runner" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -412,11 +412,11 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-17: FIX O — REMOTE_CR must NOT be a bake variable; ARCH_SUFFIX and NPROC must be.
+# FIX O — REMOTE_CR must NOT be a bake variable; ARCH_SUFFIX and NPROC must be.
 # REMOTE_CR is now resolved concretely at generation time from the env so that
 # args.REMOTE_CR and contexts keys always match (no bake-time divergence risk).
 # ---------------------------------------------------------------------------
-@test "GBH-17: document header has NO variable.REMOTE_CR; ARCH_SUFFIX and NPROC are declared" {
+@test "document header has NO variable.REMOTE_CR; ARCH_SUFFIX and NPROC are declared" {
     _run_generator debian
     [ "$status" -eq 0 ]
     # REMOTE_CR must NOT be a bake variable (concrete, not overridable at bake time)
@@ -429,9 +429,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-18: Non-template container (debian) uses dockerfile path, not inline
+# Non-template container (debian) uses dockerfile path, not inline
 # ---------------------------------------------------------------------------
-@test "GBH-18: debian target uses dockerfile key (not dockerfile-inline)" {
+@test "debian target uses dockerfile key (not dockerfile-inline)" {
     _run_generator debian
     [ "$status" -eq 0 ]
 
@@ -454,9 +454,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-19: Multiple containers requested — all appear in group.default.targets
+# Multiple containers requested — all appear in group.default.targets
 # ---------------------------------------------------------------------------
-@test "GBH-19: requesting web-shell github-runner debian puts all three in default group" {
+@test "requesting web-shell github-runner debian puts all three in default group" {
     _run_generator web-shell github-runner debian
     [ "$status" -eq 0 ]
 
@@ -474,9 +474,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-20: --cells mode emits a JSON array (MG8)
+# --cells mode emits a JSON array (MG8)
 # ---------------------------------------------------------------------------
-@test "GBH-20: --cells mode emits a JSON array" {
+@test "--cells mode emits a JSON array" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
     local type
@@ -485,9 +485,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-21: --cells objects have the 5 required fields (MG8)
+# --cells objects have the 5 required fields (MG8)
 # ---------------------------------------------------------------------------
-@test "GBH-21: --cells objects have container/tag/flavor/is_default/intermediate_ref" {
+@test "--cells objects have container/tag/flavor/is_default/intermediate_ref" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq 'length')" -gt 0 ]
@@ -504,10 +504,10 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-22: FIX O — intermediate_ref is CONCRETE (ghcr.io/oorabona/…), no ${REMOTE_CR} token,
+# FIX O — intermediate_ref is CONCRETE (ghcr.io/oorabona/…), no ${REMOTE_CR} token,
 # and has NO ${ARCH_SUFFIX} either. (MG9 updated)
 # ---------------------------------------------------------------------------
-@test "GBH-22: --cells intermediate_ref is concrete ghcr.io ref with no bake-variable tokens" {
+@test "--cells intermediate_ref is concrete ghcr.io ref with no bake-variable tokens" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
 
@@ -537,13 +537,13 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-23: --cells cell set for web-shell matches bake-mode target set (MG10)
+# --cells cell set for web-shell matches bake-mode target set (MG10)
 # Cell parity: every --cells entry must correspond to a bake target for the
 # same container+tag, and vice versa (same cardinality).
 # Both modes use the same default (latest-only); use --all-retained to compare
 # the retained-version path.
 # ---------------------------------------------------------------------------
-@test "GBH-23: --cells and bake mode produce same container/tag set for web-shell github-runner debian" {
+@test "--cells and bake mode produce same container/tag set for web-shell github-runner debian" {
     # Bake mode target count (default: latest-only)
     _run_generator web-shell github-runner debian
     [ "$status" -eq 0 ]
@@ -564,10 +564,10 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-24: default mode (no --cells) output is unchanged — bake document
+# default mode (no --cells) output is unchanged — bake document
 # structure still present after the refactor (regression guard).
 # ---------------------------------------------------------------------------
-@test "GBH-24: default mode (no --cells) still produces bake JSON with variable/target/group" {
+@test "default mode (no --cells) still produces bake JSON with variable/target/group" {
     _run_generator debian
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.variable' >/dev/null
@@ -580,10 +580,10 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-25: F1 — postgres final image is explicitly bake-emittable when activated
+# F1 — postgres final image is explicitly bake-emittable when activated
 # Catches: dropping build.bake_final_build support would re-exclude postgres.
 # ---------------------------------------------------------------------------
-@test "GBH-25: postgres --include-final-build --cells emits 21 final-image cells across all supported majors/flavors" {
+@test "postgres --include-final-build --cells emits 21 final-image cells across all supported majors/flavors" {
     _run_generator --include-final-build --cells postgres
     [ "$status" -eq 0 ]
 
@@ -597,7 +597,7 @@ YAML
     [ "$flavor_count" -eq 7 ]
 }
 
-@test "GBH-25b: postgres bake graph materializes inline base/vector/timeseries Dockerfiles offline" {
+@test "postgres bake graph materializes inline base/vector/timeseries Dockerfiles offline" {
     local lineage_root
     lineage_root=$(mktemp -d)
     _make_timescaledb_lineage_root "$lineage_root"
@@ -643,7 +643,7 @@ YAML
     grep -Fxq "FROM ghcr.io/oorabona/ext-timescaledb:pg18-${timescaledb_ver} AS ext-timescaledb" <<< "$timeseries_inline"
 }
 
-@test "GBH-25e: postgres bake VERSION build arg carries base_suffix (matches the non-bake base image)" {
+@test "postgres bake VERSION build arg carries base_suffix (matches the non-bake base image)" {
     local lineage_root
     lineage_root=$(mktemp -d)
     _make_timescaledb_lineage_root "$lineage_root"
@@ -661,7 +661,7 @@ YAML
     [ "$(echo "$output" | jq -r '.target.postgres_18_base.args.MAJOR_VERSION')" = "18" ]
 }
 
-@test "GBH-25c: postgres inline Dockerfiles escape bake interpolation triggers" {
+@test "postgres inline Dockerfiles escape bake interpolation triggers" {
     local lineage_root
     lineage_root=$(mktemp -d)
     _make_timescaledb_lineage_root "$lineage_root"
@@ -680,7 +680,7 @@ YAML
     [ "$bare_count" -eq 0 ]
 }
 
-@test "GBH-25d: no-arg whole-fleet generate excludes postgres without final-build activation" {
+@test "no-arg whole-fleet generate excludes postgres without final-build activation" {
     local lineage_root out err
     lineage_root=$(mktemp -d)
     out=$(mktemp)
@@ -704,7 +704,7 @@ YAML
     rm -f "$out" "$err"
 }
 
-@test "GBH-26: F1 — whole-fleet generate has no postgres target" {
+@test "F1 — whole-fleet generate has no postgres target" {
     # Generate for a small fleet that includes postgres (it is in ./make list).
     # We only request a known non-extension container but verify postgres never appears.
     _run_generator debian
@@ -714,7 +714,7 @@ YAML
     [ "$postgres_targets" -eq 0 ]
 }
 
-@test "GBH-26b: F1 — extension container without bake_final_build remains excluded" {
+@test "F1 — extension container without bake_final_build remains excluded" {
     local variants backup out err
     variants="${PROJECT_ROOT}/postgres/variants.yaml"
     backup=$(mktemp)
@@ -741,7 +741,7 @@ YAML
     rm -f "$backup" "$out" "$err"
 }
 
-@test "GBH-26c: non-postgres extensionless graph stays on the committed-Dockerfile path" {
+@test "non-postgres extensionless graph stays on the committed-Dockerfile path" {
     [ ! -f "${PROJECT_ROOT}/debian/extensions/config.yaml" ]
     [ "$(yq -r '.build.bake_final_build // false' "${PROJECT_ROOT}/debian/variants.yaml")" = "false" ]
 
@@ -759,9 +759,9 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-27: F2 — --cells objects include is_latest_version field (MG12)
+# F2 — --cells objects include is_latest_version field (MG12)
 # ---------------------------------------------------------------------------
-@test "GBH-27: --cells objects include is_latest_version field" {
+@test "--cells objects include is_latest_version field" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq 'length')" -gt 0 ]
@@ -771,7 +771,7 @@ YAML
     [ "$missing_field" -eq 0 ]
 }
 
-@test "GBH-28: F2 — debian latest cell has is_latest_version=true" {
+@test "F2 — debian latest cell has is_latest_version=true" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
     local latest_count
@@ -780,13 +780,13 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-29: F3+concrete-key — wordpress→php consumer contexts key is CONCRETE
+# F3+concrete-key — wordpress→php consumer contexts key is CONCRETE
 # (ghcr.io/oorabona/php:…), not a ${REMOTE_CR} token. (MG13)
 # Without the absolute-path fix, _resolve_cell_base_ref doubled the path →
 # empty base ref → no contexts. Without the concrete-key fix the key would
 # carry the unresolved "${REMOTE_CR}" token instead of the registry hostname.
 # ---------------------------------------------------------------------------
-@test "GBH-29: F3+concrete — wordpress contexts key is concrete ghcr.io ref, no \${ token, maps to php target" {
+@test "F3+concrete — wordpress contexts key is concrete ghcr.io ref, no \${ token, maps to php target" {
     _run_generator wordpress php
     [ "$status" -eq 0 ]
 
@@ -814,11 +814,11 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-30: F4 — default mode emits ONE version per retained container (MG14)
+# F4 — default mode emits ONE version per retained container (MG14)
 # github-runner has 3 retained versions; default mode should emit only
 # the latest one (is_latest_version=true cells).
 # ---------------------------------------------------------------------------
-@test "GBH-30: F4 — default mode emits only latest version for github-runner (not all retained)" {
+@test "F4 — default mode emits only latest version for github-runner (not all retained)" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -856,7 +856,7 @@ YAML
     [ "$tf_retained_count" -gt "$tf_default_count" ]
 }
 
-@test "GBH-31: F4 — --all-retained emits multiple versions for terraform (retained, no bake_latest_only)" {
+@test "F4 — --all-retained emits multiple versions for terraform (retained, no bake_latest_only)" {
     # github-runner now has bake_latest_only=true so it is always latest-only.
     # Use terraform (version_retention=3, no bake_latest_only) to verify --all-retained.
     _run_generator --all-retained terraform
@@ -879,7 +879,7 @@ YAML
 # FIX D: --cells publish-set must be requested-only (not dep closure)
 # ---------------------------------------------------------------------------
 
-@test "GBH-32: FIX D — --cells wordpress emits only wordpress cells, not php" {
+@test "FIX D — --cells wordpress emits only wordpress cells, not php" {
     _run_generator --cells wordpress
     [ "$status" -eq 0 ]
 
@@ -892,7 +892,7 @@ YAML
     [[ "$containers" != *"php"* ]]
 }
 
-@test "GBH-33: FIX D — --cells with multiple explicit requests includes all requested containers" {
+@test "FIX D — --cells with multiple explicit requests includes all requested containers" {
     # When both php AND wordpress are explicitly requested, both appear in cells output.
     # This pins the no-filter-when-both-requested behavior (requested set = [php, wordpress]).
     _run_generator --cells php wordpress
@@ -905,7 +905,7 @@ YAML
     [[ "$containers" == *"php"* ]]
 }
 
-@test "GBH-34: FIX D — bake wordpress still includes php target AND contexts; --cells diverges (requested-only)" {
+@test "FIX D — bake wordpress still includes php target AND contexts; --cells diverges (requested-only)" {
     # Bake mode: closure intact — php target must exist
     _run_generator wordpress
     [ "$status" -eq 0 ]
@@ -934,7 +934,7 @@ YAML
 # FIX F: --cells objects include variant; github-runner cells have distinct variants
 # ---------------------------------------------------------------------------
 
-@test "GBH-35: FIX F — --cells objects include variant field" {
+@test "FIX F — --cells objects include variant field" {
     _run_generator --cells github-runner
     [ "$status" -eq 0 ]
 
@@ -944,7 +944,7 @@ YAML
     [ "$missing_variant" -eq 0 ]
 }
 
-@test "GBH-36: FIX F — github-runner debian-trixie-base and debian-trixie-dev have DISTINCT variants" {
+@test "FIX F — github-runner debian-trixie-base and debian-trixie-dev have DISTINCT variants" {
     _run_generator --cells github-runner
     [ "$status" -eq 0 ]
 
@@ -967,7 +967,7 @@ YAML
 # FIX O: REMOTE_CR is concrete at generation time — no bake variable, no token.
 # ---------------------------------------------------------------------------
 
-@test "GBH-37: FIX O — args.REMOTE_CR and contexts key are concrete and equal-prefixed (wordpress)" {
+@test "FIX O — args.REMOTE_CR and contexts key are concrete and equal-prefixed (wordpress)" {
     _run_generator wordpress php
     [ "$status" -eq 0 ]
 
@@ -1001,7 +1001,7 @@ YAML
     [ "$args_prefix" = "$ctx_prefix" ]
 }
 
-@test "GBH-38: FIX O — REMOTE_CR=example.test/x override makes tags/args/contexts all use example.test/x" {
+@test "FIX O — REMOTE_CR=example.test/x override makes tags/args/contexts all use example.test/x" {
     # Override REMOTE_CR at generation time — all three surfaces must be consistent.
     run env REMOTE_CR=example.test/x bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" wordpress php
     [ "$status" -eq 0 ]
@@ -1045,7 +1045,7 @@ YAML
 # so bake --print does not abort on undefined Docker ARG variables.
 # ---------------------------------------------------------------------------
 
-@test "GBH-39: FIX Q — inline target has no un-escaped \${…} in dockerfile-inline" {
+@test "FIX Q — inline target has no un-escaped \${…} in dockerfile-inline" {
     # github-runner uses inline Dockerfiles (template expansion).
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
@@ -1065,7 +1065,7 @@ YAML
     [ "$bare_count" -eq 0 ]
 }
 
-@test "GBH-40: FIX Q — inline FROM line is escaped (FROM \$\${\${…}}) and contexts key remains concrete" {
+@test "FIX Q — inline FROM line is escaped (FROM \$\${\${…}}) and contexts key remains concrete" {
     _run_generator github-runner debian
     [ "$status" -eq 0 ]
 
@@ -1090,7 +1090,7 @@ YAML
     [ "$bad_ctx_keys" -eq 0 ]
 }
 
-@test "GBH-41: FIX Q — committed-Dockerfile target (debian) uses dockerfile key, no inline, no escaping needed" {
+@test "FIX Q — committed-Dockerfile target (debian) uses dockerfile key, no inline, no escaping needed" {
     _run_generator debian
     [ "$status" -eq 0 ]
 
@@ -1110,7 +1110,7 @@ YAML
 # returns non-zero, rather than silently producing a bake graph with missing contexts.
 # ---------------------------------------------------------------------------
 
-@test "GBH-42: FIX S — generator exits non-zero with ::error:: on depgraph failure" {
+@test "FIX S — generator exits non-zero with ::error:: on depgraph failure" {
     # Verify the fail-closed depgraph guard via a wrapper script that overrides
     # _depgraph_get_deps_transitive to return non-zero.
     # Strategy: write a caller script to $TEST_TEMP_DIR (allocated by setup()) that:
@@ -1167,11 +1167,11 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-43: #595 — --cells objects include target_id field
+# #595 — --cells objects include target_id field
 # Catches: omitting target_id from cells output → bake-buildresult cannot
 # correlate --metadata-file keys to cells.
 # ---------------------------------------------------------------------------
-@test "GBH-43: --cells objects include target_id field (non-empty string)" {
+@test "--cells objects include target_id field (non-empty string)" {
     _run_generator --cells web-shell
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq 'length')" -gt 0 ]
@@ -1183,14 +1183,14 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-44: #595 — --cells[].target_id values equal bake-mode .target keys (MG10 extension)
+# #595 — --cells[].target_id values equal bake-mode .target keys (MG10 extension)
 # The join key is correct: the set of target_ids from --cells must be exactly
 # the set of target keys emitted by bake mode for the same requested containers
 # (dep-closure exclusion in --cells is correct: dep targets like debian_trixie
 #  appear in bake mode but not in --cells for a requested set that doesn't
 #  include debian directly).
 # ---------------------------------------------------------------------------
-@test "GBH-44: --cells target_id set equals bake-mode target key set for web-shell" {
+@test "--cells target_id set equals bake-mode target key set for web-shell" {
     # --cells target_ids (sorted)
     _run_generator --cells web-shell
     [ "$status" -eq 0 ]
@@ -1208,11 +1208,11 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# GBH-45: #595 — target_id format is a valid bake identifier (no dots/hyphens/slashes)
+# #595 — target_id format is a valid bake identifier (no dots/hyphens/slashes)
 # _target_id sanitises: [.\-\/] → _; leading digit → v prefix.
 # Catching: a target_id with literal dots would not match the bake metadata key.
 # ---------------------------------------------------------------------------
-@test "GBH-45: --cells target_id values contain only [A-Za-z0-9_] characters" {
+@test "--cells target_id values contain only [A-Za-z0-9_] characters" {
     _run_generator --cells web-shell github-runner
     [ "$status" -eq 0 ]
 
@@ -1224,10 +1224,10 @@ YAML
 
 # ---------------------------------------------------------------------------
 # bake_latest_only: github-runner must be latest-only even with --all-retained
-# MG17: bake_latest_only flag ignored → retained github-runner versions included
+# bake_latest_only flag ignored → retained github-runner versions included
 # ---------------------------------------------------------------------------
 
-@test "GBH-46: bake_latest_only — github-runner --all-retained emits SAME count as without flag" {
+@test "bake_latest_only — github-runner --all-retained emits SAME count as without flag" {
     # Arrange: capture latest-only cell count (stderr silenced — ::notice:: annotations ignored)
     local latest_only_count
     latest_only_count=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells github-runner 2>/dev/null \
@@ -1245,7 +1245,7 @@ YAML
     [ "$all_retained_count" -eq "$latest_only_count" ]
 }
 
-@test "GBH-47: bake_latest_only — github-runner bake mode --all-retained emits only latest version targets" {
+@test "bake_latest_only — github-runner bake mode --all-retained emits only latest version targets" {
     # Capture the latest version tag
     local latest_tag
     latest_tag=$(bash -c "
@@ -1272,7 +1272,7 @@ YAML
     [ "$non_latest_targets" -eq 0 ]
 }
 
-@test "GBH-48: bake_latest_only — --all-retained terraform still expands (non-flagged container unaffected)" {
+@test "bake_latest_only — --all-retained terraform still expands (non-flagged container unaffected)" {
     # terraform has version_retention=3 and no bake_latest_only flag
     _run_generator terraform
     [ "$status" -eq 0 ]
@@ -1288,7 +1288,7 @@ YAML
     [ "$retained_count" -gt "$default_count" ]
 }
 
-@test "GBH-49: bake_latest_only — ::notice:: emitted to stderr when flag overrides --all-retained" {
+@test "bake_latest_only — ::notice:: emitted to stderr when flag overrides --all-retained" {
     # The generator must emit a ::notice:: annotation when it overrides --all-retained
     run bash -c "
         export _DEPGRAPH_LINEAGE_DIR=/nonexistent
@@ -1301,14 +1301,14 @@ YAML
 
 # ---------------------------------------------------------------------------
 # Registry cache: per-target cache-from/cache-to (MG18)
-#   MG18: Omit cache-from → bake builds cold; emit cache-to unconditionally → PR poisons canonical buildcache
+#   Omit cache-from → bake builds cold; emit cache-to unconditionally → PR poisons canonical buildcache
 #
 # cache-from is UNCONDITIONAL (always emitted; reading is always safe).
 # cache-to is GATED on BAKE_CACHE_EXPORT=true (only the real publish path writes
 # to canonical buildcache refs — PR/dry-run builds must never poison it).
 # ---------------------------------------------------------------------------
 
-@test "GBH-50: MG18 — every bake target has cache-from unconditionally (BAKE_CACHE_EXPORT unset)" {
+@test "MG18 — every bake target has cache-from unconditionally (BAKE_CACHE_EXPORT unset)" {
     # cache-from must be present regardless of BAKE_CACHE_EXPORT
     _run_generator debian
     [ "$status" -eq 0 ]
@@ -1351,7 +1351,7 @@ YAML
     [ "$no_arch_suffix" -eq 0 ]
 }
 
-@test "GBH-50b: MG18 — cache-from also present when BAKE_CACHE_EXPORT=true (publish path)" {
+@test "MG18 — cache-from also present when BAKE_CACHE_EXPORT=true (publish path)" {
     # cache-from must also be present on the publish path (reads from prior master cache)
     run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
     [ "$status" -eq 0 ]
@@ -1364,7 +1364,7 @@ YAML
     [ "$missing_cf" -eq 0 ]
 }
 
-@test "GBH-51: MG18 — BAKE_CACHE_EXPORT=true: every target has cache-to with mode=max and ignore-error=true" {
+@test "MG18 — BAKE_CACHE_EXPORT=true: every target has cache-to with mode=max and ignore-error=true" {
     # Cache-to must be present ONLY when BAKE_CACHE_EXPORT=true (the publish path).
     run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
     [ "$status" -eq 0 ]
@@ -1396,7 +1396,7 @@ YAML
     [ "$missing_ie" -eq 0 ]
 }
 
-@test "GBH-51b: MG18 — BAKE_CACHE_EXPORT unset/false: NO cache-to emitted (PR/dry-run safety gate)" {
+@test "MG18 — BAKE_CACHE_EXPORT unset/false: NO cache-to emitted (PR/dry-run safety gate)" {
     # When BAKE_CACHE_EXPORT is unset (default), cache-to must be absent from all targets.
     # This is the PR/dry-run path — we must never poison canonical buildcache from unmerged code.
     _run_generator debian
@@ -1410,7 +1410,7 @@ YAML
     [ "$has_cache_to" -eq 0 ]
 }
 
-@test "GBH-51c: MG18 — BAKE_CACHE_EXPORT=false: NO cache-to emitted" {
+@test "MG18 — BAKE_CACHE_EXPORT=false: NO cache-to emitted" {
     # Explicit false must also suppress cache-to.
     run env BAKE_CACHE_EXPORT=false bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian
     [ "$status" -eq 0 ]
@@ -1423,7 +1423,7 @@ YAML
     [ "$has_cache_to" -eq 0 ]
 }
 
-@test "GBH-52: MG18 — two different bake targets (different containers or tags) get DISTINCT cache refs" {
+@test "MG18 — two different bake targets (different containers or tags) get DISTINCT cache refs" {
     # Request two containers with distinct tags so both produce cache refs.
     # Verify no two targets share the same cache-from ref.
     run env BAKE_CACHE_EXPORT=true bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" debian sslh
@@ -1450,7 +1450,7 @@ YAML
 # B4 scope filters: generator-only filtering for bake/cells emission
 # ---------------------------------------------------------------------------
 
-@test "GBH-53: B4 — --scope-versions keeps only matching terraform retained-version cells" {
+@test "B4 — --scope-versions keeps only matching terraform retained-version cells" {
     local unscoped_output unscoped_count pick
     unscoped_output=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform 2>/dev/null)
     unscoped_count=$(echo "$unscoped_output" | jq 'length')
@@ -1472,7 +1472,7 @@ YAML
     [ "$bad_tags" -eq 0 ]
 }
 
-@test "GBH-54: B4 — --scope-flavors keeps only matching terraform flavor cells" {
+@test "B4 — --scope-flavors keeps only matching terraform flavor cells" {
     _run_generator --cells --scope-flavors aws terraform
     [ "$status" -eq 0 ]
 
@@ -1484,7 +1484,7 @@ YAML
     [ "$bad_flavors" -eq 0 ]
 }
 
-@test "GBH-55: B4 — --scope filters terraform cells by variant substring" {
+@test "B4 — --scope filters terraform cells by variant substring" {
     _run_generator --cells --scope azure terraform
     [ "$status" -eq 0 ]
 
@@ -1496,7 +1496,7 @@ YAML
     [ "$bad_variants" -eq 0 ]
 }
 
-@test "GBH-56: B4 — no scope flags preserve the latest-only terraform cell count" {
+@test "B4 — no scope flags preserve the latest-only terraform cell count" {
     local expected_count
     expected_count=$(bash -c "
         source '${HELPERS_DIR}/variant-utils.sh'
@@ -1513,7 +1513,7 @@ YAML
     [ "$actual_count" -eq "$expected_count" ]
 }
 
-@test "GBH-57: B4 — over-narrow --scope-versions emits an empty bake target set" {
+@test "B4 — over-narrow --scope-versions emits an empty bake target set" {
     _run_generator --scope-versions 999 terraform
     [ "$status" -eq 0 ]
 
@@ -1525,7 +1525,7 @@ YAML
     [ "$default_count" -eq 0 ]
 }
 
-@test "GBH-58: B4 gate — scoped github-runner graph keeps debian internal base target and contexts" {
+@test "B4 gate — scoped github-runner graph keeps debian internal base target and contexts" {
     _run_generator --scope-flavors debian-trixie github-runner
     [ "$status" -eq 0 ]
 
@@ -1562,7 +1562,7 @@ YAML
     [ "$dangling_count" -eq 0 ]
 }
 
-@test "GBH-59: B4 gate — scoped github-runner --cells emits only requested scoped cells, not debian deps" {
+@test "B4 gate — scoped github-runner --cells emits only requested scoped cells, not debian deps" {
     _run_generator --cells --scope-flavors debian-trixie github-runner
     [ "$status" -eq 0 ]
 
@@ -1578,7 +1578,7 @@ YAML
     [ "$debian_cells" -eq 0 ]
 }
 
-@test "GBH-60: B4 gate — unscoped github-runner graph target keys stay on the pre-fix default set" {
+@test "B4 gate — unscoped github-runner graph target keys stay on the pre-fix default set" {
     _run_generator github-runner
     [ "$status" -eq 0 ]
 
@@ -1609,7 +1609,7 @@ YAML
     [ "$actual_keys" = "$expected_keys" ]
 }
 
-@test "GBH-61: container scopes — terraform flavor scope keeps only aws cells" {
+@test "container scopes — terraform flavor scope keeps only aws cells" {
     _run_generator --cells --container-scopes '{"terraform":{"flavors":"aws"}}' terraform
     [ "$status" -eq 0 ]
 
@@ -1626,7 +1626,7 @@ YAML
     [ "$per_container_json" = "$(echo "$output" | jq -cS '.')" ]
 }
 
-@test "GBH-62: container scopes — terraform retained version scope keeps only matching-version cells" {
+@test "container scopes — terraform retained version scope keeps only matching-version cells" {
     local unscoped_output unscoped_count pick
     unscoped_output=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells --all-retained terraform 2>/dev/null)
     unscoped_count=$(echo "$unscoped_output" | jq 'length')
@@ -1647,7 +1647,7 @@ YAML
     [ "$bad_tags" -eq 0 ]
 }
 
-@test "GBH-63: container scopes — different containers keep isolated scope filters" {
+@test "container scopes — different containers keep isolated scope filters" {
     _run_generator --cells debian
     [ "$status" -eq 0 ]
     local unscoped_debian_count
@@ -1667,7 +1667,7 @@ YAML
     [ "$debian_count" -eq "$unscoped_debian_count" ]
 }
 
-@test "GBH-64: container scopes — containers absent from the map fall back to global flavor scope" {
+@test "container scopes — containers absent from the map fall back to global flavor scope" {
     _run_generator --cells --include-final-build \
         --container-scopes '{"terraform":{"flavors":"aws"}}' \
         --scope-flavors full postgres terraform
@@ -1685,7 +1685,7 @@ YAML
     [ "$postgres_bad_flavors" -eq 0 ]
 }
 
-@test "GBH-65: container scopes — scoped github-runner graph keeps debian dependency target and contexts" {
+@test "container scopes — scoped github-runner graph keeps debian dependency target and contexts" {
     _run_generator --container-scopes '{"github-runner":{"flavors":"debian-trixie"}}' github-runner
     [ "$status" -eq 0 ]
 
@@ -1726,7 +1726,7 @@ YAML
     [ "$dangling_count" -eq 0 ]
 }
 
-@test "GBH-66: container scopes — empty map is byte-identical to no container scope flag" {
+@test "container scopes — empty map is byte-identical to no container scope flag" {
     _run_generator terraform debian
     [ "$status" -eq 0 ]
     local no_flag_json

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -329,7 +329,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# NL-1: trailing-newline stripping by command substitution must not concatenate
+# trailing-newline stripping by command substitution must not concatenate
 #        the collector final COPY with the next extension's COPY line.
 #
 # Mutation caught: removing the `$'\n'` appended to copies_block after the
@@ -349,7 +349,7 @@ EOF
 #   whole-line match for the clean COPY fails → test fails.
 # GREEN (after fix): each COPY/FROM is on its own whole line.
 # ---------------------------------------------------------------------------
-@test "NL-1: collector final COPY is on its own line, not concatenated with the next extension (trailing-newline bug)" {
+@test "collector final COPY is on its own line, not concatenated with the next extension (trailing-newline bug)" {
     # Mutation caught: removing `$'\n'` after copies_block+= in generate_dockerfile
     # causes command-substitution to strip the trailing newline, concatenating
     # COPY --from=ext_collect_timescaledb / /tmp/ext/timescaledb/ with the
@@ -523,7 +523,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# FIX3: tag-based fallback (no-version_digests artifact) must use the caller's
+# tag-based fallback (no-version_digests artifact) must use the caller's
 #       explicit registry/owner, not the default get_registry()/get_repo_owner().
 #
 # Before fix: ext_image_name called without registry/owner → uses get_registry()
@@ -534,7 +534,7 @@ EOF
 #   owner="customowner" against a no-version_digests artifact (LOCAL_ONLY/old path).
 #   All per-version COPY --from= refs inside the collector must use custom.io/customowner.
 # ---------------------------------------------------------------------------
-@test "FIX3-tag-fallback-uses-explicit-registry-owner: no-digests artifact refs use caller registry/owner" {
+@test "no-digests artifact refs use caller registry/owner" {
     # No-version_digests artifact (LOCAL_ONLY / old build path).
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
@@ -575,7 +575,7 @@ EOF
 # GREEN after fix: uses ${ROOT_DIR:-${PROJECT_ROOT:-...}} → finds artifact via
 #   PROJECT_ROOT → multi-version path (3 FROM stages).
 # ---------------------------------------------------------------------------
-@test "Y-production-cwd: artifact found via PROJECT_ROOT when ROOT_DIR unset and cwd is container subdir" {
+@test "artifact found via PROJECT_ROOT when ROOT_DIR unset and cwd is container subdir" {
     # Simulate repo root in a DIFFERENT temp dir from the container subdir.
     local fake_repo_root
     fake_repo_root=$(mktemp -d)
@@ -642,7 +642,7 @@ EOF
 # RED before fix: emits older-only stages, exits 0.
 # GREEN after fix: exits non-zero with actionable error.
 # ---------------------------------------------------------------------------
-@test "Z-ceiling-absent: non-empty available[] without ceiling → generate_dockerfile exits non-zero" {
+@test "non-empty available[] without ceiling → generate_dockerfile exits non-zero" {
     # Artifact: available has 2 older versions but ceiling (2.27.1) is MISSING.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.23.0","2.25.0","2.27.1"],"available":["2.23.0","2.25.0"],"excluded":[{"version":"2.27.1","reason":"not available"}]}
@@ -659,7 +659,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "Z-ceiling-present: ceiling in available[] → collector stage + single final COPY" {
+@test "ceiling in available[] → collector stage + single final COPY" {
     # Sanity: ceiling IS present → normal multi-version success with collector stage.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
@@ -682,13 +682,13 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# CC-1: available[] entry ABOVE the ceiling → generate_dockerfile exits non-zero.
+# available[] entry ABOVE the ceiling → generate_dockerfile exits non-zero.
 #
 # RED before fix: no validation → the bad entry is emitted as a FROM stage,
 #   exits 0 (injection-unsafe / wrong image).
 # GREEN after fix: validation rejects above-ceiling entry, exits non-zero.
 # ---------------------------------------------------------------------------
-@test "CC-1-above-ceiling: available[] version above ceiling → generate_dockerfile exits non-zero" {
+@test "available[] version above ceiling → generate_dockerfile exits non-zero" {
     # Artifact: available has an entry (2.99.0) above the configured ceiling (2.27.1).
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1","2.99.0"],"available":["2.25.0","2.27.1","2.99.0"],"excluded":[]}
@@ -706,14 +706,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# CC-2: available[] entry with non-semver content → generate_dockerfile exits
+# available[] entry with non-semver content → generate_dockerfile exits
 # non-zero.
 #
 # RED before fix: no validation → the malformed string is emitted verbatim
 #   as a Docker stage/tag (injection risk), exits 0.
 # GREEN after fix: validation rejects non-semver entry, exits non-zero.
 # ---------------------------------------------------------------------------
-@test "CC-2-non-semver-injection: available[] non-semver string → generate_dockerfile exits non-zero" {
+@test "available[] non-semver string → generate_dockerfile exits non-zero" {
     # Artifact: available has a non-semver entry.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1; rm -rf"],"excluded":[]}
@@ -730,7 +730,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "CC-3-non-semver-latest: available[] 'latest' tag → generate_dockerfile exits non-zero" {
+@test "available[] 'latest' tag → generate_dockerfile exits non-zero" {
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","latest"],"excluded":[]}
 EOF
@@ -754,15 +754,15 @@ EOF
 #   multi-version stages. Fail closed only if the resolver or registry probe fails.
 #
 # Tests assert the NEW self-heal contract:
-#   EE-a-1: resolver-backed, no artifact, all resolved images PRESENT → self-heal,
+#   resolver-backed, no artifact, all resolved images PRESENT → self-heal,
 #            multi-version stages, exit 0.
-#   EE-a-2: resolver-backed, no artifact, resolve_version_set FAILS → fail closed,
+#   resolver-backed, no artifact, resolve_version_set FAILS → fail closed,
 #            exit non-zero.
-#   EE-a-3: resolver-backed, no artifact, resolves OK but ceiling image ABSENT
+#   resolver-backed, no artifact, resolves OK but ceiling image ABSENT
 #            from registry → fail closed (ceiling enforcement).
 # ---------------------------------------------------------------------------
 
-@test "EE-a-1-self-heal: resolver-backed ext + no artifact + all images present → self-heals, exit 0" {
+@test "resolver-backed ext + no artifact + all images present → self-heals, exit 0" {
     # Operator-approved contract change: versionset artifact is an optimisation,
     # not a hard dependency. When absent, generate_dockerfile self-heals via
     # resolve_version_set + image_exists_in_registry.
@@ -804,7 +804,7 @@ EOF
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "EE-a-2-resolver-fails: resolver-backed ext + no artifact + resolver fails → fail closed" {
+@test "resolver-backed ext + no artifact + resolver fails → fail closed" {
     # Self-heal cannot proceed without a resolver result. Fail closed.
     resolve_version_set() {
         echo "::error::simulated resolver failure" >&2
@@ -824,7 +824,7 @@ EOF
     [[ "$output" == *"timescaledb"* ]]
 }
 
-@test "EE-a-3-ceiling-absent: resolver-backed ext + no artifact + ceiling not in registry → fail closed" {
+@test "resolver-backed ext + no artifact + ceiling not in registry → fail closed" {
     # Self-heal resolves OK but the ceiling image (2.27.1) is absent from registry.
     # Ceiling enforcement: refuse to emit below-pin stages.
     resolve_version_set() {
@@ -856,7 +856,7 @@ EOF
 # The pgvector extension in the config fixture has no version_set.resolver.
 # GREEN before and after fix: non-resolver ext must still produce single-version.
 # ---------------------------------------------------------------------------
-@test "EE-b-non-resolver-no-artifact: non-resolver ext + no versionset → single-version, exit 0" {
+@test "non-resolver ext + no versionset → single-version, exit 0" {
     # No versionset file for pgvector (non-resolver) — use multi_mixed flavor
     # which includes pgvector (non-resolver) alongside timescaledb (resolver-backed).
     # Provide resolve_version_set + image_exists_in_registry mocks for timescaledb
@@ -886,7 +886,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# JJ-1: malformed artifact (truncated JSON) + resolver mocks that succeed
+# malformed artifact (truncated JSON) + resolver mocks that succeed
 #       → generate_dockerfile SELF-HEALS to multi-version (exit 0, N stages).
 #
 # RED before fix: jq parse fails → available_count collapses to 0 → falls
@@ -894,7 +894,7 @@ EOF
 # GREEN after fix: parse failure treated as ABSENT artifact → self-heal kicks
 #   in → resolver+registry probed → multi-version emitted (exit 0, 3 stages).
 # ---------------------------------------------------------------------------
-@test "JJ-1-malformed-truncated: truncated JSON artifact + resolver succeeds → self-heals to multi-version" {
+@test "truncated JSON artifact + resolver succeeds → self-heals to multi-version" {
     # Write a truncated/unparseable JSON artifact.
     printf '{"ext":"timescaledb"' \
         > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -928,7 +928,7 @@ EOF
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "JJ-2-malformed-garbage: non-JSON garbage artifact + resolver succeeds → self-heals to multi-version" {
+@test "non-JSON garbage artifact + resolver succeeds → self-heals to multi-version" {
     # Write non-JSON garbage as the artifact.
     printf 'NOT JSON AT ALL\x00\ngarbage data' \
         > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -959,7 +959,7 @@ EOF
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "JJ-3-malformed-no-available: JSON missing .available key + resolver succeeds → self-heals" {
+@test "JSON missing .available key + resolver succeeds → self-heals" {
     # Valid JSON but no .available key — schema mismatch.
     printf '{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1"}' \
         > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -990,7 +990,7 @@ EOF
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "JJ-4-malformed-resolver-fails: malformed artifact + resolver FAILS → fail closed (non-zero)" {
+@test "malformed artifact + resolver FAILS → fail closed (non-zero)" {
     # Malformed artifact; resolver also fails. Must fail closed.
     printf '{"ext":"timescaledb"' \
         > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
@@ -1012,9 +1012,9 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# CC-4: valid semver entries, all <= ceiling → succeeds (regression guard).
+# valid semver entries, all <= ceiling → succeeds (regression guard).
 # ---------------------------------------------------------------------------
-@test "CC-4-valid-entries: valid semver entries all at-or-below ceiling → succeeds" {
+@test "valid semver entries all at-or-below ceiling → succeeds" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1036,7 +1036,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# LEAK-1: self-heal path must NOT leave orphaned temp files in TMPDIR.
+# self-heal path must NOT leave orphaned temp files in TMPDIR.
 #
 # Before fix: mktemp creates a synthetic artifact in /tmp; the function
 # returns through multiple paths without ever deleting it → temp file leaks
@@ -1050,7 +1050,7 @@ EOF
 # generate_dockerfile; assert it is empty after the call returns.  RED
 # before fix (a .json temp file lingers), GREEN after (directory empty).
 # ---------------------------------------------------------------------------
-@test "LEAK-1-no-tempfile: self-heal path leaves no orphaned temp file in TMPDIR" {
+@test "self-heal path leaves no orphaned temp file in TMPDIR" {
     # No versionset artifact → triggers self-heal path.
     # Mocks: resolver succeeds, all images present.
     resolve_version_set() {
@@ -1100,12 +1100,12 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# LEAK-2: self-heal via empty-available artifact also leaves no temp file.
+# self-heal via empty-available artifact also leaves no temp file.
 #
 # Same leak vector but triggered via the empty-available → self-heal path
 # (the second route into self-heal added in this fix).
 # ---------------------------------------------------------------------------
-@test "LEAK-2-empty-available-no-tempfile: empty-available self-heal leaves no temp file in TMPDIR" {
+@test "empty-available self-heal leaves no temp file in TMPDIR" {
     # Empty available artifact → triggers self-heal.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":[],"available":[],"excluded":[]}
@@ -1153,7 +1153,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# NN-3: transient probe ERROR in self-heal path → fail closed.
+# transient probe ERROR in self-heal path → fail closed.
 #
 # Scenario: no versionset artifact on disk; resolver succeeds and returns
 # ["2.23.0","2.25.0","2.27.1"]. The self-heal probes registry presence:
@@ -1171,7 +1171,7 @@ EOF
 # the desired 3-state code per version, isolating the self-heal routing logic
 # from the low-level docker/skopeo probe.
 # ---------------------------------------------------------------------------
-@test "NN-3: transient probe error in self-heal path fails closed (generate_dockerfile exits non-zero)" {
+@test "transient probe error in self-heal path fails closed (generate_dockerfile exits non-zero)" {
     # No versionset artifact — forces the self-heal path.
 
     # Resolver returns 3 versions.
@@ -1218,7 +1218,7 @@ EOF
 # excluded. rc=1 from _image_registry_probe_3state is treated as ABSENT, not ERROR.
 # The over-correct guard — ensures we didn't break the musl-failed / never-built case.
 # ---------------------------------------------------------------------------
-@test "NN-3b: definitively absent version in self-heal path is excluded, not an error" {
+@test "definitively absent version in self-heal path is excluded, not an error" {
     # No versionset artifact — forces the self-heal path.
 
     resolve_version_set() {
@@ -1327,13 +1327,13 @@ _run_registry_probe_3state() {
     printf '%d' $?
 }
 
-@test "OO-gd-manifest-unknown: 'manifest unknown' stderr → ABSENT (rc 1)" {
+@test "_run_registry_probe: 'manifest unknown' stderr → ABSENT (rc 1)" {
     local rc
     rc=$(_run_registry_probe_3state "Error response from daemon: manifest unknown: manifest unknown")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-gd-404: '404 Not Found' → ERROR (rc 2, fail-closed after UU allow-list tightening)" {
+@test "_run_registry_probe: '404 Not Found' → ERROR (rc 2, fail-closed after UU allow-list tightening)" {
     # Before UU fix: bare "404" and "not found" matched → ABSENT (rc 1) — fail-open.
     # After UU fix: only registry-manifest-specific signals are ABSENT; a generic
     # "404 Not Found" (e.g. from a load-balancer or cred-helper) is ERROR (rc 2).
@@ -1342,19 +1342,19 @@ _run_registry_probe_3state() {
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-name-unknown: 'name unknown' → ABSENT (rc 1)" {
+@test "_run_registry_probe: 'name unknown' → ABSENT (rc 1)" {
     local rc
     rc=$(_run_registry_probe_3state "name unknown: repository name not known to registry")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-gd-no-such-manifest: 'no such manifest' → ABSENT (rc 1)" {
+@test "_run_registry_probe: 'no such manifest' → ABSENT (rc 1)" {
     local rc
     rc=$(_run_registry_probe_3state "no such manifest: ghcr.io/testowner/ext-timescaledb:pg18-2.27.1")
     [ "$rc" -eq 1 ]
 }
 
-@test "OO-gd-toomanyrequests-ERROR: 'toomanyrequests' → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'toomanyrequests' → ERROR (rc 2, fail-closed)" {
     # RED before fix: fell through to ABSENT (rc 1) — silently dropped retained version.
     # GREEN after fix: → ERROR (rc 2).
     local rc
@@ -1362,49 +1362,49 @@ _run_registry_probe_3state() {
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-429-ERROR: '429' in stderr → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: '429' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "Error: 429 Too Many Requests")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-denied-ERROR: 'denied' in stderr → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'denied' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "denied: access forbidden")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-unauthorized-ERROR: 'unauthorized' → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'unauthorized' → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "unauthorized: authentication required")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-no-such-host-ERROR: 'no such host' → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'no such host' → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "dial tcp: lookup ghcr.io: no such host")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-network-unreachable-ERROR: 'network is unreachable' → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'network is unreachable' → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "dial tcp: connect: network is unreachable")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-EOF-ERROR: 'EOF' in stderr → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'EOF' in stderr → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "unexpected EOF")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-context-deadline-ERROR: 'context deadline exceeded' → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: 'context deadline exceeded' → ERROR (rc 2, fail-closed)" {
     local rc
     rc=$(_run_registry_probe_3state "context deadline exceeded")
     [ "$rc" -eq 2 ]
 }
 
-@test "OO-gd-empty-stderr-ERROR: empty stderr + rc≠0 → ERROR (rc 2, fail-closed)" {
+@test "_run_registry_probe: empty stderr + rc≠0 → ERROR (rc 2, fail-closed)" {
     # RED before fix: empty stderr fell through to ABSENT (rc 1) — fail-open.
     # GREEN after fix: empty stderr + non-zero → ERROR (rc 2).
     local rc
@@ -1412,7 +1412,7 @@ _run_registry_probe_3state() {
     [ "$rc" -eq 2 ]
 }
 
-@test "UU-gd-cmd-not-found-ERROR: 'docker: command not found' stderr → ERROR (rc 2, not ABSENT)" {
+@test "_run_registry_probe: 'docker: command not found' stderr → ERROR (rc 2, not ABSENT)" {
     # Before UU fix: bare "not found" matched the allow-list → ABSENT (rc 1), mis-classifying
     # a missing docker binary as a definitively-absent image.
     # After UU fix: "command not found" no longer matches any registry-manifest-specific
@@ -1422,7 +1422,7 @@ _run_registry_probe_3state() {
     [ "$rc" -eq 2 ]
 }
 
-@test "UU-gd-cred-helper-not-found-ERROR: cred-helper 'executable file not found' → ERROR (rc 2)" {
+@test "_run_registry_probe: cred-helper 'executable file not found' → ERROR (rc 2)" {
     # A missing credential helper produces "executable file not found in PATH".
     # Before UU fix: "not found" in the message matched → ABSENT (rc 1) — mis-classifying
     # an infra misconfiguration as a definitively-absent image.
@@ -1432,7 +1432,7 @@ _run_registry_probe_3state() {
     [ "$rc" -eq 2 ]
 }
 
-@test "UU-gd-no-such-image-ERROR: 'no such image' stderr → ERROR (rc 2, fail-closed after UU)" {
+@test "_run_registry_probe: 'no such image' stderr → ERROR (rc 2, fail-closed after UU)" {
     # "no such image" is a Docker daemon local-store message, not a registry-manifest
     # API response. After UU tightening it is removed from the allow-list → ERROR.
     local rc
@@ -1452,7 +1452,7 @@ _run_registry_probe_3state() {
 # GREEN after fix: LOCAL_ONLY/PULL_ONLY routes to docker image inspect. Self-heals.
 # ---------------------------------------------------------------------------
 
-@test "PP-local-only-self-heal: LOCAL_ONLY=true + images present locally → generate_dockerfile self-heals" {
+@test "LOCAL_ONLY=true + images present locally → generate_dockerfile self-heals" {
     # No versionset artifact → forces the self-heal path.
     # Images are present in LOCAL daemon but NOT in registry.
     local tmpd="$TEST_TEMP_DIR"
@@ -1502,7 +1502,7 @@ _run_registry_probe_3state() {
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "PP-pull-only-self-heal: PULL_ONLY=true + images present locally → generate_dockerfile self-heals" {
+@test "PULL_ONLY=true + images present locally → generate_dockerfile self-heals" {
     local tmpd="$TEST_TEMP_DIR"
 
     run bash -c "
@@ -1548,7 +1548,7 @@ _run_registry_probe_3state() {
     [ "$final_copy_count" -eq 1 ]
 }
 
-@test "PP-local-only-image-absent-locally: LOCAL_ONLY=true + image NOT in local daemon → generate_dockerfile fails closed" {
+@test "LOCAL_ONLY=true + image NOT in local daemon → generate_dockerfile fails closed" {
     # In local mode, docker image inspect is 2-state (PRESENT/ABSENT).
     # All images absent locally → no available versions → ceiling absent → fail closed.
     local tmpd="$TEST_TEMP_DIR"
@@ -1629,7 +1629,7 @@ _run_registry_probe_3state() {
 #   GREEN after fix: still succeeds with multi-version COPY output (non-vacuous).
 # ---------------------------------------------------------------------------
 
-@test "ZZ-skopeo-absent-selfheal-failfast: no artifact + skopeo absent → fail-fast with 'skopeo' in message (resolver NOT reached)" {
+@test "no artifact + skopeo absent → fail-fast with 'skopeo' in message (resolver NOT reached)" {
     # No versionset artifact — forces the self-heal branch.
     # skopeo is shadowed off PATH; jq remains available.
     local tmpd="$TEST_TEMP_DIR"
@@ -1681,7 +1681,7 @@ _run_registry_probe_3state() {
     [[ "$output" != *resolve_version_set_was_reached* ]]
 }
 
-@test "ZZ-skopeo-absent-valid-artifact-ok: valid artifact present + skopeo absent → succeeds (skopeo never needed)" {
+@test "valid artifact present + skopeo absent → succeeds (skopeo never needed)" {
     # A valid, well-formed versionset artifact is on disk — self-heal must NOT fire.
     # skopeo is shadowed off PATH to prove the valid-artifact path does not touch it.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
@@ -1730,7 +1730,7 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# AG-3: generate_dockerfile artifact-consumption path — artifact whose
+# generate_dockerfile artifact-consumption path — artifact whose
 # available[] contains a poisoned element "2.25.0\n2.26.0" (one string,
 # embedded newline) must be rejected BEFORE any FROM/COPY stage emission.
 # Without the fix, jq -r '.available[]' splits the element into two lines and
@@ -1742,7 +1742,7 @@ _run_registry_probe_3state() {
 # Non-vacuous: the smuggled version must NOT appear as a FROM stage.
 # ---------------------------------------------------------------------------
 
-@test "AG-3-artifact-poisoned-available: artifact with embedded-newline element rejected before stage emission" {
+@test "artifact with embedded-newline element rejected before stage emission" {
     # Artifact with one poisoned element: "2.25.0\n2.26.0" contains an embedded newline.
     mkdir -p "$TEST_TEMP_DIR/.build-lineage"
     # Write JSON manually: the element contains a literal \n inside the string.
@@ -1765,7 +1765,7 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# AG-4: generate_dockerfile self-heal path — resolver returns a set with an
+# generate_dockerfile self-heal path — resolver returns a set with an
 # embedded-newline element where BOTH parts are below-ceiling valid semver
 # ("2.25.0\n2.26.0") so the ceiling clamp cannot catch it. Without the
 # whole-string chokepoint, both 2.25.0 and 2.26.0 get probed separately and
@@ -1778,7 +1778,7 @@ _run_registry_probe_3state() {
 # GREEN after fix: whole-string anchor rejects the element -> fail-closed.
 # ---------------------------------------------------------------------------
 
-@test "AG-4-self-heal-embedded-newline-below-ceiling: resolver returns embedded-newline element (both parts below ceiling) in self-heal path -> fail-closed" {
+@test "resolver returns embedded-newline element (both parts below ceiling) in self-heal path -> fail-closed" {
     # No versionset artifact — triggers self-heal path.
     rm -f "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
 
@@ -1814,11 +1814,11 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# AG-5: regression guard — valid versionset artifact with 3 clean elements
+# regression guard — valid versionset artifact with 3 clean elements
 # still produces collector stage + single final COPY (chokepoint must not break happy path).
 # ---------------------------------------------------------------------------
 
-@test "AG-5-valid-artifact-still-works: clean available[] with 3 valid elements -> collector stage + 1 final COPY" {
+@test "clean available[] with 3 valid elements -> collector stage + 1 final COPY" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1845,7 +1845,7 @@ _run_registry_probe_3state() {
     [ "$per_ver_count" -eq 3 ]
 }
 
-@test "SS-jq-absent: jq not on PATH + resolver-backed ext + valid artifact → fail-fast with 'jq' in error message" {
+@test "jq not on PATH + resolver-backed ext + valid artifact → fail-fast with 'jq' in error message" {
     # Write a valid versionset artifact so the test verifies the prereq path,
     # not the artifact-absent self-heal path.
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
@@ -1890,7 +1890,7 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-1: resolver-backed ext with 3 available versions →
+# resolver-backed ext with 3 available versions →
 # generated Dockerfile has a collector stage (FROM scratch AS ext_collect_<ext>)
 # with 3 per-version COPYs inside, and EXACTLY ONE final-stage COPY from the collector.
 #
@@ -1898,7 +1898,7 @@ _run_registry_probe_3state() {
 # The final stage sees exactly 1 COPY from the collector (1 exported layer).
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-1: 3 available versions → collector stage + exactly 1 final COPY" {
+@test "3 available versions → collector stage + exactly 1 final COPY" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1926,12 +1926,12 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-2: the final-stage COPY places the collector's content at
+# the final-stage COPY places the collector's content at
 # /tmp/ext/<ext>/ so that /<ver>/ dirs inside the collector land at
 # /tmp/ext/<ext>/<ver>/ which is the layout install_ext iterates.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-2: collector COPY destination is /tmp/ext/timescaledb/ (installs at correct path)" {
+@test "collector COPY destination is /tmp/ext/timescaledb/ (installs at correct path)" {
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1947,11 +1947,11 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-3: the collector stage name is derived from the extension name.
+# the collector stage name is derived from the extension name.
 # Consumer emits "FROM scratch AS ext_collect_<ext>".
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-3: collector stage name is ext_collect_timescaledb" {
+@test "collector stage name is ext_collect_timescaledb" {
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -1967,11 +1967,11 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-4: single-version (non-resolver) extension path UNCHANGED.
+# single-version (non-resolver) extension path UNCHANGED.
 # pgvector (no version_set.resolver) must still emit a FROM stage + flat COPY.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-4: single-version pgvector path unchanged — still 1 FROM + flat COPY" {
+@test "single-version pgvector path unchanged — still 1 FROM + flat COPY" {
     # No versionset artifact for pgvector (non-resolver extension).
 
     run generate_dockerfile \
@@ -1995,12 +1995,12 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-5: mixed flavor — timescaledb uses bundle COPY,
+# mixed flavor — timescaledb uses bundle COPY,
 # pgvector uses original single-version path. One bundle COPY, zero per-version
 # timescaledb COPYs, one pgvector FROM.
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-5: mixed flavor — timescaledb collector + pgvector single-version unchanged" {
+@test "mixed flavor — timescaledb collector + pgvector single-version unchanged" {
     _write_versionset "timescaledb" "18" "2.23.0" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -2030,11 +2030,11 @@ _run_registry_probe_3state() {
 }
 
 # ---------------------------------------------------------------------------
-# BUNDLE-CON-6: self-heal path (no artifact) for resolver-backed ext
+# self-heal path (no artifact) for resolver-backed ext
 # also emits a collector stage + 1 final COPY (not a mutable bundle tag).
 # ---------------------------------------------------------------------------
 
-@test "BUNDLE-CON-6: self-heal (no artifact) emits collector stage + 1 final COPY" {
+@test "self-heal (no artifact) emits collector stage + 1 final COPY" {
     # Self-heal uses the same collector emitter as the artifact-present path.
     # No versionset file — self-heal must kick in.
 
@@ -2078,7 +2078,7 @@ _run_registry_probe_3state() {
 # AP: self-heal emits one COPY pair per proved-present per-version ref.
 # No bundle ref appears in the output.
 # ---------------------------------------------------------------------------
-@test "AK-selfheal-per-version-refs: artifact absent, self-heal, all versions present → per-version COPYs, no bundle ref" {
+@test "artifact absent, self-heal, all versions present → per-version COPYs, no bundle ref" {
     # No versionset artifact → forces self-heal path.
 
     resolve_version_set() {
@@ -2129,7 +2129,7 @@ _run_registry_probe_3state() {
 # AP: the bundle ref is never probed on the self-heal path.
 # These tests verify the per-version-probe routing that feeds _sh_available.
 # ---------------------------------------------------------------------------
-@test "AK-selfheal-only-proved-versions: absent version excluded, present versions emitted as per-version COPYs" {
+@test "absent version excluded, present versions emitted as per-version COPYs" {
     # No versionset artifact → forces self-heal path.
     # 2.23.0: ABSENT; 2.25.0 and 2.27.1: PRESENT.
     # _sh_available == [2.25.0, 2.27.1]; ceiling 2.27.1 present → multi-version.
@@ -2179,7 +2179,7 @@ _run_registry_probe_3state() {
     [ "$final_count" -eq 1 ]
 }
 
-@test "AK-selfheal-error-version-failclosed: transient ERROR probe in self-heal → fail closed, no output" {
+@test "transient ERROR probe in self-heal → fail closed, no output" {
     # No versionset artifact → forces self-heal path.
     # One version returns ERROR (transient) → fail closed.
 
@@ -2223,7 +2223,7 @@ _run_registry_probe_3state() {
 #   COPY --from=ext-<name> /output/lib/ ...
 #   No bundle reference.  No bundle probe.
 # ---------------------------------------------------------------------------
-@test "AL-consumer-single-version: artifact with available=[ceiling] → single-version FROM path, no bundle ref" {
+@test "artifact with available=[ceiling] → single-version FROM path, no bundle ref" {
     # Artifact: resolver-backed extension with exactly 1 available version (the ceiling).
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.27.1"],"available":["2.27.1"],"excluded":[]}
@@ -2258,7 +2258,7 @@ EOF
 # version_digests: {"2.25.0":"sha256:<64hex>", "2.27.1":"sha256:<64hex>"}
 # Each per-version COPY inside the collector uses the digest-pinned ref.
 # ---------------------------------------------------------------------------
-@test "AM-consumer-digest-pin: artifact with version_digests → collector COPYs use repo@digest refs" {
+@test "artifact with version_digests → collector COPYs use repo@digest refs" {
     # Artifact: multi-version with version_digests.
     _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -2290,7 +2290,7 @@ EOF
 # AM-consumer-no-digest-tag-fallback: artifact present WITHOUT version_digests
 # (LOCAL_ONLY-produced artifact) → collector COPYs use tag-based references.
 # ---------------------------------------------------------------------------
-@test "AM-consumer-no-digest-tag-fallback: artifact without version_digests → tag-based refs in collector" {
+@test "artifact without version_digests → tag-based refs in collector" {
     # Artifact: multi-version, no version_digests (LOCAL_ONLY-produced case).
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -2382,7 +2382,7 @@ _write_versionset_with_malformed_ver_digest() {
         > "$TEST_TEMP_DIR/.build-lineage/ext-${ext}-pg${pg_major}-versionset.json"
 }
 
-@test "AN-consumer-rejects-embedded-newline-injection: version_digests with newline+RUN evil → fail closed" {
+@test "version_digests with newline+RUN evil → fail closed" {
     # Poisoned digest for one version: valid-looking sha256 prefix + embedded newline + injected directive.
     local evil_digest
     evil_digest=$(printf 'sha256:0000000000000000000000000000000000000000000000000000000000000000\nRUN evil')
@@ -2403,7 +2403,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$evil_count" -eq 0 ]
 }
 
-@test "AN-consumer-rejects-uppercase-hex: uppercase digest in version_digests → fail closed" {
+@test "uppercase digest in version_digests → fail closed" {
     local bad_digest="sha256:DEADBEEF00000000000000000000000000000000000000000000000000000000"
     _write_versionset_with_malformed_ver_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
 
@@ -2420,7 +2420,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$upper_count" -eq 0 ]
 }
 
-@test "AN-consumer-rejects-short-hash: sha256:<63hex> in version_digests → fail closed" {
+@test "sha256:<63hex> in version_digests → fail closed" {
     local bad_digest="sha256:000000000000000000000000000000000000000000000000000000000000000"
     _write_versionset_with_malformed_ver_digest "timescaledb" "18" "$bad_digest" "2.25.0" "2.27.1"
 
@@ -2433,7 +2433,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$status" -ne 0 ]
 }
 
-@test "AN-consumer-accepts-valid-digest: valid version_digests → per-version repo@digest COPYs inside collector" {
+@test "valid version_digests → per-version repo@digest COPYs inside collector" {
     # Proper OCI digest — must produce collector stage with digest-pinned per-version COPYs.
     _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -2454,7 +2454,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$pinned_count" -eq 2 ]
 }
 
-@test "AN-consumer-absent-digest-tag: no version_digests in artifact → tag-based refs in collector" {
+@test "no version_digests in artifact → tag-based refs in collector" {
     # LOCAL_ONLY-produced artifact: no version_digests field.
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -2476,7 +2476,7 @@ _write_versionset_with_malformed_ver_digest() {
 }
 
 # ---------------------------------------------------------------------------
-# AO-4: self-heal path, synthesized available contains ONLY an older version
+# self-heal path, synthesized available contains ONLY an older version
 # (ceiling absent) → generate_dockerfile must FAIL CLOSED.
 #
 # Context: When the versionset artifact is absent/malformed, generate_dockerfile
@@ -2506,7 +2506,7 @@ _write_versionset_with_malformed_ver_digest() {
 #   Must remain GREEN (ceiling present → allowed).
 # ---------------------------------------------------------------------------
 
-@test "AO4-selfheal-ceiling-absent-failclosed: self-heal available=[older-only] (no ceiling) → fail closed" {
+@test "self-heal available=[older-only] (no ceiling) → fail closed" {
     # No versionset artifact — forces the self-heal path.
 
     # Resolver returns 3 versions; the ceiling is 2.27.1.
@@ -2545,7 +2545,7 @@ _write_versionset_with_malformed_ver_digest() {
     fi
 }
 
-@test "AO4-selfheal-ceiling-only-singleversion: self-heal available=[ceiling] → single-version path OK" {
+@test "self-heal available=[ceiling] → single-version path OK" {
     # No versionset artifact — forces the self-heal path.
 
     # Resolver returns 3 versions.
@@ -2603,10 +2603,10 @@ _write_versionset_with_malformed_ver_digest() {
 #   (AM regression — unchanged.)
 #
 # AP-selfheal-ceiling-present-enforced:
-#   self-heal, ceiling absent from _sh_available → fail closed (AO-4 still enforced).
+#   self-heal, ceiling absent from _sh_available → fail closed (still fail-closed).
 # ---------------------------------------------------------------------------
 
-@test "AP-selfheal-per-version-not-bundle: self-heal >1 proved-present versions → collector stage, no bundle tag" {
+@test "self-heal >1 proved-present versions → collector stage, no bundle tag" {
     # No versionset artifact → forces self-heal path.
     # _sh_available = [2.23.0, 2.25.0, 2.27.1] (all present, ceiling present, count > 1).
 
@@ -2642,7 +2642,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$final_count" -eq 1 ]
 }
 
-@test "AP-selfheal-only-proved-versions: absent version not emitted; transient ERROR fails closed" {
+@test "absent version not emitted; transient ERROR fails closed" {
     # Sub-case A: one version definitively absent → only proved-present versions emitted.
 
     resolve_version_set() {
@@ -2683,7 +2683,7 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$absent_count" -eq 0 ]
 }
 
-@test "AP-artifact-path-still-version-digests: artifact with version_digests → digest-pinned collector COPYs" {
+@test "artifact with version_digests → digest-pinned collector COPYs" {
     # AM regression: artifact-present path must still emit digest-pinned refs inside the collector.
     # Self-heal is NOT triggered (valid artifact on disk with version_digests).
     _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
@@ -2710,8 +2710,8 @@ _write_versionset_with_malformed_ver_digest() {
     [ "$final_count" -eq 1 ]
 }
 
-@test "AP-selfheal-ceiling-present-enforced: self-heal ceiling absent from proved set → fail closed" {
-    # AO-4 regression: ceiling-present enforcement still applies on self-heal path
+@test "self-heal ceiling absent from proved set → fail closed" {
+    # Regression: ceiling-present enforcement still applies on self-heal path
     # after the AP fix (per-version path).
     # _sh_available = [2.25.0] only — ceiling 2.27.1 absent.
 
@@ -2735,7 +2735,7 @@ _write_versionset_with_malformed_ver_digest() {
         "timeseries" "18" \
         "ghcr.io" "testowner"
 
-    # Ceiling absent → fail closed (AO-4 still enforced on AP path).
+    # Ceiling absent → fail closed (still enforced on the self-heal path).
     [ "$status" -ne 0 ]
 
     # No per-version or bundle COPY must appear.
@@ -2745,7 +2745,7 @@ _write_versionset_with_malformed_ver_digest() {
 }
 
 # ---------------------------------------------------------------------------
-# AQ-2: artifact-present path — single available entry that is NOT the ceiling.
+# artifact-present path — single available entry that is NOT the ceiling.
 #
 # Defect: the single-entry ceiling check ("available[0] must equal ceiling") runs
 # ONLY when the data came from the self-heal path (_versionset_from_selfheal=true).
@@ -2759,7 +2759,7 @@ _write_versionset_with_malformed_ver_digest() {
 # If not → FAIL CLOSED (log_error, return 1).
 # Remove the _versionset_from_selfheal gating on this specific check.
 # ---------------------------------------------------------------------------
-@test "AQ2-artifact-single-not-ceiling-failclosed: on-disk artifact with single available != ceiling → fail closed" {
+@test "on-disk artifact with single available != ceiling → fail closed" {
     # On-disk artifact: single entry 2.25.0 in available but ceiling is 2.27.1.
     # This is a stale/corrupt artifact — build-extensions never writes this shape.
     # Before fix: falls through to single-version path emitting FROM ...:pg18-2.27.1
@@ -2785,7 +2785,7 @@ EOF
     [ "$ceiling_from_count" -eq 0 ]
 }
 
-@test "AQ2-artifact-single-is-ceiling-ok: on-disk artifact with single available == ceiling → single-version path succeeds" {
+@test "on-disk artifact with single available == ceiling → single-version path succeeds" {
     # On-disk artifact: single entry 2.27.1 in available, ceiling is also 2.27.1.
     # This is the legitimate case: ceiling built but no older versions available.
     # Must succeed and emit the single-version FROM stage.
@@ -2812,7 +2812,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# AR-2: a malformed version_digests entry containing GHA workflow-command injection
+# a malformed version_digests entry containing GHA workflow-command injection
 # bytes must be defanged in the log diagnostic and the function must fail closed.
 #
 # A poisoned artifact has version_digests["2.23.0"] = "sha256:abc\n::add-mask::secret".
@@ -2820,7 +2820,7 @@ EOF
 # non-zero). The log_error message must NOT contain a raw newline immediately followed
 # by ::add-mask:: (the injection form GHA interprets).
 # ---------------------------------------------------------------------------
-@test "AR2-digest-diagnostic-sanitized: malformed version_digests entry with injection bytes — fail closed, diagnostic defanged" {
+@test "malformed version_digests entry with injection bytes — fail closed, diagnostic defanged" {
     # Artifact with 3 available versions and a poisoned digest for one version.
     python3 -c "
 import json, os
@@ -2879,18 +2879,18 @@ with open(path, 'w') as f:
 }
 
 # ---------------------------------------------------------------------------
-# AS-2: _single_avail (extension-utils.sh ~648) log path sanitization.
+# _single_avail (extension-utils.sh ~648) log path sanitization.
 #
 # Scenario: artifact has available:["1.2.3\n::warning::pwn"] — a single entry
 # that contains an embedded GHA workflow-command injection.
 # The value is != ceiling (2.27.1), so generate_dockerfile must fail closed
-# (AO-4 guard). The log_error diagnostic at that site must NOT emit the raw
+# (the ceiling-present guard). The log_error diagnostic at that site must NOT emit the raw
 # newline+:: sequence — it must be sanitized first.
 #
 # RED before fix: _single_avail is logged raw (no _sanitize_for_log).
 # GREEN after fix: _single_avail is wrapped in _sanitize_for_log before logging.
 # ---------------------------------------------------------------------------
-@test "AS2-single-avail-log-sanitized: artifact single-available with injection bytes — fail closed, log defanged" {
+@test "artifact single-available with injection bytes — fail closed, log defanged" {
     # Write artifact with a poisoned single-entry available array.
     # We embed a literal newline in the JSON string using python3 for correctness.
     python3 -c "
@@ -2946,7 +2946,7 @@ with open(path, 'w') as f:
 }
 
 # ---------------------------------------------------------------------------
-# AS-2: _val_ver (extension-utils.sh ~694/~702) log path sanitization.
+# _val_ver (extension-utils.sh ~694/~702) log path sanitization.
 #
 # The per-element validation loop logs _val_ver when is_strict_semver fails
 # or when the above-ceiling check fails. Since validate_semver_set_json runs
@@ -2965,7 +2965,7 @@ with open(path, 'w') as f:
 #   2. Fails is_strict_semver (non-semver chars after version) → log_error at ~694
 #   3. Contains GHA injection chars that must be sanitized
 # ---------------------------------------------------------------------------
-@test "AS2-valver-log-sanitized: per-element resolved version with injection bytes — log defanged" {
+@test "per-element resolved version with injection bytes — log defanged" {
     # The injection vector at the _val_ver log site uses echo -e expansion:
     # a value like "2.25.0\n::stop-commands::x" (with a literal backslash-n, not a
     # real newline) is logged via echo -e which expands \n to a real newline, causing
@@ -3027,7 +3027,7 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# AT-2: self-heal with reduced retention must emit a log_warning naming
+# self-heal with reduced retention must emit a log_warning naming
 # the dropped versions.
 #
 # When the probed available set (_sh_available) is SMALLER than the resolved
@@ -3042,20 +3042,20 @@ ARTIFACT_EOF
 #       * is sanitised through _sanitize_for_log (no raw injection path)
 #
 # Tests:
-#   AT2-selfheal-reduced-warns: resolved=3, probed-present=2 (ceiling present),
+#   resolved=3, probed-present=2 (ceiling present),
 #     1 version absent → SUCCEEDS, log_warning names the dropped version.
 #     RED before fix: no warning at all (silent reduction).
 #     GREEN after fix: warning surfaces dropped version.
 #
-#   AT2-selfheal-full-no-warn: resolved=3, probed-present=3 (all present) →
+#   resolved=3, probed-present=3 (all present) →
 #     SUCCEEDS, NO reduction warning emitted.
 #     (Regression: the warning must not fire when no version was dropped.)
 #
-# Existing ceiling-present fail-closed (AO-4 / EE-a-3) and per-version
+# Existing ceiling-present fail-closed and per-version
 # emission (AP) remain unchanged — these tests do NOT touch or weaken them.
 # ---------------------------------------------------------------------------
 
-@test "AT2-selfheal-reduced-warns: self-heal with 1 absent version emits log_warning naming dropped version" {
+@test "self-heal with 1 absent version emits log_warning naming dropped version" {
     # No versionset artifact — forces self-heal path.
     # Resolver returns 3 versions; only 2 are present in registry.
     # 2.16.0 is definitively absent (rc=1 from _image_registry_probe_3state).
@@ -3099,7 +3099,7 @@ ARTIFACT_EOF
     [[ "$output" == *"reduc"* ]] || [[ "$output" == *"absent"* ]] || [[ "$output" == *"not retain"* ]]
 }
 
-@test "AT2-selfheal-full-no-warn: all resolved versions present — no reduction warning emitted" {
+@test "all resolved versions present — no reduction warning emitted" {
     # No versionset artifact — forces self-heal path.
     # All 3 resolved versions are present → no reduction, no warning.
 
@@ -3127,12 +3127,12 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# BB1-consumer-repo-digest: artifact with version_digests → each per-version
+# artifact with version_digests → each per-version
 # COPY inside the collector uses <registry>/<owner>/ext-<ext>@<digest>
 # (repo + digest, NO tag segment). Pure-digest references are valid across
 # any tag scope (PR-scoped or canonical).
 # ---------------------------------------------------------------------------
-@test "BB1-consumer-repo-digest: version_digests in artifact → per-version COPYs are repo@digest (no tag segment)" {
+@test "version_digests in artifact → per-version COPYs are repo@digest (no tag segment)" {
     _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
 
     run generate_dockerfile \
@@ -3160,7 +3160,7 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# BC-1: consumer PR_TAG_SUFFIX scoping for non-resolver/single-version path
+# consumer PR_TAG_SUFFIX scoping for non-resolver/single-version path
 #
 # generate_dockerfile must append ${PR_TAG_SUFFIX} to the FROM image ref for
 # single-version (non-resolver) extensions when PR_TAG_SUFFIX is set.
@@ -3172,7 +3172,7 @@ ARTIFACT_EOF
 #   PR_TAG_SUFFIX empty → canonical ref (no suffix).
 #   RED before fix: FROM always uses canonical tag.  GREEN after: -pr42 appended.
 # ---------------------------------------------------------------------------
-@test "BC1-consumer-pr-scopes-nonresolver: PR_TAG_SUFFIX=-pr42 → FROM ref for non-resolver ext carries -pr42" {
+@test "PR_TAG_SUFFIX=-pr42 → FROM ref for non-resolver ext carries -pr42" {
     # No versionset artifact — pgvector is non-resolver, uses single-version path.
     export PR_TAG_SUFFIX="-pr42"
 
@@ -3210,7 +3210,7 @@ ARTIFACT_EOF
     echo "$output" | grep -Fxq "COPY --from=ext-pgvector /output/extension/ /tmp/ext/pgvector/extension/"
 }
 
-@test "BC1-consumer-canonical-no-suffix: PR_TAG_SUFFIX empty → FROM ref is canonical (no suffix)" {
+@test "PR_TAG_SUFFIX empty → FROM ref is canonical (no suffix)" {
     # Regression: empty PR_TAG_SUFFIX must leave the FROM ref unchanged.
     export PR_TAG_SUFFIX=""
 
@@ -3234,7 +3234,7 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# BC-1: consumer PR_TAG_SUFFIX scoping for self-heal per-version COPY refs
+# consumer PR_TAG_SUFFIX scoping for self-heal per-version COPY refs
 #
 # On the self-heal path (AP), generate_dockerfile emits per-version COPY lines
 # using ext_image_name().  Those refs must also carry the PR_TAG_SUFFIX.
@@ -3244,7 +3244,7 @@ ARTIFACT_EOF
 #   all carry -pr42.  Confirmed for each version in the proved-present set.
 #   RED before fix: per-version refs use canonical tags.  GREEN after: -pr42 appended.
 # ---------------------------------------------------------------------------
-@test "BC1-consumer-pr-scopes-selfheal: PR_TAG_SUFFIX=-pr42, all canonical refs absent → self-heal COPY refs carry -pr42" {
+@test "PR_TAG_SUFFIX=-pr42, all canonical refs absent → self-heal COPY refs carry -pr42" {
     # No versionset artifact → self-heal path for timescaledb.
     # PR context (PR_TAG_SUFFIX=-pr42): both versions were built THIS PR.
     # Faithful mock: canonical refs are ABSENT (rc=1); PR-scoped refs are PRESENT (rc=0).
@@ -3288,7 +3288,7 @@ ARTIFACT_EOF
 }
 
 # ---------------------------------------------------------------------------
-# BC-3: present-empty bundle_digest fails closed; absent key → tag fallback
+# present-empty bundle_digest fails closed; absent key → tag fallback
 #
 # generate_dockerfile uses `jq '.bundle_digest // empty'` which maps both
 # ABSENT and PRESENT-EMPTY to the empty string — falling back to the mutable
@@ -3305,7 +3305,7 @@ ARTIFACT_EOF
 #   artifact has NO version_digests key → tag-based refs, exit 0 (LOCAL_ONLY case).
 #   Must remain GREEN (regression guard).
 # ---------------------------------------------------------------------------
-@test "BC3-empty-digest-failclosed: version_digests entry present-but-empty → fail closed" {
+@test "version_digests entry present-but-empty → fail closed" {
     # Artifact with version_digests having one empty-string value.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"","2.27.1":"sha256:abcdef0000000000000000000000000000000000000000000000000000000000"}}
@@ -3321,7 +3321,7 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "BC3-absent-digest-tag-fallback: NO version_digests key in artifact → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
+@test "NO version_digests key in artifact → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
     # LOCAL_ONLY-produced artifact: version_digests key is completely absent.
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -3344,7 +3344,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BD-1: legacy artifact with bundle_digest but no version_digests must fail
+# legacy artifact with bundle_digest but no version_digests must fail
 # closed — the consumer must not silently downgrade to mutable tag refs.
 #
 # A pre-collector pushed artifact carries bundle_digest (the old single-image
@@ -3361,7 +3361,7 @@ EOF
 #   artifact has neither bundle_digest nor version_digests → tag-based refs,
 #   exit 0 (LOCAL_ONLY regression guard — must stay green).
 # ---------------------------------------------------------------------------
-@test "BD1-legacy-bundle-digest-failclosed: bundle_digest present, no version_digests → fail closed, no Dockerfile" {
+@test "bundle_digest present, no version_digests → fail closed, no Dockerfile" {
     # Legacy artifact: has bundle_digest (old schema) but no version_digests.
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
 {"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"bundle_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
@@ -3382,7 +3382,7 @@ EOF
     [ "$digest_pin_count" -eq 0 ]
 }
 
-@test "BD1-neither-key-tag-fallback: no bundle_digest, no version_digests → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
+@test "no bundle_digest, no version_digests → tag-based refs, exit 0 (LOCAL_ONLY regression)" {
     # LOCAL_ONLY artifact: neither key present → tag-based fallback, exit 0.
     _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
 
@@ -3403,7 +3403,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# BE-2: self-heal availability probe must use the PR-scoped ref it emits.
+# self-heal availability probe must use the PR-scoped ref it emits.
 #
 # Defect: in the self-heal loop, _sh_image is built with ext_image_name (no
 # PR_TAG_SUFFIX) but the emitted COPY line uses _scoped_ext_ref (which appends
@@ -3426,7 +3426,7 @@ EOF
 #   Regression guard — must stay green before and after the fix.
 # ---------------------------------------------------------------------------
 
-@test "BE2-selfheal-probes-scoped-ref: PR_TAG_SUFFIX=-pr42, canonical ABSENT → probe falls back to -pr42 ref" {
+@test "PR_TAG_SUFFIX=-pr42, canonical ABSENT → probe falls back to -pr42 ref" {
     # No versionset artifact — forces self-heal path.
     # PR_TAG_SUFFIX is set to -pr42 (same-repo PR scenario).
     # Canonical-first behavior (BI-1 fix): probe canonical first; if ABSENT (rc=1),
@@ -3485,7 +3485,7 @@ EOF
     [ "$canonical_copy_count" -eq 0 ]
 }
 
-@test "BE2-push-probes-canonical: PR_TAG_SUFFIX empty → self-heal probe uses canonical ref (regression)" {
+@test "PR_TAG_SUFFIX empty → self-heal probe uses canonical ref (regression)" {
     # Push/dispatch path: PR_TAG_SUFFIX is empty.
     # Probe must use canonical refs; scoped-ref logic must be a no-op.
     local tmpd="$TEST_TEMP_DIR"
@@ -3552,7 +3552,7 @@ EOF
 #   unconditionally), even when canonical exists.
 # GREEN after fix: canonical-or-PR-scoped resolution.
 # ---------------------------------------------------------------------------
-@test "BF-consumer-canonical-or-prscoped-A: PR with canonical ext present → FROM uses canonical ref" {
+@test "PR with canonical ext present → FROM uses canonical ref" {
     local tmpd="$TEST_TEMP_DIR"
 
     run bash -c "
@@ -3599,7 +3599,7 @@ EOF
     [ "$pr_from_count" -eq 0 ]
 }
 
-@test "BF-consumer-canonical-or-prscoped-B: PR with canonical absent but PR-scoped present → FROM uses PR-scoped ref" {
+@test "PR with canonical absent but PR-scoped present → FROM uses PR-scoped ref" {
     local tmpd="$TEST_TEMP_DIR"
 
     run bash -c "
@@ -3645,13 +3645,13 @@ EOF
 # CANONICAL (not as -pr42, which would be absent and cause the version to be
 # silently dropped).
 #
-# BI1-selfheal-unchanged-canonical: unchanged version (canonical present, no -pr42)
+# unchanged version (canonical present, no -pr42)
 #   INCLUDED in output as canonical COPY ref.
 #
 # RED before fix: probed as -pr42 → absent → omitted.
 # GREEN after fix: canonical-first probe → canonical present → emitted as canonical.
 # ---------------------------------------------------------------------------
-@test "BI1-selfheal-unchanged-canonical: self-heal on PR, unchanged version has canonical only — included as canonical" {
+@test "self-heal on PR, unchanged version has canonical only — included as canonical" {
     # No versionset artifact — triggers self-heal.
     # PR_TAG_SUFFIX=-pr42: this is a same-repo PR context.
     # Version set: 2.23.0 (unchanged, canonical only) + 2.27.1 (bumped, pr42 only).
@@ -3738,7 +3738,7 @@ EOF
     }
 }
 
-@test "BI1-selfheal-bump-prscoped: self-heal on PR, bumped version has pr42 only — emitted pr-scoped" {
+@test "self-heal on PR, bumped version has pr42 only — emitted pr-scoped" {
     # Complements BI1-selfheal-unchanged-canonical: the bumped version (2.27.1)
     # exists ONLY under the PR-scoped tag. It must be emitted as -pr42.
     local tmpd="$TEST_TEMP_DIR"
@@ -3823,7 +3823,7 @@ EOF
 #   GREEN before and after (regression guard).
 # ---------------------------------------------------------------------------
 
-@test "BJ-1-FORCE-consumer-nonresolver-fresh: REBUILD=force + PR-pr42 + canonical+pr42 both present → emits pr42 ref" {
+@test "REBUILD=force + PR-pr42 + canonical+pr42 both present → emits pr42 ref" {
     # Non-resolver single-version extension (pgvector). Both canonical and -pr42
     # exist in the registry. With REBUILD=force the consumer must prefer the
     # freshly-rebuilt PR-scoped ref, not the (stale) canonical.
@@ -3883,7 +3883,7 @@ EOF
     }
 }
 
-@test "BJ-2-FORCE-consumer-noforce-canonical: REBUILD unset + PR-pr42 + canonical present → emits canonical ref" {
+@test "REBUILD unset + PR-pr42 + canonical present → emits canonical ref" {
     # Non-resolver single-version extension (pgvector). REBUILD is unset.
     # FORCE stays false → canonical-first (reuse unchanged version).
     local tmpd="$TEST_TEMP_DIR"

--- a/tests/unit/latest-github-tag.bats
+++ b/tests/unit/latest-github-tag.bats
@@ -98,7 +98,7 @@ last_output_line() {
     printf '%s' "${lines[$((${#lines[@]} - 1))]}"
 }
 
-@test "tag names with spaces are preserved for raw and both output" {
+@test "github tag: tag names with spaces are preserved for raw and both output" {
     write_fake_curl space_tag
 
     run run_helper "owner/repo" \

--- a/tests/unit/latest-gitlab-tag.bats
+++ b/tests/unit/latest-gitlab-tag.bats
@@ -244,7 +244,7 @@ last_output_line() {
     [[ "$output" == *"Extracted version '0.4.9|11' is not a safe normalized version"* ]]
 }
 
-@test "tag names with spaces are preserved for raw and both output" {
+@test "gitlab tag: tag names with spaces are preserved for raw and both output" {
     write_fake_curl space_tag
 
     run run_helper "tpo/core/tor" \

--- a/tests/unit/lifecycle-behavior.bats
+++ b/tests/unit/lifecycle-behavior.bats
@@ -2,7 +2,7 @@
 
 # Unit tests: lifecycle behavior — P1, P2 (partial), P3, P4, date escalation
 #
-# AC-3  eol-migrate surfaced via check-dependency-versions.sh (P1)
+# eol-migrate surfaced via check-dependency-versions.sh (P1)
 # AC-11 stable-pin date escalation triple (silent / countdown / loud)
 # AC-13 pre-release exclusion + fail-closed
 # AC-15 coupled-atomic refuse (P3)
@@ -84,7 +84,7 @@ _mk_container() {
 }
 
 # ---------------------------------------------------------------------------
-# P1 — eol-migrate is LOUD, never silently skipped (AC-3)
+# eol-migrate is LOUD, never silently skipped
 # The regression lock: BEFORE this change, monitor:false → silent continue.
 # AFTER: lifecycle=eol-migrate → LOUD surface, never continue-skipped.
 #
@@ -92,7 +92,7 @@ _mk_container() {
 # would cause the test to fail because no ::warning:: line would be emitted.
 # ---------------------------------------------------------------------------
 
-@test "P1: eol-migrate entry produces a LOUD ::warning:: via check-dependency-versions.sh" {
+@test "eol-migrate entry produces a LOUD ::warning:: via check-dependency-versions.sh" {
     # Synthetic container with an eol-migrate entry — must live under REPO_ROOT
     _mk_container "bats-eol-test-$$"
     local cdir="$_MK_CONTAINER_RESULT"
@@ -131,7 +131,7 @@ EOF
     }
 }
 
-@test "P1: eol-migrate entry does NOT silently continue (output contains the dep name)" {
+@test "eol-migrate entry does NOT silently continue (output contains the dep name)" {
     _mk_container "bats-eol-test2-$$"
     local cdir="$_MK_CONTAINER_RESULT"
     local cname
@@ -316,7 +316,7 @@ _sibling_lookup() {
         "${config}" 2>/dev/null | tr '\n' ' ' | sed 's/ $//' || true
 }
 
-@test "P3a: bumping RESTY_PCRE_VERSION surfaces RESTY_PCRE_SHA256 as coupled sibling (updates_with polarity)" {
+@test "bumping RESTY_PCRE_VERSION surfaces RESTY_PCRE_SHA256 as coupled sibling (updates_with polarity)" {
     # Fixture: RESTY_PCRE_SHA256 declares updates_with: RESTY_PCRE_VERSION.
     # The workflow bumps RESTY_PCRE_VERSION.
     # Correct guard: find siblings pointing AT the bumped dep.
@@ -362,7 +362,7 @@ EOF
     }
 }
 
-@test "P3b: bumping RESTY_OPENSSL_VERSION surfaces RESTY_OPENSSL_PATCH_VERSION as coupled sibling (tracks_with polarity)" {
+@test "bumping RESTY_OPENSSL_VERSION surfaces RESTY_OPENSSL_PATCH_VERSION as coupled sibling (tracks_with polarity)" {
     # Fixture: RESTY_OPENSSL_PATCH_VERSION declares tracks_with: RESTY_OPENSSL_VERSION.
     # The workflow bumps RESTY_OPENSSL_VERSION.
     _mk_container "bats-coupled-b-$$"
@@ -396,7 +396,7 @@ EOF
     }
 }
 
-@test "P3c: bumping a dep with NO declared siblings produces empty coupled_siblings (no false positive)" {
+@test "bumping a dep with NO declared siblings produces empty coupled_siblings (no false positive)" {
     # Fixture: STANDALONE_VERSION has no sibling pointing at it.
     _mk_container "bats-coupled-c-$$"
     local cdir="$_MK_CONTAINER_RESULT"
@@ -426,7 +426,7 @@ EOF
     }
 }
 
-@test "P3d: mutation trace — old polarity (broken direction) finds nothing for RESTY_PCRE_VERSION" {
+@test "mutation trace — old polarity (broken direction) finds nothing for RESTY_PCRE_VERSION" {
     # This test documents that the OLD broken yq expression returns empty.
     # When the fix is reverted to the old direction, P3a fails (siblings="").
     # This test PASSES by asserting the old expression returns empty —
@@ -458,7 +458,7 @@ EOF
     # RESTY_PCRE_VERSION has no updates_with → returns "".
     local name="RESTY_PCRE_VERSION"
     local broken_result
-    # P1-SECURITY: even in tests, use strenv() to prevent injection if name contains special chars.
+    # even in tests, use strenv() to prevent injection if name contains special chars.
     broken_result=$(YQ_DEP="$name" yq -r '.dependency_sources[strenv(YQ_DEP)].updates_with // ""' \
         "$cdir/config.yaml" 2>/dev/null || true)
 
@@ -471,7 +471,7 @@ EOF
     echo "Confirmed: old broken direction returns '${broken_result}' for ${name} (guard silent — bug demonstrated)"
 }
 
-@test "P3-compat: PCRE_SHA256 untracked is still skipped cleanly by check-dependency-versions.sh" {
+@test "PCRE_SHA256 untracked is still skipped cleanly by check-dependency-versions.sh" {
     # Regression guard for the original P3 behaviour: untracked entries must
     # still be skipped without errors — unchanged by the polarity fix.
     _mk_container "bats-coupled-compat-$$"
@@ -512,7 +512,7 @@ EOF
 # Skip gracefully if no auth available.
 # ---------------------------------------------------------------------------
 
-@test "P4: latest-github-tag returns semver for openssl/openssl ^openssl-3.5. filter" {
+@test "latest-github-tag returns semver for openssl/openssl ^openssl-3.5. filter" {
     if ! command -v gh &>/dev/null && [[ -z "${GITHUB_TOKEN:-}" ]]; then
         skip "No gh CLI auth or GITHUB_TOKEN — network test skipped"
     fi
@@ -531,7 +531,7 @@ EOF
     }
 }
 
-@test "P4: latest-github-tag returns semver for PCRE2Project/pcre2 ^pcre2-10. filter" {
+@test "latest-github-tag returns semver for PCRE2Project/pcre2 ^pcre2-10. filter" {
     if ! command -v gh &>/dev/null && [[ -z "${GITHUB_TOKEN:-}" ]]; then
         skip "No gh CLI auth or GITHUB_TOKEN — network test skipped"
     fi
@@ -550,7 +550,7 @@ EOF
     }
 }
 
-@test "P4: latest-github-tag excludes pre-release tags by default (AC-13)" {
+@test "latest-github-tag excludes pre-release tags by default (AC-13)" {
     # Test the pre-release exclusion logic using a mock tag list via stdin.
     # The helper uses: grep -viE "$PRERELEASE_EXCLUDE_REGEX"
     # where PRERELEASE_EXCLUDE_REGEX='-rc|-alpha|-beta|-dev|-pre'
@@ -587,7 +587,7 @@ pcre2-10.46"
     fi
 }
 
-@test "P4: latest-github-tag fails closed on empty tag list (AC-13)" {
+@test "latest-github-tag fails closed on empty tag list (AC-13)" {
     # Mock: pass an empty repo name that will return no tags (or fail the API)
     # We test fail-closed by calling with a repo that cannot produce valid tags.
     local result
@@ -600,7 +600,7 @@ pcre2-10.46"
     # Exit non-zero = pass (fail-closed)
 }
 
-@test "P4: latest-github-tag version_extract with no capture group is rejected" {
+@test "latest-github-tag version_extract with no capture group is rejected" {
     # version_extract must have exactly one capture group.
     # If BASH_REMATCH[1] is empty, the tag is skipped.
     # We test this by ensuring a no-capture extract produces no results.
@@ -623,7 +623,7 @@ pcre2-10.46"
 }
 
 # ---------------------------------------------------------------------------
-# P3-PRODUCTION-FORM: regression lock for the subprocess export scoping fix.
+# regression lock for the subprocess export scoping fix.
 #
 # The production workflow uses:
 #   coupled_siblings=$(YQ_DEP_NAME="${name}" yq ...)    ← CORRECT (env scopes to yq)
@@ -643,7 +643,7 @@ pcre2-10.46"
 #   3. Restore → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P3-PRODUCTION-FORM: coupled_siblings=\$(YQ_DEP_NAME=N yq ...) scopes env to yq subprocess" {
+@test "coupled_siblings=\$(YQ_DEP_NAME=N yq ...) scopes env to yq subprocess" {
     # Fixture: RESTY_PCRE_SHA256 declares updates_with: RESTY_PCRE_VERSION.
     # The workflow bumps RESTY_PCRE_VERSION.
     _mk_container "bats-p3-prod-$$"
@@ -896,7 +896,7 @@ for i, ch in enumerate(text):
 # convention (e.g. ^openssl-3\.5\.).
 # ---------------------------------------------------------------------------
 
-@test "CLASS-LEVEL: all github-tag config entries produce raw-tag URLs from build_source_url" {
+@test "all github-tag config entries produce raw-tag URLs from build_source_url" {
     # Extract build_source_url function once and reuse across all assertions.
     _call_build_source_url_fn() {
         bash -c "
@@ -1604,7 +1604,7 @@ EOF
 #   3. Restore the candidate lookup → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P2: liveness template substitutes detected latest_version over pinned version" {
+@test "liveness template substitutes detected latest_version over pinned version" {
     # Simulate the workflow step logic inline.
     # Fixture: a tracked dep with a template and a detected latest "10.99"
     local url_template="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
@@ -1675,7 +1675,7 @@ EOF
 #   3. Restore "|| true" → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P1: latest-github-tag single-page (no Link header) exits 0 and returns tags" {
+@test "latest-github-tag single-page (no Link header) exits 0 and returns tags" {
     # Simulate a real single-page GitHub API response: only one page of results,
     # no Link header in the response. The helper MUST complete without error.
     #
@@ -1723,7 +1723,7 @@ EOF
 # grep finds nothing → assignment fails → test RED.
 # ---------------------------------------------------------------------------
 
-@test "P1: Link-header grep pipeline exits 0 and returns empty when no Link header present" {
+@test "Link-header grep pipeline exits 0 and returns empty when no Link header present" {
     # Create a header file with NO Link: line (normal single-page response)
     local hdr_file
     hdr_file=$(mktemp)
@@ -1769,7 +1769,7 @@ EOF
 # → the URL contains the old version → test RED.
 # ---------------------------------------------------------------------------
 
-@test "P0: liveness jq lookup succeeds against dep_version_info shape (not version_info shape)" {
+@test "liveness jq lookup succeeds against dep_version_info shape (not version_info shape)" {
     # dep_version_info shape (correct — from check-dependency-versions action)
     local dep_info
     dep_info=$(jq -n \
@@ -1838,7 +1838,7 @@ EOF
 #   3. Restore "$effective_lifecycle" in the counter case → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P2: lifecycle counter increments lc_tracked for empty-lifecycle entry (backward-compat)" {
+@test "lifecycle counter increments lc_tracked for empty-lifecycle entry (backward-compat)" {
     # Simulate the counter logic from generate-dashboard.sh using the fixed code path.
     local lifecycle=""   # empty — entry has no explicit lifecycle: field
     local lc_tracked=0
@@ -1868,7 +1868,7 @@ EOF
     }
 }
 
-@test "P2: lifecycle counter does NOT double-count when effective_lifecycle resolves to tracked" {
+@test "lifecycle counter does NOT double-count when effective_lifecycle resolves to tracked" {
     # Explicit "tracked" must count exactly once (not confused with empty-resolved-to-tracked)
     local lifecycle="tracked"
     local lc_tracked=0
@@ -1920,7 +1920,7 @@ EOF
 #   4. Restore "tracked|stable-pin)" → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "Fix-R8: stable-pin liveness template substitutes detected candidate over pinned version" {
+@test "stable-pin liveness template substitutes detected candidate over pinned version" {
     # Simulate the upstream-monitor.yaml case logic for a stable-pin entry.
     local lifecycle="stable-pin"
     local url_template="https://www.openssl.org/source/openssl-{version}.tar.gz"
@@ -1990,7 +1990,7 @@ EOF
 # We assert the fallback URL equals the static liveness_url value.
 # ---------------------------------------------------------------------------
 
-@test "Fix-R8: stable-pin WITHOUT liveness_url_template falls back to static liveness_url" {
+@test "stable-pin WITHOUT liveness_url_template falls back to static liveness_url" {
     # Reproduce the advisory-warning fallback branch for stable-pin/no-template.
     local lifecycle="stable-pin"
     local url_template=""   # deliberately absent
@@ -2040,7 +2040,7 @@ EOF
 # The assertion "url must contain pinned_version" goes RED.
 # ---------------------------------------------------------------------------
 
-@test "Fix-R8: stable-pin template falls back to pinned version when no candidate detected" {
+@test "stable-pin template falls back to pinned version when no candidate detected" {
     local lifecycle="stable-pin"
     local url_template="https://www.openssl.org/source/openssl-{version}.tar.gz"
     local pinned_version="3.5.6"

--- a/tests/unit/lifecycle-schema.bats
+++ b/tests/unit/lifecycle-schema.bats
@@ -2,9 +2,9 @@
 
 # Unit tests: lifecycle schema validation across all container config.yaml files
 #
-# AC-1  every dependency_sources entry has a valid lifecycle:
-# AC-2  schema test green (valid lifecycle + required fields per lifecycle)
-# AC-14 lifecycle: REQUIRED on every entry; no implicit default
+# every dependency_sources entry has a valid lifecycle:
+# schema test green (valid lifecycle + required fields per lifecycle)
+# lifecycle: REQUIRED on every entry; no implicit default
 # AC-17 type: github-tag/gitlab-tags requires tag_filter: and version_extract:
 # AC-18 tracked/stable-pin/eol-migrate require type: + per-type locator
 # AC-19 every stable-pin entry declares supported_until_source:
@@ -34,7 +34,7 @@ setup() {
 VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 
 # ---------------------------------------------------------------------------
-# T1 AC-1: every entry has a lifecycle: field
+# every entry has a lifecycle: field
 # ---------------------------------------------------------------------------
 
 @test "every dependency_sources entry has a lifecycle field" {
@@ -70,7 +70,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-2: lifecycle value is in the valid enum
+# lifecycle value is in the valid enum
 # ---------------------------------------------------------------------------
 
 @test "every lifecycle value is in the valid enum {tracked,stable-pin,eol-migrate,untracked}" {
@@ -108,7 +108,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-2: stable-pin and eol-migrate entries require liveness_url:
+# stable-pin and eol-migrate entries require liveness_url:
 # ---------------------------------------------------------------------------
 
 @test "stable-pin and eol-migrate entries declare liveness_url" {
@@ -147,7 +147,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-2: stable-pin entries require supported_until: (ISO date)
+# stable-pin entries require supported_until: (ISO date)
 # ---------------------------------------------------------------------------
 
 @test "stable-pin entries declare supported_until" {
@@ -225,7 +225,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-18: tracked/stable-pin/eol-migrate entries require type: field
+# tracked/stable-pin/eol-migrate entries require type: field
 # ---------------------------------------------------------------------------
 
 @test "tracked, stable-pin, eol-migrate entries declare type" {
@@ -264,7 +264,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 }
 
 # ---------------------------------------------------------------------------
-# T1 AC-18: per-type locator check (repo/project_path/package/gem)
+# per-type locator check (repo/project_path/package/gem)
 # ---------------------------------------------------------------------------
 
 @test "each type has the required locator (github-tag/release=repo, gitlab-tags=project_path, pypi=package, rubygems=gem)" {
@@ -377,7 +377,7 @@ VALID_LIFECYCLES="tracked stable-pin eol-migrate untracked"
 # ---------------------------------------------------------------------------
 # Negative test: schema rejects an entry missing lifecycle (fail-closed)
 # This test uses a synthetic config in BATS_TEST_TMPDIR.
-# AC-14: lifecycle is REQUIRED; no implicit default.
+# lifecycle is REQUIRED; no implicit default.
 # ---------------------------------------------------------------------------
 
 @test "schema test FAILS for an entry missing lifecycle (fail-closed regression lock)" {
@@ -408,7 +408,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# P1-SECURITY regression lock: yq query injection via dep name special chars
+# Security regression lock: yq query injection via dep name special chars
 #
 # A dep name containing yq special characters (e.g. a dot, bracket) MUST
 # be treated as a literal key lookup — NOT reshaping the query path.
@@ -440,7 +440,7 @@ EOF
 #   4. Restore safe form → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P1-SECURITY: dep name with dot is treated as literal key (strenv() injection guard)" {
+@test "dep name with dot is treated as literal key (strenv() injection guard)" {
     local tmpconfig="$BATS_TEST_TMPDIR/injection-config.yaml"
     cat > "$tmpconfig" <<'EOF'
 build_args:

--- a/tests/unit/liveness-url-coherence.bats
+++ b/tests/unit/liveness-url-coherence.bats
@@ -10,7 +10,7 @@
 # Strategy: parse the Dockerfile's RUN … curl … -o lines, interpolate the
 # version values using the config's build_args, and compare to liveness_url.
 #
-# AC-10: drift between config and Dockerfile-constructed URL is a test failure.
+# drift between config and Dockerfile-constructed URL is a test failure.
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 
@@ -292,7 +292,7 @@ _dockerfile_urls_for() {
 #   3. Restore the P3 block → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "P3: pagination bound reached with more pages exits non-zero (sourced helper)" {
+@test "pagination bound reached with more pages exits non-zero (sourced helper)" {
     # Mutation trace: remove the P3 guard block from helpers/latest-github-tag
     # (the `if [[ "$pages_fetched" -ge "$max_pages" && -n "$url" ]]` block) and
     # this test goes RED — the helper exits 0 with truncated tags when max_pages
@@ -372,7 +372,7 @@ _dockerfile_urls_for() {
 #   3. Restore liveness_url_template → GREEN.
 # ---------------------------------------------------------------------------
 
-@test "Fix-R8: all stable-pin entries with liveness_url also declare liveness_url_template" {
+@test "all stable-pin entries with liveness_url also declare liveness_url_template" {
     local bad=0
     local bad_list=""
 

--- a/tests/unit/make-list-deps.bats
+++ b/tests/unit/make-list-deps.bats
@@ -6,9 +6,9 @@
 # touching the real project state.
 #
 # Mutation guards:
-#   MG1: Remove validation → unknown container accepted
-#   MG2: Remove direct dep printing → output missing 'direct' line
-#   MG3: Remove transitive dep printing → output missing 'transitive' line
+#   Remove validation → unknown container accepted
+#   Remove direct dep printing → output missing 'direct' line
+#   Remove transitive dep printing → output missing 'transitive' line
 
 load "../test_helper"
 
@@ -42,7 +42,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Test 1: Known container with direct dep prints correct output
-# MG2: verifies 'direct:' line is present
+# verifies 'direct:' line is present
 # ---------------------------------------------------------------------------
 @test "make list-deps: known container prints direct and transitive" {
     export _DEPGRAPH_CONTAINERS_OVERRIDE="php wordpress"
@@ -56,7 +56,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Test 2: Unknown container exits non-zero with error message
-# MG1: verifies validation is present
+# verifies validation is present
 # ---------------------------------------------------------------------------
 @test "make list-deps: unknown container exits 1 with error" {
     export _DEPGRAPH_CONTAINERS_OVERRIDE="php wordpress"
@@ -67,7 +67,7 @@ _write_lineage() {
 
 # ---------------------------------------------------------------------------
 # Test 3: Container with no deps prints "(none)" messages
-# MG3: verifies no-dep case is explicitly shown
+# verifies no-dep case is explicitly shown
 # ---------------------------------------------------------------------------
 @test "make list-deps: container with no internal deps prints (none)" {
     export _DEPGRAPH_CONTAINERS_OVERRIDE="debian"

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -2,18 +2,18 @@
 # Unit tests for helpers/mirror-dockerhub.sh — ADR-013 production cutover
 #
 # Mutation guards (named per test):
-#   MD1: Default latest cell mirrors both versioned AND :latest from GHCR
-#   MD2: Non-default flavored cell mirrors :latest-<variant> instead of :latest
-#   MD3: Retained non-latest cell mirrors ONLY the versioned tag (no rolling alias)
-#   MD4: Function skips when DOCKERHUB_USERNAME is unset
-#   MD5: A single mirror failure does NOT fail the function (best-effort; rc=0)
-#   MD6: BAKE_GENERATE_ALL_RETAINED ignored → retained GHCR tags absent on DockerHub
-#   MS1: MIRROR_STRICT unset → returns 0 even when all imagetools fail (best-effort preserved)
-#   MS2: MIRROR_STRICT=true + all imagetools succeed → returns 0
-#   MS3: MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0) → returns non-zero
-#   MS4: MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0
-#   MS5: MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero (structural)
-#   MS6: MIRROR_STRICT=true + generator yields no cells → returns non-zero (structural)
+#   Default latest cell mirrors both versioned AND :latest from GHCR
+#   Non-default flavored cell mirrors :latest-<variant> instead of :latest
+#   Retained non-latest cell mirrors ONLY the versioned tag (no rolling alias)
+#   Function skips when DOCKERHUB_USERNAME is unset
+#   A single mirror failure does NOT fail the function (best-effort; rc=0)
+#   BAKE_GENERATE_ALL_RETAINED ignored → retained GHCR tags absent on DockerHub
+#   MIRROR_STRICT unset → returns 0 even when all imagetools fail (best-effort preserved)
+#   MIRROR_STRICT=true + all imagetools succeed → returns 0
+#   MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0) → returns non-zero
+#   MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0
+#   MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero (structural)
+#   MIRROR_STRICT=true + generator yields no cells → returns non-zero (structural)
 
 load "../test_helper"
 
@@ -92,11 +92,11 @@ _run_mirror() {
 }
 
 # ---------------------------------------------------------------------------
-# MD-01: Default-variant (is_default=true) latest cell mirrors versioned tag
+# Default-variant (is_default=true) latest cell mirrors versioned tag
 #        AND :latest to docker.io.
 # Catches: MD1
 # ---------------------------------------------------------------------------
-@test "MD-01: default latest cell mirrors versioned tag and :latest to docker.io" {
+@test "default latest cell mirrors versioned tag and :latest to docker.io" {
     # web-shell is the simplest bake-managed container with a default variant
     run _run_mirror "web-shell"
     [ "$status" -eq 0 ]
@@ -120,10 +120,10 @@ _run_mirror() {
 }
 
 # ---------------------------------------------------------------------------
-# MD-02: Non-default flavored cell mirrors :latest-<variant> (not :latest).
+# Non-default flavored cell mirrors :latest-<variant> (not :latest).
 # Catches: MD2
 # ---------------------------------------------------------------------------
-@test "MD-02: non-default flavored cell mirrors :latest-<variant>" {
+@test "non-default flavored cell mirrors :latest-<variant>" {
     # github-runner has multiple non-default variants (e.g. ubuntu-2404)
     run _run_mirror "github-runner"
     [ "$status" -eq 0 ]
@@ -140,10 +140,10 @@ _run_mirror() {
 }
 
 # ---------------------------------------------------------------------------
-# MD-03: Retained non-latest cell mirrors ONLY the versioned tag.
+# Retained non-latest cell mirrors ONLY the versioned tag.
 # Catches: MD3
 # ---------------------------------------------------------------------------
-@test "MD-03: retained non-latest cell mirrors only versioned tag" {
+@test "retained non-latest cell mirrors only versioned tag" {
     # Use a synthetic bake-managed container that has retained non-latest versions.
     # We test this by checking the mirror logic directly: for a cell with
     # is_latest_version=false, only the versioned suffix ($tag) is published.
@@ -256,10 +256,10 @@ GEN_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MD-04: Function skips entirely when DOCKERHUB_USERNAME is unset.
+# Function skips entirely when DOCKERHUB_USERNAME is unset.
 # Catches: MD4
 # ---------------------------------------------------------------------------
-@test "MD-04: skips when DOCKERHUB_USERNAME is unset" {
+@test "skips when DOCKERHUB_USERNAME is unset" {
     unset DOCKERHUB_USERNAME
 
     run _run_mirror "web-shell"
@@ -276,10 +276,10 @@ GEN_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MD-06: BAKE_GENERATE_ALL_RETAINED=true passes --all-retained to the generator.
+# BAKE_GENERATE_ALL_RETAINED=true passes --all-retained to the generator.
 # Catches: MD6 — mirrored tag set diverges from GHCR when retained versions omitted
 # ---------------------------------------------------------------------------
-@test "MD-06: BAKE_GENERATE_ALL_RETAINED=true mirrors retained cells for terraform" {
+@test "BAKE_GENERATE_ALL_RETAINED=true mirrors retained cells for terraform" {
     # terraform has version_retention=3 and no bake_latest_only — retained versions
     # are present with --all-retained.
     export BAKE_GENERATE_ALL_RETAINED=true
@@ -306,7 +306,7 @@ GEN_EOF
             "$retained_calls" "$latest_only_calls" >&2; false)
 }
 
-@test "MD-07: BAKE_GENERATE_ALL_RETAINED=false produces latest-only mirror calls for terraform" {
+@test "BAKE_GENERATE_ALL_RETAINED=false produces latest-only mirror calls for terraform" {
     export BAKE_GENERATE_ALL_RETAINED=false
 
     run _run_mirror "terraform"
@@ -317,7 +317,7 @@ GEN_EOF
         (cat "${TEST_LOG_DIR}/run.log" >&2 && false)
 }
 
-@test "MD-08: BAKE_GENERATE_ALL_RETAINED=true github-runner remains latest-only (bake_latest_only)" {
+@test "BAKE_GENERATE_ALL_RETAINED=true github-runner remains latest-only (bake_latest_only)" {
     # github-runner has bake_latest_only=true — even with BAKE_GENERATE_ALL_RETAINED=true
     # the generator must force latest-only, so the mirror call count must equal
     # the BAKE_GENERATE_ALL_RETAINED=false call count.
@@ -342,10 +342,10 @@ GEN_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MD-05: A single mirror failure does NOT fail the function (best-effort).
+# A single mirror failure does NOT fail the function (best-effort).
 # Catches: MD5
 # ---------------------------------------------------------------------------
-@test "MD-05: single mirror failure does not fail the function" {
+@test "single mirror failure does not fail the function" {
     # Create a mock docker that always exits 1 (simulates imagetools failure)
     cat > "$MOCK_DOCKER" <<'FAIL_EOF'
 #!/usr/bin/env bash
@@ -372,10 +372,10 @@ FAIL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-01: MIRROR_STRICT unset → returns 0 even when all imagetools fail.
+# MIRROR_STRICT unset → returns 0 even when all imagetools fail.
 # Catches: MS1 — best-effort behavior must be unchanged when strict mode is off.
 # ---------------------------------------------------------------------------
-@test "MS-01: MIRROR_STRICT unset returns 0 even when all imagetools fail" {
+@test "MIRROR_STRICT unset returns 0 even when all imagetools fail" {
     unset MIRROR_STRICT
 
     # All docker calls fail
@@ -395,10 +395,10 @@ FAIL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-02: MIRROR_STRICT=true + all imagetools succeed → returns 0.
+# MIRROR_STRICT=true + all imagetools succeed → returns 0.
 # Catches: MS2 — strict mode must not break the happy path.
 # ---------------------------------------------------------------------------
-@test "MS-02: MIRROR_STRICT=true all-succeed returns 0" {
+@test "MIRROR_STRICT=true all-succeed returns 0" {
     export MIRROR_STRICT="true"
 
     # MOCK_DOCKER already exits 0 (default setup)
@@ -415,11 +415,11 @@ FAIL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-03: MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0)
+# MIRROR_STRICT=true + ALL imagetools fail (attempted>0, succeeded==0)
 #        → returns non-zero.
 # Catches: MS3 — total failure must be observable in strict mode.
 # ---------------------------------------------------------------------------
-@test "MS-03: MIRROR_STRICT=true all-fail returns non-zero" {
+@test "MIRROR_STRICT=true all-fail returns non-zero" {
     export MIRROR_STRICT="true"
 
     # All docker calls fail
@@ -445,14 +445,14 @@ FAIL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-04: MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0.
+# MIRROR_STRICT=true + PARTIAL success (some succeed, some fail) → returns 0.
 # Catches: MS4 — transient single-tag flakes must not red the nightly cron.
 #
 # Strategy: the first imagetools call succeeds, subsequent ones fail.
 # web-shell produces at least 2 tags (versioned + :latest), so the counter
 # will have succeeded≥1 and attempted≥2.
 # ---------------------------------------------------------------------------
-@test "MS-04: MIRROR_STRICT=true partial-success returns 0" {
+@test "MIRROR_STRICT=true partial-success returns 0" {
     export MIRROR_STRICT="true"
 
     # First call succeeds, all subsequent fail
@@ -483,10 +483,10 @@ PARTIAL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-05: MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero.
+# MIRROR_STRICT=true + DOCKERHUB_USERNAME unset → returns non-zero.
 # Catches: MS5 — missing credentials is a structural misconfiguration.
 # ---------------------------------------------------------------------------
-@test "MS-05: MIRROR_STRICT=true DOCKERHUB_USERNAME unset returns non-zero" {
+@test "MIRROR_STRICT=true DOCKERHUB_USERNAME unset returns non-zero" {
     export MIRROR_STRICT="true"
     unset DOCKERHUB_USERNAME
 
@@ -505,12 +505,12 @@ PARTIAL_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MS-06: MIRROR_STRICT=true + generator yields no cells → returns non-zero.
+# MIRROR_STRICT=true + generator yields no cells → returns non-zero.
 # Catches: MS6 — empty cell set is a structural failure (no-op reconciliation).
 #
 # Strategy: set _MDH_GENERATOR_OVERRIDE to a mock that returns an empty JSON array.
 # ---------------------------------------------------------------------------
-@test "MS-06: MIRROR_STRICT=true generator no-cells returns non-zero" {
+@test "MIRROR_STRICT=true generator no-cells returns non-zero" {
     export MIRROR_STRICT="true"
 
     # Mock generator returns an empty array
@@ -543,11 +543,11 @@ GEN_EOF
 }
 
 # ---------------------------------------------------------------------------
-# MD8: mirror self-derives --include-final-build for bake-final containers, so
+# mirror self-derives --include-final-build for bake-final containers, so
 # the nightly reconcile (which sets no BAKE_GENERATE_FINAL_BUILD) still mirrors
 # postgres final-image tags after the bake migration.
 # ---------------------------------------------------------------------------
-@test "MD-08: _mdh_any_bake_final true for postgres, false for non-extension containers" {
+@test "_mdh_any_bake_final true for postgres, false for non-extension containers" {
     run bash -c '
         set +u
         _MDH_SCRIPT_DIR="'"${HELPERS_DIR}"'"

--- a/tests/unit/open-dep-failure-issue.bats
+++ b/tests/unit/open-dep-failure-issue.bats
@@ -1229,7 +1229,7 @@ GHEOF
     fi
 }
 
-@test "FIX5: --mode recovery --container 'a b' is rejected, exit 0, no gh close (DRY_RUN)" {
+@test "--mode recovery --container 'a b' is rejected, exit 0, no gh close (DRY_RUN)" {
     mkdir -p "$TEST_TEMP_DIR/bin"
     local call_log="$TEST_TEMP_DIR/gh_calls.log"
     cat > "$TEST_TEMP_DIR/bin/gh" << GHEOF
@@ -1269,7 +1269,7 @@ GHEOF
 # must exit 0 (best-effort) with a warning, not abort under set -euo pipefail.
 # ---------------------------------------------------------------------------
 
-@test "FIX2: --mode recovery --container postgres, gh issue list fails → exit 0, no gh close (set -e safe)" {
+@test "--mode recovery --container postgres, gh issue list fails → exit 0, no gh close (set -e safe)" {
     # close_container_build_failure_on_recovery uses `if ! x=$(cmd); then` pattern.
     # Under set -euo pipefail, the old `x=$(cmd); rc=$?; if rc -ne 0` was dead code:
     # set -e aborted before the rc check.  The fix must keep exit 0 (best-effort).
@@ -1417,7 +1417,7 @@ GHEOF
 # F3 — FAILED_ALLOWLIST cross-check in auto-detect path
 # ---------------------------------------------------------------------------
 
-@test "F3: FAILED_ALLOWLIST set, detected container absent → exits 1 (skip, no spurious issue)" {
+@test "FAILED_ALLOWLIST set, detected container absent → exits 1 (skip, no spurious issue)" {
     # deps(php) commit detected, but FAILED_ALLOWLIST=['other'] — php is not in the failure set.
     # Script must exit 1 (no-op, same as no-dep-bump) without opening a gh issue.
     export COMMIT_SUBJECT="deps(php): bump to 8.3"
@@ -1429,7 +1429,7 @@ GHEOF
     [ "$status" -eq 1 ]
 }
 
-@test "F3: FAILED_ALLOWLIST set, detected container present → proceeds (exits 0 in DRY_RUN)" {
+@test "FAILED_ALLOWLIST set, detected container present → proceeds (exits 0 in DRY_RUN)" {
     # deps(php) commit detected, FAILED_ALLOWLIST=['php'] — php IS in the failure set.
     # Script must proceed to open the issue (DRY_RUN → exit 0 with dry-run output).
     export COMMIT_SUBJECT="deps(php): bump to 8.3"
@@ -1441,7 +1441,7 @@ GHEOF
     [ "$status" -eq 0 ]
 }
 
-@test "F3: FAILED_ALLOWLIST unset → no cross-check, original behaviour (exits 0 in DRY_RUN)" {
+@test "FAILED_ALLOWLIST unset → no cross-check, original behaviour (exits 0 in DRY_RUN)" {
     # No FAILED_ALLOWLIST → non-checkpoint run; original #514 behaviour preserved.
     # deps(php) commit detected, no allowlist → proceeds unconditionally.
     export COMMIT_SUBJECT="deps(php): bump to 8.3"
@@ -1452,7 +1452,7 @@ GHEOF
     [ "$status" -eq 0 ]
 }
 
-@test "F3: FAILED_ALLOWLIST='' (empty string) → no cross-check, original behaviour" {
+@test "FAILED_ALLOWLIST='' (empty string) → no cross-check, original behaviour" {
     # Empty string (checkpoint skipped/guard-break) → same as unset → no allowlist check.
     export COMMIT_SUBJECT="deps(php): bump to 8.3"
     export FAILED_ALLOWLIST=""
@@ -1466,7 +1466,7 @@ GHEOF
 # F4 — --container with no value exits 2 (usage error, distinct from 1)
 # ---------------------------------------------------------------------------
 
-@test "F4: --container with no value → exit 2 + warning (not exit 1 no-dep-bump)" {
+@test "--container with no value → exit 2 + warning (not exit 1 no-dep-bump)" {
     # Under set -u, bare --container with no $2 would crash with "unbound variable".
     # With ${2:-} guard it must exit 2 (usage error) with a warning, not exit 1.
     run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode failure --container
@@ -1478,7 +1478,7 @@ GHEOF
 # F2 — invalid --container name in failure mode → exit 3 (downgrade, not 0)
 # ---------------------------------------------------------------------------
 
-@test "F2: --mode failure --container 'Bad.Name' (invalid chars) → exit 3, not 0" {
+@test "--mode failure --container 'Bad.Name' (invalid chars) → exit 3, not 0" {
     # An invalid container name must return 3 (gh/op failure class) so that
     # the checkpoint loop's `|| issue_open_failed=true` fires → issue_mode
     # downgrades per-container→generic → generic backstop alerts.
@@ -1487,7 +1487,7 @@ GHEOF
     [ "$status" -eq 3 ]
 }
 
-@test "F2: --mode recovery --container 'Bad.Name' (invalid chars) → exit 0 (best-effort close, unchanged)" {
+@test "--mode recovery --container 'Bad.Name' (invalid chars) → exit 0 (best-effort close, unchanged)" {
     # Recovery path keeps best-effort return 0 for invalid names — close has no alert
     # obligation, so fail-open is correct there.  This test confirms the asymmetry.
     run bash "$SCRIPTS_DIR/open-dep-failure-issue.sh" --mode recovery --container "Bad.Name"

--- a/tests/unit/openresty-build-version.bats
+++ b/tests/unit/openresty-build-version.bats
@@ -11,12 +11,12 @@
 # We extract UPSTREAM_VERSION from that line for assertions.
 #
 # Mutation each test catches:
-#   TC1: removing the VERSION branch → version.sh called, returns 9.8.7 ≠ "1.29.2.4"
-#   TC2: removing suffix strip → UPSTREAM_VERSION would equal "1.29.2.5-alpine" ≠ "1.29.2.5"
-#   TC3: removing the else branch → version.sh never called, UPSTREAM_VERSION empty or wrong
-#   TC4: removing the -z guard → script exits 0 and emits "(source: )" instead of error exit 1
-#   TC5: suffix strip using sed/grep instead of %-alpine → "1.29.2.4" (no suffix) would break
-#   TC6-TC8: removing dotted-numeric validation → invalid upstream versions pass
+#   removing the VERSION branch → version.sh called, returns 9.8.7 ≠ "1.29.2.4"
+#   removing suffix strip → UPSTREAM_VERSION would equal "1.29.2.5-alpine" ≠ "1.29.2.5"
+#   removing the else branch → version.sh never called, UPSTREAM_VERSION empty or wrong
+#   removing the -z guard → script exits 0 and emits "(source: )" instead of error exit 1
+#   suffix strip using sed/grep instead of %-alpine → "1.29.2.4" (no suffix) would break
+#   removing dotted-numeric validation → invalid upstream versions pass
 
 bats_require_minimum_version 1.5.0
 
@@ -95,10 +95,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC1: VERSION="1.29.2.4-alpine" → RESTY_VERSION="1.29.2.4"
+# VERSION="1.29.2.4-alpine" → RESTY_VERSION="1.29.2.4"
 # =============================================================================
 
-@test "TC1: VERSION=1.29.2.4-alpine sets RESTY_VERSION to 1.29.2.4" {
+@test "VERSION=1.29.2.4-alpine sets RESTY_VERSION to 1.29.2.4" {
     export VERSION="1.29.2.4-alpine"
     _run_build
 
@@ -109,10 +109,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC2: VERSION="1.29.2.5-alpine" → RESTY_VERSION="1.29.2.5" (latest retained)
+# VERSION="1.29.2.5-alpine" → RESTY_VERSION="1.29.2.5" (latest retained)
 # =============================================================================
 
-@test "TC2: VERSION=1.29.2.5-alpine sets RESTY_VERSION to 1.29.2.5" {
+@test "VERSION=1.29.2.5-alpine sets RESTY_VERSION to 1.29.2.5" {
     export VERSION="1.29.2.5-alpine"
     _run_build
 
@@ -123,10 +123,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC3: VERSION unset → RESTY_VERSION comes from version.sh --upstream stub
+# VERSION unset → RESTY_VERSION comes from version.sh --upstream stub
 # =============================================================================
 
-@test "TC3: VERSION unset falls back to version.sh --upstream" {
+@test "VERSION unset falls back to version.sh --upstream" {
     unset VERSION
     _run_build
 
@@ -137,10 +137,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC4: VERSION="-alpine" (empty after strip) → exit 1 + "resolves to empty" in stderr
+# VERSION="-alpine" (empty after strip) → exit 1 + "resolves to empty" in stderr
 # =============================================================================
 
-@test "TC4: VERSION=-alpine (empty after strip) exits 1 with error in stderr" {
+@test "VERSION=-alpine (empty after strip) exits 1 with error in stderr" {
     export VERSION="-alpine"
     _run_build
 
@@ -149,10 +149,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC5: VERSION="1.29.2.4" (no -alpine suffix) → RESTY_VERSION="1.29.2.4" (no-op strip)
+# VERSION="1.29.2.4" (no -alpine suffix) → RESTY_VERSION="1.29.2.4" (no-op strip)
 # =============================================================================
 
-@test "TC5: VERSION=1.29.2.4 (no -alpine suffix) sets RESTY_VERSION to 1.29.2.4" {
+@test "VERSION=1.29.2.4 (no -alpine suffix) sets RESTY_VERSION to 1.29.2.4" {
     export VERSION="1.29.2.4"
     _run_build
 
@@ -163,10 +163,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC6: VERSION="alpine-alpine" -> RESTY_VERSION="alpine" -> invalid
+# VERSION="alpine-alpine" -> RESTY_VERSION="alpine" -> invalid
 # =============================================================================
 
-@test "TC6: VERSION=alpine-alpine rejects non-numeric stripped version" {
+@test "VERSION=alpine-alpine rejects non-numeric stripped version" {
     export VERSION="alpine-alpine"
     _run_build
 
@@ -175,10 +175,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC7: VERSION="1.29.2.5-alpine-beta" -> invalid
+# VERSION="1.29.2.5-alpine-beta" -> invalid
 # =============================================================================
 
-@test "TC7: VERSION=1.29.2.5-alpine-beta rejects prerelease suffix" {
+@test "VERSION=1.29.2.5-alpine-beta rejects prerelease suffix" {
     export VERSION="1.29.2.5-alpine-beta"
     _run_build
 
@@ -187,10 +187,10 @@ _extract_resty_version() {
 }
 
 # =============================================================================
-# TC8: VERSION unset and version.sh --upstream returns garbage -> invalid
+# VERSION unset and version.sh --upstream returns garbage -> invalid
 # =============================================================================
 
-@test "TC8: VERSION unset rejects invalid version.sh --upstream output" {
+@test "VERSION unset rejects invalid version.sh --upstream output" {
     unset VERSION
     _write_version_stub "alpine"
     _run_build

--- a/tests/unit/registry-utils-cache.bats
+++ b/tests/unit/registry-utils-cache.bats
@@ -200,7 +200,7 @@ GH_SHIM
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-1: cache_hit_no_refetch — the Observable Success proof
+# cache_hit_no_refetch — the Observable Success proof
 # ---------------------------------------------------------------------------
 
 @test "content-digest extract: valid Docker-Content-Digest header returns hex" {
@@ -268,7 +268,7 @@ GH_SHIM
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-2: poisoned per-arch body (.errors envelope) → return 1, no cache file
+# poisoned per-arch body (.errors envelope) → return 1, no cache file
 # ---------------------------------------------------------------------------
 
 @test "poisoned per-arch body (.errors) returns 1 and writes no cache file" {
@@ -332,7 +332,7 @@ CURL_POISON
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-3: all-or-nothing — 1st arch valid, 2nd arch returns .errors → return 1 + zero stdout
+# all-or-nothing — 1st arch valid, 2nd arch returns .errors → return 1 + zero stdout
 # ---------------------------------------------------------------------------
 
 @test "all-or-nothing: valid 1st arch + errored 2nd arch returns 1 with zero stdout" {
@@ -400,7 +400,7 @@ CURL_MIXED
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-4: single-manifest image (no .manifests) — still emits amd64:<size>
+# single-manifest image (no .manifests) — still emits amd64:<size>
 #            and writes no perarch/*.body file (no per-arch loop executed)
 # ---------------------------------------------------------------------------
 
@@ -462,7 +462,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-5: atomic-write correctness — cache bodies in perarch/ subdir,
+# atomic-write correctness — cache bodies in perarch/ subdir,
 #            no leftover .tmp.* files after successful write
 # ---------------------------------------------------------------------------
 
@@ -525,7 +525,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-7: _ghcr_verify_content_digest — matching sha256 returns 0
+# _ghcr_verify_content_digest — matching sha256 returns 0
 # ---------------------------------------------------------------------------
 
 @test "content-digest verify: matching sha256 admits cache" {
@@ -541,7 +541,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-8: _ghcr_verify_content_digest — mismatched sha256 returns 1
+# _ghcr_verify_content_digest — mismatched sha256 returns 1
 # ---------------------------------------------------------------------------
 
 @test "content-digest verify: mismatched sha256 rejects" {
@@ -557,7 +557,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-9: _ghcr_verify_content_digest — missing file returns 1
+# _ghcr_verify_content_digest — missing file returns 1
 # ---------------------------------------------------------------------------
 
 @test "content-digest verify: missing file returns 1" {
@@ -569,7 +569,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-10: _ghcr_verify_content_digest — trailing-newline-safe
+# _ghcr_verify_content_digest — trailing-newline-safe
 # Verifies that sha256sum operates on exact file bytes (no stripping).
 # ---------------------------------------------------------------------------
 
@@ -594,7 +594,7 @@ CURL_SINGLE
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-11: per-arch cache — tampered body (sha256 mismatch) is rejected
+# per-arch cache — tampered body (sha256 mismatch) is rejected
 # The OCI index carries the real digest; shim returns a different body.
 # ---------------------------------------------------------------------------
 
@@ -656,7 +656,7 @@ CURL_TAMPER
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-12: index cache — Docker-Content-Digest mismatch → body not cached
+# index cache — Docker-Content-Digest mismatch → body not cached
 # ---------------------------------------------------------------------------
 
 @test "index cache: Docker-Content-Digest mismatch body not cached" {
@@ -704,7 +704,7 @@ CURL_IDX_BAD
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-13: cache-dir warning emitted exactly once per run
+# cache-dir warning emitted exactly once per run
 # ---------------------------------------------------------------------------
 
 @test "cache-dir warning emitted once when cache dir cannot be created" {
@@ -736,7 +736,7 @@ CURL_IDX_BAD
 }
 
 # ---------------------------------------------------------------------------
-# D2-test-14: graceful degrade — unwritable cache dir must not prevent
+# graceful degrade — unwritable cache dir must not prevent
 # network fetches in _ghcr_fetch_index
 # ---------------------------------------------------------------------------
 
@@ -1059,7 +1059,7 @@ CURL_NL
 }
 
 # ---------------------------------------------------------------------------
-# r4-test-1: _ghcr_fetch_index — tampered cache body evicted and refetched
+# _ghcr_fetch_index — tampered cache body evicted and refetched
 # Pre-populate idx-*.body with bytes that don't match the Docker-Content-Digest
 # in idx-*.hdrs.  The valid body + headers come from curl.  The function must
 # evict the tampered file, emit ::warning::, and return the FRESH body.
@@ -1116,7 +1116,7 @@ CURL_NL
 }
 
 # ---------------------------------------------------------------------------
-# r4-test-2: _ghcr_fetch_index — valid cache hit uses fast path (no curl)
+# _ghcr_fetch_index — valid cache hit uses fast path (no curl)
 # Pre-populate with a body that MATCHES its Docker-Content-Digest.  The curl
 # shim is replaced with one that fails — it must not be called.
 # ---------------------------------------------------------------------------
@@ -1161,7 +1161,7 @@ CURL_FAIL
 }
 
 # ---------------------------------------------------------------------------
-# r4-test-3: per-arch cache hit — tampered body evicted and refetched
+# per-arch cache hit — tampered body evicted and refetched
 # Pre-populate perarch/<key>.body with bytes whose sha256 doesn't match
 # digest_hash.  The curl shim returns the valid body.  Function must succeed
 # with correct sizes, emit ::warning::, and replace the tampered file.
@@ -1202,7 +1202,7 @@ CURL_FAIL
 }
 
 # ---------------------------------------------------------------------------
-# r4-test-4: per-arch cache hit — valid digest → fast path (curl not called)
+# per-arch cache hit — valid digest → fast path (curl not called)
 # Pre-populate BOTH per-arch cache files with valid matching bytes.
 # Replace per-arch curl with a shim that fails on any sha256: request —
 # proving that neither cached arch triggers a network round-trip.
@@ -1283,7 +1283,7 @@ CURL_PERARCH_FAIL
 # returns 0 (data available from network) rather than failing.
 # ---------------------------------------------------------------------------
 
-@test "r6: digestless cache header evicts and refetches under set -euo pipefail (r8 security fix)" {
+@test "digestless cache header evicts and refetches under set -euo pipefail (r8 security fix)" {
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"
 
@@ -1369,7 +1369,7 @@ CURL_FRESH
 # the warning a second time.
 # ---------------------------------------------------------------------------
 
-@test "r6: cache-dir warning emitted at least once across token + manifest_sizes calls (Defect B)" {
+@test "cache-dir warning emitted at least once across token + manifest_sizes calls (Defect B)" {
     # Run in a subshell; both stderr streams (token subshell + parent direct
     # call) are merged to stdout so bats captures them in $output.
     # NOTE: do NOT redirect the token subshell's stderr to the token variable —
@@ -1413,7 +1413,7 @@ CURL_FRESH
 # outer || true suppressor, leaking a confusing error line to CI logs.
 # ---------------------------------------------------------------------------
 
-@test "r6: token cache write to unwritable dir emits no shell redirect error (Defect B)" {
+@test "token cache write to unwritable dir emits no shell redirect error (Defect B)" {
     run --separate-stderr bash -c '
         source "'"$REPO_ROOT"'/helpers/logging.sh" 2>/dev/null || true
         source "'"$REPO_ROOT"'/helpers/registry-utils.sh"
@@ -1447,7 +1447,7 @@ CURL_FRESH
 }
 
 # ---------------------------------------------------------------------------
-# r7-A: strict digest parse — malformed multi-sha256 header rejected
+# strict digest parse — malformed multi-sha256 header rejected
 #
 # Regression guard: the old greedy sed 's/.*sha256://i' | head -c 64 would
 # extract the LAST sha256 token from a header like:
@@ -1460,7 +1460,7 @@ CURL_FRESH
 # "no header stored").
 # ---------------------------------------------------------------------------
 
-@test "r7-A: malformed multi-sha256 header rejected — strict parser evicts and refetches (r8 security fix)" {
+@test "malformed multi-sha256 header rejected — strict parser evicts and refetches (r8 security fix)" {
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"
 
@@ -1528,7 +1528,7 @@ CURL_FRESH_R7A
 }
 
 # ---------------------------------------------------------------------------
-# r7-B: bats assertion correctness — direct string check catches "No such file"
+# bats assertion correctness — direct string check catches "No such file"
 #
 # Regression guard for Defect B: the original test used `! echo "$stderr" | grep`
 # which is unreliable under set -e when followed by other statements.  This test
@@ -1536,7 +1536,7 @@ CURL_FRESH_R7A
 # a synthesized stderr containing the forbidden phrase.
 # ---------------------------------------------------------------------------
 
-@test "r7-B: direct string assertion catches synthesized 'No such file or directory' in stderr" {
+@test "direct string assertion catches synthesized 'No such file or directory' in stderr" {
     # Synthesize a stderr that contains the forbidden phrase.
     local synthetic_stderr
     synthetic_stderr="bash: /proc/1/cannot-create: No such file or directory"
@@ -1558,7 +1558,7 @@ CURL_FRESH_R7A
 }
 
 # ---------------------------------------------------------------------------
-# r8: corrupted-hdrs poison-eviction regression
+# corrupted-hdrs poison-eviction regression
 #
 # Security regression guard for Defect A (r8 fix): an attacker who can write
 # to GHCR_CACHE_DIR pre-populates the body with poisoned bytes and removes the
@@ -1571,7 +1571,7 @@ CURL_FRESH_R7A
 # This proves the attack vector is closed: missing digest ≠ trust cache.
 # ---------------------------------------------------------------------------
 
-@test "r8: corrupted-hdrs (no digest) → evict + refetch, poison not served" {
+@test "corrupted-hdrs (no digest) → evict + refetch, poison not served" {
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"
 
@@ -1642,10 +1642,10 @@ CURL_FRESH_R8
 }
 
 # ---------------------------------------------------------------------------
-# r9: Defect A — cache dir trust validation
+# Defect A — cache dir trust validation
 # ---------------------------------------------------------------------------
 
-@test "r9-A1: loose-mode cache dir (0777) is rejected — switches to private mktemp (not reused)" {
+@test "loose-mode cache dir (0777) is rejected — switches to private mktemp (not reused)" {
     # r10 fix: a dir owned by us but with mode != 0700 must be treated as
     # untrusted.  It may contain attacker-planted body+hdrs files with matching
     # digests written before we arrived; silent chmod-to-700 only closes future
@@ -1683,7 +1683,7 @@ CURL_FRESH_R8
     grep -q '::warning::.*untrusted' "$stderr_log"
 }
 
-@test "r9-A2: symlink cache dir is rejected — warning emitted and private mktemp used" {
+@test "symlink cache dir is rejected — warning emitted and private mktemp used" {
     # A symlink at GHCR_CACHE_DIR could point to attacker-controlled storage.
     # _ghcr_ensure_cachedir must detect the symlink and switch to a fresh dir.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
@@ -1712,10 +1712,10 @@ CURL_FRESH_R8
 }
 
 # ---------------------------------------------------------------------------
-# r9: Defect B — fresh-fetch no-digest = skip-cache-but-return-body
+# Defect B — fresh-fetch no-digest = skip-cache-but-return-body
 # ---------------------------------------------------------------------------
 
-@test "r9-B: fresh response without Docker-Content-Digest — returns 1 (fail-closed, no body served)" {
+@test "fresh response without Docker-Content-Digest — returns 1 (fail-closed, no body served)" {
     # r10 fix: when a fresh GHCR response carries no Docker-Content-Digest header
     # the content cannot be cryptographically verified.  Returning the body to
     # the caller even "best-effort" allows a digest-stripping bypass for the
@@ -1778,11 +1778,11 @@ CURL_NODIGEST
 }
 
 # ---------------------------------------------------------------------------
-# r9: Defect B (r12) — env-var sentinel; no file sentinel created
+# Defect B (r12) — env-var sentinel; no file sentinel created
 # ---------------------------------------------------------------------------
 
-@test "r9-C: degraded mode uses env-var sentinel only — no .ghcr_cache_warned file created" {
-    # r12: the file-based PID sentinel (${TMPDIR:-/tmp}/.ghcr_cache_warned.$$)
+@test "degraded mode uses env-var sentinel only — no .ghcr_cache_warned file created" {
+    # the file-based PID sentinel (${TMPDIR:-/tmp}/.ghcr_cache_warned.$$)
     # was replaced by a pure env-var sentinel (_GHCR_CACHE_DIR_WARNED) to fix
     # PID-reuse flakes in shared /tmp environments. Verify: after degraded-mode
     # entry, no .ghcr_cache_warned.* file is created in TMPDIR.
@@ -1811,10 +1811,10 @@ CURL_NODIGEST
 }
 
 # ---------------------------------------------------------------------------
-# r10: New regression tests
+# New regression tests
 # ---------------------------------------------------------------------------
 
-@test "r10-A: loose-mode dir with pre-planted body+hdrs — switched to fresh mktemp, poison not visible" {
+@test "loose-mode dir with pre-planted body+hdrs — switched to fresh mktemp, poison not visible" {
     # Regression: r9 silently chmod'd a loose-mode dir we own, leaving any
     # pre-existing attacker-planted files accessible. r10 switches to a fresh
     # mktemp dir so the pre-existing content is structurally unreachable.
@@ -1849,7 +1849,7 @@ CURL_NODIGEST
     grep -q '::warning::.*untrusted' "$stderr_log"
 }
 
-@test "r10-B: mktemp-d failure after untrusted dir — GHCR_CACHE_DIR cleared, hostile path not used" {
+@test "mktemp-d failure after untrusted dir — GHCR_CACHE_DIR cleared, hostile path not used" {
     # Regression: when mktemp -d fails in the untrusted-dir path, the old code
     # left GHCR_CACHE_DIR pointing at the hostile original. r10 sets
     # GHCR_CACHE_DIR="" so _ghcr_temp_file falls back to TMPDIR, never touching
@@ -1896,7 +1896,7 @@ MKTEMP_FAIL
     grep -q '::warning::' "$stderr_log"
 }
 
-@test "r10-C: fresh fetch missing Docker-Content-Digest returns 1, malformed also returns 1" {
+@test "fresh fetch missing Docker-Content-Digest returns 1, malformed also returns 1" {
     # Regression guard for Defect C: both missing and malformed digest must
     # return 1 (fail-closed), not 0 with unverified body.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
@@ -1971,7 +1971,7 @@ CURL_BADDIGEST_C
 # Marker file to detect writes older than our test.
 _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
 
-@test "r11: empty GHCR_CACHE_DIR — ghcr_get_token does not write to root paths and still returns token" {
+@test "empty GHCR_CACHE_DIR — ghcr_get_token does not write to root paths and still returns token" {
     # Use a simulated "root-like" dir to avoid actually touching / in CI.
     local fake_root="${WORK_DIR}/fakeroot"
     mkdir -p "$fake_root"
@@ -1999,7 +1999,7 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
     [ -z "${GHCR_CACHE_DIR:-}" ] || { echo "FAIL: GHCR_CACHE_DIR was set to '${GHCR_CACHE_DIR}' unexpectedly" >&2; return 1; }
 }
 
-@test "r11: empty GHCR_CACHE_DIR — ghcr_get_token does not read from root paths (hostile pre-placed token ignored)" {
+@test "empty GHCR_CACHE_DIR — ghcr_get_token does not read from root paths (hostile pre-placed token ignored)" {
     _r11_marker
 
     # Pre-place a hostile token at a path that WOULD have been constructed if
@@ -2026,7 +2026,7 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
     [ "$tok" = "x" ] || { echo "FAIL: unexpected token value '$tok'" >&2; return 1; }
 }
 
-@test "r11: empty GHCR_CACHE_DIR — invalidate functions are no-ops (no root file deletions)" {
+@test "empty GHCR_CACHE_DIR — invalidate functions are no-ops (no root file deletions)" {
     _r11_marker
 
     # Pre-place sentinel files at the root of WORK_DIR to simulate root-path risk.
@@ -2049,7 +2049,7 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
     [ -f "$sentinel_idx_hdrs" ] || { echo "FAIL: idx hdrs sentinel deleted by _ghcr_invalidate_index" >&2; return 1; }
 }
 
-@test "r11: mkdir TOCTOU — pre-existing symlink triggers mktemp fallback" {
+@test "mkdir TOCTOU — pre-existing symlink triggers mktemp fallback" {
     # Create a symlink at the intended cache dir location pointing to a
     # directory we control (simulating an attacker-controlled target).
     local target_dir="${WORK_DIR}/attacker-dir"
@@ -2095,11 +2095,11 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
 }
 
 # ---------------------------------------------------------------------------
-# r12: Defect A regression — invalidate must not delete through a symlinked
+# Defect A regression — invalidate must not delete through a symlinked
 # cache dir (_ghcr_cache_enabled now calls _ghcr_validate_cachedir).
 # ---------------------------------------------------------------------------
 
-@test "r12-A: ghcr_invalidate_token does not delete through a symlinked cache dir" {
+@test "ghcr_invalidate_token does not delete through a symlinked cache dir" {
     # Regression: _ghcr_cache_enabled only checked non-empty + dir + writable,
     # so a symlinked GHCR_CACHE_DIR would pass the guard.  ghcr_invalidate_token
     # would then rm -f a path under the symlink, potentially deleting files in
@@ -2135,7 +2135,7 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
     }
 }
 
-@test "r12-B: _ghcr_invalidate_index does not delete through a symlinked cache dir" {
+@test "_ghcr_invalidate_index does not delete through a symlinked cache dir" {
     # Companion to r12-A for the index invalidation path.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"
@@ -2173,7 +2173,7 @@ _r11_marker() { touch "${WORK_DIR}/.r11_marker"; }
 # r13 regression tests: _ghcr_fetch_index globals cleared on all fail-closed paths
 # ---------------------------------------------------------------------------
 
-@test "r13-A: globals cleared when fresh response lacks Docker-Content-Digest" {
+@test "globals cleared when fresh response lacks Docker-Content-Digest" {
     # Finding 3: _GHCR_IDX_BODY/_GHCR_IDX_HDRS must be empty after fail-closed
     # return on missing digest header — prevents caller from trusting stale data.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
@@ -2219,7 +2219,7 @@ CURL_NODIGEST_R13A
     }
 }
 
-@test "r13-B: globals cleared when fresh response has malformed Docker-Content-Digest" {
+@test "globals cleared when fresh response has malformed Docker-Content-Digest" {
     # Finding 3: malformed digest (non-64-char) must clear globals before return 1.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"
@@ -2263,7 +2263,7 @@ CURL_BADDIGEST_R13B
     }
 }
 
-@test "r13-C: globals cleared when content-digest mismatch on fresh body" {
+@test "globals cleared when content-digest mismatch on fresh body" {
     # Finding 3: sha256 body-hash mismatch must clear globals before return 1.
     source "$REPO_ROOT/helpers/logging.sh" 2>/dev/null || true
     source "$REPO_ROOT/helpers/registry-utils.sh"

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -73,7 +73,7 @@ make_dockerfile() {
 # Fix A1: build_args set substitution (the sslh root cause)
 # =============================================================================
 
-@test "RBIS-01: ARG-without-default substituted via build_args set (sslh root cause)" {
+@test "ARG-without-default substituted via build_args set (sslh root cause)" {
     # Dockerfile has ARG without defaults — values must come from _prepare_build_args
     make_dockerfile "ARG OS_IMAGE_BASE
 ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
@@ -97,7 +97,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     }
 }
 
-@test "RBIS-02: CUSTOM_BUILD_ARGS precedence preserved (override wins over build_args set)" {
+@test "CUSTOM_BUILD_ARGS precedence preserved (override wins over build_args set)" {
     # REMOTE_CR cannot appear in config.yaml build_args (validator blocks it).
     # It arrives only via CUSTOM_BUILD_ARGS (CI-injected). Simulate that here:
     # build_args set contributes REMOTE_CR=ghcr.io/oorabona, but CUSTOM_BUILD_ARGS
@@ -120,7 +120,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     }
 }
 
-@test "RBIS-03: build_args set wins over Dockerfile inline default" {
+@test "build_args set wins over Dockerfile inline default" {
     # Dockerfile has ARG with a default, but build_args in config.yaml overrides it
     make_dockerfile "ARG DEBIAN_TAG=stable" "FROM ghcr.io/oorabona/debian:\${DEBIAN_TAG}"
     make_config 'ghcr.io/oorabona/debian:${DEBIAN_TAG}' '  DEBIAN_TAG: "trixie"'
@@ -136,7 +136,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     }
 }
 
-@test "RBIS-04: Undefined ARG produces empty base_image_ref with stderr warning" {
+@test "Undefined ARG produces empty base_image_ref with stderr warning" {
     make_dockerfile "ARG MYSTERY_TAG" "FROM \${MYSTERY_TAG}-base"
     make_config '${MYSTERY_TAG}-base'  # no build_args
 
@@ -165,7 +165,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     }
 }
 
-@test "RBIS-05: CUSTOM_BUILD_ARGS with shell metacharacters does NOT execute" {
+@test "CUSTOM_BUILD_ARGS with shell metacharacters does NOT execute" {
     local marker="$TEST_DIR/marker_was_created"
     [[ ! -f "$marker" ]] || rm -f "$marker"
 
@@ -188,7 +188,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
     }
 }
 
-@test "RBIS-06: Cross-arg dependencies — chain resolves or terminates bounded" {
+@test "Cross-arg dependencies — chain resolves or terminates bounded" {
     # A depends on B, B depends on C, C is concrete.
     # Values with ${...} fail the validator so we seed _BUILD_ARGS_RESOLVED directly
     # (the production code path is: _prepare_build_args assembles the map; here we
@@ -218,7 +218,7 @@ ARG C" "FROM \${A}-base"
 # Fix A2: post-template-generation relocation
 # =============================================================================
 
-@test "RBIS-07: Template-driven container reads generator's concrete FROM (Fix A2)" {
+@test "Template-driven container reads generator's concrete FROM (Fix A2)" {
     # Set up a template fixture in TEST_DIR
     local fixture_dir="$TEST_DIR/template-fixture"
     cp -r "$FIXTURES_530/template/." "$fixture_dir/"
@@ -260,7 +260,7 @@ ARG C" "FROM \${A}-base"
     }
 }
 
-@test "RBIS-08: Monolithic container unaffected by A2 relocation" {
+@test "Monolithic container unaffected by A2 relocation" {
     # Copy monolithic fixture
     local fixture_dir="$TEST_DIR/monolithic-fixture"
     cp -r "$FIXTURES_530/monolithic/." "$fixture_dir/"
@@ -284,7 +284,7 @@ ARG C" "FROM \${A}-base"
 # Fix C + D: JSON safety and eval removal (invoked indirectly via _emit_build_lineage)
 # =============================================================================
 
-@test "RBIS-09: build_arg with quote character produces valid lineage JSON" {
+@test "build_arg with quote character produces valid lineage JSON" {
     make_dockerfile "" "FROM alpine:3.21"
     # Values with quotes fail the build_args validator (correct: unsafe shell chars).
     # We test _emit_build_lineage directly by writing config.yaml with special characters
@@ -343,7 +343,7 @@ CONFIG
     }
 }
 
-@test "RBIS-10: lineage_schema_version field equals 2 in emitted JSON" {
+@test "lineage_schema_version field equals 2 in emitted JSON" {
     make_dockerfile "" "FROM alpine:3.21"
     make_config "alpine:3.21"
 
@@ -381,7 +381,7 @@ CONFIG
 # (orthogonal gate codex HIGH finding)
 # =============================================================================
 
-@test "RBIS-11: _prepare_build_args propagates prepare_build_args failure; _BUILD_ARGS_RESOLVED stays empty" {
+@test "_prepare_build_args propagates prepare_build_args failure; _BUILD_ARGS_RESOLVED stays empty" {
     # Inject a config.yaml with a build_arg containing REMOTE_CR key — this triggers
     # the validator inside prepare_build_args → build_args_flags → _vbc_validate_build_args_config
     # to return non-zero. Pre-fix: _prepare_build_args ignores the error and populates
@@ -418,7 +418,7 @@ CONFIG
 # Post-fix: the reset is unconditional (before prepare_build_args invocation).
 # =============================================================================
 
-@test "RBIS-16: _BUILD_ARGS_RESOLVED is empty after failed second call, not carrying call-1 values" {
+@test "_BUILD_ARGS_RESOLVED is empty after failed second call, not carrying call-1 values" {
     # Call 1: valid config → populates _BUILD_ARGS_RESOLVED
     make_dockerfile "ARG OS_IMAGE_BASE
 ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
@@ -459,7 +459,7 @@ ARG OS_IMAGE_TAG" "FROM \${OS_IMAGE_BASE}:\${OS_IMAGE_TAG}"
 # when from_generated=0 (default; monolithic container, no template expansion, #530).
 # =============================================================================
 
-@test "RBIS-12: Unresolved placeholder in config.yaml is NOT replaced by multi-stage FROM scratch" {
+@test "Unresolved placeholder in config.yaml is NOT replaced by multi-stage FROM scratch" {
     # config.yaml::base_image contains an unresolvable ${MYSTERY_TAG}
     # Dockerfile is multi-stage; final non-AS stage is "FROM scratch"
     # Bug: the post-substitution fallback replaces the unresolved literal with "scratch"
@@ -515,7 +515,7 @@ DOCKER
 # Pre-fix regex '^ARG [A-Z_]+=' skips names containing digits (e.g. UBUNTU_2404_TAG).
 # =============================================================================
 
-@test "RBIS-13: ARG name with embedded digits is parsed and substituted (UBUNTU_2404_TAG)" {
+@test "ARG name with embedded digits is parsed and substituted (UBUNTU_2404_TAG)" {
     # github-runner ubuntu-2404 Dockerfile contains:
     #   ARG UBUNTU_2404_TAG=24.04
     # The pre-fix regex '^ARG [A-Z_]+=' skips this ARG entirely because '2404' contains digits,
@@ -540,7 +540,7 @@ DOCKER
     }
 }
 
-@test "RBIS-14: ARG name with leading letter then digits-and-underscore mixed (R3_BASE=r3)" {
+@test "ARG name with leading letter then digits-and-underscore mixed (R3_BASE=r3)" {
     # Verify that a name starting with a letter followed by mixed digits/underscores
     # is correctly parsed after the fix.
     make_dockerfile "ARG R3_BASE=r3-img" "FROM \${R3_BASE}:latest"
@@ -564,7 +564,7 @@ DOCKER
 # emitted.  Caller can detect failure via empty string.
 # =============================================================================
 
-@test "RBIS-15: Expanding build_args chain hits iteration cap and clears _BASE_IMAGE_REF" {
+@test "Expanding build_args chain hits iteration cap and clears _BASE_IMAGE_REF" {
     # A self-referential chain where each substitution introduces a new placeholder
     # without converging: A=x${A}y — the value grows each iteration, never stabilising.
     # The 10-iteration cap must fire AND _BASE_IMAGE_REF must be cleared to empty.

--- a/tests/unit/resolver-timescaledb-ha.bats
+++ b/tests/unit/resolver-timescaledb-ha.bats
@@ -226,7 +226,7 @@ setup() {
 
 # ── H: actionable error messages reach stderr ─────────────────────────────────
 
-@test "H-unsupported-pg: unknown PG_MAJOR exits non-zero and emits 'no HA tags' on stderr" {
+@test "unknown PG_MAJOR exits non-zero and emits 'no HA tags' on stderr" {
     local combined
     combined=$(env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
@@ -241,7 +241,7 @@ setup() {
 # When the ceiling is absent from HA tags, the resolver must INJECT it and
 # return a non-empty set (at least [ceiling]), not hard-fail.
 
-@test "RR-ceiling-not-in-HA: ceiling absent from HA tags → injected into output, exit 0" {
+@test "ceiling absent from HA tags → injected into output, exit 0" {
     # CEILING_VERSION=2.27.2 is NOT in the fixture (max is 2.27.1).
     # Before fix: hard-fails (exits non-zero). After fix: exits 0, includes 2.27.2.
     run env \
@@ -255,7 +255,7 @@ setup() {
     echo "$output" | jq -e 'map(select(. == "2.27.1")) | length > 0' > /dev/null
 }
 
-@test "RR-ceiling-injected-is-last: injected ceiling appears as last (highest) element" {
+@test "injected ceiling appears as last (highest) element" {
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
         EXT_NAME=timescaledb PG_MAJOR=18 CEILING_VERSION=2.27.2 \
@@ -265,7 +265,7 @@ setup() {
     [[ "$last" == "2.27.2" ]]
 }
 
-@test "RR-HA-newer-excluded: HA tag above ceiling is dropped; ceiling present in output" {
+@test "HA tag above ceiling is dropped; ceiling present in output" {
     # Fixture contains tags up to 2.27.1. Append a hypothetical 2.28.0 above ceiling 2.27.1.
     local above_fixture
     above_fixture="$(mktemp)"
@@ -284,7 +284,7 @@ setup() {
     echo "$output" | jq -e 'map(select(. == "2.27.1")) | length > 0' > /dev/null
 }
 
-@test "RR-empty-HA-degrade: empty HA response + valid CEILING_VERSION → exits non-zero (fail-closed)" {
+@test "empty HA response + valid CEILING_VERSION → exits non-zero (fail-closed)" {
     # When HA returns no tags at all the resolver has lost its discovery basis.
     # On the publish path this must be fatal (fail-closed): a transient HA-metadata
     # outage must not silently emit [ceiling] and drop every retained older version.
@@ -314,7 +314,7 @@ setup() {
     [[ -z "$stdout_only" ]]
 }
 
-@test "RR-garbled-HA-degrade: garbled HA response (no valid ts tags) + valid CEILING_VERSION → exits non-zero (fail-closed)" {
+@test "garbled HA response (no valid ts tags) + valid CEILING_VERSION → exits non-zero (fail-closed)" {
     # A garbled registry response that contains lines but no recognisable HA tags
     # is indistinguishable from a network corruption — fail-closed.
     local garbled_fixture
@@ -338,7 +338,7 @@ setup() {
     [[ -z "$stdout_only" ]]
 }
 
-@test "RR-ceiling-already-in-HA-idempotent: ceiling present in HA tags is not duplicated" {
+@test "ceiling present in HA tags is not duplicated" {
     # When ceiling IS in HA tags, injecting it must be idempotent (no duplicate).
     # The standard fixture has pg18 up to 2.27.1, so ceiling=2.27.1 is present.
     run env \
@@ -364,7 +364,7 @@ setup() {
 
 # ── RETAIN_COUNT: cap the retained window to N most-recent versions ───────────
 
-@test "RC-default: RETAIN_COUNT unset defaults to 12" {
+@test "RETAIN_COUNT unset defaults to 12" {
     # No RETAIN_COUNT in env — default of 12 applies.
     # pg16 has 45 versions in the fixture; result must be exactly 12.
     run env \
@@ -376,7 +376,7 @@ setup() {
     [[ "$count" -eq 12 ]]
 }
 
-@test "RC-ceiling-always-present: ceiling is the last element after cap" {
+@test "ceiling is the last element after cap" {
     # After capping to N, the ceiling (highest) must still be the last element.
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
@@ -387,7 +387,7 @@ setup() {
     [[ "$last" == "2.27.1" ]]
 }
 
-@test "RC-retain-1: RETAIN_COUNT=1 returns only [ceiling]" {
+@test "RETAIN_COUNT=1 returns only [ceiling]" {
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
         EXT_NAME=timescaledb PG_MAJOR=16 CEILING_VERSION=2.27.1 RETAIN_COUNT=1 \
@@ -399,7 +399,7 @@ setup() {
     [[ "$ver" == "2.27.1" ]]
 }
 
-@test "RC-over-window: RETAIN_COUNT larger than window keeps all versions" {
+@test "RETAIN_COUNT larger than window keeps all versions" {
     # pg18 has 13 versions; RETAIN_COUNT=100 must keep all 13.
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
@@ -410,7 +410,7 @@ setup() {
     [[ "$count" -eq 13 ]]
 }
 
-@test "RC-invalid-alpha: invalid RETAIN_COUNT 'abc' falls back to 12" {
+@test "invalid RETAIN_COUNT 'abc' falls back to 12" {
     # Non-numeric RETAIN_COUNT must be treated as if unset — default 12 applies.
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
@@ -421,7 +421,7 @@ setup() {
     [[ "$count" -eq 12 ]]
 }
 
-@test "RC-invalid-zero: RETAIN_COUNT=0 falls back to 12" {
+@test "RETAIN_COUNT=0 falls back to 12" {
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
         EXT_NAME=timescaledb PG_MAJOR=16 CEILING_VERSION=2.27.1 RETAIN_COUNT=0 \
@@ -431,7 +431,7 @@ setup() {
     [[ "$count" -eq 12 ]]
 }
 
-@test "RC-invalid-negative: RETAIN_COUNT=-3 falls back to 12" {
+@test "RETAIN_COUNT=-3 falls back to 12" {
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
         EXT_NAME=timescaledb PG_MAJOR=16 CEILING_VERSION=2.27.1 RETAIN_COUNT=-3 \
@@ -441,7 +441,7 @@ setup() {
     [[ "$count" -eq 12 ]]
 }
 
-@test "RC-oldest-first: capped output is sorted oldest-first with ceiling last" {
+@test "capped output is sorted oldest-first with ceiling last" {
     run env \
         _RESOLVER_HA_TAGS_FIXTURE="$HA_FIXTURE" \
         EXT_NAME=timescaledb PG_MAJOR=16 CEILING_VERSION=2.27.1 RETAIN_COUNT=5 \
@@ -456,7 +456,7 @@ setup() {
     [[ "$output" == "$sorted" ]]
 }
 
-@test "RC-ceiling-in-window: ceiling injected above-HA is last element even after cap" {
+@test "ceiling injected above-HA is last element even after cap" {
     # Use a ceiling not in the fixture (2.27.2) — it gets injected.
     # After cap, it must still be the last element.
     run env \

--- a/tests/unit/trivy-cache.bats
+++ b/tests/unit/trivy-cache.bats
@@ -50,7 +50,7 @@ _install_gh_poison() {
 
 # ---------------------------------------------------------------------------
 
-@test "1: TRIVY_CACHE_FILE unset — uses API path, no file I/O" {
+@test "TRIVY_CACHE_FILE unset — uses API path, no file I/O" {
     unset TRIVY_CACHE_FILE
 
     GH_COUNTER_FILE=$(mktemp)
@@ -75,7 +75,7 @@ _install_gh_poison() {
     rm -f "${GH_COUNTER_FILE}"
 }
 
-@test "2: empty cache file falls through to API; file is written with JSON" {
+@test "empty cache file falls through to API; file is written with JSON" {
     local cache_file
     cache_file=$(mktemp)
     # Truncate to zero bytes (empty = cache miss).
@@ -105,7 +105,7 @@ _install_gh_poison() {
     rm -f "$cache_file" "${GH_COUNTER_FILE}"
 }
 
-@test "3: populated cache file is read; poison gh is NEVER called" {
+@test "populated cache file is read; poison gh is NEVER called" {
     local cache_file
     cache_file=$(mktemp)
 
@@ -141,7 +141,7 @@ _install_gh_poison() {
     rm -f "$cache_file" "${GH_COUNTER_FILE}"
 }
 
-@test "4: corrupt cache (non-JSON) does NOT leave garbage in _TRIVY_SUMMARY_MAP" {
+@test "corrupt cache (non-JSON) does NOT leave garbage in _TRIVY_SUMMARY_MAP" {
     local cache_file
     cache_file=$(mktemp)
     echo "not json" | tee "$cache_file" >/dev/null
@@ -166,7 +166,7 @@ _install_gh_poison() {
     rm -f "$cache_file" "${GH_COUNTER_FILE}"
 }
 
-@test "6: empty API result ({}) is cached cross-subshell — no second API call" {
+@test "empty API result ({}) is cached cross-subshell — no second API call" {
     local cache_file
     cache_file=$(mktemp)
     : > "$cache_file"
@@ -222,7 +222,7 @@ _install_gh_poison() {
     rm -f "$cache_file" "${GH_COUNTER_FILE}"
 }
 
-@test "5: sibling subshells share one API fetch via TRIVY_CACHE_FILE" {
+@test "sibling subshells share one API fetch via TRIVY_CACHE_FILE" {
     local cache_file
     cache_file=$(mktemp)
     # Ensure cache file exists but is empty (mktemp creates a non-empty tmp sometimes on some OS).

--- a/tests/unit/update-last-rebuild.bats
+++ b/tests/unit/update-last-rebuild.bats
@@ -19,14 +19,14 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# r21-A3: grep option injection — container name '--help' as CLI arg
+# grep option injection — container name '--help' as CLI arg
 # update-last-rebuild.sh calls `grep -qxF "$CONTAINER"` at line 68.
 # Without `--`, passing '--help' as $1 causes grep to print help and exit 0,
 # bypassing the container validation entirely.
 # Mutation guard: removing `--` from the grep call → grep treats '--help' as
 # option → exits 0 → script proceeds past validation with the poisoned name.
 # ---------------------------------------------------------------------------
-@test "r21-A3: container name '--help' is rejected as invalid (not a grep option)" {
+@test "container name '--help' is rejected as invalid (not a grep option)" {
     # Create a fake ./make script that returns a valid container list
     local fake_project="$TEST_TEMP_DIR/project"
     mkdir -p "$fake_project"
@@ -47,7 +47,7 @@ teardown() {
     grep -q "not a valid container" "$TEST_TEMP_DIR/r21a3-stderr.txt"
 }
 
-@test "r21-A3b: container name '-n' is rejected as invalid (not a grep option)" {
+@test "container name '-n' is rejected as invalid (not a grep option)" {
     local fake_project="$TEST_TEMP_DIR/project"
     mkdir -p "$fake_project"
     printf '%s\n' '#!/usr/bin/env bash' 'echo "foo"' > "$fake_project/make"
@@ -123,7 +123,7 @@ _setup_r27c_project_b() {
     ]' > "$base/drift-b.json"
 }
 
-@test "r25-B1: running script twice same day with IDENTICAL drift produces exactly one section" {
+@test "running script twice same day with IDENTICAL drift produces exactly one section" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -153,7 +153,7 @@ _setup_r27c_project_b() {
     [ "$count" -eq 1 ]
 }
 
-@test "r25-B1-notice: second run with same content emits ::notice:: about skipping" {
+@test "second run with same content emits ::notice:: about skipping" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -175,19 +175,19 @@ _setup_r27c_project_b() {
     ) || rc=$?
 
     [ "$rc" -eq 0 ]
-    # r27-C: skip message changed from "already present" to "already recorded"
+    # skip message changed from "already present" to "already recorded"
     printf '%s' "$stderr_output" | grep -qF "already recorded"
 }
 
 # ---------------------------------------------------------------------------
-# r27-C: two invocations same day with DIFFERENT drift content → 2 sections
+# two invocations same day with DIFFERENT drift content → 2 sections
 # Regression test for the false-negative path Copilot identified:
 # drift A merges in the morning → LAST_REBUILD.md updated → rebuild →
 # drift B (different variants) occurs same day → r25 heading-only dedupe
 # would skip → no file change → no PR trigger → silent false negative.
 # With content-hash dedupe the different-content event appends a new section.
 # ---------------------------------------------------------------------------
-@test "r27-C1: same day different drift content produces two distinct sections" {
+@test "same day different drift content produces two distinct sections" {
     local fake_project
     fake_project=$(_setup_r25b_project)
     _setup_r27c_project_b "$fake_project"
@@ -223,7 +223,7 @@ _setup_r27c_project_b() {
     [ "$hash_count" -eq 2 ]
 }
 
-@test "r27-C2: first section contains hash marker above the heading" {
+@test "first section contains hash marker above the heading" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -241,7 +241,7 @@ _setup_r27c_project_b() {
     grep -qF '<!-- drift-content-hash:' "$target"
 }
 
-@test "r25-B2: warning emission for invalid container escapes %0A via _escape_gha_command" {
+@test "warning emission for invalid container escapes %0A via _escape_gha_command" {
     # Gate r25, Defect A applied to update-last-rebuild.sh:
     # a container name containing literal %0A must appear as %250A in the
     # warning (% encoded to %25 first, then 0A suffix), not as a raw sequence
@@ -262,7 +262,7 @@ _setup_r27c_project_b() {
 }
 
 # ---------------------------------------------------------------------------
-# r29-1: run-id-scoped dedupe (gate r29, Finding 1 — cross-run recoverability)
+# run-id-scoped dedupe (gate r29, Finding 1 — cross-run recoverability)
 #
 # The r27 content-hash marker without run-id made identical-content drift
 # unrecoverable across runs: failed rebuild + same drift next run → hash
@@ -273,7 +273,7 @@ _setup_r27c_project_b() {
 # Same hash + different run_id → new run re-detecting same drift → append.
 # ---------------------------------------------------------------------------
 
-@test "r29-1a: same hash same GITHUB_RUN_ID invoked twice → exactly one section" {
+@test "same hash same GITHUB_RUN_ID invoked twice → exactly one section" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -304,7 +304,7 @@ _setup_r27c_project_b() {
     [ "$count" -eq 1 ]
 }
 
-@test "r29-1b: same hash different GITHUB_RUN_ID → two sections (cross-run re-detection)" {
+@test "same hash different GITHUB_RUN_ID → two sections (cross-run re-detection)" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 
@@ -343,7 +343,7 @@ _setup_r27c_project_b() {
     [ "$r2_count" -eq 1 ]
 }
 
-@test "r29-1c: unset GITHUB_RUN_ID falls back to run:local and dedupes within same local session" {
+@test "unset GITHUB_RUN_ID falls back to run:local and dedupes within same local session" {
     local fake_project
     fake_project=$(_setup_r25b_project)
 

--- a/tests/unit/validate-base-cache-schema.bats
+++ b/tests/unit/validate-base-cache-schema.bats
@@ -7,33 +7,33 @@
 # A slash in source is valid for both styles (Docker Hub namespace).
 #
 # Rules tested:
-#   VBC-02: new-style source without slash → REJECT
-#   VBC-03: new-style source with registry prefix (dot/colon before first slash) → REJECT
-#   VBC-04: new-style source with tag (:) → REJECT
-#   VBC-05: new-style source with digest (@) → REJECT
-#   VBC-06: new-style source with uppercase letters → REJECT
-#   VBC-07: new-style source with empty path component (//) → REJECT
-#   VBC-08: REMOTE_CR in build_args → REJECT
-#   VBC-09: old-style entry with empty/absent arg → REJECT
-#   VBC-10: valid new-style (source: library/postgres, no ghcr_repo) → PASS
-#   VBC-11: valid old-style (ghcr_repo + arg present) → PASS
-#   VBC-11d: valid old-style with namespaced source (hashicorp/terraform) → PASS [regression lock]
-#   VBC-11e: valid new-style with non-library namespace (hashicorp/terraform) → PASS
-#   VBC-12: container dir name with slash → REJECT (defensive invariant)
-#   VBC-13: new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)
-#   VBC-13b: new-style source with leading slash (multi-segment /library/postgres) → PASS
-#   VBC-13c: wordpress-real: source: /php → PASS (regression lock for #531)
-#   VBC-13d: source: /php/ (trailing slash after leading slash) → REJECT
-#   VBC-13e: source: //php (double slash) → REJECT
-#   VBC-14: new-style source with trailing slash → REJECT (empty path component)
-#   VBC-R7C-GLOB-01: build_args value with glob * → REJECT (R7c allowlist)
-#   VBC-R7C-GLOB-02: build_args value with glob ? → REJECT (R7c allowlist)
-#   VBC-R7C-BRACE-01: build_args value with brace expansion → REJECT (R7c allowlist)
-#   VBC-R7C-CMD-01: build_args value with $() command substitution → REJECT (R7c allowlist)
-#   VBC-R7C-CMD-02: build_args value with backtick substitution → REJECT (R7c allowlist)
-#   VBC-R7C-EMPTY-01: build_args value that is an empty string → REJECT (R7c allowlist)
-#   VBC-SRC-GLOB-01: new-style source with glob * → REJECT (R6d allowlist)
-#   VBC-SRC-GLOB-02: new-style source with glob ? → REJECT (R6d allowlist)
+#   new-style source without slash → REJECT
+#   new-style source with registry prefix (dot/colon before first slash) → REJECT
+#   new-style source with tag (:) → REJECT
+#   new-style source with digest (@) → REJECT
+#   new-style source with uppercase letters → REJECT
+#   new-style source with empty path component (//) → REJECT
+#   REMOTE_CR in build_args → REJECT
+#   old-style entry with empty/absent arg → REJECT
+#   valid new-style (source: library/postgres, no ghcr_repo) → PASS
+#   valid old-style (ghcr_repo + arg present) → PASS
+#   valid old-style with namespaced source (hashicorp/terraform) → PASS [regression lock]
+#   valid new-style with non-library namespace (hashicorp/terraform) → PASS
+#   container dir name with slash → REJECT (defensive invariant)
+#   new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)
+#   new-style source with leading slash (multi-segment /library/postgres) → PASS
+#   wordpress-real: source: /php → PASS (regression lock for #531)
+#   source: /php/ (trailing slash after leading slash) → REJECT
+#   source: //php (double slash) → REJECT
+#   new-style source with trailing slash → REJECT (empty path component)
+#   build_args value with glob * → REJECT (R7c allowlist)
+#   build_args value with glob ? → REJECT (R7c allowlist)
+#   build_args value with brace expansion → REJECT (R7c allowlist)
+#   build_args value with $() command substitution → REJECT (R7c allowlist)
+#   build_args value with backtick substitution → REJECT (R7c allowlist)
+#   build_args value that is an empty string → REJECT (R7c allowlist)
+#   new-style source with glob * → REJECT (R6d allowlist)
+#   new-style source with glob ? → REJECT (R6d allowlist)
 
 setup() {
     TEST_DIR=$(mktemp -d)
@@ -60,7 +60,7 @@ make_container() {
 
 # ─── REJECT cases ─────────────────────────────────────────────────────────────
 
-@test "VBC-02: new-style source without slash → REJECT" {
+@test "new-style source without slash → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: postgres
@@ -72,7 +72,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-03: new-style source with registry prefix (docker.io/) → REJECT" {
+@test "new-style source with registry prefix (docker.io/) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: docker.io/library/postgres
@@ -84,7 +84,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-03b: new-style source with ghcr.io registry prefix → REJECT" {
+@test "new-style source with ghcr.io registry prefix → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: ghcr.io/owner/image
@@ -96,7 +96,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-03c: new-style source with colon-port registry (localhost:5000/img) → REJECT" {
+@test "new-style source with colon-port registry (localhost:5000/img) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: localhost:5000/myimage
@@ -108,7 +108,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-04: new-style source with tag colon → REJECT" {
+@test "new-style source with tag colon → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres:16
@@ -120,7 +120,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-05: new-style source with digest @ → REJECT" {
+@test "new-style source with digest @ → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres@sha256:abc123
@@ -132,7 +132,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-06: new-style source with uppercase letters → REJECT" {
+@test "new-style source with uppercase letters → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: Library/Postgres
@@ -144,7 +144,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-07: new-style source with empty path component (//) → REJECT" {
+@test "new-style source with empty path component (//) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library//postgres
@@ -156,7 +156,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-08: REMOTE_CR present in build_args → REJECT" {
+@test "REMOTE_CR present in build_args → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -175,7 +175,7 @@ EOF
 # The old code used `// "null"` value-check: `REMOTE_CR:` (YAML-null) returns the
 # string "null" via `// "null"` fallback and PASSED the check. Fixed by checking
 # key presence via `yq has("REMOTE_CR")` instead of checking the value.
-@test "VBC-08b: REMOTE_CR key with null value (REMOTE_CR:) → REJECT (FIX-3 regression lock)" {
+@test "REMOTE_CR key with null value (REMOTE_CR:) → REJECT (FIX-3 regression lock)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -190,8 +190,8 @@ EOF
     # Mutation guard: the old code would have returned 0 (passed) — must NOT be 0
 }
 
-# VBC-08c: REMOTE_CR key with explicit null literal → REJECT
-@test "VBC-08c: REMOTE_CR key with explicit YAML null → REJECT" {
+# REMOTE_CR key with explicit null literal → REJECT
+@test "REMOTE_CR key with explicit YAML null → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -205,7 +205,7 @@ EOF
     [[ "$output" =~ "REMOTE_CR" ]]
 }
 
-@test "VBC-09: old-style with empty arg → REJECT" {
+@test "old-style with empty arg → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: ""
@@ -219,7 +219,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-09b: old-style with absent arg → REJECT" {
+@test "old-style with absent arg → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: ubuntu
@@ -236,7 +236,7 @@ EOF
 # A value like "BASE_IMAGE --network host" passes the non-empty check but would
 # inject extra docker CLI tokens when expanded into CUSTOM_BUILD_ARGS. The fix
 # restricts arg to a valid Docker ARG identifier: ^[A-Za-z_][A-Za-z0-9_]*$.
-@test "VBC-09c: old-style arg with spaces (injection risk) → REJECT" {
+@test "old-style arg with spaces (injection risk) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: "BASE_IMAGE --network host"
@@ -250,7 +250,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-09d: old-style arg with two words (FOO BAR) → REJECT" {
+@test "old-style arg with two words (FOO BAR) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: "FOO BAR"
@@ -264,7 +264,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-09e: old-style arg with hyphen (not a valid identifier) → REJECT" {
+@test "old-style arg with hyphen (not a valid identifier) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE-IMAGE
@@ -278,7 +278,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-09f: old-style arg BASE_IMAGE (valid identifier) → PASS (regression lock)" {
+@test "old-style arg BASE_IMAGE (valid identifier) → PASS (regression lock)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -291,7 +291,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-13: new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)" {
+@test "new-style source with leading slash (single segment /php) → PASS (chained-on-own marker)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: /php
@@ -302,7 +302,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-13b: new-style source with leading slash (multi-segment /library/postgres) → PASS" {
+@test "new-style source with leading slash (multi-segment /library/postgres) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: /library/postgres
@@ -313,7 +313,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-13c: wordpress real config — source: /php → PASS (regression lock #531)" {
+@test "wordpress real config — source: /php → PASS (regression lock #531)" {
     make_container "wordpress" "$(cat <<'EOF'
 base_image: "${REMOTE_CR}/php:${PHP_TAG}"
 base_image_cache:
@@ -327,7 +327,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-13d: new-style source with trailing slash after leading slash (/php/) → REJECT" {
+@test "new-style source with trailing slash after leading slash (/php/) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: /php/
@@ -339,7 +339,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-13e: new-style source with double slash (//php) → REJECT" {
+@test "new-style source with double slash (//php) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: //php
@@ -351,7 +351,7 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-@test "VBC-14: new-style source with trailing slash → REJECT" {
+@test "new-style source with trailing slash → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres/
@@ -365,7 +365,7 @@ EOF
 
 # ─── PASS cases ───────────────────────────────────────────────────────────────
 
-@test "VBC-10: valid new-style (source: library/postgres, no ghcr_repo) → PASS" {
+@test "valid new-style (source: library/postgres, no ghcr_repo) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -376,7 +376,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-11: valid old-style (ghcr_repo + arg present) → PASS" {
+@test "valid old-style (ghcr_repo + arg present) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -389,7 +389,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-11b: valid old-style multiple entries → PASS" {
+@test "valid old-style multiple entries → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -406,7 +406,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-11c: no base_image_cache section → PASS (no entries to validate)" {
+@test "no base_image_cache section → PASS (no entries to validate)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   FOO: bar
@@ -416,7 +416,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-11d: valid old-style with namespaced source (regression lock — hashicorp/terraform pattern) → PASS" {
+@test "valid old-style with namespaced source (regression lock — hashicorp/terraform pattern) → PASS" {
     # Regression lock: old-style entries (ghcr_repo set) may have a slash in source
     # because Docker Hub uses namespace/image paths (e.g. hashicorp/terraform).
     # The discriminator is BINARY — ghcr_repo present => old-style, full stop.
@@ -434,7 +434,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-11e: valid new-style with non-library namespace (hashicorp/terraform, no ghcr_repo) → PASS" {
+@test "valid new-style with non-library namespace (hashicorp/terraform, no ghcr_repo) → PASS" {
     # Guards against future R3 tightening that might mistakenly reject 2-segment
     # paths that are not under the 'library/' namespace.
     make_container "myapp" "$(cat <<'EOF'
@@ -447,7 +447,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-12: defensive — container dir name with slash would be invalid (path check)" {
+@test "defensive — container dir name with slash would be invalid (path check)" {
     # Container names are directory names on disk — they cannot contain /
     # This is a repo invariant. We verify the guard is consistent:
     # a container with a path traversal dir name cannot be created normally.
@@ -459,7 +459,7 @@ EOF
 
 # ─── Multi-container scan ─────────────────────────────────────────────────────
 
-@test "VBC-SCAN-01: validate_all_containers_base_cache_schema — all valid → exit 0" {
+@test "validate_all_containers_base_cache_schema — all valid → exit 0" {
     make_container "c1" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -478,7 +478,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-SCAN-02: validate_all_containers_base_cache_schema — one invalid → exit non-zero" {
+@test "validate_all_containers_base_cache_schema — one invalid → exit non-zero" {
     make_container "good" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -505,7 +505,7 @@ EOF
 # return non-zero. Previously a yq command substitution error returned "" + exit-0
 # from the subshell, causing the outer variable to be "" which the guard treated as
 # "no REMOTE_CR" → silent pass. Fixed by checking yq exit status explicitly.
-@test "VBC-FC-01: malformed config.yaml (yq parse error) → REJECT (fail-closed lock)" {
+@test "malformed config.yaml (yq parse error) → REJECT (fail-closed lock)" {
     mkdir -p badyaml
     # Deliberately malformed YAML — yq will error on this
     printf 'build_args: { REMOTE_CR: [unclosed\n' > badyaml/config.yaml
@@ -513,14 +513,14 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-# VBC-FC-02: yq missing from PATH → validation failure (not pass)
+# yq missing from PATH → validation failure (not pass)
 # Tests the command-v guard at the top of validate_container_base_cache_schema.
 # ─── FIX 1: build_args key/value injection (R7b, R7c) ────────────────────────
 
-# VBC-R7B-01: crafted key with spaces + injected --build-arg → REJECT
+# crafted key with spaces + injected --build-arg → REJECT
 # The gate finding: `"X --build-arg REMOTE_CR": value` would be expanded unquoted
 # into docker flags, bypassing the REMOTE_CR key check.
-@test "VBC-R7B-01: build_args key with spaces (injection vector) → REJECT" {
+@test "build_args key with spaces (injection vector) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   "X --build-arg REMOTE_CR": "ghcr.io/attacker"
@@ -531,8 +531,8 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-# VBC-R7B-02: key with hyphen (not a valid ARG identifier) → REJECT
-@test "VBC-R7B-02: build_args key with hyphen → REJECT" {
+# key with hyphen (not a valid ARG identifier) → REJECT
+@test "build_args key with hyphen → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   INVALID-KEY: "somevalue"
@@ -543,8 +543,8 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-# VBC-R7C-01: value containing a space (flag injection) → REJECT
-@test "VBC-R7C-01: build_args value with embedded space (flag injection) → REJECT" {
+# value containing a space (flag injection) → REJECT
+@test "build_args value with embedded space (flag injection) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "foo --network host"
@@ -555,14 +555,14 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-# VBC-R7C-02: value containing embedded newlines → REJECT (newline injection class)
+# value containing embedded newlines → REJECT (newline injection class)
 # ROOT CAUSE: a line-by-line yq read splits "ubuntu\n--build-arg\nREMOTE_CR=x" into
 # three separate lines (each clean) — the old loop passed this. The JSON-based check
 # reads the whole value atomically; \s in jq regex catches newlines before any split.
 # YAML double-quoted strings interpret \n as a literal newline character, so the
 # fixture below produces a value with actual embedded newlines that a shell would
 # word-split into separate docker CLI tokens when expanded unquoted.
-@test "VBC-R7C-02: build_args value with embedded newlines (newline injection) → REJECT" {
+@test "build_args value with embedded newlines (newline injection) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu\n--build-arg\nREMOTE_CR=ghcr.io/attacker"
@@ -578,7 +578,7 @@ EOF
 # VBC-R7C-GLOB-01 (RED→GREEN): value with glob * → REJECT
 # "ubuntu*" passes the whitespace check but glob-expands when unquoted in a shell.
 # The positive allowlist ^[A-Za-z0-9._/:@+=-]+$ has no *, so it rejects this.
-@test "VBC-R7C-GLOB-01: build_args value with glob asterisk → REJECT (R7c allowlist)" {
+@test "build_args value with glob asterisk → REJECT (R7c allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "*"
@@ -590,7 +590,7 @@ EOF
 }
 
 # VBC-R7C-GLOB-02 (RED→GREEN): value with glob ? → REJECT
-@test "VBC-R7C-GLOB-02: build_args value with glob question mark → REJECT (R7c allowlist)" {
+@test "build_args value with glob question mark → REJECT (R7c allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "a?b"
@@ -603,7 +603,7 @@ EOF
 
 # VBC-R7C-BRACE-01 (RED→GREEN): value with brace expansion → REJECT
 # "a{b,c}" passes whitespace check; in an unquoted shell context it expands to "ab ac".
-@test "VBC-R7C-BRACE-01: build_args value with brace expansion → REJECT (R7c allowlist)" {
+@test "build_args value with brace expansion → REJECT (R7c allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "a{b,c}"
@@ -616,7 +616,7 @@ EOF
 
 # VBC-R7C-CMD-01 (RED→GREEN): value with $() command substitution → REJECT
 # $(id) passes whitespace check; shell would execute id when expanded unquoted.
-@test "VBC-R7C-CMD-01: build_args value with dollar-paren command substitution → REJECT (R7c allowlist)" {
+@test "build_args value with dollar-paren command substitution → REJECT (R7c allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "$(id)"
@@ -628,7 +628,7 @@ EOF
 }
 
 # VBC-R7C-CMD-02 (RED→GREEN): value with backtick substitution → REJECT
-@test "VBC-R7C-CMD-02: build_args value with backtick command substitution → REJECT (R7c allowlist)" {
+@test "build_args value with backtick command substitution → REJECT (R7c allowlist)" {
     # shellcheck disable=SC2016
     make_container "myapp" 'build_args:
   BASE_IMAGE: "`id`"
@@ -641,7 +641,7 @@ EOF
 # VBC-R7C-EMPTY-01 (RED→GREEN): value that is an empty string → REJECT
 # An empty build_arg value is unusual and semantically void; reject to avoid
 # silent misconfigurations that produce --build-arg KEY= (empty injection).
-@test "VBC-R7C-EMPTY-01: build_args value that is an empty string → REJECT (R7c allowlist)" {
+@test "build_args value that is an empty string → REJECT (R7c allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: ""
@@ -652,8 +652,8 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-# VBC-R7B-PASS: valid identifier keys (php real config pattern) → PASS
-@test "VBC-R7B-PASS: multiple valid ARG identifier keys (php pattern) → PASS" {
+# valid identifier keys (php real config pattern) → PASS
+@test "multiple valid ARG identifier keys (php pattern) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "php"
@@ -666,8 +666,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-# VBC-R7C-PASS: value with colon+slash (docker image ref, no whitespace) → PASS
-@test "VBC-R7C-PASS: build_args value with colon and slash (image ref) → PASS" {
+# value with colon+slash (docker image ref, no whitespace) → PASS
+@test "build_args value with colon and slash (image ref) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   WORDPRESS_IMAGE: "ghcr.io/oorabona/php:latest"
@@ -677,7 +677,7 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "VBC-FC-02: yq not in PATH → REJECT (fail-closed lock)" {
+@test "yq not in PATH → REJECT (fail-closed lock)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -708,11 +708,11 @@ EOF
     [[ "$output" =~ "yq" ]]
 }
 
-# VBC-FC-03: jq required — guard emits clear error and rejects when jq unavailable
+# jq required — guard emits clear error and rejects when jq unavailable
 # PATH isolation for jq is not feasible when jq lives in /bin (always in PATH).
 # Instead we verify the guard via function override: replace jq with a stub that
 # returns 127 (command-not-found exit code) to exercise the command -v branch.
-@test "VBC-FC-03: jq unavailable (stub) → REJECT (fail-closed lock)" {
+@test "jq unavailable (stub) → REJECT (fail-closed lock)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE: "ubuntu"
@@ -730,10 +730,10 @@ EOF
 
 # ─── FIX 2: source whitespace / non-scalar checks ─────────────────────────────
 
-# VBC-SRC-WS-01: source containing a space → REJECT
+# source containing a space → REJECT
 # "library/postgres bad" passes all prior format rules (has slash, no colon, lowercase,
 # no empty component) but the embedded space would break cache probing / imagetools refs.
-@test "VBC-SRC-WS-01: new-style source with embedded space → REJECT" {
+@test "new-style source with embedded space → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: "library/postgres bad"
@@ -745,17 +745,17 @@ EOF
     [[ "$output" =~ "whitespace" ]] || [[ "$output" =~ "source" ]]
 }
 
-# VBC-SRC-WS-02: source containing a tab → REJECT
-@test "VBC-SRC-WS-02: new-style source with embedded tab → REJECT" {
+# source containing a tab → REJECT
+@test "new-style source with embedded tab → REJECT" {
     make_container "myapp" "$(printf 'base_image_cache:\n  - source: "library/postgres\teval"\n    tags: ["latest"]\n')"
     run validate_container_base_cache_schema "myapp"
     [ "$status" -ne 0 ]
 }
 
-# VBC-SRC-NS-01: non-scalar source (object/mapping) → REJECT
+# non-scalar source (object/mapping) → REJECT
 # yq emits the object as a non-string representation; the guard must detect
 # and reject it rather than treating the stringified object as a source path.
-@test "VBC-SRC-NS-01: new-style source that is an object (non-scalar) → REJECT" {
+@test "new-style source that is an object (non-scalar) → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source:
@@ -767,8 +767,8 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-# VBC-SRC-NS-02: null source → REJECT (null is non-scalar string, unusable as image ref)
-@test "VBC-SRC-NS-02: new-style source is null → REJECT" {
+# null source → REJECT (null is non-scalar string, unusable as image ref)
+@test "new-style source is null → REJECT" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - tags: ["latest"]
@@ -783,7 +783,7 @@ EOF
 # VBC-SRC-GLOB-01 (RED→GREEN): source with glob * → REJECT (R6d allowlist)
 # "lib*/postgres" passes the whitespace and uppercase checks but glob-expands
 # when used unquoted in a shell imagetools/skopeo reference.
-@test "VBC-SRC-GLOB-01: new-style source with glob asterisk → REJECT (R6d allowlist)" {
+@test "new-style source with glob asterisk → REJECT (R6d allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: "lib*/postgres"
@@ -796,7 +796,7 @@ EOF
 }
 
 # VBC-SRC-GLOB-02 (RED→GREEN): source with glob ? → REJECT (R6d allowlist)
-@test "VBC-SRC-GLOB-02: new-style source with glob question mark → REJECT (R6d allowlist)" {
+@test "new-style source with glob question mark → REJECT (R6d allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: "library/postgr?s"
@@ -809,7 +809,7 @@ EOF
 }
 
 # VBC-SRC-PASS: valid whitespace-free scalar source → PASS (regression lock)
-@test "VBC-SRC-PASS: clean source library/postgres (whitespace-free scalar) → PASS" {
+@test "clean source library/postgres (whitespace-free scalar) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -820,10 +820,10 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-# VBC-BA-NS-01: build_args value that is an object → REJECT (FIX 2: non-scalar value)
+# build_args value that is an object → REJECT (FIX 2: non-scalar value)
 # tostring on an object emits '{"foo":"bar"}' which may or may not contain \s,
 # but `type == "object"` is always a non-scalar that should be rejected explicitly.
-@test "VBC-BA-NS-01: build_args value that is an object → REJECT (non-scalar)" {
+@test "build_args value that is an object → REJECT (non-scalar)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE:
@@ -835,8 +835,8 @@ EOF
     [[ "$output" =~ "myapp" ]]
 }
 
-# VBC-BA-NS-02: build_args value that is an array → REJECT (non-scalar)
-@test "VBC-BA-NS-02: build_args value that is an array → REJECT (non-scalar)" {
+# build_args value that is an array → REJECT (non-scalar)
+@test "build_args value that is an array → REJECT (non-scalar)" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   BASE_IMAGE:
@@ -850,7 +850,7 @@ EOF
 }
 
 # VBC-BA-NS-PASS: numeric value (valid scalar, type==number) → PASS
-@test "VBC-BA-NS-PASS: build_args value that is a number (scalar) → PASS" {
+@test "build_args value that is a number (scalar) → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 build_args:
   NPROC: 4
@@ -866,7 +866,7 @@ EOF
 # The injection: "ubuntu-base --network host" would expand to:
 #   --build-arg BASE_IMAGE=ghcr.io/owner/ubuntu-base --network host
 # injecting extra docker CLI flags.
-@test "VBC-R9-01: old-style ghcr_repo with space+flag (injection) → REJECT (R9)" {
+@test "old-style ghcr_repo with space+flag (injection) → REJECT (R9)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -881,8 +881,8 @@ EOF
     [[ "$output" =~ "ghcr_repo" ]]
 }
 
-# VBC-R9-02: ghcr_repo with embedded semicolon → REJECT
-@test "VBC-R9-02: old-style ghcr_repo with semicolon → REJECT (R9)" {
+# ghcr_repo with embedded semicolon → REJECT
+@test "old-style ghcr_repo with semicolon → REJECT (R9)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -896,8 +896,8 @@ EOF
     [[ "$output" =~ "ghcr_repo" ]]
 }
 
-# VBC-R9-03: ghcr_repo with $ (parameter expansion attempt) → REJECT
-@test "VBC-R9-03: old-style ghcr_repo with dollar sign → REJECT (R9)" {
+# ghcr_repo with $ (parameter expansion attempt) → REJECT
+@test "old-style ghcr_repo with dollar sign → REJECT (R9)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -911,8 +911,8 @@ EOF
     [[ "$output" =~ "ghcr_repo" ]]
 }
 
-# VBC-R9-PASS-01: valid ghcr_repo names (all current containers) → PASS
-@test "VBC-R9-PASS-01: valid old-style ghcr_repo names (ubuntu-base, ruby-base, etc.) → PASS" {
+# valid ghcr_repo names (all current containers) → PASS
+@test "valid old-style ghcr_repo names (ubuntu-base, ruby-base, etc.) → PASS" {
     # Regression lock: all current container ghcr_repo values must pass
     for repo in ubuntu-base ruby-base php-base composer-base alpine-base rocky-base debian-base terraform-base postgres-base python-base; do
         make_container "app-${repo}" "$(cat <<EOF
@@ -931,8 +931,8 @@ EOF
     done
 }
 
-# VBC-R9-PASS-02: valid ghcr_repo with slash (org/repo) → PASS
-@test "VBC-R9-PASS-02: old-style ghcr_repo with slash (org/repo) → PASS (R9 allows slash)" {
+# valid ghcr_repo with slash (org/repo) → PASS
+@test "old-style ghcr_repo with slash (org/repo) → PASS (R9 allows slash)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -951,7 +951,7 @@ EOF
 # "18 --network host" has no injection path in the current CI (values are
 # double-quoted), but the value is still syntactically invalid as an OCI tag
 # and is rejected to close the class entirely.
-@test "VBC-R10-01: tags value with embedded space → REJECT (R10)" {
+@test "tags value with embedded space → REJECT (R10)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -965,8 +965,8 @@ EOF
     [[ "$output" =~ "tags" ]]
 }
 
-# VBC-R10-02: tag with semicolon → REJECT
-@test "VBC-R10-02: tags value with semicolon → REJECT (R10)" {
+# tag with semicolon → REJECT
+@test "tags value with semicolon → REJECT (R10)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -980,8 +980,8 @@ EOF
     [[ "$output" =~ "tags" ]]
 }
 
-# VBC-R10-03: tag with bare $ (not a valid ${IDENT} placeholder) → REJECT
-@test "VBC-R10-03: tags value with bare dollar sign (not a valid placeholder) → REJECT (R10)" {
+# tag with bare $ (not a valid ${IDENT} placeholder) → REJECT
+@test "tags value with bare dollar sign (not a valid placeholder) → REJECT (R10)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -995,8 +995,8 @@ EOF
     [[ "$output" =~ "tags" ]]
 }
 
-# VBC-R10-04: tag with new-style entry → REJECT propagates via new-style path too
-@test "VBC-R10-04: new-style entry tags value with injection chars → REJECT (R10)" {
+# tag with new-style entry → REJECT propagates via new-style path too
+@test "new-style entry tags value with injection chars → REJECT (R10)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres
@@ -1008,8 +1008,8 @@ EOF
     [[ "$output" =~ "tags" ]]
 }
 
-# VBC-R10-PASS-01: literal tags → PASS (regression lock)
-@test "VBC-R10-PASS-01: literal tags (latest, 18-alpine, 3.21, noble, 9) → PASS" {
+# literal tags → PASS (regression lock)
+@test "literal tags (latest, 18-alpine, 3.21, noble, 9) → PASS" {
     for tag in latest 18-alpine 3.21 noble 9 24.04 3.12-alpine; do
         make_container "app-tag-$(echo "$tag" | tr '.' '-')" "$(cat <<EOF
 base_image_cache:
@@ -1027,8 +1027,8 @@ EOF
     done
 }
 
-# VBC-R10-PASS-02: ${VERSION} placeholder → PASS
-@test "VBC-R10-PASS-02: tags with \${VERSION} placeholder → PASS (R10 template allowlist)" {
+# ${VERSION} placeholder → PASS
+@test "tags with \${VERSION} placeholder → PASS (R10 template allowlist)" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -1045,7 +1045,7 @@ EOF
 # "ruby-base" with tags: ["${RUBY_VERSION}-alpine${ALPINE_VERSION}"] is the
 # real jekyll config. This MUST pass — the composite template mixes literal
 # text ("-alpine") with two ${IDENT} placeholders.
-@test "VBC-R10-PASS-03: jekyll composite template tag \${RUBY_VERSION}-alpine\${ALPINE_VERSION} → PASS (regression lock)" {
+@test "jekyll composite template tag \${RUBY_VERSION}-alpine\${ALPINE_VERSION} → PASS (regression lock)" {
     make_container "jekyll" "$(cat <<'EOF'
 base_image_cache:
   - arg: BASE_IMAGE
@@ -1058,8 +1058,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-# VBC-R10-PASS-04: ${UPSTREAM_VERSION} placeholder (terraform pattern) → PASS
-@test "VBC-R10-PASS-04: tags with \${UPSTREAM_VERSION} placeholder → PASS (terraform pattern)" {
+# ${UPSTREAM_VERSION} placeholder (terraform pattern) → PASS
+@test "tags with \${UPSTREAM_VERSION} placeholder → PASS (terraform pattern)" {
     make_container "terraform" "$(cat <<'EOF'
 base_image_cache:
   - arg: TERRAFORM_BASE
@@ -1080,8 +1080,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-# VBC-R10-PASS-05: tags_from_versions=true (no tags[] to validate) → PASS
-@test "VBC-R10-PASS-05: tags_from_versions=true entries skip tag validation → PASS" {
+# tags_from_versions=true (no tags[] to validate) → PASS
+@test "tags_from_versions=true entries skip tag validation → PASS" {
     make_container "myapp" "$(cat <<'EOF'
 base_image_cache:
   - source: library/postgres

--- a/tests/unit/version-set-resolver.bats
+++ b/tests/unit/version-set-resolver.bats
@@ -140,7 +140,7 @@ setup() {
 
 # ── XX: config_file parameter — resolver reads from caller-supplied config ────
 
-@test "XX-temp-config: resolve_version_set uses caller-supplied config, not hard-coded default" {
+@test "resolve_version_set uses caller-supplied config, not hard-coded default" {
     # Write a temp config with a DIFFERENT extension at a DIFFERENT ceiling,
     # using the same resolver path (timescaledb-ha.sh).
     # Before fix: reads postgres/extensions/config.yaml → returns real timescaledb set.
@@ -173,7 +173,7 @@ YAMLEOF
     [[ "$count" -eq 1 ]]
 }
 
-@test "XX-temp-config-ceiling: resolver ceiling is read from caller-supplied config" {
+@test "resolver ceiling is read from caller-supplied config" {
     # Write a temp config with timescaledb at ceiling 2.25.0 (below the real default 2.27.1).
     # Use a resolver path pointing to the real timescaledb-ha.sh resolver.
     # After fix: the ceiling passed to the resolver must be 2.25.0 (from temp config),
@@ -206,7 +206,7 @@ YAMLEOF
     [[ "$last" == "2.25.0" ]]
 }
 
-@test "XX-default-fallback: no config_file arg still resolves correctly via default" {
+@test "no config_file arg still resolves correctly via default" {
     # Regression: direct invocation without a config_file must still work correctly
     # using the implicit default (postgres/extensions/config.yaml).
     # Default retain_count=12 in config.yaml so count must be exactly 12.
@@ -228,7 +228,7 @@ YAMLEOF
 
 # ── RC: retain_count config key threading ────────────────────────────────────
 
-@test "RC-config-retain5: retain_count=5 in config threads through to resolver" {
+@test "retain_count=5 in config threads through to resolver" {
     # A temp config with retain_count=5 must produce <=5 versions, ceiling last.
     local tmp_config
     tmp_config="$(mktemp --suffix=.yaml)"
@@ -256,7 +256,7 @@ YAMLEOF
     [[ "$last" == "2.27.1" ]]
 }
 
-@test "RC-config-no-retain: absent retain_count in config defaults to 12" {
+@test "absent retain_count in config defaults to 12" {
     # A temp config without retain_count must apply the default of 12.
     # pg16 has 45 versions in the fixture; result must be 12.
     local tmp_config
@@ -286,7 +286,7 @@ YAMLEOF
 
 # ── BA-4: missing version in non-resolver ext → fail fast, NOT ["null"] ──────
 
-@test "BA4-null-version-failclosed: non-resolver ext with no version field → non-zero exit, no null in output" {
+@test "non-resolver ext with no version field → non-zero exit, no null in output" {
     # Before fix: yq returns "null" for missing field → emit ["null"] → bogus set.
     # After fix:  detect null/empty version → fail fast with non-zero exit.
 
@@ -310,7 +310,7 @@ YAMLEOF
     [[ "$output" != *'["null"]'* ]]
 }
 
-@test "BA4-empty-version-failclosed: non-resolver ext with empty version string → non-zero exit" {
+@test "non-resolver ext with empty version string → non-zero exit" {
     # An extension with version: "" (empty string) must also fail fast, not emit [""].
 
     local tmp_config
@@ -334,7 +334,7 @@ YAMLEOF
 
 # ── CV: _read_committed_versionset — committed file fast path ─────────────────
 
-@test "CV-hit: _read_committed_versionset returns committed slice when file+major present" {
+@test "_read_committed_versionset returns committed slice when file+major present" {
     # Write a minimal committed file with a pg18 entry.
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -354,7 +354,7 @@ JSONEOF
     [[ "$output" == '["2.24.0","2.25.0","2.27.2"]' ]]
 }
 
-@test "CV-miss-absent: _read_committed_versionset exits non-zero when file is absent" {
+@test "_read_committed_versionset exits non-zero when file is absent" {
     run bash -c "
         source \"$HELPER\"
         _COMMITTED_VERSIONSET_FILE=\"/nonexistent/timescaledb-version-set.json\"
@@ -364,7 +364,7 @@ JSONEOF
     [[ -z "$output" ]]
 }
 
-@test "CV-miss-major: _read_committed_versionset exits non-zero when major key missing" {
+@test "_read_committed_versionset exits non-zero when major key missing" {
     # File present but pg15 key absent.
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -383,7 +383,7 @@ JSONEOF
     [[ -z "$output" ]]
 }
 
-@test "CV-miss-ext: _read_committed_versionset exits non-zero when ext key missing" {
+@test "_read_committed_versionset exits non-zero when ext key missing" {
     # File present but pgvector key absent (only timescaledb in file).
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -402,7 +402,7 @@ JSONEOF
     [[ -z "$output" ]]
 }
 
-@test "CV-hit-no-live: resolve_version_set uses committed slice, live resolver NOT called" {
+@test "resolve_version_set uses committed slice, live resolver NOT called" {
     # Wire: committed file has a pg18 entry with ceiling=2.27.2 (matches config ceiling)
     # AND committed_len (12) >= retain_count (12) — both acceptance conditions satisfied.
     # The live resolver (timescaledb-ha.sh) is pointed at a nonexistent fixture so any
@@ -444,7 +444,7 @@ YAMLEOF
     [[ "$output" == '["2.22.0","2.23.0","2.24.0","2.25.0","2.25.1","2.25.2","2.26.0","2.26.1","2.26.2","2.26.3","2.26.4","2.27.2"]' ]]
 }
 
-@test "CV-miss-fallback: resolve_version_set falls through to live resolver on committed miss" {
+@test "resolve_version_set falls through to live resolver on committed miss" {
     # Committed file exists but covers only pg18 (not pg19 → miss).
     # The live resolver is timescaledb-ha.sh pointed at a nonexistent fixture → fails.
     # Proof: overall exit is non-zero (live resolver was invoked and failed on miss,
@@ -489,7 +489,7 @@ YAMLEOF
 
 # ── CV-trim: committed fast path respects retain_count ───────────────────────
 
-@test "CV-trim-retain5: committed fast path trims to retain_count when slice is larger" {
+@test "committed fast path trims to retain_count when slice is larger" {
     # Committed file has 12 versions for pg18, caller config has retain_count=5.
     # Fast path must return only the last 5 (newest, ceiling-inclusive), not all 12.
     local tmp_committed
@@ -537,7 +537,7 @@ YAMLEOF
     [[ "$first" == "2.26.1" ]]
 }
 
-@test "CV-under-retain-fallthrough: committed fast path bypassed when committed_len < retain_count" {
+@test "committed fast path bypassed when committed_len < retain_count" {
     # Finding 1 fix: when committed_len (2) < retain_count (5), the fast path must NOT
     # serve the committed slice (would silently under-retain). It must fall through to
     # the live resolver. Observable: exit non-zero because the live resolver's fixture
@@ -581,7 +581,7 @@ YAMLEOF
 
 # ── CVS: _committed_versionset_satisfies — shared acceptance predicate ────────
 
-@test "CVS-hit: _committed_versionset_satisfies returns 0 when ceiling+len match" {
+@test "_committed_versionset_satisfies returns 0 when ceiling+len match" {
     local tmp_committed
     tmp_committed="$(mktemp)"
     # 12-entry pg18 slice with ceiling 2.27.2 matches config ceiling and retain_count=12.
@@ -598,7 +598,7 @@ JSONEOF
     [[ "$status" -eq 0 ]]
 }
 
-@test "CVS-miss-ceiling: _committed_versionset_satisfies returns 1 on ceiling mismatch" {
+@test "_committed_versionset_satisfies returns 1 on ceiling mismatch" {
     local tmp_committed
     tmp_committed="$(mktemp)"
     cat > "$tmp_committed" <<'JSONEOF'
@@ -614,7 +614,7 @@ JSONEOF
     [[ "$status" -ne 0 ]]
 }
 
-@test "CVS-miss-len: _committed_versionset_satisfies returns 1 when committed_len < retain_count" {
+@test "_committed_versionset_satisfies returns 1 when committed_len < retain_count" {
     local tmp_committed
     tmp_committed="$(mktemp)"
     # 2-entry slice, ceiling matches, but retain_count=5 requires at least 5 entries.
@@ -631,7 +631,7 @@ JSONEOF
     [[ "$status" -ne 0 ]]
 }
 
-@test "CVS-miss-absent: _committed_versionset_satisfies returns 1 when file absent" {
+@test "_committed_versionset_satisfies returns 1 when file absent" {
     run bash -c "
         source \"$HELPER\"
         _COMMITTED_VERSIONSET_FILE=\"/nonexistent/timescaledb-version-set.json\"
@@ -640,7 +640,7 @@ JSONEOF
     [[ "$status" -ne 0 ]]
 }
 
-@test "CVS-miss-major: _committed_versionset_satisfies returns 1 when major key missing" {
+@test "_committed_versionset_satisfies returns 1 when major key missing" {
     local tmp_committed
     tmp_committed="$(mktemp)"
     cat > "$tmp_committed" <<'JSONEOF'
@@ -660,7 +660,7 @@ JSONEOF
 # These tests call the predicate DIRECTLY with invalid retain_count values to
 # verify normalization happens inside the function (not only via the fast path).
 
-@test "CVS-raw-zero: _committed_versionset_satisfies with retain_count=0 normalizes to 12, does not abort" {
+@test "_committed_versionset_satisfies with retain_count=0 normalizes to 12, does not abort" {
     # A 12-entry committed slice with ceiling=2.27.2.
     # Passing retain_count=0 (invalid) directly → must normalize to 12 → 12 >= 12 → exit 0.
     local tmp_committed
@@ -683,7 +683,7 @@ JSONEOF
     [[ "$output" == "rc=0" ]]
 }
 
-@test "CVS-raw-empty: _committed_versionset_satisfies with empty retain_count normalizes to 12, does not abort" {
+@test "_committed_versionset_satisfies with empty retain_count normalizes to 12, does not abort" {
     # Passing retain_count="" directly → must normalize to 12 → 12 >= 12 → exit 0.
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -704,7 +704,7 @@ JSONEOF
     [[ "$output" == "rc=0" ]]
 }
 
-@test "CVS-raw-bogus: _committed_versionset_satisfies with retain_count=bogus normalizes to 12, does not abort" {
+@test "_committed_versionset_satisfies with retain_count=bogus normalizes to 12, does not abort" {
     # Passing retain_count="bogus" directly → must normalize to 12 → 12 >= 12 → exit 0.
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -727,43 +727,43 @@ JSONEOF
 
 # ── NRC: _normalize_retain_count — shared normalization helper ────────────────
 
-@test "NRC-positive: _normalize_retain_count returns valid positive int unchanged" {
+@test "_normalize_retain_count returns valid positive int unchanged" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count 5"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "5" ]]
 }
 
-@test "NRC-twelve: _normalize_retain_count returns 12 for default" {
+@test "_normalize_retain_count returns 12 for default" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count 12"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
 }
 
-@test "NRC-zero: _normalize_retain_count treats 0 as invalid → defaults to 12" {
+@test "_normalize_retain_count treats 0 as invalid → defaults to 12" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count 0"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
 }
 
-@test "NRC-negative: _normalize_retain_count treats negative as invalid → defaults to 12" {
+@test "_normalize_retain_count treats negative as invalid → defaults to 12" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count -- -1"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
 }
 
-@test "NRC-empty: _normalize_retain_count treats empty string as invalid → defaults to 12" {
+@test "_normalize_retain_count treats empty string as invalid → defaults to 12" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count ''"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
 }
 
-@test "NRC-nonnumeric: _normalize_retain_count treats non-numeric as invalid → defaults to 12" {
+@test "_normalize_retain_count treats non-numeric as invalid → defaults to 12" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count 'abc'"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
 }
 
-@test "NRC-leadingzero: _normalize_retain_count treats leading-zero number as invalid → defaults to 12" {
+@test "_normalize_retain_count treats leading-zero number as invalid → defaults to 12" {
     run bash -c "source \"$HELPER\"; _normalize_retain_count '05'"
     [[ "$status" -eq 0 ]]
     [[ "$output" == "12" ]]
@@ -774,7 +774,7 @@ JSONEOF
 # same way as the live resolver — invalid values (0, empty, non-numeric) all
 # behave as 12 and do NOT abort under set -u.
 
-@test "NRC-FP-zero: committed fast path with retain_count=0 behaves as 12, does not abort" {
+@test "committed fast path with retain_count=0 behaves as 12, does not abort" {
     # Committed file has 12 entries for pg18 (ceiling=2.27.2).
     # Config sets retain_count=0 (invalid) → must normalize to 12 → fast path accepted.
     local tmp_committed
@@ -814,7 +814,7 @@ YAMLEOF
     [[ "$count" -eq 12 ]]
 }
 
-@test "NRC-FP-empty: committed fast path with empty retain_count behaves as 12, does not abort" {
+@test "committed fast path with empty retain_count behaves as 12, does not abort" {
     # Config has no retain_count key → yq returns "" → must normalize to 12.
     local tmp_committed
     tmp_committed="$(mktemp)"
@@ -851,7 +851,7 @@ YAMLEOF
     [[ "$count" -eq 12 ]]
 }
 
-@test "NRC-FP-nonnumeric: committed fast path with non-numeric retain_count behaves as 12, does not abort" {
+@test "committed fast path with non-numeric retain_count behaves as 12, does not abort" {
     # Config sets retain_count="bogus" → must normalize to 12 (not abort/miscompare).
     local tmp_committed
     tmp_committed="$(mktemp)"


### PR DESCRIPTION
818 bats test names and their comment lines across 89 files carried short
letter-and-digit tags minted by whatever local planning step produced them,
including a family of round numbers. Each is removed; every description survives,
because the tag was always a prefix to a sentence that already said what the test
checks.

Follows the earlier sweep of source comments, deliberately kept separate so
twenty judgement calls were not buried under a thousand mechanical renames.

## What stays

Descriptive prefixes — `arg-parsing:`, `backward-compat:`, `consolidate:`,
`dedup:`, `all-or-nothing:` — name a category a reader can still use three months
from now. The rule applied is that a tag must contain a **digit**, which is what
separates a grid cell from a category, and why `pg16`, `sha256:`, `v1` and
`Pre-v2` were never candidates.

One test is kept whole where the tag looked like a label but was not: in
`B0 appears before State B loop`, `B0` is a marker in the code under test.

## The tags were also cross-references

This is the part worth reading. Production code cited them — the base-cache
helper, the extension builder, both workflows, the dashboard generator, the
decision record. Removing the names alone would have left those pointing at
nothing.

Every citation is repaired: mechanically where the tag opened a comment, by hand
where it sat mid-sentence. The base-cache helper now names the cases that cover
it. The decision record describes the assertion instead of coding it. A grep for
every removed tag across the whole tree returns nothing.

## Six names collided once their prefixes were gone

They test the same stderr classification in two different callers, and
`tests/run-tests.sh` runs every unit file in one bats invocation — so uniqueness
is a property of the whole suite, not of a file. They are distinguished now by the
function under test, `state_probe` and `_run_registry_probe`. A seventh collision,
between the github and gitlab tag helpers, predates this change and is fixed too.

## Verification

**2198 tests collected, none failing** — the same collected count as before the
change, taken from a real run and checked against the plan line rather than read
off the tail. **Zero** duplicate names across the entire unit suite. shellcheck
clean under the flags CI uses on every touched script; both workflows parse.

That collected count is the check that decides, and it had to be. An earlier
attempt used `\s` as the separator after a tag; `\s` matches a newline, so a
comment line holding nothing but a tag swallowed its line ending and commented
out the `@test` below it. Counting occurrences of the string `@test "` could not
see it — a commented-out test still contains that string — and the count read the
same before and after while a test quietly vanished. The separator is `[ \t]` now,
which cannot reach a newline.

## Out of scope, and larger than it looks

The same scheme runs through roughly 260 comment lines in production files. A
mechanical rule cannot be trusted there: the ADR references this work says to
prefer share the exact shape, as do a licence identifier, a PostgreSQL major
version, a hash algorithm name, and a literal character class inside a regex
comment. That needs per-line judgement and is its own decision.
