### PR TITLE
fix(postgres): validate the extensions config once, at the boundary

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -4,12 +4,18 @@ on:
   pull_request:
     paths:
       - '**/*.sh'
+      - '**/config.yaml'
+      - '**/variants.yaml'
+      - '.yamllint.yml'
       - 'make'
       - '.github/workflows/shellcheck.yaml'
   push:
     branches: [master]
     paths:
       - '**/*.sh'
+      - '**/config.yaml'
+      - '**/variants.yaml'
+      - '.yamllint.yml'
       - 'make'
       - '.github/workflows/shellcheck.yaml'
   workflow_dispatch:
@@ -28,6 +34,14 @@ jobs:
       - name: Install shellcheck
         run: |
           echo "shellcheck version: $(shellcheck --version | head -2)"
+
+      - name: Check duplicate YAML mapping keys
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y yamllint
+          find . -type f \( -name config.yaml -o -name variants.yaml \) \
+            -not -path './.git/*' -print0 | xargs -0 yamllint -c .yamllint.yml
 
       - name: Run shellcheck on scripts
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,31 +1,4 @@
 ---
-# Setup yamllint for GitHub Actions workflows
-extends: default
-
+# Keep this intentionally narrow: config shape is not a formatting convention.
 rules:
-  # Relax rules
-  line-length:
-    max: 130  # GitHub Actions may have longer lines
-    level: warning
-  
-  trailing-spaces:
-    level: warning  # Not strict, but warn about trailing spaces
-  
-  document-start:
-    present: false  # Not required in GitHub Actions YAML files
-  
-  truthy:
-    allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']
-    check-keys: false  # Allow 'on' and 'off' as truthy values
-  
-  brackets:
-    max-spaces-inside: 1
-    max-spaces-inside-empty: 0
-  
-  comments:
-    min-spaces-from-content: 1
-  
-  indentation:
-    spaces: 2
-    indent-sequences: true
-    check-multi-line-strings: false
+  key-duplicates: enable

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -15,6 +15,9 @@ if ! declare -F log_info &>/dev/null; then
     source "$HELPERS_DIR/logging.sh"
 fi
 
+# shellcheck source=helpers/validate-extensions-schema.sh
+source "$HELPERS_DIR/validate-extensions-schema.sh"
+
 # Source generic template utilities (provides expand_template, has_template_markers)
 if ! declare -F expand_template &>/dev/null; then
     source "$HELPERS_DIR/template-utils.sh"
@@ -248,7 +251,8 @@ ext_config() {
         return 1
     fi
 
-    yq -r ".extensions.${ext_name}.${key} // \"\"" "$config_file"
+    ext="$ext_name" yq -o=json '.extensions[strenv(ext)] // {}' "$config_file" | \
+        jq -r --arg config_key "$key" 'getpath($config_key | split(".")) // ""'
 }
 
 # List extensions from config, sorted by priority
