### PR TITLE
test(e2e): test the image this job built, and pass its cell to the suites

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -313,6 +313,7 @@ jobs:
         run: sudo modprobe tun 2>/dev/null || { sudo mkdir -p /dev/net && sudo mknod /dev/net/tun c 10 200 && sudo chmod 600 /dev/net/tun; }; test -c /dev/net/tun
 
       - name: Build loadable e2e image
+        id: build-e2e-image
         uses: ./.github/actions/build-container
         with:
           container: ${{ matrix.build.container }}
@@ -332,22 +333,36 @@ jobs:
           scan_vulnerabilities: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Require the e2e image to be loaded
+        if: steps.build-e2e-image.outputs.image_loaded != 'true'
+        shell: bash
+        run: |
+          echo "::error::E2E requires the image built in this job to be loaded locally (image_loaded=${{ steps.build-e2e-image.outputs.image_loaded }})"
+          exit 1
+
+      - name: Resolve loaded e2e image ID
+        shell: bash
+        run: |
+          image_id=$(timeout -k 2 10 docker image inspect --format '{{.Id}}' "ghcr.io/${{ github.repository_owner }}/${{ matrix.build.container }}:${{ matrix.build.tag }}")
+          test -n "$image_id"
+          echo "E2E_IMAGE_ID=$image_id" >> "$GITHUB_ENV"
+
       - name: Run e2e
         shell: bash
         env:
-          OWNER: ${{ github.repository_owner }}
           CONTAINER: ${{ matrix.build.container }}
-          TAG: ${{ matrix.build.tag }}
+          E2E_BUILD_TAG: ${{ matrix.build.tag }}
+          E2E_BUILD_VERSION: ${{ matrix.build.version }}
+          E2E_BUILD_VARIANT: ${{ matrix.build.variant }}
+          E2E_BUILD_FLAVOR: ${{ matrix.build.flavor }}
         run: |
-          E2E_IMAGE="ghcr.io/${OWNER}/${CONTAINER}:${TAG}" \
+          E2E_IMAGE="$E2E_IMAGE_ID" \
             tests/e2e-test.sh "${CONTAINER}"
 
       - name: openvpn restart lifecycle
         if: matrix.build.container == 'openvpn'
         shell: bash
-        env:
-          OPENVPN_IMAGE: ghcr.io/${{ github.repository_owner }}/openvpn:${{ matrix.build.tag }}
-        run: openvpn/tests/restart-lifecycle.sh
+        run: openvpn/tests/restart-lifecycle.sh "$E2E_IMAGE_ID"
 
   e2e-gate:
     name: e2e-gate

--- a/sslh/test.sh
+++ b/sslh/test.sh
@@ -12,6 +12,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../test-harness/test-harness.sh
 source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+# shellcheck source=../test-harness/image-identity.sh
+source "${SCRIPT_DIR}/../test-harness/image-identity.sh"
 
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-sslh}"
 
@@ -36,35 +38,15 @@ if th_capture "sslh-ev reports its version" \
     th_assert_contains "sslh-ev reports its version" "$banner" "sslh-ev"
 fi
 
-# The tag carries the upstream version, so the binary disagreeing with it means
-# the image was assembled from something other than what it claims.
-expected="${SSLH_EXPECTED_VERSION:-}"
-if [ -z "$expected" ] && [ -n "${E2E_IMAGE:-}" ]; then
-    # ghcr.io/owner/sslh:v2.3.1-alpine → 2.3.1
-    expected="${E2E_IMAGE##*:}"
-    expected="${expected%%-*}"
-    expected="${expected#v}"
-fi
-# Only a tag that carries a version can be compared against one. A moving tag
-# such as `latest` says nothing about the binary, and asserting on it would fail
-# for a reason that has nothing to do with the image.
-#
-# The comparison stays a substring match, deliberately: turning it into an exact
-# one means deciding what an image reference's version IS, and a tag carries a
-# flavour suffix, sometimes a prerelease hyphen and sometimes a digest, so every
-# stricter rule rejects some legitimate build. Tightening it is #983's work, on
-# every suite at once, not a side effect of this one. See #1002.
-if [[ "$expected" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-    if (( version_read )); then
-        th_assert_contains "the binary version matches the image tag ($expected)" \
-            "$banner" "$expected"
+# The harness resolves the reference to one declared cell before this suite
+# starts.  Compare the exact binary token: a substring lets 2.2.4 pass 12.2.40
+# and lets 3.1 pass 2.3.1.  Hyphenated prereleases remain one token.
+if (( version_read )); then
+    if [[ "$banner" =~ ^sslh-ev[[:space:]]+([^[:space:]]+) ]]; then
+        e2e_assert_reported_component_version "${BASH_REMATCH[1]}"
     else
-        # Reported as a skip rather than dropped: a test that leaves the report
-        # entirely is indistinguishable from one that was never written.
-        th_skip "the binary version matches the image tag" "the version probe failed"
+        th_fail "sslh-ev reports a parseable version token" "first line: '$banner'"
     fi
-else
-    th_skip "the binary version matches the image tag" "tag '${expected:-none}' carries no version"
 fi
 
 th_group "Multiplexer"

--- a/terraform/test.sh
+++ b/terraform/test.sh
@@ -13,6 +13,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../test-harness/test-harness.sh
 source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+# shellcheck source=../test-harness/image-identity.sh
+source "${SCRIPT_DIR}/../test-harness/image-identity.sh"
 
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-terraform}"
 
@@ -65,35 +67,15 @@ fi
 
 th_group "Flavor-specific cloud tooling"
 
-# TERRAFORM_FLAVOR is set from the selected build variant in the Dockerfile. It
-# is available even when the e2e runner resolved a local image rather than the
-# caller supplying E2E_IMAGE, so every variant is checked against its own promise.
-# The tag is the independent statement of what this image was meant to be; the
-# environment variable is the image's own account of itself. An -aws build that
-# was accidentally built as base declares base, excludes every cloud CLI and
-# passes on its own say-so — so where the tag names a flavor, the two must agree
-# before anything else is asserted.
-expected_flavor=""
-if [ -n "${E2E_IMAGE:-}" ]; then
-    case "${E2E_IMAGE##*:}" in
-        *-aws)   expected_flavor=aws ;;
-        *-azure) expected_flavor=azure ;;
-        *-gcp)   expected_flavor=gcp ;;
-        *-base)  expected_flavor=base ;;
-    esac
-fi
+# TERRAFORM_FLAVOR is the image's account of its flavor.  The harness supplies
+# the independently resolved declared cell, so a locally discovered image gets
+# the same assertion as an E2E_IMAGE run.
 
 if th_capture "Terraform image declares its flavor" \
         docker exec "$CONTAINER_NAME" sh -c 'printf %s "$TERRAFORM_FLAVOR"'; then
     flavor="$TH_OUTPUT"
 
-    if [ -n "$expected_flavor" ]; then
-        th_assert_eq "the image is the flavor its tag claims ($expected_flavor)" \
-            "$flavor" "$expected_flavor"
-    else
-        th_skip "the image is the flavor its tag claims" \
-            "tag '${E2E_IMAGE:+${E2E_IMAGE##*:}}' names no flavor"
-    fi
+    e2e_assert_declared_flavor "$flavor"
     flavor_tools=()
 
     case "$flavor" in

