### PR TITLE
ci(helpers): bound each registry attempt, and make the bound reach the caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,14 @@ That's it. The CI picks it up automatically on next push.
 - Docker Engine 20.10+ (or Podman)
 - Bash 4.0+
 - [yq](https://github.com/mikefarah/yq) (for variant containers)
-- A `timeout` accepting `-k`, to run the e2e suite — it is what keeps a probe
-  from hanging forever and leaving a container behind. GNU coreutils provides it
-  and most Linux distributions ship it; on macOS, `brew install coreutils` and
-  put its `libexec/gnubin` on `PATH`. The suite probes at startup for a `timeout`
-  that accepts `-k`, so one that does not fails immediately rather than at
-  cleanup. That probe reads the interface, not the behaviour: an implementation
-  that took the flag and ignored it would still get through.
+- A `timeout` accepting `-k`, for the e2e suite and registry helpers — it keeps
+  container cleanup and registry operations from waiting forever on a child
+  that ignores SIGTERM. GNU coreutils provides it and most Linux distributions
+  ship it; on macOS, `brew install coreutils` and put its `libexec/gnubin` on
+  `PATH`. Both consumers probe at startup for a `timeout` that accepts `-k`, so
+  one that does not fails immediately rather than during cleanup or a registry
+  operation. That probe reads the interface, not the behaviour: an
+  implementation that took the flag and ignored it would still get through.
 
 ## Documentation
 

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -58,23 +58,68 @@ if ! timeout -k 1 1 true 2>/dev/null; then
     return 1
 fi
 
-# _run_with_timeout <seconds> <command> [args...]
+# _validate_timeout_duration <variable-name> <seconds>
+_validate_timeout_duration() {
+    local variable_name="$1"
+    local timeout_seconds="$2"
+
+    # `timeout 0` disables the deadline, while option-like values can make it
+    # succeed without running the command. Only an integer greater than zero
+    # is a safe, unambiguous per-attempt bound.
+    if [[ ! "$timeout_seconds" =~ ^0*[1-9][0-9]*$ ]]; then
+        printf '::error::%s must be a positive integer number of seconds; got %q\n' \
+            "$variable_name" "$timeout_seconds" >&2
+        return 1
+    fi
+}
+
+# _timeout_exit_is_timeout <exit-code>
+#
+# GNU timeout reports 124 for its initial SIGTERM deadline and 137 when its
+# -k SIGKILL deadline fires. Both mean the registry command did not answer.
+_timeout_exit_is_timeout() {
+    [[ "$1" -eq 124 || "$1" -eq 137 ]]
+}
+
+# _run_with_timeout <variable-name> <seconds> <command> [args...]
 #
 # Run a command through bash so exported shell-function stubs work in Bats as
-# well as the real docker executable in production. Export a function command
-# on demand: callers that define docker/PROBE_CMD as a function need not know
-# that timeout executes in a child process.
+# well as the real docker executable in production. This necessarily runs a
+# function command in a fresh child shell: it may rely only on exported
+# functions and environment, and cannot read or update caller-local state.
+# Export a function command on demand for that documented child-shell contract.
 _run_with_timeout() {
-    local timeout_seconds="$1"
-    local command_name="$2"
-    shift 2
+    local variable_name="$1"
+    local timeout_seconds="$2"
+    local command_name="$3"
+    shift 3
+
+    _validate_timeout_duration "$variable_name" "$timeout_seconds" || return 2
 
     if declare -F "$command_name" &>/dev/null; then
         # shellcheck disable=SC2163 # command_name is intentionally dynamic.
         export -f "$command_name"
     fi
 
-    timeout -k 2 "$timeout_seconds" bash -c '"$@"' _ "$command_name" "$@"
+    # Output goes to a file, and the caller reads the file: bounding `timeout`
+    # does not bound a CALLER that captured through `$( … )`, because the pipe
+    # stays open while any orphan of the killed command still holds its write
+    # end. Measured: a command ignoring SIGTERM returned rc=124 at the 2s
+    # deadline while the surrounding capture waited the full 60s the orphan ran,
+    # three attempts making 180s against a 2s bound. A file has no EOF to wait
+    # for, so the deadline reaches the caller.
+    local out_file err_file status=0
+    out_file=$(mktemp) || return 2
+    err_file=$(mktemp) || { rm -f "$out_file"; return 2; }
+    timeout -k 2 -- "$timeout_seconds" bash -c '"$@"' _ "$command_name" "$@" \
+        >"$out_file" 2>"$err_file" || status=$?
+    # Replayed onto the streams the caller expects, each from its own file:
+    # merging them here would put a registry's chatter inside a value someone
+    # parses, which is the defect this helper exists alongside, not one to add.
+    cat "$out_file"
+    cat "$err_file" >&2
+    rm -f "$out_file" "$err_file"
+    return "$status"
 }
 
 # Resolve a tag template by substituting placeholders:
@@ -483,10 +528,11 @@ _sync_one_with_backoff() {
     # Overridable for focused tests and constrained runners; five minutes gives
     # layer-copy work time to finish while still recovering from a wedged client.
     local create_timeout="${SYNC_IMAGETOOLS_CREATE_TIMEOUT:-300}"
+    _validate_timeout_duration SYNC_IMAGETOOLS_CREATE_TIMEOUT "$create_timeout" || return 1
 
     while true; do
         local create_exit=0
-        if output=$(_run_with_timeout "$create_timeout" docker buildx imagetools create \
+        if output=$(_run_with_timeout SYNC_IMAGETOOLS_CREATE_TIMEOUT "$create_timeout" docker buildx imagetools create \
             --tag "$ghcr_image" \
             "$source_ref" 2>&1); then
             printf '%s' "$output"
@@ -495,7 +541,7 @@ _sync_one_with_backoff() {
             create_exit=$?
         fi
 
-        if [[ $create_exit -eq 124 ]]; then
+        if _timeout_exit_is_timeout "$create_exit"; then
             printf 'registry did not answer within %ss while copying %s' \
                 "$create_timeout" "$source_ref"
             return 1
@@ -564,21 +610,35 @@ probe_cache_image() {
     local max_attempts=3
     local delay=3
     local attempt=1
+    # Cleared before anything can return: callers read this under `set -u`, so a
+    # validation failure that returned early left it unset — aborting the shell —
+    # or, worse, left the previous call's diagnosis in place.
+    PROBE_CACHE_IMAGE_ERROR=""
+
     local read_timeout="${PROBE_CACHE_IMAGE_TIMEOUT:-30}"
+    _validate_timeout_duration PROBE_CACHE_IMAGE_TIMEOUT "$read_timeout" || {
+        PROBE_CACHE_IMAGE_ERROR="invalid PROBE_CACHE_IMAGE_TIMEOUT"
+        return 1
+    }
     local safe_ref
     safe_ref=$(_escape_gha_command "$image_ref")
-    PROBE_CACHE_IMAGE_ERROR=""
 
     while true; do
         local probe_exit=0
-        if PROBE_CACHE_IMAGE_ERROR=$(_run_with_timeout "$read_timeout" docker manifest inspect "$image_ref" 2>&1 >/dev/null); then
+        if PROBE_CACHE_IMAGE_ERROR=$(_run_with_timeout PROBE_CACHE_IMAGE_TIMEOUT "$read_timeout" docker manifest inspect "$image_ref" 2>&1 >/dev/null); then
             PROBE_CACHE_IMAGE_ERROR=""
             return 0
         else
             probe_exit=$?
         fi
-        if [[ $probe_exit -eq 124 ]]; then
+        if _timeout_exit_is_timeout "$probe_exit"; then
             PROBE_CACHE_IMAGE_ERROR="registry did not answer within ${read_timeout}s"
+        fi
+        # A bad operator override is a configuration error, not a registry
+        # blip; do not retry it and risk hiding the diagnostic among retries.
+        if [[ $probe_exit -eq 2 ]]; then
+            PROBE_CACHE_IMAGE_ERROR=$(_escape_gha_command "$PROBE_CACHE_IMAGE_ERROR")
+            return 1
         fi
         if (( attempt >= max_attempts )); then
             PROBE_CACHE_IMAGE_ERROR=$(_escape_gha_command "$PROBE_CACHE_IMAGE_ERROR")
@@ -838,11 +898,18 @@ sync_base_images_to_ghcr() {
                 local digest_read_timeout="${SYNC_IMAGETOOLS_INSPECT_TIMEOUT:-30}"
                 local digest_raw=""
                 local digest_exit=0
-                if digest_raw=$(_run_with_timeout "$digest_read_timeout" docker buildx imagetools inspect --format '{{json .Manifest}}' "$sync_image" 2>&1); then
+                if ! _validate_timeout_duration SYNC_IMAGETOOLS_INSPECT_TIMEOUT "$digest_read_timeout"; then
+                    _append_base_sync_manifest_record "$source_ref" "$sync_image" "" "failed"
+                    failed=$((failed + 1))
+                    continue
+                fi
+                # Keep diagnostics on stderr. Merging them into digest_raw
+                # corrupts otherwise-valid JSON (notably podman's greeting).
+                if digest_raw=$(_run_with_timeout SYNC_IMAGETOOLS_INSPECT_TIMEOUT "$digest_read_timeout" docker buildx imagetools inspect --format '{{json .Manifest}}' "$sync_image"); then
                     sync_digest=$(printf '%s' "$digest_raw" | jq -r '.digest // empty' 2>/dev/null || true)
                 else
                     digest_exit=$?
-                    if [[ $digest_exit -eq 124 ]]; then
+                    if _timeout_exit_is_timeout "$digest_exit"; then
                         echo "::warning::sync_base_images_to_ghcr: registry did not answer within ${digest_read_timeout}s while reading GHCR digest for ${safe_sync_image}; manifest record will fail closed"
                     fi
                 fi
@@ -892,4 +959,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _run_with_timeout _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record sync_base_images_to_ghcr
+export -f _validate_timeout_duration _timeout_exit_is_timeout _run_with_timeout _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record sync_base_images_to_ghcr

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -50,6 +50,33 @@ fi
 # Source variant utils for tags_from_versions resolution
 source "$SCRIPT_DIR/variant-utils.sh"
 
+# Registry commands below must have a real kill-after timeout. A plain timeout
+# only sends SIGTERM, then can wait forever for a stuck docker child; check the
+# interface once while this helper is loaded, before a caller starts work.
+if ! timeout -k 1 1 true 2>/dev/null; then
+    log_error "base-cache-utils.sh needs a 'timeout' accepting -k (GNU coreutils provides one)" >&2
+    return 1
+fi
+
+# _run_with_timeout <seconds> <command> [args...]
+#
+# Run a command through bash so exported shell-function stubs work in Bats as
+# well as the real docker executable in production. Export a function command
+# on demand: callers that define docker/PROBE_CMD as a function need not know
+# that timeout executes in a child process.
+_run_with_timeout() {
+    local timeout_seconds="$1"
+    local command_name="$2"
+    shift 2
+
+    if declare -F "$command_name" &>/dev/null; then
+        # shellcheck disable=SC2163 # command_name is intentionally dynamic.
+        export -f "$command_name"
+    fi
+
+    timeout -k 2 "$timeout_seconds" bash -c '"$@"' _ "$command_name" "$@"
+}
+
 # Resolve a tag template by substituting placeholders:
 #   ${VERSION}          → detected build version (e.g., "1.14.5-alpine")
 #   ${UPSTREAM_VERSION} → raw upstream version via version.sh --upstream (e.g., "1.14.5")
@@ -434,7 +461,10 @@ resolve_cache_check_tag() {
 # rate-limit (429) errors. Other failures (auth, network, malformed ref) fail
 # fast — backoff only burns wall-time when it cannot help.
 #
-# Backoff schedule: 5s, 10s, 20s (3 retries max, then give up).
+# Backoff schedule: 5s, 10s, 20s (3 retries max, then give up). Each create is
+# bounded by $SYNC_IMAGETOOLS_CREATE_TIMEOUT (default 300s): copying layers can
+# legitimately take minutes, unlike a manifest read, so the read-scale bound
+# would turn healthy large-image copies into failures.
 # Sleep is performed via the injectable $SLEEP_CMD (defaults to `sleep`); tests
 # pass `:` or `true` to skip real sleeps.
 #
@@ -450,13 +480,25 @@ _sync_one_with_backoff() {
     local base_delay=5
     local attempt=0
     local output
+    # Overridable for focused tests and constrained runners; five minutes gives
+    # layer-copy work time to finish while still recovering from a wedged client.
+    local create_timeout="${SYNC_IMAGETOOLS_CREATE_TIMEOUT:-300}"
 
     while true; do
-        if output=$(docker buildx imagetools create \
+        local create_exit=0
+        if output=$(_run_with_timeout "$create_timeout" docker buildx imagetools create \
             --tag "$ghcr_image" \
             "$source_ref" 2>&1); then
             printf '%s' "$output"
             return 0
+        else
+            create_exit=$?
+        fi
+
+        if [[ $create_exit -eq 124 ]]; then
+            printf 'registry did not answer within %ss while copying %s' \
+                "$create_timeout" "$source_ref"
+            return 1
         fi
 
         # Only retry rate-limit / 429 — anything else is non-transient.
@@ -499,7 +541,10 @@ _sync_one_with_backoff() {
 # reliably distinguishable from its error text.
 #
 # Backoff: 3 attempts, 3s then 6s. Sleep goes through the injectable $SLEEP_CMD
-# (defaults to `sleep`) so tests do not spend it.
+# (defaults to `sleep`) so tests do not spend it. Each manifest read is bounded
+# by $PROBE_CACHE_IMAGE_TIMEOUT (default 30s): a registry metadata response
+# normally takes seconds, so 30s leaves generous network slack without letting
+# one stuck read hold a build forever.
 #
 # The reference reaches a runner log, and `base_image_cache` is unvalidated
 # config, so it goes through _escape_gha_command first — a newline in it would
@@ -519,14 +564,21 @@ probe_cache_image() {
     local max_attempts=3
     local delay=3
     local attempt=1
+    local read_timeout="${PROBE_CACHE_IMAGE_TIMEOUT:-30}"
     local safe_ref
     safe_ref=$(_escape_gha_command "$image_ref")
     PROBE_CACHE_IMAGE_ERROR=""
 
     while true; do
-        if PROBE_CACHE_IMAGE_ERROR=$(docker manifest inspect "$image_ref" 2>&1 >/dev/null); then
+        local probe_exit=0
+        if PROBE_CACHE_IMAGE_ERROR=$(_run_with_timeout "$read_timeout" docker manifest inspect "$image_ref" 2>&1 >/dev/null); then
             PROBE_CACHE_IMAGE_ERROR=""
             return 0
+        else
+            probe_exit=$?
+        fi
+        if [[ $probe_exit -eq 124 ]]; then
+            PROBE_CACHE_IMAGE_ERROR="registry did not answer within ${read_timeout}s"
         fi
         if (( attempt >= max_attempts )); then
             PROBE_CACHE_IMAGE_ERROR=$(_escape_gha_command "$PROBE_CACHE_IMAGE_ERROR")
@@ -764,17 +816,36 @@ sync_base_images_to_ghcr() {
         # docker.io pull rate limit — same pattern used in build-container/action.yaml.
         # We use the literal `docker` (not $DOCKER) to match that convention: this is
         # a read-only probe, not a write/build command that dry-run mode should mock.
-        if [[ "$skip_present" == "true" ]] && docker manifest inspect "$sync_image" >/dev/null 2>&1; then
-            echo "  ⏭️ Already in GHCR, skipping (no docker.io request): ${sync_image}"
-            skipped=$((skipped + 1))
-            continue
+        if [[ "$skip_present" == "true" ]]; then
+            if probe_cache_image "$sync_image"; then
+                echo "  ⏭️ Already in GHCR, skipping (no docker.io request): ${sync_image}"
+                skipped=$((skipped + 1))
+                continue
+            fi
+            if [[ "$PROBE_CACHE_IMAGE_ERROR" == registry\ did\ not\ answer\ within* ]]; then
+                echo "  ⚠️ GHCR presence check timed out; attempting the copy: ${PROBE_CACHE_IMAGE_ERROR}"
+            fi
         fi
 
         if output=$(_sync_one_with_backoff "$source_ref" "$sync_image"); then
             echo "  ✅ Synced"
             if [[ -n "${SYNC_MANIFEST_OUT:-}" ]]; then
                 local sync_digest=""
-                sync_digest=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$sync_image" 2>/dev/null | jq -r '.digest // empty' 2>/dev/null || true)
+                # This is another metadata read, not a layer copy: use the same
+                # generous 30s default as probe_cache_image. It is separate from
+                # SYNC_IMAGETOOLS_CREATE_TIMEOUT because a completed copy should
+                # not leave manifest bookkeeping waiting minutes on a wedged read.
+                local digest_read_timeout="${SYNC_IMAGETOOLS_INSPECT_TIMEOUT:-30}"
+                local digest_raw=""
+                local digest_exit=0
+                if digest_raw=$(_run_with_timeout "$digest_read_timeout" docker buildx imagetools inspect --format '{{json .Manifest}}' "$sync_image" 2>&1); then
+                    sync_digest=$(printf '%s' "$digest_raw" | jq -r '.digest // empty' 2>/dev/null || true)
+                else
+                    digest_exit=$?
+                    if [[ $digest_exit -eq 124 ]]; then
+                        echo "::warning::sync_base_images_to_ghcr: registry did not answer within ${digest_read_timeout}s while reading GHCR digest for ${safe_sync_image}; manifest record will fail closed"
+                    fi
+                fi
                 if [[ -n "$sync_digest" && ! "$sync_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
                     echo "::warning::sync_base_images_to_ghcr: GHCR digest for ${sync_image} had unexpected shape; manifest record will fail closed"
                     sync_digest=""
@@ -821,4 +892,4 @@ sync_base_images_to_ghcr() {
 }
 
 # Export functions
-export -f _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record sync_base_images_to_ghcr
+export -f _run_with_timeout _resolve_tag_template _collect_entry_tags has_base_cache distro_uses_base_cache collect_all_cache_images resolve_cache_check_tag remote_cr_applicable emit_reachable_cache_args probe_cache_image _sync_one_with_backoff base_cache_canonical_source_ref base_cache_is_docker_io_origin_ref base_cache_canonical_docker_io_ref _append_base_sync_manifest_record sync_base_images_to_ghcr

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -120,8 +120,8 @@ _PROBE_DIGEST_ERROR=""
 _PROBE_DIGEST_OUT=""
 
 # retry_with_backoff normalizes final failures to status 1. This equivalent
-# local loop preserves timeout's 124, so callers can distinguish a registry
-# that did not answer from a failed manifest lookup.
+# local loop preserves timeout's exit status, so callers can distinguish a
+# registry that did not answer from a failed manifest lookup.
 _probe_digest_with_backoff() {
     local timeout_seconds="$1"
     local image_ref="$2"
@@ -136,14 +136,24 @@ _probe_digest_with_backoff() {
     _PROBE_DIGEST_OUT=""
 
     while true; do
-        if output=$(_run_with_timeout "$timeout_seconds" docker buildx imagetools inspect --format '{{json .Manifest}}' -- "$image_ref" 2>>"$stderr_file"); then
+        if output=$(_run_with_timeout DIGEST_PROBE_TIMEOUT "$timeout_seconds" docker buildx imagetools inspect --format '{{json .Manifest}}' -- "$image_ref" 2>>"$stderr_file"); then
             _PROBE_DIGEST_OUT="$output"
             return 0
         else
             attempt_exit=$?
         fi
-        if [[ $attempt_exit -eq 124 ]]; then
+        if _timeout_exit_is_timeout "$attempt_exit"; then
             _PROBE_DIGEST_ERROR="registry did not answer within ${timeout_seconds}s"
+        else
+            # Do not let a previous timeout mask the current 401/404/network
+            # failure. _probe_digest below promotes that final stderr detail.
+            _PROBE_DIGEST_ERROR=""
+        fi
+
+        # Validation errors cannot become successful with another registry
+        # attempt. Return now after _run_with_timeout printed its diagnostic.
+        if [[ $attempt_exit -eq 2 ]]; then
+            return "$attempt_exit"
         fi
 
         if (( attempt >= max_attempts )); then
@@ -171,6 +181,11 @@ _probe_digest() {
     # multi-minute stuck client as a useful retryable attempt.
     local digest_probe_timeout="${DIGEST_PROBE_TIMEOUT:-30}"
 
+    if ! _validate_timeout_duration DIGEST_PROBE_TIMEOUT "$digest_probe_timeout"; then
+        _PROBE_DIGEST_ERROR="DIGEST_PROBE_TIMEOUT must be a positive integer number of seconds"
+        return 1
+    fi
+
     # Explicit cleanup on every return path below.  We do NOT use
     # `trap '...' RETURN` because bash RETURN traps are GLOBAL — they fire on
     # every subsequent function return in the same shell, not just returns from
@@ -180,13 +195,15 @@ _probe_digest() {
 
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
-        raw=$(_run_with_timeout "$digest_probe_timeout" "${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        raw=$(_run_with_timeout DIGEST_PROBE_TIMEOUT "$digest_probe_timeout" "${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
-            if [[ $probe_exit -eq 124 ]]; then
+            if _timeout_exit_is_timeout "$probe_exit"; then
                 _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
                 printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+            elif [[ -n "$err_detail" ]]; then
+                _PROBE_DIGEST_ERROR="${err_detail##*$'\n'}"
             fi
             [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             rm -f "$probe_stderr"
@@ -203,9 +220,11 @@ _probe_digest() {
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
-            if [[ $probe_exit -eq 124 ]]; then
+            if _timeout_exit_is_timeout "$probe_exit"; then
                 _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
                 printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+            elif [[ -n "$err_detail" ]]; then
+                _PROBE_DIGEST_ERROR="${err_detail##*$'\n'}"
             fi
             printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             rm -f "$probe_stderr"

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -29,6 +29,11 @@
 #                     (canonical multi-arch image-index digest via buildx
 #                     imagetools — order-independent, single source of truth,
 #                     matches scripts/build-container.sh digest extraction)
+#   DIGEST_PROBE_TIMEOUT
+#                     Per-attempt registry-read bound in seconds (default 30).
+#                     Override in focused tests or constrained runners. Metadata
+#                     reads normally answer in seconds, so 30s is generous while
+#                     still preventing one wedged inspect from blocking a run.
 #   SYNC_MANIFEST_FILE
 #                     Optional path to the daily base-image sync JSONL/JSON-array
 #                     manifest. When set, Docker Hub-origin base refs are resolved
@@ -111,6 +116,47 @@ done
 # For fixture-based testing, set PROBE_CMD to a function/script that accepts
 # image_ref as $1 and outputs the `{{json .Manifest}}` JSON on stdout.
 # ---------------------------------------------------------------------------
+_PROBE_DIGEST_ERROR=""
+_PROBE_DIGEST_OUT=""
+
+# retry_with_backoff normalizes final failures to status 1. This equivalent
+# local loop preserves timeout's 124, so callers can distinguish a registry
+# that did not answer from a failed manifest lookup.
+_probe_digest_with_backoff() {
+    local timeout_seconds="$1"
+    local image_ref="$2"
+    local stderr_file="$3"
+    local max_attempts=3
+    local delay=5
+    local attempt=1
+    local output
+    local attempt_exit=0
+
+    _PROBE_DIGEST_ERROR=""
+    _PROBE_DIGEST_OUT=""
+
+    while true; do
+        if output=$(_run_with_timeout "$timeout_seconds" docker buildx imagetools inspect --format '{{json .Manifest}}' -- "$image_ref" 2>>"$stderr_file"); then
+            _PROBE_DIGEST_OUT="$output"
+            return 0
+        else
+            attempt_exit=$?
+        fi
+        if [[ $attempt_exit -eq 124 ]]; then
+            _PROBE_DIGEST_ERROR="registry did not answer within ${timeout_seconds}s"
+        fi
+
+        if (( attempt >= max_attempts )); then
+            return "$attempt_exit"
+        fi
+
+        log_warning "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..." 2>>"$stderr_file"
+        sleep "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+    done
+}
+
 _probe_digest() {
     local image_ref="$1"
     local raw
@@ -118,6 +164,12 @@ _probe_digest() {
     local probe_exit=0
     local safe_ref
     safe_ref=$(_escape_gha_command "$image_ref")
+    _PROBE_DIGEST_ERROR=""
+    _PROBE_DIGEST_OUT=""
+    # Unlike imagetools create, this is a manifest metadata read. Thirty
+    # seconds leaves ample room for slow registry/TLS paths without treating a
+    # multi-minute stuck client as a useful retryable attempt.
+    local digest_probe_timeout="${DIGEST_PROBE_TIMEOUT:-30}"
 
     # Explicit cleanup on every return path below.  We do NOT use
     # `trap '...' RETURN` because bash RETURN traps are GLOBAL — they fire on
@@ -128,10 +180,14 @@ _probe_digest() {
 
     if [[ -n "${PROBE_CMD:-}" ]]; then
         # Stub: PROBE_CMD is a function/path that accepts image_ref as $1
-        raw=$("${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        raw=$(_run_with_timeout "$digest_probe_timeout" "${PROBE_CMD}" "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
+            if [[ $probe_exit -eq 124 ]]; then
+                _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
+                printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+            fi
             [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             rm -f "$probe_stderr"
             return 1
@@ -139,10 +195,18 @@ _probe_digest() {
     else
         # `--` separates options from the image ref: belt-and-suspenders against
         # dash-prefix option injection if a poisoned ref slips past _validate_image_ref.
-        raw=$(retry_with_backoff 3 5 docker buildx imagetools inspect --format '{{json .Manifest}}' -- "${image_ref}" 2>"$probe_stderr") || probe_exit=$?
+        if _probe_digest_with_backoff "$digest_probe_timeout" "$image_ref" "$probe_stderr"; then
+            raw="$_PROBE_DIGEST_OUT"
+        else
+            probe_exit=$?
+        fi
         if [[ $probe_exit -ne 0 ]]; then
             local err_detail
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
+            if [[ $probe_exit -eq 124 ]]; then
+                _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
+                printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+            fi
             printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
             rm -f "$probe_stderr"
             return 1
@@ -166,7 +230,7 @@ _probe_digest() {
     fi
 
     rm -f "$probe_stderr"
-    printf '%s' "$digest"
+    _PROBE_DIGEST_OUT="$digest"
     return 0
 }
 
@@ -194,10 +258,9 @@ _probe_digest_cached() {
         _probe_digest_cached_out="${_DIGEST_CACHE[$image_ref]}"
         return 0
     fi
-    local digest
-    if digest=$(_probe_digest "$image_ref"); then
-        _DIGEST_CACHE[$image_ref]="$digest"
-        _probe_digest_cached_out="$digest"
+    if _probe_digest "$image_ref"; then
+        _DIGEST_CACHE[$image_ref]="$_PROBE_DIGEST_OUT"
+        _probe_digest_cached_out="$_PROBE_DIGEST_OUT"
         return 0
     fi
     return 1   # failures left UNCACHED (smallest semantic change)
@@ -731,6 +794,9 @@ for lineage_file in "${lineage_files[@]}"; do
             current_digest="$_probe_digest_cached_out"
         else
             probe_failed=true
+            if [[ -n "${_PROBE_DIGEST_ERROR:-}" ]]; then
+                error_reason="$_PROBE_DIGEST_ERROR"
+            fi
         fi
     fi
 

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -16,11 +16,11 @@ setup() {
     source "$ORIG_DIR/helpers/variant-utils.sh"
     source "$ORIG_DIR/helpers/base-cache-utils.sh"
 
-    unset SYNC_MANIFEST_OUT
+    unset SYNC_MANIFEST_OUT PROBE_CACHE_IMAGE_TIMEOUT SYNC_IMAGETOOLS_CREATE_TIMEOUT SYNC_IMAGETOOLS_INSPECT_TIMEOUT
 }
 
 teardown() {
-    unset SYNC_MANIFEST_OUT
+    unset SYNC_MANIFEST_OUT PROBE_CACHE_IMAGE_TIMEOUT SYNC_IMAGETOOLS_CREATE_TIMEOUT SYNC_IMAGETOOLS_INSPECT_TIMEOUT
     cd "$ORIG_DIR" || true
     rm -rf "$TEST_DIR"
 }
@@ -867,6 +867,9 @@ EOF
             return 1
         fi
         if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+            # Podman (and some registry helpers) can print an informational
+            # greeting on stderr even after a successful inspect.
+            echo "podman: using containers.conf" >&2
             printf '{"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"}'
             return 0
         fi
@@ -892,6 +895,7 @@ EOF
 
     [ "$synced_source" = "docker.io/library/alpine:3.18" ]
     [ "$synced_digest" = "sha256:1111111111111111111111111111111111111111111111111111111111111111" ]
+    [[ "$output" == *"podman: using containers.conf"* ]]
     [ "$failed_source" = "docker.io/library/postgres:18-alpine" ]
     [ "$failed_status" = "failed" ]
     [ "$failed_digest" = "" ]
@@ -1331,6 +1335,31 @@ EOF
     rm -f "$copy_marker"
 }
 
+@test "probe_cache_image: the deadline reaches the caller, not just timeout" {
+    # Bounding `timeout` does not bound a caller that captured through a pipe:
+    # an orphan of the killed command keeps the write end open, so `$( … )`
+    # waits for EOF long after the deadline fired. Measured before the fix: the
+    # probe returned rc=124 at its 2s deadline while the surrounding capture sat
+    # for the full 60s the orphan ran — 180s across three attempts against a 2s
+    # bound. Every other stub here exits promptly, so nothing else can see this.
+    local stub="$TEST_DIR/stubborn-docker"
+    printf '#!/usr/bin/env bash\ntrap "" TERM\nsleep 60\n' > "$stub"
+    chmod +x "$stub"
+    export STUBBORN_DOCKER="$stub"
+    docker() { "$STUBBORN_DOCKER"; }
+    export -f docker
+    export SLEEP_CMD=: PROBE_CACHE_IMAGE_TIMEOUT=2
+
+    local before=$SECONDS
+    probe_cache_image "ghcr.io/x/a:1" || true
+    local elapsed=$((SECONDS - before))
+
+    # Three attempts of 2s, plus the kill-after grace. Generous, and far below
+    # the 180s a piped capture cost.
+    [ "$elapsed" -lt 30 ]
+    [[ "$PROBE_CACHE_IMAGE_ERROR" == *"did not answer"* ]]
+}
+
 @test "probe_cache_image: a readable image needs no retry" {
     # The reference is asserted, not just the verb: a probe that read a
     # hard-coded or dropped ref would otherwise pass this.
@@ -1399,7 +1428,8 @@ EOF
 
 @test "probe_cache_image: timeout is reported and remains fail-closed after three attempts" {
     # A timeout needs its own repair path: the image may exist, but the registry
-    # did not answer. A sub-second injected bound keeps this focused test fast.
+    # did not answer. Use a whole-second duration because timeout overrides are
+    # intentionally restricted to positive integer seconds.
     local counter_file="$TEST_DIR/timeout-probe-attempts"
     echo 0 > "$counter_file"
     export COUNTER_FILE="$counter_file"
@@ -1408,17 +1438,50 @@ EOF
         local n
         n=$(( $(<"$COUNTER_FILE") + 1 ))
         echo "$n" > "$COUNTER_FILE"
-        sleep 1
+        sleep 2
     }
     export -f docker
     export SLEEP_CMD=:
-    export PROBE_CACHE_IMAGE_TIMEOUT=0.1
+    export PROBE_CACHE_IMAGE_TIMEOUT=1
 
     local rc=0
     probe_cache_image "ghcr.io/x/library/slow:1" || rc=$?
     [ "$rc" -eq 1 ]
     [ "$(<"$counter_file")" -eq 3 ]
-    [ "$PROBE_CACHE_IMAGE_ERROR" = "registry did not answer within 0.1s" ]
+    [ "$PROBE_CACHE_IMAGE_ERROR" = "registry did not answer within 1s" ]
+}
+
+@test "probe_cache_image: invalid timeout override fails before docker runs" {
+    local counter_file="$TEST_DIR/invalid-timeout-probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+
+    docker() {
+        echo $(( $(<"$COUNTER_FILE") + 1 )) > "$COUNTER_FILE"
+        return 0
+    }
+    export -f docker
+    export PROBE_CACHE_IMAGE_TIMEOUT=--help
+
+    run probe_cache_image "ghcr.io/x/library/ubuntu:noble"
+    [ "$status" -eq 1 ]
+    [ "$(<"$counter_file")" -eq 0 ]
+    [[ "$output" == *"PROBE_CACHE_IMAGE_TIMEOUT must be a positive integer number of seconds"* ]]
+}
+
+@test "_sync_one_with_backoff: kill-after exit 137 is reported as a timeout" {
+    # Ignore timeout's initial SIGTERM, then exec sleep so timeout's -k SIGKILL
+    # is what ends the command. This exercises GNU timeout's 137 exit status.
+    docker() {
+        trap '' TERM
+        exec sleep 10
+    }
+    export -f docker
+    export SYNC_IMAGETOOLS_CREATE_TIMEOUT=1
+
+    run _sync_one_with_backoff "docker.io/library/alpine:3.18" "ghcr.io/x/lib/a:3.18"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"registry did not answer within 1s while copying docker.io/library/alpine:3.18"* ]]
 }
 
 @test "probe_cache_image: a newline in the reference cannot forge a workflow command" {

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -1397,6 +1397,30 @@ EOF
     [ "$(<"$counter_file")" -eq 3 ]
 }
 
+@test "probe_cache_image: timeout is reported and remains fail-closed after three attempts" {
+    # A timeout needs its own repair path: the image may exist, but the registry
+    # did not answer. A sub-second injected bound keeps this focused test fast.
+    local counter_file="$TEST_DIR/timeout-probe-attempts"
+    echo 0 > "$counter_file"
+    export COUNTER_FILE="$counter_file"
+
+    docker() {
+        local n
+        n=$(( $(<"$COUNTER_FILE") + 1 ))
+        echo "$n" > "$COUNTER_FILE"
+        sleep 1
+    }
+    export -f docker
+    export SLEEP_CMD=:
+    export PROBE_CACHE_IMAGE_TIMEOUT=0.1
+
+    local rc=0
+    probe_cache_image "ghcr.io/x/library/slow:1" || rc=$?
+    [ "$rc" -eq 1 ]
+    [ "$(<"$counter_file")" -eq 3 ]
+    [ "$PROBE_CACHE_IMAGE_ERROR" = "registry did not answer within 0.1s" ]
+}
+
 @test "probe_cache_image: a newline in the reference cannot forge a workflow command" {
     # base_image_cache is unvalidated config, and this line lands in a runner log.
     # An unescaped newline would end the message and let the rest of the value

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -39,9 +39,9 @@ myimage"
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT
     export FIXTURES_DIR_DRIFT
-    # The detector resolves internal image ownership through this value. CI
-    # supplies it, but the unit suite must also be runnable directly locally.
-    export GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-oorabona}"
+    # Fixture references are deliberately oorabona-owned. Never inherit a fork
+    # CI owner here: tests that exercise a different owner set it explicitly.
+    export GITHUB_REPOSITORY_OWNER="oorabona"
 
     unset SYNC_MANIFEST_FILE
     unset PROBE_SENTINEL
@@ -51,6 +51,10 @@ teardown() {
     unset SYNC_MANIFEST_FILE
     unset PROBE_SENTINEL
     teardown_temp_dir
+}
+
+@test "fixtures pin the internal owner instead of inheriting fork CI" {
+    [ "$GITHUB_REPOSITORY_OWNER" = "oorabona" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -108,7 +112,9 @@ _make_slow_probe_stub() {
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$stub_path" <<'STUB_EOF'
 #!/usr/bin/env bash
-sleep 1
+# Ignore timeout's SIGTERM so its -k SIGKILL produces the distinct 137 status.
+trap '' TERM
+exec /bin/sleep 10
 STUB_EOF
     chmod +x "$stub_path"
     printf '%s' "$stub_path"
@@ -375,11 +381,51 @@ EOF
 }
 EOF
 
-    result=$(GITHUB_REPOSITORY_OWNER=oorabona DIGEST_PROBE_TIMEOUT=0.1 PROBE_CMD="$slow_stub" \
+    result=$(GITHUB_REPOSITORY_OWNER=oorabona DIGEST_PROBE_TIMEOUT=1 PROBE_CMD="$slow_stub" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
     [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "error" ]
-    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry did not answer within 0.1s" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry did not answer within 1s" ]
+}
+
+@test "probe-retry: final 401 replaces an earlier timeout reason" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local counter_file="$TEST_TEMP_DIR/docker-attempts"
+    mkdir -p "$lineage_dir" "$bin_dir"
+    echo 0 > "$counter_file"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$bin_dir/docker" <<'STUB_EOF'
+#!/usr/bin/env bash
+n=$(<"${DOCKER_COUNTER:?}")
+n=$((n + 1))
+echo "$n" > "${DOCKER_COUNTER:?}"
+if [[ "$n" -eq 1 ]]; then
+    trap '' TERM
+    exec /bin/sleep 10
+fi
+echo "stub: 401 unauthorized" >&2
+exit 1
+STUB_EOF
+    cat > "$bin_dir/sleep" <<'STUB_EOF'
+#!/usr/bin/env bash
+exit 0
+STUB_EOF
+    chmod +x "$bin_dir/docker" "$bin_dir/sleep"
+
+    result=$(PATH="$bin_dir:$PATH" DOCKER_COUNTER="$counter_file" DIGEST_PROBE_TIMEOUT=1 \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ "$(<"$counter_file")" -eq 3 ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "stub: 401 unauthorized" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -39,6 +39,9 @@ myimage"
     export TEST_TEMP_DIR
     export DETECTOR_SCRIPT
     export FIXTURES_DIR_DRIFT
+    # The detector resolves internal image ownership through this value. CI
+    # supplies it, but the unit suite must also be runnable directly locally.
+    export GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-oorabona}"
 
     unset SYNC_MANIFEST_FILE
     unset PROBE_SENTINEL
@@ -95,6 +98,17 @@ _make_failing_probe_stub() {
 #!/usr/bin/env bash
 echo "stub: simulated registry failure for '$1'" >&2
 exit 1
+STUB_EOF
+    chmod +x "$stub_path"
+    printf '%s' "$stub_path"
+}
+
+_make_slow_probe_stub() {
+    local stub_path="$TEST_TEMP_DIR/bin/probe-slow"
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$stub_path" <<'STUB_EOF'
+#!/usr/bin/env bash
+sleep 1
 STUB_EOF
     chmod +x "$stub_path"
     printf '%s' "$stub_path"
@@ -343,6 +357,29 @@ EOF
     current_digest=$(printf '%s' "$result" | \
         jq -r '.[0].variants[0].current_digest // "null"')
     [ "$current_digest" = "null" ]
+}
+
+@test "probe-timeout: error reason names the bounded registry read" {
+    local slow_stub
+    slow_stub=$(_make_slow_probe_stub)
+
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-1.0-alpine.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "1.0-alpine",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    result=$(GITHUB_REPOSITORY_OWNER=oorabona DIGEST_PROBE_TIMEOUT=0.1 PROBE_CMD="$slow_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry did not answer within 0.1s" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1012.

The base-cache probe retried a failed read three times, which helps when the read
returns. A read that never returns was waited on instead — the backoff it was
meant to drive never ran. Its neighbours had the same shape: the `imagetools
create` on the sync path and the digest probe in drift detection both retry on
failure and neither bounded an attempt.

Each attempt now carries `timeout -k`, bounded per call rather than by one
constant: a manifest read answers in seconds and gets 30, `imagetools create`
copies layers and gets 300. `-k` is what makes it a bound at all — a plain
`timeout` sends SIGTERM and then waits indefinitely for a child that ignores it.

**A bound on `timeout` is not a bound on the caller.** Measured: a command that
ignores SIGTERM returned 124 at its 2-second deadline while the surrounding
`$( … )` sat for the full 60 seconds the orphan ran — 180s across three attempts
against a 2s budget, because an orphan of the killed command still held the write
end of the capture pipe. Output goes to files replayed onto the caller's streams
now, separately, since merging them is a defect of its own. Same measurement
after: 6 seconds.

Also fixed: an unvalidated duration disabled the bound entirely
(`PROBE_CACHE_IMAGE_TIMEOUT=--help` made `timeout` exit 0 without running docker,
so the probe reported an image present that was never checked, and `0` silently
meant "no deadline"); the kill-after path returns 137, not 124, so the case `-k`
exists for was never recognised as a timeout; a successful `imagetools inspect`
had its stderr merged into the JSON being parsed, yielding an empty digest and a
`synced` record without one; a stale timeout reason survived a later, different
failure; and the drift fixture followed the ambient repository owner, which on a
fork classifies the same reference as external.

## Verification

195 unit tests in the touched suites, 2229 collected / 0 failed overall,
shellcheck clean. Empirically: `--help`, `0` and `abc` are each refused with no
registry call made; a command ignoring SIGTERM is cut off per attempt; putting the
capture back on a pipe fails the suite.

## Known gap, tracked

**#1020** — the bounded call replays its stderr to the caller, and when that is
not captured it reaches a runner log unescaped. Filed rather than patched because
the consumers already escape, so escaping at the replay double-encodes: it needs
one decision about which boundary owns escaping, which is the same question
#1014 and #1015 ask about the same helper. Marginal privilege is nil — the bytes
come from a registry, and an actor who controls those already controls the image.

Review did not sign off; pushed on the maintainer's instruction with that residue
filed.
