### PR TITLE
feat(ci): one place that speaks GitHub Actions protocol and escapes as it emits

### DIFF
--- a/helpers/gha.sh
+++ b/helpers/gha.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# GitHub Actions workflow-command and environment-file emitters.
+#
+# This file deliberately has no dependencies on the other helpers, no load-time
+# output, and does not change shell options. It requires Bash; source it from
+# Bash scripts, composite actions, or inline Bash `run:` blocks.
+#
+# `_escape_gha_command` is defined here AND, for now, still in `logging.sh` —
+# byte-identical, so a script sourcing both is unaffected by which wins. That
+# duplication is transitional and has a defined end: the eight files that reach
+# the escaper through `logging.sh` move to sourcing this file during the call-site
+# migration, and `logging.sh`'s copy is deleted with the last of them.
+#
+# The alternative, having `logging.sh` source this file, was built and reverted:
+# six test fixtures stage helpers one file at a time, so `logging.sh` acquiring a
+# sibling broke 138 tests on a path inside their own temp roots. Making those
+# fixtures stage the whole directory then changed what several of them model,
+# because a fixture that copies one helper is asserting the others are absent.
+# A slice that adds a capability should not need any of that.
+#
+# Bash variables cannot contain NUL bytes, so no shell helper can preserve or
+# validate them. This helper also does not validate encoding: it writes every
+# other byte sequence Bash can hold, while the runner reads environment files
+# as UTF-8 text. Callers with non-UTF-8 data must encode it (for example, as
+# base64) before emitting it.
+
+# _escape_gha_command <value>
+#
+# Escape a value for safe inclusion in a `::keyword::value` GitHub Actions
+# workflow command. The runner also recognizes the legacy `##[` prefix
+# anywhere in a line, so CR/LF escaping alone is not sufficient. Encode `%`
+# first, then `##[`, so the `%5B` introduced for that legacy prefix remains
+# intact. Drop remaining control bytes because they can rewrite terminal output.
+_escape_gha_command() {
+    local s="$1"
+    s="${s//\%/%25}"
+    # CR and LF are encoded rather than dropped: they are the characters a
+    # reader wants to see marked, and encoding them is what stops a value from
+    # starting a new line and with it a new `::` command.
+    s="${s//$'\n'/%0A}"
+    s="${s//$'\r'/%0D}"
+    # Every other control byte goes BEFORE the `##[` check, not after. Deleting
+    # characters closes gaps: `##<backspace>[` does not match the marker, and
+    # stripping afterwards reassembles it in the output — the escaped value then
+    # carries the very command this is here to neutralize.
+    s="${s//[[:cntrl:]]/}"
+    # These bidi controls are not C0 controls, but can reorder text in a log
+    # renderer and thereby change what a reader sees.
+    s="${s//$'\xD8\x9C'/}"
+    s="${s//$'\xE2\x80\xAA'/}"
+    s="${s//$'\xE2\x80\xAB'/}"
+    s="${s//$'\xE2\x80\xAC'/}"
+    s="${s//$'\xE2\x80\xAD'/}"
+    s="${s//$'\xE2\x80\xAE'/}"
+    s="${s//$'\xE2\x81\xA6'/}"
+    s="${s//$'\xE2\x81\xA7'/}"
+    s="${s//$'\xE2\x81\xA8'/}"
+    s="${s//$'\xE2\x81\xA9'/}"
+    s="${s//$'\xE2\x80\x8E'/}"
+    s="${s//$'\xE2\x80\x8F'/}"
+    s="${s//##\[/##%5B}"
+    printf '%s' "$s"
+}
+
+# _gha_generate_delimiter
+#
+# /dev/urandom is the only entropy source measured to exist in every shell
+# environment this repository supports. The caller checks each generated token
+# against the complete value; randomness alone is not relied on for safety.
+_gha_generate_delimiter() {
+    LC_ALL=C od -An -N 16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n'
+}
+
+# _gha_delimiter_occurs_in_value <delimiter> <value>
+#
+# A delimiter may not occur alone on a line. Treat a CRLF line ending as a line
+# ending too, because GitHub Actions environment files may contain CRLF values.
+_gha_delimiter_occurs_in_value() {
+    local delimiter="$1"
+    local value="$2"
+    local line
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" == "$delimiter" || "$line" == "$delimiter"$'\r' ]] && return 0
+    done <<< "$value"
+
+    return 1
+}
+
+# _gha_emit_annotation <level> <printf-format> [printf-argument ...]
+_gha_emit_annotation() {
+    local level="$1"
+    shift
+    local format
+    local message
+    local position=0
+    local substitutions=0
+
+    [[ "$#" -gt 0 ]] || return 2
+    format="$1"
+    shift
+
+    # The format is code, not data. Restrict it to the two literal conversions
+    # this helper needs so Bash printf cannot write through %n or allocate an
+    # arbitrary width. Matching the argument count also avoids silently losing
+    # a missing detail to printf's empty-argument behaviour.
+    while [[ "$position" -lt "${#format}" ]]; do
+        if [[ "${format:position:1}" == '%' ]]; then
+            position=$((position + 1))
+            [[ "$position" -lt "${#format}" ]] || return 2
+            case "${format:position:1}" in
+                s)
+                    substitutions=$((substitutions + 1))
+                    ;;
+                %)
+                    ;;
+                *)
+                    return 2
+                    ;;
+            esac
+        fi
+        position=$((position + 1))
+    done
+
+    [[ "$substitutions" -eq "$#" ]] || return 2
+    printf -v message -- "$format" "$@" || return 1
+    printf '::%s::%s\n' "$level" "$(_escape_gha_command "$message")"
+}
+
+# gha_error <printf-format> [printf-argument ...]
+gha_error() {
+    _gha_emit_annotation error "$@"
+}
+
+# gha_warning <printf-format> [printf-argument ...]
+gha_warning() {
+    _gha_emit_annotation warning "$@"
+}
+
+# gha_notice <printf-format> [printf-argument ...]
+gha_notice() {
+    _gha_emit_annotation notice "$@"
+}
+
+# _gha_emit_file <target-variable-name> <NAME> <VALUE>
+_gha_emit_file() {
+    local target_variable="$1"
+    local name="$2"
+    local value="$3"
+    local target="${!target_variable:-}"
+    local delimiter=""
+    local record
+    local attempt
+    local normalized_name
+
+    [[ -n "$target" ]] || return 2
+    [[ -f "$target" ]] || return 2
+
+    case "$target_variable" in
+        GITHUB_OUTPUT)
+            [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] || return 2
+            ;;
+        GITHUB_ENV)
+            [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 2
+            normalized_name="${name^^}"
+            [[ "$normalized_name" != NODE_OPTIONS && "$normalized_name" != GITHUB_* && "$normalized_name" != RUNNER_* ]] || return 2
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+
+    # The bound turns an unavailable entropy source or a deliberately hostile
+    # value into a clean failure before the target file is opened for writing.
+    attempt=0
+    while [[ "$attempt" -lt 16 ]]; do
+        delimiter="$(_gha_generate_delimiter)" || return 1
+        [[ -n "$delimiter" && "$delimiter" =~ ^[A-Fa-f0-9]+$ ]] || return 1
+        if ! _gha_delimiter_occurs_in_value "$delimiter" "$value"; then
+            break
+        fi
+        delimiter=""
+        attempt=$((attempt + 1))
+    done
+
+    [[ -n "$delimiter" ]] || return 1
+    # On Windows, the runner treats CRLF as a structural newline. Duplicate a
+    # terminal CR before this record's LF so the value retains its final byte.
+    if [[ "$value" == *$'\r' ]]; then
+        record="${name}<<${delimiter}"$'\n'"${value}"$'\r\n'"${delimiter}"$'\n'
+    else
+        record="${name}<<${delimiter}"$'\n'"${value}"$'\n'"${delimiter}"$'\n'
+    fi
+
+    if [[ "$value" == *$'\r'* || "$value" == *$'\n'* ]]; then
+        printf 'gha: %s uses the GitHub Actions multiline protocol\n' "$name" >&2
+    fi
+
+    printf '%s' "$record" >> "$target"
+}
+
+# gha_output <NAME> <VALUE>
+gha_output() {
+    [[ "$#" -eq 2 ]] || return 2
+    _gha_emit_file GITHUB_OUTPUT "$1" "$2"
+}
+
+# gha_env <NAME> <VALUE>
+gha_env() {
+    [[ "$#" -eq 2 ]] || return 2
+    _gha_emit_file GITHUB_ENV "$1" "$2"
+}
+
+# This helper is needed by exported functions in callers that source logging.sh.
+export -f _escape_gha_command

