### PR TITLE
test(e2e): bound the readiness wait by elapsed time, not poll count

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ That's it. The CI picks it up automatically on next push.
 - Docker Engine 20.10+ (or Podman)
 - Bash 4.0+
 - [yq](https://github.com/mikefarah/yq) (for variant containers)
+- A `timeout` accepting `-k`, to run the e2e suite — it is what keeps a probe
+  from hanging forever and leaving a container behind. GNU coreutils provides it
+  and most Linux distributions ship it; on macOS, `brew install coreutils` and
+  put its `libexec/gnubin` on `PATH`. The suite probes at startup for a `timeout`
+  that accepts `-k`, so one that does not fails immediately rather than at
+  cleanup. That probe reads the interface, not the behaviour: an implementation
+  that took the flag and ignored it would still get through.
 
 ## Documentation
 

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -11,8 +11,16 @@
 #
 # For containers with variants, version is required (e.g., postgres:16)
 # Set E2E_IMAGE=<image-ref> to test a preloaded image directly.
+# Set E2E_READY_TIMEOUT=<seconds> (1-99999, default 60) to give a container with a
+# slow healthcheck longer to report itself ready.
 
 set -euo pipefail
+
+# The readiness deadline is `SECONDS` plus a budget, and `SECONDS` is inherited:
+# a caller who exports a huge one would wrap that sum negative and every wait
+# would expire before it began. Reset once, here, so the deadlines below start
+# from a number this script controls.
+SECONDS=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -39,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-build    Skip building images"
             echo "  -h, --help    Show this help"
             echo ""
+            echo "Environment:"
+            echo "  E2E_IMAGE            Test this image ref directly, skipping discovery"
+            echo "  E2E_READY_TIMEOUT    Seconds a container gets to report ready (1-99999, default 60)"
+            echo ""
             echo "Examples:"
             echo "  $0                    # Test all containers"
             echo "  $0 postgres openresty # Test specific containers"
@@ -55,6 +67,28 @@ done
 # Get list of containers to test
 if [ -z "$CONTAINERS" ]; then
     CONTAINERS=$(./make list 2>/dev/null)
+fi
+
+# How long each container gets to become ready. Checked here, before anything is
+# built or started: rejecting it later would leave a running container behind,
+# since `docker run --rm` only cleans up once the container stops. The upper bound
+# keeps `$((SECONDS + max_wait))` inside machine arithmetic — a value near INT64_MAX
+# wraps to a negative deadline, which reads as a budget that has already expired.
+READY_TIMEOUT="${E2E_READY_TIMEOUT:-60}"
+if ! [[ "$READY_TIMEOUT" =~ ^[1-9][0-9]{0,4}$ ]]; then
+    log_error "E2E_READY_TIMEOUT must be a whole number of seconds between 1 and 99999 (got: $READY_TIMEOUT)"
+    exit 1
+fi
+
+# The wait bounds each docker call with `timeout -k`, and so does the cleanup that
+# removes a container after a failure. A `timeout` that is missing, or too old for
+# `-k`, would therefore leave a started container running. This asks whether the
+# flag is accepted, before anything is built or started — not whether the
+# implementation honours it, which would cost a deliberately unkillable child on
+# every invocation.
+if ! timeout -k 1 1 true 2>/dev/null; then
+    log_error "this harness needs a 'timeout' accepting -k (GNU coreutils provides one)"
+    exit 1
 fi
 
 echo ""
@@ -134,6 +168,46 @@ resolve_e2e_image() {
     ')
 
     printf '%s\n' "$image"
+}
+
+# Seconds left before the deadline, or non-zero once the budget is spent. Every
+# check of "is there time left" goes through here: the loop below asks twice per
+# iteration, since time passes inside the docker calls, and a second hand-written
+# copy of the comparison is a second place to get it wrong. It never prints 0 —
+# `timeout 0` means *no timeout* to coreutils, which is the opposite of the bound
+# the caller is asking for.
+#
+# The budget is honoured to whole seconds: `SECONDS` has that resolution, so a
+# probe admitted with a second left may return just after the deadline, and a
+# child that ignores SIGTERM adds the kill-after grace on top. The bound is
+# "about the budget", not a hard real-time guarantee — enough for a test harness,
+# and the reason nothing here reaches for a monotonic clock.
+# Usage: remaining=$(readiness_remaining <deadline>) || <budget spent>
+readiness_remaining() {
+    local left=$(( $1 - SECONDS ))
+    [ "$left" -gt 0 ] || return 1
+    printf '%s' "$left"
+}
+
+# Sleep no longer than the remaining readiness budget, so the budget is an upper
+# bound on the wait rather than on its naps alone. Returns non-zero when it could
+# not sleep the whole requested time — a poll interval does not care, but a caller
+# that treats the delay itself as evidence does, and must not read a shortened one
+# as the full one.
+# Usage: sleep_within_readiness_deadline <seconds> <deadline>
+sleep_within_readiness_deadline() {
+    local requested="$1"
+    local sleep_deadline="$2"
+    local sleep_remaining=$((sleep_deadline - SECONDS))
+
+    if [ "$sleep_remaining" -le 0 ]; then
+        return 1
+    fi
+    if [ "$requested" -gt "$sleep_remaining" ]; then
+        sleep "$sleep_remaining" || true
+        return 1
+    fi
+    sleep "$requested"
 }
 
 # Test a single container (or variant)
@@ -226,21 +300,58 @@ test_container() {
 
     # Wait for container to be ready (healthcheck or basic startup)
     log_info "Waiting for $container to be ready..."
-    local max_wait=60
-    local waited=0
+    local start=$SECONDS
+    local deadline=$((start + READY_TIMEOUT))
     local ready=false
+    # Declared here, not on the assignment below: `local x=$(cmd)` returns the
+    # builtin's status, which would swallow the one the loop condition reads.
+    local remaining health
+    # Whether an image with no healthcheck has already served its grace. It is
+    # readiness only once the loop has come back around and seen the container
+    # still listed: a container that dies during the grace is not ready, it is a
+    # container that died.
+    local grace_served=0
 
-    while [ $waited -lt $max_wait ]; do
-        # Check if container is still running
-        if ! docker ps --format '{{.Names}}' | grep -q "^${container_name}$"; then
+    while remaining=$(readiness_remaining "$deadline"); do
+        # Check if container is still running. A `docker ps` that does not answer —
+        # because it hit its bound, or the daemon is unwell — is not the same as one
+        # that answered and did not list the container, so only the latter is
+        # reported as an exit. The former keeps polling and, if that is all we ever
+        # get, ends as the timeout it is.
+        # `-k` matters as much as the bound: plain `timeout` sends SIGTERM and then
+        # waits forever for a child that ignores it, which is the hang this whole
+        # change is about. The grace is what the wait can overshoot its budget by.
+        local names ps_status=0
+        names=$(timeout -k 2 "$remaining" docker ps --format '{{.Names}}' 2>/dev/null) || ps_status=$?
+        if [ "$ps_status" -ne 0 ]; then
+            sleep_within_readiness_deadline 2 "$deadline" || true
+            continue
+        fi
+        # Fixed-string, whole-line, and fed from a here-string: a name is not a
+        # pattern (docker allows `.` in one), and a pipeline whose producer is
+        # still writing when `grep -q` exits on a match fails under `pipefail`,
+        # which would read as the container having exited.
+        if ! grep -Fxq "$container_name" <<< "$names"; then
             log_error "$container exited unexpectedly"
-            docker logs "$container_name" 2>&1 | tail -20
+            timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
             return 1
         fi
 
-        # Check health status if available
-        local health
-        health=$(docker inspect --format='{{.State.Health.Status}}' "$container_name" 2>/dev/null) || health="none"
+        # The container was listed just now, which is the liveness the grace was
+        # waiting to confirm.
+        if [ "$grace_served" -eq 1 ]; then
+            ready=true
+            break
+        fi
+
+        # Check health status if available. Time passed inside `docker ps`, so the
+        # budget is re-read rather than reused.
+        remaining=$(readiness_remaining "$deadline") || break
+        # The conditional template distinguishes a missing healthcheck from an
+        # inspect failure; treating the latter as no healthcheck would fail open.
+        if ! health=$(timeout -k 2 "$remaining" docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' "$container_name" 2>/dev/null); then
+            health="unavailable"
+        fi
 
         case "$health" in
             healthy)
@@ -249,30 +360,39 @@ test_container() {
                 ;;
             unhealthy)
                 log_error "$container is unhealthy"
-                docker logs "$container_name" 2>&1 | tail -20
-                docker rm -f "$container_name" 2>/dev/null || true
+                timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+                timeout -k 2 5 docker rm -f "$container_name" 2>/dev/null ||
+                log_warning "$container_name could not be removed and may still be running"
                 return 1
                 ;;
             starting)
                 ;;
-            none)
-                # No healthcheck, give processes time to initialize
-                sleep 3
-                ready=true
-                break
+            nohealth)
+                # Nothing to consult, so the only evidence of readiness is that
+                # the grace elapsed with the container still up. A grace cut short
+                # by the budget is not that evidence; neither is one the container
+                # did not survive, which is why this loops once more instead of
+                # declaring readiness on the strength of a liveness check taken
+                # three seconds ago.
+                if ! sleep_within_readiness_deadline 3 "$deadline"; then
+                    break
+                fi
+                grace_served=1
+                continue
                 ;;
         esac
 
