### PR TITLE
fix(e2e): --no-build with an explicit tag uses the local image

### DIFF
--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -84,28 +84,21 @@ resolve_e2e_image() {
         return 0
     fi
 
-    if [ -n "$image_tag" ]; then
-        local tagged_image
-        tagged_image="docker.io/${github_repository_owner}/${container}:${image_tag}"
-        if [[ "$output_format" == "--json" ]]; then
-            jq -cn --arg image "$tagged_image" '{image: $image, image_id: null, cell: null}'
-        else
-            printf '%s\n' "$tagged_image"
-        fi
-        return 0
-    fi
-
     local images=""
     images=$(timeout -k 2 10 docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
 
     local ids
-    ids=$(printf '%s\n' "$images" | awk -v owner="$github_repository_owner" -v container="$container" '
+    ids=$(printf '%s\n' "$images" | awk -v owner="$github_repository_owner" -v container="$container" -v tag="$image_tag" '
         function starts_with(value, prefix) {
             return substr(value, 1, length(prefix)) == prefix
         }
-        starts_with($2, "ghcr.io/" owner "/" container ":") ||
-        starts_with($2, "docker.io/" owner "/" container ":") ||
-        starts_with($2, container ":") {
+        function local_image(value) {
+            return starts_with(value, "ghcr.io/" owner "/" container ":") ||
+                starts_with(value, "docker.io/" owner "/" container ":") ||
+                starts_with(value, container ":")
+        }
+        local_image($2) && (tag == "" || $2 == "ghcr.io/" owner "/" container ":" tag ||
+            $2 == "docker.io/" owner "/" container ":" tag || $2 == container ":" tag) {
             print $1
         }
     ' | sort -u)
@@ -118,6 +111,17 @@ resolve_e2e_image() {
     fi
 
     if [ "$count" -eq 0 ]; then
+        if [ -n "$image_tag" ]; then
+            local tagged_image
+            tagged_image="docker.io/${github_repository_owner}/${container}:${image_tag}"
+            log_info "Image $tagged_image was not found locally; using remote reference"
+            if [[ "$output_format" == "--json" ]]; then
+                jq -cn --arg image "$tagged_image" '{image: $image, image_id: null, cell: null}'
+            else
+                printf '%s\n' "$tagged_image"
+            fi
+            return 0
+        fi
         log_error "No image found for $container; build it first, pass container:tag, or set E2E_IMAGE"
         return 1
     fi
@@ -179,11 +183,12 @@ resolve_e2e_image() {
                 selected_cell="$candidate_cell"
             fi
         fi
-    done < <(printf '%s\n' "$images" | awk -v id="$ids" -v owner="$github_repository_owner" -v container="$container" '
+    done < <(printf '%s\n' "$images" | awk -v id="$ids" -v owner="$github_repository_owner" -v container="$container" -v tag="$image_tag" '
         function starts_with(value, prefix) {
             return substr(value, 1, length(prefix)) == prefix
         }
-        $1 == id && (starts_with($2, "ghcr.io/" owner "/" container ":") || starts_with($2, "docker.io/" owner "/" container ":") || starts_with($2, container ":")) {
+        $1 == id && (starts_with($2, "ghcr.io/" owner "/" container ":") || starts_with($2, "docker.io/" owner "/" container ":") || starts_with($2, container ":")) &&
+            (tag == "" || $2 == "ghcr.io/" owner "/" container ":" tag || $2 == "docker.io/" owner "/" container ":" tag || $2 == container ":" tag) {
             print $2
         }
     ')

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -448,6 +448,49 @@ SH
     ! grep -q '^run ' "$DOCKER_LOG"
 }
 
+@test "an explicit tag uses its local ghcr image" {
+    add_single_image_identity_fixture debian trixie ''
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT='sha111 ghcr.io/oorabona/debian:trixie'
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian trixie --json' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.image' <<<"$output")" = "ghcr.io/oorabona/debian:trixie" ]
+    [ "$(jq -r '.image_id' <<<"$output")" = "sha111" ]
+    [ "$(jq -r '.cell.tag' <<<"$output")" = "trixie" ]
+}
+
+@test "an explicit tag on two local prefixes sharing one image ID is unambiguous" {
+    add_single_image_identity_fixture debian trixie ''
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=$'sha111 ghcr.io/oorabona/debian:trixie\nsha111 docker.io/oorabona/debian:trixie'
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian trixie --json' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.image' <<<"$output")" = "ghcr.io/oorabona/debian:trixie" ]
+    [ "$(jq -r '.image_id' <<<"$output")" = "sha111" ]
+    [ "$(jq -r '.cell.tag' <<<"$output")" = "trixie" ]
+}
+
+@test "an explicit tag absent locally falls back to Docker Hub with an explanation" {
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export DOCKER_IMAGES_OUTPUT=''
+
+    run env E2E_TEST_SOURCE_ONLY=1 bash -c 'source "$1"; resolve_e2e_image debian trixie' _ \
+        "$FIXTURE_REPO/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Image docker.io/oorabona/debian:trixie was not found locally; using remote reference"* ]]
+    [[ "$output" == *"docker.io/oorabona/debian:trixie"* ]]
+}
+
 @test "fallback image discovery keeps a declared cell when its tag precedes latest" {
     add_single_image_identity_fixture debian trixie ''
     install_docker_stub


### PR DESCRIPTION

`resolve_e2e_image` hardcoded Docker Hub whenever a tag was given:

    tagged_image="docker.io/${owner}/${container}:${image_tag}"

so `./tests/e2e-test.sh terraform:1.15.8-alpine --no-build` named a Docker Hub
reference while the locally built image was under `ghcr.io/`, and the run failed
between the "Using image" line and the summary without saying why. `--no-build`
reads as "use what is already here"; reaching for a remote registry is the
opposite of that.

An explicit tag now goes through the same discovery the no-tag path uses — one
lookup across `ghcr.io/`, `docker.io/` and the bare name, not a second
implementation — and falls back to a remote reference only when nothing local
matches, saying so when it does.

Measured on this machine: `wordpress:7.0.2-alpine`, whose four local references
share one image ID, now resolves to the `ghcr.io` one instead of Docker Hub.
`terraform:1.15.8-alpine` exists under two DIFFERENT image IDs here — a stale
Docker Hub copy and the freshly built GHCR one — and is refused with both
candidates named, which is the honest answer: the harness cannot know which was
meant, and picking one silently is how a run tests the wrong image.

Identity behaviour is unchanged: it comes from the passed cell when the caller
supplies one, and otherwise from resolving the selected tag. No parsing returns.

Harness suite 37 passing; full unit suite 2269, 0 failing; shellcheck clean.

Closes #1036