### PR TITLE
test(ci): print a failing test's captured output so a flake can be read

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -122,12 +122,33 @@ run_tests() {
     echo "==================================="
     echo ""
 
+    # --print-output-on-failure: 1201 assertions in these files are a bare
+    # `[ "$status" -eq 0 ]`, and without this flag a failing one prints that
+    # line and nothing else — not the stderr of the script that exited
+    # non-zero. Every intermittent failure recorded in #964 looks identical
+    # for that reason, which is why none could be diagnosed from its run.
+    #
+    # Probed rather than assumed: check_bats accepts whichever bats is on PATH,
+    # and one too old to know the option exits non-zero with no `not ok` line —
+    # which is exactly the signature _bats_with_retry treats as a flake, so it
+    # would sleep, retry twice, and report a phantom flake instead of naming the
+    # unsupported option. Costing an operator the time this change saves.
+    local -a output_flag=()
+    local bats_help=""
+    if ! bats_help="$(bats --help 2>&1)"; then
+        log_warning "could not read 'bats --help' to probe options; running without --print-output-on-failure, so a failing test will not show its captured output (see #964)"
+    elif grep -q -- '--print-output-on-failure' <<< "$bats_help"; then
+        output_flag=(--print-output-on-failure)
+    else
+        log_warning "this bats lacks --print-output-on-failure; a failing test will not show its captured output (see #964)"
+    fi
+
     if [[ -n "$test_pattern" ]]; then
         log_info "Running tests matching: $test_pattern"
-        _bats_with_retry --tap --jobs 4 "$SCRIPT_DIR/unit/"*"$test_pattern"*.bats
+        _bats_with_retry --tap --jobs 4 ${output_flag[@]+"${output_flag[@]}"} "$SCRIPT_DIR/unit/"*"$test_pattern"*.bats
     else
         log_info "Running all unit tests..."
-        _bats_with_retry --tap --jobs 4 "$SCRIPT_DIR/unit/"*.bats
+        _bats_with_retry --tap --jobs 4 ${output_flag[@]+"${output_flag[@]}"} "$SCRIPT_DIR/unit/"*.bats
     fi
 }
 


### PR DESCRIPTION
Closes #964.

Four intermittent unit-test failures are on record — two on CI in July, two observed locally today — and none could be diagnosed from its own run. Every report reads the same:

```
not ok 1332 no-arg whole-fleet generate excludes postgres
# (in test file tests/unit/generate-bake-hcl.bats, line 698)
#   `[ "$status" -eq 0 ]' failed
```

The script under test exited non-zero and the reason went nowhere. 1201 assertions across these files are that same bare status check, so any of them failing produces exactly this and nothing more. These failures were never hard to diagnose — the evidence was discarded before anyone could look at it.

The runner was not passing `--print-output-on-failure`, which bats has carried since long before the 1.13 vendored here. Measured side by side on a probe that writes to stderr and exits 3: without the flag, the assertion line alone; with it, `# Last output:` followed by the message naming the cause.

This fixes no flake. It makes the next one readable, which is what the issue title asks for. One of today's two already carried a clue that was being thrown away — `gpg: WARNING: running with faked system time`, from a test that generates a key while three other bats jobs run.

## Two things checked so nobody repeats them

The working tree is not mutated during a run: sampling `git status --porcelain` every 0.4s through a full suite showed only the two pre-existing untracked files. And the generator behind two of the four failures did not fail once in 183 consecutive invocations run concurrently with the full suite on this machine. The trigger is not reproducible here, which is the argument for capturing evidence rather than hunting further.

## Degradation

The flag is probed from `bats --help` rather than assumed. `check_bats` accepts whichever bats is on `PATH` and prefers a system one over the vendored copy; a version that rejects the option exits non-zero with no `not ok` line, which is exactly what the retry wrapper classifies as a flake — it would sleep, retry twice and report a phantom flake instead of naming the unsupported option. A probe that cannot run at all is reported differently from one that ran and found nothing. Both paths verified against stub executables.

The expansion uses `${output_flag[@]+"${output_flag[@]}"}` because under `set -u` on Bash 3.2, still macOS's default, a plain `"${arr[@]}"` on an empty array expands to one empty argument rather than none.

## Verified

Full suite 2292 declared and 2292 executed, 0 failing; the flag adds output only to failing tests, so a green run is unchanged. shellcheck clean. One file, and no test file touched.