-        sleep 2
-        waited=$((waited + 2))
-        printf "\r    ⏳ Waiting... (%ds)" "$waited"
+        # A shortened poll interval is fine — the loop condition re-checks anyway.
+        sleep_within_readiness_deadline 2 "$deadline" || true
+        printf "\r    ⏳ Waiting... (%ds)" "$((SECONDS - start))"
     done
     echo ""
 
     if [ "$ready" != true ]; then
         log_error "$container did not become ready in time"
-        docker logs "$container_name" 2>&1 | tail -20
-        docker rm -f "$container_name" 2>/dev/null || true
+        timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+        timeout -k 2 5 docker rm -f "$container_name" 2>/dev/null ||
+            log_warning "$container_name could not be removed and may still be running"
         return 1
     fi
 

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -5,6 +5,15 @@ load "../test_helper"
 setup() {
     setup_temp_dir
     ORIG_PATH="$PATH"
+    # Cleared going in, not just coming out: one of these exported in the shell
+    # that runs the suite would otherwise steer the stub through tests that never
+    # asked for it.
+    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
+        DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_IMAGES_OUTPUT
+    # Each bats test is its own process, so it inherits these from the shell that
+    # launched the suite: an exported E2E_IMAGE walks straight past the discovery
+    # tests, and a different owner invalidates the ambiguous-image fixture.
+    export GITHUB_REPOSITORY_OWNER=oorabona
     FIXTURE_REPO="$TEST_TEMP_DIR/repo"
     mkdir -p "$FIXTURE_REPO/tests" "$FIXTURE_REPO/helpers"
     cp "$PROJECT_ROOT/tests/e2e-test.sh" "$FIXTURE_REPO/tests/e2e-test.sh"
@@ -15,8 +24,19 @@ setup() {
 
 teardown() {
     export PATH="$ORIG_PATH"
-    unset E2E_IMAGE DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT TEST_SCRIPT_MARKER
+    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT PS_COUNT_FILE TEST_SCRIPT_MARKER
     teardown_temp_dir
+}
+
+# Every test below that expects the harness to give up wraps it in a watchdog
+# `timeout`, so that a wait which stopped bounding anything fails instead of
+# hanging. That makes the watchdog's own statuses a false pass: 124 when it sends
+# SIGTERM, 137 when its kill-after grace follows with SIGKILL. Either means the
+# harness never reached the failure the test is about.
+assert_harness_failed_on_its_own() {
+    [ "$status" -ne 0 ]
+    [ "$status" -ne 124 ]
+    [ "$status" -ne 137 ]
 }
 
 install_docker_stub() {
@@ -29,10 +49,12 @@ case "$1" in
         printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}"
         ;;
     inspect)
-        printf '%s\n' "none"
+        printf '%s\n' "${DOCKER_INSPECT_OUTPUT:-nohealth}"
+        exit "${DOCKER_INSPECT_EXIT:-0}"
         ;;
     ps)
         printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}"
