### PR TITLE
test(e2e): close the windows where cleanup could not run

### DIFF
--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -210,6 +210,64 @@ sleep_within_readiness_deadline() {
     sleep "$requested"
 }
 
+# The container name is intentionally global: EXIT/INT/TERM traps run in the
+# shell process, after test_container's locals have gone out of scope. Clearing
+# it before returning makes cleanup safe to call on every path and makes the
+# eventual EXIT trap a no-op after each container in a multi-container suite.
+CLEANUP_CONTAINER_NAME=""
+# Where a probe's stderr is kept while its stdout stays the value. Removed by
+# cleanup_container, which runs on every path including the traps.
+READINESS_STDERR_FILE=""
+
+cleanup_container() {
+    local cleanup_name="$CLEANUP_CONTAINER_NAME"
+    local cleanup_output cleanup_status=0
+
+    CLEANUP_CONTAINER_NAME=""
+    trap - EXIT INT TERM
+
+    [ -n "${READINESS_STDERR_FILE:-}" ] && rm -f "$READINESS_STDERR_FILE"
+    READINESS_STDERR_FILE=""
+
+    [ -n "$cleanup_name" ] || return 0
+
+    cleanup_output=$(timeout -k 2 5 docker rm -f "$cleanup_name" 2>&1) || cleanup_status=$?
+    # `docker rm -f` reports an already-absent name as an error. That is the
+    # desired end state for an idempotent cleanup, unlike a timeout, a daemon
+    # failure, or a permission failure that can still leave it running.
+    if [ "$cleanup_status" -ne 0 ] && [[ "$cleanup_output" != *"No such container"* ]]; then
+        log_warning "$cleanup_name could not be removed and may still be running: $cleanup_output"
+        return 1
+    fi
+}
+
+# A readiness probe can fail because its bound fired or the daemon had a
+# transient problem; neither says anything about the container. These statuses
+# cannot be repaired by another poll, though: the command is unavailable or the
+# caller cannot use Docker. Docker reports the latter on stderr, which callers
+# pass here after capturing it.
+docker_readiness_failure_is_terminal() {
+    local status="$1"
+    local output="$2"
+
+    case "$status" in
+        126|127)
+            return 0
+            ;;
+        124|137)
+            return 1
+            ;;
+    esac
+
+    case "${output,,}" in
+        *"permission denied"*|*"operation not permitted"*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 # Test a single container (or variant)
 # Usage: test_container <container> [image_tag]
 test_container() {
@@ -244,8 +302,11 @@ test_container() {
     fi
     log_info "Using image: $image"
 
-    # Clean up any existing test container
-    docker rm -f "$container_name" 2>/dev/null || true
+    # Clean up any existing test container before reusing its fixed name.
+    CLEANUP_CONTAINER_NAME="$container_name"
+    if ! cleanup_container; then
+        return 1
+    fi
 
     # Start container with appropriate options
     log_info "Starting $container..."
@@ -298,6 +359,11 @@ test_container() {
         return 1
     fi
 
+    CLEANUP_CONTAINER_NAME="$container_name"
+    trap cleanup_container EXIT
+    trap 'cleanup_container; exit 130' INT
+    trap 'cleanup_container; exit 143' TERM
+
     # Wait for container to be ready (healthcheck or basic startup)
     log_info "Waiting for $container to be ready..."
     local start=$SECONDS
@@ -305,7 +371,8 @@ test_container() {
     local ready=false
     # Declared here, not on the assignment below: `local x=$(cmd)` returns the
     # builtin's status, which would swallow the one the loop condition reads.
-    local remaining health
+    local remaining health readiness_stderr
+    READINESS_STDERR_FILE=$(mktemp)
     # Whether an image with no healthcheck has already served its grace. It is
     # readiness only once the loop has come back around and seen the container
     # still listed: a container that dies during the grace is not ready, it is a
@@ -321,12 +388,20 @@ test_container() {
         # `-k` matters as much as the bound: plain `timeout` sends SIGTERM and then
         # waits forever for a child that ignores it, which is the hang this whole
         # change is about. The grace is what the wait can overshoot its budget by.
-        local names ps_status=0
-        names=$(timeout -k 2 "$remaining" docker ps --format '{{.Names}}' 2>/dev/null) || ps_status=$?
+        local names ps_output ps_status=0
+        ps_output=$(timeout -k 2 "$remaining" docker ps --format '{{.Names}}' \
+            2>"$READINESS_STDERR_FILE") || ps_status=$?
         if [ "$ps_status" -ne 0 ]; then
+            readiness_stderr=$(cat "$READINESS_STDERR_FILE" 2>/dev/null)
+            if docker_readiness_failure_is_terminal "$ps_status" "$readiness_stderr"; then
+                log_error "docker ps failed (exit $ps_status): $readiness_stderr"
+                cleanup_container
+                return 1
+            fi
             sleep_within_readiness_deadline 2 "$deadline" || true
             continue
         fi
+        names="$ps_output"
         # Fixed-string, whole-line, and fed from a here-string: a name is not a
         # pattern (docker allows `.` in one), and a pipeline whose producer is
         # still writing when `grep -q` exits on a match fails under `pipefail`,
@@ -334,6 +409,7 @@ test_container() {
         if ! grep -Fxq "$container_name" <<< "$names"; then
             log_error "$container exited unexpectedly"
             timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+            cleanup_container
             return 1
         fi
 
@@ -349,8 +425,20 @@ test_container() {
         remaining=$(readiness_remaining "$deadline") || break
         # The conditional template distinguishes a missing healthcheck from an
         # inspect failure; treating the latter as no healthcheck would fail open.
-        if ! health=$(timeout -k 2 "$remaining" docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' "$container_name" 2>/dev/null); then
+        local inspect_output inspect_status=0
+        inspect_output=$(timeout -k 2 "$remaining" docker inspect \
+            --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' \
+            "$container_name" 2>"$READINESS_STDERR_FILE") || inspect_status=$?
+        if [ "$inspect_status" -ne 0 ]; then
+            readiness_stderr=$(cat "$READINESS_STDERR_FILE" 2>/dev/null)
+            if docker_readiness_failure_is_terminal "$inspect_status" "$readiness_stderr"; then
+                log_error "docker inspect failed (exit $inspect_status): $readiness_stderr"
+                cleanup_container
+                return 1
+            fi
             health="unavailable"
+        else
+            health="$inspect_output"
         fi
 
         case "$health" in
@@ -361,8 +449,7 @@ test_container() {
             unhealthy)
                 log_error "$container is unhealthy"
                 timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
-                timeout -k 2 5 docker rm -f "$container_name" 2>/dev/null ||
-                log_warning "$container_name could not be removed and may still be running"
+                cleanup_container
                 return 1
                 ;;
             starting)
@@ -391,8 +478,7 @@ test_container() {
     if [ "$ready" != true ]; then
         log_error "$container did not become ready in time"
         timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
-        timeout -k 2 5 docker rm -f "$container_name" 2>/dev/null ||
-            log_warning "$container_name could not be removed and may still be running"
+        cleanup_container
         return 1
     fi
 
@@ -405,24 +491,26 @@ test_container() {
     if [ ! -e "$test_script" ]; then
         log_error "$container has no test script at ${test_script#"$REPO_ROOT"/}"
         log_error "Nothing container-specific would be verified — refusing to report success."
-        docker rm -f "$container_name" 2>/dev/null || true
+        cleanup_container
         return 1
     fi
     if [ ! -x "$test_script" ]; then
         log_error "${test_script#"$REPO_ROOT"/} is not executable, so it cannot run."
-        docker rm -f "$container_name" 2>/dev/null || true
+        cleanup_container
         return 1
     fi
 
     log_info "Running custom tests for $container..."
     if ! CONTAINER_NAME="$container_name" "$test_script"; then
         log_error "Custom tests failed for $container"
-        docker rm -f "$container_name" 2>/dev/null || true
+        cleanup_container
         return 1
     fi
 
     # Cleanup
-    docker rm -f "$container_name" 2>/dev/null || true
+    if ! cleanup_container; then
+        return 1
+    fi
 
     log_success "$container passed ✅"
     return 0

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -13,6 +13,8 @@
 # Set E2E_IMAGE=<image-ref> to test a preloaded image directly.
 # Set E2E_READY_TIMEOUT=<seconds> (1-99999, default 60) to give a container with a
 # slow healthcheck longer to report itself ready.
+# Set E2E_TEST_TIMEOUT=<seconds> (1-99999, default 600) to bound each
+# container-specific test suite.
 
 set -euo pipefail
 
@@ -50,6 +52,7 @@ while [[ $# -gt 0 ]]; do
             echo "Environment:"
             echo "  E2E_IMAGE            Test this image ref directly, skipping discovery"
             echo "  E2E_READY_TIMEOUT    Seconds a container gets to report ready (1-99999, default 60)"
+            echo "  E2E_TEST_TIMEOUT     Seconds each container-specific suite may run (1-99999, default 600)"
             echo ""
             echo "Examples:"
             echo "  $0                    # Test all containers"
@@ -77,6 +80,12 @@ fi
 READY_TIMEOUT="${E2E_READY_TIMEOUT:-60}"
 if ! [[ "$READY_TIMEOUT" =~ ^[1-9][0-9]{0,4}$ ]]; then
     log_error "E2E_READY_TIMEOUT must be a whole number of seconds between 1 and 99999 (got: $READY_TIMEOUT)"
+    exit 1
+fi
+
+TEST_TIMEOUT="${E2E_TEST_TIMEOUT:-600}"
+if ! [[ "$TEST_TIMEOUT" =~ ^[1-9][0-9]{0,4}$ ]]; then
+    log_error "E2E_TEST_TIMEOUT must be a whole number of seconds between 1 and 99999 (got: $TEST_TIMEOUT)"
     exit 1
 fi
 
@@ -232,11 +241,27 @@ cleanup_container() {
     [ -n "$cleanup_name" ] || return 0
 
     cleanup_output=$(timeout -k 2 5 docker rm -f "$cleanup_name" 2>&1) || cleanup_status=$?
-    # `docker rm -f` reports an already-absent name as an error. That is the
-    # desired end state for an idempotent cleanup, unlike a timeout, a daemon
-    # failure, or a permission failure that can still leave it running.
-    if [ "$cleanup_status" -ne 0 ] && [[ "$cleanup_output" != *"No such container"* ]]; then
+    # An already-absent name is the end state an idempotent cleanup wants, unlike a
+    # timeout, a daemon failure, or a permission failure that can leave the
+    # container running. Runtimes disagree on how they say it: Docker exits
+    # non-zero with "No such container", while Podman on this machine exits 0 and
+    # prints nothing, so it never reaches this test at all. Matched
+    # case-insensitively because the casing is one vendor's choice and not a
+    # contract — the same reason the readiness classifier lowercases its input.
+    #
+    # A removal that hit its own bound is never accepted on the strength of that
+    # phrase: 124 and 137 mean the removal did not finish, whatever it had printed
+    # before, so they stay reported rather than being read as an absent container.
+    if [ "$cleanup_status" -ne 0 ] \
+        && { [ "$cleanup_status" -eq 124 ] || [ "$cleanup_status" -eq 137 ] \
+            || [[ "${cleanup_output,,}" != *"no such container"* ]]; }; then
         log_warning "$cleanup_name could not be removed and may still be running: $cleanup_output"
+        # No retry, deliberately, and the container is then leaked: a loop around a
+        # `docker rm -f` that already failed under its own bound is more machinery
+        # than the leak is worth on runners that are thrown away anyway. Nor does
+        # keeping the name buy anything — the traps are cleared just above, so
+        # nothing would run to use it, and the next container overwrites it. The
+        # warning naming the survivor is the whole of the report, on purpose.
         return 1
     fi
 }
@@ -308,6 +333,14 @@ test_container() {
         return 1
     fi
 
+    CLEANUP_CONTAINER_NAME="$container_name"
+    trap cleanup_container EXIT
+    # Cleanup failure is already reported by cleanup_container itself. The status
+    # here belongs to the caller's signal, so make cleanup non-fatal and preserve
+    # the promised signal exit rather than replacing it with that failure.
+    trap 'cleanup_container || true; exit 130' INT
+    trap 'cleanup_container || true; exit 143' TERM
+
     # Start container with appropriate options
     log_info "Starting $container..."
     local run_opts="--rm -d --name $container_name"
@@ -354,15 +387,18 @@ test_container() {
             ;;
     esac
 
-    if ! docker run $run_opts "$image" $run_cmd; then
+    # A signal cannot run this shell's trap while a foreground command is active,
+    # so this bound is what stops docker run deferring cleanup indefinitely over a
+    # container it may already have created. It is creation, not readiness:
+    # measured at ~0.7s for these images, so the budget is wide enough that only a
+    # genuine hang or an image this harness expected to be local and is silently
+    # pulling can reach it — and turning a pull into "Failed to start" would be a
+    # worse failure than the wait.
+    if ! timeout -k 5 120 docker run $run_opts "$image" $run_cmd; then
         log_error "Failed to start $container"
+        cleanup_container
         return 1
     fi
-
-    CLEANUP_CONTAINER_NAME="$container_name"
-    trap cleanup_container EXIT
-    trap 'cleanup_container; exit 130' INT
-    trap 'cleanup_container; exit 143' TERM
 
     # Wait for container to be ready (healthcheck or basic startup)
     log_info "Waiting for $container to be ready..."
@@ -372,7 +408,16 @@ test_container() {
     # Declared here, not on the assignment below: `local x=$(cmd)` returns the
     # builtin's status, which would swallow the one the loop condition reads.
     local remaining health readiness_stderr
-    READINESS_STDERR_FILE=$(mktemp)
+    # Status only — mktemp's stderr is deliberately NOT folded into the value. A
+    # capture that merges stderr into a variable is poisoned by anything the tool
+    # writes there on success, which is how a CLI that greets on stderr corrupts
+    # the one thing it was asked for. mktemp's own diagnostic still reaches the
+    # harness's stderr and so the run log; it just never reaches this path.
+    if ! READINESS_STDERR_FILE=$(mktemp); then
+        log_error "Harness could not allocate its readiness stderr temp file"
+        cleanup_container
+        return 1
+    fi
     # Whether an image with no healthcheck has already served its grace. It is
     # readiness only once the loop has come back around and seen the container
     # still listed: a container that dies during the grace is not ready, it is a
@@ -501,8 +546,30 @@ test_container() {
     fi
 
     log_info "Running custom tests for $container..."
-    if ! CONTAINER_NAME="$container_name" "$test_script"; then
-        log_error "Custom tests failed for $container"
+    # The suite is invoked directly, so `timeout` monitors the suite itself and its
+    # `-k` escalation lands on the process that is actually hanging.
+    #
+    # Which means 124 and 137 are ambiguous, and the message below does not pretend
+    # otherwise. `timeout` returns its command's own status when the deadline did
+    # not fire, and web-shell/test.sh runs `timeout` and can propagate exactly
+    # those. Two ways to resolve that ambiguity were built and both were worse than
+    # the ambiguity: comparing elapsed whole seconds is an inference that misreads a
+    # suite exiting across a tick, and having the suite record its own status through
+    # a wrapper put `bash -c` between `timeout` and the suite — so the bound killed
+    # the wrapper, `-k` never reached the suite, and a TERM-ignoring suite outlived
+    # the thing meant to bound it. The report states the status and what could have
+    # produced it, which is what is actually known.
+    local test_status=0
+    CONTAINER_NAME="$container_name" timeout -k 5 "$TEST_TIMEOUT" "$test_script" || test_status=$?
+    if [ "$test_status" -ne 0 ]; then
+        case "$test_status" in
+            124|137)
+                log_error "Custom tests failed for $container (exit $test_status — the ${TEST_TIMEOUT}s bound reports 124, or 137 after its kill grace, and a suite can also return either itself)"
+                ;;
+            *)
+                log_error "Custom tests failed for $container (exit $test_status)"
+                ;;
+        esac
         cleanup_container
         return 1
     fi

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -9,7 +9,8 @@ setup() {
     # that runs the suite would otherwise steer the stub through tests that never
     # asked for it.
     unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
-        DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_IMAGES_OUTPUT
+        DOCKER_INSPECT_ERROR DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR \
+        DOCKER_IMAGES_OUTPUT
     # Each bats test is its own process, so it inherits these from the shell that
     # launched the suite: an exported E2E_IMAGE walks straight past the discovery
     # tests, and a different owner invalidates the ambiguous-image fixture.
@@ -24,7 +25,7 @@ setup() {
 
 teardown() {
     export PATH="$ORIG_PATH"
-    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT PS_COUNT_FILE TEST_SCRIPT_MARKER
+    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR PS_COUNT_FILE TEST_SCRIPT_MARKER
     teardown_temp_dir
 }
 
@@ -49,12 +50,41 @@ case "$1" in
         printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}"
         ;;
     inspect)
+        inspect_format=""
+        shift
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --format)
+                    inspect_format="$2"
+                    shift 2
+                    ;;
+                --format=*)
+                    inspect_format="${1#--format=}"
+                    shift
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        if [ "$inspect_format" != '{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' ]; then
+            printf 'unexpected inspect format: %s\n' "$inspect_format" >&2
+            exit 64
+        fi
+        inspect_exit="${DOCKER_INSPECT_EXIT:-0}"
+        if [ "$inspect_exit" -ne 0 ]; then
+            printf '%s\n' "${DOCKER_INSPECT_ERROR:-inspect failed}" >&2
+            exit "$inspect_exit"
+        fi
         printf '%s\n' "${DOCKER_INSPECT_OUTPUT:-nohealth}"
-        exit "${DOCKER_INSPECT_EXIT:-0}"
         ;;
     ps)
+        ps_exit="${DOCKER_PS_EXIT:-0}"
+        if [ "$ps_exit" -ne 0 ]; then
+            printf '%s\n' "${DOCKER_PS_ERROR:-ps failed}" >&2
+            exit "$ps_exit"
+        fi
         printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}"
-        exit "${DOCKER_PS_EXIT:-0}"
         ;;
     rm|run|logs|exec)
         exit 0
@@ -148,6 +178,25 @@ SH
 
     [ "$status" -ne 0 ]
     [[ "$output" == *"not executable"* ]]
+}
+
+@test "a TERM after docker run removes the active container through the trap" {
+    add_openvpn_fixture
+    cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
+#!/bin/bash
+kill -TERM "$PPID"
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    # The first removal clears a possible stale name before docker run; the
+    # second proves the TERM trap removed the newly started one.
+    [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
 }
 
 @test "fallback image discovery errors on zero matches" {
@@ -426,27 +475,87 @@ STUB
     [ ! -e "$TEST_SCRIPT_MARKER" ]
 }
 
+@test "every docker call in the wait and the cleanup is bounded" {
+    # The property, not the spelling. An earlier version pinned whole source
+    # lines verbatim, which broke on reformatting and — worse — had baked the
+    # probes' `2>&1` into the expectation, so it was holding a defect in place.
+    #
+    # Two ways a bound can be missing: a `timeout` that lost its -k, and a
+    # wrapper deleted outright. Requiring every docker-invoking line to carry
+    # `timeout -k` catches both, because a deleted wrapper leaves the docker call
+    # behind on a line that no longer matches.
+    run bash -c '
+        source_file="$1"
+        # Lines that invoke docker as a command, ignoring comments, log text and
+        # the readiness stderr messages that merely name it.
+        unbounded=$(grep -nE "^[^#]*(^|[^a-zA-Z_-])docker[[:space:]]" "$source_file" |
+            grep -vE "timeout -k" |
+            grep -vE "log_error|log_warning|printf|echo")
+        # Deliberately unbounded, each for a stated reason:
+        #   docker images  — local discovery before anything is started
+        #   docker run     — the start itself; nothing to clean up if it hangs
+        allowed="docker images|docker run"
+        offenders=$(printf "%s\n" "$unbounded" | grep -vE "$allowed" | grep -c . || true)
+        if [ "$offenders" -ne 0 ]; then
+            printf "%s\n" "$unbounded" | grep -vE "$allowed" >&2
+            exit 1
+        fi
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "no timeout call omits its kill-after grace" {
-    # A plain `timeout` sends SIGTERM and then waits forever for a child that
-    # ignores it, so a bound without -k is not a bound. This checks exactly that
-    # — every `timeout` here passes -k — and not the broader claim that every
-    # docker call is bounded; the cleanup calls outside the wait are not, which
-    # is #1007. Structural because reproducing a TERM-resistant docker would
-    # demonstrate coreutils' behaviour rather than this script's — and blind to a
-    # wrapper deleted outright, which is #1008.
-    # Every line that invokes it must carry -k, rather than only rejecting a
-    # bound whose next character is not a hyphen: `timeout -s TERM 5 …` and
-    # `timeout --verbose 5 …` pass that weaker check while omitting the grace.
-    # The path is an argument, not interpolated into the program: a checkout whose
-    # path contains a quote would otherwise change what this runs. A grep that
-    # errors is not the same as one that found nothing, so the two statuses are
-    # told apart rather than both counting as a pass.
+    # A bound without -k is not a bound: plain `timeout` sends SIGTERM and then
+    # waits forever for a child that ignores it.
     run bash -c '
         matches=$(grep -nE "^[^#]*\btimeout\b" "$1") || exit 3
         printf "%s\n" "$matches" | grep -vE "(^|[[:space:]])-k[[:space:]]"
     ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
 
     [ "$status" -eq 1 ]
+}
+
+@test "a docker command missing from PATH stops readiness immediately and reports stderr" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=60
+    export DOCKER_PS_OUTPUT=""
+    export DOCKER_PS_ERROR="docker: command not found"
+    export DOCKER_PS_EXIT=127
+
+    local before=$SECONDS
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+    local elapsed=$((SECONDS - before))
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"docker ps failed (exit 127): docker: command not found"* ]]
+    [[ "$output" != *"did not become ready in time"* ]]
+    [ "$elapsed" -lt 10 ]
+}
+
+@test "a Docker permission error stops inspect readiness immediately and reports stderr" {
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=60
+    export DOCKER_INSPECT_OUTPUT=""
+    export DOCKER_INSPECT_ERROR="permission denied while trying to connect to the Docker daemon socket"
+    export DOCKER_INSPECT_EXIT=1
+
+    local before=$SECONDS
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+    local elapsed=$((SECONDS - before))
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"docker inspect failed (exit 1): permission denied while trying to connect to the Docker daemon socket"* ]]
+    [[ "$output" != *"did not become ready in time"* ]]
+    [ "$elapsed" -lt 10 ]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
 }
 
 @test "a timeout that cannot bound anything is refused before the container starts" {
@@ -464,6 +573,37 @@ STUB
     [ "$status" -ne 0 ]
     [[ "$output" == *"accepting -k"* ]]
     [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "a docker CLI that chatters on stderr does not poison the health value" {
+    # podman's docker shim prints "Emulate Docker CLI using podman…" to stderr on
+    # every call. Merging that into the captured value makes $health neither
+    # nohealth nor a status, so the wait matches no arm and polls to its budget —
+    # and real Docker says nothing there, so this passes CI and breaks everyone
+    # running podman.
+    add_openvpn_fixture
+    install_docker_stub
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+echo "Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg." >&2
+case "$1" in
+    images)  printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)      printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
+    inspect) printf '%s\n' "nohealth" ;;
+    *)       exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"did not become ready in time"* ]]
+    [ "$(cat "$TEST_SCRIPT_MARKER")" = "e2e-openvpn" ]
 }
 
 @test "a healthy inspect result proceeds to the per-container suite" {

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -8,9 +8,9 @@ setup() {
     # Cleared going in, not just coming out: one of these exported in the shell
     # that runs the suite would otherwise steer the stub through tests that never
     # asked for it.
-    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
+    unset E2E_IMAGE E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
         DOCKER_INSPECT_ERROR DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR \
-        DOCKER_IMAGES_OUTPUT
+        DOCKER_IMAGES_OUTPUT DOCKER_RM_FAIL_ON_SECOND
     # Each bats test is its own process, so it inherits these from the shell that
     # launched the suite: an exported E2E_IMAGE walks straight past the discovery
     # tests, and a different owner invalidates the ambiguous-image fixture.
@@ -25,7 +25,7 @@ setup() {
 
 teardown() {
     export PATH="$ORIG_PATH"
-    unset E2E_IMAGE E2E_READY_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR PS_COUNT_FILE TEST_SCRIPT_MARKER
+    unset E2E_IMAGE E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR DOCKER_RM_FAIL_ON_SECOND PS_COUNT_FILE TEST_SCRIPT_MARKER RUN_STARTED TEST_SUITE_STARTED HARNESS_PID_FILE
     teardown_temp_dir
 }
 
@@ -38,6 +38,28 @@ assert_harness_failed_on_its_own() {
     [ "$status" -ne 0 ]
     [ "$status" -ne 124 ]
     [ "$status" -ne 137 ]
+}
+
+# The signal fixtures run the harness beneath an outer watchdog. A missing
+# marker used to leave them polling after that watchdog had exited, so fail the
+# test itself instead of turning a harness crash into a stuck bats worker.
+wait_for_marker() {
+    local marker="$1"
+    local watchdog_pid="$2"
+    local path_description="$3"
+    local marker_deadline=$((SECONDS + 10))
+
+    while [ ! -e "$marker" ]; do
+        if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+            printf '%s marker was never written: outer watchdog exited\n' "$path_description" >&2
+            return 1
+        fi
+        if [ "$SECONDS" -ge "$marker_deadline" ]; then
+            printf '%s marker was not written within 10 seconds\n' "$path_description" >&2
+            return 1
+        fi
+        /bin/sleep 0.05
+    done
 }
 
 install_docker_stub() {
@@ -86,7 +108,15 @@ case "$1" in
         fi
         printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}"
         ;;
-    rm|run|logs|exec)
+    rm)
+        # Signal fixtures make their trapped removal fail so the asserted status
+        # proves the handler reached its explicit exit rather than falling out.
+        if [ "${DOCKER_RM_FAIL_ON_SECOND:-false}" = true ] && [ "$(grep -c '^rm ' "${DOCKER_LOG:?}")" -eq 2 ]; then
+            exit 1
+        fi
+        exit 0
+        ;;
+    run|logs|exec)
         exit 0
         ;;
     *)
