### PR TITLE
fix(wordpress): scope the WP-CLI deprecation suppression, and check what it installs

### DIFF
--- a/docs/site/_posts/2026-05-08-immutable-wordpress-sqlite-docker-single-container.md
+++ b/docs/site/_posts/2026-05-08-immutable-wordpress-sqlite-docker-single-container.md
@@ -23,7 +23,7 @@ docker pull ghcr.io/oorabona/wordpress:latest
 - **PHP-FPM** from the [oorabona/php](/docker-containers/container/php/) image (Composer, APCu baked in)
 - **Non-root user `wordpress`** with passwordless sudo scoped to `/usr/local/bin/wp` only
 - **Healthcheck** via `php-fpm -t`
-- **OPcache tuned** for WordPress (128 MB, 4 000 files, `fast_shutdown=1`)
+- **OPcache** enabled by the base PHP image, with `validate_timestamps=0` — code changes are picked up on restart, not on save
 
 The `wp-config.php` hard-codes two constants that change everything:
 

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,5 +1,9 @@
-# WordPress container based on our PHP image
-# All PHP extensions (gd, mysqli, opcache, zip) are already included
+# WordPress container based on our PHP image.
+# Every PHP extension is inherited from the base image; none is installed here.
+# test.sh asserts the ones WordPress actually needs — mysqli, json, curl, gd,
+# zip, apcu and OPcache — so that list is checked rather than merely claimed.
+# OPcache is statically built in the base, so `php -m` spells it `Zend OPcache`
+# and never `opcache`, which is what made it look absent in #1017.
 ARG REMOTE_CR=ghcr.io/oorabona
 ARG PHP_TAG
 FROM ${REMOTE_CR}/php:${PHP_TAG}
@@ -30,23 +34,61 @@ RUN set -ex; \
 # PHP 7.2. If WordPress ever does need to override the base, the file has to sort
 # after php.ini to have any effect at all.
 
-# Install WP-CLI
-# Note: WP-CLI's bundled php-cli-tools triggers PHP 8.5 deprecation warnings
-# (upstream: github.com/wp-cli/php-cli-tools/issues/162).
-# Suppress E_DEPRECATED globally — standard practice for WordPress production
-# (WP core and plugins routinely emit deprecation notices).
+# Install WP-CLI. Its bundled react/promise emits a PHP 8.5 deprecation warning
+# on every invocation. The wrapper is a process-level suppression for WP-CLI,
+# not a production error-reporting policy: PHP-FPM keeps the base configuration.
+# The base policy is E_ALL & ~E_NOTICE; preserve that decision and subtract only
+# E_DEPRECATED rather than replacing the complete error-reporting mask.
+#
+# One thing this costs: `php /usr/local/bin/wp` stops working, that path being a
+# shell script now. Callers use `wp`, which is unaffected.
+#
+# `wp cli update` is unchanged by the wrapper and worth stating precisely, since
+# it is easy to get backwards: WP-CLI replaces realpath($_SERVER['argv'][0]),
+# which through the wrapper is the phar and not the wrapper (measured). So the
+# pinned phar stays as replaceable as it was before, no more and no less, and
+# for the same reason as before — `wordpress` may run it under passwordless
+# sudo. Run the container read-only if that matters to you; nothing about this
+# change makes it easier or harder.
+#
+# When a supported WP-CLI release stops emitting the warning, remove the wrapper
+# and move the phar back to /usr/local/bin/wp.
 ARG WPCLI_VERSION
 
 # Validate required build args
 RUN : "${WPCLI_VERSION:?required}"
 
+# The phar is fetched over TLS and then executed as root two lines later, so TLS
+# is authenticating the CDN rather than the artifact. Upstream publishes a
+# SHA-512 beside every release asset; check it before the file is ever run, and
+# fail the build if it does not match.
+#
+# Be clear about what that buys, because it is not everything: the digest comes
+# from the SAME release authority as the phar, so it catches a truncated or
+# corrupted download and an attacker who can alter one file but not the other —
+# and it does NOT survive a compromise of the release itself, which could serve
+# a matching pair. Closing that needs the signature upstream also publishes
+# (.asc) verified against a fingerprint pinned in this repository, the way #918
+# does for EasyRSA. Tracked in #1025.
 RUN set -ex; \
