### PR TITLE
fix(php): stop asking to install OPcache, which silently dropped zip and apcu

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -35,7 +35,16 @@ RUN set -ex \
 		libjpeg-turbo-dev \
 		libpng-dev \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
-	&& docker-php-ext-install -j$(nproc) gd mysqli opcache zip \
+# OPcache is NOT in this list on purpose: PHP 8.5 makes it non-optional and the
+# official image builds it statically, so asking docker-php-ext-install for it
+# exits non-zero — and everything listed after it in the same command is then
+# skipped silently. That is what left `zip` out of every published image, and
+# stopped the apcu step below from ever running.
+#
+# Since the version comes from a build arg, "the base image has OPcache" is an
+# assumption about an input rather than a fact, so it is asserted explicitly
+# further down instead of being trusted.
+	&& docker-php-ext-install -j$(nproc) gd mysqli zip \
 	&& pecl install apcu-${APCU_VERSION} && docker-php-ext-enable apcu \
 # - Detect Runtime Dependencies of the installed extensions. \
 # - src: https://github.com/docker-library/wordpress/blob/master/latest/php8.0/fpm-alpine/Dockerfile \
@@ -52,7 +61,15 @@ RUN set -ex \
 		# Uninstall Everything we Installed (minus the runtime Deps)
 		apk del --no-network .build-deps; \
 		# check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)
