### PR TITLE
test(postgres): run the e2e that has been sitting unused

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -329,7 +329,8 @@ jobs:
           tag: ${{ matrix.build.tag }}
           # Pass the full build cell through so an e2e-enabled variant / alternate
           # Dockerfile builds and tests the SAME image the detector selected.
-          # (Current opt-ins are flavor-less, so these are empty today.)
+          # postgres routes through here with flavor and variant set to `full`;
+          # the other opt-ins declare no flavour and leave these empty.
           flavor: ${{ matrix.build.flavor }}
           build_flavor: ${{ matrix.build.build_flavor }}
           variant: ${{ matrix.build.variant }}

--- a/docs/site/_posts/2026-07-19-the-e2e-suite-that-never-ran-in-ci.md
+++ b/docs/site/_posts/2026-07-19-the-e2e-suite-that-never-ran-in-ci.md
@@ -49,7 +49,7 @@ The rest of the wiring:
 
 - A per-container opt-in flag, `tests.e2e.enabled` in `variants.yaml`, surfaced as an output on the container-detection action, so a run is scoped to changed, eligible containers only.
 - The job runs on non-fork pull requests. It boots images under elevated runtime options — OpenVPN needs `/dev/net/tun` and specific capabilities — which is not something to grant to code from an untrusted fork.
-- A small aggregator job is the check that can be marked required. It passes on a real green run or a legitimate skip (a fork PR, or a PR that changed no eligible container) and fails only on an actual e2e failure. Without it, a required check that is skipped for a skipped job would leave unrelated pull requests waiting indefinitely.
+- A small aggregator job is the check that can be marked required. It passes on a real green run, and on a skip that is honest: a pull request that changed no eligible container, or an event that runs no e2e at all. A fork pull request that *did* change an eligible container fails it, because the fork guard stopped the suite from running and calling that green would report a verification that never happened. The cost is real — an external contributor cannot turn the check green alone, and a maintainer has to run the branch. Without the aggregator, a required check skipped along with its job would leave unrelated pull requests waiting indefinitely.
 
 The first increment covers four containers that already had tailored run profiles: openvpn, ansible, debian, sslh.
 

--- a/postgres/variants.yaml
+++ b/postgres/variants.yaml
@@ -139,5 +139,11 @@ versions:
         when_to_use: All extensions enabled — pick when prototyping or when scope is not yet defined.
 tests:
   e2e:
-    enabled: false
+    enabled: true
+    # One cell. `full` assembles every compiled extension, so it exercises each
+    # one's install and initialisation. What it does NOT exercise is the other
+    # six `case` arms in the Dockerfile that assemble the narrower flavours:
+    # dropping an `install_ext` from the `vector)` arm leaves `full)` intact and
+    # this cell green. That gap wants the arms generated from the same filtered
+    # list rather than six more e2e jobs — #1083.
     flavor: full


### PR DESCRIPTION
`postgres/test.sh` is 620 lines and nothing has ever run it. The e2e harness was dead until it was repaired and wired into CI as a blocking pull-request gate; postgres stayed off behind a list of named blockers, the last of which (#1067) merged today.

Measured before flipping the flag, against the published `18-alpine-full`: **31 tests passed in 30 seconds**, covering citus reference tables, timescaledb hypertables and `time_bucket`, pg_cron's presence in `shared_preload_libraries` and its `cron.job` table, pg_ivm's `create_immv`, and the rest of the compiled set. This pull request's own run builds from the branch instead of pulling a published image, which is the point of gating there.

## One cell, and what it does not cover

`full` assembles every compiled extension, so it exercises each one's install and initialisation. It does **not** exercise the six other `case` arms that assemble the narrower flavours: `full` is a superset of the extension set, not of the execution paths. Dropping an `install_ext` from the `vector)` arm would leave this cell green.

That gap is real and it predates this change — the arms are hand-maintained against `config.yaml` with only a WARNING comment holding them together. The answer is to generate them from the same filtered list, not to add six more e2e jobs, and it is filed as #1083.

PostgreSQL 16 and 17 get no e2e: the selector takes only the latest version, for every container, by design.

## Two things this makes more visible

Enabling postgres makes it the tenth container whose fork pull requests cannot turn the required check green on their own. The fork guard stops the e2e job and `e2e-gate` refuses to call an unrun suite verified — deliberate, with its reasoning written beside the branch that implements it. What was wrong was the blog post claiming a fork skip passes the aggregator; it is corrected here to describe the actual behaviour and to name the cost. The contributor-facing trade-off is #1082.

The comment above the e2e build's inputs said all opt-ins were flavourless. postgres routes through with `flavor` and `variant` set to `full`, so it no longer is.

## Verification

Full suite 2327, 0 failing, declared equals executed. `tests/unit/detect-e2e-builds.bats` and `tests/unit/e2e-gate-eligibility.bats`: 15 tests, 0 failing.

The cross-family gate ran three rounds. Its findings produced the comment correction, the blog-post correction, and the two issues above; the round budget is spent and the residue is filed rather than carried.

openresty and vector still ship a `test.sh` nothing runs. Both time out on the readiness wait (#988) and would need their pre-harness scripts rewritten on `th_assert`.

Part of #978.