-    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 -o /usr/local/bin/wp https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar; \
-    chmod +x /usr/local/bin/wp; \
-    # Suppress deprecation warnings for CLI only (E_ALL & ~E_DEPRECATED = 22527)
-    echo 'error_reporting = E_ALL & ~E_DEPRECATED' > /usr/local/etc/php/conf.d/cli-no-deprecated.ini; \
-    # Verify WP-CLI works
-    wp --info --allow-root
+    rm -f /usr/local/etc/php/conf.d/cli-no-deprecated.ini; \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 -o /usr/local/bin/wp-cli.phar https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar; \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 -o /tmp/wp-cli.phar.sha512 https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar.sha512; \
+    expected_sha512="$(cat /tmp/wp-cli.phar.sha512)"; \
+    case "$expected_sha512" in \
+        *[!0-9a-fA-F]* | "") echo "wp-cli sha512 asset is not a hex digest" >&2; exit 1 ;; \
+    esac; \
+    echo "${expected_sha512}  /usr/local/bin/wp-cli.phar" | sha512sum -c -; \
+    rm -f /tmp/wp-cli.phar.sha512; \
+    printf '%s\n' \
+        '#!/bin/sh' \
+        'exec /usr/local/bin/php -d "error_reporting=E_ALL & ~E_NOTICE & ~E_DEPRECATED" \' \
+        '    /usr/local/bin/wp-cli.phar "$@"' \
+        > /usr/local/bin/wp; \
+    chown root:root /usr/local/bin/wp /usr/local/bin/wp-cli.phar; \
+    chmod 755 /usr/local/bin/wp /usr/local/bin/wp-cli.phar; \
+    # Verify WP-CLI works through the wrapper
+    /usr/local/bin/wp --info --allow-root
 
 # Copy entrypoint scripts
 # Named rather than globbed. This directory also holds test.sh, which the e2e

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -19,15 +19,16 @@ RUN set -ex; \
     echo "wordpress ALL=(ALL) NOPASSWD: /usr/local/bin/wp" > /etc/sudoers.d/wordpress; \
     chmod 440 /etc/sudoers.d/wordpress
 
-# WordPress-specific opcache settings (override defaults if needed)
-RUN { \
-        echo 'opcache.memory_consumption=128'; \
-        echo 'opcache.interned_strings_buffer=8'; \
-        echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=2'; \
-        echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
-    } > /usr/local/etc/php/conf.d/opcache-wordpress.ini
+# No opcache-wordpress.ini: the base image's conf.d/php.ini sets every key this
+# file used to set, and PHP reads conf.d alphabetically — "php.ini" after
+# "opcache-wordpress.ini" — so none of it ever applied. Verified on the published
+# image: it wrote memory_consumption=128 and the runtime reported 512.
+#
+# Nothing is lost by dropping it. The base is more generous everywhere the two
+# disagreed (512MB against 128, 20000 accelerated files against 4000) and
+# opcache.fast_shutdown, the one setting unique in spirit, has been a no-op since
+# PHP 7.2. If WordPress ever does need to override the base, the file has to sort
+# after php.ini to have any effect at all.
 
 # Install WP-CLI
 # Note: WP-CLI's bundled php-cli-tools triggers PHP 8.5 deprecation warnings

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -88,7 +88,7 @@ With `WP_AUTO_INSTALL=true`, the site is fully operational on first boot — no 
 
 - **Auto-install** — WordPress installs itself on first boot via wp-cli (idempotent)
 - **Security hardened** — `DISALLOW_FILE_MODS`, non-root user, no file editor
-- **Built on PHP image** — Inherits all PHP extensions (gd, mysqli, opcache, zip) from [ghcr.io/oorabona/php](../php/)
+- **Built on PHP image** — Inherits its PHP extensions (gd, mysqli, sodium, zip, apcu, OPcache) from [ghcr.io/oorabona/php](../php/)
 - **WP-CLI included** — Full command-line WordPress management
 - **Docker secrets** — All sensitive env vars support `_FILE` suffix
 - **Alpine-based** — Small image, fast startup
@@ -262,20 +262,28 @@ docker exec wordpress wp plugin status
 
 ## Performance
 
-### WordPress-Optimized OPcache
+OPcache and the PHP resource limits come from the base image's `conf.d/php.ini`; this image adds no tuning of its own. Read the values a given tag actually runs with rather than a copy of them:
 
