### PR TITLE
refactor(ci): the two drift detectors emit through the helper, not by hand

### DIFF
--- a/scripts/check-version-drift.sh
+++ b/scripts/check-version-drift.sh
@@ -37,8 +37,7 @@
 #   _VDRIFT_PROBE_OVERRIDE              — function/path: probe(<image> <tag>) → "present"|"absent"|"error"
 #
 # GHA command injection prevention:
-#   All user-derived strings emitted via ::notice::/::warning:: are escaped via
-#   _escape_gha_command (pattern from helpers/base-cache-utils.sh).
+#   All annotations are emitted through helpers/gha.sh, which escapes their values.
 
 set -euo pipefail
 
@@ -63,6 +62,8 @@ source "${_vdrift_self_dir}/../helpers/extension-utils.sh"
 source "${_vdrift_self_dir}/../helpers/build-cache-utils.sh"
 # shellcheck source=../helpers/logging.sh
 source "${_vdrift_self_dir}/../helpers/logging.sh"
+# shellcheck source=../helpers/gha.sh
+source "${_vdrift_self_dir}/../helpers/gha.sh"
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -86,28 +87,28 @@ while [[ $# -gt 0 ]]; do
             grep '^#' "$0" | grep -v '#!/' | sed 's/^# \?//'
             exit 0 ;;
         *)
-            printf '::error::Unknown argument: %s\n' "$(_escape_gha_command "$1")" >&2
+            gha_error 'Unknown argument: %s' "$1" >&2
             exit 2 ;;
     esac
 done
 
 if [[ -z "$MODE" ]]; then
-    echo "::error::--mode is required (post-build|sweep)" >&2
+    gha_error '--mode is required (post-build|sweep)' >&2
     exit 2
 fi
 
 if [[ "$MODE" != "post-build" && "$MODE" != "sweep" ]]; then
-    echo "::error::--mode must be 'post-build' or 'sweep'" >&2
+    gha_error "--mode must be 'post-build' or 'sweep'" >&2
     exit 2
 fi
 
 if [[ "$MODE" == "post-build" && -z "$CONTAINER_ARG" ]]; then
-    echo "::error::--container is required with --mode post-build" >&2
+    gha_error '--container is required with --mode post-build' >&2
     exit 2
 fi
 
 if ! [[ "$GRACE_HOURS" =~ ^[0-9]+$ ]]; then
-    echo "::error::--grace-hours must be a non-negative integer" >&2
+    gha_error '--grace-hours must be a non-negative integer' >&2
     exit 2
 fi
 
@@ -129,15 +130,14 @@ _vdrift_ghcr_owner() {
     fi
     local remote_url
     if ! remote_url=$(cd "$PROJECT_ROOT" && git remote get-url origin 2>/dev/null); then
-        echo "::error::Cannot determine GHCR owner (no GITHUB_REPOSITORY_OWNER and git remote get-url origin failed)" >&2
+        gha_error 'Cannot determine GHCR owner (no GITHUB_REPOSITORY_OWNER and git remote get-url origin failed)' >&2
         return 1
     fi
     if [[ "$remote_url" =~ github\.com[:/]([^/]+)/ ]]; then
         printf '%s' "${BASH_REMATCH[1]}"
         return 0
     fi
-    printf '::error::Cannot parse owner from git remote URL: %s\n' \
-        "$(_escape_gha_command "$remote_url")" >&2
+    gha_error 'Cannot parse owner from git remote URL: %s' "$remote_url" >&2
     return 1
 }
 
@@ -153,12 +153,12 @@ _vdrift_list_containers() {
     fi
     local out
     if ! out=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null); then
-        echo "::error::Failed to enumerate containers via './make list'" >&2
+        gha_error "Failed to enumerate containers via './make list'" >&2
         return 1
     fi
     out=$(printf '%s' "$out" | grep -E '^[a-z0-9_-]+$' || true)
     if [[ -z "$out" ]]; then
-        echo "::error::'./make list' returned empty container set" >&2
+        gha_error "'./make list' returned empty container set" >&2
         return 1
     fi
     printf '%s' "$out"
@@ -285,8 +285,7 @@ _vdrift_probe_published() {
                 else
                     # Linux tag backed only by a single-arch placeholder — treat as absent
                     # so partial/failed multi-arch publishes are flagged as drift.
-                    printf '::warning::version-drift: %s single-arch manifest where multi-arch expected\n' \
-                        "$(_escape_gha_command "${full_ref}")" >&2
+                    gha_warning 'version-drift: %s single-arch manifest where multi-arch expected' "$full_ref" >&2
                     printf 'absent'
                 fi
                 ;;
@@ -358,8 +357,7 @@ _vdrift_probe_published() {
                     if [[ "$tag" == *windows* ]]; then
                         printf 'present'
                     else
-                        printf '::warning::version-drift: %s single-arch manifest where multi-arch expected\n' \
-                            "$(_escape_gha_command "${full_ref}")" >&2
+                        gha_warning 'version-drift: %s single-arch manifest where multi-arch expected' "$full_ref" >&2
                         printf 'absent'
                     fi
                     ;;
@@ -411,25 +409,19 @@ _append_row() {
         window_empty)   _HAS_ERROR=true ;;
     esac
 
-    # GHA annotations
-    local safe_name safe_declared safe_status
-    safe_name=$(_escape_gha_command "$name")
-    safe_declared=$(_escape_gha_command "$declared")
-    safe_status=$(_escape_gha_command "$status")
-
     case "$status" in
         drift)
-            printf '::warning::version-drift: %s declared=%s status=%s\n' \
-                "$safe_name" "$safe_declared" "$safe_status" >&2 ;;
+            gha_warning 'version-drift: %s declared=%s status=%s' \
+                "$name" "$declared" "$status" >&2 ;;
         in_flight)
-            printf '::notice::version-drift: %s declared=%s status=in_flight (within grace window)\n' \
-                "$safe_name" "$safe_declared" >&2 ;;
+            gha_notice 'version-drift: %s declared=%s status=in_flight (within grace window)' \
+                "$name" "$declared" >&2 ;;
         error)
