### PR TITLE
test(e2e): suites that assert what the image is for

### DIFF
--- a/jekyll/test.sh
+++ b/jekyll/test.sh
@@ -64,15 +64,28 @@ th_group "Server"
 # real site into /site read-write, so this suite pointed at that container with
 # CONTAINER_NAME would otherwise overwrite the user's own page. It is removed
 # again below, and even a failed cleanup leaves their content untouched.
-probe_page="e2e-harness-probe"
-docker exec "$CONTAINER_NAME" sh -c \
-    'printf "%s\n" "---" "title: Harness Page" "---" "Rendered: {{ page.title }}" > "/site/$1.md"' \
-    _ "$probe_page" >/dev/null 2>&1 || true
+# Per run, not a constant: two runs against the same container would otherwise
+# write and delete each other's page, and a stale page left by an interrupted run
+# could satisfy the assertion below without this run's write ever succeeding.
+probe_page="e2e-harness-probe-$$-${RANDOM}"
+probe_token="harness-${probe_page}"
+
+# Creation is asserted, not attempted: `|| true` here means a failed write is
+# indistinguishable from a served page, which is the false green this check
+# exists to avoid. `set -C` refuses to clobber an existing file.
+if docker exec "$CONTAINER_NAME" sh -c \
+    'set -C; printf "%s\n" "---" "title: {{ page.token }}" "token: $2" "---" "Rendered: {{ page.token }}" > "/site/$1.md"' \
+    _ "$probe_page" "$probe_token" >/dev/null 2>&1; then
+    th_pass "the probe page is created in the watched source"
+else
+    th_fail "the probe page is created in the watched source" \
+        "could not write /site/$probe_page.md"
+fi
 
 # The runner does not publish 4000 to the host, but the Ruby runtime inside can
 # make the request. Retrying keeps this about the server rather than a race with
 # the rebuild it triggers.
-th_assert_cmd_contains "Jekyll serves the generated page on port 4000" "Rendered: Harness Page" \
+th_assert_cmd_contains "Jekyll serves the generated page on port 4000" "Rendered: $probe_token" \
     docker exec "$CONTAINER_NAME" ruby -rnet/http -e '
         page = ARGV[0]
         # The timeouts are why this uses the start form: Net::HTTP defaults are
@@ -82,7 +95,7 @@ th_assert_cmd_contains "Jekyll serves the generated page on port 4000" "Rendered
           begin
             Net::HTTP.start("127.0.0.1", 4000, open_timeout: 2, read_timeout: 2) do |http|
               response = http.get("/#{page}.html")
-              if response.is_a?(Net::HTTPSuccess) && response.body.include?("Rendered: Harness Page")
+              if response.is_a?(Net::HTTPSuccess) && response.body.include?("Rendered: #{ARGV[1]}")
                 puts response.body
                 exit 0
               end
@@ -92,7 +105,7 @@ th_assert_cmd_contains "Jekyll serves the generated page on port 4000" "Rendered
           sleep 1
         end
         exit 1
-    ' "$probe_page"
+    ' "$probe_page" "$probe_token"
 
 # The page belongs to the harness, not to the site: remove it whether or not the
 # assertion above passed.

--- a/jekyll/test.sh
+++ b/jekyll/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # E2E test for the jekyll container.
 #
-# Uses the repository's test harness so the exit code is the verdict. Bundler was
-# a warning; it holds on the published image, and a Jekyll image without it
-# cannot install a site's gems, so it is asserted.
+# Uses the repository's test harness so the exit code is the verdict. The suite
+# builds a tiny site instead of treating the presence of Ruby binaries as proof
+# that the static-site generator works.
 
 set -uo pipefail
 
@@ -15,20 +15,88 @@ CONTAINER_NAME="${CONTAINER_NAME:-e2e-jekyll}"
 
 th_init --name "Jekyll E2E" --report "${REPORT_FORMAT:-table}"
 
