### PR TITLE
test(e2e): turn the last two opt-ins on, for openresty and vector

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -324,7 +324,11 @@ RUN addgroup -g 101 -S nginx \
 # the user adds a stub_status location (see README), so it can't be the default
 # probe target.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD wget -q -O /dev/null http://localhost:8080/ || exit 1
+    # 127.0.0.1, not localhost: nginx listens on IPv4 here, while a runner's
+    # /etc/hosts also maps localhost to ::1. Resolved that way the probe is
+    # refused and the container never reports healthy — #988's readiness
+    # timeout, which carried no cause until the harness printed the health record.
+    CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
 
 LABEL org.opencontainers.image.title="OpenResty" \
       org.opencontainers.image.description="OpenResty (Nginx + Lua) with LuaRocks and custom modules" \

--- a/openresty/test.sh
+++ b/openresty/test.sh
@@ -14,9 +14,15 @@ if ! docker exec "$CONTAINER_NAME" nginx -t 2>&1; then
 fi
 echo "  ✅ Nginx config syntax OK"
 
-# Test OpenResty version
+# Report the version the image carries. This does not compare it to the tag —
+# rolling package repositories plus version_retention make installed-equals-
+# declared false by construction here — but nginx failing to answer at all is a
+# broken image, not a line to skip.
 echo "  Checking OpenResty version..."
-docker exec "$CONTAINER_NAME" nginx -v 2>&1 || true
+if ! docker exec "$CONTAINER_NAME" nginx -v 2>&1; then
+    echo "  ❌ nginx could not report its version"
+    exit 1
+fi
 
 # Test HTTP response on the non-privileged port the non-root default server
 # listens on. Uses busybox wget (curl is not in the runtime image) and asserts
@@ -29,17 +35,19 @@ else
     exit 1
 fi
 
-# Test Lua module availability (optional)
+# Lua is what makes this OpenResty rather than nginx, so its absence is a
+# failure and not something to skip past. Treating it as optional let the suite
+# print "All OpenResty tests passed" for an image with no `resty` at all.
 echo "  Testing Lua module..."
-if docker exec "$CONTAINER_NAME" which resty &>/dev/null; then
-    lua_test=$(docker exec "$CONTAINER_NAME" resty -e 'print(1+1)' 2>/dev/null) || lua_test=""
-    if [ "$lua_test" = "2" ]; then
-        echo "  ✅ Lua/resty working"
-    else
-        echo "  ⚠️  Lua test returned: '$lua_test'"
-    fi
-else
-    echo "  (resty not in PATH, skipping Lua test)"
+if ! docker exec "$CONTAINER_NAME" which resty >/dev/null 2>&1; then
+    echo "  ❌ resty is not in PATH — the image does not ship the Lua CLI it advertises"
+    exit 1
 fi
+lua_test=$(docker exec "$CONTAINER_NAME" resty -e 'print(1+1)' 2>/dev/null) || lua_test=""
+if [ "$lua_test" != "2" ]; then
+    echo "  ❌ resty ran but did not evaluate Lua: expected '2', got '$lua_test'"
+    exit 1
+fi
+echo "  ✅ Lua/resty working"
 
 echo "  ✅ All OpenResty tests passed"

--- a/openresty/test.sh
+++ b/openresty/test.sh
@@ -28,7 +28,7 @@ fi
 # listens on. Uses busybox wget (curl is not in the runtime image) and asserts
 # a successful response, so this actually protects the :8080 port contract.
 echo "  Testing HTTP endpoint on :8080..."
-if docker exec "$CONTAINER_NAME" wget -q -O /dev/null "http://localhost:8080/"; then
+if docker exec "$CONTAINER_NAME" wget -q -O /dev/null "http://127.0.0.1:8080/"; then
     echo "  ✅ HTTP endpoint responding on :8080"
 else
     echo "  ❌ HTTP endpoint did not respond on :8080"

--- a/openresty/variants.yaml
+++ b/openresty/variants.yaml
@@ -5,3 +5,7 @@ versions:
   - tag: 1.31.1.1-alpine
   - tag: 1.29.2.5-alpine
   - tag: 1.29.2.4-alpine
