### PR TITLE
fix(ci): the buildkit preflight stops claiming an absence it cannot observe

### DIFF
--- a/.github/actions/preflight-buildkit/action.yaml
+++ b/.github/actions/preflight-buildkit/action.yaml
@@ -35,13 +35,21 @@ runs:
     # per-attempt timeout so a transient registry 5xx/429/timeout does not fail
     # the build. The ref was format-validated (and is digest-pinned) above.
     - name: Verify BuildKit image is present in GHCR (retry on transient)
+      id: probe
       uses: ./.github/actions/retry-run
       with:
         max-attempts: '4'
         delay: '5'
         timeout: '45s'
         run: |
-          docker manifest inspect "${{ inputs.image }}" >/dev/null 2>&1 || {
-            echo "::error::buildkit builder image is not present in GHCR (after retries). It is seeded by the upstream-monitor workflow (Seed buildkit image to GHCR). Trigger upstream-monitor (workflow_dispatch) to seed it, then re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"
-            exit 1
-          }
+          # docker's own stderr is left to reach the step log, and nothing here
+          # reads it. A probe that fails cannot tell absence from a rate limit,
+          # a 5xx, an expired token or a DNS blip, so it does not try: any
+          # classifier over free-form registry text is a denylist that the next
+          # unseen wording escapes, and the wrong half of that guess is what
+          # sends a reader to re-seed an image that was there all along.
+          if docker manifest inspect "${{ inputs.image }}" >/dev/null; then
+            exit 0
+          fi
+          echo "::error::the BuildKit builder image probe failed; docker's own output, if it produced any, is above. This does NOT establish that the image is absent: a rate limit, a 5xx, an expired token, a DNS failure and a genuinely missing manifest all end up here. Re-run first. If docker reported specifically that the manifest does not exist, then the image needs seeding — it comes from the upstream-monitor workflow (Seed buildkit image to GHCR), so trigger that (workflow_dispatch) and re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"
+          exit 1

--- a/tests/unit/preflight-buildkit-probe.bats
+++ b/tests/unit/preflight-buildkit-probe.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+# The preflight probe reports that it failed, not why.
+#
+# `docker manifest inspect` fails for absence, for a rate limit, for a 5xx, for
+# an expired token and for a DNS blip. The probe used to read every non-zero
+# exit as absence and tell the reader to re-seed the builder image. Issue #1073
+# was filed on that basis after four attempts failed during a burst of
+# concurrent runs, while 110 sibling jobs in the same run were pulling from and
+# pushing to GHCR successfully.
+#
+# Classifying the registry's free-form stderr was tried and abandoned: every
+# pattern list is a denylist, the next unseen wording escapes it, and the wrong
+# half of the guess is the defect being fixed. The probe now states that it
+# cannot distinguish, and leaves docker's own output in the log for the reader.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# Renders the probe script the way the runner does: the step's body is a
+# composite-action input, and the image ref reaches it by expression
+# substitution. A renamed expression leaves `${{` in the body and bash rejects
+# it, so this fails loudly rather than testing a script nobody runs.
+run_probe() {
+    local stub_stderr="$1"
+    local stub_rc="$2"
+    local script="$TEST_TEMP_DIR/probe.sh"
+    local image="ghcr.io/owner/buildkit@sha256:$(printf '0%.0s' {1..64})"
+
+    yq -r '.runs.steps[] | select(.id == "probe") | .with.run' \
+        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml" \
+        | sed "s|\${{ inputs.image }}|$image|g" > "$script"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "$stub_stderr" >&2
+printf 'a manifest nobody should see in the log\n'
+exit $stub_rc
+STUB
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+
+    PATH="$TEST_TEMP_DIR/bin:$PATH" run bash -e -o pipefail "$script"
+}
+
+@test "probe: a present image exits clean and says nothing" {
+    run_probe "" 0
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"::error::"* ]]
+}
+
+@test "probe: a failing probe fails the step" {
+    run_probe "manifest unknown" 1
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+}
+
+# The #1073 regression lock. A registry answer that looks like absence must not
+# make the step assert absence, because the same exit code arrives from a rate
+# limit and the reader acts on what the message claims.
+@test "probe: an absence-looking answer does not make the step claim absence" {
+    run_probe "manifest unknown" 1
+    [[ "$output" == *"does NOT establish that the image is absent"* ]]
+}
+
+@test "probe: a rate limit produces the same non-committal message" {
+    run_probe "toomanyrequests: retry-after 60" 1
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does NOT establish that the image is absent"* ]]
+}
+
+@test "probe: the reader is told to re-run before seeding anything" {
+    run_probe "denied: denied" 1
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Re-run first"* ]]
+}
+
+# docker writes to the step log directly, as every other command in this
+# repository does. Nothing here captures, stores or replays it — which is why
+# there is no file to bound and no text of ours to escape.
+@test "probe: docker's own words reach the log on failure" {
+    run_probe "unexpected status from HEAD request: 503 Service Unavailable" 1
+    [[ "$output" == *"503 Service Unavailable"* ]]
+}
+
+@test "probe: docker's own words reach the log on success too" {
+    run_probe "warning: the registry answered slowly" 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"the registry answered slowly"* ]]
+}
+
+@test "probe: the manifest body stays out of the log on success" {
+    run_probe "" 0
+    [[ "$output" != *"a manifest nobody should see in the log"* ]]
+}


### PR DESCRIPTION
`docker manifest inspect` fails for absence, for a rate limit, for a 5xx, for an expired token and for a DNS blip. The probe discarded its stderr and read every non-zero exit as "the image is not present in GHCR", with remediation text telling the reader to seed it from upstream-monitor.

On 2026-08-04 that message was wrong. One job out of 111 failed all four probe attempts during a burst of concurrent runs, while its 110 siblings pulled from and pushed to GHCR in the same run. The automation then filed an issue whose stated remedy was to re-seed a builder image that had been present throughout.

The probe no longer guesses. It says the probe failed, that this does not establish the image is absent, that a re-run comes first, and that seeding is the answer only if docker itself reported the manifest does not exist. docker's own output is left where the reader can see it: the redirection to `/dev/null` is gone from stderr and kept on stdout, so the failure is legible and the manifest body still is not.

Classifying that output was tried first and dropped. Pattern-matching free-form registry text is a denylist: it missed `503` and numeric `429`, and it suppressed a real absence for any image path containing the word `denied`. Both halves of that mistake are the defect this change exists to remove, so the classifier went rather than growing a third list. What is left is smaller than what it replaces and has nothing to escape, bound, or keep current: no capture file, no replay of registry-controlled bytes, no vocabulary to maintain.

Eight tests execute the step's own script with a stubbed docker. A present image exits clean and keeps the manifest body out of the log; a failing one fails the step; `manifest unknown` and `toomanyrequests` produce the same non-committal message, which is the point; and docker's own words reach the log on both the failing and the succeeding path. Restoring the old absence wording turns them red, as does restoring the stderr redirection, dropping the stdout one, or returning zero on failure.

The message says docker's output is above "if it produced any", because a non-zero exit with no stderr is possible and the annotation should not promise what may not be there.

Full suite green, 2312 collected, 0 failing.

Relates to #1073, which stays open until github-runner rebuilds — its published image is still on the pre-drift base after that job failed. The `::error::` is still emitted once per retry attempt, and a hard per-attempt timeout still skips it entirely; both predate this change, belong to `retry-run` rather than to any script it wraps, and are #1075.