-th_group "Ruby toolchain"
-
-# Was printed and never read, so an image with no ruby reached the end.
-th_assert_cmd_contains "ruby reports its version" "ruby" \
-    docker exec "$CONTAINER_NAME" ruby --version
-
 # Bundler 4 prints a bare version number — no "Bundler" anywhere in it — so the
-# assertion is on the shape of what it prints, not on a word.
+# assertion is on the shape of what it prints, not on a word. Kept because the
+# image advertises Bundler, and the build below uses the global jekyll rather
+# than a Gemfile, so nothing else here would notice its absence.
 th_capture "bundler reports a version" docker exec "$CONTAINER_NAME" bundle --version &&
     th_assert_matches "bundler reports a version" "$TH_OUTPUT" '[0-9]+\.[0-9]+'
 
-th_group "Jekyll"
+th_group "Site build"
 
-th_assert_cmd_contains "jekyll reports its version" "jekyll" \
-    docker exec "$CONTAINER_NAME" jekyll --version
+# Use a self-contained site so no networked gem resolution or repository fixture
+# is required. The generated page uses Liquid, which distinguishes a real Jekyll
+# build from copying source files into _site.
+if docker exec "$CONTAINER_NAME" sh -c '
+    rm -rf /tmp/e2e-jekyll &&
+    mkdir -p /tmp/e2e-jekyll &&
+    cd /tmp/e2e-jekyll &&
+    printf "%s\\n" "title: Harness Site" > _config.yml &&
+    printf "%s\\n" "---" "---" "Rendered: {{ site.title }}" > index.md &&
+    jekyll build --source . --destination _site >/dev/null
+'; then
+    th_pass "Jekyll builds a minimal site"
+else
+    th_fail "Jekyll builds a minimal site" "jekyll build failed for the minimal site"
+fi
+
+if docker exec "$CONTAINER_NAME" sh -c \
+    'test -f /tmp/e2e-jekyll/_site/index.html && grep -Fq "Rendered: Harness Site" /tmp/e2e-jekyll/_site/index.html'; then
+    th_pass "Jekyll output contains rendered source content"
+else
+    th_fail "Jekyll output contains rendered source content" \
+        "the generated index.html is missing or did not render the site title"
+fi
+
+th_group "Server"
+
+# The image's default command is `jekyll serve --host 0.0.0.0`, which builds
+# /site into /site/_site and keeps watching /site. So the page is written to the
+# SOURCE and the rebuild is what publishes it: copying into /site/_site instead
+# races the watcher, which owns that directory and regenerates it.
+#
+# Only a page is written, never _config.yml — Jekyll does not reload its config
+# while watching, so a title taken from the config would never appear. Reading it
+# from the page's own front matter still requires Liquid to have run, which a
+# copied file would not prove.
+#
+# A uniquely named page, never index.md: jekyll/docker-compose.yml bind-mounts a
+# real site into /site read-write, so this suite pointed at that container with
+# CONTAINER_NAME would otherwise overwrite the user's own page. It is removed
+# again below, and even a failed cleanup leaves their content untouched.
+probe_page="e2e-harness-probe"
+docker exec "$CONTAINER_NAME" sh -c \
+    'printf "%s\n" "---" "title: Harness Page" "---" "Rendered: {{ page.title }}" > "/site/$1.md"' \
+    _ "$probe_page" >/dev/null 2>&1 || true
+
+# The runner does not publish 4000 to the host, but the Ruby runtime inside can
+# make the request. Retrying keeps this about the server rather than a race with
+# the rebuild it triggers.
+th_assert_cmd_contains "Jekyll serves the generated page on port 4000" "Rendered: Harness Page" \
+    docker exec "$CONTAINER_NAME" ruby -rnet/http -e '
+        page = ARGV[0]
+        # The timeouts are why this uses the start form: Net::HTTP defaults are
+        # around a minute each, so a server that accepts the connection and then
+        # says nothing would keep this loop alive for ten minutes, not ten seconds.
+        10.times do
+          begin
+            Net::HTTP.start("127.0.0.1", 4000, open_timeout: 2, read_timeout: 2) do |http|
+              response = http.get("/#{page}.html")
+              if response.is_a?(Net::HTTPSuccess) && response.body.include?("Rendered: Harness Page")
+                puts response.body
+                exit 0
+              end
+            end
+          rescue StandardError
+          end
+          sleep 1
+        end
+        exit 1
+    ' "$probe_page"
+
+# The page belongs to the harness, not to the site: remove it whether or not the
+# assertion above passed.
+docker exec "$CONTAINER_NAME" sh -c \
+    'rm -f "/site/$1.md" "/site/_site/$1.html"' _ "$probe_page" >/dev/null 2>&1 || true
 
 th_summary

