### PR TITLE
fix(postgres): a declared extension name the server cannot load fails the build

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -619,6 +619,10 @@ _generate_flavor_initdb_block() {
     local ext_name
     local mode
     local sql_name
+    # Keep the declaration key and its resolved SQL name together. The
+    # generated assertion and CREATE statement are deliberately rendered from
+    # this one list, so a CREATE cannot be added without its control-file
+    # assertion.
     local -a create_sql_names=()
     local initdb_block=""
 
@@ -630,7 +634,7 @@ _generate_flavor_initdb_block() {
 
         sql_name=$(ext="$ext_name" yq -r '.extensions[strenv(ext)].initdb.sql_name // ""' "$config_file") || return 1
         [[ -z "$sql_name" ]] && sql_name="$ext_name"
-        create_sql_names+=("$sql_name")
+        create_sql_names+=("${ext_name}"$'\t'"${sql_name}")
     done <<< "$extensions"
 
     if [[ ${#create_sql_names[@]} -eq 0 ]]; then
@@ -638,11 +642,53 @@ _generate_flavor_initdb_block() {
     fi
 
     initdb_block+="RUN set -eux; \\"$'\n'
+    initdb_block+="    sharedir=\"\$(pg_config --sharedir)\"; \\"$'\n'
+    # A zero exit says pg_config ran, not that it answered. An empty result makes
+    # every test below read /extension/<name>.control, where an unrelated match
+    # is a false pass; a relative one resolves against whatever the build stage's
+    # working directory happens to be. Neither is a directory this image installs
+    # extensions into, so refuse rather than search one.
+    # `${sharedir#/}` removes one leading slash; unchanged means there was none,
+    # which also catches the empty answer. Written as `if … fi;` like every other
+    # test in this block rather than a `case`: a `;;` inside a Dockerfile line
+    # continuation is not something the surrounding tooling reads back reliably.
+    initdb_block+="    if test \"\${sharedir#/}\" = \"\$sharedir\"; then \\"$'\n'
+    initdb_block+="        echo \"ERROR: pg_config --sharedir returned '\$sharedir', which is not an absolute path; refusing to look for extension control files there.\" >&2; \\"$'\n'
+    initdb_block+="        exit 1; \\"$'\n'
+    initdb_block+="    fi; \\"$'\n'
+    # The build runs as root and PostgreSQL does not, so `test -f` as root is the
+    # wrong question. Measured on the shipped image: a control file at 0600
+    # root:root passes both `test -f` and `test -r` for root and fails
+    # `gosu postgres test -r`, which is the read the server actually performs at
+    # first startup. `cp -av` preserves mode from the staging tree, and this
+    # repository has already shipped a 0700 onto a PostgreSQL system directory
+    # that way, so the mode is not hypothetical.
+    #
+    # gosu is required rather than optional: without it the check would silently
+    # become the root test it is replacing, which is a guard that reports success
+    # for the case it exists to catch.
+    initdb_block+="    command -v gosu >/dev/null || { echo \"ERROR: gosu is required to verify extension control files as the postgres user, and was not found.\" >&2; exit 1; }; \\"$'\n'
+    local create_entry
+    local create_ext_name
+    local create_sql_lines=""
+    for create_entry in "${create_sql_names[@]}"; do
+        create_ext_name="${create_entry%%$'\t'*}"
+        sql_name="${create_entry#*$'\t'}"
+        initdb_block+="    if ! gosu postgres test -r \"\${sharedir}/extension/${sql_name}.control\"; then \\"$'\n'
+        initdb_block+="        echo \"ERROR: extension key '${create_ext_name}' resolves to SQL name '${sql_name}', but the postgres user cannot read a control file at \${sharedir}/extension/${sql_name}.control. Either it was never installed, or its mode or a parent directory keeps the server out. The SQL name comes from initdb.sql_name in postgres/extensions/config.yaml (or the extension key when initdb.sql_name is omitted).\" >&2; \\"$'\n'
+        initdb_block+="        exit 1; \\"$'\n'
+        initdb_block+="    fi; \\"$'\n'
+        # Quoted, as the built-in block already quotes "uuid-ossp". Measured on
+        # PostgreSQL 18: `CREATE EXTENSION IF NOT EXISTS select;` is a syntax
+        # error while the quoted form parses, and for a name the schema already
+        # admits — folded lowercase — the two are indistinguishable. So quoting
+        # removes the reserved-keyword class outright instead of asking the
+        # validator to carry a keyword list that grows with each release.
+        create_sql_lines+="        'CREATE EXTENSION IF NOT EXISTS \"${sql_name}\";' \\"$'\n'
+    done
     initdb_block+="    printf '%s\\n' \\"$'\n'
     initdb_block+="        '-- ${flavor} flavor: compiled extensions' \\"$'\n'
-    for sql_name in "${create_sql_names[@]}"; do
-        initdb_block+="        'CREATE EXTENSION IF NOT EXISTS ${sql_name};' \\"$'\n'
-    done
+    initdb_block+="${create_sql_lines}"
     initdb_block+="        > /docker-entrypoint-initdb.d/01-init-flavor.sql"$'\n'
     printf '%s' "$initdb_block"
 }

--- a/helpers/validate-extensions-schema.sh
+++ b/helpers/validate-extensions-schema.sh
@@ -106,7 +106,17 @@ validate_extensions_schema() {
         # newline — so validation sees two distinct names where the build sees
         # one, and a collision check comparing them finds nothing to report.
         def name_shaped: type == "string" and test("\\A[A-Za-z0-9_-]+\\z");
-        def sql_identifier: type == "string" and test("\\A[a-z_][a-z0-9_]*\\z");
+        # 63 is the PostgreSQL limit, measured: `SHOW max_identifier_length`
+        # returns 63, and a 64-character name is TRUNCATED rather than rejected —
+        # for the quoted form as much as the bare one. So the build would check
+        # <64-char>.control while the server looks up the 63-character name, and
+        # the check would vouch for a file the server never opens. utf8bytelength
+        # because the limit is in bytes, not characters.
+        # (No apostrophes in this program: it is a single-quoted shell string.)
+        def sql_identifier:
+          type == "string"
+          and test("\\A[a-z_][a-z0-9_]*\\z")
+          and (utf8bytelength <= 63);
         def valid_flavor_members: type == "array" and all(.[]; name_shaped);
         def valid_extension_entry:
           type == "object"
@@ -177,7 +187,7 @@ validate_extensions_schema() {
                            then $extension.value.initdb.sql_name
                            else $extension.key end) | sql_identifier) | not)) then
                   "R4 extension " + ($extension.key | @json)
-                  + " resolves to an invalid SQL name (expected ^[a-z_][a-z0-9_]*$)"
+                  + " resolves to an invalid SQL name (expected ^[a-z_][a-z0-9_]*$, at most 63 bytes)"
                 else empty end,
                 if (($extension.value | valid_extension_entry)
                     and $extension.value.initdb.mode == "manual"

--- a/tests/fixtures/extensions-schema/sql-name-at-limit.yaml
+++ b/tests/fixtures/extensions-schema/sql-name-at-limit.yaml
@@ -1,0 +1,16 @@
+# Exactly 63 bytes: the longest name PostgreSQL stores whole. The boundary is
+# asserted from both sides so the rule cannot drift into off-by-one and go
+# unnoticed — a limit tested only from the rejecting side passes just as well
+# when it rejects everything.
+extensions:
+  atlimit:
+    version: "1.0.0"
+    repo: "example/atlimit"
+    initdb:
+      mode: create
+      sql_name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+flavors:
+  base: []
+  long:
+    - atlimit

--- a/tests/fixtures/extensions-schema/sql-name-too-long.yaml
+++ b/tests/fixtures/extensions-schema/sql-name-too-long.yaml
@@ -1,0 +1,17 @@
+# A 64-byte SQL name: one over PostgreSQL's limit, measured as 63 by
+# `SHOW max_identifier_length` on the image this repository ships. PostgreSQL
+# TRUNCATES rather than rejects, and it truncates the quoted form too — so the
+# build would check a 64-character control filename while the server opens the
+# 63-character one, and the check would vouch for a file nothing ever reads.
+extensions:
+  overlong:
+    version: "1.0.0"
+    repo: "example/overlong"
+    initdb:
+      mode: create
+      sql_name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+flavors:
+  base: []
+  long:
+    - overlong

--- a/tests/unit/postgres-flavor-installs.bats
+++ b/tests/unit/postgres-flavor-installs.bats
@@ -43,6 +43,67 @@ _initdb_sql_block() {
         "$generated_file"
 }
 
+_flavor_initdb_block() {
+    local generated_file="$1"
+
+    awk '
+        /^RUN set -eux; \\$/ {
+            candidate = $0 ORS
+            collecting = 1
+            next
+        }
+        collecting {
+            candidate = candidate $0 ORS
+        }
+        collecting && /-- .* flavor: compiled extensions/ {
+            printf "%s", candidate
+            collecting = 0
+            emitting = 1
+            next
+        }
+        emitting {
+            print
+            if (/01-init-flavor\.sql/) {
+                exit
+            }
+        }
+    ' "$generated_file"
+}
+
+_extract_flavor_initdb_shell() {
+    local generated_file="$1"
+    local shell_file="$2"
+    local sql_file="$3"
+
+    printf '%s\n' '#!/bin/sh' > "$shell_file"
+    _flavor_initdb_block "$generated_file" \
+        | sed -e '1s/^RUN //' -e 's/; \\$//' \
+            -e "s|/docker-entrypoint-initdb.d/01-init-flavor.sql|$sql_file|g" \
+        >> "$shell_file"
+    chmod +x "$shell_file"
+}
+
+_mock_pg_config_sharedir() {
+    local sharedir="$1"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    printf '%s\n' '#!/bin/sh' "printf '%s\\n' '$sharedir'" \
+        > "$TEST_TEMP_DIR/bin/pg_config"
+    chmod +x "$TEST_TEMP_DIR/bin/pg_config"
+    _mock_gosu
+}
+
+# The generated block asks `gosu postgres test -r …` because the build runs as
+# root and PostgreSQL does not, and root reads files the server cannot. There is
+# no postgres user here and no privilege to drop, so the stub drops the username
+# and runs the rest as whoever is running the suite — which still distinguishes a
+# readable file from an unreadable one, as long as that is not root.
+_mock_gosu() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    printf '%s\n' '#!/bin/sh' 'shift' 'exec "$@"' > "$TEST_TEMP_DIR/bin/gosu"
+    chmod +x "$TEST_TEMP_DIR/bin/gosu"
+}
+
 _declared_extensions() {
     local flavor="$1"
 
@@ -184,11 +245,227 @@ teardown() {
     [ "$status" -eq 0 ]
 
     initdb_sql=$(_initdb_sql_block "$generated_file")
-    [[ "$initdb_sql" == *'CREATE EXTENSION IF NOT EXISTS vector;'* ]]
-    [[ "$initdb_sql" == *'CREATE EXTENSION IF NOT EXISTS pg_search;'* ]]
+    # Quoted, as the built-in block quotes "uuid-ossp". Measured on PostgreSQL 18:
+    # the bare form is a syntax error for a reserved word while the quoted form
+    # parses, and the two are indistinguishable for the folded lowercase names the
+    # schema admits.
+    [[ "$initdb_sql" == *'CREATE EXTENSION IF NOT EXISTS "vector";'* ]]
+    [[ "$initdb_sql" == *'CREATE EXTENSION IF NOT EXISTS "pg_search";'* ]]
     [[ "$initdb_sql" != *'pg_cron'* ]]
     grep -Fqx '    install_ext pg_cron; \' "$generated_file"
     grep -Fq 'PRELOAD="${PRELOAD:+$PRELOAD,}pg_cron"' "$generated_file"
+}
+
+@test "every real create-mode extension gets a control-file check before flavor SQL" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.full"
+    local initdb_block
+    local last_check
+    local first_create
+    local ext_name
+    local sql_name
+
+    run _generate full "$generated_file"
+    [ "$status" -eq 0 ]
+
+    initdb_block=$(_flavor_initdb_block "$generated_file")
+    # The LAST check against the FIRST create, not first-against-first: the
+    # property is that no statement is written before every name behind it has
+    # been vouched for. Comparing the first of each is satisfied by a block that
+    # interleaves them, which would write SQL for a name checked afterwards.
+    last_check=$(grep -n 'gosu postgres test -r' <<< "$initdb_block" | tail -n 1 | cut -d: -f1)
+    first_create=$(grep -n 'CREATE EXTENSION' <<< "$initdb_block" | head -n 1 | cut -d: -f1)
+    [ "$last_check" -lt "$first_create" ]
+
+    while IFS=$'\t' read -r ext_name sql_name; do
+        [[ -z "$ext_name" ]] && continue
+        # As the postgres user, not as root: root reads a 0600 control the server
+        # cannot, so a root-run test reports success for the exact case this
+        # check exists to catch.
+        [[ "$initdb_block" == *"gosu postgres test -r \"\${sharedir}/extension/${sql_name}.control\""* ]]
+        [[ "$initdb_block" == *"extension key '${ext_name}' resolves to SQL name '${sql_name}'"* ]]
+        [[ "$initdb_block" == *"CREATE EXTENSION IF NOT EXISTS \"${sql_name}\";"* ]]
+    done < <(
+        yq -r '
+            .extensions | to_entries[]
+            | select(.value.initdb.mode == "create")
+            | [.key, (.value.initdb.sql_name // .key)]
+            | @tsv
+        ' "$CONFIG_FILE"
+    )
+
+    [[ "$initdb_block" != *'extension/pg_cron.control'* ]]
+    [[ "$initdb_block" != *'CREATE EXTENSION IF NOT EXISTS "pg_cron";'* ]]
+}
+
+@test "generated control-file check fails before writing flavor SQL when control is absent" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.vector"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local sharedir="$TEST_TEMP_DIR/sharedir"
+
+    run _generate vector "$generated_file"
+    [ "$status" -eq 0 ]
+    _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+    _mock_pg_config_sharedir "$sharedir"
+
+    run env "PATH=$TEST_TEMP_DIR/bin:$PATH" sh "$shell_file"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"extension key 'pgvector' resolves to SQL name 'vector'"* ]]
+    [[ "$output" == *"$sharedir/extension/vector.control"* ]]
+    [[ "$output" == *'initdb.sql_name in postgres/extensions/config.yaml'* ]]
+    [ ! -e "$sql_file" ]
+}
+
+@test "generated control-file check accepts a present control file and writes flavor SQL" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.vector"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local sharedir="$TEST_TEMP_DIR/sharedir"
+
+    run _generate vector "$generated_file"
+    [ "$status" -eq 0 ]
+    _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+    _mock_pg_config_sharedir "$sharedir"
+    mkdir -p "$sharedir/extension"
+    touch "$sharedir/extension/vector.control" "$sharedir/extension/pg_search.control" \
+        "$sharedir/extension/pg_ivm.control"
+
+    run env "PATH=$TEST_TEMP_DIR/bin:$PATH" sh "$shell_file"
+
+    [ "$status" -eq 0 ]
+    [ -f "$sql_file" ]
+    grep -Fq 'CREATE EXTENSION IF NOT EXISTS "vector";' "$sql_file"
+}
+
+# The absent-control case above removes the FIRST name the block checks. A
+# regression that left `exit 1` in only the first branch would pass it while
+# writing SQL for every later name. This removes the last one instead.
+@test "a control file missing for the LAST checked name still withholds the SQL" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.full"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local sharedir="$TEST_TEMP_DIR/sharedir"
+    local last name
+
+    run _generate full "$generated_file"
+    [ "$status" -eq 0 ]
+    _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+    _mock_pg_config_sharedir "$sharedir"
+
+    # Every name the block checks, in the order it checks them.
+    last=$(grep -o 'extension/[a-z_][a-z0-9_]*\.control' "$shell_file" \
+        | sed 's|extension/||;s|\.control||' | awk '!seen[$0]++' | tail -n 1)
+    [ -n "$last" ]
+
+    mkdir -p "$sharedir/extension"
+    for name in $(grep -o 'extension/[a-z_][a-z0-9_]*\.control' "$shell_file" \
+        | sed 's|extension/||;s|\.control||' | awk '!seen[$0]++'); do
+        [ "$name" = "$last" ] && continue
+        : > "$sharedir/extension/${name}.control"
+    done
+
+    run env "PATH=$TEST_TEMP_DIR/bin:$PATH" sh "$shell_file"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"$sharedir/extension/${last}.control"* ]]
+    [ ! -e "$sql_file" ]
+}
+
+# A control file that exists but the server cannot read is the failure this check
+# exists to move from first startup to build time, and `test -f` as root reports
+# success for it. Measured on the shipped image: a 0600 root:root control passes
+# both `test -f` and `test -r` for root, and fails `gosu postgres test -r`.
+# `cp -av` preserves mode from the staging tree, and this repository has already
+# shipped a 0700 onto a PostgreSQL system directory that way.
+@test "a control file that exists but is unreadable fails the build" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.vector"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local sharedir="$TEST_TEMP_DIR/sharedir"
+    local name
+
+    # root reads regardless of mode, so this case is unobservable as root.
+    [ "$(id -u)" -ne 0 ] || skip "running as root: an unreadable file is still readable"
+
+    run _generate vector "$generated_file"
+    [ "$status" -eq 0 ]
+    _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+    _mock_pg_config_sharedir "$sharedir"
+
+    mkdir -p "$sharedir/extension"
+    for name in $(grep -o 'extension/[a-z_][a-z0-9_]*\.control' "$shell_file" \
+        | sed 's|extension/||;s|\.control||' | awk '!seen[$0]++'); do
+        : > "$sharedir/extension/${name}.control"
+    done
+    chmod 000 "$sharedir/extension/vector.control"
+
+    run env "PATH=$TEST_TEMP_DIR/bin:$PATH" sh "$shell_file"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot read a control file"* ]]
+    [[ "$output" == *"$sharedir/extension/vector.control"* ]]
+    [ ! -e "$sql_file" ]
+}
+
+# Without gosu the check would silently become the root test it replaces, which
+# reports success for the one case it exists to catch. So its absence has to be
+# an error rather than a fallback, and that is only observable when it is absent.
+@test "the build refuses to run the check at all when gosu is missing" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.vector"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local sharedir="$TEST_TEMP_DIR/sharedir"
+    local name
+
+    run _generate vector "$generated_file"
+    [ "$status" -eq 0 ]
+    _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+    _mock_pg_config_sharedir "$sharedir"
+    rm -f "$TEST_TEMP_DIR/bin/gosu"
+
+    # Every control file present, so the only reason to fail is the missing gosu.
+    mkdir -p "$sharedir/extension"
+    for name in $(grep -o 'extension/[a-z_][a-z0-9_]*\.control' "$shell_file" \
+        | sed 's|extension/||;s|\.control||' | awk '!seen[$0]++'); do
+        : > "$sharedir/extension/${name}.control"
+    done
+
+    # PATH holds only the stub directory, so a gosu installed on the host cannot
+    # answer for one that would be missing in the image. `sh` is linked into it
+    # deliberately: with an EMPTY directory every `command -v` fails alike, and
+    # the test would pass just as well if the guard probed some other binary.
+    ln -sf /bin/sh "$TEST_TEMP_DIR/bin/sh"
+    run env "PATH=$TEST_TEMP_DIR/bin" /bin/sh "$shell_file"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gosu is required"* ]]
+    [ ! -e "$sql_file" ]
+}
+
+# A zero exit says pg_config ran, not that it answered. An empty result would make
+# every test read /extension/<name>.control, where an unrelated match is a false
+# pass; a relative one resolves against whatever directory the build stage is in.
+@test "a sharedir that is empty or relative is refused rather than searched" {
+    local generated_file="$TEST_TEMP_DIR/Dockerfile.vector"
+    local shell_file="$TEST_TEMP_DIR/flavor-initdb.sh"
+    local sql_file="$TEST_TEMP_DIR/01-init-flavor.sql"
+    local answer
+
+    run _generate vector "$generated_file"
+    [ "$status" -eq 0 ]
+
+    for answer in "" "relative" "./relative"; do
+        rm -f "$sql_file"
+        _extract_flavor_initdb_shell "$generated_file" "$shell_file" "$sql_file"
+        _mock_pg_config_sharedir "$answer"
+
+        run env "PATH=$TEST_TEMP_DIR/bin:$PATH" sh "$shell_file"
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"is not an absolute path"* ]]
+        [ ! -e "$sql_file" ]
+    done
 }
 
 @test "disabled and version-incompatible extensions are absent from stages copies installs and initdb SQL" {
@@ -207,9 +484,9 @@ teardown() {
         ! grep -Fq " AS ext-${ext}" "$generated_file"
         ! grep -Fq "/tmp/ext/${ext}/" "$generated_file"
         ! grep -Fqx "    install_ext ${ext}; \\" "$generated_file"
-        ! grep -Fq "CREATE EXTENSION IF NOT EXISTS ${ext};" "$generated_file"
+        ! grep -Fq "CREATE EXTENSION IF NOT EXISTS \"${ext}\";" "$generated_file"
     done
-    ! grep -Fq 'CREATE EXTENSION IF NOT EXISTS vector;' "$generated_file"
+    ! grep -Fq 'CREATE EXTENSION IF NOT EXISTS "vector";' "$generated_file"
 }
 
 @test "a compiled extension without initdb.mode fails generation" {

--- a/tests/unit/validate-extensions-schema.bats
+++ b/tests/unit/validate-extensions-schema.bats
@@ -55,6 +55,21 @@ assert_rejected_fixture() {
     assert_rejected_fixture "implicit-sql-name.yaml" "invalid SQL name"
 }
 
+# PostgreSQL stores 63 bytes of an identifier and TRUNCATES the rest — measured
+# with `SHOW max_identifier_length` on the image this repository ships, and it
+# truncates the quoted form as readily as the bare one. A 64-byte name would have
+# the build check a control filename the server never opens. The boundary is
+# asserted from both sides: a limit tested only where it rejects passes equally
+# well when it rejects everything.
+@test "R4 rejects a SQL name longer than PostgreSQL's 63 bytes" {
+    assert_rejected_fixture "sql-name-too-long.yaml" "invalid SQL name"
+}
+
+@test "R4 accepts a SQL name of exactly 63 bytes" {
+    run validate_extensions_schema "$FIXTURES_DIR/sql-name-at-limit.yaml"
+    [ "$status" -eq 0 ]
+}
+
 @test "R5 rejects manual policies without a non-empty reason" {
     assert_rejected_fixture "manual-reason-empty.yaml" "R5 extension"
 }


### PR DESCRIPTION
Closes #1091

## The problem

`initdb.sql_name` was validated for its **form** — a PostgreSQL unquoted identifier in the folded form, unique within its flavour, not colliding with the built-in block. Nothing confirmed the name was one PostgreSQL would recognise. A typo, or a name that changed upstream, built a green image whose **first startup** failed on `CREATE EXTENSION`. "The next build surfaces it" meant "the next fresh container", which may be a user's.

## What changes

The generated flavour block asserts, for every name it is about to create, that the postgres user can read `<name>.control` under `pg_config --sharedir`. The assertion and the `CREATE EXTENSION` line come from one list in one loop, so a statement cannot be added without its check, and every assertion precedes the write — a failing one leaves no init SQL behind.

It reads only whether the file is there and readable, never its contents. #1067 built an assertion deriving the loadable module from `module_pathname` and it was reverted in full: successive attempts each hit another documented property of that format the shell handled wrongly — case-insensitive keys, an optional `=`, last-assignment-wins, `directory =`, escaped quotes, relative paths.

## Four things the form check let through

Each measured on the shipped image or a running PostgreSQL 18.

**A control root can read and the server cannot.** The build runs as root; PostgreSQL does not. A control at 0600 root:root passes `test -f` **and** `test -r` for root, and fails `gosu postgres test -r`. `cp -av` preserves mode from the staging tree, and this repository has already shipped a 0700 onto a PostgreSQL system directory that way. The check asks gosu, and gosu's absence is an error rather than a fallback — otherwise the check silently becomes the root test it replaces.

**A reserved word.** `CREATE EXTENSION IF NOT EXISTS select;` → `syntax error at or near "select"`; the quoted form parses. The statement is quoted now, as the built-in block already quotes `"uuid-ossp"`. For the folded lowercase names the schema admits, the two forms are indistinguishable — so quoting removes the class instead of asking the validator to carry a keyword list that grows each release. Three **negative** test assertions would have passed for the wrong reason afterwards and were updated with it.

**A name over 63 bytes.** `SHOW max_identifier_length` returns 63 and PostgreSQL **truncates** rather than rejects — for the quoted form as readily as the bare one — so the build would check `<64-char>.control` while the server opens the 63-character name. The validator rejects longer names, with a fixture on each side of the limit.

**A `pg_config --sharedir` that exits zero without answering.** An empty result makes every test read `/extension/<name>.control`, where an unrelated match is a false pass; a relative one resolves against the build stage's working directory. Both refused, verified with control files planted where the relative form would have found them.

## Verification

By executing the generated shell against a temporary sharedir, not by reading it: every control present and readable → exit 0, SQL written; one absent, one unreadable, or a missing gosu → exit 1, nothing written, for the first and last name alike.

Per flavour the checks and the CREATE statements are equal in number and identical as sets — 9 full, 5 analytics, 4 timeseries, 3 vector, 2 spatial, 2 distributed, 0 base. `pg_cron`, whose policy is `manual`, appears in neither.

Unit suite 2375 collected, 0 failed. shellcheck clean. Eight mutations, each proving one lock bites with a green control.

The gate is satisfiable today: all nine create-mode resolved names have a control file in the `full` image, so this does not turn the tree red on merge.

## Not covered, deliberately

The built-in block's names. They ship with PostgreSQL; a missing one is a base-image regression rather than an invalid flavour declaration, and covering them would duplicate the `MAJOR_VERSION < 17` conditional guarding `adminpack`.

## Left open — #1099

Where the build looks and where the server will look can diverge in two ways a `RUN` cannot decide: `extension_control_path` is a runtime setting, and `pg_config` is resolved independently of the binary the entrypoint execs. Both fail in **either** direction — a false pass or a false build failure. Neither is reachable for the images this repository builds today (measured `$system`, single installation), and closing them means checking at startup rather than at build.

Two review rounds against the declared budget of three.
