### PR TITLE
fix(e2e): a readiness timeout reports what the probes said

### DIFF
--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -562,7 +562,11 @@ test_container() {
     local ready=false
     # Declared here, not on the assignment below: `local x=$(cmd)` returns the
     # builtin's status, which would swallow the one the loop condition reads.
-    local remaining health readiness_stderr
+    local remaining health readiness_stderr readiness_stderr_for_log
+    # A timeout after probes failed is different from a container that simply
+    # stayed unready. Preserve the most recent failed probe so the report says
+    # what the wait observed without changing which failures are retryable.
+    local last_readiness_probe="" last_readiness_status="" last_readiness_stderr=""
     # Status only — mktemp's stderr is deliberately NOT folded into the value. A
     # capture that merges stderr into a variable is poisoned by anything the tool
     # writes there on success, which is how a CLI that greets on stderr corrupts
@@ -593,8 +597,12 @@ test_container() {
             2>"$READINESS_STDERR_FILE") || ps_status=$?
         if [ "$ps_status" -ne 0 ]; then
             readiness_stderr=$(cat "$READINESS_STDERR_FILE" 2>/dev/null)
+            readiness_stderr_for_log=$(_escape_gha_command "$readiness_stderr")
+            last_readiness_probe="ps"
+            last_readiness_status="$ps_status"
+            last_readiness_stderr="$readiness_stderr_for_log"
             if docker_readiness_failure_is_terminal "$ps_status" "$readiness_stderr"; then
-                log_error "docker ps failed (exit $ps_status): $readiness_stderr"
+                log_error "readiness ps probe attempt returned status $ps_status: $readiness_stderr_for_log"
                 cleanup_container
                 return 1
             fi
@@ -631,8 +639,12 @@ test_container() {
             "$container_name" 2>"$READINESS_STDERR_FILE") || inspect_status=$?
         if [ "$inspect_status" -ne 0 ]; then
             readiness_stderr=$(cat "$READINESS_STDERR_FILE" 2>/dev/null)
+            readiness_stderr_for_log=$(_escape_gha_command "$readiness_stderr")
+            last_readiness_probe="inspect"
+            last_readiness_status="$inspect_status"
+            last_readiness_stderr="$readiness_stderr_for_log"
             if docker_readiness_failure_is_terminal "$inspect_status" "$readiness_stderr"; then
-                log_error "docker inspect failed (exit $inspect_status): $readiness_stderr"
+                log_error "readiness inspect probe attempt returned status $inspect_status: $readiness_stderr_for_log"
                 cleanup_container
                 return 1
             fi
@@ -676,7 +688,11 @@ test_container() {
     echo ""
 
     if [ "$ready" != true ]; then
-        log_error "$container did not become ready in time"
+        if [ -n "$last_readiness_probe" ]; then
+            log_error "$container readiness timed out; last probe failure: $last_readiness_probe probe attempt returned status $last_readiness_status: $last_readiness_stderr"
+        else
+            log_error "$container did not become ready in time"
+        fi
         timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
         cleanup_container
         return 1

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -650,7 +650,10 @@ STUB
     local elapsed=$((SECONDS - before))
 
     assert_harness_failed_on_its_own
-    [[ "$output" == *"did not become ready in time"* ]]
+    # The final probe may be admitted with a one-second bound and either finish
+    # or be killed by that bound.  Both reports are correct; this test is about
+    # the elapsed readiness deadline, not which side of that scheduling edge won.
+    [[ "$output" == *"readiness timed out"* || "$output" == *"did not become ready in time"* ]]
     # Both probes ran: without this, an implementation that skipped every docker
     # call and declared a timeout immediately would satisfy the timing bound.
     grep -q '^ps ' "$DOCKER_LOG"
@@ -665,12 +668,35 @@ STUB
     [ "$elapsed" -lt 20 ]
 }
 
+@test "a container whose probes remain starting reports a readiness timeout" {
+    add_openvpn_fixture
+    install_docker_stub
+    # The normal test stub suppresses sleeps. Restore them here so each successful
+    # poll is followed by a real retry delay rather than spinning until a probe is
+    # admitted with only one second left and gets killed by its own bound.
+    printf '#!/bin/bash\nexec /bin/sleep "$@"\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
+    export E2E_READY_TIMEOUT=3
+    export DOCKER_INSPECT_OUTPUT=starting
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    # Successful probes can still be starved after admission at the final
+    # one-second boundary.  If that happens it is a real probe failure and the
+    # report must name it; otherwise the no-failure wording is correct.
+    [[ "$output" == *"did not become ready in time"* || "$output" == *"readiness timed out; last probe failure:"* ]]
+    [ ! -e "$TEST_SCRIPT_MARKER" ]
+}
+
 @test "an inspect failure never treats the container as ready" {
     add_openvpn_fixture
     install_docker_stub
-    # A second of real time per inspect: with the suite's no-op sleep stub the
-    # wait would otherwise spin hot for its whole budget, spawning processes for
-    # nothing.
+    # Restore retry sleeps below: with the suite's no-op sleep stub the wait would
+    # otherwise spin hot for its whole budget, spawning processes for nothing.
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
@@ -681,11 +707,16 @@ fi
 case "$1" in
     images)  printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
     ps)      printf '%s\n' "${DOCKER_PS_OUTPUT:-e2e-openvpn}" ;;