-            printf '::warning::version-drift: %s declared=%s probe error\n' \
-                "$safe_name" "$safe_declared" >&2 ;;
+            gha_warning 'version-drift: %s declared=%s probe error' \
+                "$name" "$declared" >&2 ;;
         window_empty)
-            printf '::warning::version-drift: %s declared=%s timescaledb window empty\n' \
-                "$safe_name" "$safe_declared" >&2 ;;
+            gha_warning 'version-drift: %s declared=%s timescaledb window empty' \
+                "$name" "$declared" >&2 ;;
     esac
 }
 
@@ -489,7 +481,7 @@ _process_container() {
     # so validate the file directly here: a malformed or schema-broken
     # variants.yaml must fail closed (exit 2), not silently yield "no versions".
     if ! yq -e '.versions[].tag' "$variants_file" >/dev/null 2>&1; then
-        echo "::error::version-drift: variants.yaml for ${container} failed to parse or declares no .versions[].tag" >&2
+        gha_error 'version-drift: variants.yaml for %s failed to parse or declares no .versions[].tag' "$container" >&2
         _HAS_ERROR=true
         return 0
     fi
@@ -498,7 +490,7 @@ _process_container() {
     # Distinguish parse/tool failure (non-zero exit) from genuinely empty result.
     local versions
     if ! versions=$(list_versions "$container_dir" 2>/dev/null); then
-        echo "::error::version-drift: failed to read declared versions for ${container} (yq/parse error)" >&2
+        gha_error 'version-drift: failed to read declared versions for %s (yq/parse error)' "$container" >&2
         _HAS_ERROR=true
         return 0
     fi
@@ -564,7 +556,7 @@ _process_extensions() {
     # Read PG major versions — distinguish tool failure from genuinely empty config.
     local pg_majors
     if ! pg_majors=$(yq -r '.pg_versions[]' "$ext_config" 2>/dev/null); then
-        echo "::error::version-drift: failed to read pg_versions from ${ext_config} (yq/parse error)" >&2
+        gha_error 'version-drift: failed to read pg_versions from %s (yq/parse error)' "$ext_config" >&2
         _HAS_ERROR=true
         return 0
     fi
@@ -580,7 +572,7 @@ _process_extensions() {
 
         local ext_names
         if ! ext_names=$(list_extensions_by_priority "$ext_config" "$pg_major" 2>/dev/null); then
-            echo "::error::version-drift: failed to list extensions for pg${pg_major} from ${ext_config} (yq/parse error)" >&2
+            gha_error 'version-drift: failed to list extensions for pg%s from %s (yq/parse error)' "$pg_major" "$ext_config" >&2
             _HAS_ERROR=true
             continue
         fi
@@ -600,7 +592,7 @@ _process_extensions() {
             local has_resolver
             if ! has_resolver=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version_set.resolver // ""' \
                 "$ext_config" 2>/dev/null); then
-                echo "::error::version-drift: failed to read version_set resolver for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+                gha_error 'version-drift: failed to read version_set resolver for %s from %s (yq/parse error)' "$ext_name" "$ext_config" >&2
                 _HAS_ERROR=true
                 continue
             fi
@@ -616,7 +608,7 @@ _process_extensions() {
                 local ext_version
                 if ! ext_version=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version // ""' \
                     "$ext_config" 2>/dev/null); then
-                    echo "::error::version-drift: failed to read declared version for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+                    gha_error 'version-drift: failed to read declared version for %s from %s (yq/parse error)' "$ext_name" "$ext_config" >&2
                     _HAS_ERROR=true
                     continue
                 fi
@@ -674,7 +666,7 @@ _check_timescaledb_extension() {
     local resolver
     if ! resolver=$(VDRIFT_EXT="$ext_name" yq -r '.extensions[strenv(VDRIFT_EXT)].version_set.resolver // ""' \
         "$ext_config" 2>/dev/null); then
-        echo "::error::version-drift: failed to read version_set resolver for $(_escape_gha_command "$ext_name") from $(_escape_gha_command "$ext_config") (yq/parse error)" >&2
+        gha_error 'version-drift: failed to read version_set resolver for %s from %s (yq/parse error)' "$ext_name" "$ext_config" >&2
         _HAS_ERROR=true
         return 0
     fi
@@ -795,16 +787,16 @@ _emit_output() {
 # A missing tool causes silent false-clean results; we must exit 2 explicitly.
 # ---------------------------------------------------------------------------
 if ! command -v yq >/dev/null 2>&1; then
-    echo "::error::version-drift: required tool 'yq' not found on PATH — cannot run guard" >&2
+    gha_error "version-drift: required tool 'yq' not found on PATH — cannot run guard" >&2
     exit 2
 fi
 if ! command -v jq >/dev/null 2>&1; then
-    echo "::error::version-drift: required tool 'jq' not found on PATH — cannot run guard" >&2
+    gha_error "version-drift: required tool 'jq' not found on PATH — cannot run guard" >&2
     exit 2
 fi
 
 if ! GHCR_OWNER=$(_vdrift_ghcr_owner); then
-    echo "::error::version-drift: GHCR owner resolution failed — cannot run guard" >&2
+    gha_error 'version-drift: GHCR owner resolution failed — cannot run guard' >&2
     exit 2
 fi
 
@@ -817,7 +809,7 @@ else
     # Sweep mode: all containers + extensions
     containers=""
     if ! containers=$(_vdrift_list_containers); then
-        echo "::error::version-drift: container enumeration failed — cannot run guard" >&2
+        gha_error 'version-drift: container enumeration failed — cannot run guard' >&2
         exit 2
     fi
 

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -62,6 +62,8 @@ source "${PROJECT_ROOT}/helpers/lineage-utils.sh"
 source "${PROJECT_ROOT}/helpers/dependency-graph.sh"
 # shellcheck source=../helpers/logging.sh
 source "${PROJECT_ROOT}/helpers/logging.sh"
+# shellcheck source=../helpers/gha.sh
+source "${PROJECT_ROOT}/helpers/gha.sh"
 # shellcheck source=../helpers/retry.sh
 source "${PROJECT_ROOT}/helpers/retry.sh"
 # shellcheck source=../helpers/base-cache-utils.sh
@@ -82,14 +84,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --container)
             if [[ -z "${2:-}" ]]; then
-                echo "::error::--container requires a value" >&2
+                gha_error '--container requires a value' >&2
                 exit 1
             fi
             CONTAINER_FILTER="$2"
             shift 2
             ;;
         -*)
-            echo "::error::Unknown flag: $1" >&2
+            gha_error 'Unknown flag: %s' "$1" >&2
             exit 1
             ;;
         *)
@@ -172,8 +174,6 @@ _probe_digest() {
     local raw
     local probe_stderr
     local probe_exit=0
-    local safe_ref
-    safe_ref=$(_escape_gha_command "$image_ref")
     _PROBE_DIGEST_ERROR=""
     _PROBE_DIGEST_OUT=""
     # Unlike imagetools create, this is a manifest metadata read. Thirty
@@ -201,11 +201,11 @@ _probe_digest() {
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             if _timeout_exit_is_timeout "$probe_exit"; then
                 _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
-                printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+                gha_error '%s for %s' "$_PROBE_DIGEST_ERROR" "$image_ref" >&2
             elif [[ -n "$err_detail" ]]; then
                 _PROBE_DIGEST_ERROR="${err_detail##*$'\n'}"
             fi
-            [[ -n "$err_detail" ]] && printf '::error::probe-cmd-error for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
+            [[ -n "$err_detail" ]] && gha_error 'probe-cmd-error for %s: %s' "$image_ref" "$err_detail" >&2
             rm -f "$probe_stderr"
             return 1
         fi
@@ -222,18 +222,18 @@ _probe_digest() {
             err_detail=$(cat "$probe_stderr" 2>/dev/null || true)
             if _timeout_exit_is_timeout "$probe_exit"; then
                 _PROBE_DIGEST_ERROR="registry did not answer within ${digest_probe_timeout}s"
-                printf '::error::%s for %s\n' "$_PROBE_DIGEST_ERROR" "$safe_ref" >&2
+                gha_error '%s for %s' "$_PROBE_DIGEST_ERROR" "$image_ref" >&2
             elif [[ -n "$err_detail" ]]; then
                 _PROBE_DIGEST_ERROR="${err_detail##*$'\n'}"
             fi
-            printf '::error::imagetools inspect failed for %s: %s\n' "$safe_ref" "$(_escape_gha_command "$err_detail")" >&2
+            gha_error 'imagetools inspect failed for %s: %s' "$image_ref" "$err_detail" >&2
             rm -f "$probe_stderr"
             return 1
         fi
     fi
 
     if [[ -z "$raw" ]]; then
-        printf '::error::imagetools inspect returned empty output for %s\n' "$safe_ref" >&2
+        gha_error 'imagetools inspect returned empty output for %s' "$image_ref" >&2
         rm -f "$probe_stderr"
         return 1
     fi
@@ -243,7 +243,7 @@ _probe_digest() {
     digest=$(printf '%s' "$raw" | jq -r '.digest // empty' 2>/dev/null || true)
 
     if [[ -z "$digest" ]]; then
-        printf '::error::could not extract digest from manifest for %s\n' "$safe_ref" >&2
+        gha_error 'could not extract digest from manifest for %s' "$image_ref" >&2
         rm -f "$probe_stderr"
         return 1
     fi
@@ -445,7 +445,7 @@ _validate_image_ref() {
 # Walk lineage directory
 # ---------------------------------------------------------------------------
 if [[ ! -d "$LINEAGE_DIR" ]]; then
-    echo "::warning::Lineage directory '$LINEAGE_DIR' does not exist — nothing to check" >&2
+    gha_warning "Lineage directory '%s' does not exist — nothing to check" "$LINEAGE_DIR" >&2
     printf '[]'
     exit 0
 fi
@@ -454,7 +454,7 @@ fi
 mapfile -t lineage_files < <(find "$LINEAGE_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | sort)
 
 if [[ ${#lineage_files[@]} -eq 0 ]]; then
-    echo "::warning::Lineage cache empty — no .json files in '$LINEAGE_DIR'; skipping drift check" >&2
+    gha_warning "Lineage cache empty — no .json files in '%s'; skipping drift check" "$LINEAGE_DIR" >&2
     printf '[]'
     exit 0
 fi
@@ -479,7 +479,7 @@ for lineage_file in "${lineage_files[@]}"; do
     # Parse required fields
     container=$(jq -re '.container // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$container" ]]; then
-        printf '::warning::Skipping %s: missing '\''container'\'' field\n' "$(_escape_gha_command "$basename_file")" >&2
+        gha_warning "Skipping %s: missing 'container' field" "$basename_file" >&2
         continue
     fi
 
@@ -488,8 +488,8 @@ for lineage_file in "${lineage_files[@]}"; do
     # as TWO patterns, so "ansible" matches and "malicious" passes validation silently.
     # Explicit cntrl-char rejection at entry point closes that bypass entirely.
     if [[ "$container" =~ [[:cntrl:]] ]]; then
-        printf '::warning::Rejecting lineage entry %s: container name contains control chars: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
+        gha_warning 'Rejecting lineage entry %s: container name contains control chars: %s' \
+            "$basename_file" "$container" >&2
         continue
     fi
 
@@ -499,8 +499,8 @@ for lineage_file in "${lineage_files[@]}"; do
     # pass grep -xF while containing shell metacharacters.  Rejecting here ensures
     # NO container reaching the emitted drift matrices can contain metacharacters.
     if ! [[ "$container" =~ ^[a-z0-9_-]+$ ]]; then
-        printf '::warning::Rejecting lineage entry %s: container name contains invalid characters: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
+        gha_warning 'Rejecting lineage entry %s: container name contains invalid characters: %s' \
+            "$basename_file" "$container" >&2
         continue
     fi
 
@@ -524,20 +524,20 @@ for lineage_file in "${lineage_files[@]}"; do
         else
             _valid_containers=$(cd "$PROJECT_ROOT" && ./make list) || _valid_containers=""
             if [[ -z "$_valid_containers" ]]; then
-                printf '::error::./make list returned empty — canonical container list unavailable\n' >&2
+                gha_error './make list returned empty — canonical container list unavailable' >&2
                 exit 2
             fi
         fi
     fi
     if ! grep -qxF -- "$container" <<<"$_valid_containers"; then
-        printf '::warning::Skipping %s: invalid container name '\''%s'\'' (not in ./make list)\n' \
-            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$container")" >&2
+        gha_warning "Skipping %s: invalid container name '%s' (not in ./make list)" \
+            "$basename_file" "$container" >&2
         continue
     fi
 
     variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$variant_tag" ]]; then
-        printf '::warning::Skipping %s: missing '\''tag'\'' field\n' "$(_escape_gha_command "$basename_file")" >&2
+        gha_warning "Skipping %s: missing 'tag' field" "$basename_file" >&2
         continue
     fi
 
@@ -545,14 +545,10 @@ for lineage_file in "${lineage_files[@]}"; do
     # A tag like "active\npayload" would pass grep -xF (multiple patterns) and
     # reach markdown with incomplete escaping. Validate early to close bypass.
     if [[ "$variant_tag" =~ [[:cntrl:]] ]]; then
-        printf '::warning::Rejecting lineage entry %s: tag contains control chars: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$variant_tag")" >&2
+        gha_warning 'Rejecting lineage entry %s: tag contains control chars: %s' \
+            "$basename_file" "$variant_tag" >&2
         continue
     fi
-
-    # Sanitize tag for safe embedding in GHA commands / markdown.
-    # Applied here so every downstream use of $variant_tag_safe is already clean.
-    variant_tag_safe=$(_escape_gha_command "$variant_tag")
 
     # Filter to active build-matrix tags only (NORMAL MODE ONLY).
     # In --baseline-only mode, we intentionally emit ALL pre-v2 entries including
@@ -594,17 +590,17 @@ for lineage_file in "${lineage_files[@]}"; do
                 # drift on the live container is silently undetected until the version PR merges.
                 # When `current` resolves to empty (new container, never built), get_build_version
                 # returns "unknown", list_container_builds emits empty output, and the existing
-                # fail-closed path below handles it with a ::warning:: (no new code needed).
+                # fail-closed path below handles it with a warning annotation (no new code needed).
                 _lb_rc=0
                 _fetched=$(cd "$PROJECT_ROOT" && ./make list-builds "$container" current 2>/dev/null) || _lb_rc=$?
                 if [[ "$_lb_rc" -ne 0 ]]; then
-                    printf '::warning::./make list-builds %s failed (rc=%s) — skipping entire container (fail-closed; retry next cron run)\n' "$container" "$_lb_rc" >&2
+                    gha_warning './make list-builds %s failed (rc=%s) — skipping entire container (fail-closed; retry next cron run)' "$container" "$_lb_rc" >&2
                     # Mark container as fully skipped so the outer loop continues to the next container
                     printf -v "$_active_tags_var" '%s' "__CONTAINER_SKIP__"
                 else
                     _fetched=$(printf '%s' "$_fetched" | jq -r '.[].tag // empty' 2>/dev/null | sort -u || echo "")
                     if [[ -z "$_fetched" ]]; then
-                        printf '::warning::./make list-builds %s returned no tags — skipping entire container (fail-closed; retry next cron run)\n' "$container" >&2
+                        gha_warning './make list-builds %s returned no tags — skipping entire container (fail-closed; retry next cron run)' "$container" >&2
                         printf -v "$_active_tags_var" '%s' "__CONTAINER_SKIP__"
                     else
                         printf -v "$_active_tags_var" '%s' "$_fetched"
@@ -640,8 +636,8 @@ for lineage_file in "${lineage_files[@]}"; do
         # Skip filtering if: test-mode no-filter (__TEST_NO_FILTER__),
         # empty override (backward compat), or tag matches active set
         if [[ "$_active_tags" != "__TEST_NO_FILTER__" && -n "$_active_tags" ]] && ! grep -qxF -- "$variant_tag" <<<"$_active_tags"; then
-            printf '::notice::Skipping stale lineage entry: %s:%s (no longer in active build matrix)\n' \
-                "$(_escape_gha_command "$container")" "$variant_tag_safe" >&2
+            gha_notice 'Skipping stale lineage entry: %s:%s (no longer in active build matrix)' \
+                "$container" "$variant_tag" >&2
             continue
         fi
     fi
@@ -683,8 +679,8 @@ for lineage_file in "${lineage_files[@]}"; do
 
         # Skip if base_image_ref is a placeholder (non-legacy entry with unresolved ref)
         if [[ "$base_image_ref" =~ \$ ]]; then
-            printf '::warning::Skipping %s: base_image_ref contains unresolved placeholder: %s\n' \
-                "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$base_image_ref")" >&2
+            gha_warning 'Skipping %s: base_image_ref contains unresolved placeholder: %s' \
+                "$basename_file" "$base_image_ref" >&2
             continue
         fi
 
@@ -694,15 +690,15 @@ for lineage_file in "${lineage_files[@]}"; do
 
     # Normal mode: placeholder-skip runs before legacy check to prevent mis-classification
     if [[ "$base_image_ref" =~ \$ ]]; then
-        printf '::warning::Skipping %s: base_image_ref contains unresolved placeholder: %s\n' \
-            "$(_escape_gha_command "$basename_file")" "$(_escape_gha_command "$base_image_ref")" >&2
+        gha_warning 'Skipping %s: base_image_ref contains unresolved placeholder: %s' \
+            "$basename_file" "$base_image_ref" >&2
         continue
     fi
 
     # Skip if base_image_ref is unknown or missing (must run BEFORE legacy check
     # which would otherwise emit a legacy record for a corrupt/unknown entry).
     if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
-        printf '::warning::Skipping %s: base_image_ref is unknown or missing\n' "$(_escape_gha_command "$basename_file")" >&2
+        gha_warning 'Skipping %s: base_image_ref is unknown or missing' "$basename_file" >&2
         continue
     fi
 
@@ -726,9 +722,8 @@ for lineage_file in "${lineage_files[@]}"; do
     if [[ ! "$recorded_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")
-        printf '::warning::Malformed recorded_digest for %s:%s ('\''%s'\''); treating as corrupt lineage\n' \
-            "$(_escape_gha_command "$container")" "$(_escape_gha_command "$variant_tag")" \
-            "$(_escape_gha_command "$recorded_digest")" >&2
+        gha_warning "Malformed recorded_digest for %s:%s ('%s'); treating as corrupt lineage" \
+            "$container" "$variant_tag" "$recorded_digest" >&2
         variant_json=$(jq -cn \
             --arg variant_tag       "$variant_tag" \
             --arg base_ref          "$safe_ref" \
@@ -744,11 +739,10 @@ for lineage_file in "${lineage_files[@]}"; do
     # Poisoned lineage with an attacker-controlled ref could cause the workflow
     # to probe an untrusted registry with Docker credentials.
     if ! _validate_image_ref "$base_image_ref"; then
-        printf '::warning::Refusing to probe untrusted base_image_ref for %s:%s: %s\n' \
-            "$(_escape_gha_command "$container")" "$variant_tag_safe" \
-            "$(_escape_gha_command "$base_image_ref")" >&2
+        gha_warning 'Refusing to probe untrusted base_image_ref for %s:%s: %s' \
+            "$container" "$variant_tag" "$base_image_ref" >&2
         # r29 Finding 3: emit an explicit error record so error_count surfaces the
-        # rejection in workflow output.  The ::warning:: above is kept for the audit
+        # rejection in workflow output. The warning annotation above is kept for the audit
         # trail on stderr; the record here is the machine-readable signal.
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")
@@ -823,7 +817,7 @@ for lineage_file in "${lineage_files[@]}"; do
         if [[ -z "$error_reason" ]]; then
             error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
         fi
-        printf '::error::probe-error: %s\n' "$(_escape_gha_command "$error_reason")" >&2
+        gha_error 'probe-error: %s' "$error_reason" >&2
         safe_ref=$(_sanitize_for_json "$base_image_ref")
         safe_recorded=$(_sanitize_for_json "$recorded_digest")
         safe_error=$(_sanitize_for_json "$error_reason")
@@ -840,8 +834,8 @@ for lineage_file in "${lineage_files[@]}"; do
 
     # Validate digest shape (injection prevention)
     if ! _validate_digest_shape "$current_digest"; then
-        printf '::error::Registry returned malformed digest for %s: '\''%s'\'' — refusing to emit record\n' \
-            "$(_escape_gha_command "$base_image_ref")" "$(_escape_gha_command "$current_digest")" >&2
+        gha_error "Registry returned malformed digest for %s: '%s' — refusing to emit record" \
+            "$base_image_ref" "$current_digest" >&2
         exit 1
     fi
 
@@ -900,8 +894,8 @@ for container in "${_container_order[@]}"; do
 
     # Validate the variants array is valid JSON
     if ! printf '%s' "$variants_array" | jq '.' >/dev/null 2>&1; then
-        printf '::warning::Skipping container '\''%s'\'': could not build valid variants JSON\n' \
-            "$(_escape_gha_command "$container")" >&2
+        gha_warning "Skipping container '%s': could not build valid variants JSON" \
+            "$container" >&2
         continue
     fi
 
@@ -935,11 +929,11 @@ for container in "${_container_order[@]}"; do
         _depgraph_err_msg=$(cat "$_depgraph_err_tmp" 2>/dev/null || true)
         rm -f "$_depgraph_err_tmp"
         if [[ -n "$_depgraph_err_msg" ]]; then
-            printf '::error::dep-graph failed for %s: %s\n' \
-                "$(_escape_gha_command "$container")" "$(_escape_gha_command "$_depgraph_err_msg")" >&2
+            gha_error 'dep-graph failed for %s: %s' \
+                "$container" "$_depgraph_err_msg" >&2
         else
-            printf '::error::Failed to compute internal_deps for %s; cannot make cascade decision\n' \
-                "$(_escape_gha_command "$container")" >&2
+            gha_error 'Failed to compute internal_deps for %s; cannot make cascade decision' \
+                "$container" >&2
         fi
         # Emit the container as an error-only record, discarding any already-assembled
         # variant fragments for this run.  Rationale: internal_deps is unavailable, so
@@ -993,7 +987,7 @@ output+="]"
 
 # Final validation — output must be valid JSON
 if ! printf '%s' "$output" | jq '.' >/dev/null 2>&1; then
-    echo "::error::Internal error: output is not valid JSON" >&2
+    gha_error 'Internal error: output is not valid JSON' >&2
     exit 1
 fi
 

--- a/tests/unit/check-version-drift.bats
+++ b/tests/unit/check-version-drift.bats
@@ -784,29 +784,37 @@ DRIFT_YAML="${REPO_ROOT}/.github/workflows/version-drift.yaml"
     [ "$guard_count" -ge 1 ]
 }
 
-@test "check-version-drift.sh routes untrusted names through _escape_gha_command" {
-    # Every ::warning:: / ::notice:: annotation line that includes a user-derived
-    # value (name, declared, status from JSON data) must route through _escape_gha_command.
-    # In _append_row, annotations use $safe_name, $safe_declared, $safe_status — never
-    # the raw $name/$declared/$status.  Verify no annotation line uses the raw variables.
-    local raw_name_in_annotation
-    # Check that ::warning:: / ::notice:: lines do NOT interpolate raw $name, $declared, $status
-    # (i.e. no 'printf ...::warning::...$name' outside safe_ variables)
-    raw_name_in_annotation=$(grep -cE \
-        '::(warning|notice)::[^"]*\$name[^_]|::(warning|notice)::[^"]*\$declared[^_]|::(warning|notice)::[^"]*\$status[^_]' \
-        "$DRIFT_SCRIPT" || true)
-    [ "$raw_name_in_annotation" -eq 0 ]
+# This checks two things it can, and deliberately stops there.
+#
+# It does NOT verify that a format's arguments are bound in the right order:
+# swapping two `%s` values passes every assertion here, and the only honest way
+# to catch that is to read the call — which the review of this migration did,
+# confirming all 26. Twenty-six per-call assertions would be a second copy of the
+# source, wrong the moment the source changes, and the next slice would owe fifty
+# more.
+#
+# The raw-emission check finds the literal spelling and nothing else.
+# `printf '::%s::...' error` passes it. That escape is not closable here: shell
+# is not a structured format, and a check over its text always has one more
+# spelling. The repository-wide policy check lands after the last call site
+# migrates and will carry the same bound, stated rather than implied.
+@test "check-version-drift.sh emits no literal workflow command and sources the emitter" {
+    # The script sources the settled emitter API directly rather than relying on
+    # logging.sh's transitional copy of the escaper.
+    grep -q 'source "${_vdrift_self_dir}/../helpers/gha.sh"' "$DRIFT_SCRIPT"
 
-    # _append_row must assign safe_ variables via _escape_gha_command
-    local safe_assignments
-    safe_assignments=$(grep -c 'safe_.*=.*_escape_gha_command' "$DRIFT_SCRIPT" || true)
-    [ "$safe_assignments" -ge 3 ]
-
-    # _escape_gha_command must be called for all ::error:: lines that include user data
-    # (grep for ::error:: lines that use printf %s with a subshell call to _escape_gha_command)
-    local escaped_errors
-    escaped_errors=$(grep -cE '::error::.*_escape_gha_command' "$DRIFT_SCRIPT" || true)
-    [ "$escaped_errors" -ge 1 ]
+    # The command NAME followed by its closing delimiter or the space that starts
+    # its parameters, and the legacy `##[` spelling the runner also accepts. An
+    # earlier version matched `::error::` alone, which `::error file=x::y` walks
+    # straight past — the same escape found in the retry-run guard this morning,
+    # and the same shape of fix. `tests/unit/retry-run-annotations.bats` carries
+    # the repository-wide version of this pattern.
+    #
+    # A comment mentioning one of these fails the test too: a false positive
+    # costs a word, the reverse costs a regression.
+    local raw_annotations
+    raw_annotations=$(grep -cE '(::|##\[)(error|warning|notice)(::|\]|[[:space:]])' "$DRIFT_SCRIPT" || true)
+    [ "$raw_annotations" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -1652,6 +1652,7 @@ EOF
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
@@ -1692,6 +1693,7 @@ STUB
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
@@ -3713,6 +3715,7 @@ STUBEOF
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
@@ -3787,6 +3790,7 @@ EOF
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$fake_root/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$fake_root/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$fake_root/helpers/"
@@ -4120,6 +4124,7 @@ php" \
     cp "${SCRIPTS_DIR}/../helpers/lineage-utils.sh" "$TEST_TEMP_DIR/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/dependency-graph.sh" "$TEST_TEMP_DIR/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/logging.sh" "$TEST_TEMP_DIR/helpers/"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$TEST_TEMP_DIR/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/retry.sh" "$TEST_TEMP_DIR/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/variant-utils.sh" "$TEST_TEMP_DIR/helpers/"
     cp "${SCRIPTS_DIR}/../helpers/base-cache-utils.sh" "$TEST_TEMP_DIR/helpers/"
@@ -4317,6 +4322,37 @@ STUB_EOF
 
     # Non-matching filter -> no entries -> empty array
     [ "$result" = "[]" ]
+}
+
+# This checks two things it can, and deliberately stops there.
+#
+# It does NOT verify that a format's arguments are bound in the right order:
+# swapping two `%s` values passes every assertion here, and the only honest way
+# to catch that is to read the call. Per-call assertions would be a second copy
+# of the source, wrong the moment the source changes.
+#
+# The raw-emission check finds the literal spelling and nothing else.
+# `printf '::%s::...' error` passes it. That escape is not closable here: shell
+# is not a structured format, and a check over its text always has one more
+# spelling. The repository-wide policy check lands after the last call site
+# migrates and will carry the same bound, stated rather than implied.
+@test "detect-base-digest-drift.sh emits no literal workflow command and sources the emitter" {
+    # The script sources the settled emitter API directly rather than relying on
+    # logging.sh's transitional copy of the escaper.
+    grep -q 'source "${PROJECT_ROOT}/helpers/gha.sh"' "$DETECTOR_SCRIPT"
+
+    # The command NAME followed by its closing delimiter or the space that starts
+    # its parameters, and the legacy `##[` spelling the runner also accepts. An
+    # earlier version matched `::error::` alone, which `::error file=x::y` walks
+    # straight past — the same escape found in the retry-run guard this morning,
+    # and the same shape of fix. `tests/unit/retry-run-annotations.bats` carries
+    # the repository-wide version of this pattern.
+    #
+    # A comment mentioning one of these fails the test too: a false positive
+    # costs a word, the reverse costs a regression.
+    local raw_annotations
+    raw_annotations=$(grep -cE '(::|##\[)(error|warning|notice)(::|\]|[[:space:]])' "$DETECTOR_SCRIPT" || true)
+    [ "$raw_annotations" -eq 0 ]
 }
 
 # MG6 field-vs-filename: filtering uses the .container JSON field, NOT the


### PR DESCRIPTION
Refs #1014 — the first two call sites. `helpers/gha.sh` landed in #1106; nothing
used it yet.

`scripts/check-version-drift.sh` (27 emissions) and
`scripts/detect-base-digest-drift.sh` (33) wrote GitHub Actions annotations by
hand — literals, inline escaping, and raw interpolation of registry and git
values. All of them go through `gha_error` / `gha_warning` / `gha_notice` now,
and no literal annotation spelling survives in either file.

Every format is a literal with one `%s` per interpolated value, so a value can no
longer become a format string or open a workflow command of its own.

`detect-base-digest-drift.sh` had a shape its sibling did not: two variables
pre-escaped a value that several annotations then consumed. Those call sites pass
the raw value and the intermediates are gone — the emitters escape as part of
emitting, so an already-escaped argument double-encodes and a `%` becomes
`%2525`. One of those variables shares its name with an unrelated `safe_ref`
assigned by `_sanitize_for_json` and consumed by `jq --arg` at four sites; that
one is untouched, because deleting on the name would have broken the JSON output.

Each file gains a structural test asserting the source line and that no literal
annotation spelling remains, with a header stating what it cannot see: an
argument order, or a command assembled at runtime as `printf '::%s::' error`.

## Verification

Unit suite 2399 collected, 0 failed. shellcheck clean. Checked independently of
the delegate that wrote the diff: no literal annotation remains, no call passes an
interpolated format, no hand-escape survives in front of an emitter, and every one
of the 60 removed messages is still present.

The raw-annotation guard in both structural tests matches the command name
followed by its closing delimiter or a space, and the legacy `##[` spelling. An
earlier version matched `::error::` alone, which `::error file=x::y` walks
straight past.
