### PR TITLE
fix(postgres): give the paradedb build the OpenBLAS it now links against

### DIFF
--- a/postgres/extensions/build/paradedb.Dockerfile
+++ b/postgres/extensions/build/paradedb.Dockerfile
@@ -33,13 +33,16 @@ RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}" "${RUST_VERSION:?requir
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 # Install build dependencies
-# pgrx requires Rust, clang (for bindgen/libclang), and OpenSSL
+# pgrx requires Rust, clang (for bindgen/libclang), and OpenSSL.
+# openblas-dev arrived with 0.25.0: pg_search links against OpenBLAS, and without
+# it the build reaches the link step and stops at `ld: cannot find -lopenblas`.
 RUN apk add --no-cache \
     build-base \
     clang-dev \
     clang-libclang \
     openssl-dev \
     icu-dev \
+    openblas-dev \
     git \
     curl \
     pkgconf \

--- a/postgres/extensions/config.yaml
+++ b/postgres/extensions/config.yaml
@@ -68,6 +68,13 @@ extensions:
       - llvm-dev
       - openssl-dev
       - icu-dev
+      # 0.25.0 links pg_search against OpenBLAS; without this the build fails at
+      # the link step with `ld: cannot find -lopenblas`.
+      - openblas-dev
+    # Needed in the final image too: the extension is dynamically linked, so
+    # libopenblas.so.3 must be present where postgres loads pg_search.
+    runtime_deps:
+      - openblas
     shared_preload: false # Not required for PG17+
     priority: 3
     # EXPERIMENTAL: Alpine/musl build with RUSTFLAGS="-C target-feature=-crt-static"


### PR DESCRIPTION
Closes #994.

`Build PostgreSQL Extensions` has been red on `master` since paradedb was bumped
from `0.24.3` to `0.25.0` this morning — on **both** architectures, every run.

## Cause

0.25.0 links `pg_search` against OpenBLAS. 0.24.3 did not, the dependency is
declared nowhere here, and the builder has never installed it, so the build reaches
the link step and stops:

```
ld: cannot find -lopenblas: No such file or directory
error: could not compile `pg_search` (lib) due to 1 previous error
```

Identical across all three retry attempts, each after roughly 31 minutes of
compilation, so the retry wrapper cannot absorb it.

Worth saying plainly: the CI log truncates the `cc` invocation exactly where the
message is, which is why the first read of this looked like a symbol or
version-script problem. It is neither, and nothing about the Rust toolchain or its
pinned version is involved.

## Fix

Three lines, in two files, because the extension is dynamically linked
(`RUSTFLAGS="-C target-feature=-crt-static"`) and the final image is built
`FROM scratch`:

| Where | What | Why |
|---|---|---|
| `paradedb.Dockerfile` | `openblas-dev` in the builder's `apk add` | what the link step needs |
| `config.yaml` → `build_deps` | the same | so the declaration matches what is installed |
| `config.yaml` → `runtime_deps` | `openblas` | without it the extension builds, then fails to load — `libopenblas.so.3` would be absent where postgres opens `pg_search.so` |

Both links were checked rather than assumed: `openblas-dev` installs in the exact
builder base and provides `/usr/lib/libopenblas.so`, which is what `-lopenblas`
resolves to; and `runtime_deps` is genuinely consumed —
`helpers/extension-utils.sh` turns it into a `RUN apk add` block in the generated
postgres Dockerfile.

## What this pull request does not prove

The fix is **not** demonstrated end to end here. A local build installs openblas
and proceeds, but dies before the link step on crate downloads — `cargo metadata
exited with an error: failed to download adler2 v2.0.1` — three attempts across two
runs, with the cargo caches cleared in between. That is a sandbox network limit,
not a repository problem, and it means the step under test was never reached
locally.

CI has the network this build needs, so its `Build PostgreSQL Extensions` job is
the evidence. Until that is green, treat this as reasoned and verified in its
parts rather than demonstrated as a whole. The unit suite is green (2198 collected,
none failing), but that says nothing about this particular fix.

If the build gets past the link step and stops on a *different* missing library,
that is expected rather than surprising: the linker names only the first one it
cannot find.

## Beyond the fix

The automated bump merged a release that cannot build on either published
architecture, and the failure surfaced on `master` rather than on the bump's own
pull request. That is the more durable problem, and it is not addressed here.