+        exit "${DOCKER_PS_EXIT:-0}"
         ;;
     rm|run|logs|exec)
         exit 0
@@ -209,4 +231,281 @@ SH
     # The trailing space matters: without it `--entrypoint sleeper` satisfies the
     # match while being an invalid entrypoint.
     [[ "$run_line" == *"--entrypoint sleep "*"ghcr.io/example/terraform:e2e"*"infinity"* ]]
+}
+
+@test "the readiness budget bounds elapsed time, not the number of polls" {
+    # The wait used to add 2 to a counter per iteration, so everything spent
+    # inside docker was free: with calls this slow it would have kept polling for
+    # 30 iterations — a minute of wall clock against a 3-second budget. The stub
+    # sleeps through the real /bin/sleep because install_docker_stub shadows sleep
+    # with a no-op, which is what keeps the other tests instant.
+    add_openvpn_fixture
+    install_docker_stub
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)     /bin/sleep 1; printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
+    inspect) /bin/sleep 1; printf '%s\n' "starting" ;;
+    *)      exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=3
+
+    # Bounded so that a budget which has stopped bounding anything fails this test
+    # rather than hanging it: the wait would otherwise poll for its full 60s
+    # default, or forever if the deadline check itself is broken.
+    local before=$SECONDS
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+    local elapsed=$((SECONDS - before))
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"did not become ready in time"* ]]
+    # Both probes ran: without this, an implementation that skipped every docker
+    # call and declared a timeout immediately would satisfy the timing bound.
+    grep -q '^ps ' "$DOCKER_LOG"
+    grep -q '^inspect ' "$DOCKER_LOG"
+    # It also spent the budget rather than giving up early.
+    [ "$elapsed" -ge 3 ]
+    # The regression this has to fail is a wait that counts polls again, which
+    # takes its full 60-second default. Anything well under that catches it, so
+    # the ceiling is set for margin rather than tightness: bats runs four files at
+    # once in CI, and a ceiling near the ~4s this actually takes would turn a busy
+    # runner into a red suite.
+    [ "$elapsed" -lt 20 ]
+}
+
+@test "an inspect failure never treats the container as ready" {
+    add_openvpn_fixture
+    install_docker_stub
+    # A second of real time per inspect: with the suite's no-op sleep stub the
+    # wait would otherwise spin hot for its whole budget, spawning processes for
+    # nothing.
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    images)  printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)      printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
+    inspect) /bin/sleep 1; exit 1 ;;
+    *)       exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    # Enough budget for two things at once: the loop certainly reaches the inspect
+    # (at one second it can expire between the ps and the inspect), and a failed
+    # inspect misread as "no healthcheck" would have room for its full grace and
+    # would therefore pass — which is what makes this test a lock on that misread
+    # rather than on the budget running out.
+    export E2E_READY_TIMEOUT=6
+
+    # Bounded for the same reason as the budget test above: this expectation is
+    # "the wait gives up", so a wait that stopped giving up must fail here, not
+    # hang the suite.
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"did not become ready in time"* ]]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
+    # The branch under test is the one that reads a failed inspect, so prove the
+    # inspect was actually attempted rather than skipped past.
+    grep -q '^inspect ' "$DOCKER_LOG"
+}
+
+@test "a grace period cut short by the budget is not readiness" {
+    # With no healthcheck to consult, the elapsed grace is the only evidence the
+    # container is up. A budget too small to hold it leaves that evidence
+    # unavailable, which is a timeout, not a pass.
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=1
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"did not become ready in time"* ]]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
+}
+
+@test "a container that dies during its grace period is not ready" {
+    # With no healthcheck the grace is the whole readiness argument, and it rests
+    # on a liveness check taken before it started. A container that exits while
+    # the harness waits is an exit, not a slow start.
+    add_openvpn_fixture
+    install_docker_stub
+    export PS_COUNT_FILE="$TEST_TEMP_DIR/ps-count"
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)
+        seen=$(cat "${PS_COUNT_FILE:?}" 2>/dev/null || printf '0')
+        printf '%s' "$((seen + 1))" > "$PS_COUNT_FILE"
+        # Listed the first time, gone by the time the grace is over. The exit is
+        # explicit: a trailing `[ … ] && printf` would leave the stub exiting 1
+        # when the test wants an empty list, which is a different answer.
+        if [ "$seen" -eq 0 ]; then printf '%s\n' "e2e-openvpn"; fi
+        exit 0
+        ;;
+    inspect) printf '%s\n' "nohealth" ;;
+    *) exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"exited unexpectedly"* ]]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
+}
+
+@test "a container name is matched literally, not as a pattern" {
+    # Docker allows `.` in a name, and as a pattern it matches any character: a
+    # sibling called e2e-v1X2 would then stand in for e2e-v1.2, and the harness
+    # would call an exited container running. No fixture directory is needed —
+    # this fails before the per-container suite is ever looked for.
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/dotted:e2e"
+    export DOCKER_PS_OUTPUT="e2e-v1X2"
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" v1.2
+
+    assert_harness_failed_on_its_own
+    # The message is the oracle: read as a pattern this container looks alive, and
+    # the run fails later for an unrelated reason.
+    [[ "$output" == *"exited unexpectedly"* ]]
+}
+
+@test "a docker ps that cannot answer is a timeout, not a container exit" {
+    # The two are different claims: one says the runtime did not answer, the other
+    # says it answered and the container was gone. Reporting the first as the
+    # second blames the image for the daemon.
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=2
+    # A real delay in the failing probe: the suite's sleep stub is a no-op, so a
+    # stub that fails instantly would have the wait forking processes flat out for
+    # its whole budget — CPU that shows up as flake in the timing test running
+    # alongside it.
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)     /bin/sleep 1; exit 1 ;;
+    *)      exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"did not become ready in time"* ]]
+    [[ "$output" != *"exited unexpectedly"* ]]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
+}
+
+@test "no timeout call omits its kill-after grace" {
+    # A plain `timeout` sends SIGTERM and then waits forever for a child that
+    # ignores it, so a bound without -k is not a bound. This checks exactly that
+    # — every `timeout` here passes -k — and not the broader claim that every
+    # docker call is bounded; the cleanup calls outside the wait are not, which
+    # is #1007. Structural because reproducing a TERM-resistant docker would
+    # demonstrate coreutils' behaviour rather than this script's — and blind to a
+    # wrapper deleted outright, which is #1008.
+    # Every line that invokes it must carry -k, rather than only rejecting a
+    # bound whose next character is not a hyphen: `timeout -s TERM 5 …` and
+    # `timeout --verbose 5 …` pass that weaker check while omitting the grace.
+    # The path is an argument, not interpolated into the program: a checkout whose
+    # path contains a quote would otherwise change what this runs. A grep that
+    # errors is not the same as one that found nothing, so the two statuses are
+    # told apart rather than both counting as a pass.
+    run bash -c '
+        matches=$(grep -nE "^[^#]*\btimeout\b" "$1") || exit 3
+        printf "%s\n" "$matches" | grep -vE "(^|[[:space:]])-k[[:space:]]"
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+
+    [ "$status" -eq 1 ]
+}
+
+@test "a timeout that cannot bound anything is refused before the container starts" {
+    add_openvpn_fixture
+    install_docker_stub
+    # Stands in for a missing or too-old timeout: the harness cannot bound its
+    # docker calls, and must say so while there is still nothing to leak.
+    printf '#!/bin/bash\nexit 127\n' > "$TEST_TEMP_DIR/bin/timeout"
+    chmod +x "$TEST_TEMP_DIR/bin/timeout"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"accepting -k"* ]]
+    [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "a healthy inspect result proceeds to the per-container suite" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export DOCKER_INSPECT_OUTPUT=healthy
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_SCRIPT_MARKER")" = "e2e-openvpn" ]
+}
+
+@test "an invalid E2E_READY_TIMEOUT is rejected before anything is started" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=zero
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"between 1 and 99999"* ]]
+    # Rejecting it after `docker run` would strand the container: --rm removes it
+    # when it stops, and nothing stops it on this path.
+    [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "a value too large to hold as a deadline is rejected" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=99999999999999999999
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"between 1 and 99999"* ]]
+    [ ! -s "$DOCKER_LOG" ]
 }