@@ -180,23 +210,148 @@ SH
     [[ "$output" == *"not executable"* ]]
 }
 
-@test "a TERM after docker run removes the active container through the trap" {
+@test "a TERM while docker run is still returning removes the active container through the armed trap" {
+    # #1008: docker run creates the detached container before it returns. The old
+    # trap was armed after that return, so a TERM in this window left the newly
+    # created container behind; the marker below stands in for that creation.
+    add_openvpn_fixture
+    install_docker_stub
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+case "$1" in
+    run)
+        : > "${RUN_STARTED:?}"
+        /bin/sleep 2
+        ;;
+    rm)
+        # The stale-name cleanup succeeds; the signal-path removal fails. This
+        # makes the status assertion below red against the old fatal handler.
+        if [ "$(grep -c '^rm ' "${DOCKER_LOG:?}")" -eq 2 ]; then
+            exit 1
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export RUN_STARTED="$TEST_TEMP_DIR/container-created"
+    export HARNESS_PID_FILE="$TEST_TEMP_DIR/harness.pid"
+
+    timeout -k 2 15 bash -c 'printf "%s\\n" "$$" > "$1"; shift; exec "$@"' _ \
+        "$HARNESS_PID_FILE" "$FIXTURE_REPO/tests/e2e-test.sh" openvpn > "$TEST_TEMP_DIR/harness.out" 2>&1 &
+    local watchdog_pid=$!
+    if ! wait_for_marker "$RUN_STARTED" "$watchdog_pid" "docker run signal fixture"; then
+        kill "$watchdog_pid" 2>/dev/null || true
+        wait "$watchdog_pid" 2>/dev/null || true
+        return 1
+    fi
+    # Signal the harness PID only. The test is specifically not relying on a
+    # terminal-style process-group signal to interrupt docker run for us.
+    kill -TERM "$(cat "$HARNESS_PID_FILE")"
+    local watchdog_status=0
+    wait "$watchdog_pid" || watchdog_status=$?
+
+    # The first removal clears a possible stale name before docker run; the
+    # second proves the armed TERM trap removed the newly started one. Before
+    # #1008 this was one: the signal arrived before any trap existed.
+    [ "$watchdog_status" -eq 143 ]
+    [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
+}
+
+@test "a TERM during a hanging custom suite reaches cleanup once its bound ends" {
+    # #1007: Bash defers a TERM trap while the foreground suite runs. Without
+    # this bound, signalling only the harness PID leaves both it and its named
+    # container stuck forever; the outer watchdog makes that regression fail.
     add_openvpn_fixture
     cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
 #!/bin/bash
-kill -TERM "$PPID"
+: > "${TEST_SUITE_STARTED:?}"
+while :; do /bin/sleep 1; done
 SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_TEST_TIMEOUT=1
+    export HARNESS_PID_FILE="$TEST_TEMP_DIR/harness.pid"
+    export TEST_SUITE_STARTED="$TEST_TEMP_DIR/custom-suite-started"
+    export DOCKER_RM_FAIL_ON_SECOND=true
+
+    local before=$SECONDS
+    timeout -k 2 15 bash -c 'printf "%s\\n" "$$" > "$1"; shift; exec "$@"' _ \
+        "$HARNESS_PID_FILE" "$FIXTURE_REPO/tests/e2e-test.sh" openvpn > "$TEST_TEMP_DIR/harness.out" 2>&1 &
+    local watchdog_pid=$!
+    if ! wait_for_marker "$TEST_SUITE_STARTED" "$watchdog_pid" "custom-suite signal fixture"; then
+        kill "$watchdog_pid" 2>/dev/null || true
+        wait "$watchdog_pid" 2>/dev/null || true
+        return 1
+    fi
+    # This is intentionally the script PID, not the foreground process group.
+    kill -TERM "$(cat "$HARNESS_PID_FILE")"
+    local watchdog_status=0
+    wait "$watchdog_pid" || watchdog_status=$?
+    local elapsed=$((SECONDS - before))
+
+    [ "$watchdog_status" -eq 143 ]
+    [ "$elapsed" -lt 13 ]
+    # As above, one removal is stale-name cleanup; the other is the deferred TERM
+    # trap after timeout has ended the otherwise infinite suite.
+    [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
+}
+
+@test "a hanging custom suite is stopped by the bound and names it in the report" {
+    # #1007: the point of the bound is that a suite which never returns still ends,
+    # and that the report says what happened. It does not say "timed out" as a
+    # fact — see the sibling test below for why the harness cannot know that from
+    # the status alone — but the bound has to be named, or an operator reading
+    # "exit 124" has nothing to go on.
+    add_openvpn_fixture
+    cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
+#!/bin/bash
+while :; do /bin/sleep 1; done
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_TEST_TIMEOUT=1
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
     assert_harness_failed_on_its_own
-    # The first removal clears a possible stale name before docker run; the
-    # second proves the TERM trap removed the newly started one.
+    [[ "$output" == *"Custom tests failed for openvpn (exit 124"* ]]
+    [[ "$output" == *"1s bound"* ]]
     [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
+}
+
+@test "a custom suite returning 124 is not asserted to have timed out" {
+    # `timeout` preserves its command's status when its deadline did not fire, and
+    # web-shell/test.sh runs `timeout` and can propagate 124 without having timed
+    # out. The harness cannot tell the two apart from the status alone — every
+    # mechanism tried for that cost more than the ambiguity — so what is locked
+    # here is that it does not CLAIM to: the status is reported, the bound is
+    # offered as one cause among others, and nothing states a timeout as fact.
+    add_openvpn_fixture
+    cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
+#!/bin/bash
+exit 124
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_TEST_TIMEOUT=10
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Custom tests failed for openvpn (exit 124"* ]]
+    [[ "$output" != *"Custom tests timed out for openvpn"* ]]
 }
 
 @test "fallback image discovery errors on zero matches" {
@@ -475,6 +630,30 @@ STUB
     [ ! -e "$TEST_SCRIPT_MARKER" ]
 }
 
+@test "a failed readiness stderr allocation reports the harness failure" {
+    # #1009: readiness stderr classifies terminal Docker failures. Falling back
+    # to an empty filename turns mktemp's own failure into repeated transient
+    # probes, ending with the false claim that the container was merely slow.
+    add_openvpn_fixture
+    install_docker_stub
+    printf '#!/bin/bash\nprintf "mktemp: fixture allocation failed\\n" >&2\nexit 1\n' > "$TEST_TEMP_DIR/bin/mktemp"
+    chmod +x "$TEST_TEMP_DIR/bin/mktemp"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_READY_TIMEOUT=1
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"Harness could not allocate its readiness stderr temp file"* ]]
+    # mktemp's own diagnostic reaches the log on its own stderr rather than being
+    # folded into the harness's value, so both are present and neither depends on
+    # a capture that a chatty tool could poison.
+    [[ "$output" == *"mktemp: fixture allocation failed"* ]]
+    [[ "$output" != *"did not become ready in time"* ]]
+    [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
+}
+
 @test "every docker call in the wait and the cleanup is bounded" {
     # The property, not the spelling. An earlier version pinned whole source
     # lines verbatim, which broke on reformatting and — worse — had baked the
@@ -491,10 +670,9 @@ STUB
         unbounded=$(grep -nE "^[^#]*(^|[^a-zA-Z_-])docker[[:space:]]" "$source_file" |
             grep -vE "timeout -k" |
             grep -vE "log_error|log_warning|printf|echo")
-        # Deliberately unbounded, each for a stated reason:
+        # Deliberately unbounded, for a stated reason:
         #   docker images  — local discovery before anything is started
-        #   docker run     — the start itself; nothing to clean up if it hangs
-        allowed="docker images|docker run"
+        allowed="docker images"
         offenders=$(printf "%s\n" "$unbounded" | grep -vE "$allowed" | grep -c . || true)
         if [ "$offenders" -ne 0 ]; then
             printf "%s\n" "$unbounded" | grep -vE "$allowed" >&2
@@ -633,6 +811,22 @@ STUB
     [[ "$output" == *"between 1 and 99999"* ]]
     # Rejecting it after `docker run` would strand the container: --rm removes it
     # when it stops, and nothing stops it on this path.
+    [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "an invalid E2E_TEST_TIMEOUT is rejected before anything is started" {
+    # #1007: this value bounds a foreground suite that can otherwise defer the
+    # cleanup trap indefinitely, so it must be rejected before docker run.
+    add_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_TEST_TIMEOUT=zero
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"E2E_TEST_TIMEOUT must be a whole number of seconds between 1 and 99999"* ]]
     [ ! -s "$DOCKER_LOG" ]
 }
 


### PR DESCRIPTION
Closes #1007
Closes #1008
Closes #1009

Cleanup in the e2e harness existed in seven places, five of them bare
`docker rm -f … || true`, and none of it ran on a signal — so an interrupted run
left the container behind and a removal that failed said nothing. There is now
one bounded, idempotent cleanup installed on EXIT/INT/TERM, cleared as it runs so
the next container in a multi-container run re-arms it, and a removal that fails
is reported.

Three windows where that still could not run are closed here.

**The trap was armed too late.** `docker run --rm -d` creates the container
before it returns, so a signal in that window orphaned it — the exact case the
trap exists for. Arming moved ahead of the run. That in turn invalidated the
reason `docker run` was exempt from the "every docker call is bounded" rule
("nothing to clean up if it hangs" was true only while nothing was armed), so it
is bounded now and the exemption list says so.

**The per-container suite was unbounded.** Bash runs no trap while a foreground
command is active — measured: SIGTERM at t=2s ran the handler at t=12s, after a
foreground `sleep 12` returned, and at t=4s when the same command was wrapped in
`timeout -k 2 4`. A suite that hung forever therefore meant cleanup never.
`E2E_TEST_TIMEOUT` bounds it, defaulting to 600s — openvpn alone sets a
150-second deadline internally and keeps asserting after it, and a bound that
fires on a healthy run costs more than the hang it prevents.

**An unchecked `mktemp` was lying about the container.** With an empty filename
the readiness probe's redirect fails with status 1, which is not in the terminal
set, so the loop retried to the deadline and reported that the container had not
become ready — blaming the container for the harness's own broken temp file.

Also here: the INT/TERM handlers no longer lose the exit status they promise (a
failing cleanup ended them at 1 under `set -e`), and the signal tests assert that
status with a fixture whose removal fails, so they can no longer pass by reaching
the ordinary cleanup that produces the same number of removals.

## On what the harness does not claim

`timeout` returns its command's own status when the deadline did not fire, and
`web-shell/test.sh` runs `timeout` and can propagate 124. Two mechanisms for
telling those apart were built and both removed: comparing elapsed whole seconds
is an inference that misreads a suite exiting across a tick, and having the suite
record its own status put a wrapper between `timeout` and the suite that absorbed
the bound — measured, a TERM-ignoring suite outlived it. The report states the
exit status and names the bound as one thing that produces it.

## Verification

- `shellcheck -x -S warning tests/e2e-test.sh`: clean
- `bats tests/unit/e2e-test.bats`: 30 passed
- unit suite: 2232 collected, 0 failed
- real e2e against a real image passes and leaves no container behind

Every assertion added here was run against the defect it names and seen to fail,
one mutation at a time, with the file restored between each.

## Follow-ups filed rather than folded in

- #1026 — the readiness classifier fails open, so an unrecognised Docker error
  still reads as a slow container
- #1027 — signals and bounds address single processes where they mean process
  trees
- #1028 — the two structural tests policing this file's bounding discipline do
  not enforce the properties they name
