### PR TITLE
test(e2e): make an unbounded docker call inexpressible, not merely detected

### DIFF
--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -18,6 +18,41 @@
 # Set E2E_TEST_TIMEOUT=<seconds> (1-99999, default 600) to bound each
 # container-specific test suite.
 
+# Every Docker invocation in this harness goes through this implementation.
+# `timeout` executes a binary rather than a shell function, so run a short
+# shell which replaces itself with the real Docker binary through `env`.
+# `command timeout` likewise prevents an inherited shell function from removing
+# the bound.
+#
+# BASH_ENV must be absent while the intermediary Bash starts, or Bash sources
+# it once per Docker invocation. Preserve it for Docker itself, though: it is
+# Docker's caller environment, not configuration for this harness.
+#
+# Per-call prefix assignments are intentionally scoped to the function call:
+# `_DOCKER_TIMEOUT=120 _DOCKER_TIMEOUT_KILL_AFTER=5 _e2e_docker run ...`
+# changes one bound without leaking to later calls.
+_e2e_docker() {
+    local duration="${_DOCKER_TIMEOUT:-10}"
+    local grace="${_DOCKER_TIMEOUT_KILL_AFTER:-2}"
+
+    # A zero or empty duration is `timeout`'s "no limit", which would silently
+    # turn the bound off — an inherited environment variable or a typo, not an
+    # attack. Refuse rather than run unbounded.
+    if ! [[ "$duration" =~ ^[1-9][0-9]*$ ]] || ! [[ "$grace" =~ ^[1-9][0-9]*$ ]]; then
+        printf '::error::e2e: _e2e_docker needs positive bounds, got duration=%s grace=%s\n' \
+            "$(_escape_gha_command "$duration")" "$(_escape_gha_command "$grace")" >&2
+        return 64
+    fi
+
+    # `timeout` execs the binary, so this line is the one place the script names
+    # docker after timeout — the guard below exempts it by line, and nothing
+    # else. An earlier version routed through `bash -c` to keep even this line
+    # clear of the construct; that bought one less exemption at the price of a
+    # shell per call, a BASH_ENV question, and a guard pinned to the payload's
+    # exact spelling. One exemption on the single source of truth is cheaper.
+    command timeout -k "$grace" "$duration" docker "$@"
+}
+
 # Resolve the real version exactly as the workflow does for a `tag: latest`
 # declaration: ask version.sh and use latest as its failure/unknown fallback.
 # There is no live lookup when the declaration has no latest tag, which keeps
