### PR TITLE
fix(ci): a swallowed extension read no longer passes for a checked one

### DIFF
--- a/scripts/check-version-drift.sh
+++ b/scripts/check-version-drift.sh
@@ -593,19 +593,34 @@ _process_extensions() {
         while IFS= read -r ext_name; do
             [[ -z "$ext_name" ]] && continue
 
-            # Check if this extension has a version_set resolver (timescaledb pattern)
+            # Check if this extension has a version_set resolver (timescaledb pattern).
+            # Same rule as the container path above: `// ""` already yields empty
+            # for an absent key, so a non-zero exit is a parse or tool failure and
+            # nothing else. Swallowing it classified the extension as standard on
+            # a file that could not be read.
             local has_resolver
-            has_resolver=$(yq -r ".extensions.${ext_name}.version_set.resolver // \"\"" \
-                "$ext_config" 2>/dev/null || true)
+            if ! has_resolver=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version_set.resolver // ""' \
+                "$ext_config" 2>/dev/null); then
+                echo "::error::version-drift: failed to read version_set resolver for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+                _HAS_ERROR=true
+                continue
+            fi
 
             if [[ -n "$has_resolver" ]]; then
                 # Timescaledb-style: check the resolver window per PG major
                 _check_timescaledb_extension "$owner" "$ext_name" "$pg_major" "$ext_config"
             else
-                # Standard extension: single declared version from config
+                # Standard extension: single declared version from config.
+                # An unreadable file is not an extension without a version — it is
+                # a target this sweep never evaluated, and skipping it silently let
+                # a clean verdict cover it.
                 local ext_version
-                ext_version=$(yq -r ".extensions.${ext_name}.version // \"\"" \
-                    "$ext_config" 2>/dev/null || true)
+                if ! ext_version=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version // ""' \
+                    "$ext_config" 2>/dev/null); then
+                    echo "::error::version-drift: failed to read declared version for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+                    _HAS_ERROR=true
+                    continue
+                fi
 
                 if [[ -z "$ext_version" || "$ext_version" == "null" ]]; then
                     continue
@@ -658,8 +673,12 @@ _check_timescaledb_extension() {
     local ext_config="$4"
 
     local resolver
-    resolver=$(yq -r ".extensions.${ext_name}.version_set.resolver // \"\"" \
-        "$ext_config" 2>/dev/null || true)
+    if ! resolver=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version_set.resolver // ""' \
+        "$ext_config" 2>/dev/null); then
+        echo "::error::version-drift: failed to read version_set resolver for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+        _HAS_ERROR=true
+        return 0
+    fi
 
     if [[ -z "$resolver" ]]; then
         return 0
@@ -667,11 +686,11 @@ _check_timescaledb_extension() {
 
     # Derive ceiling from declared version field
     local ceiling
-    ceiling=$(yq -r ".extensions.${ext_name}.version // \"\"" \
+    ceiling=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version // ""' \
         "$ext_config" 2>/dev/null || true)
 
     local retain_count
-    retain_count=$(yq -r ".extensions.${ext_name}.version_set.retain_count // 12" \
+    retain_count=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version_set.retain_count // 12' \
         "$ext_config" 2>/dev/null || echo "12")
 
     # Run the resolver to get the version window


### PR DESCRIPTION
Closes #1052.

Three per-extension `yq` reads in the drift sweep were guarded with `2>/dev/null || true`, so a parse or tool failure became an empty string. The extension was then skipped — or classified as standard, when its resolver was the unreadable field — while the remaining rows still allowed the sweep to exit 0. A clean verdict covered a target the sweep never evaluated, and nothing downstream could tell that apart from a genuinely complete run.

The file already stated the rule twenty lines above, over the container-level read:

```
# Distinguish parse/tool failure (non-zero exit) from genuinely empty result.
```

The extension reads simply did not follow it. They do now, through the same idiom their neighbour uses: an error naming the extension and its config, `_HAS_ERROR=true`, and on to the next — so the sweep exits 2, the code it already reserves for having no visibility into drift state. `// ""` yields empty for an absent key without failing, which is what makes distinguishing a failure from an empty result safe rather than noisy.

## A second door to the same false-clean

The extension name was interpolated into the `yq` program, so a key with a dot, bracket or yq operator changed what the query meant rather than failing. Measured on a config declaring `foo.bar`: the interpolated form returns empty, `strenv` returns `1.2.3`. All five per-extension reads use `strenv` now — including two that predate this change in the same function, since leaving them would have kept the hole open for the fields they read.

The three new annotations also interpolated the name and path into `::error::` unescaped, against the convention this file states in its own header. They go through `_escape_gha_command`.

## Deliberately untouched

Eight other `|| true` reads in this script: a `git log` with no commit for an untracked file, captured skopeo stderr, optional variant fields. Each has an empty result that is legitimate rather than a swallowed failure, and treating them alike would turn a fix into noise.

## Verified

A `yq` stub failing only on `pgvector` queries: the sweep exits 2 and names `failed to read version_set resolver for pgvector`, where it previously exited 0 having skipped the extension. `check-version-drift.bats` 79 passing; full suite 2292 declared and 2292 executed, 0 failing; shellcheck clean.