--- a/test-harness/image-identity.sh
+++ b/test-harness/image-identity.sh
@@ -35,7 +35,7 @@ _image_identity_emit_record() {
     if [[ -z "$variant" && -z "$flavor" ]]; then
         kind="single"
     fi
-    if ! record=$(jq -cncer \
+    if ! record=$(jq -c -n -e -r \
         --arg reference "$reference" --arg tag "$tag" --arg component_version "$component_version" \
         --arg kind "$kind" --arg variant "$variant" --arg flavor "$flavor" '
         def nonempty_string: type == "string" and length > 0;
@@ -123,7 +123,7 @@ image_identity_resolve() {
         # This is an internal hand-off from resolve_e2e_image. It still has to
         # name the reference tag exactly, so an unrelated selected cell cannot
         # be attached to this image accidentally.
-        if ! cell=$(jq -cer --arg tag "$tag" '
+        if ! cell=$(jq -c -e -r --arg tag "$tag" '
             if type == "object" and .tag == $tag then .
             else error("does not name the reference tag") end
         ' <<<"$selected_cell"); then
@@ -152,7 +152,7 @@ image_identity_resolve() {
             printf 'image identity: list_build_matrix failed for %s\n' "$container_dir" >&2
             return 1
         fi
-        if ! cell=$(jq -cer --arg tag "$tag" '
+        if ! cell=$(jq -c -e -r --arg tag "$tag" '
             if type != "array" then error("build matrix is not an array")
             else [.[] | select(.tag == $tag)] as $matches |
               if ($matches | length) == 1 then $matches[0]

--- a/test-harness/image-identity.sh
+++ b/test-harness/image-identity.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Resolve an image reference to one declared build cell.  The build matrix is
+# the source of truth for cells and generated tags; this harness only looks one
+# up and derives the component version from that declared value.
+
+# _image_identity_emit_record <reference> <tag> <version> <variant> <flavor> <container-dir>
+_image_identity_emit_record() {
+    local reference="$1" tag="$2" version="$3" variant="$4" flavor="$5" container_dir="$6"
+    local version_suffix component_version kind record
+
+    if [[ ! -x "$container_dir/version.sh" ]]; then
+        printf 'image identity: cannot execute %s/version.sh --tag-suffix\n' "$container_dir" >&2
+        return 1
+    fi
+    if ! version_suffix=$("$container_dir/version.sh" --tag-suffix); then
+        printf 'image identity: %s/version.sh --tag-suffix failed\n' "$container_dir" >&2
+        return 1
+    fi
+    if [[ "$version_suffix" == *$'\n'* ]]; then
+        printf 'image identity: %s/version.sh --tag-suffix returned more than one line\n' "$container_dir" >&2
+        return 1
+    fi
+
+    component_version="$version"
+    if [[ -n "$version_suffix" && "$component_version" == *"$version_suffix" ]]; then
+        component_version="${component_version%"$version_suffix"}"
+    fi
+    component_version="${component_version#v}"
+    if [[ -z "$component_version" || "$component_version" == "latest" ]]; then
+        printf 'image identity: %s is a moving alias, not a declared version\n' "$version" >&2
+        return 1
+    fi
+
+    kind="variant"
+    if [[ -z "$variant" && -z "$flavor" ]]; then
+        kind="single"
+    fi
+    if ! record=$(jq -cncer \
+        --arg reference "$reference" --arg tag "$tag" --arg component_version "$component_version" \
+        --arg kind "$kind" --arg variant "$variant" --arg flavor "$flavor" '
+        def nonempty_string: type == "string" and length > 0;
+        {reference: $reference, tag: $tag, component_version: $component_version,
+         kind: $kind,
+         variant: (if $kind == "single" then null else $variant end),
+         flavor: (if $kind == "single" then null else $flavor end)} as $record |
+        if ($record.reference | nonempty_string) and ($record.tag | nonempty_string) and
+           ($record.component_version | nonempty_string) and
+           (($record.kind == "single" and $record.variant == null and $record.flavor == null) or
+            ($record.kind == "variant" and ($record.variant | nonempty_string) and ($record.flavor | type == "string"))) then
+          $record
+        else error("invalid declared build cell") end
+    '); then
+        printf 'image identity: invalid declared build cell\n' >&2
+        return 1
+    fi
+    printf '%s\n' "$record"
+}
+
+# image_identity_resolve <container-dir> <image-reference> [selected-cell]
+#
+# Writes one JSON record on stdout:
+#   {reference, tag, component_version, kind, variant, flavor}
+#
+# The workflow passes E2E_BUILD_{TAG,VERSION,VARIANT,FLAVOR} for its exact build
+# cell.  When those are present they are authoritative: do not parse the image
+# reference or inspect declarations again. Manual callers fall back to matching
+# the reference tag against helpers/variant-utils.sh::list_build_matrix. The e2e
+# harness may pass the cell it already selected from that matrix, avoiding a
+# second enumeration of the same retained cells.
+image_identity_resolve() {
+    local container_dir="$1" reference="$2" selected_cell="${3:-}"
+
+    if [[ -n "${E2E_BUILD_TAG+x}${E2E_BUILD_VERSION+x}${E2E_BUILD_VARIANT+x}${E2E_BUILD_FLAVOR+x}" ]]; then
+        if [[ -z "${E2E_BUILD_TAG+x}" || -z "${E2E_BUILD_VERSION+x}" || -z "${E2E_BUILD_VARIANT+x}" || -z "${E2E_BUILD_FLAVOR+x}" ]]; then
+            printf 'image identity: pass all E2E_BUILD_TAG, E2E_BUILD_VERSION, E2E_BUILD_VARIANT, and E2E_BUILD_FLAVOR\n' >&2
+            return 1
+        fi
+        _image_identity_emit_record "$reference" "$E2E_BUILD_TAG" "$E2E_BUILD_VERSION" \
+            "$E2E_BUILD_VARIANT" "$E2E_BUILD_FLAVOR" "$container_dir"
+        return
+    fi
+
+    if [[ ! -r "$container_dir/variants.yaml" ]]; then
+        printf 'image identity: cannot read %s/variants.yaml\n' "$container_dir" >&2
+        return 1
+    fi
+
+    # This is deliberately a declared-cell parser, not an OCI reference
+    # validator. Its bounded job is deciding whether a reference names a
+    # declared cell; Docker remains responsible for full reference grammar.
+    # A tag plus digest could name a manifest different from the tag's current
+    # declaration, so only an explicitly passed build cell can identify it.
+    local last_segment tag name_without_tag image_name expected_name
+    if [[ "$reference" == *"@"* ]]; then
+        printf 'image identity: %s has a digest; pass the build cell explicitly\n' "$reference" >&2
+        return 1
+    fi
+    if [[ -z "$reference" || "$reference" =~ ^[[:alpha:]][[:alnum:].+-]*:// ]]; then
+        printf 'image identity: %s has an invalid image name\n' "$reference" >&2
+        return 1
+    fi
+    last_segment="${reference##*/}"
+    if [[ "$last_segment" != *:* || "${last_segment##*:}" == "$last_segment" ]]; then
+        printf 'image identity: %s has no tag (digest-only references are not declared cells)\n' "$reference" >&2
+        return 1
+    fi
+    tag="${last_segment##*:}"
+    name_without_tag="${reference%:*}"
+    if [[ -z "$tag" || -z "$name_without_tag" ]]; then
+        printf 'image identity: %s has an empty image name or tag\n' "$reference" >&2
+        return 1
+    fi
+    image_name="${name_without_tag##*/}"
+    expected_name="${container_dir##*/}"
+    if [[ "$image_name" != "$expected_name" ]]; then
+        printf 'image identity: %s does not name container %s\n' "$reference" "$expected_name" >&2
+        return 1
+    fi
+
+    local harness_dir matrix real_version cell version variant flavor
+    harness_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -n "$selected_cell" ]]; then
+        # This is an internal hand-off from resolve_e2e_image. It still has to
+        # name the reference tag exactly, so an unrelated selected cell cannot
+        # be attached to this image accidentally.
+        if ! cell=$(jq -cer --arg tag "$tag" '
+            if type == "object" and .tag == $tag then .
+            else error("does not name the reference tag") end
+        ' <<<"$selected_cell"); then
+            printf 'image identity: %s does not resolve to one declared cell\n' "$reference" >&2
+            return 1
+        fi
+    else
+        # Match the workflow's latest declaration handling: it resolves the
+        # current version and falls back to the literal latest only if that
+        # resolution is unavailable. Pinned declarations need no live lookup.
+        real_version=""
+        if yq -e '.versions[]? | select(.tag == "latest")' "$container_dir/variants.yaml" >/dev/null 2>&1; then
+            if ! real_version=$(cd "$container_dir" && ./version.sh 2>/dev/null); then
+                real_version="latest"
+            fi
+            if [[ -z "$real_version" || "$real_version" == "unknown" ]]; then
+                real_version="latest"
+            fi
+        fi
+        # Source the same enumerator the workflow uses. Resolution asks whether
+        # this names any declared cell, including retained versions that are
+        # still published; the default matrix view is only the latest version.
+        # The subshell keeps its shell options out of test suites that source
+        # this resolver directly.
+        if ! matrix=$(source "$harness_dir/../helpers/variant-utils.sh" && list_build_matrix "$container_dir" "$real_version" true 2>/dev/null); then
+            printf 'image identity: list_build_matrix failed for %s\n' "$container_dir" >&2
+            return 1
+        fi
+        if ! cell=$(jq -cer --arg tag "$tag" '
+            if type != "array" then error("build matrix is not an array")
+            else [.[] | select(.tag == $tag)] as $matches |
+              if ($matches | length) == 1 then $matches[0]
+              elif ($matches | length) == 0 then error("does not name a declared cell")
+              else error("matches more than one declared cell") end
+            end
+        ' <<<"$matrix"); then
+            printf 'image identity: %s does not resolve to one declared cell\n' "$reference" >&2
+            return 1
+        fi
+    fi
+    if ! version=$(jq -er '.version | strings' <<<"$cell") || \
+        ! variant=$(jq -er '.variant | strings' <<<"$cell") || \
+        ! flavor=$(jq -er '.flavor | strings' <<<"$cell"); then
+        printf 'image identity: %s has an invalid declared build cell\n' "$reference" >&2
+        return 1
+    fi
+    _image_identity_emit_record "$reference" "$tag" "$version" "$variant" "$flavor" "$container_dir"
+}
+
+_image_identity_record_field() {
+    local field="$1"
+    # E2E_IMAGE_IDENTITY is an internal harness-to-suite channel. This
+    # structural check catches a harness bug; it is not a trust boundary for a
+    # hand-forged record, so it deliberately does not re-resolve cross-fields.
+    jq -er --arg field "$field" '
+        def nonempty_string: type == "string" and length > 0;
+        if (.reference | nonempty_string) and (.tag | nonempty_string) and
+           (.component_version | nonempty_string) and
+           ((.kind == "single" and .variant == null and .flavor == null) or
+            (.kind == "variant" and (.variant | nonempty_string) and (.flavor | type == "string"))) then
+          .[$field]
+        else error("invalid image identity record") end
+    ' <<<"${E2E_IMAGE_IDENTITY:-}" 2>/dev/null
+}
+
+# Harness assertions for container suites. Suites pass their observed value;
+# they never parse an image reference or the identity record themselves.
+e2e_assert_reported_component_version() {
+    local actual="$1" expected
+    if ! expected=$(_image_identity_record_field component_version); then
+        th_fail "the reported component version has resolved image identity" \
+            "the harness did not provide a valid resolved image identity"
+        return 0
+    fi
+    th_assert_eq "the reported component version matches the resolved image ($expected)" \
+        "$actual" "$expected"
+}
+
+e2e_assert_declared_variant() {
+    local actual="$1" expected kind
+    if ! kind=$(_image_identity_record_field kind) || [[ "$kind" != "variant" ]] || ! expected=$(_image_identity_record_field variant); then
+        th_fail "the image reports the resolved declared variant" \
+            "the resolved image is not a variant cell"
+        return 0
+    fi
+    th_assert_eq "the image reports the resolved declared variant ($expected)" "$actual" "$expected"
+}
+
+e2e_assert_declared_flavor() {
+    local actual="$1" expected kind
+    if ! kind=$(_image_identity_record_field kind) || [[ "$kind" != "variant" ]] || ! expected=$(_image_identity_record_field flavor); then
+        th_fail "the image reports the resolved declared flavor" \
+            "the resolved image is not a variant cell"
+        return 0
+    fi
+    th_assert_eq "the image reports the resolved declared flavor ($expected)" "$actual" "$expected"
+}

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -11,10 +11,210 @@
 #
 # For containers with variants, version is required (e.g., postgres:16)
 # Set E2E_IMAGE=<image-ref> to test a preloaded image directly.
+# Set E2E_BUILD_TAG, E2E_BUILD_VERSION, E2E_BUILD_VARIANT, and
+# E2E_BUILD_FLAVOR when the caller already knows the exact build cell.
 # Set E2E_READY_TIMEOUT=<seconds> (1-99999, default 60) to give a container with a
 # slow healthcheck longer to report itself ready.
 # Set E2E_TEST_TIMEOUT=<seconds> (1-99999, default 600) to bound each
 # container-specific test suite.
+
+# Resolve the real version exactly as the workflow does for a `tag: latest`
+# declaration: ask version.sh and use latest as its failure/unknown fallback.
+# There is no live lookup when the declaration has no latest tag, which keeps
+# resolution of pinned retained cells independent of the current upstream.
+resolve_declared_real_version() {
+    local container_dir="$1"
+    local real_version
+
+    if ! yq -e '.versions[]? | select(.tag == "latest")' "$container_dir/variants.yaml" >/dev/null 2>&1; then
+        printf '\n'
+        return 0
+    fi
+
+    if ! real_version=$(cd "$container_dir" && ./version.sh 2>/dev/null); then
+        real_version="latest"
+    fi
+    if [[ -z "$real_version" || "$real_version" == "unknown" ]]; then
+        real_version="latest"
+    fi
+    printf '%s\n' "$real_version"
+}
+
+# Resolve a local image only after inspecting every tag attached to its one
+# image ID. The default output is the image reference for callers of the
+# original helper; --json also carries the selected declared cell and local
+# image ID to the identity resolver, so the normal harness path does not
+# enumerate or re-resolve it twice.
+# This is defined before source-only mode so unit tests can source this routing
+# helper without entering the CLI setup below.
+resolve_e2e_image() {
+    local container="$1"
+    local image_tag="${2:-}"
+    local output_format="${3:-image}"
+    local repo_root="${REPO_ROOT:-}"
+    local github_repository_owner="${GITHUB_REPOSITORY_OWNER:-oorabona}"
+
+    case "$output_format" in
+        image|--json) ;;
+        *)
+            printf 'Unknown resolve_e2e_image output format: %s\n' "$output_format" >&2
+            return 2
+            ;;
+    esac
+
+    if [[ -z "$repo_root" ]]; then
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    fi
+
+    if ! declare -F image_identity_resolve >/dev/null; then
+        # shellcheck source=../test-harness/image-identity.sh
+        source "$repo_root/test-harness/image-identity.sh"
+    fi
+    if ! declare -F log_error >/dev/null; then
+        # shellcheck source=../helpers/logging.sh
+        source "$repo_root/helpers/logging.sh"
+    fi
+
+    if [ -n "${E2E_IMAGE:-}" ]; then
+        if [[ "$output_format" == "--json" ]]; then
+            jq -cn --arg image "$E2E_IMAGE" '{image: $image, image_id: null, cell: null}'
+        else
+            printf '%s\n' "$E2E_IMAGE"
+        fi
+        return 0
+    fi
+
+    if [ -n "$image_tag" ]; then
+        local tagged_image
+        tagged_image="docker.io/${github_repository_owner}/${container}:${image_tag}"
+        if [[ "$output_format" == "--json" ]]; then
+            jq -cn --arg image "$tagged_image" '{image: $image, image_id: null, cell: null}'
+        else
+            printf '%s\n' "$tagged_image"
+        fi
+        return 0
+    fi
+
+    local images=""
+    images=$(timeout -k 2 10 docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
+
+    local ids
+    ids=$(printf '%s\n' "$images" | awk -v owner="$github_repository_owner" -v container="$container" '
+        function starts_with(value, prefix) {
+            return substr(value, 1, length(prefix)) == prefix
+        }
+        starts_with($2, "ghcr.io/" owner "/" container ":") ||
+        starts_with($2, "docker.io/" owner "/" container ":") ||
+        starts_with($2, container ":") {
+            print $1
+        }
+    ' | sort -u)
+
+    local count
+    if [ -z "$ids" ]; then
+        count=0
+    else
+        count=$(printf '%s\n' "$ids" | grep -c .)
+    fi
+
+    if [ "$count" -eq 0 ]; then
+        log_error "No image found for $container; build it first, pass container:tag, or set E2E_IMAGE"
+        return 1
+    fi
+
+    if [ "$count" -gt 1 ]; then
+        log_error "Ambiguous local images for $container ($count distinct image IDs); set E2E_IMAGE"
+        printf '%s\n' "$images" | awk -v owner="$github_repository_owner" -v container="$container" '
+            function starts_with(value, prefix) {
+                return substr(value, 1, length(prefix)) == prefix
+            }
+            starts_with($2, "ghcr.io/" owner "/" container ":") ||
+            starts_with($2, "docker.io/" owner "/" container ":") ||
+            starts_with($2, container ":") {
+                print "  " $1 " " $2
+            }
+        ' >&2
+        return 1
+    fi
+
+    # :latest commonly shares an image ID with one declared tag. Listing order
+    # is not an identity contract: enumerate all retained declared cells once,
+    # collect every matching tag on the image ID, and refuse if it names more
+    # than one distinct cell.
+    local harness_dir matrix real_version image image_id candidate candidate_tag candidate_cell selected_cell declared_cells declared_candidates declared_count
+    harness_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    if ! real_version=$(resolve_declared_real_version "$repo_root/$container"); then
+        log_error "Could not resolve the current version for $container"
+        return 1
+    fi
+    if ! matrix=$(source "$harness_dir/helpers/variant-utils.sh" && list_build_matrix "$repo_root/$container" "$real_version" true 2>/dev/null); then
+        log_error "Could not enumerate declared image tags for $container"
+        return 1
+    fi
+    image=""
+    image_id="$ids"
+    selected_cell=""
+    declared_cells=""
+    declared_candidates=""
+    declared_count=0
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        candidate_tag="${candidate##*:}"
+        # A cell is the matrix record, rather than just its tag: duplicate tags
+        # are not a valid resolution and therefore do not count as a match.
+        if candidate_cell=$(jq -cer --arg tag "$candidate_tag" '
+            [.[] | select(.tag == $tag)] |
+            if length == 1 then .[0] else error("not one declared cell") end
+        ' <<<"$matrix" 2>/dev/null); then
+            if [[ $'\n'"$declared_cells"$'\n' != *$'\n'"$candidate_cell"$'\n'* ]]; then
+                if [[ -n "$declared_cells" ]]; then
+                    declared_candidates+=$'\n'
+                fi
+                declared_cells+="${declared_cells:+$'\n'}$candidate_cell"
+                declared_candidates+="$candidate"
+                declared_count=$((declared_count + 1))
+                image="$candidate"
+                # Keep the selected cell separate from the probe result: a
+                # later undeclared alias must not erase this successful match.
+                selected_cell="$candidate_cell"
+            fi
+        fi
+    done < <(printf '%s\n' "$images" | awk -v id="$ids" -v owner="$github_repository_owner" -v container="$container" '
+        function starts_with(value, prefix) {
+            return substr(value, 1, length(prefix)) == prefix
+        }
+        $1 == id && (starts_with($2, "ghcr.io/" owner "/" container ":") || starts_with($2, "docker.io/" owner "/" container ":") || starts_with($2, container ":")) {
+            print $2
+        }
+    ')
+
+    if [ "$declared_count" -eq 0 ]; then
+        log_error "No declared image tag found for local image $ids; set E2E_IMAGE"
+        return 1
+    fi
+
+    if [ "$declared_count" -gt 1 ]; then
+        log_error "Ambiguous declared image tags for $container on local image $ids ($declared_count distinct declared cells); set E2E_IMAGE"
+        while IFS= read -r candidate; do
+            printf '  %s\n' "$candidate"
+        done <<<"$declared_candidates" >&2
+        return 1
+    fi
+
+    if [[ "$output_format" == "--json" ]]; then
+        jq -cn --arg image "$image" --arg image_id "$image_id" --argjson cell "$selected_cell" \
+            '{image: $image, image_id: $image_id, cell: $cell}'
+    else
+        printf '%s\n' "$image"
+    fi
+}
+
+# This must stay before shell options, argument parsing, ./make, command
+# validation, and the banner: sourcing for the helper above must not mutate the
+# caller's shell state or run startup work.
+if [[ "${E2E_TEST_SOURCE_ONLY:-}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 set -euo pipefail
 
@@ -28,6 +228,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$REPO_ROOT/helpers/logging.sh"
 source "$REPO_ROOT/helpers/variant-utils.sh"
+# shellcheck source=../test-harness/image-identity.sh
+source "$REPO_ROOT/test-harness/image-identity.sh"
 
 BUILD=true
 CONTAINERS=""
@@ -51,6 +253,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Environment:"
             echo "  E2E_IMAGE            Test this image ref directly, skipping discovery"
+            echo "  E2E_BUILD_*          Authoritative build cell for E2E_IMAGE (workflow use)"
             echo "  E2E_READY_TIMEOUT    Seconds a container gets to report ready (1-99999, default 60)"
             echo "  E2E_TEST_TIMEOUT     Seconds each container-specific suite may run (1-99999, default 600)"
             echo ""
@@ -104,80 +307,6 @@ echo ""
 echo "🧪 E2E Container Tests"
 echo "======================"
 echo ""
-
-resolve_e2e_image() {
-    local container="$1"
-    local image_tag="${2:-}"
-
-    if [ -n "${E2E_IMAGE:-}" ]; then
-        printf '%s\n' "$E2E_IMAGE"
-        return 0
-    fi
-
-    if [ -n "$image_tag" ]; then
-        printf 'docker.io/%s/%s:%s\n' "$GITHUB_REPOSITORY_OWNER" "$container" "$image_tag"
-        return 0
-    fi
-
-    local images=""
-    images=$(docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
-
-    local ids
-    ids=$(printf '%s\n' "$images" | awk -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
-        function starts_with(value, prefix) {
-            return substr(value, 1, length(prefix)) == prefix
-        }
-        starts_with($2, "ghcr.io/" owner "/" container ":") ||
-        starts_with($2, "docker.io/" owner "/" container ":") ||
-        starts_with($2, container ":") {
-            print $1
-        }
-    ' | sort -u)
-
-    local count
-    if [ -z "$ids" ]; then
-        count=0
-    else
-        count=$(printf '%s\n' "$ids" | grep -c .)
-    fi
-
-    if [ "$count" -eq 0 ]; then
-        log_error "No image found for $container; build it first, pass container:tag, or set E2E_IMAGE"
-        return 1
-    fi
-
-    if [ "$count" -gt 1 ]; then
-        log_error "Ambiguous local images for $container ($count distinct image IDs); set E2E_IMAGE"
-        printf '%s\n' "$images" | awk -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
-            function starts_with(value, prefix) {
-                return substr(value, 1, length(prefix)) == prefix
-            }
-            starts_with($2, "ghcr.io/" owner "/" container ":") ||
-            starts_with($2, "docker.io/" owner "/" container ":") ||
-            starts_with($2, container ":") {
-                print "  " $1 " " $2
-            }
-        ' >&2
-        return 1
-    fi
-
-    local image
-    image=$(printf '%s\n' "$images" | awk -v id="$ids" -v owner="$GITHUB_REPOSITORY_OWNER" -v container="$container" '
-        function starts_with(value, prefix) {
-            return substr(value, 1, length(prefix)) == prefix
-        }
-        $1 == id && (
-            starts_with($2, "ghcr.io/" owner "/" container ":") ||
-            starts_with($2, "docker.io/" owner "/" container ":") ||
-            starts_with($2, container ":")
-        ) {
-            print $2
-            exit
-        }
-    ')
-
-    printf '%s\n' "$image"
-}
 
 # Seconds left before the deadline, or non-zero once the budget is spent. Every
 # check of "is there time left" goes through here: the loop below asks twice per
@@ -317,15 +446,36 @@ test_container() {
     fi
 
     # Determine image name
-    local image
-    if ! image=$(resolve_e2e_image "$container" "$image_tag"); then
+    local image_resolution image identity selected_cell image_id
+    if ! image_resolution=$(resolve_e2e_image "$container" "$image_tag" --json); then
         return 1
     fi
+    if ! image=$(jq -er '.image | strings | select(length > 0)' <<<"$image_resolution") || \
+        ! selected_cell=$(jq -c '.cell' <<<"$image_resolution") || \
+        ! image_id=$(jq -er '
+            if .image_id == null then ""
+            elif (.image_id | type == "string" and length > 0) then .image_id
+            else error("invalid image ID") end
+        ' <<<"$image_resolution"); then
+        log_error "Could not read the resolved image for $test_name"
+        return 1
+    fi
+    [[ "$selected_cell" == "null" ]] && selected_cell=""
     if [ -z "$image" ]; then
         log_error "No image found for $test_name"
         return 1
     fi
     log_info "Using image: $image"
+    if ! identity=$(image_identity_resolve "$REPO_ROOT/$container" "$image" "$selected_cell"); then
+        log_error "Could not resolve image identity for $image"
+        return 1
+    fi
+    if [[ -z "$image_id" ]]; then
+        if ! image_id=$(timeout -k 2 10 docker image inspect --format '{{.Id}}' "$image") || [[ -z "$image_id" ]]; then
+            log_error "Could not resolve local image ID for $image"
+            return 1
+        fi
+    fi
 
     # Clean up any existing test container before reusing its fixed name.
     CLEANUP_CONTAINER_NAME="$container_name"
@@ -391,10 +541,10 @@ test_container() {
     # so this bound is what stops docker run deferring cleanup indefinitely over a
     # container it may already have created. It is creation, not readiness:
     # measured at ~0.7s for these images, so the budget is wide enough that only a
-    # genuine hang or an image this harness expected to be local and is silently
-    # pulling can reach it — and turning a pull into "Failed to start" would be a
-    # worse failure than the wait.
-    if ! timeout -k 5 120 docker run $run_opts "$image" $run_cmd; then
+    # genuine hang can reach it. Run the immutable local image ID, not its mutable
+    # tag: the container started is the exact image whose tags established the
+    # identity above, so docker cannot pull or retag-substitute it before run.
+    if ! timeout -k 5 120 docker run $run_opts "$image_id" $run_cmd; then
         log_error "Failed to start $container"
         cleanup_container
         return 1
@@ -560,7 +710,11 @@ test_container() {
     # the thing meant to bound it. The report states the status and what could have
     # produced it, which is what is actually known.
     local test_status=0
-    CONTAINER_NAME="$container_name" timeout -k 5 "$TEST_TIMEOUT" "$test_script" || test_status=$?
+    # Suites receive one already-resolved record and assertion helpers, rather
+    # than the reference itself or separately-derived version/flavor variables.
+    # Unset E2E_IMAGE so a suite cannot accidentally revive tag parsing.
+    env -u E2E_IMAGE CONTAINER_NAME="$container_name" E2E_IMAGE_IDENTITY="$identity" \
+        timeout -k 5 "$TEST_TIMEOUT" "$test_script" || test_status=$?
     if [ "$test_status" -ne 0 ]; then
         case "$test_status" in
             124|137)

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -162,7 +162,7 @@ resolve_e2e_image() {
         candidate_tag="${candidate##*:}"
         # A cell is the matrix record, rather than just its tag: duplicate tags
         # are not a valid resolution and therefore do not count as a match.
-        if candidate_cell=$(jq -cer --arg tag "$candidate_tag" '
+        if candidate_cell=$(jq -c -e -r --arg tag "$candidate_tag" '
             [.[] | select(.tag == $tag)] |
             if length == 1 then .[0] else error("not one declared cell") end
         ' <<<"$matrix" 2>/dev/null); then

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -8,7 +8,7 @@ setup() {
     # Cleared going in, not just coming out: one of these exported in the shell
     # that runs the suite would otherwise steer the stub through tests that never
     # asked for it.
-    unset E2E_IMAGE E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
+    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
         DOCKER_INSPECT_ERROR DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR \
         DOCKER_IMAGES_OUTPUT DOCKER_RM_FAIL_ON_SECOND
     # Each bats test is its own process, so it inherits these from the shell that
@@ -20,12 +20,14 @@ setup() {
     cp "$PROJECT_ROOT/tests/e2e-test.sh" "$FIXTURE_REPO/tests/e2e-test.sh"
     cp "$PROJECT_ROOT/helpers/logging.sh" "$FIXTURE_REPO/helpers/logging.sh"
     cp "$PROJECT_ROOT/helpers/variant-utils.sh" "$FIXTURE_REPO/helpers/variant-utils.sh"
+    mkdir -p "$FIXTURE_REPO/test-harness"
+    cp "$PROJECT_ROOT/test-harness/image-identity.sh" "$FIXTURE_REPO/test-harness/image-identity.sh"
     chmod +x "$FIXTURE_REPO/tests/e2e-test.sh"
 }
 
 teardown() {
     export PATH="$ORIG_PATH"
-    unset E2E_IMAGE E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR DOCKER_RM_FAIL_ON_SECOND PS_COUNT_FILE TEST_SCRIPT_MARKER RUN_STARTED TEST_SUITE_STARTED HARNESS_PID_FILE
+    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR DOCKER_RM_FAIL_ON_SECOND PS_COUNT_FILE TEST_SCRIPT_MARKER RUN_STARTED TEST_SUITE_STARTED HARNESS_PID_FILE
     teardown_temp_dir
 }
 
@@ -67,6 +69,9 @@ install_docker_stub() {
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    shift
+fi
 case "$1" in
     images)
         printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}"
@@ -89,6 +94,10 @@ case "$1" in
                     ;;
             esac
         done
+        if [ "$inspect_format" = '{{.Id}}' ]; then
+            printf '%s\n' "${DOCKER_IMAGE_ID:-sha256:e2e-loaded-image}"
+            exit 0
+        fi
         if [ "$inspect_format" != '{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' ]; then
             printf 'unexpected inspect format: %s\n' "$inspect_format" >&2
             exit 64
@@ -140,11 +149,28 @@ add_openvpn_fixture() {
 versions:
   - tag: v2.7.5-alpine
 YAML
+    cat > "$FIXTURE_REPO/openvpn/version.sh" <<'SH'
+#!/bin/bash
+if [[ "${1:-}" == "--tag-suffix" ]]; then
+    printf '%s\n' '-alpine'
+    exit 0
+fi
+exit 1
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/version.sh"
     cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
 #!/bin/bash
 printf '%s\n' "${CONTAINER_NAME:-}" > "${TEST_SCRIPT_MARKER:?}"
 SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+}
+
+add_single_image_identity_fixture() {
+    local container="$1" tag="$2" suffix="$3"
+    mkdir -p "$FIXTURE_REPO/$container"
+    printf 'versions:\n  - tag: %s\n' "$tag" > "$FIXTURE_REPO/$container/variants.yaml"
+    printf '#!/bin/bash\nif [[ "${1:-}" == "--tag-suffix" ]]; then printf "%%s\\n" %q; exit 0; fi\nexit 1\n' "$suffix" > "$FIXTURE_REPO/$container/version.sh"
+    chmod +x "$FIXTURE_REPO/$container/version.sh"
 }
 
 @test "helper sourcing resolves from repo root" {
@@ -154,17 +180,55 @@ SH
     [[ "$output" == *"--no-build"* ]]
 }
 
-@test "S3/AD3: E2E_IMAGE bypasses variant routing but still applies openvpn run profile and test.sh" {
+@test "source-only mode leaves the caller and startup commands untouched" {
+    local caller_dir="$TEST_TEMP_DIR/caller"
+    mkdir -p "$caller_dir" "$TEST_TEMP_DIR/bin"
+    printf '#!/bin/bash\n: > "${SOURCE_ONLY_MAKE_MARKER:?}"\n' > "$caller_dir/make"
+    chmod +x "$caller_dir/make"
+    printf '#!/bin/bash\n: > "${SOURCE_ONLY_TIMEOUT_MARKER:?}"\n' > "$TEST_TEMP_DIR/bin/timeout"
+    chmod +x "$TEST_TEMP_DIR/bin/timeout"
+    export SOURCE_ONLY_MAKE_MARKER="$TEST_TEMP_DIR/make-ran"
+    export SOURCE_ONLY_TIMEOUT_MARKER="$TEST_TEMP_DIR/timeout-ran"
+
+    run env E2E_TEST_SOURCE_ONLY=1 PATH="$TEST_TEMP_DIR/bin:$PATH" bash -c '
+        script="$1"
+        caller_dir="$2"
+        cd "$caller_dir"
+        set +e +u
+        set +o pipefail
+        SECONDS=37
+        set -- caller-first caller-second
+        source "$script"
+        [[ "$SECONDS" -ge 37 ]]
+        [[ "$#" -eq 2 && "$1" == caller-first && "$2" == caller-second ]]
+        [[ "$-" != *e* && "$-" != *u* ]]
+        [[ "$(set -o | awk "\$1 == \"pipefail\" { print \$2 }")" == off ]]
+        declare -F resolve_e2e_image >/dev/null
+    ' _ "$FIXTURE_REPO/tests/e2e-test.sh" "$caller_dir"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -e "$SOURCE_ONLY_MAKE_MARKER" ]
+    [ ! -e "$SOURCE_ONLY_TIMEOUT_MARKER" ]
+}
+
+@test "S3/AD3: an E2E image ID and passed build cell bypass routing and run unchanged" {
     add_openvpn_fixture
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="sha256:ci-loaded-image"
+    export DOCKER_IMAGE_ID="sha256:ci-loaded-image"
+    export E2E_BUILD_TAG="v2.7.5-alpine"
+    export E2E_BUILD_VERSION="v2.7.5-alpine"
+    export E2E_BUILD_VARIANT=""
+    export E2E_BUILD_FLAVOR=""
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_SCRIPT_MARKER")" = "e2e-openvpn" ]
+    grep -q '^run .*sha256:ci-loaded-image' "$DOCKER_LOG"
 
     run_line=$(grep '^run ' "$DOCKER_LOG")
     [[ "$run_line" == *"--cap-drop ALL"* ]]
@@ -174,7 +238,7 @@ SH
     [[ "$run_line" == *"--device /dev/net/tun:/dev/net/tun"* ]]
     [[ "$run_line" == *"-e AUTO_INSTALL=y"* ]]
     [[ "$run_line" == *"-e AUTO_START=y"* ]]
-    [[ "$run_line" == *"ghcr.io/example/openvpn:e2e"* ]]
+    [[ "$run_line" == *"sha256:ci-loaded-image"* ]]
     ! grep -q '^images ' "$DOCKER_LOG"
 }
 
@@ -187,7 +251,7 @@ SH
     rm "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
@@ -202,7 +266,7 @@ SH
     chmod -x "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
@@ -219,6 +283,10 @@ SH
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 case "$1" in
     run)
         : > "${RUN_STARTED:?}"
@@ -238,7 +306,7 @@ esac
 STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export RUN_STARTED="$TEST_TEMP_DIR/container-created"
     export HARNESS_PID_FILE="$TEST_TEMP_DIR/harness.pid"
 
@@ -276,7 +344,7 @@ SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_TEST_TIMEOUT=1
     export HARNESS_PID_FILE="$TEST_TEMP_DIR/harness.pid"
     export TEST_SUITE_STARTED="$TEST_TEMP_DIR/custom-suite-started"
@@ -318,7 +386,7 @@ SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_TEST_TIMEOUT=1
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -344,7 +412,7 @@ SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_TEST_TIMEOUT=10
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -380,8 +448,57 @@ SH
     ! grep -q '^run ' "$DOCKER_LOG"
 }
 
+@test "fallback image discovery keeps a declared cell when its tag precedes latest" {
+    add_single_image_identity_fixture debian trixie ''
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    # A build adds both of these tags to one image. A later undeclared alias
+    # must not erase the cell selected from the declared tag.
+    export DOCKER_IMAGES_OUTPUT=$'sha111 ghcr.io/oorabona/debian:trixie\nsha111 ghcr.io/oorabona/debian:latest'
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian "" --json' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.image' <<<"$output")" = "ghcr.io/oorabona/debian:trixie" ]
+    [ "$(jq -r '.image_id' <<<"$output")" = "sha111" ]
+    [ "$(jq -r '.cell.tag' <<<"$output")" = "trixie" ]
+}
+
+@test "fallback image discovery keeps a declared cell when latest precedes its tag" {
+    add_single_image_identity_fixture debian trixie ''
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=$'sha111 ghcr.io/oorabona/debian:latest\nsha111 ghcr.io/oorabona/debian:trixie'
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian "" --json' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.image' <<<"$output")" = "ghcr.io/oorabona/debian:trixie" ]
+    [ "$(jq -r '.image_id' <<<"$output")" = "sha111" ]
+    [ "$(jq -r '.cell.tag' <<<"$output")" = "trixie" ]
+}
+
+@test "fallback image discovery rejects two declared cells on one image ID" {
+    add_single_image_identity_fixture debian bookworm ''
+    printf '  - tag: trixie\n' >> "$FIXTURE_REPO/debian/variants.yaml"
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=$'sha111 ghcr.io/oorabona/debian:bookworm\nsha111 docker.io/oorabona/debian:trixie'
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Ambiguous declared image tags for debian"* ]]
+    [[ "$output" == *"ghcr.io/oorabona/debian:bookworm"* ]]
+    [[ "$output" == *"docker.io/oorabona/debian:trixie"* ]]
+}
+
 @test "sslh run profile: args-only command, port 443, NET_BIND_SERVICE (entrypoint+healthcheck match)" {
     mkdir -p "$FIXTURE_REPO/sslh"
+    add_single_image_identity_fixture sslh v2.3.1-alpine -alpine
     # The real container has one, and the harness now requires it — this fixture
     # stands in for it so the assertions below stay about the run profile.
     printf '#!/bin/bash\nexit 0\n' > "$FIXTURE_REPO/sslh/test.sh"
@@ -389,7 +506,7 @@ SH
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export DOCKER_PS_OUTPUT="e2e-sslh"
-    export E2E_IMAGE="ghcr.io/example/sslh:e2e"
+    export E2E_IMAGE="ghcr.io/example/sslh:v2.3.1-alpine"
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" sslh
 
@@ -408,18 +525,35 @@ SH
 @test "sslh/test.sh proves liveness without pgrep (scratch image lacks it)" {
     # The sslh image is FROM scratch: no pgrep. The smoke check must use the
     # busybox nc applet that ships in the image, not pgrep.
-    ! grep -qE '\bpgrep\b' "$PROJECT_ROOT/sslh/test.sh"
+    if sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$PROJECT_ROOT/sslh/test.sh" | grep -qE '\bpgrep\b'; then
+        false
+    fi
     grep -q '/bin/busybox nc' "$PROJECT_ROOT/sslh/test.sh"
 }
 
 @test "terraform run profile: --entrypoint sleep, because the image entrypoint execs terraform with its args" {
     mkdir -p "$FIXTURE_REPO/terraform"
+    cat > "$FIXTURE_REPO/terraform/variants.yaml" <<'YAML'
+versions:
+  - tag: 1.15.8-alpine
+    variants:
+      - name: full
+        suffix: ""
+        flavor: full
+        default: true
+YAML
+    cat > "$FIXTURE_REPO/terraform/version.sh" <<'SH'
+#!/bin/bash
+[[ "${1:-}" == "--tag-suffix" ]] && { printf '%s\n' '-alpine'; exit 0; }
+exit 1
+SH
+    chmod +x "$FIXTURE_REPO/terraform/version.sh"
     printf '#!/bin/bash\nexit 0\n' > "$FIXTURE_REPO/terraform/test.sh"
     chmod +x "$FIXTURE_REPO/terraform/test.sh"
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export DOCKER_PS_OUTPUT="e2e-terraform"
-    export E2E_IMAGE="ghcr.io/example/terraform:e2e"
+    export E2E_IMAGE="ghcr.io/example/terraform:1.15.8-alpine"
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" terraform
 
@@ -434,7 +568,7 @@ SH
     # stop applying. One glob pins the sequence.
     # The trailing space matters: without it `--entrypoint sleeper` satisfies the
     # match while being an invalid entrypoint.
-    [[ "$run_line" == *"--entrypoint sleep "*"ghcr.io/example/terraform:e2e"*"infinity"* ]]
+    [[ "$run_line" == *"--entrypoint sleep "*"sha256:e2e-loaded-image"*"infinity"* ]]
 }
 
 @test "the readiness budget bounds elapsed time, not the number of polls" {
@@ -448,6 +582,10 @@ SH
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 case "$1" in
     images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
     ps)     /bin/sleep 1; printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
@@ -458,7 +596,7 @@ STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=3
 
     # Bounded so that a budget which has stopped bounding anything fails this test
@@ -493,6 +631,10 @@ STUB
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 case "$1" in
     images)  printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
     ps)      printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
@@ -503,7 +645,7 @@ STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     # Enough budget for two things at once: the loop certainly reaches the inspect
     # (at one second it can expire between the ps and the inspect), and a failed
     # inspect misread as "no healthcheck" would have room for its full grace and
@@ -532,7 +674,7 @@ STUB
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=1
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -552,6 +694,10 @@ STUB
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 case "$1" in
     images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
     ps)
@@ -570,7 +716,7 @@ STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
@@ -584,9 +730,13 @@ STUB
     # sibling called e2e-v1X2 would then stand in for e2e-v1.2, and the harness
     # would call an exited container running. No fixture directory is needed —
     # this fails before the per-container suite is ever looked for.
+    add_single_image_identity_fixture v1.2 v1.2-alpine -alpine
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/dotted:e2e"
+    # The resolver correctly requires the repository component to name the
+    # requested container, so use a compatible reference and reach the
+    # liveness assertion this test is about.
+    export E2E_IMAGE="ghcr.io/example/v1.2:v1.2-alpine"
     export DOCKER_PS_OUTPUT="e2e-v1X2"
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" v1.2
@@ -605,7 +755,7 @@ STUB
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=2
     # A real delay in the failing probe: the suite's sleep stub is a no-op, so a
     # stub that fails instantly would have the wait forking processes flat out for
@@ -614,6 +764,10 @@ STUB
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 case "$1" in
     images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
     ps)     /bin/sleep 1; exit 1 ;;
@@ -639,7 +793,7 @@ STUB
     printf '#!/bin/bash\nprintf "mktemp: fixture allocation failed\\n" >&2\nexit 1\n' > "$TEST_TEMP_DIR/bin/mktemp"
     chmod +x "$TEST_TEMP_DIR/bin/mktemp"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=1
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -670,12 +824,9 @@ STUB
         unbounded=$(grep -nE "^[^#]*(^|[^a-zA-Z_-])docker[[:space:]]" "$source_file" |
             grep -vE "timeout -k" |
             grep -vE "log_error|log_warning|printf|echo")
-        # Deliberately unbounded, for a stated reason:
-        #   docker images  — local discovery before anything is started
-        allowed="docker images"
-        offenders=$(printf "%s\n" "$unbounded" | grep -vE "$allowed" | grep -c . || true)
+        offenders=$(printf "%s\n" "$unbounded" | grep -c . || true)
         if [ "$offenders" -ne 0 ]; then
-            printf "%s\n" "$unbounded" | grep -vE "$allowed" >&2
+            printf "%s\n" "$unbounded" >&2
             exit 1
         fi
     ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
@@ -698,7 +849,7 @@ STUB
     add_openvpn_fixture
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=60
     export DOCKER_PS_OUTPUT=""
     export DOCKER_PS_ERROR="docker: command not found"
@@ -719,7 +870,7 @@ STUB
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=60
     export DOCKER_INSPECT_OUTPUT=""
     export DOCKER_INSPECT_ERROR="permission denied while trying to connect to the Docker daemon socket"
@@ -744,7 +895,7 @@ STUB
     printf '#!/bin/bash\nexit 127\n' > "$TEST_TEMP_DIR/bin/timeout"
     chmod +x "$TEST_TEMP_DIR/bin/timeout"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
@@ -764,6 +915,10 @@ STUB
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
 echo "Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg." >&2
 case "$1" in
     images)  printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
@@ -775,7 +930,7 @@ STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
@@ -789,7 +944,7 @@ STUB
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export DOCKER_INSPECT_OUTPUT=healthy
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -802,7 +957,7 @@ STUB
     add_openvpn_fixture
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=zero
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -820,7 +975,7 @@ STUB
     add_openvpn_fixture
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_TEST_TIMEOUT=zero
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
@@ -834,7 +989,7 @@ STUB
     add_openvpn_fixture
     install_docker_stub
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
-    export E2E_IMAGE="ghcr.io/example/openvpn:e2e"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=99999999999999999999
 
     run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn

--- a/tests/unit/image-identity.bats
+++ b/tests/unit/image-identity.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    RESOLVER="$PROJECT_ROOT/test-harness/image-identity.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+resolve() {
+    run bash -c 'source "$1"; image_identity_resolve "$2" "$3"' _ \
+        "$RESOLVER" "$1" "$2"
+}
+
+make_container() {
+    local name="$1" yaml="$2" suffix="$3"
+    local dir="$TEST_TEMP_DIR/$name"
+    mkdir -p "$dir"
+    printf '%s\n' "$yaml" > "$dir/variants.yaml"
+    printf '#!/usr/bin/env bash\nif [[ "${1:-}" == "--tag-suffix" ]]; then printf %%s %q; exit 0; fi\nexit 1\n' "$suffix" > "$dir/version.sh"
+    chmod +x "$dir/version.sh"
+    printf '%s\n' "$dir"
+}
+
+@test "resolves a port-bearing reference" {
+    local dir
+    dir=$(make_container web-shell '
+versions:
+  - tag: "1.7.7"
+    variants:
+      - name: debian
+        suffix: ""
+        flavor: debian
+        default: true
+      - name: ubuntu
+        suffix: "-ubuntu"
+        flavor: ubuntu
+' '')
+
+    resolve "$dir" "registry.example:5000/ns/web-shell:1.7.7-ubuntu"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.component_version + ":" + .variant + ":" + .flavor' <<<"$output")" = "1.7.7:ubuntu:ubuntu" ]
+}
+
+@test "uses a passed build cell without parsing its image reference" {
+    local dir
+    dir=$(make_container direct 'versions:
+  - tag: v2.3.1-alpine' '-alpine')
+
+    run env E2E_BUILD_TAG=v2.3.1-alpine E2E_BUILD_VERSION=v2.3.1-alpine \
+        E2E_BUILD_VARIANT='' E2E_BUILD_FLAVOR='' bash -c \
+        'source "$1"; image_identity_resolve "$2" "$3"' _ "$RESOLVER" "$dir" \
+        'unrelated:ignored@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tag + ":" + .component_version + ":" + .kind' <<<"$output")" = "v2.3.1-alpine:2.3.1:single" ]
+}
+
+@test "constructs tags with build.base_suffix, independently from version.sh's marker" {
+    local dir
+    dir=$(make_container construction '
+versions:
+  - tag: 1.2.3
+' '-alpine')
+
+    # base_suffix is empty here, even though version.sh identifies -alpine as
+    # the component marker.  The generator therefore builds :1.2.3, not
+    # :1.2.3-alpine.
+    resolve "$dir" "example/construction:1.2.3"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.component_version' <<<"$output")" = "1.2.3" ]
+}
+
+@test "rejects a digest-only reference" {
+    local dir
+    dir=$(make_container single 'versions:
+  - tag: 1.2.3-alpine' '-alpine')
+
+    resolve "$dir" "registry.example/ns/single@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"has a digest"* ]]
+}
+
+@test "resolves a versioned tag from a latest declaration" {
+    local dir
+    dir=$(make_container moving 'versions:
+  - tag: latest' '-alpine')
+
+    # The workflow replaces a latest declaration with this resolved version
+    # before generating the matrix; reverse resolution must do the same.
+    printf '#!/usr/bin/env bash\ncase "${1:-}" in\n  --tag-suffix) printf "%%s\\n" "-alpine" ;;\n  "") printf "%%s\\n" "1.2.3-alpine" ;;\n  *) exit 1 ;;\nesac\n' > "$dir/version.sh"
+    chmod +x "$dir/version.sh"
+
+    resolve "$dir" "example/moving:1.2.3-alpine"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.tag + ":" + .component_version' <<<"$output")" = "1.2.3-alpine:1.2.3" ]
+}
+
+@test "fails closed when variants.yaml is unreadable YAML" {
+    local dir="$TEST_TEMP_DIR/broken"
+    mkdir -p "$dir"
+    printf 'versions: [not valid\n' > "$dir/variants.yaml"
+    printf '#!/bin/bash\n[[ "${1:-}" == "--tag-suffix" ]] && exit 0\nexit 1\n' > "$dir/version.sh"
+    chmod +x "$dir/version.sh"
+
+    resolve "$dir" "example/broken:1.2.3"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not resolve to one declared cell"* ]]
+}
+
+@test "normalises sslh's leading v while preserving a prerelease" {
+    local dir
+    dir=$(make_container sslh 'versions:
+  - tag: v2.3.1-rc1-alpine' '-alpine')
+
+    resolve "$dir" "ghcr.io/example/sslh:v2.3.1-rc1-alpine"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.component_version' <<<"$output")" = "2.3.1-rc1" ]
+    [ "$(jq -r '.kind, .variant, .flavor' <<<"$output")" = $'single\nnull\nnull' ]
+}
+
+@test "resolves terraform's retained empty-suffix full variant as a variant cell" {
+    resolve "$PROJECT_ROOT/terraform" "ghcr.io/oorabona/terraform:1.15.6-alpine"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.component_version + ":" + .kind + ":" + .variant + ":" + .flavor' <<<"$output")" = "1.15.6:variant:full:full" ]
+}
+
+@test "mirrors generator coercions for version, suffix, and empty flavor" {
+    local dir
+    dir=$(make_container generator-compatible '
+versions:
+  - tag: 1.2
+    variants:
+      - name: null-suffix
+        suffix: null
+        flavor: ""
+' '')
+
+    resolve "$dir" "generator-compatible:1.2"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.component_version + ":" + .kind + ":" + .variant + ":" + .flavor' <<<"$output")" = "1.2:variant:null-suffix:" ]
+
+}
+
+@test "rejects a neighbouring version instead of prefix matching" {
+    local dir
+    dir=$(make_container version-boundary 'versions:
+  - tag: 12.2.40-alpine' '-alpine')
+
+    resolve "$dir" "example/version-boundary:2.2.4-alpine"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not name a declared cell"* ]]
+}
+
+@test "resolves web-shell ubuntu but rejects a typo instead of falling back to debian" {
+    resolve "$PROJECT_ROOT/web-shell" "web-shell:1.7.7-ubuntu"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.variant' <<<"$output")" = "ubuntu" ]
+
+    resolve "$PROJECT_ROOT/web-shell" "web-shell:1.7.7-typo"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not name a declared cell"* ]]
+}
+
+@test "uses the longest github-runner suffix and preserves the distinct variant name" {
+    resolve "$PROJECT_ROOT/github-runner" "github-runner:2.336.0-debian-trixie-dev"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.variant + ":" + .flavor' <<<"$output")" = "debian-trixie-dev:debian-trixie" ]
+
+    resolve "$PROJECT_ROOT/github-runner" "github-runner:2.336.0-dev"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.variant + ":" + .flavor' <<<"$output")" = "ubuntu-2404-dev:ubuntu-2404" ]
+}
+
+@test "accepts only postgres's generated base-before-variant tag order" {
+    resolve "$PROJECT_ROOT/postgres" "postgres:17-alpine-vector"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.variant' <<<"$output")" = "vector" ]
+
+    resolve "$PROJECT_ROOT/postgres" "postgres:17-vector-alpine"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not name a declared cell"* ]]
+}
+
+@test "rejects duplicate declared cell tags" {
+    local dir
+    dir=$(make_container duplicate 'versions:
+  - tag: 1.2.3-alpine
+    variants:
+      - name: first
+        suffix: ""
+        flavor: first
+      - name: second
+        suffix: ""
+        flavor: second
+' '-alpine')
+
+    resolve "$dir" "duplicate:1.2.3-alpine"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not resolve to one declared cell"* ]]
+}
+
+@test "refuses digest references and a repository for another container" {
+    local dir reference
+    dir=$(make_container refs 'versions:
+  - tag: v2.3.1-alpine' '')
+
+    for reference in \
+        'refs:v2.3.1-alpine@garbage' \
+        'refs:v2.3.1-alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' \
+        ':v2.3.1-alpine' \
+        'https://host/refs:v2.3.1-alpine' \
+        'unrelated:v2.3.1-alpine'; do
+        resolve "$dir" "$reference"
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "rejects incomplete and ill-typed image identity records" {
+    local record
+    for record in \
+        '{"reference":"image:1","tag":"1","component_version":"1","kind":"variant","variant":"","flavor":""}' \
+        '{"reference":"image:1","tag":"1","component_version":"1","kind":"variant","variant":7,"flavor":"alpine"}' \
+        '{"reference":"","tag":"1","component_version":"1","kind":"single","variant":null,"flavor":null}' \
+        '{"reference":"image:1","tag":"","component_version":"1","kind":"single","variant":null,"flavor":null}' \
+        '{"reference":"image:1","tag":"1","component_version":"1","kind":"single","variant":"base","flavor":null}'; do
+        run bash -c 'source "$1"; E2E_IMAGE_IDENTITY="$2"; _image_identity_record_field component_version' _ \
+            "$RESOLVER" "$record"
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "accepts an empty flavor for a variant identity record" {
+    local record='{"reference":"image:1","tag":"1","component_version":"1","kind":"variant","variant":"base","flavor":""}'
+
+    run bash -c 'source "$1"; E2E_IMAGE_IDENTITY="$2"; _image_identity_record_field kind' _ \
+        "$RESOLVER" "$record"
+    [ "$status" -eq 0 ]
+    [ "$output" = "variant" ]
+}
+
+@test "resolves every workflow build cell of every e2e-enabled container" {
+    local variants_file container_dir matrix cell tag version variant flavor expected_count=0 count=0
+    while IFS= read -r variants_file; do
+        container_dir="${variants_file%/variants.yaml}"
+        if ! yq -e '.tests.e2e.enabled == true' "$variants_file" >/dev/null 2>&1; then
+            continue
+        fi
+        matrix=$(bash -c 'source "$1/helpers/variant-utils.sh"; list_build_matrix "$2" "" true' _ \
+            "$PROJECT_ROOT" "$container_dir")
+        expected_count=$((expected_count + $(jq 'length' <<<"$matrix")))
+        while IFS= read -r cell; do
+            tag=$(jq -r '.tag' <<<"$cell")
+            version=$(jq -r '.version' <<<"$cell")
+            variant=$(jq -r '.variant' <<<"$cell")
+            flavor=$(jq -r '.flavor' <<<"$cell")
+            run env E2E_BUILD_TAG="$tag" E2E_BUILD_VERSION="$version" \
+                E2E_BUILD_VARIANT="$variant" E2E_BUILD_FLAVOR="$flavor" bash -c \
+                'source "$1"; image_identity_resolve "$2" "$3"' _ \
+                "$RESOLVER" "$container_dir" "${container_dir##*/}:$tag"
+            [ "$status" -eq 0 ]
+            [ "$(jq -r '.tag' <<<"$output")" = "$tag" ]
+            count=$((count + 1))
+        done < <(jq -c '.[]' <<<"$matrix")
+    done < <(find "$PROJECT_ROOT" -mindepth 2 -maxdepth 2 -name variants.yaml | sort)
+
+    [ "$count" -eq "$expected_count" ]
+}

--- a/wordpress/test.sh
+++ b/wordpress/test.sh
@@ -10,6 +10,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../test-harness/test-harness.sh
 source "${SCRIPT_DIR}/../test-harness/test-harness.sh"
+# shellcheck source=../test-harness/image-identity.sh
+source "${SCRIPT_DIR}/../test-harness/image-identity.sh"
 
 CONTAINER_NAME="${CONTAINER_NAME:-e2e-wordpress}"
 
@@ -28,21 +30,9 @@ if th_capture "WP-CLI loads the installed WordPress core" \
     th_assert_matches "WP-CLI reports the installed WordPress core version" \
         "$reported_core" '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
 
-    # A well-formed version is not the RIGHT version: the tag says which release
-    # this image is, so a 7.0.2 build shipping 6.9.4 has to fail rather than pass
-    # for looking version-shaped.
-    expected_core=""
-    if [ -n "${E2E_IMAGE:-}" ]; then
-        expected_core="${E2E_IMAGE##*:}"
-        expected_core="${expected_core%%-*}"
-    fi
-    if [[ "$expected_core" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-        th_assert_eq "the core version matches the image tag ($expected_core)" \
-            "$reported_core" "$expected_core"
-    else
-        th_skip "the core version matches the image tag" \
-            "tag '${expected_core:-none}' carries no version"
-    fi
+    # A well-formed version is not the RIGHT version.  The identity assertion
+    # comes from the harness's declared-cell resolver, never from splitting a tag.
+    e2e_assert_reported_component_version "$reported_core"
 fi
 
 # `wp core version` succeeds without a database, making it a real WP-CLI probe


### PR DESCRIPTION
Closes #1018
Closes #1002

Three e2e suites answered "what version and flavour is this image?" by cutting up
`${E2E_IMAGE##*:}`, and each was wrong differently — a substring that let `2.2.4`
pass against a binary reporting `12.2.40`, a first-hyphen cut that destroyed
prereleases, a digest-pinned reference that yielded digest hex, and a default tag
carrying no flavour suffix so a mistagged `base` build passed on its own say-so.
All four ended as a **skip**: a check that could not determine the identity
reported success.

## The workflow already knew

It passes the whole build cell to the build action, then ran the e2e with only the
container and the tag. It exports the cell now, so on the CI path the harness
parses nothing at all.

That is only sound if the image under test is the one the job built — and it was
not. The build step had no `id`, nothing checked the action's `image_loaded`
output, and the harness ran a mutable GHCR tag with no restriction on pulling. A
build that loaded no image left the e2e validating the **previously published**
one, and handing that an authoritative identity would have made every assertion
vouch for it. The job now fails unless the image was loaded, and discovery returns
the image ID it inspected so the container started is the exact image whose tags
established the identity.

## Reverse resolution calls the generator instead of copying it

For a hand-run bare reference the harness matches the observed tag against
`list_build_matrix` — the same function that produces this workflow's matrix —
rather than reimplementing tag construction. Parity stops being a property to
maintain and becomes identity. Retained versions resolve, and a `tag: latest`
declaration resolves through the concrete tag the generator substitutes.

Two refusals, both previously silent successes: a reference carrying **both** a
tag and a digest, because Docker runs the digest while the tag need not still name
that manifest; and a repository that does not name the container being resolved,
where `wordpress` accepted `unrelated/image:7.0.2-alpine`.

## Verification

- unit suite 2261, 0 failing; 18 resolver tests; 34 harness tests
- shellcheck clean; the workflow parses
- wordpress **18 passed + 1 skipped → 19 passed, 0 skipped**, on local discovery
  and on the CI shape of an image ID plus the cell
- sslh asserts an exact `2.3.1` from a shape-checked banner
- terraform's default tag resolves to the `full` variant it had been skipping
- retained `terraform:1.15.6-alpine` resolves; `postgres:17-vector-alpine` and
  `web-shell:1.7.7-typo` are rejected
- no run leaves a container behind

Every docker call the harness makes is bounded, including the two inspections
added here — the guard enforcing that had been given an exemption for the newest
of them, and the exemption is gone.

## Note for review

This changes the harness that gates every other PR, so CI on this PR is the
strongest available evidence: it exercises the new gate across containers and both
architectures, which local runs cannot. Merging is conditional on that being green.

Follow-up filed rather than folded in: #1036 (`--no-build` with an explicit tag
names a Docker Hub reference instead of the local image; reproduces on `master`),
and the design record in #1037.
