### PR TITLE
fix(postgres): make install_ext fail on the payload it used to drop silently

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -41,6 +41,23 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           yq --version
 
+      - name: Install busybox
+        timeout-minutes: 5
+        # postgres images are built FROM an Alpine base with no SHELL directive,
+        # so their RUN steps execute under BusyBox ash with BusyBox applets.
+        # tests/unit/postgres-extension-presence.bats runs the extracted
+        # install_ext under this runner's BusyBox — the same shell and applet
+        # family, not Alpine's own build of it — which is what lets the suite
+        # see a GNU-only construct before the image build does. The test fails
+        # rather than skips when /bin/busybox is absent.
+        run: |
+          command -v busybox >/dev/null 2>&1 || {
+            sudo apt-get update
+            sudo apt-get install -y busybox-static
+          }
+          test -x /bin/busybox || sudo ln -s "$(command -v busybox)" /bin/busybox
+          /bin/busybox sh -c 'echo busybox ok'
+
       - name: Install bats
         uses: ./.github/actions/setup-bats
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -88,28 +88,177 @@ RUN set -eux; \
     #    ceiling; existing databases on older versions continue to load their .so. \
     # \
     # 2. Single-version (no retention): /tmp/ext/<ext>/{extension,lib}/ \
-    #    Original flat layout, unchanged behaviour. \
+    #    Original flat layout. Its copies now fail the build rather than being \
+    #    suppressed, so a successful build means more here than it used to. \
+    # Bound: Docker's staged copy dereferences symlinks; only this repository's extension-build stages can create these artifacts. \
+    # This transports staged files only; artifact completeness and PostgreSQL loadability belong to extension-build or image integration tests. \
+    copy_payload() { \
+        source_dir=$1; \
+        destination_dir=$2; \
+        ext=$3; \
+        if [ ! -d "$source_dir" ]; then \
+            return 0; \
+        fi; \
+        # A directory whose permissions forbid listing is not an empty one. \
+        # Catch that case before the globs below read it as "nothing to copy". \
+        # Bound: a glob has no exit status, so an I/O failure that begins after \
+        # this probe passes is still indistinguishable from an empty match. \
+        # POSIX shell offers no way to tell those apart; the permission case is \
+        # the one that is detectable and the one that has occurred. \
+        if [ ! -r "$source_dir" ] || [ ! -x "$source_dir" ]; then \
+            echo "ERROR: could not inspect extension ${ext} payload at ${source_dir}" >&2; \
+            return 1; \
+        fi; \
+        # Entry by entry, so each keeps its own mode and ownership and the \
+        # destination directory keeps its. `cp -a "$source_dir/."` would copy \
+        # the staging directory's metadata onto a PostgreSQL system directory. \
+        # The three globs are the same idiom the layout scan below uses; a \
+        # source with no entries matches none of them and copies nothing. \
+        for entry in "$source_dir"/* "$source_dir"/.[!.]* "$source_dir"/..?*; do \
+            if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then \
+                continue; \
+            fi; \
+            if ! cp -av "$entry" "$destination_dir/"; then \
+                echo "ERROR: could not copy extension ${ext} payload from ${source_dir}" >&2; \
+                return 1; \
+            fi; \
+        done; \
+    }; \
     install_ext() { \
-        local ext=$1; \
-        if [ -d "/tmp/ext/${ext}/extension" ]; then \
+        ext=$1; \
+        root="/tmp/ext/${ext}"; \
+        entry_name=''; \
+        entry=''; \
+        version_entry=''; \
+        version_entry_name=''; \
+        found_entries=''; \
+        version_found_entries=''; \
+        version_invalid_entries=0; \
+        has_single_extension=0; \
+        has_single_lib=0; \
+        multi_versions=0; \
+        invalid_entries=0; \
+        layout=''; \
+        layout_error=''; \
+        ver=''; \
+        ver_dir=''; \
+        ceiling_ver=''; \
+        ceiling_dir=''; \
+        versions_file=''; \
+        sorted_versions_file=''; \
+        if [ ! -d "$root" ]; then \
+            echo "ERROR: extension ${ext} has no staging root at ${root}" >&2; \
+            return 1; \
+        fi; \
+        if [ ! -r "$root" ] || [ ! -x "$root" ]; then \
+            echo "ERROR: extension ${ext} could not enumerate staging root ${root}" >&2; \
+            return 1; \
+        fi; \
+        set --; \
+        for entry in "$root"/* "$root"/.[!.]* "$root"/..?*; do \
+            [ -e "$entry" ] || [ -L "$entry" ] || continue; \
+            entry_name=${entry##*/}; \
+            if [ -n "$found_entries" ]; then \
+                found_entries="$found_entries, $entry_name"; \
+            else \
+                found_entries=$entry_name; \
+            fi; \
+            if [ "$entry_name" = metadata.txt ]; then \
+                : ; \
+            elif [ "$entry_name" = extension ]; then \
+                if [ -d "$entry" ]; then has_single_extension=1; else invalid_entries=1; fi; \
+            elif [ "$entry_name" = lib ]; then \
+                if [ -d "$entry" ]; then has_single_lib=1; else invalid_entries=1; fi; \
+            elif [ -d "$entry" ] && { [ -d "$entry/extension" ] || [ -d "$entry/lib" ]; }; then \
+                version_found_entries=''; \
+                version_invalid_entries=0; \
+                # Same probe as the two enumerations above: a version directory \
+                # whose permissions forbid listing must not read as one holding \
+                # nothing, which is how its contents would be dropped silently. \
+                if [ ! -r "$entry" ] || [ ! -x "$entry" ]; then \
+                    echo "ERROR: extension ${ext} could not inspect version directory ${entry}" >&2; \
+                    return 1; \
+                fi; \
+                for version_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do \
+                    [ -e "$version_entry" ] || [ -L "$version_entry" ] || continue; \
+                    version_entry_name=${version_entry##*/}; \
+                    if [ -n "$version_found_entries" ]; then \
+                        version_found_entries="$version_found_entries, $version_entry_name"; \
+                    else \
+                        version_found_entries=$version_entry_name; \
+                    fi; \
+                    if [ "$version_entry_name" = metadata.txt ]; then \
+                        :; \
+                    elif { [ "$version_entry_name" = extension ] || [ "$version_entry_name" = lib ]; } && [ -d "$version_entry" ]; then \
+                        :; \
+                    else \
+                        version_invalid_entries=1; \
+                    fi; \
+                done; \
+                if [ "$version_invalid_entries" -ne 0 ]; then \
+                    echo "ERROR: extension ${ext} version ${entry_name} staging directory has unsupported layout; found: $version_found_entries" >&2; \
+                    return 1; \
+                fi; \
+                multi_versions=$((multi_versions + 1)); \
+                set -- "$@" "$entry_name"; \
+            else \
+                invalid_entries=1; \
+            fi; \
+        done; \
+        if [ "$has_single_extension" -eq 1 ] && [ "$multi_versions" -eq 0 ] && [ "$invalid_entries" -eq 0 ]; then \
+            layout=single; \
+        elif [ "$has_single_extension" -eq 0 ] && [ "$has_single_lib" -eq 0 ] && [ "$multi_versions" -gt 0 ] && [ "$invalid_entries" -eq 0 ]; then \
+            layout=multi; \
+        fi; \
+        if [ -z "$layout" ]; then \
+            if [ -z "$found_entries" ]; then found_entries='(empty)'; fi; \
+            layout_error='matches no supported layout'; \
+            if [ "$has_single_extension" -eq 1 ] && [ "$multi_versions" -gt 0 ]; then \
+                layout_error='matches multiple supported layouts'; \
+            fi; \
+            echo "ERROR: extension ${ext} staging root ${root} ${layout_error}; found: $found_entries" >&2; \
+            return 1; \
+        fi; \
+        if [ "$layout" = single ]; then \
             echo "Installing extension (single-version): ${ext}"; \
-            cp -v /tmp/ext/${ext}/extension/* /usr/local/share/postgresql/extension/ 2>/dev/null || true; \
-            cp -v /tmp/ext/${ext}/lib/* /usr/local/lib/postgresql/ 2>/dev/null || true; \
-        elif ls -d /tmp/ext/${ext}/*/ 1>/dev/null 2>&1; then \
+            copy_payload "${root}/extension" /usr/local/share/postgresql/extension/ "$ext" || return 1; \
+            copy_payload "${root}/lib" /usr/local/lib/postgresql/ "$ext" || return 1; \
+        fi; \
+        if [ "$layout" = multi ]; then \
+            if ! versions_file=$(mktemp); then \
+                echo "ERROR: extension ${ext} could not enumerate staging root ${root}" >&2; \
+                return 1; \
+            fi; \
+            if ! sorted_versions_file=$(mktemp); then \
+                rm -f "$versions_file"; \
+                echo "ERROR: extension ${ext} could not enumerate staging root ${root}" >&2; \
+                return 1; \
+            fi; \
+            if ! printf '%s\n' "$@" > "$versions_file" || \
+                ! sort -t. -k1,1n -k2,2n -k3,3n "$versions_file" > "$sorted_versions_file"; then \
+                rm -f "$versions_file" "$sorted_versions_file"; \
+                echo "ERROR: extension ${ext} could not enumerate staging root ${root}" >&2; \
+                return 1; \
+            fi; \
             echo "Installing extension (multi-version): ${ext}"; \
-            sorted_vers=$(ls /tmp/ext/${ext}/ | sort -t. -k1,1n -k2,2n -k3,3n); \
-            for ver in $sorted_vers; do \
-                ver_dir="/tmp/ext/${ext}/${ver}/"; \
+            ceiling_ver=''; \
+            while IFS= read -r ver || [ -n "$ver" ]; do \
+                ver_dir="${root}/$ver/"; \
+                if [ ! -d "$ver_dir" ] || { [ ! -d "${ver_dir}extension" ] && [ ! -d "${ver_dir}lib" ]; }; then \
+                    rm -f "$versions_file" "$sorted_versions_file"; \
+                    echo "ERROR: extension ${ext} has unsupported staging layout at ${ver_dir}" >&2; \
+                    return 1; \
+                fi; \
                 echo "  version: ${ver_dir}"; \
-                if [ -d "${ver_dir}lib" ]; then \
-                    cp -v "${ver_dir}lib/"* /usr/local/lib/postgresql/ 2>/dev/null || true; \
+                if ! copy_payload "${ver_dir}lib" /usr/local/lib/postgresql/ "$ext" || \
+                    ! copy_payload "${ver_dir}extension" /usr/local/share/postgresql/extension/ "$ext"; then \
+                    rm -f "$versions_file" "$sorted_versions_file"; \
+                    return 1; \
                 fi; \
-                if [ -d "${ver_dir}extension" ]; then \
-                    cp -v "${ver_dir}extension/"* /usr/local/share/postgresql/extension/ 2>/dev/null || true; \
-                fi; \
-            done; \
-            ceiling_ver=$(ls /tmp/ext/${ext}/ | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); \
-            ceiling_dir="/tmp/ext/${ext}/${ceiling_ver}/"; \
+                ceiling_ver=$ver; \
+            done < "$sorted_versions_file"; \
+            rm -f "$versions_file" "$sorted_versions_file"; \
+            ceiling_dir="${root}/$ceiling_ver/"; \
             if [ -f "${ceiling_dir}extension/${ext}.control" ]; then \
                 cp -v "${ceiling_dir}extension/${ext}.control" \
                     /usr/local/share/postgresql/extension/${ext}.control; \

--- a/tests/unit/postgres-extension-presence.bats
+++ b/tests/unit/postgres-extension-presence.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+#
+# Execute the install_ext transport shell from postgres/Dockerfile. These tests
+# deliberately do not inspect a generated Dockerfile: they exercise the guards
+# that decide whether a staged payload is copied or a build stops. CI needs
+# BusyBox installed: the shipped PostgreSQL image uses BusyBox ash and applets.
+
+load "../test_helper"
+
+_extract_install_ext() {
+    printf '%s\n' '# shellcheck shell=sh' > "$TEST_TEMP_DIR/install-ext.sh"
+    sed -n '/^RUN set -eux; \\/,/^    # Install extensions based on flavor/{p; /^    # Install extensions based on flavor/q;}' \
+        "$PROJECT_ROOT/postgres/Dockerfile" \
+        | sed -e '1s/^RUN //' -e 's/; \\$//' \
+            -e "s|/tmp/ext|$STAGING_ROOT|g" \
+            -e "s|/usr/local/share/postgresql/extension|$EXTENSION_DEST|g" \
+            -e "s|/usr/local/lib/postgresql|$LIB_DEST|g" \
+        >> "$TEST_TEMP_DIR/install-ext.sh"
+    printf '%s\n' 'install_ext "$@"' >> "$TEST_TEMP_DIR/install-ext.sh"
+
+    # A total extraction failure announces itself — install_ext would be
+    # undefined and every test would die. A PARTIAL one does not: the sed range
+    # still yields a callable function while silently dropping whichever guard
+    # the Dockerfile's continuation style moved out of range. Pin the landmarks
+    # that must survive, so drift fails here rather than passing a suite that
+    # tests less than it names.
+    local body="$TEST_TEMP_DIR/install-ext.sh"
+    grep -q 'install_ext() {' "$body"
+    grep -q 'copy_payload' "$body"
+    grep -q 'set -eux' "$body"
+    grep -q 'has no staging root at' "$body"
+    grep -q 'ceiling control' "$body"
+    [ "$(wc -l < "$body")" -gt 60 ]
+}
+
+_run_install_ext() {
+    run env "PATH=$BUSYBOX_APPLET_DIR" /bin/busybox sh \
+        "$TEST_TEMP_DIR/install-ext.sh" "$@"
+}
+
+_write_file() {
+    local path=$1
+    local content=${2:-payload}
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+}
+
+setup() {
+    setup_temp_dir
+    if [[ ! -x /bin/busybox ]]; then
+        echo "BusyBox is required for this test; CI must install /bin/busybox" >&2
+        return 1
+    fi
+    export STAGING_ROOT="$TEST_TEMP_DIR/ext"
+    export EXTENSION_DEST="$TEST_TEMP_DIR/destination/extension"
+    export LIB_DEST="$TEST_TEMP_DIR/destination/lib"
+    export BUSYBOX_APPLET_DIR="$TEST_TEMP_DIR/busybox-bin"
+    mkdir -p "$STAGING_ROOT" "$EXTENSION_DEST" "$LIB_DEST" "$BUSYBOX_APPLET_DIR"
+    for utility in $(/bin/busybox --list); do
+        ln -s /bin/busybox "$BUSYBOX_APPLET_DIR/$utility"
+    done
+    _extract_install_ext
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+@test "install_ext fails when the declared staging root is absent" {
+    _run_install_ext absent
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension absent has no staging root"* ]]
+}
+
+@test "install_ext fails when the staging root matches neither supported layout" {
+    mkdir -p "$STAGING_ROOT/malformed/unexpected"
+
+    _run_install_ext malformed
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension malformed staging root"* ]]
+    [[ "$output" == *"matches no supported layout"* ]]
+}
+
+@test "install_ext fails when the staging root matches multiple layouts" {
+    _write_file "$STAGING_ROOT/ambiguous/extension/ambiguous.control"
+    _write_file "$STAGING_ROOT/ambiguous/2.9.0/extension/ambiguous--2.9.0.sql"
+
+    _run_install_ext ambiguous
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension ambiguous staging root"* ]]
+    [[ "$output" == *"matches multiple supported layouts"* ]]
+    [[ "$output" == *"found:"*"extension"* ]]
+    [[ "$output" == *"found:"*"2.9.0"* ]]
+    [ ! -e "$EXTENSION_DEST/ambiguous.control" ]
+}
+
+@test "install_ext fails when a single-version staging root contains an unknown sibling" {
+    _write_file "$STAGING_ROOT/misspelled/extension/misspelled.control"
+    mkdir -p "$STAGING_ROOT/misspelled/liib"
+
+    _run_install_ext misspelled
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension misspelled staging root"* ]]
+    [[ "$output" == *"matches no supported layout"* ]]
+    [[ "$output" == *"found:"*"extension"* ]]
+    [[ "$output" == *"found:"*"liib"* ]]
+    [ ! -e "$EXTENSION_DEST/misspelled.control" ]
+}
+
+@test "install_ext fails when a retained version contains an unknown sibling" {
+    _write_file "$STAGING_ROOT/version-misspelled/2.10.0/extension/version-misspelled.control"
+    mkdir -p "$STAGING_ROOT/version-misspelled/2.10.0/liib"
+
+    _run_install_ext version-misspelled
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension version-misspelled version 2.10.0 staging directory"* ]]
+    [[ "$output" == *"unsupported layout"* ]]
+    [[ "$output" == *"found:"*"extension"* ]]
+    [[ "$output" == *"found:"*"liib"* ]]
+    [ ! -e "$EXTENSION_DEST/version-misspelled.control" ]
+}
+
+@test "BusyBox harness does not resolve utilities outside its applet directory" {
+    mkdir -p "$STAGING_ROOT/busybox-only/extension"
+    printf '%s\n' 'if command -v bash >/dev/null; then exit 1; fi' \
+        >> "$TEST_TEMP_DIR/install-ext.sh"
+
+    _run_install_ext busybox-only
+
+    [ "$status" -eq 0 ]
+}
+
+@test "install_ext fails when a payload copy fails" {
+    _write_file "$STAGING_ROOT/broken/extension/broken--1.0.sql"
+    rmdir "$EXTENSION_DEST"
+    touch "$EXTENSION_DEST"
+
+    _run_install_ext broken
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not copy extension broken payload from $STAGING_ROOT/broken/extension"* ]]
+}
+
+@test "install_ext accepts an extension payload with no lib directory" {
+    _write_file "$STAGING_ROOT/sqlonly/extension/sqlonly.control"
+    _write_file "$STAGING_ROOT/sqlonly/extension/sqlonly--1.0.sql"
+
+    _run_install_ext sqlonly
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/sqlonly.control" ]
+    [ -f "$EXTENSION_DEST/sqlonly--1.0.sql" ]
+}
+
+@test "install_ext accepts an empty lib directory" {
+    _write_file "$STAGING_ROOT/emptylib/extension/emptylib.control"
+    mkdir -p "$STAGING_ROOT/emptylib/lib"
+
+    _run_install_ext emptylib
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/emptylib.control" ]
+}
+
+# Every one of the ten recipes under postgres/extensions/build/ writes
+# /output/metadata.txt beside extension/ and lib/, and that whole directory is
+# what `COPY --from=ext-<name>` stages. A layout rule that recognises only the
+# two directories rejects every artifact this repository actually produces.
+@test "install_ext accepts the metadata.txt every build recipe stages" {
+    _write_file "$STAGING_ROOT/withmeta/extension/withmeta.control"
+    _write_file "$STAGING_ROOT/withmeta/lib/withmeta.so"
+    _write_file "$STAGING_ROOT/withmeta/metadata.txt" "extension=withmeta"
+
+    _run_install_ext withmeta
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/withmeta.control" ]
+    [ -f "$LIB_DEST/withmeta.so" ]
+}
+
+@test "install_ext accepts metadata.txt inside a retained version directory" {
+    _write_file "$STAGING_ROOT/metaver/2.9.0/extension/metaver.control"
+    _write_file "$STAGING_ROOT/metaver/2.9.0/lib/metaver.so"
+    _write_file "$STAGING_ROOT/metaver/2.9.0/metadata.txt" "version=2.9.0"
+    _write_file "$STAGING_ROOT/metaver/2.10.0/extension/metaver.control"
+    _write_file "$STAGING_ROOT/metaver/2.10.0/lib/metaver.so"
+    _write_file "$STAGING_ROOT/metaver/2.10.0/metadata.txt" "version=2.10.0"
+
+    _run_install_ext metaver
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/metaver.control" ]
+    [ -f "$LIB_DEST/metaver.so" ]
+}
+
+@test "install_ext copies a dotfile-only payload" {
+    _write_file "$STAGING_ROOT/dotfile/extension/dotfile.control"
+    _write_file "$STAGING_ROOT/dotfile/lib/.hidden.so"
+
+    _run_install_ext dotfile
+
+    [ "$status" -eq 0 ]
+    [ -f "$LIB_DEST/.hidden.so" ]
+}
+
+@test "install_ext completes multi-version enumeration with BusyBox find" {
+    _write_file "$STAGING_ROOT/enumeration/2.9.0/extension/enumeration--2.9.0.sql"
+
+    _run_install_ext enumeration
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/enumeration--2.9.0.sql" ]
+}
+
+@test "install_ext preserves numeric multi-version order under BusyBox ash" {
+    _write_file "$STAGING_ROOT/multi/2.9.0/extension/multi--2.9.0.sql" "one"
+    _write_file "$STAGING_ROOT/multi/2.9.0/extension/multi.control" "default_version = '2.9.0'"
+    _write_file "$STAGING_ROOT/multi/2.9.0/lib/multi-2.9.0.so" "one"
+    _write_file "$STAGING_ROOT/multi/2.10.0/extension/multi--2.10.0.sql" "two"
+    _write_file "$STAGING_ROOT/multi/2.10.0/extension/multi.control" "default_version = '2.10.0'"
+    _write_file "$STAGING_ROOT/multi/2.10.0/lib/multi-2.10.0.so" "two"
+
+    _run_install_ext multi
+
+    [ "$status" -eq 0 ]
+    [ -f "$EXTENSION_DEST/multi--2.9.0.sql" ]
+    [ -f "$EXTENSION_DEST/multi--2.10.0.sql" ]
+    [ -f "$LIB_DEST/multi-2.9.0.so" ]
+    [ -f "$LIB_DEST/multi-2.10.0.so" ]
+    [ "$(cat "$EXTENSION_DEST/multi.control")" = "default_version = '2.10.0'" ]
+    [[ "$output" == *"version: $STAGING_ROOT/multi/2.9.0/"*"version: $STAGING_ROOT/multi/2.10.0/"* ]]
+}
+
+@test "install_ext reports an invalid layout under the image set -u mode" {
+    mkdir -p "$STAGING_ROOT/unset-layout/unexpected"
+
+    _run_install_ext unset-layout
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension unset-layout staging root"* ]]
+    [[ "$output" == *"matches no supported layout"* ]]
+    [[ "$output" != *"parameter not set"* ]]
+}


### PR DESCRIPTION
A flavour that declared an extension whose files never reached the image built, started and looked healthy. `install_ext` lost them two ways and reported neither: no `else`, so a staging directory matching no supported layout — including one never staged — was a no-op; and every `cp` ended in `2>/dev/null || true`, so a failed copy was indistinguishable from one with nothing to copy.

Both now fail the build in the same `RUN`, naming the extension. A source directory legitimately absent or empty still passes: a SQL-only extension has no `lib` payload.

## What is deliberately not here

A generated post-install assertion — control file, installation script, and the module named by `module_pathname` — was built first and reverted in full, along with a `sql_name` config key and a template marker. Review kept surfacing another documented property of PostgreSQL's control-file format the shell got wrong: case-insensitive parameter names, optional `=`, last-assignment-wins, escaped quotes, `directory =` relocating the script directory, relative paths with a slash, an upgrade-only `foo--1.0--1.1.sql` satisfying an installation-script glob. Passing all of it still would not prove PostgreSQL can load the extension. `/tmp/ext` is removed at the end of the installation `RUN`, so a source-versus-destination comparison in a later `RUN` is not available either.

The known edge of what remains is #1077.

## POSIX, because it has to be

`postgres/variants.yaml` sets `base_suffix: "-alpine"` and this Dockerfile declares no `SHELL`, so every `RUN` executes under BusyBox ash with BusyBox applets. An intermediate version used `find -printf` and `$'\n'`; BusyBox has neither, and it would have failed every multi-version extension build while the suite stayed green in Bats' bash. The tests now run the extracted `RUN set -eux` body under `/bin/busybox sh` with a PATH of BusyBox applet symlinks and nothing else, which is what the new workflow step installs. Reintroducing `find -printf` turns the suite red.

The recognised layout entries are `extension/`, `lib/` and `metadata.txt`. All ten recipes under `postgres/extensions/build/` write that file beside the two directories and `COPY --from=ext-<name>` stages the whole of `/output`, so an earlier rule naming only the directories would have rejected every artifact this repository produces.

## Verification

Fifteen tests execute the shell rather than inspecting generated text, because a string check would not have caught the suppressed copy that started this. Mutations turned them red for each guard: the staging-root check, `|| true` on the copy, the numeric sort keys, `find -printf`, an uninitialised `layout`, and `metadata.txt` acceptance at both levels. `shellcheck -x -S warning` clean; `actionlint` clean on the workflow.

**Two deviations from the usual evidence, both deliberate and both documented.**

The local full suite cannot be run to green on the machine this was written on. Three different files failed under `--jobs 4` today and passed in isolation; the two whose cause is legible are **segmentation faults**, one in CPython encoding a 26 MB document and one in a shell process. One was reproduced on unmodified `origin/master` extracted to a clean directory. CI is green on `master`. That is #1079, and CI is the evidence for this branch.

The cross-family gate's last verdict is a single Medium: a version directory whose name contains a newline would be dropped rather than rejected. Those names come from the extension build pipeline's resolved version strings; producing one with an embedded newline requires control of the resolver, and anyone holding that can already stage arbitrary content. It is filed with one other unreachable-trigger finding as #1078. Every other dimension came back CLEAN.

Closes #1067.