--- a/terraform/test.sh
+++ b/terraform/test.sh
@@ -40,19 +40,104 @@ else
         "terraform init -backend=false && terraform validate failed on 'terraform {}'"
 fi
 
-th_group "Entrypoint dependencies"
+th_group "Entrypoint"
 
-# The image entrypoint renders *.tf.j2 through jinja2 before running terraform,
-# so a missing jinja2 breaks every templated configuration while `terraform
-# version` still answers.
-if docker exec "$CONTAINER_NAME" sh -c 'command -v jinja2 >/dev/null 2>&1'; then
-    th_pass "jinja2 is installed for the entrypoint's template rendering"
+# tests/e2e-test.sh overrides this image's entrypoint so the CLI container stays
+# alive. Invoke the shipped entrypoint explicitly: rendering a template and then
+# reaching `terraform version` proves both halves of its normal execution path.
+if docker exec "$CONTAINER_NAME" sh -c '
+    work=$(mktemp -d) &&
+    cd "$work" &&
+    printf "%s\\n" "{\"message\": \"rendered-by-entrypoint\"}" > config.json &&
+    printf "%s\\n" \
+        "output \"message\" {" \
+        "  value = \"{{ message }}\"" \
+        "}" > generated.tf.j2 &&
+    /docker-entrypoint.sh version >/dev/null &&
+    test -f generated.tf &&
+    grep -Fqx "  value = \"rendered-by-entrypoint\"" generated.tf
+'; then
+    th_pass "entrypoint renders a Terraform template before running Terraform"
 else
-    th_fail "jinja2 is installed for the entrypoint's template rendering" "command -v jinja2 found nothing"
+    th_fail "entrypoint renders a Terraform template before running Terraform" \
+        "the rendered .tf file or entrypoint Terraform invocation failed"
 fi
 
-th_group "Tools"
+th_group "Flavor-specific cloud tooling"
 