-		err="$(php --version 3>&1 1>&2 2>&3)"; 	[ -z "$err" ] \
+		err="$(php --version 3>&1 1>&2 2>&3)"; 	[ -z "$err" ]; \
+		# That stderr check only catches a dynamic extension that failed to LOAD.
+		# It says nothing about one that was never there, so assert the set this
+		# image promises — including OPcache, which comes from the base image
+		# rather than from any step here.
+		for ext in gd mysqli zip apcu "Zend OPcache"; do \
+			php -r "exit(extension_loaded(\$argv[1]) ? 0 : 1);" "$ext" \
+				|| { echo "missing extension: $ext" >&2; exit 1; }; \
+		done \
 	&& rm -rf /var/cache/apk/* /tmp/* /var/tmp/* \
 	&& rm -f /usr/local/etc/php-fpm.d/*
 

--- a/php/test.sh
+++ b/php/test.sh
@@ -1,43 +1,59 @@
 #!/bin/bash
-# E2E test for php container
+# E2E test for the php container.
+#
+# Uses the repository's test harness so the exit code is the verdict. The
+# extension checks were warnings; each is a dependency a PHP application will
+# assume, so they are asserted.
+#
+# Extensions are checked with extension_loaded() rather than by grepping `php -m`.
+# That output is not a flat list of the names you pass elsewhere: OPcache appears
+# as "Zend OPcache" and is invisible to an exact-match grep, while `php --ri
+# opcache` denies it exists. Asking the engine avoids guessing at its spelling.
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-harness/test-harness.sh
+source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-php}"
 
-echo "  Testing PHP-FPM..."
+th_init --name "PHP-FPM E2E" --report "${REPORT_FORMAT:-table}"
 
-# Test PHP version
-echo "  Checking PHP version..."
-docker exec "$CONTAINER_NAME" php -v | head -1
+th_group "Interpreter"
 
-# Test PHP-FPM is running (process name varies: php-fpm, php-fpm8, php-fpm81, etc.)
-echo "  Checking PHP-FPM process..."
-if docker exec "$CONTAINER_NAME" pgrep -f "php-fpm" &>/dev/null; then
-    echo "  ✅ PHP-FPM process running"
+# Was printed and never read.
+th_assert_cmd_contains "php reports its version" "PHP" \
+    docker exec "$CONTAINER_NAME" php -v
+
+th_capture "php evaluates code" docker exec "$CONTAINER_NAME" php -r "echo 1 + 1;" &&
+    th_assert_eq "php evaluates code" "${TH_OUTPUT//[[:space:]]/}" "2"
+
+th_group "Service"
+
+# The process name varies by build (php-fpm, php-fpm8, php-fpm81…), so match the
+# prefix rather than an exact name.
+if docker exec "$CONTAINER_NAME" pgrep -f "php-fpm" >/dev/null 2>&1; then
+    th_pass "a php-fpm master process is running"
 else
-    echo "  ❌ PHP-FPM not running"
-    exit 1
+    th_fail "a php-fpm master process is running" "pgrep -f php-fpm found nothing"
 fi
 
-# Test basic PHP execution
-echo "  Testing PHP execution..."
-result=$(docker exec "$CONTAINER_NAME" php -r "echo 1 + 1;" 2>/dev/null)
-if [ "$result" = "2" ]; then
-    echo "  ✅ PHP execution OK"
-else
-    echo "  ❌ PHP execution failed"
-    exit 1
-fi
+th_group "Extensions"
 
-# Test common extensions
-echo "  Checking extensions..."
-for ext in pdo curl json mbstring; do
-    if docker exec "$CONTAINER_NAME" php -m 2>/dev/null | grep -qi "^$ext$"; then
-        echo "    ✓ $ext"
-    else
-        echo "    ⚠️  $ext not loaded"
-    fi
+# Every extension the image advertises, asserted. "Zend OPcache" is the name the
+# engine registers, and it comes from the base image's static build rather than
+# from an install step — which is exactly what made `zip` and `apcu` go missing
+# for a while: asking to install OPcache anyway failed, and everything listed
+# after it in the same command was skipped without a word.
+#
+# The probe asserts the command SUCCEEDED as well as what it printed. Printing
+# the expected answer and exiting non-zero are independent: a wrapper that echoes
+# `y` and then fails would otherwise pass every check here.
+for ext in PDO curl json mbstring mysqli gd zip apcu "Zend OPcache"; do
+    th_assert_cmd_contains "extension $ext is loaded" "loaded" \
+        docker exec "$CONTAINER_NAME" php -r \
+        "echo extension_loaded('$ext') ? 'loaded' : 'absent';"
 done
 
-echo "  ✅ All PHP tests passed"
+th_summary

--- a/php/variants.yaml
+++ b/php/variants.yaml
@@ -5,3 +5,6 @@ versions:
   - tag: 8.5.8-fpm-alpine
   - tag: 8.5.7-fpm-alpine
   - tag: 8.5.6-fpm-alpine
+tests:
+  e2e:
+    enabled: true


### PR DESCRIPTION
Closes #982.

The php image has been shipping without two extensions its Dockerfile installs and
its README advertises.

## Cause

PHP 8.5 makes OPcache non-optional and the official image builds it statically.
Asking `docker-php-ext-install` for it anyway exits non-zero — and everything
listed after it in the same command is skipped without a word. `zip` was after it,
so it never installed, and the `pecl install apcu` further along the same `&&`
chain never ran either.

Measured against the base image rather than reasoned about:

```
docker-php-ext-install gd mysqli opcache zip  → exit 2, extension_dir: gd.so mysqli.so sodium.so
docker-php-ext-install gd mysqli zip          → exit 0, extension_dir: gd.so mysqli.so sodium.so zip.so
```

Nothing failed at build time, and OPcache *is* loaded from the static build, so the
one absence that would have been obvious looked fine. Dropping `opcache` from the
list loses nothing.

## The build now asserts what the image promises

The pre-existing `php --version` stderr check only catches a **dynamic** extension
that failed to load. An extension that was never there leaves stderr silent, so
that check could not have caught this — and since the base version comes from a
build arg, "the base image has OPcache" is an assumption about an input rather
than a fact.

The build asserts `extension_loaded()` for gd, mysqli, zip, apcu and
`Zend OPcache`. The image rebuilds green with that in place, which is what
establishes the assertion holds.

## php rejoins the e2e opt-in

With `zip` and `apcu` as assertions, not the skips that recorded the gap while it
stood. A build that loses either now fails the suite instead of excusing it.

Its probes assert command **success** as well as output, which they did not at
first: the suite was recovered from a commit predating the harness's command
probes, so it carried the raw captures those replaced elsewhere. A stub printing
each expected answer and exiting 42 passed all twelve checks. Printing the expected
value and succeeding are independent — only the exit status tells them apart. The
same stub now fails all twelve.

## Verification

| | |
|---|---|
| Build with the new assertion | green |
| Extensions loaded in the built image | gd, mysqli, zip, apcu, Zend OPcache |
| php e2e against that image | 12 of 12, no skips |
| Mutation stub at exit 42 / exit 0 | 12 failed / 12 passed |
| Full unit suite | 2198 collected, none failing |
| shellcheck under CI's flags | clean |

One note for anyone reading the suite and reaching for `procps-ng`: the process
probe uses `pgrep`, which this image has **without** that package. Alpine ships a
busybox applet and symlinks it — `/usr/bin/pgrep -> /bin/busybox`, owned by
busybox, present in the official base image too — and `pgrep -f php-fpm` exits 0 in
a running container. Nothing needs installing for that check to work.
