### PR TITLE
refactor(ci): the stats-snapshot scripts emit through the helper

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -34,6 +34,7 @@ on:
       - "scripts/snapshot-stats.sh"
       - "scripts/collect-stats-snapshot.sh"
       - "scripts/commit-stats-snapshot.sh"
+      - "helpers/gha.sh"
       # Bot stats commits are authenticated with a GitHub App token (needed
       # to satisfy master's branch protection), which — unlike GITHUB_TOKEN —
       # DOES retrigger workflow push events, so this path naturally covers

--- a/scripts/collect-stats-snapshot.sh
+++ b/scripts/collect-stats-snapshot.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GHA_HELPER="${SCRIPT_DIR}/../helpers/gha.sh"
 if [[ ! -r "$GHA_HELPER" ]]; then
-  printf '%s\n' "scripts/collect-stats-snapshot.sh cannot run: required helper is not readable: $GHA_HELPER" >&2
+  # Static text. This runs before the helper that escapes workflow commands is
+  # loaded, so an interpolated path — which a symlinked invocation takes from
+  # its own directory name — would be the one place in this script where a
+  # newline in that name could open a workflow command. The path is a constant
+  # relative to this file, so naming it literally loses no diagnosis.
+  printf '%s\n' 'scripts/collect-stats-snapshot.sh cannot run: required helper helpers/gha.sh is not readable' >&2
   exit 2
 fi
 # shellcheck source=../helpers/gha.sh

--- a/scripts/collect-stats-snapshot.sh
+++ b/scripts/collect-stats-snapshot.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GHA_HELPER="${SCRIPT_DIR}/../helpers/gha.sh"
+if [[ ! -r "$GHA_HELPER" ]]; then
+  printf '%s\n' "scripts/collect-stats-snapshot.sh cannot run: required helper is not readable: $GHA_HELPER" >&2
+  exit 2
+fi
 # shellcheck source=../helpers/gha.sh
-source "${SCRIPT_DIR}/../helpers/gha.sh"
+source "$GHA_HELPER"
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   gha_error 'scripts/collect-stats-snapshot.sh is CI-only' >&2
@@ -43,7 +48,10 @@ if [[ "$still_missing" == "true" ]]; then
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-  gha_output still_missing "$still_missing"
+  if ! gha_output still_missing "$still_missing"; then
+    gha_warning 'Stats snapshot artifact was collected, but its workflow output could not be delivered'
+    exit 1
+  fi
 fi
 
 exit 0

--- a/scripts/collect-stats-snapshot.sh
+++ b/scripts/collect-stats-snapshot.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../helpers/gha.sh
+source "${SCRIPT_DIR}/../helpers/gha.sh"
+
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
-  echo "::error::scripts/collect-stats-snapshot.sh is CI-only" >&2
+  gha_error 'scripts/collect-stats-snapshot.sh is CI-only' >&2
   exit 2
 fi
 
@@ -26,20 +30,20 @@ for attempt in 1 2 3; do
     still_missing=false
     break
   fi
-  echo "::warning::Stats snapshot collection failed on attempt $attempt; some containers failed, but valid rows from successful containers are still kept"
+  gha_warning 'Stats snapshot collection failed on attempt %s; some containers failed, but valid rows from successful containers are still kept' "$attempt"
   if [[ "$attempt" -lt 3 ]]; then
     if ! sleep $((attempt * 5)); then
-      echo "::warning::Stats snapshot collection retry sleep failed after attempt $attempt"
+      gha_warning 'Stats snapshot collection retry sleep failed after attempt %s' "$attempt"
     fi
   fi
 done
 
 if [[ "$still_missing" == "true" ]]; then
-  echo "::warning::Stats snapshot collection ended with some containers still missing after 3 attempts"
+  gha_warning 'Stats snapshot collection ended with some containers still missing after 3 attempts'
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-  echo "still_missing=$still_missing" >> "$GITHUB_OUTPUT"
+  gha_output still_missing "$still_missing"
 fi
 
 exit 0

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../helpers/gha.sh
+source "${SCRIPT_DIR}/../helpers/gha.sh"
+
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
-  echo "::error::scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it opens and auto-merges stats PRs" >&2
+  gha_error 'scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it opens and auto-merges stats PRs' >&2
   exit 2
 fi
 
@@ -87,7 +91,7 @@ load_stats_validation_context() {
   fi
 
   if ! STATS_DATE_CEILING=$(date -u -d '+1 day' +%Y-%m-%d); then
-    echo "::error::Could not compute Docker stats date validation ceiling" >&2
+    gha_error 'Could not compute Docker stats date validation ceiling' >&2
     return 1
   fi
 }
@@ -142,7 +146,7 @@ emit_persisted_output() {
   local persisted_value="$1"
 
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "persisted=$persisted_value" >> "$GITHUB_OUTPUT"
+    gha_output persisted "$persisted_value"
   fi
 }
 
@@ -150,7 +154,7 @@ emit_still_missing_after_reconcile_output() {
   local still_missing_value="$1"
 
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "still_missing_after_reconcile=$still_missing_value" >> "$GITHUB_OUTPUT"
+    gha_output still_missing_after_reconcile "$still_missing_value"
   fi
 }
 