-```ini
-opcache.memory_consumption=128
-opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=4000
-opcache.revalidate_freq=2
-opcache.fast_shutdown=1
-opcache.enable_cli=1
+```bash
+docker run --rm --entrypoint php ghcr.io/oorabona/wordpress:latest -r \
+  'foreach (["memory_limit","upload_max_filesize","post_max_size",
+             "opcache.memory_consumption","opcache.max_accelerated_files",
+             "opcache.validate_timestamps"] as $k) printf("%s=%s\n", $k, ini_get($k));'
 ```
 
-### PHP Resource Limits
+`opcache.validate_timestamps=0` is the one worth knowing about: PHP never re-checks a file's mtime, so changed code is picked up on container restart, not on save. That is the intended behaviour for an immutable image.
 
-Inherited from base PHP image: memory 512M, upload 64M, execution 300s. Override via custom PHP config mount.
+To override a setting, mount a `.ini` into `/usr/local/etc/php/conf.d/` read-only:
+
+```yaml
+volumes:
+  - ./php-overrides.ini:/usr/local/etc/php/conf.d/zz-overrides.ini:ro
+```
+
+Two things that bite:
+
+- **PHP reads that directory in alphabetical order and the base's file is named `php.ini`, so an override has to sort after it.** `zz-overrides.ini` applies. So does `wordpress.ini`, since `p` precedes `w`. What does not is anything sorting earlier — `00-overrides.ini`, `cli-tuning.ini`, `opcache-tuning.ini` — which is read and then overwritten by the base, silently. Two files in this image were written that way and neither ever took effect.
+- **`:ro` is not optional.** A bind mount is writable by default, and this one is PHP configuration the interpreter obeys — a WordPress process that can rewrite it can change how PHP runs, permanently, across restarts.
 
 ## Architecture
 
@@ -303,7 +311,7 @@ Inherited from base PHP image: memory 512M, upload 64M, execution 300s. Override
 ```
 Alpine Linux
   └── PHP-FPM (from oorabona/php)
-      ├── gd, mysqli, opcache, zip, apcu
+      ├── gd, mysqli, sodium, zip, apcu, OPcache
       └── WordPress
           ├── WordPress core (downloaded at build time)
           ├── WP-CLI

--- a/wordpress/test.sh
+++ b/wordpress/test.sh
@@ -45,6 +45,20 @@ if th_capture "WP-CLI loads the installed WordPress core" \
     fi
 fi
 
+# `wp core version` succeeds without a database, making it a real WP-CLI probe
+# whose stderr contains only diagnostics rather than the version it prints.
+if th_capture "WP-CLI command runs while diagnostics are captured" \
+        docker exec "$CONTAINER_NAME" sh -c \
+        'wp core version --path=/var/www/html --allow-root 2>&1 >/dev/null'; then
+    wp_stderr="$TH_OUTPUT"
+    # The wrapper exists to keep the react/promise PHP 8.5 deprecation out of
+    # the user-visible WP-CLI command, so any diagnostic is a regression.
+    th_assert_eq "WP-CLI writes no diagnostics to stderr" "$wp_stderr" ""
+else
+    th_skip "WP-CLI writes no diagnostics to stderr" \
+        "WP-CLI diagnostic probe did not run"
+fi
+
 # `wp core version` is a before_wp_load command: it reads wp-includes/version.php
 # and never loads WordPress, so it answers for a tree that is missing most of
 # core. The file check is what covers that, which is why it stays alongside.
@@ -87,22 +101,128 @@ if th_capture "php -m lists the loaded extensions" \
     # Everything the Dockerfile promises and a current build carries. `zip` and
     # `apcu` are here because a freshly pulled image has them — they were missing
     # only from an older pinned tag, so asserting them catches the silent-drop
-    # class (#996) rather than encoding a stale observation.
-    #
-    # OPcache is deliberately absent from this list and is NOT an oversight: the
-    # base has not shipped it since #996 removed it, while this image's Dockerfile
-    # still claims it and writes an opcache ini that configures nothing. Asserting
-    # it would fail every build until that contradiction is settled, which is
-    # #1017's job; asserting nothing at all is what let it go unnoticed.
-    for ext in mysqli json curl gd zip apcu; do
+    # class (#996) rather than encoding a stale observation. OPcache is inherited
+    # from the base image as a static build and `php -m` spells it `Zend OPcache`.
+    for ext in mysqli json curl gd zip apcu sodium; do
+        # The module list is line-oriented, so each ordinary extension must
+        # appear as its own complete line rather than as an incidental substring.
         if grep -qix "$ext" <<< "$TH_OUTPUT"; then
             th_pass "extension $ext is loaded"
         else
             th_fail "extension $ext is loaded" "not present in php -m"
         fi
     done
