### PR TITLE
feat(ci): let a container name the build cell its e2e runs against

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -884,6 +884,7 @@ runs:
           --argjson verification "$verification_builds_input" \
           '$builds + $verification | unique_by(.container, .tag)')
         e2e_builds='[]'
+        e2e_declared_flavors='{}'
 
         while IFS= read -r build; do
           [[ -z "$build" ]] && continue
@@ -897,14 +898,42 @@ runs:
           fi
 
           e2e_enabled=false
+          e2e_flavor=""
           if [[ -f "$container/variants.yaml" ]]; then
             e2e_enabled=$(yq -r '.tests.e2e.enabled // false' "$container/variants.yaml" 2>/dev/null || echo "false")
+            # A flavor here is the matrix cell's `.flavor` value. A full image
+            # contains every Postgres extension, so its e2e suite covers the
+            # narrower flavors as a superset instead of spending seven builds to
+            # learn less.
+            e2e_flavor=$(yq -r '.tests.e2e.flavor // ""' "$container/variants.yaml" 2>/dev/null || echo "")
           fi
 
           if [[ "$e2e_enabled" == "true" ]]; then
-            e2e_builds=$(jq -c --argjson build "$build" '. + [$build]' <<< "$e2e_builds")
+            if [[ -n "$e2e_flavor" ]]; then
+              e2e_declared_flavors=$(jq -c --arg container "$container" --arg flavor "$e2e_flavor" \
+                '. + {($container): $flavor}' <<< "$e2e_declared_flavors")
+            fi
+            build_flavor=$(echo "$build" | jq -r '.flavor // ""')
+            if [[ -z "$e2e_flavor" || "$build_flavor" == "$e2e_flavor" ]]; then
+              e2e_builds=$(jq -c --argjson build "$build" '. + [$build]' <<< "$e2e_builds")
+            fi
           fi
         done < <(echo "$e2e_candidates" | jq -c '.[]')
+
+        # A configured flavor is a contract, not a best-effort filter. Failing
+        # here prevents a typo or a removed cell from silently disabling e2e for
+        # an opted-in container.
+        while IFS=$'\t' read -r container e2e_flavor; do
+          [[ -z "$container" || -z "$e2e_flavor" ]] && continue
+          matching_cells=$(echo "$e2e_candidates" | jq -r \
+            --arg container "$container" \
+            --arg flavor "$e2e_flavor" \
+            '[.[] | select(.container == $container and (.is_latest_version // false) == true and (.os // "linux") != "windows" and (.flavor // "") == $flavor)] | length')
+          if [[ "$matching_cells" -eq 0 ]]; then
+            echo "::error::${container} declares tests.e2e.flavor=${e2e_flavor}, but no latest non-Windows build cell has that flavor"
+            exit 1
+          fi
+        done < <(echo "$e2e_declared_flavors" | jq -r 'to_entries[] | [.key, .value] | @tsv')
 
         bake_count=$(echo "$bake_builds" | jq 'length')
         matrix_count=$(echo "$matrix_builds" | jq 'length')

--- a/postgres/variants.yaml
+++ b/postgres/variants.yaml
@@ -137,3 +137,7 @@ versions:
         flavor: full
         description: "PostgreSQL with all compiled extensions"
         when_to_use: All extensions enabled — pick when prototyping or when scope is not yet defined.
+tests:
+  e2e:
+    enabled: false
+    flavor: full

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -734,8 +734,14 @@ test_container() {
     # Suites receive one already-resolved record and assertion helpers, rather
     # than the reference itself or separately-derived version/flavor variables.
     # Unset E2E_IMAGE so a suite cannot accidentally revive tag parsing.
-    env -u E2E_IMAGE CONTAINER_NAME="$container_name" E2E_IMAGE_IDENTITY="$identity" \
-        timeout -k 5 "$TEST_TIMEOUT" "$test_script" || test_status=$?
+    local -a test_environment=(env -u E2E_IMAGE "CONTAINER_NAME=$container_name" "E2E_IMAGE_IDENTITY=$identity")
+    # CI knows the exact matrix cell it loaded. Preserve that flavor for suites
+    # that select assertions by flavor, but leave FLAVOR untouched for hand-run
+    # harnesses where there is no build cell and the suite owns its default.
+    if [[ -v E2E_BUILD_FLAVOR ]]; then
+        test_environment+=("FLAVOR=$E2E_BUILD_FLAVOR")
+    fi
+    "${test_environment[@]}" timeout -k 5 "$TEST_TIMEOUT" "$test_script" || test_status=$?
     if [ "$test_status" -ne 0 ]; then
         case "$test_status" in
             124|137)