@@ -158,7 +162,7 @@ emit_still_missing_after_reconcile_output() {
 cleanup() {
   if [[ "$origin_restore_needed" == "true" && -n "$safe_origin_url" ]]; then
     if ! git remote set-url origin "$safe_origin_url" >/dev/null 2>&1; then
-      echo "::warning::Could not restore unauthenticated origin remote after stats snapshot"
+      gha_warning 'Could not restore unauthenticated origin remote after stats snapshot'
     fi
   fi
   rm -f "$CANDIDATE_FILE"
@@ -173,7 +177,7 @@ fi
 
 if [[ -n "$CANDIDATE_SOURCE_FILE" ]]; then
   if [[ ! -f "$CANDIDATE_SOURCE_FILE" ]]; then
-    echo "::error::CANDIDATE_SOURCE_FILE is set but does not exist: $CANDIDATE_SOURCE_FILE"
+    gha_error 'CANDIDATE_SOURCE_FILE is set but does not exist: %s' "$CANDIDATE_SOURCE_FILE"
     emit_persisted_output false
     exit 1
   fi
@@ -198,25 +202,25 @@ merge_candidate_into_worktree() {
   # manual deletion/correction of a row racing a stale collect artifact with the
   # same (date, container) key. Tombstones or base-SHA deltas would be a larger
   # design for a narrow, non-security edge case in an append-only dashboard log.
-  local merged_tmp merge_stderr_tmp
+  local merged_tmp merge_stderr_tmp merge_diagnostic
 
   if ! mkdir -p "$(dirname "$STATS_FILE")"; then
-    echo "::warning::Could not prepare stats directory before stats candidate merge"
+    gha_warning 'Could not prepare stats directory before stats candidate merge'
     return 1
   fi
   if [[ ! -f "$STATS_FILE" ]]; then
     : > "$STATS_FILE" || {
-      echo "::warning::Could not create missing stats file before stats candidate merge"
+      gha_warning 'Could not create missing stats file before stats candidate merge'
       return 1
     }
   fi
 
   if ! merged_tmp=$(mktemp); then
-    echo "::warning::Could not create temporary file for stats candidate merge"
+    gha_warning 'Could not create temporary file for stats candidate merge'
     return 1
   fi
   if ! merge_stderr_tmp=$(mktemp); then
-    echo "::warning::Could not create temporary stderr file for stats candidate merge"
+    gha_warning 'Could not create temporary stderr file for stats candidate merge'
     rm -f "$merged_tmp"
     return 1
   fi
@@ -279,7 +283,7 @@ merge_candidate_into_worktree() {
               | if .candidate_raw_counts[$line] > (.stats_raw_counts[$line] // 0) then
                   . as $state
                   | (
-                      "::warning::Dropping nonconforming candidate-only stats line before signed PR"
+                      "Dropping nonconforming candidate-only stats line before signed PR"
                       | stderr
                     )
                   | $state
@@ -304,18 +308,20 @@ merge_candidate_into_worktree() {
       end
   ' "$STATS_FILE" "$CANDIDATE_FILE" > "$merged_tmp" 2> "$merge_stderr_tmp"; then
     if [[ -s "$merge_stderr_tmp" ]]; then
-      cat "$merge_stderr_tmp" >&2
+      while IFS= read -r merge_diagnostic || [[ -n "$merge_diagnostic" ]]; do
+        gha_warning '%s' "$merge_diagnostic" >&2
+      done < "$merge_stderr_tmp"
     fi
     if mv "$merged_tmp" "$STATS_FILE"; then
       rm -f "$merge_stderr_tmp"
       return 0
     fi
-    echo "::warning::Could not replace stats file after stats candidate merge"
+    gha_warning 'Could not replace stats file after stats candidate merge'
     rm -f "$merged_tmp" "$merge_stderr_tmp"
     return 1
   fi
 
-  echo "::warning::Could not merge collected stats candidate into the worktree"
+  gha_warning 'Could not merge collected stats candidate into the worktree'
   rm -f "$merged_tmp" "$merge_stderr_tmp"
   return 1
 }
@@ -343,12 +349,12 @@ validate_stats_file_jsonl() {
     | select(.invalid_line_number != null)
     | .invalid_line_number
   ' "$STATS_FILE"); then
-    echo "::warning::Could not validate stats snapshot JSONL before commit"
+    gha_warning 'Could not validate stats snapshot JSONL before commit'
     return 1
   fi
 
   if [[ -n "$invalid_line" ]]; then
-    echo "::warning::Refusing to commit stats snapshot because $STATS_FILE has invalid JSON at line $invalid_line"
+    gha_warning 'Refusing to commit stats snapshot because %s has invalid JSON at line %s' "$STATS_FILE" "$invalid_line"
     return 1
   fi
 
@@ -360,7 +366,7 @@ compute_still_missing_after_reconcile() {
   local still_missing
 
   if ! today_utc=$(date -u +%Y-%m-%d); then
-    echo "::warning::Could not compute Docker stats completion date" >&2
+    gha_warning 'Could not compute Docker stats completion date' >&2
     return 1
   fi
 
@@ -392,7 +398,7 @@ compute_still_missing_after_reconcile() {
     | ($container_allowlist | split("\n") | map(select(. != ""))) as $containers
     | ([$containers[] | select(($state.seen[.] // false) | not)] | length > 0)
   ' "$STATS_FILE"); then
-    echo "::warning::Could not reconcile stats snapshot completion state" >&2
+    gha_warning 'Could not reconcile stats snapshot completion state' >&2
     return 1
   fi
 
@@ -401,7 +407,7 @@ compute_still_missing_after_reconcile() {
       printf '%s\n' "$still_missing"
       ;;
     *)
-      echo "::warning::Unexpected stats snapshot completion state: $still_missing" >&2
+      gha_warning 'Unexpected stats snapshot completion state: %s' "$still_missing" >&2
       return 1
       ;;
   esac
@@ -415,7 +421,7 @@ delete_remote_pr_branch() {
   fi
 
   if ! git push origin --delete "$branch" >/dev/null 2>&1; then
-    echo "::warning::Could not delete stale stats snapshot branch $branch after failure"
+    gha_warning 'Could not delete stale stats snapshot branch %s after failure' "$branch"
     return 1
   fi
 
@@ -429,7 +435,7 @@ cleanup_failed_pr() {
 
   if [[ -n "$pr_number" ]]; then
     if ! gh pr close "$pr_number" --delete-branch 2>&1; then
-      echo "::warning::Could not close stale stats snapshot PR #$pr_number or delete branch $pr_branch after failure"
+      gha_warning 'Could not close stale stats snapshot PR #%s or delete branch %s after failure' "$pr_number" "$pr_branch"
       if [[ "$remote_branch_maybe_pushed" == "true" ]]; then
         delete_remote_pr_branch "$pr_branch" || true
       fi
@@ -458,7 +464,7 @@ parse_created_pr_number() {
     return 0
   fi
 
-  echo "::warning::Could not determine stats snapshot PR number after creation" >&2
+  gha_warning 'Could not determine stats snapshot PR number after creation' >&2
   return 1
 }
 
@@ -472,12 +478,12 @@ wait_for_pr_merge() {
 
   while true; do
     if ! now_epoch=$(date +%s); then
-      echo "::warning::Could not read wall-clock time while waiting for stats snapshot PR #$pr_number"
+      gha_warning 'Could not read wall-clock time while waiting for stats snapshot PR #%s' "$pr_number"
       return 1
     fi
     remaining_seconds=$((deadline_epoch - now_epoch))
     if ((remaining_seconds <= 0)); then
-      echo "::warning::Timed out waiting for stats snapshot PR #$pr_number to merge"
+      gha_warning 'Timed out waiting for stats snapshot PR #%s to merge' "$pr_number"
       return 1
     fi
 
@@ -485,32 +491,32 @@ wait_for_pr_merge() {
       consecutive_query_failures=$((consecutive_query_failures + 1))
       printf '%s\n' "$pr_view" >&2
       if ((consecutive_query_failures >= max_query_failures)); then
-        echo "::warning::Could not inspect stats snapshot PR #$pr_number merge state after $consecutive_query_failures consecutive attempt(s)"
+        gha_warning 'Could not inspect stats snapshot PR #%s merge state after %s consecutive attempt(s)' "$pr_number" "$consecutive_query_failures"
         return 1
       fi
-      echo "::warning::Could not inspect stats snapshot PR #$pr_number merge state (attempt $consecutive_query_failures/$max_query_failures); continuing within the remaining wait budget"
+      gha_warning 'Could not inspect stats snapshot PR #%s merge state (attempt %s/%s); continuing within the remaining wait budget' "$pr_number" "$consecutive_query_failures" "$max_query_failures"
     else
       consecutive_query_failures=0
 
       IFS=$'\t' read -r state merged_at <<< "$pr_view"
       if [[ "$state" == "MERGED" || -n "${merged_at:-}" ]]; then
-        echo "::notice::Stats snapshot PR #$pr_number merged"
+        gha_notice 'Stats snapshot PR #%s merged' "$pr_number"
         return 0
       fi
 
       if [[ "$state" == "CLOSED" ]]; then
-        echo "::warning::Stats snapshot PR #$pr_number closed without merging"
+        gha_warning 'Stats snapshot PR #%s closed without merging' "$pr_number"
         return 1
       fi
     fi
 
     if ! now_epoch=$(date +%s); then
-      echo "::warning::Could not read wall-clock time while waiting for stats snapshot PR #$pr_number"
+      gha_warning 'Could not read wall-clock time while waiting for stats snapshot PR #%s' "$pr_number"
       return 1
     fi
     remaining_seconds=$((deadline_epoch - now_epoch))
     if ((remaining_seconds <= 0)); then
-      echo "::warning::Timed out waiting for stats snapshot PR #$pr_number to merge"
+      gha_warning 'Timed out waiting for stats snapshot PR #%s to merge' "$pr_number"
       return 1
     fi
 
@@ -519,7 +525,7 @@ wait_for_pr_merge() {
       sleep_seconds="$remaining_seconds"
     fi
     if ! sleep "$sleep_seconds"; then
-      echo "::warning::Stats snapshot PR merge polling sleep failed"
+      gha_warning 'Stats snapshot PR merge polling sleep failed'
       return 1
     fi
   done
@@ -537,7 +543,7 @@ validate_pr_budget_config() {
       ! [[ "$max_query_failures" =~ ^[0-9]+$ ]] ||
       [[ "$poll_seconds" -eq 0 ]] ||
       [[ "$max_query_failures" -eq 0 ]]; then
-    echo "::warning::Invalid stats PR merge polling configuration"
+    gha_warning 'Invalid stats PR merge polling configuration'
     return 1
   fi
 }
@@ -547,7 +553,7 @@ remaining_pr_budget_seconds() {
   local now_epoch
 
   if ! now_epoch=$(date +%s); then
-    echo "::warning::Could not read wall-clock time for stats snapshot PR budget" >&2
+    gha_warning 'Could not read wall-clock time for stats snapshot PR budget' >&2
     printf '0\n'
     return 1
   fi
@@ -578,7 +584,7 @@ sleep_before_retry() {
     fi
 
     if ! sleep "$sleep_seconds"; then
-      echo "::warning::Stats snapshot retry sleep failed after attempt $attempt"
+      gha_warning 'Stats snapshot retry sleep failed after attempt %s' "$attempt"
     fi
   fi
 }
@@ -587,12 +593,12 @@ reset_worktree_to_fresh_master() {
   local attempt="$1"
 
   if ! git fetch --force origin refs/heads/master:refs/remotes/origin/master; then
-    echo "::warning::Could not fetch origin/master before stats snapshot attempt $attempt"
+    gha_warning 'Could not fetch origin/master before stats snapshot attempt %s' "$attempt"
     return 1
   fi
 
   if ! git reset --hard origin/master; then
-    echo "::warning::Could not reset stats snapshot worktree before attempt $attempt"
+    gha_warning 'Could not reset stats snapshot worktree before attempt %s' "$attempt"
     return 1
   fi
 }
@@ -608,9 +614,9 @@ ensure_stats_snapshot_pr() {
       --title "chore(stats): daily Docker Hub pull-count snapshot" \
       --body "Automated Docker Hub pull-count snapshot for this workflow run." 2>&1); then
     printf '%s\n' "$pr_create_output" >&2
-    echo "::warning::Could not create stats snapshot PR from $pr_branch" >&2
+    gha_warning 'Could not create stats snapshot PR from %s' "$pr_branch" >&2
     if pr_number=$(parse_created_pr_number "$pr_branch" "$pr_create_output"); then
-      echo "::notice::Using existing stats snapshot PR #$pr_number for $pr_branch" >&2
+      gha_notice 'Using existing stats snapshot PR #%s for %s' "$pr_number" "$pr_branch" >&2
       printf '%s\n' "$pr_number"
       return 0
     fi
@@ -638,7 +644,7 @@ persist_stats_snapshot_via_pr() {
   local attempts_remaining attempt_wait_epoch now_epoch_for_attempt_cap
 
   if [[ -z "$stats_pr_branch" ]]; then
-    echo "::warning::GITHUB_RUN_ID or STATS_PR_BRANCH is required to name the stats snapshot PR branch"
+    gha_warning 'GITHUB_RUN_ID or STATS_PR_BRANCH is required to name the stats snapshot PR branch'
     return 1
   fi
 
@@ -647,7 +653,7 @@ persist_stats_snapshot_via_pr() {
   fi
 
   if ! start_epoch=$(date +%s); then
-    echo "::warning::Could not read wall-clock time before stats snapshot PR attempts"
+    gha_warning 'Could not read wall-clock time before stats snapshot PR attempts'
     return 1
   fi
   deadline_epoch=$((start_epoch + total_budget_seconds))
@@ -657,7 +663,7 @@ persist_stats_snapshot_via_pr() {
       remaining_seconds=0
     fi
     if ((remaining_seconds < min_wait_seconds)); then
-      echo "::warning::Not enough stats PR budget remains before attempt $attempt (${remaining_seconds}s left, need at least ${min_wait_seconds}s)"
+      gha_warning 'Not enough stats PR budget remains before attempt %s (%ss left, need at least %ss)' "$attempt" "$remaining_seconds" "$min_wait_seconds"
       return 1
     fi
 
@@ -680,7 +686,7 @@ persist_stats_snapshot_via_pr() {
     else
       diff_status=$?
       if [[ "$diff_status" -gt 1 ]]; then
-        echo "::warning::Could not inspect stats snapshot diff on attempt $attempt"
+        gha_warning 'Could not inspect stats snapshot diff on attempt %s' "$attempt"
         sleep_before_retry "$attempt" "$deadline_epoch"
         continue
       fi
@@ -692,31 +698,31 @@ persist_stats_snapshot_via_pr() {
     fi
 
     if ! git checkout -B "$attempt_pr_branch"; then
-      echo "::warning::Could not create or reset stats snapshot branch $attempt_pr_branch on attempt $attempt"
+      gha_warning 'Could not create or reset stats snapshot branch %s on attempt %s' "$attempt_pr_branch" "$attempt"
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
     fi
 
     if ! git add "$STATS_FILE"; then
-      echo "::warning::Could not stage stats snapshot on attempt $attempt"
+      gha_warning 'Could not stage stats snapshot on attempt %s' "$attempt"
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
     fi
 
     if ! git commit -m "chore(stats): daily Docker Hub pull-count snapshot" -- "$STATS_FILE"; then
-      echo "::warning::Could not commit stats snapshot on attempt $attempt"
+      gha_warning 'Could not commit stats snapshot on attempt %s' "$attempt"
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
     fi
 
     if ! head_commit=$(git rev-parse HEAD); then
-      echo "::warning::Could not resolve stats snapshot head commit on attempt $attempt"
+      gha_warning 'Could not resolve stats snapshot head commit on attempt %s' "$attempt"
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
     fi
 
     if ! git push --force origin "HEAD:${attempt_pr_branch}"; then
-      echo "::warning::Could not push stats snapshot branch $attempt_pr_branch on attempt $attempt"
+      gha_warning 'Could not push stats snapshot branch %s on attempt %s' "$attempt_pr_branch" "$attempt"
       cleanup_failed_pr "" "$attempt_pr_branch" true
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
@@ -730,15 +736,15 @@ persist_stats_snapshot_via_pr() {
     fi
 
     if ! sleep 2; then
-      echo "::warning::Stats snapshot PR label delay failed on attempt $attempt"
+      gha_warning 'Stats snapshot PR label delay failed on attempt %s' "$attempt"
     elif ! gh pr edit "$attempt_pr_number" --add-label "automation" 2>&1; then
-      echo "::warning::Failed to apply automation label to stats snapshot PR #${attempt_pr_number}; PR created successfully — continuing"
+      gha_warning 'Failed to apply automation label to stats snapshot PR #%s; PR created successfully — continuing' "$attempt_pr_number"
     fi
 
     if gh pr merge "$attempt_pr_number" --squash --auto --delete-branch --match-head-commit "$head_commit" 2>&1; then
-      echo "::notice::Auto-merge enabled for stats snapshot PR #$attempt_pr_number"
+      gha_notice 'Auto-merge enabled for stats snapshot PR #%s' "$attempt_pr_number"
     else
-      echo "::warning::Failed to enable auto-merge for stats snapshot PR #$attempt_pr_number on attempt $attempt"
+      gha_warning 'Failed to enable auto-merge for stats snapshot PR #%s on attempt %s' "$attempt_pr_number" "$attempt"
       cleanup_failed_pr "$attempt_pr_number" "$attempt_pr_branch" "$attempt_remote_branch_maybe_pushed"
       sleep_before_retry "$attempt" "$deadline_epoch"
       continue
@@ -785,10 +791,10 @@ if [[ -n "$push_token" && -n "$github_repository" ]]; then
   export GH_TOKEN="$push_token"
   origin_restore_needed=true
   if ! git remote set-url origin "https://x-access-token:${push_token}@github.com/${github_repository}.git"; then
-    echo "::warning::Could not configure authenticated origin remote for stats snapshot"
+    gha_warning 'Could not configure authenticated origin remote for stats snapshot'
   fi
 else
-  echo "::warning::Missing push token or repository; stats snapshot push may not be authenticated"
+  gha_warning 'Missing push token or repository; stats snapshot push may not be authenticated'
 fi
 
 persisted=false
@@ -807,7 +813,7 @@ fi
 emit_still_missing_after_reconcile_output "$still_missing_after_reconcile"
 
 if [[ "$persisted" != "true" ]]; then
-  echo "::error::Could not persist stats snapshot this run — another same-day trigger may still cover it"
+  gha_error 'Could not persist stats snapshot this run — another same-day trigger may still cover it'
   exit 1
 fi
 

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GHA_HELPER="${SCRIPT_DIR}/../helpers/gha.sh"
+if [[ ! -r "$GHA_HELPER" ]]; then
+  printf '%s\n' "scripts/commit-stats-snapshot.sh cannot run: required helper is not readable: $GHA_HELPER" >&2
+  exit 2
+fi
 # shellcheck source=../helpers/gha.sh
-source "${SCRIPT_DIR}/../helpers/gha.sh"
+source "$GHA_HELPER"
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   gha_error 'scripts/commit-stats-snapshot.sh is CI-only; refusing to run outside GitHub Actions because it opens and auto-merges stats PRs' >&2
@@ -146,7 +151,14 @@ emit_persisted_output() {
   local persisted_value="$1"
 
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    gha_output persisted "$persisted_value"
+    if ! gha_output persisted "$persisted_value"; then
+      if [[ "$persisted_value" == "true" ]]; then
+        gha_warning 'Stats snapshot was persisted, but its workflow output could not be delivered'
+      else
+        gha_warning 'Stats snapshot was not persisted, and its workflow output could not be delivered'
+      fi
+      return 1
+    fi
   fi
 }
 
@@ -154,7 +166,14 @@ emit_still_missing_after_reconcile_output() {
   local still_missing_value="$1"
 
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    gha_output still_missing_after_reconcile "$still_missing_value"
+    if ! gha_output still_missing_after_reconcile "$still_missing_value"; then
+      if [[ "$still_missing_value" == "true" ]]; then
+        gha_warning 'Stats snapshot reconciliation completed with containers still missing, but its workflow output could not be delivered'
+      else
+        gha_warning 'Stats snapshot reconciliation completed with no containers missing, but its workflow output could not be delivered'
+      fi
+      return 1
+    fi
   fi
 }
 

--- a/scripts/commit-stats-snapshot.sh
+++ b/scripts/commit-stats-snapshot.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GHA_HELPER="${SCRIPT_DIR}/../helpers/gha.sh"
 if [[ ! -r "$GHA_HELPER" ]]; then
-  printf '%s\n' "scripts/commit-stats-snapshot.sh cannot run: required helper is not readable: $GHA_HELPER" >&2
+  # Static text. This runs before the helper that escapes workflow commands is
+  # loaded, so an interpolated path — which a symlinked invocation takes from
+  # its own directory name — would be the one place in this script where a
+  # newline in that name could open a workflow command. The path is a constant
+  # relative to this file, so naming it literally loses no diagnosis.
+  printf '%s\n' 'scripts/commit-stats-snapshot.sh cannot run: required helper helpers/gha.sh is not readable' >&2
   exit 2
 fi
 # shellcheck source=../helpers/gha.sh

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -205,6 +205,11 @@ get_mock_call_count() {
 #
 # Last assignment wins, because that is what the runner does: it reads the file
 # top to bottom and a later record overwrites an earlier one.
+#
+# One bound this cannot hold: callers use `$(get_output NAME)`, and command
+# substitution strips trailing newlines, so a value ending in one arrives one
+# short. Nothing the function does can prevent that — a caller needing such a
+# value must read it without a subshell.
 get_output() {
     local key="$1"
     local line record delimiter value result="" found=0 first terminated
@@ -242,7 +247,12 @@ get_output() {
             done
             if [[ "$record" == "$key" ]]; then
                 if [[ "$terminated" -eq 1 ]]; then
-                    result="$value"
+                    # One trailing CR is the record's line terminator, not part
+                    # of the value. `gha_output` duplicates a CR the value
+                    # genuinely ends with precisely so this strip leaves it, so
+                    # removing exactly one inverts what the writer did — and it
+                    # is also right for a producer whose file simply uses CRLF.
+                    result="${value%$'\r'}"
                     found=1
                 else
                     # A block for our key that no delimiter closed: what we

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -220,12 +220,20 @@ get_output() {
     # inside another key's multiline value as a record of its own, so
     # `OTHER<<D` / `TARGET=forged` / `D` would answer `forged` for TARGET.
     #
-    # Which of the two forms a line is, is decidable: it is a block header when
-    # the text before the first `<<` is a legal output name, and a record when
-    # the text before the first `=` is. That ordering keeps `X=a<<b` a record of
-    # X, because `X=a` is not a legal name.
+    # ANY line containing `<<` opens a block. An earlier version required the
+    # name to match a charset, which put every name outside that charset back
+    # inside the hole: `OTHER.INVALID<<D` failed the test, the header was
+    # skipped, and `TARGET=forged` was read as a record again. Guessing the
+    # runner's name grammar is the wrong shape — each guess leaves the names it
+    # did not think of. Recognising the marker instead cannot leave any.
+    #
+    # The cost is that `X=a<<b`, which might be a record whose value contains
+    # `<<`, is read as a block header for `X=a` and therefore answers absent for
+    # X. That is the direction to be wrong in: an ambiguous line yields no
+    # value, never a wrong one, and a test oracle that returns nothing fails
+    # loudly where one that returns a forged value passes.
     while IFS= read -r line || [[ -n "$line" ]]; do
-        if [[ "$line" == *'<<'* ]] && [[ "${line%%<<*}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+        if [[ "$line" == *'<<'* ]]; then
             record="${line%%<<*}"
             delimiter="${line#*<<}"
             value=""
@@ -235,7 +243,12 @@ get_output() {
             first=1
             terminated=0
             while IFS= read -r line || [[ -n "$line" ]]; do
-                if [[ "$line" == "$delimiter" ]]; then
+                # An empty delimiter is malformed — the runner rejects it — and
+                # honouring it would let the first blank line close the block and
+                # hand the rest of the file back to record classification, which
+                # is the hole this whole branch exists to close. Consume to EOF
+                # instead, so a malformed header answers absent.
+                if [[ -n "$delimiter" && "$line" == "$delimiter" ]]; then
                     terminated=1
                     break
                 fi

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -198,45 +198,70 @@ get_mock_call_count() {
 # Read one value out of a $GITHUB_OUTPUT file, decoding either form the
 # protocol defines: `NAME=value` on one line, or `NAME<<DELIM` followed by the
 # value's lines and a line holding DELIM alone. `helpers/gha.sh` always writes
-# the second form, so a reader that greps `^NAME=` finds nothing at all once a
-# script has been migrated onto it — which is how three tests went red without
-# their subject changing behaviour.
+# the second form, even for a one-line value, so a reader that greps `^NAME=`
+# finds nothing at all once a script has been migrated onto it. The value a
+# runner decodes is the same either way; the raw file text is not, and that text
+# is what a grep-shaped reader was reading.
 #
 # Last assignment wins, because that is what the runner does: it reads the file
 # top to bottom and a later record overwrites an earlier one.
 get_output() {
     local key="$1"
-    local line delimiter value result="" found=0 first
+    local line record delimiter value result="" found=0 first terminated
 
-    while IFS= read -r line; do
-        case "$line" in
-            "${key}="*)
+    # Every line is classified at the top level before anything is read as a
+    # record, and a block is consumed whole no matter whose it is. Matching
+    # `${key}=` anywhere in the file instead would read a line that is DATA
+    # inside another key's multiline value as a record of its own, so
+    # `OTHER<<D` / `TARGET=forged` / `D` would answer `forged` for TARGET.
+    #
+    # Which of the two forms a line is, is decidable: it is a block header when
+    # the text before the first `<<` is a legal output name, and a record when
+    # the text before the first `=` is. That ordering keeps `X=a<<b` a record of
+    # X, because `X=a` is not a legal name.
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" == *'<<'* ]] && [[ "${line%%<<*}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+            record="${line%%<<*}"
+            delimiter="${line#*<<}"
+            value=""
+            # Count lines rather than test the accumulator for emptiness: a
+            # value whose first line is blank is legal, and testing `-n` would
+            # swallow its separator.
+            first=1
+            terminated=0
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                if [[ "$line" == "$delimiter" ]]; then
+                    terminated=1
+                    break
+                fi
+                if [[ "$first" -eq 0 ]]; then
+                    value+=$'\n'
+                fi
+                first=0
+                value+="$line"
+            done
+            if [[ "$record" == "$key" ]]; then
+                if [[ "$terminated" -eq 1 ]]; then
+                    result="$value"
+                    found=1
+                else
+                    # A block for our key that no delimiter closed: what we
+                    # would report is not what the writer meant to write, and a
+                    # later truncated record must not leave an earlier value
+                    # standing. Absent is the only honest answer.
+                    result=""
+                    found=0
+                fi
+            fi
+        elif [[ "$line" == *=* ]] && [[ "${line%%=*}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+            if [[ "${line%%=*}" == "$key" ]]; then
                 result="${line#*=}"
+                # A CR here terminates the record on a Windows runner; it is not
+                # part of the value.
+                result="${result%$'\r'}"
                 found=1
-                ;;
-            "${key}"'<<'*)
-                delimiter="${line#*<<}"
-                value=""
-                # Count lines rather than test the accumulator for emptiness: a
-                # value whose first line is blank is legal, and testing `-n`
-                # would swallow its separator.
-                first=1
-                while IFS= read -r line; do
-                    if [[ "$line" == "$delimiter" ]]; then
-                        result="$value"
-                        found=1
-                        break
-                    fi
-                    if [[ "$first" -eq 0 ]]; then
-                        value+=$'\n'
-                    fi
-                    first=0
-                    value+="$line"
-                done
-                # An unterminated block leaves `found` as it was, so a truncated
-                # file reads as absent rather than as a silently short value.
-                ;;
-        esac
+            fi
+        fi
     done < "$GITHUB_OUTPUT"
 
     [[ "$found" -eq 1 ]] || return 1

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -195,5 +195,53 @@ get_mock_call_count() {
     fi
 }
 
+# Read one value out of a $GITHUB_OUTPUT file, decoding either form the
+# protocol defines: `NAME=value` on one line, or `NAME<<DELIM` followed by the
+# value's lines and a line holding DELIM alone. `helpers/gha.sh` always writes
+# the second form, so a reader that greps `^NAME=` finds nothing at all once a
+# script has been migrated onto it — which is how three tests went red without
+# their subject changing behaviour.
+#
+# Last assignment wins, because that is what the runner does: it reads the file
+# top to bottom and a later record overwrites an earlier one.
+get_output() {
+    local key="$1"
+    local line delimiter value result="" found=0 first
+
+    while IFS= read -r line; do
+        case "$line" in
+            "${key}="*)
+                result="${line#*=}"
+                found=1
+                ;;
+            "${key}"'<<'*)
+                delimiter="${line#*<<}"
+                value=""
+                # Count lines rather than test the accumulator for emptiness: a
+                # value whose first line is blank is legal, and testing `-n`
+                # would swallow its separator.
+                first=1
+                while IFS= read -r line; do
+                    if [[ "$line" == "$delimiter" ]]; then
+                        result="$value"
+                        found=1
+                        break
+                    fi
+                    if [[ "$first" -eq 0 ]]; then
+                        value+=$'\n'
+                    fi
+                    first=0
+                    value+="$line"
+                done
+                # An unterminated block leaves `found` as it was, so a truncated
+                # file reads as absent rather than as a silently short value.
+                ;;
+        esac
+    done < "$GITHUB_OUTPUT"
+
+    [[ "$found" -eq 1 ]] || return 1
+    printf '%s\n' "$result"
+}
+
 # Export variables
 export PROJECT_ROOT SCRIPTS_DIR HELPERS_DIR TESTS_DIR FIXTURES_DIR

--- a/tests/unit/dockerhub-stats-collect.bats
+++ b/tests/unit/dockerhub-stats-collect.bats
@@ -45,7 +45,10 @@ teardown() {
 
     run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"scripts/collect-stats-snapshot.sh cannot run: required helper is not readable: $TEST_REPO/scripts/../helpers/gha.sh"* ]]
+    [[ "$output" == *"scripts/collect-stats-snapshot.sh cannot run: required helper helpers/gha.sh is not readable"* ]]
+    # The message carries no interpolation, so a hostile directory name cannot
+    # reach the log through it.
+    [[ "$output" != *"$TEST_REPO"* ]]
 }
 
 @test "collect-stats-snapshot stops early on a fully successful first attempt" {

--- a/tests/unit/dockerhub-stats-collect.bats
+++ b/tests/unit/dockerhub-stats-collect.bats
@@ -36,8 +36,16 @@ teardown() {
     unset GITHUB_ACTIONS
 
     run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"::error::scripts/collect-stats-snapshot.sh is CI-only"* ]]
+}
+
+@test "collect-stats-snapshot reports an unreadable helper before its CI-only guard" {
+    rm -f "$TEST_REPO/helpers/gha.sh"
+
+    run bash -c 'cd "$1" && ./scripts/collect-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"scripts/collect-stats-snapshot.sh cannot run: required helper is not readable: $TEST_REPO/scripts/../helpers/gha.sh"* ]]
 }
 
 @test "collect-stats-snapshot stops early on a fully successful first attempt" {

--- a/tests/unit/dockerhub-stats-collect.bats
+++ b/tests/unit/dockerhub-stats-collect.bats
@@ -6,7 +6,11 @@ setup() {
     setup_temp_dir
     TEST_REPO="$TEST_TEMP_DIR/repo"
     FAKE_STATE="$TEST_TEMP_DIR/state"
-    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$FAKE_STATE"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$TEST_REPO/helpers" "$FAKE_STATE"
+    # The script is mounted below by symlink, and Bash does not resolve a
+    # symlink in BASH_SOURCE — so the helper it sources resolves inside this
+    # fixture, not in the repository it came from.
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$TEST_REPO/helpers/"
 
     ln -s "$SCRIPTS_DIR/collect-stats-snapshot.sh" "$TEST_REPO/scripts/collect-stats-snapshot.sh"
 
@@ -26,11 +30,6 @@ EOF
 
 teardown() {
     teardown_temp_dir
-}
-
-get_output() {
-    local key="$1"
-    grep "^${key}=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
 }
 
 @test "collect-stats-snapshot refuses to run outside GitHub Actions" {

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -6,12 +6,13 @@ setup() {
     setup_temp_dir
     TEST_REPO="$TEST_TEMP_DIR/repo"
     FAKE_GIT_STATE="$TEST_TEMP_DIR/git-state"
-    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$FAKE_GIT_STATE"
+    mkdir -p "$TEST_REPO/scripts" "$TEST_REPO/stats" "$TEST_REPO/bin" "$TEST_REPO/helpers" "$FAKE_GIT_STATE"
     mkdir -p "$TEST_REPO/alpha" "$TEST_REPO/gamma"
     printf 'FROM scratch\n' > "$TEST_REPO/alpha/Dockerfile"
     printf 'FROM scratch\n' > "$TEST_REPO/gamma/Dockerfile"
 
     ln -s "$SCRIPTS_DIR/commit-stats-snapshot.sh" "$TEST_REPO/scripts/commit-stats-snapshot.sh"
+    cp "${SCRIPTS_DIR}/../helpers/gha.sh" "$TEST_REPO/helpers/"
     # Simulates what the (separate, already-run) collect step left behind.
     printf '{"ts":"2026-07-12T07:00:00Z","date":"2026-07-12","container":"alpha","pull_count":42,"star_count":1,"source":"dockerhub"}\n' \
         > "$TEST_REPO/stats/dockerhub-pull-history.jsonl"
@@ -513,11 +514,6 @@ EOF
 
 teardown() {
     teardown_temp_dir
-}
-
-get_output() {
-    local key="$1"
-    grep "^${key}=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
 }
 
 @test "commit-stats-snapshot refuses to run outside GitHub Actions before touching git state" {

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -520,9 +520,18 @@ teardown() {
     unset GITHUB_ACTIONS
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"::error::scripts/commit-stats-snapshot.sh is CI-only"* ]]
 
+    [ ! -e "$FAKE_GIT_STATE/git.log" ]
+}
+
+@test "commit-stats-snapshot reports an unreadable helper before its CI-only guard" {
+    rm -f "$TEST_REPO/helpers/gha.sh"
+
+    run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"scripts/commit-stats-snapshot.sh cannot run: required helper is not readable: $TEST_REPO/scripts/../helpers/gha.sh"* ]]
     [ ! -e "$FAKE_GIT_STATE/git.log" ]
 }
 

--- a/tests/unit/dockerhub-stats-commit.bats
+++ b/tests/unit/dockerhub-stats-commit.bats
@@ -531,7 +531,10 @@ teardown() {
 
     run bash -c 'cd "$1" && ./scripts/commit-stats-snapshot.sh' _ "$TEST_REPO"
     [ "$status" -eq 2 ]
-    [[ "$output" == *"scripts/commit-stats-snapshot.sh cannot run: required helper is not readable: $TEST_REPO/scripts/../helpers/gha.sh"* ]]
+    [[ "$output" == *"scripts/commit-stats-snapshot.sh cannot run: required helper helpers/gha.sh is not readable"* ]]
+    # The message carries no interpolation, so a hostile directory name cannot
+    # reach the log through it.
+    [[ "$output" != *"$TEST_REPO"* ]]
     [ ! -e "$FAKE_GIT_STATE/git.log" ]
 }
 


### PR DESCRIPTION
Refs #1014 — the third call site, stacked on #1114.

`scripts/commit-stats-snapshot.sh` (51 annotations) and
`scripts/collect-stats-snapshot.sh` (4) wrote workflow commands by hand, plus
three `$GITHUB_OUTPUT` records between them. All go through `helpers/gha.sh`, and
no literal annotation spelling survives in either file. Every message here is
plain text with no `%`, CR or LF, so the bytes a runner receives are unchanged —
the 34 assertions already locking that text are untouched and still pass.

Three things this slice had to solve that the earlier ones did not.

**Reading `$GITHUB_OUTPUT` back.** `gha_output` always uses the `NAME<<DELIM`
form, including for a one-line value, so a test reading it with `grep "^NAME="`
finds nothing the moment its script migrates. Two test files carried such a
reader. There is now one decoder in `tests/test_helper.bash`, which both load: it
takes either form, keeps the last assignment as the runner does, and returns
non-zero on an absent key rather than a wrong value. Any line containing `<<`
opens a block — an earlier version required the name to match a charset, which
put every name outside that guess back inside the hole it was closing.

**Refusing without a file.** Both scripts sourced the helper before checking
`GITHUB_ACTIONS`, so a missing helper killed them inside `source` with status 1
and a raw Bash message instead of their own refusal. A readability precondition
now precedes the source and reports in plain text on stderr; the CI-only guard
keeps its position, wording and exit 2. The refusal tests pin the exact code,
which is what let the two cases look alike.

**Failing after an irreversible step.** `gha_output` failing after the merge
aborted with no message. It still fails — the workflow step that reports an
incomplete snapshot is skipped when its input is absent, so tolerating the
failure would turn a fail-closed check into a silent pass — but it now warns
first, distinguishing "persisted and could not be reported" from "not persisted".
A local run with `GITHUB_OUTPUT` unset attempts nothing and still exits 0.

`helpers/gha.sh` also joins `update-dashboard.yaml`'s push path filter, which
listed both scripts but not the helper they now source.

## Verification

Unit suite 2399 collected, 0 failed. shellcheck reports nothing new. The output
decoder answers 22 inputs correctly, 9 of which it must refuse — a record inside
a foreign block, a block header inside one, a name outside every charset, an
empty delimiter, a truncated block that must not revive an earlier value.

Both scripts refuse with exit 2 and their own message, with and without the
helper present, run from a sandbox rather than the repository root because
`collect-stats-snapshot.sh` invokes a script that appends to tracked data.

## Left as issues

Four findings from review are real and identical on this branch's base, verified
with `git blame` and `git show <base>:<file>`: #1108 (a failed container
discovery reports a complete, green snapshot), #1109 (a run crossing UTC midnight
reconciles against the wrong day), #1110 (captured diagnostics deleted unread,
unguarded copies, cleanup paths that swallow failures), #1111 (helper resolution
follows a symlink, so sourcing runs adjacent code before any guard).