@@ -85,7 +120,7 @@ resolve_e2e_image() {
     fi
 
     local images=""
-    images=$(timeout -k 2 10 docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
+    images=$(_DOCKER_TIMEOUT=10 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker images --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null) || true
 
     local ids
     ids=$(printf '%s\n' "$images" | awk -v owner="$github_repository_owner" -v container="$container" -v tag="$image_tag" '
@@ -223,6 +258,12 @@ fi
 
 set -euo pipefail
 
+# Source-only users keep their own docker function, while normal execution
+# makes a bare docker call bounded too.
+docker() {
+    _e2e_docker "$@"
+}
+
 # The readiness deadline is `SECONDS` plus a budget, and `SECONDS` is inherited:
 # a caller who exports a huge one would wrap that sum negative and every wait
 # would expire before it began. Reset once, here, so the deadlines below start
@@ -297,13 +338,12 @@ if ! [[ "$TEST_TIMEOUT" =~ ^[1-9][0-9]{0,4}$ ]]; then
     exit 1
 fi
 
-# The wait bounds each docker call with `timeout -k`, and so does the cleanup that
-# removes a container after a failure. A `timeout` that is missing, or too old for
-# `-k`, would therefore leave a started container running. This asks whether the
-# flag is accepted, before anything is built or started — not whether the
-# implementation honours it, which would cost a deliberately unkillable child on
-# every invocation.
-if ! timeout -k 1 1 true 2>/dev/null; then
+# The Docker wrapper bounds each call with `timeout -k`, including cleanup after
+# a failure. A `timeout` that is missing, or too old for `-k`, would therefore
+# leave a started container running. This asks whether the flag is accepted,
+# before anything is built or started — not whether the implementation honours
+# it, which would cost a deliberately unkillable child on every invocation.
+if ! command timeout -k 1 1 true 2>/dev/null; then
     log_error "this harness needs a 'timeout' accepting -k (GNU coreutils provides one)"
     exit 1
 fi
@@ -374,7 +414,7 @@ cleanup_container() {
 
     [ -n "$cleanup_name" ] || return 0
 
-    cleanup_output=$(timeout -k 2 5 docker rm -f "$cleanup_name" 2>&1) || cleanup_status=$?
+    cleanup_output=$(_DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker rm -f "$cleanup_name" 2>&1) || cleanup_status=$?
     # An already-absent name is the end state an idempotent cleanup wants, unlike a
     # timeout, a daemon failure, or a permission failure that can leave the
     # container running. Runtimes disagree on how they say it: Docker exits
@@ -476,7 +516,7 @@ test_container() {
         return 1
     fi
     if [[ -z "$image_id" ]]; then
-        if ! image_id=$(timeout -k 2 10 docker image inspect --format '{{.Id}}' "$image") || [[ -z "$image_id" ]]; then
+        if ! image_id=$(_DOCKER_TIMEOUT=10 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker image inspect --format '{{.Id}}' "$image") || [[ -z "$image_id" ]]; then
             log_error "Could not resolve local image ID for $image"
             return 1
         fi
@@ -549,7 +589,7 @@ test_container() {
     # genuine hang can reach it. Run the immutable local image ID, not its mutable
     # tag: the container started is the exact image whose tags established the
     # identity above, so docker cannot pull or retag-substitute it before run.
-    if ! timeout -k 5 120 docker run $run_opts "$image_id" $run_cmd; then
+    if ! _DOCKER_TIMEOUT=120 _DOCKER_TIMEOUT_KILL_AFTER=5 _e2e_docker run $run_opts "$image_id" $run_cmd; then
         log_error "Failed to start $container"
         cleanup_container
         return 1
@@ -593,7 +633,7 @@ test_container() {
         # waits forever for a child that ignores it, which is the hang this whole
         # change is about. The grace is what the wait can overshoot its budget by.
         local names ps_output ps_status=0
-        ps_output=$(timeout -k 2 "$remaining" docker ps --format '{{.Names}}' \
+        ps_output=$(_DOCKER_TIMEOUT="$remaining" _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker ps --format '{{.Names}}' \
             2>"$READINESS_STDERR_FILE") || ps_status=$?
         if [ "$ps_status" -ne 0 ]; then
             readiness_stderr=$(cat "$READINESS_STDERR_FILE" 2>/dev/null)
@@ -616,7 +656,7 @@ test_container() {
         # which would read as the container having exited.
         if ! grep -Fxq "$container_name" <<< "$names"; then
             log_error "$container exited unexpectedly"
-            timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+            _DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker logs "$container_name" 2>&1 | tail -20
             cleanup_container
             return 1
         fi
@@ -634,7 +674,7 @@ test_container() {
         # The conditional template distinguishes a missing healthcheck from an
         # inspect failure; treating the latter as no healthcheck would fail open.
         local inspect_output inspect_status=0
-        inspect_output=$(timeout -k 2 "$remaining" docker inspect \
+        inspect_output=$(_DOCKER_TIMEOUT="$remaining" _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker inspect \
             --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}nohealth{{end}}' \
             "$container_name" 2>"$READINESS_STDERR_FILE") || inspect_status=$?
         if [ "$inspect_status" -ne 0 ]; then
@@ -660,7 +700,7 @@ test_container() {
                 ;;
             unhealthy)
                 log_error "$container is unhealthy"
-                timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+                _DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker logs "$container_name" 2>&1 | tail -20
                 cleanup_container
                 return 1
                 ;;
@@ -693,7 +733,7 @@ test_container() {
         else
             log_error "$container did not become ready in time"
         fi
-        timeout -k 2 5 docker logs "$container_name" 2>&1 | tail -20
+        _DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker logs "$container_name" 2>&1 | tail -20
         cleanup_container
         return 1
     fi

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -189,6 +189,7 @@ add_single_image_identity_fixture() {
     chmod +x "$TEST_TEMP_DIR/bin/timeout"
     export SOURCE_ONLY_MAKE_MARKER="$TEST_TEMP_DIR/make-ran"
     export SOURCE_ONLY_TIMEOUT_MARKER="$TEST_TEMP_DIR/timeout-ran"
+    export SOURCE_ONLY_DOCKER_MARKER="$TEST_TEMP_DIR/docker-ran"
 
     run env E2E_TEST_SOURCE_ONLY=1 PATH="$TEST_TEMP_DIR/bin:$PATH" bash -c '
         script="$1"
@@ -198,18 +199,44 @@ add_single_image_identity_fixture() {
         set +o pipefail
         SECONDS=37
         set -- caller-first caller-second
+        docker() { : > "${SOURCE_ONLY_DOCKER_MARKER:?}"; }
         source "$script"
         [[ "$SECONDS" -ge 37 ]]
         [[ "$#" -eq 2 && "$1" == caller-first && "$2" == caller-second ]]
         [[ "$-" != *e* && "$-" != *u* ]]
         [[ "$(set -o | awk "\$1 == \"pipefail\" { print \$2 }")" == off ]]
-        declare -F resolve_e2e_image >/dev/null
+        declare -F resolve_e2e_image >/dev/null || exit 1
+        docker
     ' _ "$FIXTURE_REPO/tests/e2e-test.sh" "$caller_dir"
 
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     [ ! -e "$SOURCE_ONLY_MAKE_MARKER" ]
     [ ! -e "$SOURCE_ONLY_TIMEOUT_MARKER" ]
+    [ -e "$SOURCE_ONLY_DOCKER_MARKER" ]
+}
+
+@test "source-only callers retain docker while the bounded helper reaches Docker" {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    printf '#!/bin/sh\n: > "${SOURCE_ONLY_HELPER_TIMEOUT_MARKER:?}"\nshift 3\nexec "$@"\n' > "$TEST_TEMP_DIR/bin/timeout"
+    chmod +x "$TEST_TEMP_DIR/bin/timeout"
+    printf '#!/bin/sh\n: > "${SOURCE_ONLY_HELPER_DOCKER_MARKER:?}"\n' > "$TEST_TEMP_DIR/bin/docker"
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export SOURCE_ONLY_HELPER_TIMEOUT_MARKER="$TEST_TEMP_DIR/helper-timeout-ran"
+    export SOURCE_ONLY_HELPER_DOCKER_MARKER="$TEST_TEMP_DIR/helper-docker-ran"
+    export SOURCE_ONLY_DOCKER_MARKER="$TEST_TEMP_DIR/caller-docker-ran"
+
+    run env E2E_TEST_SOURCE_ONLY=1 PATH="$TEST_TEMP_DIR/bin:$PATH" bash -c '
+        docker() { : > "${SOURCE_ONLY_DOCKER_MARKER:?}"; }
+        source "$1"
+        docker
+        _e2e_docker images
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ -e "$SOURCE_ONLY_DOCKER_MARKER" ]
+    [ -e "$SOURCE_ONLY_HELPER_TIMEOUT_MARKER" ]
+    [ -e "$SOURCE_ONLY_HELPER_DOCKER_MARKER" ]
 }
 
 @test "S3/AD3: an E2E image ID and passed build cell bypass routing and run unchanged" {
@@ -926,41 +953,116 @@ STUB
     [ "$(grep -c '^rm ' "$DOCKER_LOG")" -eq 2 ]
 }
 
-@test "every docker call in the wait and the cleanup is bounded" {
-    # The property, not the spelling. An earlier version pinned whole source
-    # lines verbatim, which broke on reformatting and — worse — had baked the
-    # probes' `2>&1` into the expectation, so it was holding a defect in place.
-    #
-    # Two ways a bound can be missing: a `timeout` that lost its -k, and a
-    # wrapper deleted outright. Requiring every docker-invoking line to carry
-    # `timeout -k` catches both, because a deleted wrapper leaves the docker call
-    # behind on a line that no longer matches.
+@test "the bounded implementation carries a kill-after and the facade delegates to it" {
+    # The property, not the spelling. An earlier version of this test pinned
+    # whole source lines with `grep -Fx`, which is what the comment above the
+    # docker-call guard already warns against: it breaks on reformatting and
+    # holds one implementation in place rather than the behaviour.
     run bash -c '
-        source_file="$1"
-        # Lines that invoke docker as a command, ignoring comments, log text and
-        # the readiness stderr messages that merely name it.
-        unbounded=$(grep -nE "^[^#]*(^|[^a-zA-Z_-])docker[[:space:]]" "$source_file" |
-            grep -vE "timeout -k" |
-            grep -vE "log_error|log_warning|printf|echo")
-        offenders=$(printf "%s\n" "$unbounded" | grep -c . || true)
-        if [ "$offenders" -ne 0 ]; then
-            printf "%s\n" "$unbounded" >&2
-            exit 1
-        fi
+        awk "/^_e2e_docker\\(\\) \\{/,/^}/" "$1" | grep -qE "timeout[[:space:]]+-k[[:space:]]"
     ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+    [ "$status" -eq 0 ]
 
+    run bash -c '
+        awk "/^docker\\(\\) \\{/,/^}/" "$1" | grep -qE "_e2e_docker[[:space:]]+\"\\\$@\""
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
     [ "$status" -eq 0 ]
 }
 
-@test "no timeout call omits its kill-after grace" {
-    # A bound without -k is not a bound: plain `timeout` sends SIGTERM and then
-    # waits forever for a child that ignores it.
+@test "only the bounded implementation names docker after timeout" {
+    # Counted rather than pattern-exempted: exactly one line may spell
+    # `timeout ... docker`, and that is the line applying the bound. A second
+    # occurrence is a call that escaped the function. Counting avoids an
+    # exemption regex pinned to the implementation's current wording.
     run bash -c '
-        matches=$(grep -nE "^[^#]*\btimeout\b" "$1") || exit 3
-        printf "%s\n" "$matches" | grep -vE "(^|[[:space:]])-k[[:space:]]"
+        grep -cE "timeout[[:space:]].*[[:space:]]docker([[:space:]]|$)" "$1"
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}
+
+@test "the bounded implementation refuses a non-positive bound" {
+    # `timeout 0` means no limit, so an inherited or mistyped zero would turn the
+    # bound off silently. It must fail loudly instead.
+    run bash -c '
+        set -uo pipefail
+        E2E_TEST_SOURCE_ONLY=1 source "$1" >/dev/null 2>&1 || true
+        _DOCKER_TIMEOUT=0 _e2e_docker ps
+    ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
+
+    [ "$status" -eq 64 ]
+    [[ "$output" == *"needs positive bounds"* ]]
+}
+
+@test "no script invocation bypasses the bounded Docker implementation" {
+    # This is intentionally a token-absence check, not a shell parser. The
+    # implementation is the sole place that resolves Docker's binary; every
+    # script call must name _e2e_docker instead.
+    run bash -c '
+        set -o pipefail
+        grep -E "^[^#]*(^|[[:space:]])docker[[:space:]]" "$1" |
+            grep -vE "^[[:space:]]*command timeout -k \"\\\$grace\" \"\\\$duration\" docker \"\\\$@\"$"
     ' _ "$PROJECT_ROOT/tests/e2e-test.sh"
 
     [ "$status" -eq 1 ]
+}
+
+@test "the bounded Docker implementation stops a slow Docker binary at its configured bound" {
+    add_openvpn_fixture
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'STUB'
+#!/bin/sh
+: > "${DOCKER_MARKER:?}"
+printf '%s\n' "$$" > "${DOCKER_PID_FILE:?}"
+trap '' TERM
+exec /bin/sleep 1000
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    cat > "$TEST_TEMP_DIR/bash-env" <<'BASH_ENV'
+printf 'BASH_ENV was sourced unexpectedly\n' >&2
+: > "${BASH_ENV_MARKER:?}"
+BASH_ENV
+    cat > "$TEST_TEMP_DIR/bin/timeout" <<'STUB'
+#!/bin/bash
+export BASH_ENV="${TEST_BASH_ENV:?}"
+exec "${REAL_TIMEOUT:?}" "$@"
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/timeout"
+    export DOCKER_MARKER="$TEST_TEMP_DIR/docker-invoked"
+    export DOCKER_PID_FILE="$TEST_TEMP_DIR/docker.pid"
+    export BASH_ENV_MARKER="$TEST_TEMP_DIR/bash-env-sourced"
+    export TEST_BASH_ENV="$TEST_TEMP_DIR/bash-env"
+    REAL_TIMEOUT="$(command -v timeout)"
+    export REAL_TIMEOUT
+    export E2E_IMAGE="ghcr.io/oorabona/openvpn:v2.7.5-alpine"
+
+    local before=$SECONDS
+    # The outer watchdog only protects this test if the wrapper regresses. The
+    # Docker stub ignores TERM, so only the wrapper's kill-after can end it.
+    # The inherited function removes a bare timeout bound; `command timeout`
+    # must bypass it. The timeout stub also injects BASH_ENV immediately before
+    # the wrapper's bash -c, so its marker proves that environment was cleared.
+    run bash -c '
+        "$REAL_TIMEOUT" --foreground -k 2 20 env PATH="$1" bash -c "
+            timeout() { shift 3; \"\$@\"; }
+            export -f timeout
+            exec \"\$@\"
+        " _ "$2" openvpn
+        run_status=$?
+        if [ -s "$DOCKER_PID_FILE" ]; then
+            kill -KILL "$(cat "$DOCKER_PID_FILE")" 2>/dev/null || true
+        fi
+        exit "$run_status"
+    ' _ "$TEST_TEMP_DIR/bin:$PATH" "$FIXTURE_REPO/tests/e2e-test.sh"
+    local elapsed=$((SECONDS - before))
+
+    [ "$status" -eq 1 ]
+    [ -e "$DOCKER_MARKER" ]
+    [ ! -e "$BASH_ENV_MARKER" ]
+    [[ "$output" != *"BASH_ENV was sourced unexpectedly"* ]]
+    [ "$elapsed" -ge 10 ]
+    [ "$elapsed" -lt 16 ]
 }
 
 @test "a docker command missing from PATH stops readiness immediately and reports stderr" {


### PR DESCRIPTION
Closes #1028.

Two tests in `tests/unit/e2e-test.bats` were named for properties they did not enforce. Their exclusions applied per source LINE, so a real unbounded call sharing a line with a logger sailed through, and `-k` belonging to a wrapped command counted as `timeout`'s own.

Fixing them by parsing better did not converge. Each successive attempt was defeated by another shell construct — a logger sharing a line, backgrounding with `&`, a command substitution inside a logger's argument, a separator inside a quoted string, process substitution, text containing `timeout -k`. Six holes, and no reason to expect the seventh to be the last: the guards were parsing shell with regexes, and shell grammar is not regular.

## What replaced it

`tests/e2e-test.sh` now holds the bound in `_e2e_docker`, defined above every use. The nine call sites name it, keeping their own durations — 10, 5, 10, 120, the remaining readiness budget, 5 for the log tails, with a 5-second grace on `docker run` and 2 elsewhere. After the source-only return, `docker()` delegates to it, so a bare `docker` is bounded in a normal run while a caller that sources this script keeps its own function.

Three measurements shaped it:

- `timeout -k 2 5 docker ps` reaches the **binary**, not a shell function — `timeout` execs its argument. So the nine explicit timeouts had to be converted, not layered on.
- A prefix assignment on a function call is visible inside it and does not leak, which is how each site keeps its own duration.
- A zero or empty duration is `timeout`'s "no limit". Non-positive bounds now fail with exit 64 rather than running unbounded.

## The guards

They assert the property instead of hunting violations: the implementation carries a kill-after, the facade delegates to it, exactly one line in the script spells `timeout … docker`, and no script call names `docker` bare. The counting guard replaced an exemption regex pinned to the implementation's wording.

The one that matters most is behavioural — the harness against a deliberately slow docker stub must return rather than hang. It exists because a static check cannot see a wrapper edited to stop bounding. Its stub ignores SIGTERM, so the kill-after grace is actually exercised; an earlier version slept with a TERM-responsive `sleep` and passed with `-k` removed.

## Declined

An inherited shell function named `command` defeats `command timeout`, and one named after whatever replaces that would defeat it in turn. The regress has no end, and an actor who can export a function into this harness's environment can edit the harness. Stopping here is a decision, not a claim of completeness.

Container logs still reach GitHub Actions commands unescaped at three failure branches. Real and pre-existing — three of the 291 sites tracked in #1014.

## Verified

Full suite 2296 declared and 2296 executed, 0 failing; targeted file 43. shellcheck clean.

Mutations applied at the definition site, since appending to the file proves nothing — the script exits before reaching a trailing redefinition, and that reported a false clean once during this work. An unbounded implementation, a bound without `-k`, and a second `timeout … docker` each turn tests red.
