### PR TITLE
fix(dashboard): pin the generation timestamp once instead of reading the clock twice

### DIFF
--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -31,6 +31,12 @@ DATA_FILE="$SCRIPT_DIR/docs/site/_data/containers.yml"
 STATS_FILE="$SCRIPT_DIR/docs/site/_data/stats.yml"
 CONTAINERS_DIR="$SCRIPT_DIR/docs/site/_containers"
 DASHBOARD_BUILD_DATE="$(date -u +"%Y-%m-%d")"
+# Pinned once, and overridable, because two runs of this script are compared
+# byte-for-byte to prove a change alters nothing. Reading the clock at each
+# emission made that comparison fail whenever the two runs straddled a minute
+# boundary, which looks exactly like the real behaviour difference the
+# comparison exists to catch.
+DASHBOARD_BUILD_TIMESTAMP="${DASHBOARD_BUILD_TIMESTAMP:-$(date -u +"%Y-%m-%d %H:%M UTC")}"
 
 # --- Lineage resolution helpers ---
 
@@ -1451,7 +1457,7 @@ write_stats_file() {
 
     cat > "$STATS_FILE" << EOF
 # Auto-generated dashboard statistics
-# Generated: $(date -u +"%Y-%m-%d %H:%M UTC")
+# Generated: ${DASHBOARD_BUILD_TIMESTAMP}
 
 total_containers: $total
 up_to_date: $up_to_date
@@ -1875,7 +1881,7 @@ generate_data() {
     # Write containers.yml from accumulated JSON
     {
         echo "# Auto-generated container data"
-        echo "# Generated: $(date -u +"%Y-%m-%d %H:%M UTC")"
+        echo "# Generated: ${DASHBOARD_BUILD_TIMESTAMP}"
         echo ""
         echo "$all_containers_json" | yq -P
     } > "$DATA_FILE"

--- a/tests/unit/dashboard-profiling.bats
+++ b/tests/unit/dashboard-profiling.bats
@@ -247,6 +247,27 @@ teardown() {
 # @test 5: profiling data is NOT written into yml (no PROFILE in data file)
 # ===================================================================
 
+@test "the generation timestamp is pinned once, not read at each emission" {
+    # The byte-comparison above proves this only when two runs happen to straddle
+    # a minute boundary, which is how it failed intermittently and looked like a
+    # real behaviour difference. This asserts the property directly: both
+    # emission sites render the pinned value, so restoring a `$(date …)` call at
+    # either one fails here every time rather than once in a while.
+    DASHBOARD_BUILD_TIMESTAMP="1999-01-01 00:00 UTC"
+    export DASHBOARD_BUILD_TIMESTAMP
+
+    generate_data 2>/dev/null
+
+    grep -q '^# Generated: 1999-01-01 00:00 UTC$' "$DATA_FILE" || \
+        (echo "Expected the pinned timestamp in the container data:" >&2
+         head -3 "$DATA_FILE" >&2
+         false)
+
+    # Nothing may render a second, differently-clocked timestamp.
+    [ "$(grep -c '^# Generated: ' "$DATA_FILE")" -eq 1 ]
+    ! grep -qE '^# Generated: 20[0-9]{2}-' "$DATA_FILE"
+}
+
 @test "profiling-ON: PROFILE telemetry does not appear in containers.yml" {
     # Mutation caught: any code that writes profiling output to stdout (DATA_FILE)
     # instead of stderr makes the `*"PROFILE "* ` check fail.


### PR DESCRIPTION
Closes #1120.

The generated dashboard files carry their own generation time at minute resolution, read separately at each of the two emission sites. `tests/unit/dashboard-profiling.bats` proves profiling changes nothing by generating the data twice and comparing byte-for-byte, so whenever the two runs straddle a minute boundary the comparison fails on that line alone — looking exactly like the real behaviour difference it exists to catch.

Observed on run 31178583078:

```
FAIL: containers.yml differs between profiling-ON and profiling-OFF runs
2c2
< # Generated: 2026-08-07 12:34 UTC
---
> # Generated: 2026-08-07 12:35 UTC
```

The same commit passed the other trigger's run minutes earlier, which is the signature: the outcome depended on when the suite happened to run.

`DASHBOARD_BUILD_TIMESTAMP` is now pinned once at file scope, beside `DASHBOARD_BUILD_DATE` which already worked that way, and both emission sites render it. It is overridable, so a caller needing two runs to agree can say so.

## Verification

Unit suite 2415 collected, 0 failed; shellcheck clean.

The regression lock asserts the property rather than waiting for the race: with the timestamp set, the emitted line is exactly that value and no second differently-clocked line appears. Restoring a `$(date …)` call at either site fails it every time — mutation-proven, control green and mutant red.

Worth stating why this one was taken now while #1118 and #1123 were closed unworked: it is the only one of the three with an observed occurrence. A flake that fires rarely costs a debugging pass each time and erodes the suite's authority, which has cost this repository before.