### PR TITLE
docs(ci): say why e2e-gate is red on a fork pull request, and that it blocks nothing

### DIFF
--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -633,6 +633,34 @@ ENV CONTAINER_VERSION=${VERSION}        # Runtime version visibility
 
 ## Troubleshooting
 
+### `e2e-gate` is red on a pull request from a fork
+
+Expected, and not something the contributor can fix. It does not block the merge.
+
+The e2e job is guarded on `github.event.pull_request.head.repo.full_name == github.repository`,
+so it never runs for a fork. `e2e-gate` then sees eligible containers and a job that did
+not run, and fails — deliberately. Reporting success there would call a suite verified
+that never executed, which is the one outcome worse than a red mark. Its output says so:
+
+```
+e2e-gate FAIL: e2e was eligible ([…]) but the job did not run.
+A pull request from a fork cannot run it; a maintainer has to run this branch.
+```
+
+**What it does not do is block anything.** The only required status check on `master` is
+`unit-tests`. A red `e2e-gate` on a fork pull request is a mark, not a gate.
+
+**The handshake.** A maintainer pushes the branch inside the repository and lets the run
+complete there, then merges. Nothing is expected of the contributor.
+
+The guard is deliberate: running a fork's code with this workflow's `DOCKERHUB_TOKEN` and
+`GITHUB_TOKEN` in scope is the escalation class `pull_request_target` is known for, and it
+is not worth trading for a green mark on a check that blocks nothing.
+
+Every container shipping a `test.sh` is e2e-enabled — ansible, debian, jekyll, openresty,
+openvpn, php, postgres, sslh, terraform, vector, web-shell, wordpress — so a pull request
+touching any of the twelve reaches this.
+
 ### Workflow Architecture Issues
 
 **Scheduling Conflicts (RESOLVED):**


### PR DESCRIPTION
Closing with a documentation change, after two measurements that correct this issue's premise.

## `e2e-gate` is not a required check

The title says a fork pull request "cannot turn the required check green", and the body says the contributor "sees a red required check they have no way to fix". Measured just now: the `main` ruleset is active and its only required status check is **`unit-tests`**.

```
ruleset main [active]: unit-tests
```

So `e2e-gate` going red on a fork pull request is a mark, not a gate. The contributor is not blocked from merging; nothing is waiting on them.

That changes what the three options were being weighed against. `pull_request_target` would put this workflow's `DOCKERHUB_TOKEN` and `GITHUB_TOKEN` in scope for fork-authored code — the escalation class it is known for — to turn green a check that blocks nothing.

## No pull request has ever come from a fork

Of the last 400 of this repository's 895 pull requests, **zero** have a head repository other than `oorabona`. (An earlier count of mine said 300; that query filtered on author and was counting bots, not fork heads. The number above is from `headRepositoryOwner`.)

The friction is real and worth naming. It has not yet happened, and when it does it costs a maintainer one push, not a redesign.

## What shipped

`docs/GITHUB_ACTIONS.md` gains a Troubleshooting entry under **`e2e-gate` is red on a pull request from a fork**: why it fails, that it blocks nothing, the maintainer handshake, and why the guard is deliberate rather than an oversight. The gate's own failure output already says a maintainer has to run the branch; what was missing was somewhere a contributor reads it before wondering whether they are stuck.

The entry also corrects a count this issue carries: the surface is **twelve** containers, not ten — #988 enabled openresty and vector after this was filed. Verified against every `variants.yaml`, the list in the doc and the set with `tests.e2e.enabled: true` are identical.

## What did not change

The guard, the gate, and its reasoning. Reporting success for a suite that never ran is the one outcome worse than a red mark, and that judgement in the workflow was sound.

If a fork pull request ever does arrive and the handshake proves awkward in practice, the labelled-rerun option is the one to reach for — it keeps the decision human and costs one click. Reopening then, with a real case to size it against, beats building it now.