### PR TITLE
fix(ci): a retried script's diagnosis belongs after the retry, not inside it

### DIFF
--- a/.github/actions/preflight-buildkit/action.yaml
+++ b/.github/actions/preflight-buildkit/action.yaml
@@ -42,14 +42,26 @@ runs:
         delay: '5'
         timeout: '45s'
         run: |
-          # docker's own stderr is left to reach the step log, and nothing here
-          # reads it. A probe that fails cannot tell absence from a rate limit,
-          # a 5xx, an expired token or a DNS blip, so it does not try: any
-          # classifier over free-form registry text is a denylist that the next
-          # unseen wording escapes, and the wrong half of that guess is what
-          # sends a reader to re-seed an image that was there all along.
           if docker manifest inspect "${{ inputs.image }}" >/dev/null; then
             exit 0
           fi
-          echo "::error::the BuildKit builder image probe failed; docker's own output, if it produced any, is above. This does NOT establish that the image is absent: a rate limit, a 5xx, an expired token, a DNS failure and a genuinely missing manifest all end up here. Re-run first. If docker reported specifically that the manifest does not exist, then the image needs seeding — it comes from the upstream-monitor workflow (Seed buildkit image to GHCR), so trigger that (workflow_dispatch) and re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"
           exit 1
+
+    - name: Diagnose failed BuildKit image probe
+      id: diagnose
+      # always(), not failure(): failure() is false once a job is cancelled, so a
+      # cancellation landing between the exhausted probe and this step would drop
+      # the only explanation of a probe that really did fail — and this repository
+      # cancels superseded runs. The outcome clause is what decides, and it is
+      # what keeps the message tied to THIS probe as the composite grows; measured
+      # under act, neither form fires when the probe succeeds.
+      if: ${{ always() && steps.probe.outcome == 'failure' }}
+      shell: bash
+      run: |
+        # docker's own stderr is left to reach the step log, and nothing here
+        # reads it. A probe that fails cannot tell absence from a rate limit,
+        # a 5xx, an expired token or a DNS blip, so it does not try: any
+        # classifier over free-form registry text is a denylist that the next
+        # unseen wording escapes, and the wrong half of that guess is what
+        # sends a reader to re-seed an image that was there all along.
+        echo "::error::the BuildKit builder image probe failed; docker's own output, if it produced any, is above. This does NOT establish that the image is absent: a rate limit, a 5xx, an expired token, a DNS failure and a genuinely missing manifest all end up here. Re-run first. If docker reported specifically that the manifest does not exist, then the image needs seeding — it comes from the upstream-monitor workflow (Seed buildkit image to GHCR), so trigger that (workflow_dispatch) and re-run. (Egress is fail-closed: there is no Docker Hub fallback for the builder image.)"

--- a/.github/actions/retry-run/action.yaml
+++ b/.github/actions/retry-run/action.yaml
@@ -5,6 +5,19 @@ description: |
   `run:` step (registry probe/pull/push, GHCR/API call) so a transient failure
   retries with backoff instead of failing the job on the first blip.
 