+# TERRAFORM_FLAVOR is set from the selected build variant in the Dockerfile. It
+# is available even when the e2e runner resolved a local image rather than the
+# caller supplying E2E_IMAGE, so every variant is checked against its own promise.
+# The tag is the independent statement of what this image was meant to be; the
+# environment variable is the image's own account of itself. An -aws build that
+# was accidentally built as base declares base, excludes every cloud CLI and
+# passes on its own say-so — so where the tag names a flavor, the two must agree
+# before anything else is asserted.
+expected_flavor=""
+if [ -n "${E2E_IMAGE:-}" ]; then
+    case "${E2E_IMAGE##*:}" in
+        *-aws)   expected_flavor=aws ;;
+        *-azure) expected_flavor=azure ;;
+        *-gcp)   expected_flavor=gcp ;;
+        *-base)  expected_flavor=base ;;
+    esac
+fi
+
+if th_capture "Terraform image declares its flavor" \
+        docker exec "$CONTAINER_NAME" sh -c 'printf %s "$TERRAFORM_FLAVOR"'; then
+    flavor="$TH_OUTPUT"
+
+    if [ -n "$expected_flavor" ]; then
+        th_assert_eq "the image is the flavor its tag claims ($expected_flavor)" \
+            "$flavor" "$expected_flavor"
+    else
+        th_skip "the image is the flavor its tag claims" \
+            "tag '${E2E_IMAGE##*:}' names no flavor"
+    fi
+    flavor_tools=()
+
+    case "$flavor" in
+        base) ;;  # nothing to provide; the exclusion loop below is its contract
+        aws) flavor_tools=(aws) ;;
+        azure) flavor_tools=(az) ;;
+        gcp) flavor_tools=(gcloud) ;;
+        full) flavor_tools=(aws az gcloud) ;;
+        *) th_fail "Terraform image declares a supported flavor" \
+               "expected base, aws, azure, gcp, or full; got '$flavor'" ;;
+    esac
+
+    # Run each CLI rather than locating it: a launcher can be on PATH and still
+    # fail on its first call because its interpreter, a Python module or a shared
+    # library did not come with it. `--version` is the cheapest call that proves
+    # the thing actually starts, and it touches no network.
+    for tool in "${flavor_tools[@]}"; do
+        if docker exec "$CONTAINER_NAME" sh -c '"$1" --version >/dev/null 2>&1' _ "$tool"; then
+            th_pass "$flavor flavor provides a working $tool"
+        else
+            th_fail "$flavor flavor provides a working $tool" \
+                "$tool is missing, or it is on PATH but does not run"
+        fi
+    done
+
+    # The reduced flavors exist to be smaller and expose less, so the CLIs they
+    # exclude are part of the contract too — without this, a build that quietly
+    # shipped all three would pass every flavor.
+    for tool in aws az gcloud; do
+        case " ${flavor_tools[*]} " in
+            *" $tool "*) continue ;;
+        esac
+        if docker exec "$CONTAINER_NAME" sh -c 'command -v "$1" >/dev/null 2>&1' _ "$tool"; then
+            th_fail "$flavor flavor excludes $tool" "$tool is present in a flavor that should not carry it"
+        else
+            th_pass "$flavor flavor excludes $tool"
+        fi
+    done
+fi
+
+th_group "Base utilities"
+
+# Promised by every flavor in the README, and dropping one is exactly the kind of
+# silent regression a flavor rebuild can introduce.
 for tool in git curl jq; do
     # `command -v` is a POSIX shell builtin; `which` is a separate package that
     # RHEL-family minimal images do not ship.

--- a/terraform/test.sh
+++ b/terraform/test.sh
@@ -92,7 +92,7 @@ if th_capture "Terraform image declares its flavor" \
             "$flavor" "$expected_flavor"
     else
         th_skip "the image is the flavor its tag claims" \
-            "tag '${E2E_IMAGE##*:}' names no flavor"
+            "tag '${E2E_IMAGE:+${E2E_IMAGE##*:}}' names no flavor"
     fi
     flavor_tools=()
 

--- a/wordpress/test.sh
+++ b/wordpress/test.sh
@@ -84,11 +84,17 @@ th_group "Extensions"
 # than reported as three separate absences.
 if th_capture "php -m lists the loaded extensions" \
         docker exec "$CONTAINER_NAME" php -m; then
-    # The list this suite has always pinned, plus gd, which the base provides and
-    # the Dockerfile promises. `zip`, `apcu` and `opcache` are promised too and
-    # are NOT in the published image — that is #1017, an image defect rather than
-    # a missing assertion, and this list grows to match once it is settled.
-    for ext in mysqli json curl gd; do
+    # Everything the Dockerfile promises and a current build carries. `zip` and
+    # `apcu` are here because a freshly pulled image has them — they were missing
+    # only from an older pinned tag, so asserting them catches the silent-drop
+    # class (#996) rather than encoding a stale observation.
+    #
+    # OPcache is deliberately absent from this list and is NOT an oversight: the
+    # base has not shipped it since #996 removed it, while this image's Dockerfile
+    # still claims it and writes an opcache ini that configures nothing. Asserting
+    # it would fail every build until that contradiction is settled, which is
+    # #1017's job; asserting nothing at all is what let it go unnoticed.
+    for ext in mysqli json curl gd zip apcu; do
         if grep -qix "$ext" <<< "$TH_OUTPUT"; then
             th_pass "extension $ext is loaded"
         else

