### PR TITLE
docs(postgres): correct the documented tag order to the one the build emits

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -212,12 +212,12 @@ versions:
 ### Output Tags
 
 ```
-<major_version><variant_suffix><base_suffix>
+<major_version><base_suffix><variant_suffix>
 
 Examples:
   17-alpine           (base variant)
-  17-vector-alpine    (vector variant)
-  17-full-alpine      (full variant)
+  17-alpine-vector    (vector variant)
+  17-alpine-full      (full variant)
 ```
 
 ### Adding a New Variant

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -265,7 +265,7 @@ requires_extensions() {
 
 # Generate image tag for a variant
 # Usage: variant_image_tag <pg_version> <variant_name> <container_dir>
-# Example: variant_image_tag "17" "vector" "./postgres" -> "17-vector-alpine"
+# Example: variant_image_tag "17" "vector" "./postgres" -> "17-alpine-vector"
 variant_image_tag() {
     local pg_version="$1"
     local variant_name="$2"

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -23,7 +23,7 @@ Full walkthrough (SBOM payload, Trivy findings, multi-arch manifest inspection, 
 docker pull ghcr.io/oorabona/postgres:17-alpine
 
 # With pgvector for AI/RAG applications
-docker pull ghcr.io/oorabona/postgres:17-vector-alpine
+docker pull ghcr.io/oorabona/postgres:17-alpine-vector
 
 # With analytics extensions
 docker pull ghcr.io/oorabona/postgres:17-analytics-alpine
@@ -38,7 +38,7 @@ docker pull ghcr.io/oorabona/postgres:17-spatial-alpine
 docker pull ghcr.io/oorabona/postgres:17-distributed-alpine
 
 # All extensions included
-docker pull ghcr.io/oorabona/postgres:17-full-alpine
+docker pull ghcr.io/oorabona/postgres:17-alpine-full
 ```
 
 ## Available Flavors
@@ -63,7 +63,7 @@ Standard PostgreSQL with built-in extensions:
 - `btree_gin`, `btree_gist` - Additional index types
 - `pg_trgm` - Trigram matching for fuzzy search
 
-#### Vector (`*-vector-alpine`)
+#### Vector (`*-alpine-vector`)
 Includes base + **pgvector** for AI/ML workloads:
 ```sql
 -- Store embeddings from OpenAI, Anthropic, etc.
@@ -168,7 +168,7 @@ FROM events
 GROUP BY tenant_id;
 ```
 
-#### Full (`*-full-alpine`)
+#### Full (`*-alpine-full`)
 All extensions for development and testing. Includes everything from all other flavors (vector, analytics, timeseries, spatial, distributed).
 
 ## Supported Versions
@@ -187,9 +187,9 @@ ghcr.io/oorabona/postgres:{version}-{flavor}-alpine
 
 Examples:
 - `17-alpine` or `17-base-alpine` - PG17 base
-- `17-vector-alpine` - PG17 with pgvector
+- `17-alpine-vector` - PG17 with pgvector
 - `16-analytics-alpine` - PG16 with analytics extensions
-- `17-full-alpine` - PG17 with all extensions
+- `17-alpine-full` - PG17 with all extensions
 
 ## Usage
 
@@ -198,7 +198,7 @@ Examples:
 ```yaml
 services:
   postgres:
-    image: ghcr.io/oorabona/postgres:17-vector-alpine
+    image: ghcr.io/oorabona/postgres:17-alpine-vector
     environment:
       POSTGRES_DB: myapp
       POSTGRES_USER: myuser
@@ -227,7 +227,7 @@ docker run -d \
   -e POSTGRES_PASSWORD=secret \
   -p 5432:5432 \
   -v postgres_data:/var/lib/postgresql/data \
-  ghcr.io/oorabona/postgres:17-vector-alpine
+  ghcr.io/oorabona/postgres:17-alpine-vector
 ```
 
 ### Building Locally

--- a/postgres/version.sh
+++ b/postgres/version.sh
@@ -17,7 +17,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --tag-suffix)
             # Network-free suffix of the published tags (e.g. 18-alpine,
-            # 17-vector-alpine). Mirrors the other bake-managed version.sh
+            # 17-alpine-vector). Mirrors the other bake-managed version.sh
             # scripts so the bake generator's UPSTREAM_VERSION derivation stays
             # offline. postgres's Dockerfile does not consume UPSTREAM_VERSION
             # today, but the branch keeps the fleet parity contract intact.


### PR DESCRIPTION

`postgres/README.md` told users to `docker pull ghcr.io/oorabona/postgres:17-vector-alpine`.
That tag does not exist and never has. Checked against the registry:

    17-alpine-vector   EXISTS        17-vector-alpine   absent
    17-alpine-full     EXISTS        17-full-alpine     absent
    18.4-alpine-vector EXISTS        18.4-vector-alpine absent

The generator has always emitted `<version><base_suffix><variant_suffix>` —
`echo "${pg_version}${base_sfx}${suffix}"` in `variant_image_tag`, with an inline
comment saying so — while three places nearby documented the opposite order,
including that same function's own docstring one line above the code, and the
grammar in DEVELOPMENT.md.

Eight of the twelve corrections are in `postgres/README.md`, where they are pull
commands and image references a reader would copy. The rest are the grammar line,
the docstring, and a comment in `postgres/version.sh`.

Nothing executable changes: no script derived a tag from the documented order, or
postgres would never have built. What changes is that the documentation now
describes the images that exist.

Found while designing the image-identity resolver for #1018 and #1002, which has
to parse this grammar and would have rejected every real postgres tag if it had
been built from the documented one.