+  Boundary: the wrapped script signals with its exit status and prints no workflow
+  command (`::name::…`, or the legacy `##[name]…`). Ordinary output is fine and
+  belongs here — a wrapped command's own stdout and stderr are what a reader needs
+  to see per attempt. A workflow command is not ordinary output: this script runs
+  once per attempt, so one written here is emitted once per FAILING attempt,
+  including attempts a later retry makes moot, and a per-attempt `timeout` kills
+  the script before it can emit one at all. Annotations, masks and `::group::`
+  therefore belong in a step after the retry, which runs once.
+
+  Enforced for the literal forms by tests/unit/retry-run-annotations.bats. A
+  command a script assembles at runtime is beyond what reading the workflow can
+  see; the guard catches the mistake, not a determined author.
+
   Scope: this wraps a SHELL script. It cannot wrap a `uses:` action step (GitHub
   composite actions cannot re-invoke another action) — for those (setup-buildx,
   attest-sbom, upload-sarif) use a staged retry (attempt + conditional retry +

--- a/tests/unit/preflight-buildkit-probe.bats
+++ b/tests/unit/preflight-buildkit-probe.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# The preflight probe reports that it failed, not why.
+# The preflight probe reports that it failed, not why — and it reports it once.
 #
 # `docker manifest inspect` fails for absence, for a rate limit, for a 5xx, for
 # an expired token and for a DNS blip. The probe used to read every non-zero
@@ -11,8 +11,17 @@
 #
 # Classifying the registry's free-form stderr was tried and abandoned: every
 # pattern list is a denylist, the next unseen wording escapes it, and the wrong
-# half of the guess is the defect being fixed. The probe now states that it
-# cannot distinguish, and leaves docker's own output in the log for the reader.
+# half of the guess is the defect being fixed. The probe states that it cannot
+# distinguish, and leaves docker's own output in the log for the reader.
+#
+# The probe runs under `retry-run`, so its script executes once per attempt.
+# Issue #1075: a `::error::` printed there fired on every failing attempt — a job
+# that failed three times and succeeded on the fourth ended green carrying three
+# error annotations, and a per-attempt `timeout` killed the script before its
+# failure path ran at all, losing the annotation entirely. So the two halves are
+# now two steps and are tested as two: the retried block signals with its exit
+# status and prints no workflow command, and a following step, which the timeout
+# cannot reach and which runs once, carries the operator-facing message.
 
 load "../test_helper"
 
@@ -24,6 +33,16 @@ teardown() {
     teardown_temp_dir
 }
 
+_step_script() {
+    local step_id="$1"
+    # The probe's body is a composite-action input (.with.run); the diagnosis is
+    # an ordinary step body (.run). Reading both spellings keeps this anchored to
+    # whichever shape each step actually has.
+    id="$step_id" yq -r \
+        '.runs.steps[] | select(.id == strenv(id)) | (.with.run // .run)' \
+        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml"
+}
+
 # Renders the probe script the way the runner does: the step's body is a
 # composite-action input, and the image ref reaches it by expression
 # substitution. A renamed expression leaves `${{` in the body and bash rejects
@@ -32,11 +51,12 @@ run_probe() {
     local stub_stderr="$1"
     local stub_rc="$2"
     local script="$TEST_TEMP_DIR/probe.sh"
-    local image="ghcr.io/owner/buildkit@sha256:$(printf '0%.0s' {1..64})"
+    local digest image
+    digest=$(printf '0%.0s' {1..64})
+    image="ghcr.io/owner/buildkit@sha256:$digest"
 
-    yq -r '.runs.steps[] | select(.id == "probe") | .with.run' \
-        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml" \
-        | sed "s|\${{ inputs.image }}|$image|g" > "$script"
+    _step_script probe | sed "s|\${{ inputs.image }}|$image|g" > "$script"
+    [ -s "$script" ] || fail "no script extracted for the probe step"
 
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/docker" <<STUB
@@ -50,6 +70,21 @@ STUB
     PATH="$TEST_TEMP_DIR/bin:$PATH" run bash -e -o pipefail "$script"
 }
 
+# The diagnosis step needs no docker: it runs only after the probe has failed,
+# and says the same thing whatever the registry answered.
+run_diagnosis() {
+    local script="$TEST_TEMP_DIR/diagnose.sh"
+
+    _step_script diagnose > "$script"
+    [ -s "$script" ] || fail "no script extracted for the diagnose step"
+
+    run bash -e -o pipefail "$script"
+}
+
+# ---------------------------------------------------------------------------
+# The retried block: exit status and docker's own output, no workflow commands.
+# ---------------------------------------------------------------------------
+
 @test "probe: a present image exits clean and says nothing" {
     run_probe "" 0
     [ "$status" -eq 0 ]
@@ -59,27 +94,19 @@ STUB
 @test "probe: a failing probe fails the step" {
     run_probe "manifest unknown" 1
     [ "$status" -eq 1 ]
-    [[ "$output" == *"::error::"* ]]
 }
 
-# The #1073 regression lock. A registry answer that looks like absence must not
-# make the step assert absence, because the same exit code arrives from a rate
-# limit and the reader acts on what the message claims.
-@test "probe: an absence-looking answer does not make the step claim absence" {
+# The #1075 lock, and the reason the message moved. This block runs once per
+# retry attempt, so a workflow command here is emitted once per attempt —
+# including attempts a later retry makes moot.
+@test "probe: the retried block emits no workflow command, in either direction" {
     run_probe "manifest unknown" 1
-    [[ "$output" == *"does NOT establish that the image is absent"* ]]
-}
+    [[ "$output" != *"::error::"* ]]
+    [[ "$output" != *"::warning::"* ]]
+    [[ "$output" != *"::notice::"* ]]
 
-@test "probe: a rate limit produces the same non-committal message" {
-    run_probe "toomanyrequests: retry-after 60" 1
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"does NOT establish that the image is absent"* ]]
-}
-
-@test "probe: the reader is told to re-run before seeding anything" {
-    run_probe "denied: denied" 1
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"Re-run first"* ]]
+    run_probe "" 0
+    [[ "$output" != *"::"* ]]
 }
 
 # docker writes to the step log directly, as every other command in this