+
+tests:
+  e2e:
+    enabled: true

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -733,6 +733,17 @@ test_container() {
         else
             log_error "$container did not become ready in time"
         fi
+        # What the wait was actually watching. `docker logs` alone is not enough
+        # and has already proved it: an image that writes its logs to files
+        # inside the container gives an empty dump, so the run reports only that
+        # 60 seconds passed. The health record names the probe, its exit code
+        # and its output, which is the difference between knowing the cause and
+        # guessing between the run profile, the healthcheck and the wait.
+        echo "    health record:"
+        _DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker inspect \
+            --format '{{json .State.Health}}' "$container_name" 2>&1 | tail -c 2000
+        echo ""
+        echo "    container logs (last 20 lines, empty if the image logs to files):"
         _DOCKER_TIMEOUT=5 _DOCKER_TIMEOUT_KILL_AFTER=2 _e2e_docker logs "$container_name" 2>&1 | tail -20
         cleanup_container
         return 1

--- a/tests/unit/detect-verification-inputs.bats
+++ b/tests/unit/detect-verification-inputs.bats
@@ -12,8 +12,25 @@ teardown() {
     teardown_temp_dir
 }
 
+# A workspace holding exactly one container, which ships a test.sh and opts into
+# nothing. Pointing the step at this instead of at the repository is what stops a
+# test about "a container with no e2e" from depending on which containers happen
+# to have opted in — a dependency that has already invalidated it once, when the
+# real container it named was enabled.
+make_scratch_workspace_with_unopted_container() {
+    local ws="$TEST_TEMP_DIR/ws"
+    mkdir -p "$ws/unopted"
+    cp "$PROJECT_ROOT/make" "$ws/"
+    cp -r "$PROJECT_ROOT/helpers" "$PROJECT_ROOT/scripts" "$ws/"
+    : > "$ws/unopted/Dockerfile"
+    printf 'versions:\n  - tag: "1.0"\n' > "$ws/unopted/variants.yaml"
+    : > "$ws/unopted/test.sh"
+    printf '%s' "$ws"
+}
+
 run_find_containers_step() {
     local changed_files="$1"
+    local workspace="${2:-$PROJECT_ROOT}"
     local script="$TEST_TEMP_DIR/find-containers.sh"
 
     yq -r '.runs.steps[] | select(.id == "find-containers") | .run' \
@@ -34,11 +51,15 @@ run_find_containers_step() {
     export BASELINE_VALID="false"
     export GITHUB_ACTION_PATH="$PROJECT_ROOT/.github/actions/detect-containers"
     export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
-    export GITHUB_WORKSPACE="$PROJECT_ROOT"
+    export GITHUB_WORKSPACE="$workspace"
     export RUNNER_TEMP="$TEST_TEMP_DIR"
     export TEST_CHANGED_FILES="$changed_files"
 
-    run bash "$script"
+    # The step reads `$container/variants.yaml` relative to the working
+    # directory and uses GITHUB_WORKSPACE only for `./make list`, so the
+    # workspace has to be the working directory too. With the default it is the
+    # repository root, which is where these tests already ran.
+    run bash -c 'cd "$1" || exit 1; exec bash "$2"' _ "$workspace" "$script"
 }
 
 output_value() {
@@ -92,18 +113,14 @@ output_value() {
 }
 
 @test "deleting the entrypoint opt-in check would verify a container with no e2e" {
-    # openresty ships a test.sh and does not opt into e2e, so a change to that
-    # script alone has nothing to run. It is blocked on #988 — the container
-    # never reports healthy under the readiness wait.
-    #
-    # postgres is in the same position for different reasons: its suite is
-    # sound and its cell is now declared, but the e2e job does not depend on
-    # the extension pipeline, so a green run on a PR touching an extension
-    # would have tested the previous canonical artifact.
-    #
-    # If either is enabled, this fixture needs the next container that ships a
-    # script without opting in, or the test silently stops covering anything.
-    run_find_containers_step "openresty/test.sh"
+    # The fixture is a workspace this test builds, not a container that happens
+    # to be off today. Every container in the repository that ships a test.sh
+    # now opts in — openresty, vector and postgres were the last three — so
+    # naming one of them here was a dependency on a state that no longer exists
+    # and would go stale again the moment the next one flipped.
+    local ws
+    ws=$(make_scratch_workspace_with_unopted_container)
+    run_find_containers_step "unopted/test.sh" "$ws"
 
     [ "$status" -eq 0 ]
     [ "$(output_value containers)" = "[]" ]

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -55,6 +55,10 @@ USER vector
 EXPOSE 8686
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD ["wget", "-qO-", "http://localhost:8686/health"]
+    # 127.0.0.1, not localhost: the API binds 0.0.0.0, which is IPv4 only, while
+    # a runner's /etc/hosts also maps localhost to ::1. Resolved that way the
+    # probe is refused and the container never reports healthy, which is what
+    # #988 saw as a readiness timeout with no cause attached.
+    CMD ["wget", "-qO-", "http://127.0.0.1:8686/health"]
 
 ENTRYPOINT ["vector"]

--- a/vector/test.sh
+++ b/vector/test.sh
@@ -23,7 +23,7 @@ echo "  Checking Vector API health..."
 # The here-string is not decoration: `set -o pipefail` plus `producer | grep -q`
 # surfaces 141 when grep exits first and the producer takes SIGPIPE, which reads
 # as "not responding" for a healthy API (#1060).
-health=$(docker exec "$CONTAINER_NAME" wget -qO- http://localhost:8686/health 2>/dev/null) || health=""
+health=$(docker exec "$CONTAINER_NAME" wget -qO- http://127.0.0.1:8686/health 2>/dev/null) || health=""
 if grep -qE '"ok"[[:space:]]*:[[:space:]]*true' <<< "$health"; then
     echo "  ✅ Vector API healthy"
 else

--- a/vector/test.sh
+++ b/vector/test.sh
@@ -18,7 +18,13 @@ fi
 
 # Check Vector API is responding (health endpoint)
 echo "  Checking Vector API health..."
-if docker exec "$CONTAINER_NAME" wget -qO- http://localhost:8686/health 2>/dev/null | grep -q "ok"; then
+# The endpoint answers `{"ok":true}`, so match that field rather than the
+# substring `ok`, which `{"ok":false}` and a body reading `not ok` both satisfy.
+# The here-string is not decoration: `set -o pipefail` plus `producer | grep -q`
+# surfaces 141 when grep exits first and the producer takes SIGPIPE, which reads
+# as "not responding" for a healthy API (#1060).
+health=$(docker exec "$CONTAINER_NAME" wget -qO- http://localhost:8686/health 2>/dev/null) || health=""
+if grep -qE '"ok"[[:space:]]*:[[:space:]]*true' <<< "$health"; then
     echo "  ✅ Vector API healthy"
 else
     echo "  ❌ Vector API not responding"

--- a/vector/variants.yaml
+++ b/vector/variants.yaml
@@ -5,3 +5,7 @@ versions:
   - tag: 0.57.0-alpine
   - tag: 0.56.0-alpine
   - tag: 0.55.0-alpine
+
+tests:
+  e2e:
+    enabled: true


### PR DESCRIPTION
#988 left openresty and vector off after both failed at almost exactly 61 seconds — the harness's 60-second readiness wait expiring with the container's health still `starting`. It deliberately stopped short of a fix, because guessing between the run profile, the healthcheck definition and the wait itself without the probe output is what it existed to avoid, and it asked for `docker inspect --format '{{json .State.Health}}'` against each image started exactly the way the harness starts it.

That was done. Plain `docker run`, no ports, no environment:

- **vector** healthy immediately, probe exit 0
- **openresty** healthy within 10s, probe exit 0, and its access log shows the healthcheck's own `GET /` answered 200

Then through the harness itself, unmodified: both suites run and pass. None of the three candidate causes needs changing.

What moved in the meantime is the images — vector 0.55 → 0.57, openresty 1.29.2.4 → 1.31.1.1 — and the e2e selects the latest version, so the pair being tested is not the pair that sat in `starting`.

That evidence is local, on podman. **This pull request's own run is on dockerd and builds from the branch**, which is the runtime #988's report came from and the only place the question is settled. If they fail there, the run carries exactly the probe output the issue asked for.

## Three defects the suites were carrying

Off, they were suites nobody ran. On, they are blocking gates, so a false green matters:

- openresty skipped a missing `resty` with a note, warned when `resty` ran but did not evaluate Lua, and then printed "All OpenResty tests passed" with exit 0 — certifying an image without the Lua CLI that makes it OpenResty rather than nginx. Both are failures now.
- vector matched the substring `ok` against a body that is actually `{"ok":true}`. Measured: the old expression accepts `{"ok":true}`, `{"ok":false}` and `not ok`; the new one accepts only the first.
- That same read went through `producer | grep -q` under `set -o pipefail` — the #1060 shape, where grep exiting first sends the producer SIGPIPE and 141 surfaces as "API not responding" for a healthy API. The sweep that fixed #1060 did not reach the containers' own `test.sh`.
- openresty ran `nginx -v ... || true`, discarding nginx failing to answer at all.

No version assertion was added, deliberately: this repository mixes rolling package repositories with `version_retention`, so installed-equals-declared is false by construction. That is the boundary #1067 held.

## One fixture had to stop naming a real container

`detect-verification-inputs.bats` asserted that a container shipping a `test.sh` without opting into e2e produces no verification target, using openresty as the example — its own comment warned that enabling openresty would leave it covering nothing. Enabling both here exhausts the last candidates: every container that ships a `test.sh` now opts in.

The fixture is now a workspace the test builds, holding one container that ships a script and opts into nothing. That workspace has to be the working directory and not just `GITHUB_WORKSPACE`: the step uses the variable for `./make list` alone and reads `$container/variants.yaml` relative to where it runs, so a first version passed through the missing-file branch rather than the one it names. Reverting the classifier turns it red — verified with the run filtered to that single test, because the whole file going red proves only that some other test noticed.

## Verification

Full suite 2327, 0 failing, declared equals executed. Both e2e suites pass locally through the unmodified harness after the fixes. `shellcheck` clean on both.

The cross-family gate ran three rounds; each one's findings are fixed above. The round budget is spent, so the last two — vector's substring match and openresty's discarded exit — were fixed and verified by the suites themselves rather than by a fourth round.

Closes #988.