+
+    # OPcache uses PHP's `Zend OPcache` module name, not the `opcache` spelling
+    # used in configuration, so it needs an explicit whole-line check.
+    if grep -qix "Zend OPcache" <<< "$TH_OUTPUT"; then
+        th_pass "extension Zend OPcache is loaded"
+    else
+        th_fail "extension Zend OPcache is loaded" "not present in php -m"
+    fi
 else
     th_skip "the required extensions are loaded" "php -m did not run"
+fi
+
+th_group "WP-CLI error reporting"
+
+# This derives the expected WP-CLI mask from the live base PHP policy instead
+# of freezing an integer that would conceal a legitimate base-image policy change.
+if th_capture "PHP reports the base error-reporting mask" \
+        docker exec "$CONTAINER_NAME" php -r 'echo error_reporting() & ~E_DEPRECATED;'; then
+    expected_error_reporting="$TH_OUTPUT"
+
+    # The wrapper must remove deprecations from that live base policy and leave
+    # every other reporting bit unchanged.
+    if th_capture "WP-CLI reports its error-reporting mask" \
+            docker exec "$CONTAINER_NAME" wp eval 'echo error_reporting();' \
+            --skip-wordpress --allow-root; then
+        actual_error_reporting="$TH_OUTPUT"
+        th_assert_eq "WP-CLI subtracts only deprecations from the base policy" \
+            "$actual_error_reporting" "$expected_error_reporting"
+    else
+        th_skip "WP-CLI subtracts only deprecations from the base policy" \
+            "WP-CLI error-reporting probe did not run"
+    fi
+else
+    th_skip "WP-CLI subtracts only deprecations from the base policy" \
+        "base PHP error-reporting probe did not run"
+fi
+
+# The shared PHP configuration serves PHP-FPM too, so deprecations must remain
+# enabled for a plain PHP process. This is what fails if anyone reaches for the
+# `zz-` rename instead of the wrapper.
+#
+# PHP decides and reports through its EXIT STATUS rather than printing a number
+# for the host to compare. `th_assert_ge`/`th_assert_gt` evaluate their operand
+# in a Bash arithmetic context, where a value like `x[$(cmd)0]` coming out of
+# the container would run `cmd` on the host running this suite. Nothing here
+# needs a number, so nothing here produces one.
+if docker exec "$CONTAINER_NAME" \
+        php -r 'exit((error_reporting() & E_DEPRECATED) ? 0 : 1);' >/dev/null 2>&1; then
+    th_pass "shared PHP configuration still reports deprecations"
+else
+    th_fail "shared PHP configuration still reports deprecations" \
+        "a plain php process does not report E_DEPRECATED"
+fi
+
+# The two files this container used to write into conf.d both configured a PHP
+# that the base image's php.ini configures again afterwards, php.ini sorting
+# later. Their absence is the fix, so it is asserted by name.
+#
+# By NAME is the whole bound: this catches those two files coming back, not the
+# behaviour they had. A reintroduction under a name sorting after php.ini —
+# `zz-opcache.ini`, say — would actually take effect and would pass here. What
+# covers that case is the assertion below on an effective value, plus the mask
+# assertion above; between them the settings this image is documented to have
+# are checked directly rather than inferred from a directory listing.
+if th_capture "the container lists its PHP configuration directory" \
+        docker exec "$CONTAINER_NAME" ls -1 /usr/local/etc/php/conf.d/; then
+    conf_d_listing="$TH_OUTPUT"
+    for dead_ini in opcache-wordpress.ini cli-no-deprecated.ini; do
+        if grep -qix "$dead_ini" <<< "$conf_d_listing"; then
+            th_fail "conf.d carries no $dead_ini" "the file is back in conf.d"
+        else
+            th_pass "conf.d carries no $dead_ini"
+        fi
+    done
+else
+    th_skip "conf.d carries neither dead override" "the conf.d listing did not run"
+fi
+
+# README and the 2026-05-08 post both tell readers that changed code is picked
+# up on restart rather than on save. That is only true while the base keeps
+# opcache.validate_timestamps at 0, and nothing else in this suite would notice
+# it changing — so the documented promise is asserted here.
+if th_capture "PHP reports opcache.validate_timestamps" \
+        docker exec "$CONTAINER_NAME" php -r 'echo ini_get("opcache.validate_timestamps");'; then
+    th_assert_eq "opcache.validate_timestamps is 0, as the docs promise" \
+        "$TH_OUTPUT" "0"
+else
+    th_skip "opcache.validate_timestamps is 0, as the docs promise" \
+        "the opcache.validate_timestamps probe did not run"
+fi
+
+# Both probes above ask PHP-CLI, while what the documentation describes is
+# WordPress served through PHP-FPM. The two agree only because nothing overrides
+# these settings per pool — and the pool file DOES use that mechanism, carrying
+# php_admin_flag entries for log_errors and fastcgi.logging today. One line for
+# error_reporting or any opcache key would contradict the docs while every CLI
+# probe above stayed green, so the pool config is checked for exactly that
+# rather than left to a FastCGI request this suite has no client for.
+if th_capture "the pool configuration is readable" \
+        docker exec "$CONTAINER_NAME" sh -c \
+        'cat /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/*.conf'; then
+    if grep -qiE '^[[:space:]]*php_(admin_)?(value|flag)\[[[:space:]]*(error_reporting|opcache\.)' \
+            <<< "$TH_OUTPUT"; then
+        th_fail "no pool override contradicts the CLI-probed settings" \
+            "the FPM pool sets error_reporting or an opcache key per pool"
+    else
+        th_pass "no pool override contradicts the CLI-probed settings"
+    fi
+else
+    th_skip "no pool override contradicts the CLI-probed settings" \
+        "the pool configuration did not read"
 fi
 
 th_summary