--- a/tests/unit/detect-e2e-builds.bats
+++ b/tests/unit/detect-e2e-builds.bats
@@ -8,7 +8,7 @@ setup() {
 }
 
 teardown() {
-    unset BUILDS VERIFICATION_BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS IS_FORK_PR GITHUB_ACTION_PATH GITHUB_OUTPUT
+    unset BUILDS VERIFICATION_BUILDS EVENT_NAME BUILD_ALL_RETAINED RUN_TESTS IS_FORK_PR GITHUB_ACTION_PATH GITHUB_OUTPUT SPLIT_BUILD_ENGINE_ROOT
     teardown_temp_dir
 }
 
@@ -27,12 +27,24 @@ run_split_build_engine_step() {
     export GITHUB_ACTION_PATH="$PROJECT_ROOT/.github/actions/detect-containers"
     export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
 
-    run bash "$script"
+    run bash -c 'cd "$1" && bash "$2"' _ "${SPLIT_BUILD_ENGINE_ROOT:-$PROJECT_ROOT}" "$script"
 }
 
 output_value() {
     local name="$1"
     sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
+}
+
+add_e2e_config_fixture() {
+    local container="$1"
+    local flavor="${2:-}"
+
+    mkdir -p "$TEST_TEMP_DIR/e2e-config-fixture/$container"
+    {
+        printf 'tests:\n  e2e:\n    enabled: true\n'
+        [[ -z "$flavor" ]] || printf '    flavor: %s\n' "$flavor"
+    } > "$TEST_TEMP_DIR/e2e-config-fixture/$container/variants.yaml"
+    export SPLIT_BUILD_ENGINE_ROOT="$TEST_TEMP_DIR/e2e-config-fixture"
 }
 
 @test "deleting e2e filtering would stop an enabled changed container from running its latest Linux suite" {
@@ -105,4 +117,60 @@ output_value() {
     [ "$(output_value bake_builds)" = "[]" ]
     [ "$(output_value matrix_builds)" = "[]" ]
     [ "$(output_value e2e_builds)" = "[]" ]
+}
+
+@test "a declared e2e flavor selects exactly its matching latest Linux cell" {
+    # Regression lock for tests.e2e.flavor: full contains every extension, so it
+    # is a superset check rather than seven flavor-specific e2e jobs.
+    add_e2e_config_fixture postgres full
+    builds=$(jq -cn '
+      [
+        {"container":"postgres","tag":"18-alpine","flavor":"base","is_latest_version":true,"os":"linux"},
+        {"container":"postgres","tag":"18-vector-alpine","flavor":"vector","is_latest_version":true,"os":"linux"},
+        {"container":"postgres","tag":"18-full-alpine","flavor":"full","is_latest_version":true,"os":"linux"},
+        {"container":"postgres","tag":"17-full-alpine","flavor":"full","is_latest_version":false,"os":"linux"}
+      ]')
+
+    run_split_build_engine_step "$builds"
+
+    [ "$status" -eq 0 ]
+    e2e_builds=$(output_value e2e_builds)
+    [ "$(echo "$e2e_builds" | jq 'length')" -eq 1 ]
+    [ "$(echo "$e2e_builds" | jq -r '.[0].flavor')" = "full" ]
+    [ "$(echo "$e2e_builds" | jq -r '.[0].tag')" = "18-full-alpine" ]
+}
+
+@test "an e2e container without a declared flavor retains every eligible cell" {
+    # Regression lock for backwards compatibility: without tests.e2e.flavor,
+    # selection remains the existing latest-version non-Windows behavior.
+    add_e2e_config_fixture unscoped
+    builds=$(jq -cn '
+      [
+        {"container":"unscoped","tag":"2-base","flavor":"base","is_latest_version":true,"os":"linux"},
+        {"container":"unscoped","tag":"2-full","flavor":"full","is_latest_version":true,"os":"linux"},
+        {"container":"unscoped","tag":"2-windows","flavor":"full","is_latest_version":true,"os":"windows"},
+        {"container":"unscoped","tag":"1-full","flavor":"full","is_latest_version":false,"os":"linux"}
+      ]')
+
+    run_split_build_engine_step "$builds"
+
+    [ "$status" -eq 0 ]
+    e2e_builds=$(output_value e2e_builds)
+    [ "$(echo "$e2e_builds" | jq 'length')" -eq 2 ]
+    [ "$(echo "$e2e_builds" | jq -r '.[].tag' | sort | tr '\n' ' ')" = "2-base 2-full " ]
+}
+
+@test "a declared e2e flavor with no matching latest cell errors instead of silently selecting none" {
+    # Regression lock for the fail-closed configuration contract.
+    add_e2e_config_fixture postgres full
+    builds=$(jq -cn '
+      [
+        {"container":"postgres","tag":"18-alpine","flavor":"base","is_latest_version":true,"os":"linux"},
+        {"container":"postgres","tag":"18-vector-alpine","flavor":"vector","is_latest_version":true,"os":"linux"}
+      ]')
+
+    run_split_build_engine_step "$builds"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"declares tests.e2e.flavor=full"* ]]
 }

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -92,11 +92,18 @@ output_value() {
 }
 
 @test "deleting the entrypoint opt-in check would verify a container with no e2e" {
-    # postgres has a test.sh and deliberately does not opt into e2e yet, so there
-    # is nothing for a change to it to run. Its suite is sound; enabling it means
-    # importing the heavy postgres build into every PR that touches it, which is
-    # a separate decision.
-    run_find_containers_step "postgres/test.sh"
+    # openresty ships a test.sh and does not opt into e2e, so a change to that
+    # script alone has nothing to run. It is blocked on #988 — the container
+    # never reports healthy under the readiness wait.
+    #
+    # postgres is in the same position for different reasons: its suite is
+    # sound and its cell is now declared, but the e2e job does not depend on
+    # the extension pipeline, so a green run on a PR touching an extension
+    # would have tested the previous canonical artifact.
+    #
+    # If either is enabled, this fixture needs the next container that ships a
+    # script without opting in, or the test silently stops covering anything.
+    run_find_containers_step "openresty/test.sh"
 
     [ "$status" -eq 0 ]
     [ "$(output_value containers)" = "[]" ]

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -8,7 +8,7 @@ setup() {
     # Cleared going in, not just coming out: one of these exported in the shell
     # that runs the suite would otherwise steer the stub through tests that never
     # asked for it.
-    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
+    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT \
         DOCKER_INSPECT_ERROR DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR \
         DOCKER_IMAGES_OUTPUT DOCKER_RM_FAIL_ON_SECOND
     # Each bats test is its own process, so it inherits these from the shell that
@@ -27,7 +27,7 @@ setup() {
 
 teardown() {
     export PATH="$ORIG_PATH"
-    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR DOCKER_RM_FAIL_ON_SECOND PS_COUNT_FILE TEST_SCRIPT_MARKER RUN_STARTED TEST_SUITE_STARTED HARNESS_PID_FILE
+    unset E2E_IMAGE E2E_BUILD_TAG E2E_BUILD_VERSION E2E_BUILD_VARIANT E2E_BUILD_FLAVOR FLAVOR E2E_READY_TIMEOUT E2E_TEST_TIMEOUT DOCKER_LOG DOCKER_IMAGES_OUTPUT DOCKER_PS_OUTPUT DOCKER_PS_EXIT DOCKER_PS_ERROR DOCKER_IMAGE_ID DOCKER_INSPECT_OUTPUT DOCKER_INSPECT_EXIT DOCKER_INSPECT_ERROR DOCKER_RM_FAIL_ON_SECOND PS_COUNT_FILE TEST_SCRIPT_MARKER RUN_STARTED TEST_SUITE_STARTED HARNESS_PID_FILE
     teardown_temp_dir
 }
 
@@ -165,6 +165,15 @@ SH
     chmod +x "$FIXTURE_REPO/openvpn/test.sh"
 }
 
+add_flavor_aware_openvpn_fixture() {
+    add_openvpn_fixture
+    cat > "$FIXTURE_REPO/openvpn/test.sh" <<'SH'
+#!/bin/bash
+printf '%s\n' "${FLAVOR:-base}" > "${TEST_SCRIPT_MARKER:?}"
+SH
+    chmod +x "$FIXTURE_REPO/openvpn/test.sh"
+}
+
 add_single_image_identity_fixture() {
     local container="$1" tag="$2" suffix="$3"
     mkdir -p "$FIXTURE_REPO/$container"
@@ -240,6 +249,40 @@ add_single_image_identity_fixture() {
     [[ "$run_line" == *"-e AUTO_START=y"* ]]
     [[ "$run_line" == *"sha256:ci-loaded-image"* ]]
     ! grep -q '^images ' "$DOCKER_LOG"
+}
+
+@test "E2E_BUILD_FLAVOR reaches a flavor-aware test suite as FLAVOR" {
+    # Regression lock: removing the forwarding makes postgres/test.sh fall back
+    # to base while the workflow has loaded the full image.
+    add_flavor_aware_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/flavor.marker"
+    export E2E_IMAGE="sha256:ci-loaded-image"
+    export E2E_BUILD_TAG="v2.7.5-alpine"
+    export E2E_BUILD_VERSION="v2.7.5-alpine"
+    export E2E_BUILD_VARIANT="full"
+    export E2E_BUILD_FLAVOR="full"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_SCRIPT_MARKER")" = "full" ]
+}
+
+@test "an unset E2E_BUILD_FLAVOR leaves the test suite's own flavor default intact" {
+    # Regression lock for hand-run harnesses: only a supplied build-cell flavor
+    # may set FLAVOR; otherwise a suite's own default remains authoritative.
+    add_flavor_aware_openvpn_fixture
+    install_docker_stub
+    export DOCKER_LOG="$TEST_TEMP_DIR/docker.log"
+    export TEST_SCRIPT_MARKER="$TEST_TEMP_DIR/flavor.marker"
+    export E2E_IMAGE="ghcr.io/oorabona/openvpn:v2.7.5-alpine"
+
+    run "$FIXTURE_REPO/tests/e2e-test.sh" openvpn
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_SCRIPT_MARKER")" = "base" ]
 }
 
 @test "deleting the missing-script check would pass a run that verified nothing" {


### PR DESCRIPTION

The e2e selection took every latest-version non-Windows cell, which is one job
for most containers and seven for postgres — one per flavour. And the harness
documented `E2E_BUILD_FLAVOR` without forwarding it, so a flavour-aware
`test.sh` fell back to its own default and tested the base surface against
whatever image it was handed.

A container may now declare `tests.e2e.flavor` in its `variants.yaml`. When set,
only the matching latest-version cell is eligible; when absent, selection is
unchanged. A declared flavour matching no cell fails the selector rather than
silently selecting nothing. The harness forwards `E2E_BUILD_FLAVOR` as `FLAVOR`
when it is set, and leaves the suite's own default alone when it is not — a
hand-run harness has no build cell, and the script's default is right there.

The reasoning behind declaring one cell, recorded where the field is read: a
flavour containing every extension is a superset of the others, so testing it
covers them. Testing all seven costs seven builds to learn less.

postgres declares `full` and stays disabled. Two things must be true before its
e2e means anything, and neither is: the e2e job does not depend on
`build-extensions` or `merge-extension-manifests` and does not export
`PR_TAG_SUFFIX`, so a green run on a PR touching an extension would have tested
the previous canonical artifact (#1064); and the suite reports success on
assertions whose operation failed, so the 31-of-31 it produces counts some
hollow ones (#1065). Enabling is one word once both are fixed.

`detect-verification-inputs.bats` keeps openresty as its example of a container
shipping a test script without opting in, and its comment now records why both
openresty and postgres hold that property — the fixture stops covering anything
if the last opted-out container is enabled and nobody notices.

Full suite 2297, 0 failing. shellcheck and actionlint clean.