### PR TITLE
ci(build): retry a base-cache read, and one GHA escaper instead of six

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -434,6 +434,9 @@ runs:
               # upstream mirror.  sync-base-images does NOT produce these images.
               has_chained_entry=false
               chained_parents=""
+              # Config-derived and headed for a workflow command, so escaped at
+              # the point it is built rather than at each of its uses below.
+              safe_container=$(_escape_gha_command "$container")
               declare -a probe_flags=()
               for ((i = 0; i < entry_count; i++)); do
                 ghcr_repo=$(yq -r ".base_image_cache[$i].ghcr_repo" "./$container/config.yaml")
@@ -446,7 +449,7 @@ runs:
                   if [[ "$source_path" == /* ]]; then
                     has_chained_entry=true
                     parent_name="${source_path#/}"
-                    chained_parents="${chained_parents:+$chained_parents, }${parent_name}"
+                    chained_parents="${chained_parents:+$chained_parents, }$(_escape_gha_command "$parent_name")"
                   fi
                   explicit_tag=$(resolve_cache_check_tag "./$container/config.yaml" "$i" "$build_version")
                   check_image="ghcr.io/${owner}/${source_path#/}:${explicit_tag}"
@@ -484,17 +487,17 @@ runs:
                   echo "✅ Using GHCR base images: $filtered_args"
                 else
                   if [[ "$has_chained_entry" == "true" ]]; then
-                    echo "::error::GHCR base cache is configured for $container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
+                    echo "::error::GHCR base cache is configured for $safe_container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
                   else
-                    echo "::error::GHCR base cache is configured for $container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
+                    echo "::error::GHCR base cache is configured for $safe_container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
                   fi
                   exit 1
                 fi
               else
                 if [[ "$has_chained_entry" == "true" ]]; then
-                  echo "::error::GHCR base cache is configured for $container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
+                  echo "::error::GHCR base cache is configured for $safe_container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
                 else
-                  echo "::error::GHCR base cache is configured for $container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
+                  echo "::error::GHCR base cache is configured for $safe_container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
                 fi
                 exit 1
               fi

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -423,7 +423,9 @@ runs:
               #       registry-root knob; applying it when any mirror is missing → hard-fail).
               #
               # emit_reachable_cache_args() encodes this logic as a pure helper (bats-tested).
-              # The action owns only the I/O (docker manifest inspect); the decision is in the helper.
+              # The read itself is probe_cache_image() in the same helper, so that
+              # "can this be read" answers the same way here and under test — a
+              # single failed read is retried before a mirror is called missing.
               entry_count=$(yq -r '.base_image_cache | length' "./$container/config.yaml")
               owner="${{ github.repository_owner }}"
               cache_ok=false
@@ -453,13 +455,16 @@ runs:
                   resolved_tag=$(resolve_cache_check_tag "./$container/config.yaml" "$i" "$build_version")
                   check_image="ghcr.io/${owner}/${ghcr_repo}:${resolved_tag}"
                 fi
-                if docker manifest inspect "$check_image" &>/dev/null; then
+                # base_image_cache is unvalidated config and this reaches a runner
+                # log, so the reference is escaped before it is printed.
+                safe_check_image=$(_escape_gha_command "$check_image")
+                if probe_cache_image "$check_image"; then
                   probe_flags[$i]="true"
                   cache_ok=true
-                  echo "✅ GHCR cache accessible: $check_image"
+                  echo "✅ GHCR cache accessible: $safe_check_image"
                 else
                   probe_flags[$i]="false"
-                  echo "⚠️ Not accessible: $check_image"
+                  echo "⚠️ Not readable after 3 attempts: $safe_check_image — ${PROBE_CACHE_IMAGE_ERROR:-no error text}"
                 fi
               done
 
@@ -481,7 +486,7 @@ runs:
                   if [[ "$has_chained_entry" == "true" ]]; then
                     echo "::error::GHCR base cache is configured for $container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
                   else
-                    echo "::error::GHCR base cache is configured for $container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). The GHCR base cache is seeded by the daily upstream-monitor sync; trigger that workflow (workflow_dispatch) to seed it now."
+                    echo "::error::GHCR base cache is configured for $container but all reachable entries produced no usable args — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
                   fi
                   exit 1
                 fi
@@ -489,7 +494,7 @@ runs:
                 if [[ "$has_chained_entry" == "true" ]]; then
                   echo "::error::GHCR base cache is configured for $container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). This container depends on project-built image(s): ${chained_parents}. Build and publish those parent containers first; sync-base-images does not produce them. For upstream-mirrored bases: trigger the upstream-monitor workflow (workflow_dispatch) to seed the GHCR cache."
                 else
-                  echo "::error::GHCR base cache is configured for $container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). The GHCR base cache is seeded by the daily upstream-monitor sync; trigger that workflow (workflow_dispatch) to seed it now."
+                  echo "::error::GHCR base cache is configured for $container but no cache image is accessible — Docker Hub fallback is disabled (egress containment). Every unreadable entry was retried 3 times, so this is not one failed read. Either the mirror is not seeded — the daily upstream-monitor sync does that, and workflow_dispatch runs it now — or the read itself failed; the registry's own error for the last attempt is logged above each entry."
                 fi
                 exit 1
               fi

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -477,7 +477,64 @@ _sync_one_with_backoff() {
         # 5s, 10s, 20s — sublinear total wait (~35s worst case per image)
         local delay=$((base_delay * (1 << (attempt - 1))))
         echo "  ⏳ rate-limited; backing off ${delay}s (retry ${attempt}/${max_retries})" >&2
-        ${sleep_cmd} "$delay"
+        "${sleep_cmd}" "$delay"
+    done
+}
+
+# probe_cache_image <image_ref>
+#
+# Answer whether a GHCR cache image can be read, retrying a failed read before
+# concluding it cannot. A single failed `docker manifest inspect` is not evidence
+# that a mirror is missing: on PR #1010 one read of ghcr.io/<owner>/library/ubuntu:noble
+# failed while its sibling probes in the same job succeeded, the image was
+# pullable anonymously throughout, and an unchanged re-run passed. That one blip
+# failed a container build and told the operator to seed a mirror that was
+# already there.
+#
+# Retries are unconditional rather than error-matched, unlike the 429-only
+# backoff in _sync_one_with_backoff above: that one guards a mutating create and
+# fails fast when waiting cannot help, while this is an idempotent read whose
+# failure modes (transient TLS, a proxy hiccup, a registry blip) are not
+# reliably distinguishable from its error text.
+#
+# Backoff: 3 attempts, 3s then 6s. Sleep goes through the injectable $SLEEP_CMD
+# (defaults to `sleep`) so tests do not spend it.
+#
+# The reference reaches a runner log, and `base_image_cache` is unvalidated
+# config, so it goes through _escape_gha_command first — a newline in it would
+# otherwise close the line and let the rest forge its own workflow command.
+#
+# On failure the last attempt's stderr is left in $PROBE_CACHE_IMAGE_ERROR for
+# the caller to report: "missing manifest", "unauthorized" and "connection
+# refused" are the same boolean here but not the same problem, and the operator
+# cannot re-run the read with the runner's credentials from their laptop.
+#
+# stderr: retry progress
+# exit:   0 when readable, 1 when three attempts all failed
+probe_cache_image() {
+    local image_ref="$1"
+    local sleep_cmd="${SLEEP_CMD:-sleep}"
+
+    local max_attempts=3
+    local delay=3
+    local attempt=1
+    local safe_ref
+    safe_ref=$(_escape_gha_command "$image_ref")
+    PROBE_CACHE_IMAGE_ERROR=""
+
+    while true; do
+        if PROBE_CACHE_IMAGE_ERROR=$(docker manifest inspect "$image_ref" 2>&1 >/dev/null); then
+            PROBE_CACHE_IMAGE_ERROR=""
+            return 0
+        fi
+        if (( attempt >= max_attempts )); then
+            PROBE_CACHE_IMAGE_ERROR=$(_escape_gha_command "$PROBE_CACHE_IMAGE_ERROR")
+            return 1
+        fi
+        echo "  ⏳ read of ${safe_ref} failed; retrying in ${delay}s (${attempt}/$((max_attempts - 1)))" >&2
+        "${sleep_cmd}" "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
     done
 }
 
@@ -616,11 +673,23 @@ _append_base_sync_manifest_record() {
 #   %  → %25
 #   \n → %0A
 #   \r → %0D
+#
+# `::` is not the only prefix the runner honours. ActionCommand.cs declares
+# `public const string Prefix = "##["` and locates it with `IndexOf`, so a
+# `##[...]` anywhere in a line is parsed — no newline required, which is why
+# encoding CR/LF alone does not close this. The `[` is percent-encoded after the
+# `%` pass, so the encoding introduced here is not itself re-encoded.
+#
+# Remaining C0 bytes are dropped rather than encoded: ESC and backspace do
+# nothing useful in a log and plenty for someone rewriting what a reader sees.
+# CR and LF are already gone by then, so this cannot eat them.
 _escape_gha_command() {
     local s="$1"
     s="${s//\%/%25}"
     s="${s//$'\n'/%0A}"
     s="${s//$'\r'/%0D}"
+    s="${s//##\[/##%5B}"
+    s="${s//[[:cntrl:]]/}"
     printf '%s' "$s"
 }
 
@@ -772,4 +841,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr
+export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -41,8 +41,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source logging if not already loaded
-if ! declare -F log_error &>/dev/null; then
+# Source logging if not already loaded.  The escaper is a logging helper too;
+# require both so a caller that defined only log_error cannot leave us without it.
+if ! declare -F log_error &>/dev/null || ! declare -F _escape_gha_command &>/dev/null; then
     source "$SCRIPT_DIR/logging.sh"
 fi
 
@@ -664,35 +665,6 @@ _append_base_sync_manifest_record() {
     fi
 }
 
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
-# workflow command. Without this, a newline/CR/`%` in the value could
-# terminate the command early and inject another (e.g. `::stop-commands::`,
-# `::add-mask::`, `::error::`). Mapping per GitHub's runner spec:
-#   %  → %25
-#   \n → %0A
-#   \r → %0D
-#
-# `::` is not the only prefix the runner honours. ActionCommand.cs declares
-# `public const string Prefix = "##["` and locates it with `IndexOf`, so a
-# `##[...]` anywhere in a line is parsed — no newline required, which is why
-# encoding CR/LF alone does not close this. The `[` is percent-encoded after the
-# `%` pass, so the encoding introduced here is not itself re-encoded.
-#
-# Remaining C0 bytes are dropped rather than encoded: ESC and backspace do
-# nothing useful in a log and plenty for someone rewriting what a reader sees.
-# CR and LF are already gone by then, so this cannot eat them.
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    s="${s//##\[/##%5B}"
-    s="${s//[[:cntrl:]]/}"
-    printf '%s' "$s"
-}
-
 # sync_base_images_to_ghcr <images_json> [source_registry]
 #
 # Copy each base image from <source_registry> (default: docker.io) to GHCR
@@ -745,7 +717,10 @@ sync_base_images_to_ghcr() {
         return 0
     fi
 
-    echo "📦 Syncing $count unique base images to GHCR (source: $source_registry)"
+    local safe_count safe_source_registry
+    safe_count=$(_escape_gha_command "$count")
+    safe_source_registry=$(_escape_gha_command "$source_registry")
+    echo "📦 Syncing ${safe_count} unique base images to GHCR (source: ${safe_source_registry})"
 
     local synced=0 skipped=0 failed=0
     while IFS= read -r img; do
@@ -777,8 +752,12 @@ sync_base_images_to_ghcr() {
             continue
         }
 
+        local safe_source_ref safe_sync_image
+        safe_source_ref=$(_escape_gha_command "$source_ref")
+        safe_sync_image=$(_escape_gha_command "$sync_image")
+
         echo ""
-        echo "🔄 ${source_ref} → ${sync_image}"
+        echo "🔄 ${safe_source_ref} → ${safe_sync_image}"
 
         # Presence gate: when skip_present=true, probe the GHCR target first.
         # `docker manifest inspect` against ghcr.io is read-only and free vs the
@@ -805,21 +784,22 @@ sync_base_images_to_ghcr() {
             synced=$((synced + 1))
         else
             echo "  ⚠️ Failed (continuing; daily sync will retry)"
-            # Prefix every line of $output (docker stderr) with "  Error: " so
-            # no line can begin at column 0 with `::` and be interpreted as a
-            # GitHub Actions workflow command. The upstream registry response
-            # is technically attacker-influenced, even if remote. Normalize
-            # CR → LF first so a bare carriage return (which GHA also treats
-            # as a line terminator) cannot bypass the prefix.
-            printf '%s\n' "$output" | tr '\r' '\n' | sed 's/^/  Error: /'
+            # Docker's stderr is attacker-influenced, and prefixing cannot
+            # protect against the runner's legacy `##[` parser, which scans the
+            # whole line. Escape it — but per line, keeping the lines apart: a
+            # buildx failure's useful part is its tail, and escaping the blob as
+            # one value turns every break into %0A and buries that tail in a
+            # single line long enough for a log transport to truncate.
+            # CR → LF first, since GHA treats a bare CR as a terminator too.
+            local _line
+            while IFS= read -r _line; do
+                printf '  Error: %s\n' "$(_escape_gha_command "$_line")"
+            done < <(printf '%s\n' "$output" | tr '\r' '\n')
             # Surface in the workflow summary so the maintainer notices that
             # a stale GHCR tag may persist until the next successful sync.
             # Refs come from base_image_cache.source which is not schema-
             # validated (see top-of-file docstring); escape to prevent a
             # newline-bearing value from injecting a second workflow command.
-            local safe_source_ref safe_sync_image
-            safe_source_ref=$(_escape_gha_command "$source_ref")
-            safe_sync_image=$(_escape_gha_command "$sync_image")
             echo "::warning::sync_base_images_to_ghcr: failed to sync ${safe_source_ref} → ${safe_sync_image}"
             _append_base_sync_manifest_record "$source_ref" "$sync_image" "" "failed"
             failed=$((failed + 1))
@@ -841,4 +821,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record _escape_gha_command sync_base_images_to_ghcr
+export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record sync_base_images_to_ghcr

--- a/helpers/dependency-graph.sh
+++ b/helpers/dependency-graph.sh
@@ -45,31 +45,9 @@ fi
 _depgraph_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lineage-utils.sh
 source "${_depgraph_dir}/lineage-utils.sh"
+# shellcheck source=./logging.sh
+source "${_depgraph_dir}/logging.sh"
 unset _depgraph_dir
-
-# ---------------------------------------------------------------------------
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
-# workflow command.  Without this, a newline/CR/`%` in the value could
-# terminate the command early and inject another (e.g. `::set-env::`,
-# `::add-mask::`, `::stop-commands::`).  Mapping per GitHub runner spec:
-#   %  → %25
-#   \n → %0A
-#   \r → %0D
-#
-# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command;
-# inlined here to avoid importing the full base-cache helper (which has
-# set -euo pipefail and sources logging.sh/variant-utils.sh at parse time,
-# breaking this file's explicit no-pipefail contract).
-# ---------------------------------------------------------------------------
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    printf '%s' "$s"
-}
 
 # ---------------------------------------------------------------------------
 # _depgraph_valid_containers

--- a/helpers/logging.sh
+++ b/helpers/logging.sh
@@ -54,6 +54,33 @@ log_step() {
     printf '%b%s%b\n' "${BLUE}🔵 " "$*" "${NC}" >&2
 }
 
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command. The runner also recognizes the legacy `##[` prefix
+# anywhere in a line, so CR/LF escaping alone is not sufficient. Encode `%`
+# first, then `##[`, so the `%5B` introduced for that legacy prefix remains
+# intact. Drop remaining control bytes because they can rewrite terminal output.
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    # CR and LF are encoded rather than dropped: they are the characters a
+    # reader wants to see marked, and encoding them is what stops a value from
+    # starting a new line and with it a new `::` command.
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    # Every other control byte goes BEFORE the `##[` check, not after. Deleting
+    # characters closes gaps: `##<backspace>[` does not match the marker, and
+    # stripping afterwards reassembles it in the output — the escaped value then
+    # carries the very command this is here to neutralize.
+    s="${s//[[:cntrl:]]/}"
+    s="${s//##\[/##%5B}"
+    printf '%s' "$s"
+}
+
+# This helper is needed by exported functions in callers that source logging.sh.
+export -f _escape_gha_command
+
 # Helper for help text formatting (from make script)
 log_help() {
     printf "\033[36m%-25s\033[0m %s\n" "$1" "$2"

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -17,25 +17,6 @@ source "$PROJECT_ROOT/helpers/extension-utils.sh"
 # shellcheck source=../helpers/extension-duration-utils.sh
 [[ -f "$PROJECT_ROOT/helpers/extension-duration-utils.sh" ]] && source "$PROJECT_ROOT/helpers/extension-duration-utils.sh"
 
-# ---------------------------------------------------------------------------
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
-# workflow command.  Without this, a %0A/%0D in the value could terminate
-# the command early and inject another workflow command.  Mapping per GitHub's
-# runner spec:  %→%25  \n→%0A  \r→%0D
-#
-# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command;
-# inlined here to avoid importing the full base-cache helper.
-# ---------------------------------------------------------------------------
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    printf '%s' "$s"
-}
-
 # Function to check if multi-platform builds are supported (QEMU emulation)
 check_multiplatform_support() {
     # Cache the result to avoid repeated checks

--- a/scripts/check-version-drift.sh
+++ b/scripts/check-version-drift.sh
@@ -61,21 +61,8 @@ source "${_vdrift_self_dir}/../helpers/variant-utils.sh"
 source "${_vdrift_self_dir}/../helpers/extension-utils.sh"
 # shellcheck source=../helpers/build-cache-utils.sh
 source "${_vdrift_self_dir}/../helpers/build-cache-utils.sh"
-
-# ---------------------------------------------------------------------------
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a ::keyword::value GHA workflow command.
-# Mapping per GitHub runner spec: % → %25, \n → %0A, \r → %0D.
-# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command.
-# ---------------------------------------------------------------------------
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    printf '%s' "$s"
-}
+# shellcheck source=../helpers/logging.sh
+source "${_vdrift_self_dir}/../helpers/logging.sh"
 
 # ---------------------------------------------------------------------------
 # Argument parsing

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -63,28 +63,6 @@ source "${PROJECT_ROOT}/helpers/retry.sh"
 source "${PROJECT_ROOT}/helpers/base-cache-utils.sh"
 
 # ---------------------------------------------------------------------------
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
-# workflow command.  Without this, a newline/CR/`%` in the value could
-# terminate the command early and inject another (e.g. `::add-mask::`,
-# `::stop-commands::`).  Mapping per GitHub's runner spec:
-#   %  → %25
-#   \n → %0A
-#   \r → %0D
-#
-# Pattern sourced from helpers/base-cache-utils.sh::_escape_gha_command;
-# inlined here to avoid importing the full base-cache helper.
-# ---------------------------------------------------------------------------
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    printf '%s' "$s"
-}
-
-# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 BASELINE_ONLY=false

--- a/scripts/update-last-rebuild.sh
+++ b/scripts/update-last-rebuild.sh
@@ -31,27 +31,6 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# _escape_gha_command <value>
-#
-# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
-# workflow command.  A %0A in the value would terminate the command line and
-# inject the remainder as a new command.  Mapping per GitHub's runner spec:
-#   %  → %25
-#   \n → %0A
-#   \r → %0D
-#
-# Inlined from helpers/base-cache-utils.sh::_escape_gha_command to avoid
-# importing the full base-cache helper.
-# ---------------------------------------------------------------------------
-_escape_gha_command() {
-    local s="$1"
-    s="${s//\%/%25}"
-    s="${s//$'\n'/%0A}"
-    s="${s//$'\r'/%0D}"
-    printf '%s' "$s"
-}
-
-# ---------------------------------------------------------------------------
 # Argument validation
 # ---------------------------------------------------------------------------
 if [[ $# -lt 2 ]]; then
@@ -75,6 +54,8 @@ fi
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=../helpers/logging.sh
+source "${SCRIPT_DIR}/../helpers/logging.sh"
 
 # _ULR_PROJECT_ROOT_OVERRIDE: test hook — when set, use this path as PROJECT_ROOT
 # instead of deriving it from BASH_SOURCE[0].  Avoids needing the full project

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -912,10 +912,38 @@ EOF
     local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 1 ]
-    # The injected line must never appear at column 0 — every stderr line is
-    # prefixed with "  Error: " so it's quoted text, not a workflow command.
+    # Each line is escaped and stays its own line: the injected command never
+    # begins one, and the diagnostic is still readable rather than joined into a
+    # single %0A-separated run.
     [[ "$output" != *$'\n::stop-commands::'* ]]
-    [[ "$output" == *"  Error: ::stop-commands::xx"* ]]
+    # Anchored and counted: a substring check passes just as well when every
+    # line has been joined into one, which is the shape being ruled out.
+    [ "$(grep -c '^  Error: ' <<< "$output")" -eq 3 ]
+    grep -qx '  Error: fake error line1' <<< "$output"
+    grep -qx '  Error: ::stop-commands::xx' <<< "$output"
+    grep -qx '  Error: line3' <<< "$output"
+}
+
+@test "sync_base_images_to_ghcr: the legacy marker in docker stderr is neutralized per line" {
+    # `::` is defanged by the "  Error: " prefix alone, because that parser wants
+    # the command at the start of a line — which is why the other two cases pass
+    # with or without escaping. `##[` is the one a prefix cannot help with: the
+    # legacy parser finds it anywhere. This is the case that requires each line
+    # to actually go through the escaper.
+    docker() {
+        if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "create" ]]; then
+            printf 'pull failed\ndenied##[add-mask]secret\n' >&2
+            return 1
+        fi
+        return 0
+    }
+    export -f docker
+
+    local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
+    run sync_base_images_to_ghcr "$input"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *'##[add-mask]'* ]]
+    grep -qx '  Error: denied##%5Badd-mask]secret' <<< "$output"
 }
 
 @test "sync_base_images_to_ghcr: carriage return in docker stderr cannot inject workflow commands" {
@@ -933,10 +961,16 @@ EOF
     local input='[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
     run sync_base_images_to_ghcr "$input"
     [ "$status" -eq 1 ]
-    # The CR-injected `::stop-commands::` must not appear preceded by raw CR.
+    # A bare CR is a line terminator for the parser too, so it must not survive
+    # as one — and the command it tried to start must sit behind the prefix
+    # rather than at the beginning of a line.
     [[ "$output" != *$'\r::stop-commands::'* ]]
-    # And it must appear in prefixed form.
-    [[ "$output" == *"  Error: ::stop-commands::xx"* ]]
+    [[ "$output" != *$'\n::stop-commands::'* ]]
+    # The CR became a line break of its own, so four lines, each prefixed.
+    [ "$(grep -c '^  Error: ' <<< "$output")" -eq 4 ]
+    grep -qx '  Error: first line' <<< "$output"
+    grep -qx '  Error: ::stop-commands::xx' <<< "$output"
+    grep -qx '  Error: last line' <<< "$output"
 }
 
 @test "sync_base_images_to_ghcr: newline in image ref is refused (injection prevention)" {
@@ -1425,28 +1459,6 @@ EOF
     run bash -c 'probe_cache_image ghcr.io/x/a:1'
     [ "$status" -eq 0 ]
     [[ "$output" != *"command not found"* ]]
-}
-
-@test "_escape_gha_command: neutralizes the legacy ##[ command prefix" {
-    # ActionCommand.cs declares Prefix = "##[" and finds it with IndexOf, so it
-    # is honoured mid-line — encoding CR/LF alone leaves this open.
-    run _escape_gha_command 'ghcr.io/x/a:1##[add-mask]secret'
-    [ "$status" -eq 0 ]
-    [[ "$output" != *'##[add-mask]'* ]]
-    [[ "$output" == *'##%5Badd-mask]'* ]]
-}
-
-@test "_escape_gha_command: drops control bytes that rewrite a log" {
-    run _escape_gha_command "$(printf 'ghcr.io/x/a:1\033[2Kforged')"
-    [ "$status" -eq 0 ]
-    [[ "$output" != *$'\033'* ]]
-    [[ "$output" == *"ghcr.io/x/a:1"* ]]
-}
-
-@test "_escape_gha_command: still encodes the characters it always did" {
-    run _escape_gha_command "$(printf 'a%%b\nc\rd')"
-    [ "$status" -eq 0 ]
-    [ "$output" = 'a%25b%0Ac%0Dd' ]
 }
 
 @test "probe_cache_image: a registry error cannot forge a command either" {

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -1296,3 +1296,169 @@ EOF
 
     rm -f "$copy_marker"
 }
+
+@test "probe_cache_image: a readable image needs no retry" {
+    # The reference is asserted, not just the verb: a probe that read a
+    # hard-coded or dropped ref would otherwise pass this.
+    local counter_file="$TEST_DIR/probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+    docker() {
+        echo $(( $(<"$COUNTER_FILE") + 1 )) > "$COUNTER_FILE"
+        [[ "$1" == "manifest" && "$2" == "inspect" ]] || return 1
+        [[ "$3" == "ghcr.io/x/library/ubuntu:noble" ]] || return 1
+        return 0
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    probe_cache_image "ghcr.io/x/library/ubuntu:noble"
+    # Counted, not inferred from the absence of a message: a probe that read
+    # three times without saying so would pass an output-only assertion.
+    [ "$(<"$counter_file")" -eq 1 ]
+}
+
+@test "probe_cache_image: a transient read failure does not condemn the mirror" {
+    # The case seen on PR #1010: one read failed, the image was there all along.
+    # docker runs in a forked subshell, so the attempt counter lives in a file.
+    # Under TEST_DIR so teardown removes it even when an assertion fails.
+    local counter_file="$TEST_DIR/probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+
+    docker() {
+        local n
+        n=$(<"$COUNTER_FILE")
+        n=$((n + 1))
+        echo "$n" > "$COUNTER_FILE"
+        # Fails once, then reads fine.
+        [ "$n" -ge 2 ]
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run probe_cache_image "ghcr.io/x/library/ubuntu:noble"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"retrying"* ]]
+    [ "$(<"$counter_file")" -eq 2 ]
+}
+
+@test "probe_cache_image: an image that is really absent still fails, after three tries" {
+    local counter_file="$TEST_DIR/probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+
+    docker() {
+        local n
+        n=$(<"$COUNTER_FILE")
+        echo "$((n + 1))" > "$COUNTER_FILE"
+        return 1
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run probe_cache_image "ghcr.io/x/library/nope:1"
+    # Fail-closed is the point: a mirror that cannot be read must not be used.
+    [ "$status" -eq 1 ]
+    [ "$(<"$counter_file")" -eq 3 ]
+}
+
+@test "probe_cache_image: a newline in the reference cannot forge a workflow command" {
+    # base_image_cache is unvalidated config, and this line lands in a runner log.
+    # An unescaped newline would end the message and let the rest of the value
+    # start its own ::stop-commands:: or ::error::.
+    docker() { return 1; }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run probe_cache_image "ghcr.io/x/a:1"$'\n'"::error::forged"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *$'\n'"::error::forged"* ]]
+    [[ "$output" == *"%0A::error::forged"* ]]
+}
+
+@test "probe_cache_image: the registry's own error survives for the caller to report" {
+    # Every failure is the same boolean here; the text is what says whether the
+    # manifest is missing, the token is wrong, or the daemon never answered.
+    # Distinct text per attempt: with the same text every time this could not
+    # tell whether the first or the last error was the one kept.
+    local counter_file="$TEST_DIR/probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+    docker() {
+        local n
+        n=$(( $(<"$COUNTER_FILE") + 1 ))
+        echo "$n" > "$COUNTER_FILE"
+        echo "attempt ${n}: manifest unknown" >&2
+        return 1
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    probe_cache_image "ghcr.io/x/library/ubuntu:noble" || true
+    [ "$(<"$counter_file")" -eq 3 ]
+    [[ "$PROBE_CACHE_IMAGE_ERROR" == *"attempt 3: manifest unknown"* ]]
+    [[ "$PROBE_CACHE_IMAGE_ERROR" != *"attempt 1"* ]]
+}
+
+@test "probe_cache_image: a successful read leaves no stale error behind" {
+    docker() { return 0; }
+    export -f docker
+    export SLEEP_CMD=:
+
+    PROBE_CACHE_IMAGE_ERROR="left over from an earlier probe"
+    probe_cache_image "ghcr.io/x/library/ubuntu:noble"
+    [ -z "$PROBE_CACHE_IMAGE_ERROR" ]
+}
+
+@test "probe_cache_image: is exported, so a child shell can see it" {
+    # Its peers are exported; one that is not disappears in an executed child.
+    # The child asks whether the function is defined rather than running it —
+    # executing the probe here would reach the real docker and the real sleeps.
+    # Run it in the child rather than just looking for the name: probe_cache_image
+    # calls _escape_gha_command, so an unexported dependency fails here too. The
+    # stub keeps the child off the network and away from the real sleeps.
+    docker() { return 0; }
+    export -f docker
+    export SLEEP_CMD=:
+
+    run bash -c 'probe_cache_image ghcr.io/x/a:1'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"command not found"* ]]
+}
+
+@test "_escape_gha_command: neutralizes the legacy ##[ command prefix" {
+    # ActionCommand.cs declares Prefix = "##[" and finds it with IndexOf, so it
+    # is honoured mid-line — encoding CR/LF alone leaves this open.
+    run _escape_gha_command 'ghcr.io/x/a:1##[add-mask]secret'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'##[add-mask]'* ]]
+    [[ "$output" == *'##%5Badd-mask]'* ]]
+}
+
+@test "_escape_gha_command: drops control bytes that rewrite a log" {
+    run _escape_gha_command "$(printf 'ghcr.io/x/a:1\033[2Kforged')"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *$'\033'* ]]
+    [[ "$output" == *"ghcr.io/x/a:1"* ]]
+}
+
+@test "_escape_gha_command: still encodes the characters it always did" {
+    run _escape_gha_command "$(printf 'a%%b\nc\rd')"
+    [ "$status" -eq 0 ]
+    [ "$output" = 'a%25b%0Ac%0Dd' ]
+}
+
+@test "probe_cache_image: a registry error cannot forge a command either" {
+    # This one is not config: it is whatever the registry chose to say.
+    docker() {
+        printf 'denied##[add-mask]x\n' >&2
+        return 1
+    }
+    export -f docker
+    export SLEEP_CMD=:
+
+    probe_cache_image "ghcr.io/x/a:1" || true
+    [[ "$PROBE_CACHE_IMAGE_ERROR" != *'##[add-mask]'* ]]
+    [[ "$PROBE_CACHE_IMAGE_ERROR" == *'denied'* ]]
+}

--- a/tests/unit/check-version-drift.bats
+++ b/tests/unit/check-version-drift.bats
@@ -789,18 +789,13 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
     # value (name, declared, status from JSON data) must route through _escape_gha_command.
     # In _append_row, annotations use $safe_name, $safe_declared, $safe_status — never
     # the raw $name/$declared/$status.  Verify no annotation line uses the raw variables.
-    local raw_name_in_annotation raw_declared_in_annotation
+    local raw_name_in_annotation
     # Check that ::warning:: / ::notice:: lines do NOT interpolate raw $name, $declared, $status
     # (i.e. no 'printf ...::warning::...$name' outside safe_ variables)
     raw_name_in_annotation=$(grep -cE \
         '::(warning|notice)::[^"]*\$name[^_]|::(warning|notice)::[^"]*\$declared[^_]|::(warning|notice)::[^"]*\$status[^_]' \
         "$DRIFT_SCRIPT" || true)
     [ "$raw_name_in_annotation" -eq 0 ]
-
-    # The script must define _escape_gha_command
-    local fn_defined
-    fn_defined=$(grep -c '_escape_gha_command()' "$DRIFT_SCRIPT" || true)
-    [ "$fn_defined" -ge 1 ]
 
     # _append_row must assign safe_ variables via _escape_gha_command
     local safe_assignments
@@ -2862,4 +2857,3 @@ GH_EOF
     new_message_count=$(grep -cE 'probe error|resolver failure|missing prerequisite' "$DRIFT_YAML" || true)
     [ "$new_message_count" -ge 1 ]
 }
-

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -842,11 +842,16 @@ _drift_json_for_container() {
     printf '%s' '[{"container":"'"$container"'","variants":[{"variant_tag":"1.0","base_image_ref":"alpine:3.21","recorded_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","current_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","status":"drift"}]}]'
 }
 
+_copy_update_last_rebuild_fixture() {
+    local fake_root="$1"
+    mkdir -p "$fake_root/scripts" "$fake_root/helpers"
+    cp "${SCRIPTS_DIR}/update-last-rebuild.sh" "$fake_root/scripts/update-last-rebuild.sh"
+    cp "${HELPERS_DIR}/logging.sh" "$fake_root/helpers/logging.sh"
+}
+
 @test "update-last-rebuild: exits 0 when container directory does not exist" {
     local fake_root="$TEST_TEMP_DIR/fake-root-r4"
-    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
-    mkdir -p "$fake_root/scripts"
-    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+    _copy_update_last_rebuild_fixture "$fake_root"
 
     # Stub ./make list — "mycontainer" is valid, but directory is never created
     cat > "$fake_root/make" <<'STUB'
@@ -869,9 +874,7 @@ STUB
 
 @test "update-last-rebuild: emits ::warning:: when container directory missing" {
     local fake_root="$TEST_TEMP_DIR/fake-root-r4b"
-    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
-    mkdir -p "$fake_root/scripts"
-    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+    _copy_update_last_rebuild_fixture "$fake_root"
 
     cat > "$fake_root/make" <<'STUB'
 #!/usr/bin/env bash
@@ -889,9 +892,7 @@ STUB
 
 @test "update-last-rebuild: exits 0 for invalid container name not in make list" {
     local fake_root="$TEST_TEMP_DIR/fake-root-r4c"
-    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
-    mkdir -p "$fake_root/scripts"
-    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+    _copy_update_last_rebuild_fixture "$fake_root"
 
     # ./make list returns only "ansible"; "docs" is not valid
     cat > "$fake_root/make" <<'STUB'
@@ -910,10 +911,8 @@ STUB
 
 @test "update-last-rebuild: normal path appends section when container dir exists" {
     local fake_root="$TEST_TEMP_DIR/fake-root-r4d"
-    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
-    mkdir -p "$fake_root/scripts"
+    _copy_update_last_rebuild_fixture "$fake_root"
     mkdir -p "$fake_root/mycontainer"
-    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
 
     cat > "$fake_root/make" <<'STUB'
 #!/usr/bin/env bash
@@ -1674,9 +1673,7 @@ EOF
 # ---------------------------------------------------------------------------
 @test "update-last-rebuild exits 2 when make list returns empty" {
     local fake_root="$TEST_TEMP_DIR/r7fix4d"
-    local update_script="${SCRIPTS_DIR}/update-last-rebuild.sh"
-    mkdir -p "$fake_root/scripts"
-    cp "$update_script" "$fake_root/scripts/update-last-rebuild.sh"
+    _copy_update_last_rebuild_fixture "$fake_root"
 
     # ./make list succeeds but returns nothing
     cat > "$fake_root/make" <<'STUB'
@@ -1866,8 +1863,8 @@ EOF
     # Regression guard: a poisoned variant_tag containing backticks or pipes in the
     # drift JSON must be escaped before embedding in LAST_REBUILD.md markdown.
     local fake_root="$TEST_TEMP_DIR/r9fix2"
-    mkdir -p "$fake_root/scripts" "$fake_root/myimage"
-    cp "${SCRIPTS_DIR}/update-last-rebuild.sh" "$fake_root/scripts/update-last-rebuild.sh"
+    _copy_update_last_rebuild_fixture "$fake_root"
+    mkdir -p "$fake_root/myimage"
 
     # Provide a minimal ./make list stub
     cat > "$fake_root/make" <<'STUB'

--- a/tests/unit/logging.bats
+++ b/tests/unit/logging.bats
@@ -88,6 +88,36 @@ teardown() {
     [[ "$output" == *"ls"* ]]
 }
 
+@test "_escape_gha_command: a control byte cannot splice the marker back together" {
+    # The escaper deletes control bytes, and deleting closes gaps. If the marker
+    # is checked before that deletion, `##<BS>[` slips past the check and the
+    # strip reassembles `##[` in the output — an injectable command produced by
+    # the escaper itself.
+    run _escape_gha_command "$(printf 'a##\b[add-mask]secret')"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'##[add-mask]'* ]]
+    [ "$output" = 'a##%5Badd-mask]secret' ]
+}
+
+@test "_escape_gha_command: the splice is caught wherever the control byte sits" {
+    for value in "$(printf '#\b#[x')" "$(printf '##[\bx')" "$(printf '#\b#\b[x')"; do
+        run _escape_gha_command "$value"
+        [ "$status" -eq 0 ]
+        [[ "$output" != *'##['* ]]
+    done
+}
+
+@test "_escape_gha_command escapes workflow-command values comprehensively" {
+    local value expected
+    value=$'before%\nafter\rlegacy##[add-mask]\033\bforged'
+    expected='before%25%0Aafter%0Dlegacy##%5Badd-mask]forged'
+
+    run _escape_gha_command "$value"
+    [ "$status" -eq 0 ]
+    # The inserted %5B remains intact, proving the % pass occurs first.
+    [ "$output" = "$expected" ]
+}
+
 # =============================================================================
 # Color variable tests
 # =============================================================================


### PR DESCRIPTION
Closes #1011. Closes #1013.

Two commits, one subject each.

## A base-cache read is retried before the mirror is called missing

One failed `docker manifest inspect` aborted a container build and told the
operator to seed a mirror that was already there: on PR #1010 the read of
`ghcr.io/oorabona/library/ubuntu:noble` failed while its sibling probes in the
same job succeeded, the image was pullable anonymously throughout, and an
unchanged re-run passed all 25 checks. Every other GHCR call on that path — the
logins, `imagetools inspect`, `skopeo copy`, `gh run view` — already retries.

The read moved into `probe_cache_image`, next to the helper that decides what to
do with the answer, which is what makes it testable: a stubbed docker that fails
once then succeeds proves the retry, one that always fails proves the probe still
gives up and the build still fails closed. Both are mutation-proven.

It also keeps two things the old probe discarded. The registry's own error —
`manifest unknown`, `unauthorized` and `connection refused` are one boolean but
three different repairs — is reported instead of dropped. And the reference is
escaped before it reaches a runner log, because `base_image_cache` is unvalidated
config.

The message no longer asserts a cause: it says every unreadable entry was retried
three times, offers both explanations, and points at the registry error logged
above rather than a command the operator cannot reproduce with the runner's
credentials.

## One `_escape_gha_command` instead of six

The function guarding every untrusted value that reaches a runner log existed six
times, and the bodies had already drifted three ways. Two files sourced a copy
and then defined their own, so the local one shadowed the corrected one — nothing
made a caller use the fixed version, which is the defect.

From the runner's own source, `ActionCommand.cs`:

```csharp
public const string Prefix = "##[";
int prefixIndex = message.IndexOf(Prefix);
```

`IndexOf`, so `##[add-mask]…` is honoured anywhere in a line. Encoding CR and LF —
which four of the six copies did, and nothing else — never closed that.

The order of the passes turned out to be the subtle part. CR and LF are encoded,
since they are what would start a new line and with it a new `::` command. Every
other control byte is dropped **before** the `##[` check, because deleting
characters closes gaps: `##<BS>[` does not match the marker, and stripping
afterwards reassembles `##[` in the output — the escaper emitting the very
command it exists to neutralize.

Three sinks in the base-cache helper printed untrusted values raw and no longer
do, including docker's stderr, which was only line-prefixed with `  Error: ` —
which does nothing, as the parser scans whole lines. That stderr is still printed
line by line rather than escaped as one blob: a buildx failure's useful part is
its tail, and joining it into a single `%0A` run is where that tail goes to die.

## Verification

- full unit suite: **2222 collected, 0 failed**; shellcheck clean on every
  touched file
- the guards are mutation-proven, each failing the suite when removed: the retry,
  the give-up, the export, the last-error retention, the `##[` neutralization,
  the pass ordering, the per-line escaping, and the line structure
- `grep -rn "^_escape_gha_command()" helpers/ scripts/` returns exactly one line

## Known gaps, tracked

- **#1014** — 291 workflow-command emissions interpolate values raw. Escaping
  call sites by hand is a convention; the issue proposes `gha_error`/`gha_notice`
  emitters that escape by construction, plus a lint rule.
- **#1015** — the escaper lives in `logging.sh`, so acquiring it imports that
  module's side effects. Wants a side-effect-free home.
- **#1012** — a read that stalls rather than fails is still unbounded, here and
  in its neighbours.

Review has not signed off on this branch; it was pushed and merged on the
maintainer's explicit instruction, with the residue filed above.