### PR DESCRIPTION
Closes #1017

The image wrote two files into `/usr/local/etc/php/conf.d/` and neither ever took
effect. PHP reads that directory alphabetically and the base image ships its own
`php.ini` there, which sorts last — so `opcache-wordpress.ini` and
`cli-no-deprecated.ini` were both set and then overwritten. Measured on the built
image: the opcache file asked for `memory_consumption=128` while the runtime
reported `512`, and the deprecation file asked for `E_ALL & ~E_DEPRECATED` while
the runtime reported `30711`, deprecations included.

Deleting the opcache file changes nothing, which is the point — the base sets
every key it set, higher wherever the two disagreed.

The deprecation file is different, because the warning it was meant to hide is
real: WP-CLI's bundled `react/promise` emits one on every `wp` invocation,
including during `docker build`, and the entrypoint calls `wp` many times while
installing a site. Renaming it to sort later would apply it to PHP-FPM too,
silencing deprecations on the SAPI that serves traffic. So the phar moved to
`/usr/local/bin/wp-cli.phar` and `/usr/local/bin/wp` became a wrapper that sets
the mask for that one process — `E_ALL & ~E_NOTICE & ~E_DEPRECATED`, subtracting
deprecations from the base's policy rather than replacing it.

While rewriting that install line: the phar was fetched over TLS and executed as
root two lines later, so nothing authenticated the artifact. It is now checked
against the SHA-512 upstream publishes beside it, before it is ever run.

## Answering the issue's second question

A rebuilt image **does** carry `zip` and `apcu`. The published tag predates their
return in #996; nothing in this build drops them. OPcache is present too — PHP
8.5 builds it statically, so `php -m` spells it `Zend OPcache` and never
`opcache`, which is what made it look absent.

## What users see

`wp` no longer prints a deprecation warning on every call. The README stops
advertising OPcache tuning that never applied and resource limits that were never
right (512M/64M/300s against a measured 256M/100M/360s); it now says where the
values live, how to read them from a running image, and how to override one —
read-only, and sorting after `php.ini`. The same correction went to the
2026-05-08 post.

## Verification

- `./make build wordpress` green; the checksum step prints `OK`
- e2e `wordpress:7.0.2-alpine`: 18 passed, 1 skipped, 0 failed
- unit suite: 2229 collected, 0 failed
- `shellcheck -x -S warning wordpress/test.sh`: clean
- wrapper argv compared against a direct phar invocation: identical, including
  spaces, quotes, globs, leading dashes and an empty argument list
- `sudo /usr/local/bin/wp …` as user `wordpress`: rc 0, no stderr

Every assertion added here was run against a rebuilt image carrying the defect it
describes and seen to fail: restoring the phar and the dead ini fails three,
the `zz-` rename shortcut fails the one guarding PHP-FPM, a pool override fails
the one guarding the docs' promise, and a mismatched release digest fails the
build itself.

## Follow-ups filed rather than folded in

- #1024 — the shared test harness evaluates container output in a bash arithmetic
  context (six pre-existing callers; this suite no longer has one)
- #1025 — verify the phar against a pinned signing fingerprint rather than a
  same-origin digest