### PR DESCRIPTION
Closes #1000.

The readiness wait added 2 to a counter after each sleep, so time spent inside
`docker ps` and `docker inspect` was free: the budget bounded the naps, not the
wait. It now runs against an absolute deadline, and every docker call it makes is
capped by what is left of it.

## Bounding the calls alone would have made this worse

Every `docker inspect` failure was read as "no healthcheck", and that arm
declares the container **ready**. Under podman, `--format='{{.State.Health.Status}}'`
on a container without a healthcheck exits 125 with empty output — so the wait
was already taking that path routinely, and adding a timeout would have turned a
hang into a silent pass.

Asking for the field conditionally makes "no healthcheck" a value the runtime
returns, leaving a non-zero status to mean only that we could not ask:

```
--format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}'
```

Measured on podman 5.8.3: `nohealth` at rc 0 without a healthcheck, and real
statuses (`starting`, `unhealthy`) with one.

Two more claims the wait was making without evidence:

- a `docker ps` killed by its own bound was reported as **"container exited
  unexpectedly"** — a statement about the container from a call that never
  answered. Only an answered "not in the list" says that now.
- where there is no healthcheck, the elapsed grace is the entire readiness
  argument. A grace cut short by the budget was still counted, and so was one
  taken on the strength of a liveness check from three seconds earlier. The wait
  now requires the full grace *and* loops once more to see the container still
  listed.