-    inspect) /bin/sleep 1; exit 1 ;;
+    inspect)
+        printf '%s\n' "inspect transport failed" "inspect retry diagnostic" >&2
+        exit 42
+        ;;
     *)       exit 0 ;;
 esac
 STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+    printf '#!/bin/bash\nexec /bin/sleep "$@"\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
     export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
     export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
@@ -702,7 +733,7 @@ STUB
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
     assert_harness_failed_on_its_own
-    [[ "$output" == *"did not become ready in time"* ]]
+    [[ "$output" == *"readiness timed out; last probe failure: inspect probe attempt returned status 42: inspect transport failed%0Ainspect retry diagnostic"* ]]
     [ ! -e "$TEST_SCRIPT_MARKER" ]
     # The branch under test is the one that reads a failed inspect, so prove the
     # inspect was actually attempted rather than skipped past.
@@ -790,7 +821,7 @@ STUB
     [[ "$output" == *"exited unexpectedly"* ]]
 }
 
-@test "a docker ps that cannot answer is a timeout, not a container exit" {
+@test "an unrecognised docker ps failure is reported at the timeout, not as a container exit" {
     # The two are different claims: one says the runtime did not answer, the other
     # says it answered and the container was gone. Reporting the first as the
     # second blames the image for the daemon.
@@ -800,10 +831,8 @@ STUB
     export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/openvpn-test.marker"
     export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
     export E2E_READY_TIMEOUT=2
-    # A real delay in the failing probe: the suite's sleep stub is a no-op, so a
-    # stub that fails instantly would have the wait forking processes flat out for
-    # its whole budget — CPU that shows up as flake in the timing test running
-    # alongside it.
+    # Restore retry sleeps below: without them a failing probe would make the wait
+    # fork processes flat out for its whole budget, adding flaky CPU pressure.
     cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
@@ -813,18 +842,64 @@ if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
 fi
 case "$1" in
     images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
-    ps)     /bin/sleep 1; exit 1 ;;
+    ps)
+        printf '%s\n' "ps transport failed" "ps retry diagnostic" >&2
+        exit 42
+        ;;
     *)      exit 0 ;;
 esac
 STUB
     chmod +x "$TEST_TEMP_DIR/bin/docker"
+    printf '#!/bin/bash\nexec /bin/sleep "$@"\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
 
     run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
 
     assert_harness_failed_on_its_own
-    [[ "$output" == *"did not become ready in time"* ]]
+    [[ "$output" == *"readiness timed out; last probe failure: ps probe attempt returned status 42: ps transport failed%0Aps retry diagnostic"* ]]
     [[ "$output" != *"exited unexpectedly"* ]]
     [ ! -e "$TEST_SCRIPT_MARKER" ]