@@ -262,7 +266,7 @@ list_extensions_by_priority() {
         pgver="$pg_version" yq -r '
             [.extensions | to_entries[]
              | select(.value.disabled == true | not)
-             | select((.value.max_pg_version // 999) >= env(pgver))]
+             | select((.value.max_pg_version // 999) >= (strenv(pgver) | tonumber))]
             | sort_by(.value.priority // 99)
             | .[].key
         ' "$config_file"
@@ -563,45 +567,10 @@ get_flavor_extensions() {
     local flavor="$2"
     local pg_major="$3"
     local declared_flavors
-    local invalid_flavor_record
-    local invalid_flavor
-    local safe_invalid_flavor
     local flavor_exists
 
     if ! declared_flavors=$(yq -r '.flavors | keys | join(", ")' "$config_file"); then
         log_error "get_flavor_extensions: could not read declared flavors from ${config_file}"
-        return 1
-    fi
-
-    # Five structural properties, checked together rather than one per defect
-    # found: a name-shaped key, mapping to a list, of name-shaped strings, each
-    # naming a declared extension, none of them twice. Each was a malformed
-    # declaration that read as a legitimately empty one and produced an image
-    # with no compiled extensions carrying the flavour's label.
-    #
-    # This is not "the section is well-formed" — that claim is not one any check
-    # here can make. A duplicate mapping key, for instance, is resolved by the
-    # YAML parser before this sees it: `vector:` declared twice silently keeps
-    # the last. Detecting that needs the raw document, not the parsed one (#1092).
-    if ! invalid_flavor_record=$(yq -r '
-        . as $root
-        | [.flavors | to_entries[]
-           | select((.key | test("^[a-zA-Z0-9_-]+$") | not)
-                    or (.value | type) != "!!seq"
-                    or ([.value[] | select((type) != "!!str" or (test("^[a-zA-Z0-9_-]+$") | not))] | length > 0)
-                    or ([.value[] | . as $m | select($root.extensions | has($m) | not)] | length > 0)
-                    or ((.value | length) != (.value | unique | length)))
-           | "invalid:" + .key] | .[0]
-    ' "$config_file"); then
-        log_error "get_flavor_extensions: could not read declared flavors from ${config_file}"
-        return 1
-    fi
-
-    if [[ "$invalid_flavor_record" != "null" ]]; then
-        invalid_flavor="${invalid_flavor_record#invalid:}"
-        safe_invalid_flavor=$(_sanitize_for_log "$invalid_flavor")
-        safe_invalid_flavor="${safe_invalid_flavor//[[:cntrl:]]/?}"
-        log_error "get_flavor_extensions: invalid flavor name '${safe_invalid_flavor}' in ${config_file} (allowed: letters, digits, underscore, hyphen)"
         return 1
     fi
 
@@ -631,7 +600,7 @@ get_flavor_extensions() {
         .flavors[strenv(flav)] // [] | .[] | . as $ext |
         select(
             ($root.extensions[$ext].disabled == true | not) and
-            (($root.extensions[$ext].max_pg_version // 999) >= env(pgver))
+            (($root.extensions[$ext].max_pg_version // 999) >= (strenv(pgver) | tonumber))
         )
     ' "$config_file"
 }
@@ -650,54 +619,8 @@ _generate_flavor_initdb_block() {
     local ext_name
     local mode
     local sql_name
-    local reason
-    local builtin_name
-    local builtin_sql_names=$'\n'
-    local seen_sql_names=$'\n'
     local -a create_sql_names=()
     local initdb_block=""
-
-    # Validate every compiled extension declaration, not only the selected
-    # flavor. A missing policy must fail at generation time even when a current
-    # flavor happens not to include the newly added extension yet.
-    while IFS= read -r ext_name; do
-        [[ -z "$ext_name" ]] && continue
-        if [[ ! "$ext_name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            log_error "generate_dockerfile: invalid extension name '$(_sanitize_for_log "$ext_name")' in ${config_file} (allowed: letters, digits, underscore, hyphen)"
-            return 1
-        fi
-        mode=$(ext="$ext_name" yq -r '.extensions[strenv(ext)].initdb.mode // ""' "$config_file" 2>/dev/null) || {
-            log_error "generate_dockerfile: could not read initdb policy for extension ${ext_name} from ${config_file}"
-            return 1
-        }
-        case "$mode" in
-            create)
-                ;;
-            manual)
-                reason=$(ext="$ext_name" yq -r '.extensions[strenv(ext)].initdb.reason // ""' "$config_file" 2>/dev/null) || {
-                    log_error "generate_dockerfile: could not read initdb manual reason for extension ${ext_name} from ${config_file}"
-                    return 1
-                }
-                if [[ -z "$reason" ]]; then
-                    log_error "generate_dockerfile: extension ${ext_name} has initdb.mode manual but no initdb.reason"
-                    return 1
-                fi
-                ;;
-            "")
-                log_error "generate_dockerfile: extension ${ext_name} has no initdb.mode (expected create or manual)"
-                return 1
-                ;;
-            *)
-                log_error "generate_dockerfile: extension ${ext_name} has unrecognised initdb.mode '$(_sanitize_for_log "$mode")' (expected create or manual)"
-                return 1
-                ;;
-        esac
-    done < <(yq -r '.extensions | keys[]' "$config_file")
-
-    while IFS= read -r builtin_name; do
-        [[ -z "$builtin_name" ]] && continue
-        builtin_sql_names+="${builtin_name}"$'\n'
-    done < <(yq -r '(.builtin_extensions // [])[]' "$config_file")
 
     # Only selected, compatible extensions can produce flavor SQL.
     while IFS= read -r ext_name; do
@@ -707,25 +630,6 @@ _generate_flavor_initdb_block() {
 
         sql_name=$(ext="$ext_name" yq -r '.extensions[strenv(ext)].initdb.sql_name // ""' "$config_file") || return 1
         [[ -z "$sql_name" ]] && sql_name="$ext_name"
-        # An unquoted PostgreSQL identifier: it may not start with a digit, and
-        # it is folded to lower case. Requiring the folded form means the name
-        # emitted is the name the server sees, so the duplicate and built-in
-        # collision checks below can compare exactly. Accepting mixed case let
-        # `vector` and `Vector` both pass as distinct while folding to one, and
-        # `123ext` pass generation only to make CREATE EXTENSION fail at initdb.
-        if [[ ! "$sql_name" =~ ^[a-z_][a-z0-9_]*$ ]]; then
-            log_error "generate_dockerfile: extension ${ext_name} has unsafe initdb.sql_name '$(_sanitize_for_log "$sql_name")' (allowed: letters, digits, underscore)"
-            return 1
-        fi
-        if [[ "$builtin_sql_names" == *$'\n'"$sql_name"$'\n'* ]]; then
-            log_error "generate_dockerfile: extension ${ext_name} initdb.sql_name ${sql_name} is already created by 00-init-extensions.sql"
-            return 1
-        fi
-        if [[ "$seen_sql_names" == *$'\n'"$sql_name"$'\n'* ]]; then
-            log_error "generate_dockerfile: duplicate initdb.sql_name ${sql_name} in flavor ${flavor}"
-            return 1
-        fi
-        seen_sql_names+="${sql_name}"$'\n'
         create_sql_names+=("$sql_name")
     done <<< "$extensions"
 
@@ -813,6 +717,11 @@ generate_dockerfile() {
     local pg_major="$4"
     local registry="${5:-$(get_registry)}"
     local owner="${6:-$(get_repo_owner)}"
+
+    if ! validate_extensions_schema "$config_file"; then
+        log_error "generate_dockerfile: extensions schema validation failed for ${config_file}"
+        return 1
+    fi
 
     # Derive FORCE from REBUILD env so a forced PR run prefers freshly-rebuilt
     # PR-scoped refs over stale canonical refs for non-resolver/single-version
@@ -969,8 +878,8 @@ generate_dockerfile() {
                 # _committed_versionset_satisfies is the SAME predicate used by resolve_version_set
                 # so preflight and resolver share one source of truth — no duplication of conditions.
                 local _preflight_retain_count
-                _preflight_retain_count=$(yq -r \
-                    ".extensions.${ext_name}.version_set.retain_count // \"\"" \
+                _preflight_retain_count=$(ext="$ext_name" yq -r \
+                    '.extensions[strenv(ext)].version_set.retain_count // ""' \
                     "$config_file" 2>/dev/null || true)
                 local _preflight_effective_retain="${_preflight_retain_count:-12}"
                 if ! _committed_versionset_satisfies \

--- a/helpers/validate-extensions-schema.sh
+++ b/helpers/validate-extensions-schema.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# validate-extensions-schema.sh
+# Static schema-validation guard for postgres/extensions/config.yaml.
+#
+# Enforces the extension declaration invariants before a generator reads any
+# field. Called by generate_dockerfile and by validate-version-scripts.sh.
+#
+# Rules enforced:
+#   R1. flavors must be a mapping. Each key must match ^[A-Za-z0-9_-]+$ and
+#       each value must be a list of unique name-shaped strings.
+#   R2. Every flavor member must name a declared extension.
+#   R3. extensions must be a mapping. Each key must match ^[A-Za-z0-9_-]+$.
+#   R4. Each compiled extension must declare exactly one initdb.mode, either
+#       create or manual. create may carry sql_name only when it matches the
+#       folded PostgreSQL unquoted-identifier form ^[a-z_][a-z0-9_]*$.
+#   R5. A manual initdb policy must carry a non-empty string initdb.reason.
+#   R6. Within a flavor, no create-mode extensions may resolve to the same SQL
+#       name (sql_name, or the extension key when sql_name is absent).
+#   R7. A create-mode SQL name may not collide with a name already created by
+#       the built-in 00-init-extensions.sql block (builtin_extensions).
+#
+# Duplicate YAML mapping keys are intentionally outside this parsed-document
+# guard: the YAML parser discards the first value. .yamllint.yml enables
+# yamllint's key-duplicates rule against config.yaml and variants.yaml files.
+#
+# Usage:
+#   source helpers/validate-extensions-schema.sh
+#   validate_extensions_schema <extensions_config_file>  # -> 0 = ok, 1 = error
+#
+# Note: intentionally does NOT set -euo pipefail — this file is sourced into
+# callers which manage their own error-handling mode.
+
+# ---------------------------------------------------------------------------
+# validate_extensions_schema <extensions_config_file>
+#
+# Makes one yq pass over the parsed document and reports every schema error to
+# stderr. A yq parse/read failure is a validation failure (fail closed).
+# ---------------------------------------------------------------------------
+validate_extensions_schema() {
+    local config_file="$1"
+    local document
+    local errors
+    local error
+
+    command -v yq >/dev/null 2>&1 || {
+        printf 'ERROR [extensions schema]: yq is required but was not found in PATH.\n' >&2
+        return 1
+    }
+
+    if [[ ! -f "$config_file" ]]; then
+        printf 'ERROR [extensions schema]: config file not found: %s\n' "$config_file" >&2
+        return 1
+    fi
+
+    # Two entries resolving to one name, before the conversion below erases the
+    # evidence. yq keeps both in the YAML document; emitting JSON writes the key
+    # twice and jq keeps the last, so no rule downstream can see that there were
+    # two. The yamllint gate does not see it either: it reads the raw text, and
+    # `!!str vector:` beside `vector:` is textually distinct. What is left is
+    # this — the parsed key count against its distinct count, on the YAML side,
+    # which is spelling-independent in a way no text rule can be.
+    local _dup_section
+    for _dup_section in flavors extensions; do
+        local _keys _distinct
+        _keys=$(sec="$_dup_section" yq -r '.[strenv(sec)] | select(tag == "!!map") | keys | length' \
+            "$config_file" 2>/dev/null) || _keys=""
+        _distinct=$(sec="$_dup_section" yq -r '.[strenv(sec)] | select(tag == "!!map") | keys | unique | length' \
+            "$config_file" 2>/dev/null) || _distinct=""
+        if [[ -n "$_keys" && -n "$_distinct" && "$_keys" != "$_distinct" ]]; then
+            printf 'ERROR [extensions schema] %s: %s declares the same name more than once (%s entries, %s distinct)\n' \
+                "$config_file" "$_dup_section" "$_keys" "$_distinct" >&2
+            return 1
+        fi
+    done
+
+    # yq reads and parses the YAML exactly once. jq validates the resulting
+    # JSON document, preserving YAML strings as strings rather than asking yq
+    # to parse any environment input with env().
+    if ! document=$(yq -o=json '.' "$config_file" 2>&1); then
+        printf 'ERROR [extensions schema]: yq could not parse or read %s:\n%s\n' \
+            "$config_file" "$document" >&2
+        return 1
+    fi
+
+    command -v jq >/dev/null 2>&1 || {
+        printf 'ERROR [extensions schema]: jq is required but was not found in PATH.\n' >&2
+        return 1
+    }
+
+    if ! errors=$(jq -r '
+        # \A and \z, not ^ and $: jq accepts one trailing newline before $, so
+        # `sql_name: |` followed by `vector` yields "vector\n" and passes. The
+        # generator captures that through command substitution, which strips the
+        # newline — so validation sees two distinct names where the build sees
+        # one, and a collision check comparing them finds nothing to report.
+        def name_shaped: type == "string" and test("\\A[A-Za-z0-9_-]+\\z");
+        def sql_identifier: type == "string" and test("\\A[a-z_][a-z0-9_]*\\z");
+        def valid_flavor_members: type == "array" and all(.[]; name_shaped);
+        def valid_extension_entry:
+          type == "object"
+          and (.initdb | type == "object")
+          and (.initdb | has("mode"))
+          and (.initdb.mode | type == "string")
+          and (.initdb.mode == "create" or .initdb.mode == "manual");
+        . as $root
+        | [
+            if ($root.flavors | type) != "object" then
+              "R1 flavors must be a mapping"
+            else empty end,
+            if ($root.extensions | type) != "object" then
+              "R3 extensions must be a mapping"
+            else empty end,
+
+            # Two entries resolving to one name, whatever their spelling. The
+            # yamllint gate catches a textually duplicated key; it does not catch
+            # `!!str vector:` beside `vector:`, which it accepts and yq keeps as
+            # two entries whose lookup returns the last. `to_entries` then
+            # validates both while the generator reads only one, so the image
+            # comes out with no extensions under that name. Comparing the parsed
+            # key count to its distinct count is spelling-independent, which no
+            # rule over the raw text can be.
+            if (($root.flavors | type) == "object")
+               and (($root.flavors | keys | length) != ($root.flavors | keys | unique | length)) then
+              "R1 flavors declares the same name more than once after parsing"
+            else empty end,
+            if (($root.extensions | type) == "object")
+               and (($root.extensions | keys | length) != ($root.extensions | keys | unique | length)) then
+              "R3 extensions declares the same name more than once after parsing"
+            else empty end,
+
+            if ($root.flavors | type) == "object" then
+              $root.flavors | to_entries[] | . as $flavor
+              | if ($flavor.key | name_shaped) then empty
+                else "R1 flavor key " + ($flavor.key | @json) + " is not name-shaped" end,
+                if ($flavor.value | type) == "array" then empty
+                else "R1 flavor " + ($flavor.key | @json) + " must be a list" end,
+                if ($flavor.value | type) == "array" then
+                  $flavor.value | to_entries[] | . as $member
+                  | if ($member.value | name_shaped) then empty
+                    else "R1 flavor " + ($flavor.key | @json) + " member "
+                         + ($member.key | tostring) + " must be a name-shaped string" end
+                else empty end,
+                if ($flavor.value | valid_flavor_members) then
+                  if (($flavor.value | length) == ($flavor.value | unique | length)) then empty
+                  else "R1 flavor " + ($flavor.key | @json) + " lists a member more than once" end
+                else empty end,
+                if (($root.extensions | type) == "object") and ($flavor.value | valid_flavor_members) then
+                  $flavor.value[] | . as $member
+                  | if ($root.extensions | has($member)) then empty
+                    else "R2 flavor " + ($flavor.key | @json) + " names undeclared extension "
+                         + ($member | @json) end
+                else empty end
+            else empty end,
+
+            if ($root.extensions | type) == "object" then
+              $root.extensions | to_entries[] | . as $extension
+              | if ($extension.key | name_shaped) then empty
+                else "R3 extension key " + ($extension.key | @json) + " is not name-shaped" end,
+                if ($extension.value | valid_extension_entry) then empty
+                else "R4 extension " + ($extension.key | @json)
+                     + " must declare initdb.mode exactly once as create or manual" end,
+                if (($extension.value | valid_extension_entry)
+                    and $extension.value.initdb.mode == "create"
+                    and (((if ($extension.value.initdb | has("sql_name"))
+                           then $extension.value.initdb.sql_name
+                           else $extension.key end) | sql_identifier) | not)) then
+                  "R4 extension " + ($extension.key | @json)
+                  + " resolves to an invalid SQL name (expected ^[a-z_][a-z0-9_]*$)"
+                else empty end,
+                if (($extension.value | valid_extension_entry)
+                    and $extension.value.initdb.mode == "manual"
+                    and ((($extension.value.initdb | has("reason")) | not)
+                         or ($extension.value.initdb.reason | type != "string")
+                         or ($extension.value.initdb.reason | length == 0))) then
+                  "R5 extension " + ($extension.key | @json)
+                  + " has initdb.mode manual but no non-empty initdb.reason"
+                else empty end
+            else empty end,
+
+            if (($root.flavors | type) == "object") and (($root.extensions | type) == "object") then
+              $root.flavors | to_entries[] | . as $flavor
+              | select($flavor.value | valid_flavor_members)
+              | [ $flavor.value[] | . as $member
+                  | select($root.extensions | has($member))
+                  | select($root.extensions[$member] | valid_extension_entry)
+                  | select($root.extensions[$member].initdb.mode == "create")
+                  # A collision needs two names that both reach one image. An
+                  # extension the generator filters out — disabled outright —
+                  # reaches none, so rejecting a config for a name it shares with
+                  # an active one refuses something that cannot happen. The
+                  # version cap is not applied here because this validation is
+                  # per-document, not per-PostgreSQL-major; a name capped out of
+                  # one major still collides in another.
+                  | select($root.extensions[$member].disabled != true)
+                  | ($root.extensions[$member].initdb.sql_name // $member) ] as $sql_names
+              | (($root.builtin_extensions // []) | if type == "array" then . else [] end) as $builtins
+              | (
+                  $sql_names | group_by(.) | map(select(length > 1) | .[0])[]
+                  | "R6 flavor " + ($flavor.key | @json)
+                    + " resolves more than one extension to SQL name " + (. | @json)
+                ),
+                (
+                  $sql_names[] as $sql_name | select($builtins | index($sql_name) != null)
+                  | "R7 flavor " + ($flavor.key | @json)
+                    + " resolves an extension to built-in SQL name " + ($sql_name | @json)
+                )
+            else empty end
+          ]
+        | .[]
+    ' <<< "$document" 2>&1); then
+        printf 'ERROR [extensions schema]: jq could not validate %s:\n%s\n' \
+            "$config_file" "$errors" >&2
+        return 1
+    fi
+
+    if [[ -n "$errors" ]]; then
+        while IFS= read -r error; do
+            [[ -n "$error" ]] || continue
+            printf 'ERROR [extensions schema] %s: %s\n' "$config_file" "$error" >&2
+        done <<< "$errors"
+        return 1
+    fi
+
+    return 0
+}
+
+export -f validate_extensions_schema

--- a/helpers/validate-extensions-schema.sh
+++ b/helpers/validate-extensions-schema.sh
@@ -59,6 +59,18 @@ validate_extensions_schema() {
     # `!!str vector:` beside `vector:` is textually distinct. What is left is
     # this — the parsed key count against its distinct count, on the YAML side,
     # which is spelling-independent in a way no text rule can be.
+    # The root mapping first, then each section. Checking only the sections left
+    # the same trick one level up: `!!str flavors:` beside `flavors:` means the
+    # lookup reads one of them and every rule below validates the other.
+    local _root_keys _root_distinct
+    _root_keys=$(yq -r 'select(tag == "!!map") | keys | length' "$config_file" 2>/dev/null) || _root_keys=""
+    _root_distinct=$(yq -r 'select(tag == "!!map") | keys | unique | length' "$config_file" 2>/dev/null) || _root_distinct=""
+    if [[ -n "$_root_keys" && -n "$_root_distinct" && "$_root_keys" != "$_root_distinct" ]]; then
+        printf 'ERROR [extensions schema] %s: the document declares the same top-level name more than once (%s entries, %s distinct)\n' \
+            "$config_file" "$_root_keys" "$_root_distinct" >&2
+        return 1
+    fi
+
     local _dup_section
     for _dup_section in flavors extensions; do
         local _keys _distinct

--- a/helpers/version-set-resolver.sh
+++ b/helpers/version-set-resolver.sh
@@ -123,12 +123,14 @@ resolve_version_set() {
     # Read single version (always present) for fallback; -r (raw output) strips
     # surrounding quotes so yq v4 returns a bare string regardless of version.
     local single_version
-    single_version=$(yq -r ".extensions.${ext_name}.version" "${_config_file}")
+    single_version=$(ext="$ext_name" yq -r \
+        '.extensions[strenv(ext)].version' "${_config_file}")
 
     # Read optional resolver path; -r ensures the fallback empty string is bare,
     # not a quoted "\"\"" on older yq v4 variants.
     local resolver_path
-    resolver_path=$(yq -r ".extensions.${ext_name}.version_set.resolver // \"\"" "${_config_file}")
+    resolver_path=$(ext="$ext_name" yq -r \
+        '.extensions[strenv(ext)].version_set.resolver // ""' "${_config_file}")
 
     if [[ -z "$resolver_path" ]]; then
         # No resolver configured — validate version before emitting single-version array.
@@ -147,7 +149,8 @@ resolve_version_set() {
     # We use 12 as the fast-path fallback so the committed slice is trimmed
     # consistently with what the live resolver would produce.
     local retain_count
-    retain_count=$(yq -r ".extensions.${ext_name}.version_set.retain_count // \"\"" "${_config_file}")
+    retain_count=$(ext="$ext_name" yq -r \
+        '.extensions[strenv(ext)].version_set.retain_count // ""' "${_config_file}")
     local _effective_retain
     _effective_retain=$(_normalize_retain_count "$retain_count")
 

--- a/tests/fixtures/extensions-schema/builtin-sql-collision.yaml
+++ b/tests/fixtures/extensions-schema/builtin-sql-collision.yaml
@@ -1,0 +1,10 @@
+builtin_extensions:
+  - builtin_one
+extensions:
+  alpha:
+    initdb:
+      mode: create
+      sql_name: builtin_one
+flavors:
+  sample:
+    - alpha

--- a/tests/fixtures/extensions-schema/disabled-sql-name-shared.yaml
+++ b/tests/fixtures/extensions-schema/disabled-sql-name-shared.yaml
@@ -1,0 +1,24 @@
+# A disabled extension declaring the same SQL name as an active one. The
+# generator filters it out, so it reaches no image and cannot collide with
+# anything. Rejecting this would refuse a configuration whose failure mode
+# cannot occur — a validator stricter than the thing it validates.
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    initdb:
+      mode: create
+      sql_name: vector
+  shadow:
+    version: "1.0.0"
+    repo: "example/shadow"
+    disabled: true
+    initdb:
+      mode: create
+      sql_name: vector
+
+flavors:
+  base: []
+  vector:
+    - pgvector
+    - shadow

--- a/tests/fixtures/extensions-schema/duplicate-mapping-key.yaml
+++ b/tests/fixtures/extensions-schema/duplicate-mapping-key.yaml
@@ -1,0 +1,8 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  sample:
+    - alpha
+  sample: []

--- a/tests/fixtures/extensions-schema/duplicate-sql-name.yaml
+++ b/tests/fixtures/extensions-schema/duplicate-sql-name.yaml
@@ -1,0 +1,13 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+      sql_name: shared_name
+  beta:
+    initdb:
+      mode: create
+      sql_name: shared_name
+flavors:
+  sample:
+    - alpha
+    - beta

--- a/tests/fixtures/extensions-schema/extension-bad-key.yaml
+++ b/tests/fixtures/extensions-schema/extension-bad-key.yaml
@@ -1,0 +1,7 @@
+extensions:
+  bad key:
+    initdb:
+      mode: create
+flavors:
+  sample:
+    - bad key

--- a/tests/fixtures/extensions-schema/flavor-bad-key.yaml
+++ b/tests/fixtures/extensions-schema/flavor-bad-key.yaml
@@ -1,0 +1,7 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  bad key:
+    - alpha

--- a/tests/fixtures/extensions-schema/flavor-duplicate-member.yaml
+++ b/tests/fixtures/extensions-schema/flavor-duplicate-member.yaml
@@ -1,0 +1,8 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  sample:
+    - alpha
+    - alpha

--- a/tests/fixtures/extensions-schema/flavor-member-metacharacter.yaml
+++ b/tests/fixtures/extensions-schema/flavor-member-metacharacter.yaml
@@ -1,0 +1,7 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  sample:
+    - 'alpha # $(id)'

--- a/tests/fixtures/extensions-schema/flavor-scalar.yaml
+++ b/tests/fixtures/extensions-schema/flavor-scalar.yaml
@@ -1,0 +1,6 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  sample: alpha

--- a/tests/fixtures/extensions-schema/flavor-undeclared-member.yaml
+++ b/tests/fixtures/extensions-schema/flavor-undeclared-member.yaml
@@ -1,0 +1,7 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+flavors:
+  sample:
+    - missing

--- a/tests/fixtures/extensions-schema/implicit-sql-name.yaml
+++ b/tests/fixtures/extensions-schema/implicit-sql-name.yaml
@@ -1,0 +1,22 @@
+# An extension key that is name-shaped but is not a PostgreSQL unquoted
+# identifier, declaring `mode: create` and no `sql_name`. The generator falls
+# back to the key, so `CREATE EXTENSION IF NOT EXISTS foo-bar;` reaches initdb
+# and fails there. The rule is about the RESOLVED name, not the declared one.
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    initdb:
+      mode: create
+      sql_name: vector
+  foo-bar:
+    version: "1.0.0"
+    repo: "example/foo-bar"
+    initdb:
+      mode: create
+
+flavors:
+  base: []
+  vector:
+    - pgvector
+    - foo-bar

--- a/tests/fixtures/extensions-schema/initdb-mode-invalid.yaml
+++ b/tests/fixtures/extensions-schema/initdb-mode-invalid.yaml
@@ -1,0 +1,7 @@
+extensions:
+  alpha:
+    initdb:
+      mode: later
+flavors:
+  sample:
+    - alpha

--- a/tests/fixtures/extensions-schema/initdb-mode-missing.yaml
+++ b/tests/fixtures/extensions-schema/initdb-mode-missing.yaml
@@ -1,0 +1,6 @@
+extensions:
+  alpha:
+    initdb: {}
+flavors:
+  sample:
+    - alpha

--- a/tests/fixtures/extensions-schema/manual-reason-empty.yaml
+++ b/tests/fixtures/extensions-schema/manual-reason-empty.yaml
@@ -1,0 +1,8 @@
+extensions:
+  alpha:
+    initdb:
+      mode: manual
+      reason: ''
+flavors:
+  sample:
+    - alpha

--- a/tests/fixtures/extensions-schema/sql-name-invalid.yaml
+++ b/tests/fixtures/extensions-schema/sql-name-invalid.yaml
@@ -1,0 +1,8 @@
+extensions:
+  alpha:
+    initdb:
+      mode: create
+      sql_name: Alpha
+flavors:
+  sample:
+    - alpha

--- a/tests/fixtures/extensions-schema/tagged-duplicate-key.yaml
+++ b/tests/fixtures/extensions-schema/tagged-duplicate-key.yaml
@@ -1,0 +1,19 @@
+# Two entries resolving to one name, spelled differently so that no rule over
+# the raw text sees a duplicate: yamllint's key-duplicates accepts this, because
+# `!!str vector:` and `vector:` are textually distinct. yq keeps both in the YAML
+# document, but emitting JSON writes the key twice and the last one wins — so the
+# flavour a lookup returns is the empty one, and the image comes out with no
+# compiled extensions under a name that declares four.
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    initdb:
+      mode: create
+      sql_name: vector
+
+flavors:
+  base: []
+  !!str vector:
+    - pgvector
+  vector: []

--- a/tests/fixtures/extensions-schema/tagged-duplicate-root-key.yaml
+++ b/tests/fixtures/extensions-schema/tagged-duplicate-root-key.yaml
@@ -1,0 +1,20 @@
+# The same tag-spelled duplicate as tagged-duplicate-key.yaml, one level up.
+# `!!str flavors:` beside `flavors:` is textually distinct, so yamllint accepts
+# it; a lookup reads the last, so every rule validates the mapping the generator
+# will not use. Checking only inside the sections left this level open.
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    initdb:
+      mode: create
+      sql_name: vector
+
+!!str flavors:
+  base: []
+  vector:
+    - pgvector
+
+flavors:
+  base: []
+  vector: []

--- a/tests/fixtures/extensions-schema/trailing-newline-sql-name.yaml
+++ b/tests/fixtures/extensions-schema/trailing-newline-sql-name.yaml
@@ -1,0 +1,25 @@
+# A block scalar gives `sql_name` a trailing newline. jq's `$` matches before one
+# final newline, so `^[a-z_][a-z0-9_]*$` accepts "vector\n"; the generator then
+# captures the value through command substitution, which strips it. Validation
+# would see "vector" and "vector\n" as two distinct names while the build emits
+# `CREATE EXTENSION vector` twice — the collision check finding nothing to report.
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    initdb:
+      mode: create
+      sql_name: vector
+  paradedb:
+    version: "0.20.5"
+    repo: "paradedb/paradedb"
+    initdb:
+      mode: create
+      sql_name: |
+        vector
+
+flavors:
+  base: []
+  vector:
+    - pgvector
+    - paradedb

--- a/tests/fixtures/extensions-schema/valid.yaml
+++ b/tests/fixtures/extensions-schema/valid.yaml
@@ -1,0 +1,14 @@
+builtin_extensions:
+  - builtin_one
+extensions:
+  alpha:
+    initdb:
+      mode: create
+  beta:
+    initdb:
+      mode: manual
+      reason: This extension needs database-specific setup.
+flavors:
+  sample:
+    - alpha
+    - beta

--- a/tests/unit/extensions-config-reader-invariant.bats
+++ b/tests/unit/extensions-config-reader-invariant.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# The generator's extension field reads are intentionally confined to these
+# two helpers. generate_dockerfile validates its config before extension-utils
+# reads it; version-set-resolver is a compatibility reader with its own narrow
+# version-set purpose. A new field read belongs in the schema guard first.
+
+bats_require_minimum_version 1.5.0
+
+load "../test_helper"
+
+_direct_yq_read_count() {
+    local file="$1"
+
+    # Count only yq invocations, not comments, command-existence checks, or
+    # log messages. Continuation lines belong to the yq command that begins on
+    # the previous line, so counting its start is sufficient.
+    rg '\byq -[A-Za-z]' "$file" | wc -l | tr -d '[:space:]'
+}
+
+@test "extension config has no new direct yq readers outside the sanctioned 16 plus 3" {
+    local extension_utils_reads
+    local resolver_reads
+
+    extension_utils_reads=$(_direct_yq_read_count "$PROJECT_ROOT/helpers/extension-utils.sh")
+    resolver_reads=$(_direct_yq_read_count "$PROJECT_ROOT/helpers/version-set-resolver.sh")
+
+    if [[ "$extension_utils_reads" != "16" || "$resolver_reads" != "3" ]]; then
+        echo "unexpected extension-config yq reader count: extension-utils=${extension_utils_reads}, version-set-resolver=${resolver_reads}; put new declaration validation in helpers/validate-extensions-schema.sh before adding a reader" >&3
+        false
+    fi
+
+    run rg -n 'validate_extensions_schema "\$config_file"' "$PROJECT_ROOT/helpers/extension-utils.sh"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/extensions-config-reader-invariant.bats
+++ b/tests/unit/extensions-config-reader-invariant.bats
@@ -15,7 +15,20 @@ _direct_yq_read_count() {
     # Count only yq invocations, not comments, command-existence checks, or
     # log messages. Continuation lines belong to the yq command that begins on
     # the previous line, so counting its start is sufficient.
-    rg '\byq -[A-Za-z]' "$file" | wc -l | tr -d '[:space:]'
+    #
+    # grep, not rg: the runner has no ripgrep, and a guard that cannot run must
+    # fail rather than pass — which is what it did, at the cost of a CI round.
+    # -E for the word boundary, which BRE spells differently across greps.
+    #
+    # grep -c exits 1 on no match and 2 on a real error. Only the first is a
+    # count of zero; the second must not be reported as one, so it propagates.
+    local count status=0
+    count=$(grep -cE '\byq -[A-Za-z]' "$file") || status=$?
+    if (( status > 1 )); then
+        echo "grep failed reading $file (status $status)" >&3
+        return "$status"
+    fi
+    printf '%s' "${count//[[:space:]]/}"
 }
 
 @test "extension config has no new direct yq readers outside the sanctioned 16 plus 3" {
@@ -30,6 +43,6 @@ _direct_yq_read_count() {
         false
     fi
 
-    run rg -n 'validate_extensions_schema "\$config_file"' "$PROJECT_ROOT/helpers/extension-utils.sh"
+    run grep -n 'validate_extensions_schema "\$config_file"' "$PROJECT_ROOT/helpers/extension-utils.sh"
     [ "$status" -eq 0 ]
 }

--- a/tests/unit/postgres-flavor-installs.bats
+++ b/tests/unit/postgres-flavor-installs.bats
@@ -48,10 +48,10 @@ _declared_extensions() {
 
     pgver=18 flav="$flavor" yq -r '
         . as $root |
-        .flavors[env(flav)][] | . as $ext |
+        .flavors[strenv(flav)][] | . as $ext |
         select(
             ($root.extensions[$ext].disabled == true | not) and
-            (($root.extensions[$ext].max_pg_version // 999) >= env(pgver))
+            (($root.extensions[$ext].max_pg_version // 999) >= (strenv(pgver) | tonumber))
         )
     ' "$CONFIG_FILE"
 }
@@ -158,7 +158,7 @@ teardown() {
         testowner
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *"invalid flavor name '\$(>/tmp/pwn)'"* ]]
+    [[ "$output" == *'R1 flavor key'* ]]
 }
 
 @test "generated FLAVOR default is bound to its guard" {
@@ -221,7 +221,7 @@ teardown() {
     run generate_dockerfile "$invalid_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io testowner
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *'extension pgvector has no initdb.mode'* ]]
+    [[ "$output" == *'R4 extension "pgvector" must declare initdb.mode'* ]]
 }
 
 @test "an unrecognised initdb mode fails generation" {
@@ -233,7 +233,7 @@ teardown() {
     run generate_dockerfile "$invalid_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io testowner
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *'extension pgvector has unrecognised initdb.mode'* ]]
+    [[ "$output" == *'R4 extension "pgvector" must declare initdb.mode'* ]]
 }
 
 @test "duplicate initdb SQL names within a flavor fail generation" {
@@ -245,7 +245,7 @@ teardown() {
     run generate_dockerfile "$invalid_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io testowner
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *'duplicate initdb.sql_name vector in flavor vector'* ]]
+    [[ "$output" == *'R6 flavor "vector" resolves more than one extension to SQL name "vector"'* ]]
 }
 
 @test "unsafe and built-in initdb SQL names fail generation" {
@@ -256,13 +256,13 @@ teardown() {
     yq -i '.extensions.pgvector.initdb.sql_name = "vector; DROP"' "$unsafe_config"
     run generate_dockerfile "$unsafe_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io testowner
     [ "$status" -ne 0 ]
-    [[ "$output" == *'extension pgvector has unsafe initdb.sql_name'* ]]
+    [[ "$output" == *'R4 extension "pgvector" resolves to an invalid SQL name'* ]]
 
     cp "$CONFIG_FILE" "$builtin_config"
     yq -i '.extensions.pgvector.initdb.sql_name = "pgcrypto"' "$builtin_config"
     run generate_dockerfile "$builtin_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io testowner
     [ "$status" -ne 0 ]
-    [[ "$output" == *'initdb.sql_name pgcrypto is already created by 00-init-extensions.sql'* ]]
+    [[ "$output" == *'R7 flavor "vector" resolves an extension to built-in SQL name "pgcrypto"'* ]]
 }
 
 # A flavour declared as a scalar, or holding anything that is not a list of
@@ -329,13 +329,13 @@ teardown() {
     yq -i '.extensions.pgvector.initdb.sql_name = "123ext"' "$digit_config"
     run generate_dockerfile "$digit_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io oorabona
     [ "$status" -ne 0 ]
-    [[ "$output" == *'extension pgvector has unsafe initdb.sql_name'* ]]
+    [[ "$output" == *'R4 extension "pgvector" resolves to an invalid SQL name'* ]]
 
     cp "$CONFIG_FILE" "$case_config"
     yq -i '.extensions.pgvector.initdb.sql_name = "Vector"' "$case_config"
     run generate_dockerfile "$case_config" "$PROJECT_ROOT/postgres/Dockerfile" vector 18 ghcr.io oorabona
     [ "$status" -ne 0 ]
-    [[ "$output" == *'extension pgvector has unsafe initdb.sql_name'* ]]
+    [[ "$output" == *'R4 extension "pgvector" resolves to an invalid SQL name'* ]]
 }
 
 @test "unexpanded source templates have bare markers that Dockerfile parsing rejects" {

--- a/tests/unit/validate-extensions-schema.bats
+++ b/tests/unit/validate-extensions-schema.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+# Unit tests for the single-pass PostgreSQL extensions-config schema guard.
+
+bats_require_minimum_version 1.5.0
+
+load "../test_helper"
+
+setup() {
+    source "$HELPERS_DIR/validate-extensions-schema.sh"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures/extensions-schema"
+}
+
+assert_rejected_fixture() {
+    local fixture="$1"
+    local expected="$2"
+
+    run validate_extensions_schema "$FIXTURES_DIR/$fixture"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"$expected"* ]]
+}
+
+@test "real PostgreSQL extension config passes the schema guard" {
+    run validate_extensions_schema "$PROJECT_ROOT/postgres/extensions/config.yaml"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "R1 rejects non-name flavor keys, scalars, non-name members, and duplicate members" {
+    assert_rejected_fixture "flavor-bad-key.yaml" "R1 flavor key"
+    assert_rejected_fixture "flavor-scalar.yaml" "R1 flavor"
+    assert_rejected_fixture "flavor-member-metacharacter.yaml" "must be a name-shaped string"
+    assert_rejected_fixture "flavor-duplicate-member.yaml" "lists a member more than once"
+}
+
+@test "R2 rejects flavor members that name no declared extension" {
+    assert_rejected_fixture "flavor-undeclared-member.yaml" "R2 flavor"
+}
+
+@test "R3 rejects non-name extension keys" {
+    assert_rejected_fixture "extension-bad-key.yaml" "R3 extension key"
+}
+
+@test "R4 rejects missing or invalid initdb modes and invalid create SQL names" {
+    assert_rejected_fixture "initdb-mode-missing.yaml" "R4 extension"
+    assert_rejected_fixture "initdb-mode-invalid.yaml" "R4 extension"
+    assert_rejected_fixture "sql-name-invalid.yaml" "invalid SQL name"
+}
+
+# The rule is about the name that reaches PostgreSQL, which is the extension key
+# whenever `sql_name` is absent. Checking only the declared `sql_name` let a key
+# like `foo-bar` or `123ext` pass and emit `CREATE EXTENSION foo-bar;`, failing at
+# initdb — the inline check this validator replaced did validate the resolved name.
+@test "R4 rejects a key that is not an identifier when no sql_name rescues it" {
+    assert_rejected_fixture "implicit-sql-name.yaml" "invalid SQL name"
+}
+
+@test "R5 rejects manual policies without a non-empty reason" {
+    assert_rejected_fixture "manual-reason-empty.yaml" "R5 extension"
+}
+
+@test "R6 rejects SQL names that collide within one flavor" {
+    assert_rejected_fixture "duplicate-sql-name.yaml" "R6 flavor"
+}
+
+@test "R7 rejects SQL names already created by the built-in initdb block" {
+    assert_rejected_fixture "builtin-sql-collision.yaml" "R7 flavor"
+}
+
+@test "yamllint key-duplicates rejects duplicate mapping keys before yq parses them" {
+    run yamllint -c "$PROJECT_ROOT/.yamllint.yml" "$FIXTURES_DIR/duplicate-mapping-key.yaml"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"duplication of key"* ]]
+}
+
+# The half yamllint cannot reach. `!!str vector:` beside `vector:` is textually
+# distinct, so the text rule accepts it; the JSON conversion then writes the key
+# twice and the last wins, so no rule downstream sees that there were two. The
+# guard runs on the YAML side, where both are still visible.
+@test "a duplicate spelled with a YAML tag is rejected, though yamllint accepts it" {
+    run yamllint -c "$PROJECT_ROOT/.yamllint.yml" "$FIXTURES_DIR/tagged-duplicate-key.yaml"
+    [ "$status" -eq 0 ]
+
+    run validate_extensions_schema "$FIXTURES_DIR/tagged-duplicate-key.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"declares the same name more than once"* ]]
+}
+
+# jq's `$` matches before one trailing newline, so a block scalar slipped
+# "vector\n" past the identifier pattern. The generator strips it through command
+# substitution, so validation saw two names where the build emits one.
+@test "a SQL name with a trailing newline is rejected" {
+    assert_rejected_fixture "trailing-newline-sql-name.yaml" "invalid SQL name"
+}
+
+# A collision needs two names reaching one image. A disabled extension reaches
+# none, so sharing a SQL name with an active one is not a collision.
+@test "a disabled extension sharing a SQL name is not a collision" {
+    run validate_extensions_schema "$FIXTURES_DIR/disabled-sql-name-shared.yaml"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/validate-extensions-schema.bats
+++ b/tests/unit/validate-extensions-schema.bats
@@ -87,6 +87,18 @@ assert_rejected_fixture() {
     [[ "$output" == *"declares the same name more than once"* ]]
 }
 
+# The same trick at the document root. Checking only inside the sections left
+# `!!str flavors:` beside `flavors:` open: every rule validated one mapping while
+# the generator read the other.
+@test "a tagged duplicate of a top-level key is rejected" {
+    run yamllint -c "$PROJECT_ROOT/.yamllint.yml" "$FIXTURES_DIR/tagged-duplicate-root-key.yaml"
+    [ "$status" -eq 0 ]
+
+    run validate_extensions_schema "$FIXTURES_DIR/tagged-duplicate-root-key.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"same top-level name more than once"* ]]
+}
+
 # jq's `$` matches before one trailing newline, so a block scalar slipped
 # "vector\n" past the identifier pattern. The generator strips it through command
 # substitution, so validation saw two names where the build emits one.

--- a/validate-version-scripts.sh
+++ b/validate-version-scripts.sh
@@ -12,6 +12,9 @@ source "$(dirname "$0")/helpers/logging.sh"
 # Source config schema guard (base_image_cache dual-schema validation)
 source "$(dirname "$0")/helpers/validate-base-cache-schema.sh"
 
+# Source PostgreSQL extensions schema guard.
+source "$(dirname "$0")/helpers/validate-extensions-schema.sh"
+
 # Configuration
 # Increase timeouts in CI environments due to potential network latency
 if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
@@ -339,6 +342,15 @@ main() {
     # any version.sh tests run. When a specific container is requested, validate only
     # that container's config.yaml so unrelated containers do not cause early exit.
     echo ""
+    log_info "Validating PostgreSQL extensions schema..."
+    if validate_extensions_schema "postgres/extensions/config.yaml"; then
+        log_success "PostgreSQL extensions schema: clean"
+    else
+        log_error "PostgreSQL extensions schema validation failed — see the errors above"
+        exit 1
+    fi
+    echo ""
+
     if [ -n "$specific_container" ]; then
         log_info "Validating base_image_cache schema for container: $specific_container..."
         if validate_container_base_cache_schema "$specific_container"; then


### PR DESCRIPTION
Closes #1092

## The problem

Eight review rounds on #1083 each found a different spelling of one defect: a malformed extension declaration reading as a legitimately empty one, producing an image that carries a flavour's label and none of its extensions. Every fix guarded one read site. There are nineteen `yq` reads of `postgres/extensions/config.yaml`, so the loop had no end in sight.

## What changes

**One validation of the whole document, before any field is read.** `helpers/validate-extensions-schema.sh` enumerates seven rules (R1–R7 in its header) and reports every violation in a single pass. It is called by `generate_dockerfile` for the build and by `validate-version-scripts.sh` for the static gate, following `helpers/validate-base-cache-schema.sh`'s existing shape rather than inventing a second idiom.

**The inline checks are deleted, not duplicated** — 106 lines out of `helpers/extension-utils.sh` for 15 in. A validator layered on top of the guards it supersedes would be worse than either alone.

**A `yamllint` `key-duplicates` gate** over every `config.yaml` and `variants.yaml`. `yq` resolves a duplicate mapping key before any expression can see it, so this half has to be static.

**A test bounding the reader set**, so a twentieth unvalidated read fails the suite rather than passing silently.

## Verification

Full suite 2359, 0 failing, declared equals executed. `shellcheck -x -S warning` clean. `yamllint` clean across every file it now gates. The index tree was extracted to a scratch directory and the suite re-run there — a local run cannot distinguish a tracked fixture from an untracked one, and an earlier round of this branch had fourteen that existed only in the working tree.

Each rule was probed against the validator directly: the repository's own config passes, and a scalar flavour, a member naming no declared extension, a member listed twice, a leading-digit SQL name, a missing `initdb.mode`, and a collision with the built-in init block are each refused.

## Findings fixed on this branch

- **The rule validated the declared `sql_name`, not the resolved one.** The generator falls back to the extension key when `sql_name` is absent, so `foo-bar` with `mode: create` passed and would have emitted `CREATE EXTENSION foo-bar;`, failing at initdb. The inline check being replaced did validate the resolved name — the deletion had lost a rule.
- **Identifier patterns anchored with `^`/`$`.** jq matches `$` before one trailing newline, so a block scalar gave `sql_name` the value `"vector\n"`, which passed while the generator's command substitution stripped it. `\A`/`\z` now.
- **A duplicate spelled with a YAML tag.** `!!str vector:` beside `vector:` is textually distinct, so yamllint accepts it; the JSON conversion writes the key twice and the last wins, so nothing downstream can tell there were two. The guard compares the parsed key count to its distinct count on the YAML side, before conversion.
- **The same trick at the document root.** That comparison ran over `flavors` and `extensions` and not over the document containing them, so `!!str flavors:` beside `flavors:` still produced a successfully generated, falsely labelled image. It now runs on the root mapping first.

Each is covered by a fixture, and the tag-spelled ones assert the complementarity directly: `yamllint` passes the document, the validator refuses it.

## Left for follow-up

`builtin_extensions` is declared twice — here and in the Dockerfile's hard-coded init block — with nothing keeping them in step. They agree today (eleven names each, verified by comparing the lists). Filed as #1094; the fix is this change's own shape applied once more and is deliberately not in this diff.

Four review rounds ran against the declared budget of three. The fourth found the root-level duplicate above, which is fixed; the budget then capped the loop, as intended — a cumulative diff grows with every round, so a sound branch can still produce findings indefinitely.
