### PR TITLE
fix(ci): a short enumeration no longer authorises a write outside the repo

### DIFF
--- a/github-runner/generate-dockerfile.sh
+++ b/github-runner/generate-dockerfile.sh
@@ -22,6 +22,7 @@ HELPERS_DIR="$(cd "$SCRIPT_DIR/../helpers" && pwd)"
 source "$HELPERS_DIR/logging.sh"
 source "$HELPERS_DIR/template-utils.sh"
 source "$HELPERS_DIR/generate-utils.sh"
+source "$HELPERS_DIR/collect-lines.sh"
 
 CONFIG="$SCRIPT_DIR/config.yaml"
 TEMPLATE="$SCRIPT_DIR/Dockerfile.linux"
@@ -186,6 +187,13 @@ generate_one() {
 if [[ $# -eq 0 ]]; then
     # Generate all Linux distros × all flavors
     all_flavors=$(list_flavors "$CONFIG")
+    distros_file=$(mktemp "${TMPDIR:-/tmp}/generate-dockerfile-distros.XXXXXX") || exit 1
+    trap 'rm -f "$distros_file"' EXIT
+    if ! collect_lines "$distros_file" -- list_distros "$CONFIG" --exclude-windows; then
+        rm -f "$distros_file"
+        log_error "Could not enumerate all Linux distros; writing no Dockerfiles"
+        exit 1
+    fi
 
     while IFS= read -r distro; do
         while IFS= read -r flv; do
@@ -193,7 +201,9 @@ if [[ $# -eq 0 ]]; then
             log_info "Writing $out_file" >&2
             generate_one "$distro" "$flv" > "$out_file"
         done <<< "$all_flavors"
-    done < <(list_distros "$CONFIG" --exclude-windows)
+    done < "$distros_file"
+    rm -f "$distros_file"
+    trap - EXIT
 elif parse_generator_args "$@"; then
     generate_one "$GEN_DISTRO" "$GEN_FLAVOR"
 else

--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -49,6 +49,8 @@ fi
 
 # Source variant utils for tags_from_versions resolution
 source "$SCRIPT_DIR/variant-utils.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/collect-lines.sh"
 
 # Registry commands below must have a real kill-after timeout. A plain timeout
 # only sends SIGTERM, then can wait forever for a stuck docker child; check the
@@ -835,6 +837,13 @@ sync_base_images_to_ghcr() {
     echo "📦 Syncing ${safe_count} unique base images to GHCR (source: ${safe_source_registry})"
 
     local synced=0 skipped=0 failed=0
+    local images_file
+    images_file=$(mktemp "${TMPDIR:-/tmp}/sync-base-images-entries.XXXXXX") || return 1
+    if ! collect_lines "$images_file" -- jq -c '.[]' <<< "$images_json"; then
+        rm -f "$images_file"
+        log_error "sync_base_images_to_ghcr: could not enumerate all base images; syncing none"
+        return 1
+    fi
     while IFS= read -r img; do
         local source_img tag sync_image source_ref output
         source_img=$(echo "$img" | jq -r '.source')
@@ -942,7 +951,8 @@ sync_base_images_to_ghcr() {
             _append_base_sync_manifest_record "$source_ref" "$sync_image" "" "failed"
             failed=$((failed + 1))
         fi
-    done < <(echo "$images_json" | jq -c '.[]')
+    done < "$images_file"
+    rm -f "$images_file"
 
     echo ""
     echo "📊 Sync summary: $synced synced, $skipped skipped (already in GHCR), $failed failed"

--- a/helpers/collect-lines.sh
+++ b/helpers/collect-lines.sh
@@ -9,6 +9,15 @@
 # read it only after success cannot observe partial output or a stale result.
 # The caller owns the output path and removes it when finished.
 #
+# What this preserves is the producer's RETURN VALUE, and one bound follows from
+# that. The producer runs as an `if` condition, and Bash suppresses errexit
+# throughout a shell function invoked that way — a subshell with its own `set -e`
+# does not restore it, measured. So a producer function that relies on errexit to
+# stop will run past its own failure, reach its last command, and return that
+# command's status instead. Such a producer has no failure status to preserve.
+# Producers used here return explicitly; `helpers/generate-utils.sh::list_distros`
+# is the one that had to be changed to.
+#
 # Bash 4.0 compatibility is deliberate: do not use local/declare -n namerefs
 # (they require Bash 4.3).  This covers array collection through mapfile/readarray
 # from process substitution.  It does not cover while-read process-substitution

--- a/helpers/collect-lines.sh
+++ b/helpers/collect-lines.sh
@@ -51,3 +51,8 @@ collect_lines() {
     rm -f "$_collect_lines_tmp"
     return "$_collect_lines_status"
 }
+
+# Exported because `compute_cell_tags` and `sync_base_images_to_ghcr` are, and
+# they call this. Without it a fresh child imports the public function and dies
+# on `collect_lines: command not found`.
+export -f collect_lines

--- a/helpers/generate-utils.sh
+++ b/helpers/generate-utils.sh
@@ -72,13 +72,19 @@ list_distros() {
     local exclude_windows=false
     [[ "${2:-}" == "--exclude-windows" ]] && exclude_windows=true
 
+    # Explicit returns rather than relying on errexit. A caller reaching this
+    # through `collect_lines` runs it inside an `if` condition, and Bash
+    # suppresses errexit throughout a function invoked that way — measured, and
+    # a subshell with its own `set -e` does not restore it. Without these, a
+    # failing `yq` leaves an empty variable, the final `echo` succeeds, and the
+    # function reports a complete distro list that is empty.
     local distros
-    distros=$(yq e '.distros | keys | .[]' "$config")
+    distros=$(yq e '.distros | keys | .[]' "$config") || return 1
 
     if [[ "$exclude_windows" == "true" ]]; then
         while IFS= read -r distro; do
             local pm
-            pm=$(yq e ".distros.${distro}.pkg_manager" "$config")
+            pm=$(yq e ".distros.${distro}.pkg_manager" "$config") || return 1
             [[ "$pm" == "none" ]] && continue
             echo "$distro"
         done <<< "$distros"

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -181,6 +181,7 @@ mirror_to_dockerhub() {
     fi
 
     # Counters for strict-mode observability: track across all cells/tags.
+    local _planned=0
     local _attempted=0
     local _succeeded=0
 
@@ -234,6 +235,12 @@ mirror_to_dockerhub() {
 
             # Dry-run: explicit branch prints the command and skips execution.
             # Real path: "$DOCKER" (quoted) runs the actual binary or bats mock.
+            # Counted in both branches: this measures what the enumeration
+            # produced, which is a different question from what was attempted.
+            # A dry run plans every tag and attempts none, so testing _attempted
+            # for "the enumeration produced nothing" fails every strict dry run —
+            # and `dockerhub-reconcile.yaml` combines the two.
+            (( _planned++ )) || true
             if [[ "${DRY_RUN:-false}" == "true" ]]; then
                 printf 'DRY-RUN: docker buildx imagetools create -t %s %s\n' \
                     "$dh_dst" "$ghcr_src" >&2
@@ -256,8 +263,8 @@ mirror_to_dockerhub() {
         # enumeration produced nothing for every cell. That is a producer
         # regression, and reporting `0/0 tags mirrored` as a successful strict
         # reconciliation is the fail-open this whole change exists to remove.
-        if [[ "$ncells" -gt 0 && "$_attempted" -eq 0 ]]; then
-            printf '::error::mirror-dockerhub: %d cells requested and no tag was attempted — enumeration produced nothing, reconciliation not performed\n' \
+        if [[ "$ncells" -gt 0 && "$_planned" -eq 0 ]]; then
+            printf '::error::mirror-dockerhub: %d cells requested and no tag was planned — enumeration produced nothing, reconciliation not performed\n' \
                 "$ncells" >&2
             return 1
         fi

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -53,6 +53,8 @@ fi
 source "${_MDH_SCRIPT_DIR}/logging.sh"
 # shellcheck disable=SC1091
 source "${_MDH_SCRIPT_DIR}/variant-utils.sh"
+# shellcheck disable=SC1091
+source "${_MDH_SCRIPT_DIR}/collect-lines.sh"
 
 # DOCKER is already set by logging.sh (honours DRY_RUN); provide a fallback
 # only when the caller sourced this file before logging.sh.
@@ -210,6 +212,17 @@ mirror_to_dockerhub() {
         # Enumerate tags using the same routing as compute_cell_tag_suffixes.
         # For retained non-latest cells, publish ONLY the versioned tag.
         local sfx
+        local suffixes_file
+        suffixes_file=$(mktemp "${TMPDIR:-/tmp}/mirror-dockerhub-suffixes.XXXXXX") || return 1
+        if ! collect_lines "$suffixes_file" -- compute_cell_tag_suffixes "$tag" "$routing_suffix" "$is_default"; then
+            rm -f "$suffixes_file"
+            printf '::warning::mirror-dockerhub: could not enumerate all tags for %s:%s; mirroring none for this cell\n' \
+                "$container" "$tag" >&2
+            if [[ "$_strict" == "true" ]]; then
+                return 1
+            fi
+            continue
+        fi
         while IFS= read -r sfx; do
             [[ -n "$sfx" ]] || continue
             # F2 gate: retained non-latest → versioned tag only
@@ -233,7 +246,8 @@ mirror_to_dockerhub() {
                         "$dh_dst" >&2
                 fi
             fi
-        done < <(compute_cell_tag_suffixes "$tag" "$routing_suffix" "$is_default")
+        done < "$suffixes_file"
+        rm -f "$suffixes_file"
     done
 
     # Strict-mode: emit summary and return non-zero on total failure.

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -268,6 +268,16 @@ mirror_to_dockerhub() {
                 "$ncells" >&2
             return 1
         fi
+        # A dry run copies nothing, so strict mode has nothing to assert about.
+        # Saying `0/0 tags mirrored` here reads as a successful reconciliation in
+        # the workflow's history, which is false: `dockerhub-reconcile.yaml`
+        # hardcodes MIRROR_STRICT and takes dry-run from its dispatch input, so
+        # this combination is one click away and its summary must name itself.
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            printf '::notice::mirror-dockerhub: %d tags planned across %d cells — dry run, nothing was mirrored and no reconciliation was performed\n' \
+                "$_planned" "$ncells" >&2
+            return 0
+        fi
         if [[ "$_attempted" -gt 0 && "$_succeeded" -eq 0 ]]; then
             printf '::error::mirror-dockerhub: 0/%d tags mirrored — reconciliation failed\n' \
                 "$_attempted" >&2

--- a/helpers/mirror-dockerhub.sh
+++ b/helpers/mirror-dockerhub.sh
@@ -252,6 +252,15 @@ mirror_to_dockerhub() {
 
     # Strict-mode: emit summary and return non-zero on total failure.
     if [[ "$_strict" == "true" ]]; then
+        # Cells were requested and not one tag was even attempted: the suffix
+        # enumeration produced nothing for every cell. That is a producer
+        # regression, and reporting `0/0 tags mirrored` as a successful strict
+        # reconciliation is the fail-open this whole change exists to remove.
+        if [[ "$ncells" -gt 0 && "$_attempted" -eq 0 ]]; then
+            printf '::error::mirror-dockerhub: %d cells requested and no tag was attempted — enumeration produced nothing, reconciliation not performed\n' \
+                "$ncells" >&2
+            return 1
+        fi
         if [[ "$_attempted" -gt 0 && "$_succeeded" -eq 0 ]]; then
             printf '::error::mirror-dockerhub: 0/%d tags mirrored — reconciliation failed\n' \
                 "$_attempted" >&2

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+# shellcheck source=./collect-lines.sh
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/collect-lines.sh"
+
 # Resolve a full version string to a variants.yaml tag
 # Usage: resolve_major_version <container_dir> <full_version>
 # Example: resolve_major_version ./postgres "18.1-alpine" → "18"
@@ -357,10 +361,18 @@ compute_cell_tags() {
     local ghcr_image="$5"
 
     local _sfx
+    local _suffixes_file
+    _suffixes_file=$(mktemp "${TMPDIR:-/tmp}/compute-cell-tags-suffixes.XXXXXX") || return 1
+    if ! collect_lines "$_suffixes_file" -- compute_cell_tag_suffixes "$tag" "$flavor" "$is_default"; then
+        rm -f "$_suffixes_file"
+        printf 'compute_cell_tags: could not enumerate tag suffixes\n' >&2
+        return 1
+    fi
     while IFS= read -r _sfx; do
         printf '%s:%s\n' "$dockerhub_image" "$_sfx"
         printf '%s:%s\n' "$ghcr_image"      "$_sfx"
-    done < <(compute_cell_tag_suffixes "$tag" "$flavor" "$is_default")
+    done < "$_suffixes_file"
+    rm -f "$_suffixes_file"
 }
 
 # Check if a container always builds all retained versions (not just the latest)

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -368,11 +368,19 @@ compute_cell_tags() {
         printf 'compute_cell_tags: could not enumerate tag suffixes\n' >&2
         return 1
     fi
+    # Keep the emission status across the cleanup. `rm` is the last command
+    # otherwise, so its success becomes this function's return value and a
+    # `printf` that failed — a full filesystem is the ordinary way — reports a
+    # complete tag set to the caller. The caller reaches this through
+    # `collect_lines`, whose `if "$@"` suppresses errexit, so nothing else is
+    # watching.
+    local _emit_status=0
     while IFS= read -r _sfx; do
-        printf '%s:%s\n' "$dockerhub_image" "$_sfx"
-        printf '%s:%s\n' "$ghcr_image"      "$_sfx"
+        printf '%s:%s\n' "$dockerhub_image" "$_sfx" || _emit_status=$?
+        printf '%s:%s\n' "$ghcr_image"      "$_sfx" || _emit_status=$?
     done < "$_suffixes_file"
     rm -f "$_suffixes_file"
+    return "$_emit_status"
 }
 
 # Check if a container always builds all retained versions (not just the latest)

--- a/scripts/bake-merge-manifests.sh
+++ b/scripts/bake-merge-manifests.sh
@@ -48,6 +48,8 @@ source "${PROJECT_ROOT}/helpers/logging.sh"
 source "${PROJECT_ROOT}/helpers/retry.sh"
 # shellcheck source=../helpers/variant-utils.sh
 source "${PROJECT_ROOT}/helpers/variant-utils.sh"
+# shellcheck source=../helpers/collect-lines.sh
+source "${PROJECT_ROOT}/helpers/collect-lines.sh"
 
 # Force config-only dep resolution (no lineage dir needed for merge)
 export _DEPGRAPH_LINEAGE_DIR=/nonexistent
@@ -109,6 +111,14 @@ _merge_cell() {
     # ------------------------------------------------------------------
     local -a ghcr_refs=()
     local sfx
+    local suffixes_file
+    suffixes_file=$(mktemp "${TMPDIR:-/tmp}/bake-merge-cell-suffixes.XXXXXX") || return 1
+    if ! collect_lines "$suffixes_file" -- compute_cell_tag_suffixes "$tag" "$variant" "$is_default"; then
+        rm -f "$suffixes_file"
+        printf '::error::Could not enumerate all GHCR refs for %s:%s — skipping cell\n' \
+            "$container" "$tag" >&2
+        return 1
+    fi
     while IFS= read -r sfx; do
         [[ -n "$sfx" ]] || continue
         # F2 gate: for retained non-latest cells, publish only the versioned
@@ -117,7 +127,8 @@ _merge_cell() {
             continue
         fi
         ghcr_refs+=("${ghcr_image}:${sfx}")
-    done < <(compute_cell_tag_suffixes "$tag" "$variant" "$is_default")
+    done < "$suffixes_file"
+    rm -f "$suffixes_file"
 
     if [[ ${#ghcr_refs[@]} -eq 0 ]]; then
         printf '::error::No GHCR refs computed for %s:%s — skipping cell\n' \
@@ -230,6 +241,13 @@ main() {
         # Use the same routing logic as _merge_cell (variant for rolling suffix)
         local _routing_suffix="${_chk_variant:-$_chk_flavor}"
         local _sfx
+        local _suffixes_file
+        _suffixes_file=$(mktemp "${TMPDIR:-/tmp}/bake-merge-duplicate-suffixes.XXXXXX") || exit 1
+        if ! collect_lines "$_suffixes_file" -- compute_cell_tag_suffixes "$_chk_tag" "$_routing_suffix" "$_chk_default"; then
+            rm -f "$_suffixes_file"
+            printf '::error::Could not enumerate all final refs for duplicate detection — aborting\n' >&2
+            exit 1
+        fi
         while IFS= read -r _sfx; do
             [[ -n "$_sfx" ]] || continue
             if [[ "$_chk_latest" != "true" && "$_sfx" != "$_chk_tag" ]]; then
@@ -240,10 +258,12 @@ main() {
             if [[ -n "${_seen_refs[$_fref]+set}" ]]; then
                 printf '::error::Duplicate final ref detected: %s would be published by both %s and %s — aborting\n' \
                     "$_fref" "${_seen_refs[$_fref]}" "$_cell_id" >&2
+                rm -f "$_suffixes_file"
                 exit 1
             fi
             _seen_refs["$_fref"]="$_cell_id"
-        done < <(compute_cell_tag_suffixes "$_chk_tag" "$_routing_suffix" "$_chk_default")
+        done < "$_suffixes_file"
+        rm -f "$_suffixes_file"
     done
 
     # ------------------------------------------------------------------

--- a/scripts/open-key-lifecycle-issue.sh
+++ b/scripts/open-key-lifecycle-issue.sh
@@ -11,6 +11,9 @@ source "$ROOT_DIR/helpers/logging.sh"
 # shellcheck source=../helpers/retry.sh
 # shellcheck disable=SC1091
 source "$ROOT_DIR/helpers/retry.sh"
+# shellcheck source=../helpers/collect-lines.sh
+# shellcheck disable=SC1091
+source "$ROOT_DIR/helpers/collect-lines.sh"
 
 usage() {
     cat >&2 <<'USAGE'
@@ -341,6 +344,13 @@ process_findings() {
     fi
 
     local row
+    local findings_file
+    findings_file=$(mktemp "${TMPDIR:-/tmp}/open-key-lifecycle-findings.XXXXXX") || return 1
+    if ! collect_lines "$findings_file" -- jq -c '.[]' <<< "$findings"; then
+        rm -f "$findings_file"
+        printf 'open-key-lifecycle-issue: could not enumerate all findings; opening no issues\n' >&2
+        return 1
+    fi
     while IFS= read -r row; do
         [[ -z "$row" ]] && continue
         local expiry_severity expiry_reason rotation_status rotation_reason rotation_runtime key_reason config_reason
@@ -397,7 +407,8 @@ process_findings() {
                 issue_failures=$((issue_failures + 1))
             fi
         fi
-    done < <(jq -c '.[]' <<< "$findings")
+    done < "$findings_file"
+    rm -f "$findings_file"
 
     if (( issue_failures > 0 )); then
         printf 'open-key-lifecycle-issue: %d issue operation(s) failed\n' "$issue_failures" >&2

--- a/terraform/docker-entrypoint.sh
+++ b/terraform/docker-entrypoint.sh
@@ -5,11 +5,21 @@ CONFIGFILE=${CONFIGFILE:-config.json}
 # jinja2 is invoked directly with quoted arguments — never eval — and filenames
 # are read NUL-delimited, so a crafted *.j2 filename or CONFIGFILE value in a
 # mounted working directory cannot inject shell commands.
+templates_file=$(mktemp "${TMPDIR:-/tmp}/terraform-tf-templates.XXXXXX") || exit 1
+trap 'rm -f "$templates_file"' EXIT
+if ! find . -name "*.tf.j2" -type f -print0 > "$templates_file"; then
+    rm -f "$templates_file"
+  echo "Could not enumerate all Terraform templates; rendering none" >&2
+  exit 1
+fi
+
 while IFS= read -r -d '' j2file; do
   outfile="${j2file%.tf.j2}.tf"
   echo "\$ jinja2 ${j2file} ${CONFIGFILE} > ${outfile}" >&2
   jinja2 "${j2file}" "${CONFIGFILE}" > "${outfile}"
-done < <(find . -name "*.tf.j2" -type f -print0)
+done < "$templates_file"
+rm -f "$templates_file"
+trap - EXIT
 
 # Run Terraform with supplied arguments
 exec /bin/terraform "$@"

--- a/tests/unit/bake-merge-manifests.bats
+++ b/tests/unit/bake-merge-manifests.bats
@@ -328,6 +328,66 @@ CALLER
     [[ "$output" == *"Duplicate final ref"* ]]
 }
 
+@test "short suffix enumeration refuses a cell before any manifest publish [catches partial GHCR publish]" {
+    local caller_script="${TEST_TEMP_DIR}/_short_cell_caller.sh"
+    cat > "$caller_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "${PROJECT_ROOT}/scripts/bake-merge-manifests.sh"
+compute_cell_tag_suffixes() { printf 'partial\n'; return 1; }
+_merge_cell debian trixie '' true ghcr.io/oorabona/debian:trixie true
+EOF
+    chmod +x "$caller_script"
+
+    run bash "$caller_script"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Could not enumerate all GHCR refs"* ]]
+    [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "short suffix enumeration makes duplicate detection fail rather than report clean [catches incomplete detector]" {
+    local mock_gen="${TEST_TEMP_DIR}/bin/generate-bake-hcl.sh"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        'printf '\''[{"container":"debian","tag":"trixie","flavor":"","variant":"","is_default":true,"intermediate_ref":"ghcr.io/oorabona/debian:trixie"}]\n'\''' > "$mock_gen"
+    chmod +x "$mock_gen"
+
+    local caller_script="${TEST_TEMP_DIR}/_short_duplicate_caller.sh"
+    cat > "$caller_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "${PROJECT_ROOT}/scripts/bake-merge-manifests.sh"
+compute_cell_tag_suffixes() { printf 'partial\n'; return 1; }
+SCRIPT_DIR="${TEST_TEMP_DIR}/bin"
+main
+EOF
+    chmod +x "$caller_script"
+
+    run bash "$caller_script"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Could not enumerate all final refs for duplicate detection"* ]]
+    [ ! -s "$DOCKER_LOG" ]
+}
+
+@test "empty successful suffix enumeration still triggers the no-GHCR-refs guard" {
+    local caller_script="${TEST_TEMP_DIR}/_empty_cell_caller.sh"
+    cat > "$caller_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+source "${PROJECT_ROOT}/scripts/bake-merge-manifests.sh"
+compute_cell_tag_suffixes() { return 0; }
+_merge_cell debian trixie '' true ghcr.io/oorabona/debian:trixie true
+EOF
+    chmod +x "$caller_script"
+
+    run bash "$caller_script"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No GHCR refs computed"* ]]
+    [ ! -s "$DOCKER_LOG" ]
+}
+
 # ---------------------------------------------------------------------------
 # FIX H / MM11: DRY_RUN=true emits command to stdout and does NOT execute.
 # Catches MM11: if the dry-run branch is removed, the command is captured

--- a/tests/unit/base-cache-utils.bats
+++ b/tests/unit/base-cache-utils.bats
@@ -792,6 +792,27 @@ EOF
     [[ "$output" == *"sync_base_images_to_ghcr: images_json is not a JSON array"* ]]
 }
 
+@test "sync_base_images_to_ghcr: a short image enumeration syncs nothing [catches partial GHCR sync]" {
+    # Mutation caught: restoring the jq process substitution would sync the
+    # first row even though the producer reported that the full set is unknown.
+    local docker_log="$TEST_DIR/short-enumeration-docker.log"
+    collect_lines() {
+        printf '%s\n' '{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}' > "$1"
+        return 1
+    }
+    docker() {
+        printf '%s\n' "$*" >> "$docker_log"
+        return 0
+    }
+    export -f docker
+
+    run sync_base_images_to_ghcr '[{"source":"library/alpine","tag":"3.18","sync_image":"ghcr.io/x/library/alpine:3.18"}]'
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not enumerate all base images; syncing none"* ]]
+    [ ! -s "$docker_log" ]
+}
+
 @test "sync_base_images_to_ghcr: single library/X image uses explicit library/ prefix" {
     # Mock docker to capture the source_ref argument
     docker() {

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -506,3 +506,41 @@ EOF
 
     unset GITHUB_REPOSITORY_OWNER
 }
+
+@test "build_container refuses the build when compute_cell_tags sees a short suffix enumeration [catches untagged partial build]" {
+    export MULTIPLATFORM_SUPPORTED="false"
+    export GITHUB_REPOSITORY_OWNER="myowner"
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/docker" <<'EOF'
+#!/bin/bash
+echo "ARGS: $*" >> "$TEST_TEMP_DIR/docker_calls.log"
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/docker"
+    export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    create_mock_container "testcontainer" "1.0.0"
+    source_build_script
+
+    # Mutation caught: the old process substitution made compute_cell_tags
+    # report success after emitting this one suffix, so docker built it anyway.
+    compute_cell_tag_suffixes() {
+        printf 'partial\n'
+        return 1
+    }
+    export -f compute_cell_tag_suffixes
+
+    cd "$TEST_TEMP_DIR"
+    run build_container "testcontainer" "1.0.0" "1.0.0"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Could not enumerate image tags"* ]]
+    if grep -Eq '(^| )build( |$)|buildx build' "$TEST_TEMP_DIR/docker_calls.log"; then
+        echo "A partial tag set reached the build invocation:" >&2
+        cat "$TEST_TEMP_DIR/docker_calls.log" >&2
+        return 1
+    fi
+
+    unset GITHUB_REPOSITORY_OWNER
+}

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -20,6 +20,9 @@ setup() {
     cp "$PROJECT_ROOT/tests/e2e-test.sh" "$FIXTURE_REPO/tests/e2e-test.sh"
     cp "$PROJECT_ROOT/helpers/logging.sh" "$FIXTURE_REPO/helpers/logging.sh"
     cp "$PROJECT_ROOT/helpers/variant-utils.sh" "$FIXTURE_REPO/helpers/variant-utils.sh"
+    # variant-utils.sh sources it, so an isolated root without it fails at the
+    # source line rather than in the test's subject.
+    cp "$PROJECT_ROOT/helpers/collect-lines.sh" "$FIXTURE_REPO/helpers/collect-lines.sh"
     mkdir -p "$FIXTURE_REPO/test-harness"
     cp "$PROJECT_ROOT/test-harness/image-identity.sh" "$FIXTURE_REPO/test-harness/image-identity.sh"
     chmod +x "$FIXTURE_REPO/tests/e2e-test.sh"

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -14,6 +14,9 @@ setup() {
     mkdir -p helpers scripts bin wordpress
 
     cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+    # variant-utils.sh sources it, so an isolated root without it fails at the
+    # source line rather than in the test's subject.
+    cp "$ORIG_DIR/helpers/collect-lines.sh" helpers/
     cp "$ORIG_DIR/scripts/rotate-versions.sh" scripts/
     chmod +x scripts/rotate-versions.sh
 
@@ -468,6 +471,9 @@ EOF
 EOF
 
     cp "$ORIG_DIR/helpers/variant-utils.sh" helpers/
+    # variant-utils.sh sources it, so an isolated root without it fails at the
+    # source line rather than in the test's subject.
+    cp "$ORIG_DIR/helpers/collect-lines.sh" helpers/
     cp "$ORIG_DIR/helpers/version-utils.sh" helpers/
 
     # Copy make to $TEST_DIR so `./make check-updates` runs with TEST_DIR as $(dirname $0).

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -473,6 +473,44 @@ FAIL_EOF
 # web-shell produces at least 2 tags (versioned + :latest), so the counter
 # will have succeeded≥1 and attempted≥2.
 # ---------------------------------------------------------------------------
+@test "MIRROR_STRICT=true cells requested but no suffix produced returns non-zero" {
+    # Distinct from the no-cells case: cells EXIST and the suffix enumeration
+    # comes back successfully empty, so nothing is attempted. The mutation this
+    # catches is removing the `ncells > 0 && _attempted -eq 0` guard, which
+    # leaves `_attempted -gt 0 && _succeeded -eq 0` false and prints
+    # `0/0 tags mirrored` as a successful strict reconciliation.
+    export MIRROR_STRICT="true"
+
+    # The cell list is injected rather than generated, so the test does not
+    # depend on lineage data being present: without this it falls through to the
+    # pre-existing "generator produced no cells" path and proves nothing about
+    # the guard it is here for.
+    local generator="${TEST_LOG_DIR}/empty-enumeration-generator.sh"
+    cat > "$generator" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '[{"container":"web-shell","tag":"1.0.0","flavor":"","variant":"","is_default":true,"is_latest_version":true}]'
+EOF
+    chmod +x "$generator"
+    export _MDH_GENERATOR_OVERRIDE="$generator"
+
+    run bash -c '
+        source "$1"
+        # Successfully empty, defined after the source so nothing overwrites it.
+        compute_cell_tag_suffixes() { return 0; }
+        mirror_to_dockerhub web-shell
+    ' bash "$MDH"
+
+    [ "$status" -ne 0 ] || \
+        (echo "Expected non-zero rc (strict, cells but no suffixes) but got 0" >&2
+         echo "$output" >&2
+         false)
+
+    grep -q "no tag was attempted" <<< "$output" || \
+        (echo "Expected the enumeration-produced-nothing annotation:" >&2
+         echo "$output" >&2
+         false)
+}
+
 @test "MIRROR_STRICT=true partial-success returns 0" {
     export MIRROR_STRICT="true"
 

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -473,6 +473,41 @@ FAIL_EOF
 # web-shell produces at least 2 tags (versioned + :latest), so the counter
 # will have succeeded≥1 and attempted≥2.
 # ---------------------------------------------------------------------------
+@test "MIRROR_STRICT=true DRY_RUN=true returns 0 after planning every tag" {
+    # A dry run plans tags and attempts none, and `dockerhub-reconcile.yaml`
+    # combines its dry-run input with MIRROR_STRICT=true. The mutation this
+    # catches is pointing the enumeration-produced-nothing guard at `_attempted`
+    # instead of `_planned`, which fails every strict dry run while claiming the
+    # enumeration produced nothing.
+    export MIRROR_STRICT="true"
+    export DRY_RUN="true"
+
+    # Injected rather than generated: the real generator needs lineage data, and
+    # without it this falls through to the no-cells path and proves nothing.
+    local generator="${TEST_LOG_DIR}/dry-run-generator.sh"
+    cat > "$generator" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '[{"container":"web-shell","tag":"1.0.0","flavor":"","variant":"","is_default":true,"is_latest_version":true,"intermediate_ref":"ghcr.io/oorabona/web-shell:1.0.0"}]'
+EOF
+    chmod +x "$generator"
+    export _MDH_GENERATOR_OVERRIDE="$generator"
+
+    run _run_mirror "web-shell"
+
+    [ "$status" -eq 0 ] || \
+        (echo "Expected rc=0 for a strict dry run but got $status" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    grep -q 'DRY-RUN: docker buildx imagetools create' "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected the dry run to plan at least one tag:" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+
+    # Planned, not executed.
+    [ ! -s "$DOCKER_LOG" ]
+}
+
 @test "MIRROR_STRICT=true cells requested but no suffix produced returns non-zero" {
     # Distinct from the no-cells case: cells EXIST and the suffix enumeration
     # comes back successfully empty, so nothing is attempted. The mutation this
@@ -505,7 +540,7 @@ EOF
          echo "$output" >&2
          false)
 
-    grep -q "no tag was attempted" <<< "$output" || \
+    grep -q "no tag was planned" <<< "$output" || \
         (echo "Expected the enumeration-produced-nothing annotation:" >&2
          echo "$output" >&2
          false)

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -139,6 +139,27 @@ _run_mirror() {
          false)
 }
 
+@test "short suffix enumeration mirrors no Docker Hub tags [catches partial imagetools publish]" {
+    local generator="${TEST_LOG_DIR}/short-enumeration-generator.sh"
+    cat > "$generator" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '[{"container":"web-shell","tag":"1.0.0","flavor":"","variant":"","is_default":true,"is_latest_version":true,"intermediate_ref":"ghcr.io/oorabona/web-shell:1.0.0"}]'
+EOF
+    chmod +x "$generator"
+    export _MDH_GENERATOR_OVERRIDE="$generator"
+
+    run bash -c '
+        source "$1"
+        compute_cell_tag_suffixes() { printf "partial\\n"; return 1; }
+        mirror_to_dockerhub web-shell
+    ' bash "$MDH"
+
+    # Best-effort mode remains non-gating, but it must not publish the partial tag.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"could not enumerate all tags"* ]]
+    [ ! -s "$DOCKER_LOG" ]
+}
+
 # ---------------------------------------------------------------------------
 # Retained non-latest cell mirrors ONLY the versioned tag.
 # Catches: MD3

--- a/tests/unit/mirror-dockerhub.bats
+++ b/tests/unit/mirror-dockerhub.bats
@@ -506,6 +506,14 @@ EOF
 
     # Planned, not executed.
     [ ! -s "$DOCKER_LOG" ]
+
+    # And the summary names itself, instead of reading as a reconciliation that
+    # mirrored nothing successfully.
+    grep -q 'dry run, nothing was mirrored' "${TEST_LOG_DIR}/run.log" || \
+        (echo "Expected the dry run summary to name itself:" >&2
+         cat "${TEST_LOG_DIR}/run.log" >&2
+         false)
+    ! grep -q '0/0 tags mirrored' "${TEST_LOG_DIR}/run.log"
 }
 
 @test "MIRROR_STRICT=true cells requested but no suffix produced returns non-zero" {

--- a/tests/unit/open-key-lifecycle-issue.bats
+++ b/tests/unit/open-key-lifecycle-issue.bats
@@ -24,6 +24,21 @@ teardown() {
     unset FAKE_ISSUE_LIST_MODE FAKE_ISSUE_CREATE_MODE FAKE_ISSUE_EDIT_MODE REQUIRE_LABEL_FORCE FAKE_LABEL_CREATE_MODE GH_CREATE_COUNT_FILE GH_SERVER_CREATED_FILE GH_LABEL_COUNT_FILE
 }
 
+@test "short findings enumeration opens no issues [catches partial lifecycle reporting]" {
+    export GH_LOG="$TEST_TEMP_DIR/gh.log"
+    local findings='[{"container":"openvpn","dependency":"EASYRSA_VERSION","expiry":{"severity":"warn","reason":"expiring"}}]'
+
+    run bash -c '
+        source "$1"
+        collect_lines() { printf "%s\\n" "$3" > "$1"; return 1; }
+        process_findings "$2"
+    ' bash "$SCRIPT" "$findings"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not enumerate all findings; opening no issues"* ]]
+    [ ! -s "$GH_LOG" ]
+}
+
 write_fake_gh() {
 cat > "$TEST_TEMP_DIR/bin/gh" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -1138,6 +1138,33 @@ setup_fallback_test() {
 #   (c) flavor non-empty + is_default="false" → versioned + :latest-<flavor> (both registries)
 #   (d) tag == "latest"                       → only versioned refs, no rolling latest
 
+@test "compute_cell_tags: an emission that fails is not reported as a full tag set" {
+    # The mutation this catches: dropping `return "$_emit_status"`, or the
+    # `|| _emit_status=$?` on either printf. Without them the cleanup `rm` is the
+    # last command and its success becomes the return value — measured rc=0 with
+    # every reference lost.
+    #
+    # /dev/full accepts writes and fails them with ENOSPC, which is what a full
+    # filesystem does to printf. The caller reaches this function through
+    # `collect_lines`, whose `if "$@"` suppresses errexit, so the return value is
+    # the only channel left.
+    run bash -c '
+        set +e
+        source "$1/helpers/collect-lines.sh"
+        source "$1/helpers/variant-utils.sh"
+        set +e
+        compute_cell_tags "2.3.1" "" "false" "docker.io/o/p" "ghcr.io/o/p" > /dev/full 2>/dev/null
+        printf "%s" "$?"
+    ' _ "$ORIG_DIR"
+    [ "$output" != "0" ]
+
+    # Control: the same call with a writable stdout still succeeds with all four
+    # references, so the test above cannot pass by breaking the happy path.
+    run compute_cell_tags "2.3.1" "" "false" "docker.io/o/p" "ghcr.io/o/p"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 4 ]
+}
+
 @test "compute_cell_tags: (a) no-flavor → versioned + :latest on both registries" {
     # No variants.yaml needed — function is now pure (no yq lookup)
     run compute_cell_tags "2.3.1" "" "false" "docker.io/owner/plain" "ghcr.io/owner/plain"

--- a/tests/unit/variant-utils.bats
+++ b/tests/unit/variant-utils.bats
@@ -1219,6 +1219,21 @@ setup_fallback_test() {
     [ "$bare_latest_count" -eq 0 ]
 }
 
+@test "compute_cell_tags: a short suffix enumeration returns failure and emits no partial refs [catches process-substitution partial publish]" {
+    # Mutation caught: restoring `done < <(compute_cell_tag_suffixes ...)`
+    # emits refs for "partial" and returns success despite this producer failure.
+    compute_cell_tag_suffixes() {
+        printf 'partial\n'
+        return 1
+    }
+
+    run compute_cell_tags "1.0.0" "" "true" "docker.io/owner/app" "ghcr.io/owner/app"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"docker.io/owner/app:partial"* ]]
+    [[ "$output" != *"ghcr.io/owner/app:partial"* ]]
+}
+
 # --- compute_cell_tag_suffixes ---
 #
 # Unit tests for the registry-independent suffix helper. Four cases:


### PR DESCRIPTION
First slice of #1118. Eight loops read a process substitution whose exit status
they never saw, and each authorised something that leaves this repository.

What a partial read bought, per site: an incomplete tag set published to Docker
Hub while the counters reported success; a manifest published missing refs;
templates rendered to `.tf` files Terraform then applies, from part of the set;
per-distro Dockerfiles silently never written; fewer base images synced to GHCR
than intended; key-lifecycle findings that never reached an issue. Each now
produces its list in full before it acts, and a producer that fails leaves
nothing done rather than some of it.

Three of the eight were not that shape.

`compute_cell_tags` in `variant-utils.sh` is itself one of these loops. Its
callers already check its status, so returning its producer's status propagates
without touching them.

The duplicate-ref check in `bake-merge-manifests.sh` is a detection. Running it
on a truncated input made it report no duplicates, so it refuses instead. The
emptiness guard forty lines above stays: `${#ghcr_refs[@]} -eq 0` catches a
genuinely empty result and says nothing about a partial one.

`terraform/docker-entrypoint.sh` is a container entrypoint and its image does not
carry `helpers/`, so it gets a self-contained fix; it also reads NUL-delimited,
which a line-based helper cannot represent.

## Fixed along the way

Four defects this branch introduced and then closed.

`compute_cell_tags` ended on the `rm` that removes its temporary, so cleanup's
success became the return value and a failed `printf` reported a complete tag
set. Reproduced with stdout on `/dev/full`.

Strict mirroring returned success when cells were requested and no tag was
attempted, then — after that fix — failed every dry run, because a dry run
attempts nothing by design and `dockerhub-reconcile.yaml` combines dry-run with
`MIRROR_STRICT`. A `_planned` counter separates what the enumeration produced
from what was executed, and the dry-run summary now names itself rather than
printing `0/0 tags mirrored`.

`collect_lines` was not exported while two exported functions call it, so a fresh
child died on `command not found`.

## One bound, measured and stated

`collect_lines` runs its producer as an `if` condition, and Bash suppresses
errexit throughout a function invoked that way. Measured across four forms: a
subshell with its own `set -e` does not restore it, nor does reading the status
after `||`. So what the collector preserves is a producer's **return value**, and
a producer relying on errexit has none. `list_distros` was such a producer and
now returns explicitly; the helper's header states the bound instead of implying
a guarantee it cannot give.

A fresh `bash -c` does restore errexit, which would dissolve the class. It is
#1123 rather than this branch: 3 of the 9 producer files were never written under
errexit, and `PROJECT_ROOT` is assigned unexported, so imposing it is a
behaviour change with real blast radius.

## Verification

Unit suite 2425 collected, 0 failed. shellcheck clean on all seven scripts.

The entrypoint is shown rendering every template from a directory holding nothing
but itself and the templates, and a `find` that fails there renders nothing and
exits non-zero. Four regression locks are mutation-proven — control green, mutant
red — covering the emission status, the empty-enumeration guard, the strict dry
run, and its summary wording. Two of those tests inject their cell list rather
than generating one: without it they depend on lineage data and, in a
git-selected projection, fall through to a pre-existing path and prove nothing.

## Left as issues

#1122 — producing in full does not stop a malformed *member* mid-way; three sites
can still act once before a later member aborts the loop. Decided: skip and count
with an accurate final status rather than all-or-nothing, since mirroring is
documented best-effort and opening three issues of four beats opening none. Rides
with #1118's decision-class slice.

#1123 — the errexit bound above, with the fresh-shell option and its measured
cost.

#1120 — a byte-comparison of two generated files races the minute boundary. It
reddened this PR's first run and is not this branch's doing.