+}
+
+@test "a retained readiness diagnostic cannot forge a workflow command" {
+    # The report is a log sink.  In particular, the second physical stderr line
+    # must stay part of the value rather than becoming a GitHub Actions command.
+    # An oversized tail confirms the report is no longer truncated while the
+    # second physical stderr line remains a value rather than an annotation.
+    add_openvpn_fixture
+    install_docker_stub
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "$1" == "image" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "sha256:e2e-loaded-image"
+    exit 0
+fi
+case "$1" in
+    images) printf '%s\n' "${DOCKER_IMAGES_OUTPUT:-}" ;;
+    ps)
+        printf '%s\n' "ps transport failed" "::error::forged annotation" >&2
+        head -c 2048 /dev/zero | tr '\0' x >&2
+        exit 42
+        ;;
+    *) exit 0 ;;
+esac
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    printf '#!/bin/bash\nexec /bin/sleep "$@"\n' > "$TEST_TEMP_DIR/bin/sleep"
+    chmod +x "$TEST_TEMP_DIR/bin/sleep"
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export E2E_IMAGE="ghcr.io/example/openvpn:v2.7.5-alpine"
+    export E2E_READY_TIMEOUT=2
+
+    run timeout -k 2 30 "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    assert_harness_failed_on_its_own
+    [[ "$output" == *"readiness timed out; last probe failure: ps probe attempt returned status"* ]]
+    [[ "$output" == *"%0A::error::forged annotation"* ]]
+    [[ "$output" != *$'\n::error::forged annotation'* ]]
+    [[ "$output" != *"[stderr truncated after 1024 bytes]"* ]]
+    [[ "$output" == *"$(head -c 2048 /dev/zero | tr '\0' x)"* ]]
 }
 
 @test "a failed readiness stderr allocation reports the harness failure" {
@@ -903,7 +978,7 @@ STUB
     local elapsed=$((SECONDS - before))
 
     assert_harness_failed_on_its_own
-    [[ "$output" == *"docker ps failed (exit 127): docker: command not found"* ]]
+    [[ "$output" == *"readiness ps probe attempt returned status 127: docker: command not found"* ]]
     [[ "$output" != *"did not become ready in time"* ]]
     [ "$elapsed" -lt 10 ]
 }
@@ -924,7 +999,7 @@ STUB
     local elapsed=$((SECONDS - before))
 
     assert_harness_failed_on_its_own
-    [[ "$output" == *"docker inspect failed (exit 1): permission denied while trying to connect to the Docker daemon socket"* ]]
+    [[ "$output" == *"readiness inspect probe attempt returned status 1: permission denied while trying to connect to the Docker daemon socket"* ]]
     [[ "$output" != *"did not become ready in time"* ]]
     [ "$elapsed" -lt 10 ]
     [ ! -e "$TEST_SCRIPT_MARKER" ]


### PR DESCRIPTION
Closes #1026

The readiness loop captured each failed probe's stderr, used it to classify the failure, and dropped it on the retry path. When the budget expired the report was `<container> did not become ready in time` — asserting a cause it does not know, while the evidence it had collected went unmentioned.

The message now carries the last probe failure when there was one: which probe, its status, and what Docker said. A container whose probes all succeeded and simply never reported healthy keeps the original wording, because that is a different outcome and the two must stay distinguishable. The stderr goes through `_escape_gha_command`, and the wording names the probe *attempt* rather than claiming Docker returned the status — `timeout`'s own 125, or a failed redirection, means Docker may never have run.

## What this deliberately does not do

It does not invert `docker_readiness_failure_is_terminal`, which is what #1026 proposed. Measured on this repository's CI — 12 recent auto-build runs, 65 readiness waits — there were zero transient probe failures, zero timeouts and zero unexpected exits. That is structural rather than lucky: a GitHub-hosted runner always has a local daemon on a unix socket, so the modes the inversion would catch sooner do not arise there. Inverting buys failing ~60s earlier on events that do not happen, and costs turning any unrecognised hiccup into a hard failure on a gate that runs for every PR.

A cap on the reported stderr was tried and reverted: it left the underlying write unbounded, carried bypasses of its own, and truncated the string passed to the classifier — so a `permission denied` beyond the cap turned a permanent authorization failure into a retried one. Bounding is tracked in #1042 with the three conditions that attempt taught: bound the write, bound the report copy, never bound what the classifier sees.

## Verification

- `bats tests/unit/e2e-test.bats` five consecutive runs, 0 failures each — a single green run does not demonstrate a timing fix
- full unit suite 2271, 0 failing; shellcheck clean
- the injection test asserts both directions: the forged `::error::` line appears escaped as `%0A::error::…` and does not appear as a real newline followed by `::error::`

Review reached CLEAN on security, edge cases, error paths, concurrency and contract; residue is on #1042.