### PR TITLE
test(sslh): fail the version check when sslh-ev does

### DIFF
--- a/sslh/test.sh
+++ b/sslh/test.sh
@@ -19,11 +19,22 @@ th_init --name "SSLH E2E" --report "${REPORT_FORMAT:-table}"
 
 th_group "Binary"
 
-# The old version check tried sslh-ev, fell back to a plain `sslh`, and shrugged
-# if both failed. Only sslh-ev is in the image — `sslh` is not a file there — so
-# the fallback was dead and the shrug hid a real failure.
-version=$(docker exec "$CONTAINER_NAME" sslh-ev --version 2>&1 | head -1)
-th_assert_contains "sslh-ev reports its version" "$version" "sslh-ev"
+# Only sslh-ev is in the image — `sslh` is not a file there. The probe takes the
+# command, so a binary that prints a plausible banner and then exits non-zero
+# fails here instead of satisfying the text assertion. It writes the banner to
+# stdout, so nothing needs merging: the probes discard stderr on purpose, and a
+# diagnostic must not be able to pass an assertion about a version.
+banner=""
+version_read=0
+if th_capture "sslh-ev reports its version" \
+        docker exec "$CONTAINER_NAME" sslh-ev --version; then
+    version_read=1
+    # `sslh-ev 2.3.1`, then a line per compile-time option. Both checks read the
+    # first line only, as the `head -1` this probe replaced did: what appears
+    # further down says nothing about which binary answered.
+    banner="${TH_OUTPUT%%$'\n'*}"
+    th_assert_contains "sslh-ev reports its version" "$banner" "sslh-ev"
+fi
 
 # The tag carries the upstream version, so the binary disagreeing with it means
 # the image was assembled from something other than what it claims.
@@ -37,8 +48,21 @@ fi
 # Only a tag that carries a version can be compared against one. A moving tag
 # such as `latest` says nothing about the binary, and asserting on it would fail
 # for a reason that has nothing to do with the image.
+#
+# The comparison stays a substring match, deliberately: turning it into an exact
+# one means deciding what an image reference's version IS, and a tag carries a
+# flavour suffix, sometimes a prerelease hyphen and sometimes a digest, so every
+# stricter rule rejects some legitimate build. Tightening it is #983's work, on
+# every suite at once, not a side effect of this one. See #1002.
 if [[ "$expected" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-    th_assert_contains "the binary version matches the image tag ($expected)" "$version" "$expected"
+    if (( version_read )); then
+        th_assert_contains "the binary version matches the image tag ($expected)" \
+            "$banner" "$expected"
+    else
+        # Reported as a skip rather than dropped: a test that leaves the report
+        # entirely is indistinguishable from one that was never written.
+        th_skip "the binary version matches the image tag" "the version probe failed"
+    fi
 else
     th_skip "the binary version matches the image tag" "tag '${expected:-none}' carries no version"
 fi

--- a/tests/unit/test-harness-command-probes.bats
+++ b/tests/unit/test-harness-command-probes.bats
@@ -23,6 +23,12 @@ succeeding() {
     echo "ruby 3.3.0"
 }
 
+stderr_banner() {
+    # Shaped like a real banner: a reviewer reading this stub should not come away
+    # with a false picture of what the binary prints.
+    echo "sslh-ev 2.3.1" >&2
+}
+
 secret_bearing() {
     return 7
 }
@@ -74,6 +80,20 @@ secret_bearing() {
     TH_OUTPUT="stale"
     th_capture "version is readable" plausible_but_failing || true
     [ -z "$TH_OUTPUT" ]
+}
+
+@test "th_capture discards stderr, so a diagnostic cannot satisfy an assertion" {
+    # An error message that happens to carry the needle must not be able to pass
+    # a `contains` assertion, so no probe merges the two streams.
+    #
+    # Asserting only that $TH_OUTPUT excludes stderr would prove nothing: command
+    # substitution captures stdout alone whether or not the harness redirects
+    # stderr. What the redirect actually does is swallow the command's stderr, so
+    # that is what this pins — the probe itself must emit none.
+    local probe_stderr="$BATS_TEST_TMPDIR/probe-stderr"
+    th_capture "a banner written to stderr" stderr_banner 2>"$probe_stderr"
+    [ -z "$TH_OUTPUT" ]
+    [ ! -s "$probe_stderr" ]
 }
 
 @test "th_capture with no command fails instead of passing on an empty substitution" {


### PR DESCRIPTION
Closes #990.

`sslh/test.sh` was the last opted-in suite still capturing a command's output and
asserting only on its text, so a binary that printed a plausible banner and then
exited non-zero passed. The version check now goes through the harness probe,
which takes the command and records a failure on its exit status.

Two smaller things follow from that: both checks read the banner's first line, as
the `head -1` this replaced did, and a failed probe leaves a skip in the report
instead of the tag comparison silently disappearing.

## The issue's diagnosis does not hold

#990 explained sslh's exclusion from the earlier sweep as a stderr-only version
banner, needing an opt-in stderr merge on the probes. Measured on both retained
variants, the banner is on **stdout**:

```
$ docker run --rm ghcr.io/oorabona/sslh:v2.3.1-alpine --version 2>/dev/null
sslh-ev 2.3.1
ENABLE_REGEX
LIBCONFIG
HAVE_LANDLOCK
$ docker run --rm ghcr.io/oorabona/sslh:v2.3.0-alpine --version 2>/dev/null
sslh-ev 2.3.0
```

`git log -S` puts the original `2>&1` inside a bulk e2e refactor rather than a
response to an observed banner. A `--merge-stderr` opt-in was built to the issue's
recommendation and then removed: deleting the flag from the converted suite left
the e2e green, so it was inert at its only call site. The harness is therefore
unchanged, and the probes keep discarding stderr — one bats case now pins that
default by asserting the probe emits no stderr of its own, since checking only
that `$TH_OUTPUT` excludes it holds with the redirect deleted.

## What is deliberately not in here

The tag/binary version comparison stays the substring match it is on master, and
#1002 explains why in detail: an exact comparison has to decide what an image
reference's version is, and each stricter rule rejects some legitimate reference —
a prerelease hyphen reads like a flavour suffix, the repository's own `v2.3.1`
format is normalized on one path and not the other, a digest-qualified reference
has no version where the tag is read from. That decision belongs to #983's
assertion-depth work across every suite at once.

## Verification

Against the published image, on this exact head:

- the sslh e2e passes (`E2E_IMAGE=ghcr.io/oorabona/sslh:v2.3.1-alpine
  tests/e2e-test.sh sslh --no-build`)
- it goes **red** when the needle can never match, and when the probed command
  does not exist — the case the old form let through
- the new bats case **fails** when the harness's `2>/dev/null` is removed, so it
  pins the behaviour it names rather than one command substitution already gives
- full unit suite green, shellcheck clean as `unit-tests.yaml` runs it
