### PR TITLE
fix(ci): order the e2e after the extension pipeline it consumes

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -278,11 +278,15 @@ jobs:
 
   e2e-test:
     name: E2E ${{ matrix.build.container }}:${{ matrix.build.tag }}
-    needs: [detect-containers]
-    if: >-
-      github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && needs.detect-containers.outputs.e2e_builds != '[]'
+    needs: [detect-containers, build-extensions, merge-extension-manifests, sync-base-images]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.detect-containers.outputs.e2e_builds != '[]' &&
+      (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
+      (needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped') &&
+      (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Least privilege: this job checks out and runs branch-controlled build/test
@@ -298,6 +302,10 @@ jobs:
       # so PR-built layers can't land in the canonical <ref>:buildcache
       # (mirrors the bake engine's PR guard).
       BUILD_CACHE_EXPORT: 'false'
+      # Keep postgres's extension refs aligned with the production build: on a
+      # same-repository PR, build-extensions and merge-extension-manifests
+      # publish the PR-scoped extension images that this e2e build must consume.
+      PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/unit/e2e-gate-eligibility.bats
+++ b/tests/unit/e2e-gate-eligibility.bats
@@ -10,13 +10,42 @@ load "../test_helper"
 
 setup() {
     setup_temp_dir
-    E2E_IF=$(yq -r '.jobs["e2e-test"]["if"]' \
-        "$PROJECT_ROOT/.github/workflows/auto-build.yaml")
+    local workflow="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    E2E_IF=$(yq -r '.jobs["e2e-test"]["if"]' "$workflow")
+    E2E_NEEDS=$(yq -o=json '.jobs["e2e-test"].needs' "$workflow")
+    BUILD_EXTENSIONS_IF=$(yq -r '.jobs["build-extensions"]["if"]' "$workflow")
+    E2E_PR_TAG_SUFFIX=$(yq -r '.jobs["e2e-test"].env.PR_TAG_SUFFIX' "$workflow")
+    PRODUCTION_PR_TAG_SUFFIX=$(yq -r '.jobs["build-and-push"].env.PR_TAG_SUFFIX' "$workflow")
 }
 
 teardown() {
-    unset E2E_IF
+    unset E2E_IF E2E_NEEDS BUILD_EXTENSIONS_IF E2E_PR_TAG_SUFFIX PRODUCTION_PR_TAG_SUFFIX
     teardown_temp_dir
+}
+
+@test "e2e waits for the extension pipeline and base-image sync" {
+    [ "$E2E_NEEDS" = '[
+  "detect-containers",
+  "build-extensions",
+  "merge-extension-manifests",
+  "sync-base-images"
+]' ]
+}
+
+@test "a skipped extension pipeline still permits e2e" {
+    # `build-extensions` itself skips for extension_builds == '[]'. Since a
+    # `needs` dependency otherwise skips its dependent job before its condition
+    # runs, e2e must use the production guard's always() and success|skipped
+    # result allowance for every new upstream dependency.
+    [[ "$BUILD_EXTENSIONS_IF" == *"needs.detect-containers.outputs.extension_builds != '[]'"* ]]
+    [[ "$E2E_IF" == *"always()"* ]]
+    [[ "$E2E_IF" == *"(needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped')"* ]]
+    [[ "$E2E_IF" == *"(needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped')"* ]]
+    [[ "$E2E_IF" == *"(needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')"* ]]
+}
+
+@test "e2e and production builds use the identical PR extension tag suffix" {
+    [ "$E2E_PR_TAG_SUFFIX" = "$PRODUCTION_PR_TAG_SUFFIX" ]
 }
 
 @test "deleting the identity check would skip e2e on a repository that is itself a fork" {


### PR DESCRIPTION

The e2e job had `needs: [detect-containers]`. The production build has
`needs: [detect-containers, build-extensions, merge-extension-manifests,
sync-base-images]` and exports `PR_TAG_SUFFIX`, so it consumes what this pull
request produced.

For every container but postgres that difference is invisible. postgres is the
only image whose build consumes artifacts another job produces, and both
outcomes were wrong: the canonical extension tag exists, so the e2e image pulled
the previous artifact and a green run said nothing about the change under
review; or a version bump introduced a tag that did not exist yet, so the e2e
image build failed for something the extension pipeline would have produced
moments later.

The e2e job now carries the same dependencies and the same `PR_TAG_SUFFIX`
expression, under the `always()` plus result-in-`(success, skipped)` guard this
file already uses and documents above `build-extensions`. Depending on a job
that can skip needs that guard, and `build-extensions` gates on
`extension_builds != '[]'`, so it skips outright when nothing needs building —
which is why ordering every container's e2e behind it costs nothing on a pull
request that touches no extension.

`needs` is per job rather than per matrix cell, so this does order all of them.
That is the trade, and it is cheap for the reason above.

One expression, six occurrences, and a test asserting the e2e's matches the
production build's — two hand-maintained copies of the same expression is the
shape that has produced several defects in this repository.

Full suite 2295, 0 failing. Removing the extension dependency turns the wiring
test red.

actionlint is not run locally on this file: it hangs on `auto-build.yaml`,
including on the version already in master, while completing normally on the
other workflows. CI lints it by auto-discovery from the repo root and passes.

Closes #1064.