--- a/wordpress/test.sh
+++ b/wordpress/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # E2E test for the wordpress container.
 #
-# Uses the repository's test harness so the exit code is the verdict. WP-CLI and
-# the PHP extensions were warnings; all of them hold on the published image, and
-# WordPress cannot talk to its database without mysqli, so they are asserted.
+# Uses the repository's test harness so the exit code is the verdict. The runner
+# starts the image's PHP-FPM command, so this suite verifies the usable WordPress
+# core and the long-running FPM process rather than only files and binaries.
 
 set -uo pipefail
 
@@ -15,43 +15,88 @@ CONTAINER_NAME="${CONTAINER_NAME:-e2e-wordpress}"
 
 th_init --name "WordPress E2E" --report "${REPORT_FORMAT:-table}"
 
-th_group "Interpreter"
-
-# Was printed and never read.
-th_assert_cmd_contains "php reports its version" "PHP" \
-    docker exec "$CONTAINER_NAME" php -v
-
 th_group "WordPress"
 
-# The core files are what makes this a WordPress image rather than a PHP one.
+# `wp core version` loads the installed tree through WP-CLI. It works without a
+# configured database, which matches the harness run profile, while a plain
+# `wp --version` only proves that the phar is on PATH.
+if th_capture "WP-CLI loads the installed WordPress core" \
+        docker exec "$CONTAINER_NAME" wp core version --path=/var/www/html --allow-root; then
+    reported_core="$TH_OUTPUT"
+    # Anchored at both ends: "6.9-corrupt-output" satisfies a leading-anchor-only
+    # pattern, and this is the only assertion about the core's identity.
+    th_assert_matches "WP-CLI reports the installed WordPress core version" \
+        "$reported_core" '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+
+    # A well-formed version is not the RIGHT version: the tag says which release
+    # this image is, so a 7.0.2 build shipping 6.9.4 has to fail rather than pass
+    # for looking version-shaped.
+    expected_core=""
+    if [ -n "${E2E_IMAGE:-}" ]; then
+        expected_core="${E2E_IMAGE##*:}"
+        expected_core="${expected_core%%-*}"
+    fi
+    if [[ "$expected_core" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+        th_assert_eq "the core version matches the image tag ($expected_core)" \
+            "$reported_core" "$expected_core"
+    else
+        th_skip "the core version matches the image tag" \
+            "tag '${expected_core:-none}' carries no version"
+    fi
+fi
+
+# `wp core version` is a before_wp_load command: it reads wp-includes/version.php
+# and never loads WordPress, so it answers for a tree that is missing most of
+# core. The file check is what covers that, which is why it stays alongside.
 if docker exec "$CONTAINER_NAME" test -f /var/www/html/wp-settings.php >/dev/null 2>&1; then
     th_pass "the WordPress core files are in place"
 else
     th_fail "the WordPress core files are in place" "/var/www/html/wp-settings.php is absent"
 fi
 
-th_assert_cmd_contains "wp-cli is installed" "WP-CLI" \
-    docker exec "$CONTAINER_NAME" wp --version --allow-root
+th_group "PHP-FPM"
+
+# docker-entrypoint.sh ends with `exec "$@"`, so PID 1 is the PHP-FPM master
+# process when the image's default command is healthy. This verifies the service
+# the run profile actually starts; it avoids inventing an HTTP check for an image
+# that exposes FastCGI only and has no host port published by the runner.
+# The first argv token, not a substring of the whole vector: `sh -c 'sleep inf
+# # php-fpm'` contains the word while no FPM exists anywhere.
+# Resolved through /proc/1/exe, not the name PID 1 was invoked under: a prefix
+# match on argv accepts `php-fpm-placeholder`, and argv is whatever the process
+# chose to call itself.
+if docker exec "$CONTAINER_NAME" sh -c \
+    'exe=$(readlink /proc/1/exe 2>/dev/null) && [ "${exe##*/}" = "php-fpm" ]'; then
+    th_pass "PHP-FPM is running as the container's master process"
+else
+    th_fail "PHP-FPM is running as the container's master process" \
+        "PID 1 is not php-fpm"
+fi
 
 th_group "Extensions"
 
-# mysqli is how WordPress reaches its database; without it the image cannot serve
-# a site at all. It was reported as a warning.
-#
-# One capture feeds all three checks. If it fails, that single failure is
-# recorded and the per-extension checks are skipped: a `php -m` that did not run
-# says nothing about which extensions are loaded, so reporting three failures —
-# or three passes — would both be inventions.
+# Kept alongside the runtime checks above, not replaced by them: a WordPress that
+# answers `wp core version` still fails at runtime if an extension it needs went
+# missing, and an install list that silently drops one is not hypothetical — it
+# happened to the php image, where asking for OPcache dropped zip and apcu (#996).
+# A `php -m` that did not run says nothing about which extensions are loaded, so
+# its failure is recorded once and the per-extension checks are skipped rather
+# than reported as three separate absences.
 if th_capture "php -m lists the loaded extensions" \
         docker exec "$CONTAINER_NAME" php -m; then
-    modules=$TH_OUTPUT
-    for ext in mysqli json curl; do
-        if printf '%s\n' "$modules" | grep -qix "$ext"; then
+    # The list this suite has always pinned, plus gd, which the base provides and
+    # the Dockerfile promises. `zip`, `apcu` and `opcache` are promised too and
+    # are NOT in the published image — that is #1017, an image defect rather than
+    # a missing assertion, and this list grows to match once it is settled.
+    for ext in mysqli json curl gd; do
+        if grep -qix "$ext" <<< "$TH_OUTPUT"; then
             th_pass "extension $ext is loaded"
         else
             th_fail "extension $ext is loaded" "not present in php -m"
         fi
     done
+else
+    th_skip "the required extensions are loaded" "php -m did not run"
 fi
 
 th_summary


### PR DESCRIPTION
Closes #983.

The opted-in suites asserted version strings. terraform ran byte-identical checks
across its five variant jobs and never touched the entrypoint that is the
container's reason to exist; jekyll never built a site; wordpress checked that
files existed rather than that WordPress ran.

**terraform** — the entrypoint now renders a `.tf.j2` and the rendered HCL is
asserted. Cloud CLIs follow the image's flavor and are *run* rather than located
(a launcher can sit on PATH and fail on its first call), each flavor also asserts
the CLIs it must not carry, and the tag is compared against what the image
declares about itself. `git`/`curl`/`jq` are back.

**jekyll** — builds a site with Liquid in it, then reads the page back over HTTP
from the server the image starts. The page goes into the watched source, because
`/site/_site` is owned by the watcher that regenerates it; the name and token are
per-run and creation is asserted, so a stale page cannot satisfy the assertion;
`set -C` refuses to clobber, which matters because `jekyll/docker-compose.yml`
bind-mounts a real site there.

**wordpress** — `wp core version` against the installed tree, PID 1 resolved
through `/proc/1/exe`, the core version compared to the tag, and the extension
list kept *alongside* those rather than replaced by them.

## Verification

Each suite run against its published image: terraform 9 + 1 skip, jekyll 5,
wordpress 9 + 1 skip. Full unit suite 2222 collected / 0 failed; shellcheck clean.
The flavor comparison was proven to fire by retagging the full image as `-aws` —
it fails, which is the mis-built case it exists for.

## Known gaps, tracked

- **#1018** — the identity checks skip rather than fail when the tag names no
  flavor (the default `-alpine` *is* full) or when the image was resolved locally
  and `E2E_IMAGE` is unset. Both infer expected identity from an optional
  environment variable when the build matrix already knows it.
- **#1017** — wordpress promises OPcache it does not ship and tunes it in a
  conf.d file. The suite deliberately does not assert OPcache until that is
  settled; asserting it would fail every build, and asserting nothing is how it
  went unnoticed.

Review did not sign off; pushed on the maintainer's instruction with the residue
above filed.