--- a/helpers/logging.sh
+++ b/helpers/logging.sh
@@ -74,6 +74,20 @@ _escape_gha_command() {
     # stripping afterwards reassembles it in the output — the escaped value then
     # carries the very command this is here to neutralize.
     s="${s//[[:cntrl:]]/}"
+    # These bidi controls are not C0 controls, but can reorder text in a log
+    # renderer and thereby change what a reader sees.
+    s="${s//$'\xD8\x9C'/}"
+    s="${s//$'\xE2\x80\xAA'/}"
+    s="${s//$'\xE2\x80\xAB'/}"
+    s="${s//$'\xE2\x80\xAC'/}"
+    s="${s//$'\xE2\x80\xAD'/}"
+    s="${s//$'\xE2\x80\xAE'/}"
+    s="${s//$'\xE2\x81\xA6'/}"
+    s="${s//$'\xE2\x81\xA7'/}"
+    s="${s//$'\xE2\x81\xA8'/}"
+    s="${s//$'\xE2\x81\xA9'/}"
+    s="${s//$'\xE2\x80\x8E'/}"
+    s="${s//$'\xE2\x80\x8F'/}"
     s="${s//##\[/##%5B}"
     printf '%s' "$s"
 }

--- a/tests/unit/gha.bats
+++ b/tests/unit/gha.bats
@@ -1,0 +1,286 @@
+#!/usr/bin/env bats
+
+# Unit tests for helpers/gha.sh.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    source "$HELPERS_DIR/gha.sh"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+@test "annotations escape the complete rendered message before emitting" {
+    local value
+    value=$'before%\r\n##[add-mask]legacy\001\033\b\n::add-mask::forged'
+
+    run gha_error 'untrusted value: %s' "$value"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '::error::untrusted value: before%25%0D%0A##%5Badd-mask]legacy%0A::add-mask::forged' ]
+    [[ "$output" != *$'\r'* ]]
+    [[ "$output" != *$'\n::'* ]]
+    [[ "$output" != *'##['* ]]
+}
+
+@test "annotation formatting cannot bypass escaping" {
+    local format
+    format=$'bad value: %s\n::add-mask::forged'
+
+    run gha_warning "$format" '100%'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '::warning::bad value: 100%25%0A::add-mask::forged' ]
+    [[ "$output" != *$'\n::add-mask::'* ]]
+}
+
+@test "annotations accept only percent-s and literal-percent formats with matching arguments" {
+    run gha_notice 'complete: %% %s' '100%'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '::notice::complete: %25 100%25' ]
+
+    run gha_notice 'missing %s %s' 'detail'
+
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+
+    run gha_notice 'extra detail' 'detail'
+
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+
+    run gha_notice '-literal'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '::notice::-literal' ]
+}
+
+@test "annotations let strict-shell callers emit and continue" {
+    local target="$TEST_TEMP_DIR/annotations"
+
+    run bash -c 'set -euo pipefail
+        source "$1"
+        {
+            gha_error "literal message"
+            printf "after literal\\n"
+            gha_error "saw %s" value
+            printf "after formatted\\n"
+        } > "$2"' _ "$HELPERS_DIR/gha.sh" "$target"
+
+    [ "$status" -eq 0 ]
+    [ "$(<"$target")" = $'::error::literal message\nafter literal\n::error::saw value\nafter formatted' ]
+}
+
+@test "annotations refuse unsafe printf conversions without emitting" {
+    run gha_error 'attempt %n' PATH
+
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+
+    run gha_warning 'attempt %10s' 'width'
+
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "annotations remove bidi controls before emitting" {
+    local value=$'visible\u061Creversed\u202Eisolated\u2066marked\u200Fend'
+
+    run gha_notice '%s' "$value"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '::notice::visiblereversedisolatedmarkedend' ]
+}
+
+@test "bidi controls are removed when Bash is running in the C locale" {
+    run env LC_ALL=C bash -c 'source "$1"; _escape_gha_command $'"'"'before\xE2\x80\xAEafter'"'"'' _ \
+        "$HELPERS_DIR/gha.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'beforeafter' ]
+}
+
+@test "gha_output preserves multiline and CRLF values without a second output" {
+    local target="$TEST_TEMP_DIR/github-output"
+    local value=$'first line\n\r\nFORGED=value\nlast line'
+    local delimiter expected="$TEST_TEMP_DIR/expected-output"
+    : > "$target"
+    export GITHUB_OUTPUT="$target"
+
+    run gha_output SAFE_VALUE "$value"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'SAFE_VALUE uses the GitHub Actions multiline protocol'* ]]
+    IFS= read -r delimiter < "$target"
+    delimiter=${delimiter#SAFE_VALUE<<}
+    delimiter=${delimiter%%$'\n'*}
+    printf '%s<<%s\n%s\n%s\n' SAFE_VALUE "$delimiter" "$value" "$delimiter" > "$expected"
+    cmp -s "$target" "$expected"
+    [ "$(grep -c '^FORGED=value$' "$target")" -eq 1 ]
+    [ "$(grep -c '^SAFE_VALUE<<' "$target")" -eq 1 ]
+}
+
+@test "gha_env preserves multiline values without a second variable" {
+    local target="$TEST_TEMP_DIR/github-env"
+    local value=$'line one\nINJECTED=wrong\nline three'
+    local delimiter expected="$TEST_TEMP_DIR/expected-env"
+    : > "$target"
+    export GITHUB_ENV="$target"
+
+    run gha_env TARGET_VALUE "$value"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'TARGET_VALUE uses the GitHub Actions multiline protocol'* ]]
+    IFS= read -r delimiter < "$target"
+    delimiter=${delimiter#TARGET_VALUE<<}
+    delimiter=${delimiter%%$'\n'*}
+    printf '%s<<%s\n%s\n%s\n' TARGET_VALUE "$delimiter" "$value" "$delimiter" > "$expected"
+    cmp -s "$target" "$expected"
+    [ "$(grep -c '^INJECTED=wrong$' "$target")" -eq 1 ]
+}
+
+@test "a colliding generated delimiter is retried before writing" {
+    local target="$TEST_TEMP_DIR/github-output"
+    local value=$'before\nc0111de5\nafter'
+    local content delimiter
+    : > "$target"
+    export GITHUB_OUTPUT="$target"
+    _gha_generate_delimiter() {
+        if [[ ! -f "$TEST_TEMP_DIR/generated-once" ]]; then
+            : > "$TEST_TEMP_DIR/generated-once"
+            printf '%s' c0111de5
+        else
+            printf '%s' a11ce123
+        fi
+    }
+
+    run gha_output SAFE_VALUE "$value"
+
+    [ "$status" -eq 0 ]
+    content=$(<"$target")
+    delimiter=${content#SAFE_VALUE<<}
+    delimiter=${delimiter%%$'\n'*}
+    [ "$delimiter" = a11ce123 ]
+    [[ "$content" != *$'\nc0111de5\nc0111de5\n'* ]]
+}
+
+@test "delimiter collisions that exhaust the bound fail without writing" {
+    local target="$TEST_TEMP_DIR/github-output"
+    printf 'existing\n' > "$target"
+    export GITHUB_OUTPUT="$target"
+    _gha_generate_delimiter() {
+        printf '%s' c0111de5
+    }
+
+    run gha_output SAFE_VALUE $'before\nc0111de5\nafter'
+
+    [ "$status" -ne 0 ]
+    [ "$(<"$target")" = existing ]
+}
+
+@test "output IDs permit hyphens and reject other invalid characters" {
+    local target="$TEST_TEMP_DIR/github-output"
+    printf 'existing\n' > "$target"
+    export GITHUB_OUTPUT="$target"
+
+    run gha_output 'random-number' 'value'
+
+    [ "$status" -eq 0 ]
+    grep -q '^random-number<<' "$target"
+
+    run gha_output 'NOT/VALID' 'value'
+
+    [ "$status" -ne 0 ]
+    [ "$(grep -c '^NOT/VALID<<' "$target")" -eq 0 ]
+}
+
+@test "environment names reject runner-blocked and output-only names" {
+    local target="$TEST_TEMP_DIR/github-env"
+    printf 'existing\n' > "$target"
+    export GITHUB_ENV="$target"
+    local name
+
+    for name in NODE_OPTIONS node_options GITHUB_TOKEN github_token RUNNER_OS runner_os NOT-VALID; do
+        run gha_env "$name" 'value'
+
+        [ "$status" -ne 0 ]
+        [ "$(<"$target")" = existing ]
+    done
+}
+
+@test "gha_env preserves a terminal CR on Windows CRLF parsing" {
+    local target="$TEST_TEMP_DIR/github-env"
+    local value=$'ends with CR\r'
+    local delimiter expected="$TEST_TEMP_DIR/expected-env" stored_value
+    : > "$target"
+    export GITHUB_ENV="$target"
+
+    run gha_env TARGET_VALUE "$value"
+
+    [ "$status" -eq 0 ]
+    IFS= read -r delimiter < "$target"
+    delimiter=${delimiter#TARGET_VALUE<<}
+    printf '%s<<%s\n%s\r\n%s\n' TARGET_VALUE "$delimiter" "$value" "$delimiter" > "$expected"
+    cmp -s "$target" "$expected"
+
+    # StreamReader.ReadLine on Windows consumes one CR as part of the record's
+    # CRLF terminator, leaving the duplicated CR as the value's final byte.
+    IFS= read -r _ < "$target"
+    IFS= read -r stored_value < <(sed -n '2p' "$target")
+    stored_value=${stored_value%$'\r'}
+    [ "$stored_value" = "$value" ]
+}
+
+@test "a nonexistent output target fails without creating a file" {
+    local target="$TEST_TEMP_DIR/github-output"
+    export GITHUB_OUTPUT="$target"
+
+    run gha_output SAFE_VALUE 'value'
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$target" ]
+}
+
+@test "a nonexistent env target fails without creating a file" {
+    local target="$TEST_TEMP_DIR/github-env"
+    export GITHUB_ENV="$target"
+
+    run gha_env SAFE_VALUE 'value'
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$target" ]
+}
+
+@test "environment files are byte-transparent but are not UTF-8 validated" {
+    local target="$TEST_TEMP_DIR/github-output"
+    local value=$'valid\377byte'
+    : > "$target"
+    export GITHUB_OUTPUT="$target"
+
+    run gha_output SAFE_VALUE "$value"
+
+    [ "$status" -eq 0 ]
+    LC_ALL=C grep -q $'valid\377byte' "$target"
+}
+
+@test "logging.sh still exposes _escape_gha_command" {
+    run bash -c 'source "$1/helpers/logging.sh"; _escape_gha_command "$2"' _ \
+        "$PROJECT_ROOT" $'before%\n##[add-mask]'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'before%25%0A##%5Badd-mask]' ]
+}
+
+@test "gha.sh and logging.sh keep byte-identical command escapers" {
+    local gha_escaper="$TEST_TEMP_DIR/gha-escaper"
+    local logging_escaper="$TEST_TEMP_DIR/logging-escaper"
+
+    run bash -c 'source "$1"; declare -f _escape_gha_command > "$3"; source "$2"; declare -f _escape_gha_command > "$4"; cmp -s "$3" "$4"' _ \
+        "$HELPERS_DIR/gha.sh" "$PROJECT_ROOT/helpers/logging.sh" "$gha_escaper" "$logging_escaper"
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Refs #1014 — first slice. **No call site is migrated.**

## The problem

This repository speaks two GitHub Actions shell protocols by hand, everywhere.

- **291 annotation emissions** interpolate a raw value. #1013 added one `_escape_gha_command`; it did not make callers use it, and most do not.
- **178 writes to `$GITHUB_ENV` / `$GITHUB_OUTPUT`** use `name=value` on one line — 86 pure literals, 1 a GHA expression, 92 interpolating a shell variable across 73 distinct names. **None** uses the delimiter form, so a newline in a value defines an arbitrary variable for every later step of the job.

Escaping 383 sites by hand is a convention. The 384th will be raw.

## What this adds

`helpers/gha.sh` — one emitter that escapes as part of emitting:

```bash
gha_error 'GHCR base cache is configured for %s but %s' "$container" "$reason"
gha_output 'image_name' "$value"
gha_env    'E2E_IMAGE_ID' "$image_id"
```

**The format is code, not data.** Bash's builtin printf honours `%n`, which writes through a name — measured, not assumed: `printf -v out 'AAAA%n' PATH` sets `PATH` to `4`. A width is equally live. So the format is restricted to `%s` and `%%`, count-matched, and anything else is refused with nothing emitted. Escaping the rendered result cannot help; the damage happens during rendering.

**Values always use the delimiter form.** Upstream requires the delimiter not appear alone on a line of the value, so the helper generates, compares against every line, regenerates on collision, and after bounded attempts returns non-zero having written nothing. Randomness is a probability; the comparison is the property.

**Names follow the runner's rules**, per sink and case-insensitively as the runner compares them. An output id may contain `-`. An environment name may not be `NODE_OPTIONS` or carry a `GITHUB_`/`RUNNER_` prefix — the runner blocks or ignores those, and returning success is a contract a caller would believe. The sink must already exist, as the official toolkit requires: creating it means the runner keeps reading its own file and receives nothing, silently.

## Measured before the shape was chosen

| context | uuidgen | openssl | od | /dev/urandom |
|---|---|---|---|---|
| workstation | yes | yes | yes | yes |
| `alpine:3` | **no** | **no** | yes | yes |
| runner image | **no** | yes | yes | yes |

`/dev/urandom` is the only generator present everywhere. The first proposal reached for `uuidgen`, which works on a workstation and fails in CI.

Provenance of the 92 interpolated values was attempted and abandoned: the suspicious names are function parameters, so origin lives at the call site and is not settleable by static reading. **The sink is decidable where the source is not** — which is why this fixes the sink.

## Three review rounds, and what they caught

Every finding was real and introduced by this slice.

- **The helper aborted its own callers.** `((n++))` returns status 1 when `n` is zero, so under `set -euo pipefail` — which every script here sets — `gha_error` exited before emitting. The shipped tests could not see it: Bats `run` isolates the caller from exactly that.
- **The name rule was wrong in both directions**, with a test locking the mismatch in.
- **A nonexistent sink was created rather than refused.**
- **Unicode bidi controls survived `[[:cntrl:]]`.** Now removed in both escaper copies — `logging.sh` gains the same, which strengthens its existing callers and restores the byte-identical property this file's header asserts.

## Verification

Unit suite 2396 collected, 0 failed. shellcheck clean.

**Twenty-four properties checked independently of the suite that ships with the helper**, because a suite written beside the code is jointly consistent with it under one misconception. The env file is parsed the way the runner parses it rather than grepped — in delimiter form the value's lines are content, not assignments, and a first probe that grepped reported a false failure. Annotations are exercised in a real `set -euo pipefail` shell rather than through `run`.

The collision path was forced with a pinned generator against a value containing that delimiter: exit 1, zero bytes, no loop.

## Deliberately deferred

A parent process pointing `GITHUB_ENV` at a symlink. Whoever controls that variable is inside the job already, and this repository's only untrusted input is external data — registry responses and upstream release APIs. Marginal privilege nil.

## What comes next

The 383 call sites migrate in later slices, per file. The check that rejects direct use lands only once the last one has, so it never carries an exception list. `_escape_gha_command` is duplicated with `logging.sh` until then — byte-identical, with the end condition in the file header.
