### PR TITLE
fix(ci): a pipeline into grep -q could report 141 instead of an answer

### DIFF
--- a/scripts/check-version-drift.sh
+++ b/scripts/check-version-drift.sh
@@ -253,8 +253,7 @@ _vdrift_probe_published() {
             # Only manifest-specific messages map to absent; everything else is error
             # (fail-closed): credential helper failures, "command not found", auth-endpoint
             # 404s, network errors, and 5xx responses all remain in the error branch.
-            if printf '%s' "$sk_stderr" | grep -qiE \
-                'manifest unknown|MANIFEST_UNKNOWN|was deleted or has expired'; then
+            if grep -qiE 'manifest unknown|MANIFEST_UNKNOWN|was deleted or has expired' <<< "$sk_stderr"; then
                 printf 'absent'
             else
                 printf 'error'

--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -81,7 +81,7 @@ for CONTAINER in $CONTAINERS; do
     KEEP_REASON=""
 
     # Rule 1: Keep "latest" tag
-    if echo ",$TAGS," | grep -q ",latest,"; then
+    if grep -q ",latest," <<< ",$TAGS,"; then
       KEEP_REASON="has 'latest' tag"
     fi
 

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -392,7 +392,7 @@ _materialize_dockerfile() {
     fi
 
     # Verify no @@ markers remain after expansion.
-    if printf '%s' "$content" | grep -qE '@@[A-Z_]+@@' 2>/dev/null; then
+    if grep -qE '@@[A-Z_]+@@' <<< "$content" 2>/dev/null; then
         printf 'ERROR: unexpanded @@ markers remain in generated Dockerfile for %s (flavor=%s)\n' \
             "$container" "$flavor" >&2
         return 1
@@ -413,7 +413,7 @@ _df_declares_arg() {
     [[ -n "$df" ]] || return 1
     local re="^ARG[[:space:]]+${arg_name}([[:space:]=]|\$)"
     if [[ "$is_inline" == "1" ]]; then
-        printf '%s' "$df" | grep -qE "$re" 2>/dev/null
+        grep -qE "$re" <<< "$df" 2>/dev/null
     else
         [[ -f "$df" ]] && grep -qE "$re" "$df" 2>/dev/null
     fi
@@ -607,7 +607,7 @@ _resolve_cell_base_ref() {
 
         # Extract first non-AS FROM line
         local from_line
-        from_line=$(printf '%s' "$df_text" | grep -m1 -E '^FROM ') || from_line=""
+        from_line=$(grep -m1 -E '^FROM ' <<< "$df_text") || from_line=""
         local raw_ref
         raw_ref=$(awk '{print $2}' <<< "$from_line") || raw_ref=""
         [[ -z "$raw_ref" ]] && { printf ''; return 0; }
@@ -782,7 +782,7 @@ _enumerate_cells_init() {
 
     local c
     for c in "${requested_containers[@]}"; do
-        if ! printf '%s\n' "$all_containers_newline" | grep -qxF -- "$c"; then
+        if ! grep -qxF -- "$c" <<< "$all_containers_newline"; then
             printf 'ERROR: unknown container %q — not in ./make list\n' "$c" >&2
             printf 'Valid containers:\n%s\n' "$all_containers_newline" >&2
             return 1
@@ -1031,7 +1031,7 @@ _on_cell_bake() {
             df_text_for_stage=$(< "$abs_dockerfile")
         fi
         if [[ -n "$df_text_for_stage" ]] && \
-           printf '%s' "$df_text_for_stage" | grep -qE "^FROM .* AS ${build_flavor}\b" 2>/dev/null; then
+           grep -qE "^FROM .* AS ${build_flavor}\b" <<< "$df_text_for_stage" 2>/dev/null; then
             target_stage="$build_flavor"
         fi
     fi


### PR DESCRIPTION
Closes #1060.

Under `set -o pipefail`, `producer | grep -q pattern` does not return grep's verdict. `grep -q` exits at its first match and closes the pipe; the producer takes SIGPIPE and dies with 141; pipefail surfaces that. The condition testing the pipeline sees 141 — neither "found" nor "not found".

It is timing-dependent, which is exactly why it presented as a flake. When the producer finishes writing before grep exits — usually, for output that fits the pipe buffer — nothing is signalled. Under load the scheduler lets grep exit first.

```
set -o pipefail; big=$(seq 1 200000)
printf '%s\n' "$big" | grep -qxF -- "3"   → rc=141   (five times out of five)
grep -qxF -- "3" <<< "$big"               → rc=0
grep -qxF -- "999999" <<< "$big"          → rc=1
```

That is the mechanism behind the report: the container-validity check rejected `postgres` as unknown while printing it among the valid containers. Steady-state reading could not explain the contradiction, and 183 consecutive unloaded invocations of that generator never reproduced it.

Both directions are wrong, which is worth stating: without a negation a SIGPIPE reads as "no match"; with one it reads as "the match failed" and takes the branch. The second is how a container present in the list was declared unknown.

## Class swept, not just the cited line

Four sites consume such a status under pipefail:

| file | what it decides |
|---|---|
| `scripts/generate-bake-hcl.sh` | container validity; template placeholders |
| `scripts/cleanup-old-versions.sh` | latest-tag membership |
| `scripts/check-version-drift.sh` | skopeo stderr classification |

All four drop the pipe for a here-string. `scripts/build-container.sh` and `helpers/registry-utils.sh` carry the same construct but set no pipefail, so their pipelines do return grep's status — sound as written, and left alone.

## Verified

Full suite 2292 declared and 2292 executed, 0 failing. shellcheck clean on all three scripts. The generator still accepts `postgres` and still rejects a genuinely unknown container, so the fix did not invert the semantics it was protecting.

This does not close #964, which covers the flake class as a whole. It names and removes one mechanism inside it — found because `--print-output-on-failure` (#1058) captured the contradictory output an hour after landing.