@@ -99,4 +126,79 @@ STUB
 @test "probe: the manifest body stays out of the log on success" {
     run_probe "" 0
     [[ "$output" != *"a manifest nobody should see in the log"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# The diagnosis step: one annotation, and what it is allowed to claim.
+# ---------------------------------------------------------------------------
+
+@test "diagnosis: emits exactly one error annotation" {
+    run_diagnosis
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '::error::' <<< "$output")" -eq 1 ]
+}
+
+# The #1073 regression lock, now asserted where the message lives. A registry
+# answer that looks like absence must not make the step assert absence, because
+# the same exit code arrives from a rate limit and the reader acts on the claim.
+@test "diagnosis: does not claim the image is absent" {
+    run_diagnosis
+    [[ "$output" == *"does NOT establish that the image is absent"* ]]
+}
+
+@test "diagnosis: the reader is told to re-run before seeding anything" {
+    run_diagnosis
+    [[ "$output" == *"Re-run first"* ]]
+}
+
+@test "diagnosis: names the causes that all land on the same exit code" {
+    run_diagnosis
+    [[ "$output" == *"rate limit"* ]]
+    [[ "$output" == *"expired token"* ]]
+    [[ "$output" == *"DNS failure"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# The wiring between the two, which no execution of either script can show.
+# ---------------------------------------------------------------------------
+
+@test "the diagnosis runs only when this probe is what failed" {
+    local guard
+    guard=$(yq -r '.runs.steps[] | select(.id == "diagnose") | .if' \
+        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml")
+
+    # The exact expression, not three substrings. Checked independently they are
+    # all satisfied by `always() || steps.probe.outcome != 'failure'`, which
+    # diagnoses an earlier validation failure as a registry problem and stays
+    # silent after a real probe failure — the two things this guard prevents.
+    #
+    # always() rather than failure(): failure() is false once a job is cancelled,
+    # so a cancellation landing between the exhausted probe and this step drops
+    # the only explanation of a probe that really did fail, and this repository
+    # cancels superseded runs. The outcome clause is what decides; measured under
+    # act, neither form fires when the probe succeeds.
+    [ "$guard" = "\${{ always() && steps.probe.outcome == 'failure' }}" ]
+}
+
+# Order is part of the wiring: `steps.probe.outcome` is unset until the probe has
+# run, so a diagnosis placed before it is never correct however its guard reads.
+@test "the diagnosis step comes after the probe it diagnoses" {
+    local ids probe_index diagnose_index
+    ids=$(yq -r '[.runs.steps[] | .id // ""] | to_entries | .[] | [.key, .value] | @tsv' \
+        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml")
+
+    probe_index=$(awk -F'\t' '$2 == "probe" { print $1 }' <<< "$ids")
+    diagnose_index=$(awk -F'\t' '$2 == "diagnose" { print $1 }' <<< "$ids")
+
+    [ -n "$probe_index" ]
+    [ -n "$diagnose_index" ]
+    [ "$diagnose_index" -gt "$probe_index" ]
+}
+
+@test "the diagnosis step is not itself wrapped by retry-run" {
+    local uses
+    uses=$(yq -r '.runs.steps[] | select(.id == "diagnose") | (.uses // "none")' \
+        "$PROJECT_ROOT/.github/actions/preflight-buildkit/action.yaml")
+
+    [ "$uses" = "none" ]
 }

--- a/tests/unit/retry-run-annotations.bats
+++ b/tests/unit/retry-run-annotations.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+# Reject a LITERAL workflow command inside a retry-run block.
+#
+# `retry-run` executes its wrapped script once per attempt, so a workflow command
+# printed there is emitted once per failing attempt — including attempts a later
+# retry makes moot (#1075) — and a per-attempt `timeout` kills the script before
+# it can emit one at all. Annotations, masks and `::group::` belong in a step
+# after the retry, which runs once. Ordinary output is fine and belongs in the
+# block: a wrapped command's own stdout and stderr are what a reader needs per
+# attempt.
+#
+# WHAT THIS CANNOT DO, and the reason the test is named for the literal form.
+# A block such as `kind=stop-commands; printf '::%s::x\n' "$kind"` contains no
+# matching literal, passes here, and disables the runner's command processing at
+# runtime. No reading of shell source decides what that shell will emit — the
+# same goes for a sourced helper, a subprocess, or any assembled string. This
+# catches the mistake (someone writes `echo "::error::…"` in the wrong place),
+# not a determined author, who controls CI anyway. Claiming otherwise would be
+# the defect: a guard whose name overstates it is trusted past what it checks.
+#
+# It reads the YAML rather than scanning its text. The first version walked lines
+# and tracked indentation, and successive reviews each found a legal spelling
+# that walked past it: a value on the same line as the key, a `|2` explicit
+# indentation indicator, a flow mapping, a here-document line beginning with
+# "- " that read as the start of a new step, and a step whose `run:` key precedes
+# its `uses:`. Hardening the walker would have invited the next one. yq resolves
+# the document, so every spelling of one value arrives as the same string.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+_die() {
+    printf '%s\n' "$1" >&2
+    return 1
+}
+
+# Every workflow and action file, NUL-delimited into a file so find's exit status
+# is checked. A guard that scans an empty list and reports success is worse than
+# no guard: it outlives whatever broke it, silently.
+_collect_files() {
+    local out="$TEST_TEMP_DIR/files.z"
+    find "$PROJECT_ROOT/.github/workflows" "$PROJECT_ROOT/.github/actions" \
+        -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 > "$out" || return 1
+    [ -s "$out" ] || return 1
+    printf '%s' "$out"
+}
+
+# Every `run` belonging to a step that uses the local retry-run action, one per
+# NUL-delimited record, written to a file so yq's exit status is checked too.
+# Reading it through a process substitution discards that status, which is how a
+# file the parser choked on would be scanned as zero sites and pass.
+_retry_run_scripts() {
+    local src="$1" out="$2"
+    yq -r -0 '
+        [ (.jobs // {} | .[]? | .steps // [] | .[]?),
+          (.runs.steps // [] | .[]?) ]
+        | .[]
+        | select((.uses // "") | test("\.github/actions/retry-run"))
+        | (.with.run // .run // "")
+    ' "$src" > "$out"
+}
+
+# Both forms the runner parses, and it tries the modern one then the legacy one.
+# The command NAME is what is matched, followed by either the closing delimiter
+# or the space that starts its parameters — so a parameter value containing a
+# colon (`::error title=phase:retry::failed`) or a bracket does not evade it, and
+# matching the form rather than a list of names covers ::add-mask::,
+# ::stop-commands:: and ::group:: as well as the three annotation levels.
+# ::stop-commands:: in a retried block changes how the runner reads everything
+# after it, which is further from ordinary output than a duplicate annotation is.
+_command_form='(::|##\[)[A-Za-z][A-Za-z-]*(::|\]|[[:space:]])'
+
+# Collects every retry-run script in the repository into $TEST_TEMP_DIR/sites.z
+# and echoes how many there are, failing closed on any enumeration error.
+_all_sites() {
+    local list file per="$TEST_TEMP_DIR/per-file.z" all="$TEST_TEMP_DIR/sites.z"
+    local n=0 script
+
+    list=$(_collect_files) || return 1
+    : > "$all"
+
+    while IFS= read -r -d '' file; do
+        _retry_run_scripts "$file" "$per" || return 1
+        while IFS= read -r -d '' script; do
+            n=$((n + 1))
+            printf '%s\0' "$file" >> "$all"
+            printf '%s\0' "$script" >> "$all"
+        done < "$per"
+    done < "$list"
+
+    printf '%s' "$n"
+}
+
+@test "no retry-run block contains a literal workflow command" {
+    local sites offenders=() file script
+
+    sites=$(_all_sites) || _die "enumeration failed; the guard scanned an unknown subset"
+
+    # Finding zero means the selector stopped matching. A guard that quietly
+    # matches nothing outlives whatever broke it.
+    [ "$sites" -gt 0 ] \
+        || _die "no retry-run steps found; the selector no longer matches this repository"
+
+    while IFS= read -r -d '' file && IFS= read -r -d '' script; do
+        [[ "$script" =~ $_command_form ]] && offenders+=("$file")
+    done < "$TEST_TEMP_DIR/sites.z"
+
+    if [ "${#offenders[@]}" -gt 0 ]; then
+        printf 'literal workflow command inside a retry-run block: %s\n' "${offenders[@]}" >&2
+        _die 'It is emitted once per failing attempt. Move it to a step after the retry.'
+    fi
+}
+
+# The count above is load-bearing for its own assertion, so it is cross-checked
+# against an independent reading. The text count anchors on a `uses:` key at the
+# start of a line, because a bare substring search also counts the action's name
+# inside a comment or a here-document and would block CI on prose.
+@test "the yq selector sees the same retry-run sites a text search does" {
+    local sites textual
+
+    sites=$(_all_sites) || _die "enumeration failed; the guard scanned an unknown subset"
+
+    textual=$(grep -rhE '^[[:space:]]*uses:[[:space:]]*\.?/?\.github/actions/retry-run[[:space:]]*$' \
+        "$PROJECT_ROOT/.github/workflows" "$PROJECT_ROOT/.github/actions" \
+        --include='*.yaml' --include='*.yml' 2>/dev/null | wc -l)
+
+    [ "$sites" -gt 0 ] || _die "yq found no retry-run steps at all"
+    [ "$sites" -eq "$textual" ] || _die "yq sees $sites retry-run steps, the text search sees $textual"
+}


### PR DESCRIPTION
Closes #1075

## The problem

`retry-run` executes its wrapped script once per attempt, so a `::error::` printed there is printed once per failing attempt. A job that failed a transient probe three times and succeeded on the fourth ended **green carrying three error annotations**; one that failed all four ended with four identical annotations for one event. And a per-attempt `timeout` sends SIGTERM before the script's failure path runs, so the annotation was lost entirely — a job failing with no diagnosis at all.

The wrapped script cannot fix either: it does not know whether it is running the last attempt, and it is not alive when the timeout fires.

## What changes

**The two halves become two steps.** The retried block runs `docker manifest inspect` and signals with its exit status. The operator-facing message moves to a following step in the same composite action, guarded `always() && steps.probe.outcome == 'failure'` — outside the retry, so it runs once, and beyond the timeout's reach. The message is unchanged, byte for byte.

`always()` rather than `failure()`: `failure()` is false once a job is cancelled, and this repository cancels superseded runs, so a cancellation landing between the exhausted probe and this step would drop the only explanation of a probe that really did fail. Measured under `act`: neither form fires when the probe succeeds.

**Ordinary output stays in the retried block** and should — a wrapped command's own stdout and stderr are what a reader needs per attempt. The boundary is workflow commands, not operator-facing text, and `retry-run`'s description now says that.

**A new test rejects a literal workflow command in any retry-run block**, so a future author is told by the suite rather than by duplicate annotations in a run log.

## Verification

Unit suite 2366 collected, 0 failed. shellcheck and yamllint clean. Eight mutations each proving one lock bites, control green in every case.

Measured before the design was chosen: 13 retry-run call sites, exactly one emitting a workflow command from its wrapped script. A composite action does reach a later guarded step after an earlier step failed, and that step can read the failed step's `outcome` — probed under `gh act` 0.2.89.

## The guard reads YAML, and says what it cannot do

The first version walked lines and tracked indentation. Successive reviews each found a legal spelling that walked past it — a value on the same line as the key, a `|2` indentation indicator, a flow mapping, a here-document line beginning with `- `, a step whose `run:` precedes its `uses:`, an annotation carrying parameters, an uppercase name, a parameter containing a colon, the legacy `##[error]` form. Two rounds of that is the signal the class is unbounded, so the guard stopped scanning text: `yq` resolves the document and every spelling of one value arrives as the same string.

It matches both forms the runner parses, anchored on the command name, so `::add-mask::`, `::group::` and `::stop-commands::` are rejected too.

It is named for the *literal* form because that is what it can enforce. A block that assembles a command at runtime contains no matching literal and passes — no reading of shell source decides what that shell will emit. The header says so: a guard whose name overstates it is trusted past what it checks. The actor it stops is someone making a mistake, not someone determined, who controls CI anyway.

It also fails closed on its own enumeration. `find` and `yq` in process substitutions do not propagate exit status, so an unreadable directory or an unparseable file produced an empty list and a passing test.

## Rejected

A diagnosis-file channel in `retry-run` — an env var pointing at a file the wrapped script writes and `retry-run` reads after the last attempt. It needs a new contract for one caller, and a timeout-killed attempt can leave descendant processes that write to that file after the next attempt truncates it, so the channel reports the wrong attempt's diagnosis. That is the class of defect being removed.

## Left open

- **#967** — docker's stderr reaches the runner log unescaped and can forge a workflow command. Identical on the base.
- **#1097** — a `retry-run` infrastructure failure (`mktemp`, a missing `helpers/retry.sh`) is now diagnosed as a registry failure. Introduced by this change; fixing it means `retry-run` signalling its own failures apart from its script's, across 13 call sites for the benefit of one.

Three review rounds against the declared budget of three.
