### PR TITLE
fix(ci): report why a version script failed instead of only that it did

### DIFF
--- a/validate-version-scripts.sh
+++ b/validate-version-scripts.sh
@@ -44,36 +44,59 @@ execute_with_retry() {
     local retry_count=0
     local result=""
     local exit_code=0
-    
+    local stderr_file script_error=""
+
+    # version.sh's own stderr is the only thing that says WHY it failed. Without
+    # it a network outage, a rate limit, a parse failure and an outright broken
+    # script all reach the caller as the same empty value, and the operator is
+    # left re-running and hoping. It goes to a FILE rather than into the value:
+    # merging stderr into a capture poisons the version string with anything the
+    # script writes there on a successful run.
+    #
+    # The reports below are safe inside a command substitution because every
+    # logging helper writes to stderr, which passes through untouched — only
+    # stdout is captured, and stdout here is the version.
+    if ! stderr_file=$(mktemp); then
+        log_error "$container ($mode): cannot allocate a temp file for version.sh's error output"
+        echo ""
+        return 1
+    fi
+
     while [ $retry_count -lt $MAX_RETRIES ]; do
-        if [ "$mode" = "current" ]; then
-            result=$(timeout "$timeout" bash version.sh 2>/dev/null)
-            exit_code=$?
-        else
-            result=$(timeout "$timeout" bash version.sh 2>/dev/null)
-            exit_code=$?
-        fi
-        
+        result=$(timeout "$timeout" bash version.sh 2>"$stderr_file")
+        exit_code=$?
+        script_error=$(cat "$stderr_file" 2>/dev/null)
+
         # Handle special case for no published version
         if [[ "$result" == "no-published-version" ]]; then
+            rm -f "$stderr_file"
             echo "$result"
             return 2  # Special return code for no published version
         fi
-        
+
         # Check if result is valid
         if [[ $exit_code -eq 0 && -n "$result" && "$result" != "null" && "$result" != "unknown" ]]; then
+            rm -f "$stderr_file"
             echo "$result"
             return 0
         fi
-        
+
         retry_count=$((retry_count + 1))
         if [ $retry_count -lt $MAX_RETRIES ]; then
-            log_warning "Retry $retry_count/$MAX_RETRIES for $container ($mode mode) - got: '$result'"
+            log_warning "Retry $retry_count/$MAX_RETRIES for $container ($mode mode) - exit $exit_code, got: '$result'"
+            [ -n "$script_error" ] && log_warning "  version.sh said: $script_error"
             sleep $RETRY_DELAY
         fi
     done
-    
-    # All retries exhausted
+
+    rm -f "$stderr_file"
+    # All retries exhausted. The last attempt's reason is what turns this from a
+    # re-run-and-hope into a diagnosis, so it is reported rather than dropped.
+    if [ -n "$script_error" ]; then
+        log_error "$container ($mode): version.sh failed (exit $exit_code): $script_error"
+    else
+        log_error "$container ($mode): version.sh failed (exit $exit_code) and wrote nothing to stderr"
+    fi
     echo ""
     return 1
 }


### PR DESCRIPTION
Addresses part of #1023 — deliberately does not close it, see below.

`validate-version-scripts` ran `bash version.sh 2>/dev/null`, so the only thing
that could explain a failure was discarded before anyone could read it. A network
outage, a rate limit, a parse failure and an outright broken script all reached
the operator as the same line:

```
❌ Failed to get current version after 3 retries
```

with `got: ''` in every retry warning. That is what happened on #1021: the
trigger was transient upstream unreachability, the retry did its job, and the
failure was still undiagnosable — re-running was the only way to learn anything.

`version.sh`'s stderr is now captured and reported, on each retry and once more
at the end with the last attempt's message and exit status. When the script fails
and says nothing at all, the report says that too, which is a different and
equally useful fact.

The capture goes to a file rather than into the value. Merging stderr into a
command substitution poisons the version string with whatever a script writes
there on a **successful** run — not hypothetical here, a CLI that greets on
stderr has produced exactly that defect in this repo before.

## What this does not fix

`execute_with_retry` still branches on `current` versus `latest` and both arms
run the identical command, so the version-difference comparison downstream
compares a value with itself and can never fire. Whichever mode was meant to ask
for something other than the default has never asked for it.

Which one that should be is a question about what this check is *for*, not a
defect with an obvious fix: `upstream-monitor` already compares declared against
upstream and `check-version-drift` compares declared against published, so the
only comparison missing is published-against-upstream. #1023 stays open for that
decision. This change is the half that makes the next failure legible — which is
also what will make the dead branch visible the next time it matters.

## Verification

- unit suite: 2229 collected, 0 failed
- `shellcheck -x -S warning validate-version-scripts.sh`: clean
- a `version.sh` that fails with a message: the message reaches the operator, on
  each retry and in the final report
- a `version.sh` that writes to stderr and then succeeds: still yields a clean
  version string, unpoisoned