## Also

- Each `timeout` carries `-k`: a plain one sends SIGTERM and waits indefinitely
  for a child that ignores it — the same hang, one layer down.
- The harness probes at startup for a `timeout` accepting `-k`. Discovering
  otherwise on a cleanup path means a container is already running. The probe
  reads the interface, not the behaviour, and the README says so.
- `E2E_READY_TIMEOUT` (1–99999, default 60) is validated once at startup, before
  anything is built or started — rejecting it later would strand a running
  container, since `--rm` only cleans up when the container stops. `SECONDS` is
  reset there too: it is inherited, and a caller exporting a huge one would wrap
  every deadline negative.
- The unit stub returned `none` for inspect, a value no runtime produces.

## Verification

- full unit suite: **2210 collected, 0 failed**; shellcheck clean as
  `unit-tests.yaml` runs it
- sslh e2e green against the published image on this exact head
- seven guards are mutation-proven — the suite goes red when each is removed:
  the budget check, the inspect distinction, the `docker ps` distinction, the
  startup validation, the whole-grace requirement, literal name matching, and
  the liveness re-check after the grace

## Known gaps, tracked

- **#1007** — cleanup outside the wait is unbounded, silent on failure, and
  absent on interruption. Pre-existing (seven `docker rm -f … || true` sites, no
  trap); centralising them is a lifecycle change, not a line fix.
- **#1008** — the guard tests are weaker than the guards: a `timeout` wrapper
  deleted outright, or a broken inspect template, would both stay green.
- **#1009** — a docker failure that can never succeed (no binary, permissions) is
  retried until the budget expires and then blamed on the container.

Review has not signed off on this branch; it was pushed on the maintainer's
explicit instruction with the residue filed above.
