### PR TITLE
test(harness): stop numeric assertions evaluating container output as arithmetic

### DIFF
--- a/test-harness/test-harness.sh
+++ b/test-harness/test-harness.sh
@@ -350,7 +350,12 @@ th_assert_not_empty() {
 # Assert numeric greater-than-or-equal.
 th_assert_ge() {
     local name="$1" actual="$2" minimum="$3"
-    if [[ "$actual" -ge "$minimum" ]] 2>/dev/null; then
+
+    _th_trim_whitespace "$actual"; actual="$REPLY"
+    _th_trim_whitespace "$minimum"; minimum="$REPLY"
+    if ! _th_is_decimal "$actual" || ! _th_is_decimal "$minimum"; then
+        _th_record fail "$name" "expected decimal operands; received actual: '$actual', minimum: '$minimum'"
+    elif [[ "$actual" -ge "$minimum" ]] 2>/dev/null; then
         _th_record pass "$name"
     else
         _th_record fail "$name" "expected >= $minimum, got: '$actual'"
@@ -361,12 +366,30 @@ th_assert_ge() {
 # Assert numeric greater-than.
 th_assert_gt() {
     local name="$1" actual="$2" minimum="$3"
-    if [[ "$actual" -gt "$minimum" ]] 2>/dev/null; then
+
+    _th_trim_whitespace "$actual"; actual="$REPLY"
+    _th_trim_whitespace "$minimum"; minimum="$REPLY"
+    if ! _th_is_decimal "$actual" || ! _th_is_decimal "$minimum"; then
+        _th_record fail "$name" "expected decimal operands; received actual: '$actual', minimum: '$minimum'"
+    elif [[ "$actual" -gt "$minimum" ]] 2>/dev/null; then
         _th_record pass "$name"
     else
         _th_record fail "$name" "expected > $minimum, got: '$actual'"
     fi
     return 0
+}
+
+# Trim surrounding whitespace without evaluating the value as shell code.
+_th_trim_whitespace() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    REPLY="${value%"${value##*[![:space:]]}"}"
+}
+
+# Decimal-only validation before an arithmetic comparison prevents bash from
+# interpreting an assertion operand as an arithmetic expression.
+_th_is_decimal() {
+    [[ "$1" =~ ^[+-]?[0-9]+$ ]]
 }
 
 # Assert value matches regex pattern.

--- a/tests/unit/test-harness-command-probes.bats
+++ b/tests/unit/test-harness-command-probes.bats
@@ -129,3 +129,62 @@ secret_bearing() {
     echo "$output" | jq -e '.tests[0].status == "fail"' >/dev/null
     [[ "$output" != *"s3cr3t"* ]]
 }
+
+@test "numeric assertions accept plain integers" {
+    run th_assert_ge "four is at least three" "4" "3"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+
+    run th_assert_gt "four is greater than three" "4" "3"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "numeric assertions preserve negative and zero comparisons" {
+    run th_assert_ge "negative equality" "-2" "-2"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+
+    run th_assert_gt "zero is greater than negative one" "0" "-1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "numeric assertions trim surrounding whitespace" {
+    run th_assert_ge "whitespace is ignored" $' \t 4 \n' $' 3 '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
+@test "numeric assertions fail for non-decimal operands" {
+    run th_assert_ge "invalid actual" "not-a-number" "3"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FAIL"* ]]
+    [[ "$output" == *"received actual: 'not-a-number'"* ]]
+    [[ "$output" != *"PASS"* ]]
+    [[ "$output" != *"SKIP"* ]]
+
+    run th_assert_gt "invalid minimum" "3" "not-a-number"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FAIL"* ]]
+    [[ "$output" == *"minimum: 'not-a-number'"* ]]
+}
+
+@test "numeric assertions do not evaluate arithmetic-looking operands" {
+    local pwned_file="/tmp/pwned"
+    local malicious='x[$(touch /tmp/pwned)0]'
+
+    if [[ -e "$pwned_file" ]]; then
+        skip "$pwned_file already exists"
+    fi
+
+    run th_assert_ge "malicious operand" "$malicious" "0"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FAIL"* ]]
+    [ ! -e "$pwned_file" ]
+
+    run th_assert_gt "malicious operand" "$malicious" "0"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FAIL"* ]]
+    [ ! -e "$pwned_file" ]
+}


### PR DESCRIPTION
Closes #1024

`th_assert_ge` and `th_assert_gt` compared inside `[[ … -ge … ]]`, an arithmetic context where bash performs command substitution on both operands. An operand shaped like `x[$(command)0]` ran `command` on the host running the suite, not in the container under test. The `2>/dev/null` hid the diagnostic; it never prevented the execution.

Seven call sites feed these helpers the output of a command run inside a container — five in postgres, one in ansible.

The guard is in the helper, not at the call sites, so a new assertion written the obvious way cannot reintroduce it. A non-numeric operand now fails with a message naming what arrived; it does not pass and does not skip. Every current caller passes a count, so no legitimate input changes behaviour.

The test asserts the side effect did **not** happen: it passes `x[$(touch <marker>)0]` and checks the marker was never created. Asserting only that the assertion failed would pass even while the command ran.

Harness suite 15 passing; full unit suite 2244, 0 failing; shellcheck clean.