### PR TITLE
feat(ci): propose a signing-key refresh when its trust shape changes

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -257,6 +257,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      refresh_candidates: ${{ steps.gpg.outputs.refresh_candidates }}
     concurrency:
       group: gpg-key-lifecycle-${{ github.workflow }}
       cancel-in-progress: false
@@ -293,9 +295,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "$SCOPE_CONTAINER" ]]; then
-            scripts/check-gpg-keys.sh "$SCOPE_CONTAINER" --json > findings.json
+            scripts/check-gpg-keys.sh "$SCOPE_CONTAINER" --json --refresh-check > findings.json
           else
-            scripts/check-gpg-keys.sh --all --json > findings.json
+            scripts/check-gpg-keys.sh --all --json --refresh-check > findings.json
           fi
 
           has_findings="$(jq -r '
@@ -315,6 +317,15 @@ jobs:
           else
             echo "has_findings=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # A changed key shape is routine refresh work, deliberately separate
+          # from the expiry/contract issue channel above.  Do not include
+          # unavailable fetches: a keyserver outage must not open a PR.
+          refresh_candidates="$(jq -c '[.[]
+            | select(.refresh.status == "changed")
+            | {container: .container, dependency: .dependency, key_file: .key_file}
+          ]' findings.json)"
+          echo "refresh_candidates=${refresh_candidates}" >> "$GITHUB_OUTPUT"
 
       # workflow_dispatch using branch YAML is a pre-existing repo-wide
       # property for tokened jobs; this guard hardens this new GPG issue path.
@@ -339,6 +350,147 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         shell: bash
         run: scripts/open-key-lifecycle-issue.sh --json-file findings.json
+
+  refresh-vendored-gpg-keys:
+    needs: [check-gpg-keys]
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      needs.check-gpg-keys.outputs.refresh_candidates != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: gpg-key-refresh-${{ matrix.container }}-${{ matrix.dependency }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJson(needs.check-gpg-keys.outputs.refresh_candidates) }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Install yq
+        uses: ./.github/actions/retry-run
+        with:
+          run: |
+            sudo wget -qO /usr/local/bin/yq \
+              https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+            echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq" | sha256sum -c -
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          max-attempts: '3'
+          timeout: '60s'
+
+      - name: Fetch and stage the current pinned key
+        id: refresh
+        env:
+          CONTAINER: ${{ matrix.container }}
+          DEPENDENCY: ${{ matrix.dependency }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/check-gpg-keys.sh "$CONTAINER" --json --refresh-dir .gpg-key-refresh > refresh.json
+          refresh_row="$(jq -cer --arg dependency "$DEPENDENCY" '
+            .[] | select(.dependency == $dependency)
+          ' refresh.json)"
+          refresh="$(jq -cer '.refresh' <<< "$refresh_row")"
+          if [[ "$(jq -r '.status' <<< "$refresh")" != "changed" ]]; then
+            echo "::warning::GPG key refresh changed between monitor passes; no PR opened"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          key_file="$(jq -er '.key_file' <<< "$refresh_row")"
+          staged=".gpg-key-refresh/${key_file}"
+          if [[ ! -s "$staged" ]]; then
+            echo "::warning::GPG key refresh did not produce expected staged key: ${staged}"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cp "$staged" "$key_file"
+
+          {
+            echo "delta<<EOF"
+            echo "The monitor compares only \`pub\`/\`sub\` records: validity (field 2), expiry (field 7), and capability flags (field 12)."
+            jq -r '
+              [.delta.added[] | "- Added: `\(.)`"]
+              + [.delta.removed[] | "- Removed: `\(.)`"]
+              | join("\n")
+            ' <<< "$refresh"
+            echo "EOF"
+            echo "ready=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate App token
+        if: steps.refresh.outputs.ready == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Import GPG key
+        if: steps.refresh.outputs.ready == 'true'
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: Olivier ORABONA
+          git_committer_email: oorabona@users.noreply.github.com
+
+      - name: Open or update GPG key refresh PR
+        if: steps.refresh.outputs.ready == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "build(${{ matrix.container }}): refresh vendored GPG signing key"
+          committer: Olivier ORABONA <oorabona@users.noreply.github.com>
+          title: "🔐 build(${{ matrix.container }}): refresh vendored GPG signing key"
+          body: |
+            ## Vendored GPG signing-key refresh
+
+            **Dependency:** `${{ matrix.dependency }}`
+            **Key file:** `${{ matrix.key_file }}`
+
+            The fetched primary still matches the pinned Dockerfile fingerprint.
+            This PR changes no pin or Dockerfile; it refreshes the vendored
+            snapshot because its trust-relevant key shape changed.
+
+            ### Shape delta
+
+            ${{ steps.refresh.outputs.delta }}
+
+            ---
+            *Auto-generated by Upstream Version Monitor*
+          branch: update/gpg-key-${{ matrix.container }}-${{ matrix.dependency }}
+          delete-branch: true
+          add-paths: ${{ matrix.key_file }}
+
+      # Labels applied separately — peter-evans/create-pull-request has a race condition
+      # where addLabels fails with "Could not resolve to a node" (issue #4321).
+      # Failure tolerance: labels are triage metadata; the PR is authoritative.
+      - name: Apply labels
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          CONTAINER: ${{ matrix.container }}
+        run: |
+          sleep 2
+          if ! gh pr edit "$PR_NUMBER" --add-label "automation,gpg-key-lifecycle,container:${CONTAINER}" 2>&1; then
+            echo "::warning::Failed to apply GPG key refresh labels to PR #${PR_NUMBER}; PR created successfully — continuing"
+          fi
 
   create-update-prs:
     # check-source-liveness runs as a parallel sibling job (no needs:

--- a/scripts/check-gpg-keys.sh
+++ b/scripts/check-gpg-keys.sh
@@ -19,6 +19,10 @@ CURL_BIN="${GPG_KEYS_CURL_BIN:-$(command -v curl || true)}"
 YQ_BIN="${GPG_KEYS_YQ_BIN:-$(command -v yq || true)}"
 JQ_BIN="${GPG_KEYS_JQ_BIN:-$(command -v jq || true)}"
 LATEST_GH_RELEASE="${GPG_KEYS_LATEST_GH_RELEASE:-$PROJECT_ROOT/helpers/latest-github-release}"
+GPG_KEYSERVER="${GPG_KEYS_KEYSERVER:-keyserver.ubuntu.com}"
+GPG_KEYS_REFRESH_TIMEOUT_SECONDS="${GPG_KEYS_REFRESH_TIMEOUT_SECONDS:-30}"
+GPG_KEYS_REFRESH_KILL_AFTER_SECONDS="${GPG_KEYS_REFRESH_KILL_AFTER_SECONDS:-5}"
+TIMEOUT_BIN="${GPG_KEYS_TIMEOUT_BIN:-$(command -v timeout || true)}"
 
 _gha_escape() {
     local s="$1"
@@ -30,7 +34,7 @@ _gha_escape() {
 
 usage() {
     cat >&2 <<'USAGE'
-usage: check-gpg-keys.sh [--all | <container>] [--json] [--warn-days N]
+usage: check-gpg-keys.sh [--all | <container>] [--json] [--warn-days N] [--refresh-check] [--refresh-dir DIR]
 USAGE
 }
 
@@ -54,6 +58,10 @@ validate_tools() {
     fi
     if [[ -z "$LATEST_GH_RELEASE" || ! -x "$LATEST_GH_RELEASE" ]]; then
         echo "check-gpg-keys: unable to resolve latest-github-release; set GPG_KEYS_LATEST_GH_RELEASE" >&2
+        missing=1
+    fi
+    if [[ -z "$TIMEOUT_BIN" || ! -x "$TIMEOUT_BIN" ]]; then
+        echo "check-gpg-keys: unable to resolve timeout; set GPG_KEYS_TIMEOUT_BIN" >&2
         missing=1
     fi
     (( missing == 0 ))
@@ -126,6 +134,253 @@ empty_expiry() {
 
 empty_rotation() {
     jq -nc '{status:"error", rotation:false, reason:"rotation-check-unavailable", severity:"warn", latest:null, runtime:false}'
+}
+
+empty_refresh() {
+    jq -nc '{status:"not-checked", proposed:false, reason:"not-checked", severity:"none", primary_fpr:null, pinned_fpr:null, delta:{added:[], removed:[]}}'
+}
+
+key_shape_from_colons() {
+    # A pub/sub record is followed by its full fingerprint record.  Keep the
+    # pair together: a key ID is only a 64-bit selector, whereas the full
+    # fingerprint identifies the material that the build verifies with.
+    awk -F: '
+        $1 == "pub" || $1 == "sub" {
+            if (pending) {
+                invalid = 1
+                exit
+            }
+            pending = 1
+            type = $1
+            validity = $2
+            expiry = $7
+            capabilities = $12
+            next
+        }
+        pending && $1 == "fpr" {
+            if ($10 == "") {
+                invalid = 1
+                exit
+            }
+            print type ":" validity ":" expiry ":" capabilities ":" $10
+            pending = 0
+            rows++
+        }
+        END {
+            if (pending || !rows || invalid) {
+                exit 1
+            }
+        }
+    ' | LC_ALL=C sort
+}
+
+key_shape_from_file() {
+    local keyfile="$1"
+
+    "$GPG_BIN" --batch --with-colons --show-keys "$keyfile" 2>/dev/null \
+        | key_shape_from_colons
+}
+
+key_shape_from_keyring() {
+    local fingerprint="$1"
+
+    "$GPG_BIN" --batch --with-colons --list-keys "$fingerprint" 2>/dev/null \
+        | key_shape_from_colons
+}
+
+shape_lines_json() {
+    jq -Rsc 'split("\n") | map(select(length > 0))'
+}
+
+refresh_result() {
+    local container="$1"
+    local key_rel="$2"
+    local keyfile="$3"
+    local pinned_fpr="$4"
+    local refresh_dir="$5"
+
+    local gnupg_tmp shape_tmp vendored_shape fetched_shape fetched_primary fetched_primary_validity vendored_primary_validity
+    local added removed export_path export_tmp recv_status missing_fingerprints exported_shape exported_primary
+    # This runs inside a command substitution, where Bash clears errexit, so a
+    # failing mktemp would leave GNUPGHOME empty — and an empty GNUPGHOME is not
+    # an isolated one, it is the caller's real keyring, which the fetch would
+    # then import into.  A boundary that cannot be established refuses.
+    if ! gnupg_tmp="$(mktemp -d)" || [[ -z "$gnupg_tmp" ]] \
+        || ! shape_tmp="$(mktemp -d)" || [[ -z "$shape_tmp" ]] \
+        || ! chmod 700 "$gnupg_tmp"; then
+        [[ -n "${gnupg_tmp:-}" ]] && rm -rf "$gnupg_tmp"
+        [[ -n "${shape_tmp:-}" ]] && rm -rf "$shape_tmp"
+        jq -nc --arg pinned_fpr "$pinned_fpr" '
+          {status:"unavailable", proposed:false, reason:"refresh-workspace-unavailable", severity:"warn", primary_fpr:null, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    cleanup_refresh_tmp() {
+        rm -rf "$gnupg_tmp" "$shape_tmp"
+    }
+
+    # The fingerprint argument is the trust anchor.  A keyserver can fail or
+    # lie by omission, but it must not be able to turn a refresh into an
+    # unpinned primary key replacement.
+    # dirmngr owns keyserver timeouts in current GnuPG, so bound the entire
+    # receive operation here.  GNU timeout returns 124 for the initial timeout
+    # and 137 if kill-after has to terminate a stubborn child.
+    if GNUPGHOME="$gnupg_tmp" "$TIMEOUT_BIN" \
+        --kill-after="${GPG_KEYS_REFRESH_KILL_AFTER_SECONDS}s" \
+        "${GPG_KEYS_REFRESH_TIMEOUT_SECONDS}s" \
+        "$GPG_BIN" --batch --keyserver "$GPG_KEYSERVER" --recv-keys "$pinned_fpr" >/dev/null 2>&1; then
+        :
+    else
+        recv_status=$?
+        cleanup_refresh_tmp
+        if [[ "$recv_status" == "124" || "$recv_status" == "137" ]]; then
+            jq -nc --arg pinned_fpr "$pinned_fpr" '
+              {status:"unavailable", proposed:false, reason:"keyserver-timeout", severity:"warn", primary_fpr:null, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+        fi
+        jq -nc --arg pinned_fpr "$pinned_fpr" '
+          {status:"unavailable", proposed:false, reason:"keyserver-unavailable", severity:"warn", primary_fpr:null, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    if ! fetched_shape="$(GNUPGHOME="$gnupg_tmp" key_shape_from_keyring "$pinned_fpr")"; then
+        cleanup_refresh_tmp
+        jq -nc --arg pinned_fpr "$pinned_fpr" '
+          {status:"unavailable", proposed:false, reason:"key-shape-unavailable", severity:"warn", primary_fpr:null, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    fetched_primary="$(awk -F: '$1 == "pub" {print $5; exit}' <<< "$fetched_shape")"
+    fetched_primary_validity="$(awk -F: '$1 == "pub" {print $2; exit}' <<< "$fetched_shape")"
+    if [[ "$fetched_primary" != "$pinned_fpr" ]]; then
+        cleanup_refresh_tmp
+        jq -nc --arg primary_fpr "${fetched_primary:-unknown}" --arg pinned_fpr "$pinned_fpr" '
+          {status:"alarm", proposed:false, reason:"primary-fingerprint-mismatch", severity:"high", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    case "$fetched_primary_validity" in
+        r)
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"alarm", proposed:false, reason:"primary-key-revoked", severity:"high", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+            ;;
+        i)
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"alarm", proposed:false, reason:"primary-key-invalid", severity:"high", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+            ;;
+        d)
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"alarm", proposed:false, reason:"primary-key-disabled", severity:"high", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+            ;;
+    esac
+
+    if ! vendored_shape="$(key_shape_from_file "$keyfile")"; then
+        cleanup_refresh_tmp
+        jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+          {status:"unavailable", proposed:false, reason:"key-shape-unavailable", severity:"warn", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    vendored_primary_validity="$(awk -F: '$1 == "pub" {print $2; exit}' <<< "$vendored_shape")"
+    if [[ "$fetched_primary_validity" == "e" && "$vendored_primary_validity" != "e" ]]; then
+        cleanup_refresh_tmp
+        jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+          {status:"unavailable", proposed:false, reason:"fetched-primary-expired", severity:"warn", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    printf '%s\n' "$vendored_shape" > "$shape_tmp/vendored"
+    printf '%s\n' "$fetched_shape" > "$shape_tmp/fetched"
+    awk -F: '{print $5}' "$shape_tmp/vendored" | LC_ALL=C sort -u > "$shape_tmp/vendored-fingerprints"
+    awk -F: '{print $5}' "$shape_tmp/fetched" | LC_ALL=C sort -u > "$shape_tmp/fetched-fingerprints"
+    missing_fingerprints="$(comm -23 "$shape_tmp/vendored-fingerprints" "$shape_tmp/fetched-fingerprints" | paste -sd, -)"
+    if [[ -n "$missing_fingerprints" ]]; then
+        cleanup_refresh_tmp
+        jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" \
+            --arg missing_fingerprints "$missing_fingerprints" '
+          {status:"alarm", proposed:false, reason:("missing-key-fingerprints: " + $missing_fingerprints), severity:"high", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, missing_fingerprints:($missing_fingerprints | split(",")), delta:{added:[], removed:[]}}'
+        return 0
+    fi
+    added="$(comm -13 "$shape_tmp/vendored" "$shape_tmp/fetched" | shape_lines_json)"
+    removed="$(comm -23 "$shape_tmp/vendored" "$shape_tmp/fetched" | shape_lines_json)"
+
+    if cmp -s "$shape_tmp/vendored" "$shape_tmp/fetched"; then
+        cleanup_refresh_tmp
+        jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+          {status:"unchanged", proposed:false, reason:"shape-unchanged", severity:"none", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+        return 0
+    fi
+
+    if [[ -n "$refresh_dir" ]]; then
+        export_path="$refresh_dir/$container/$key_rel"
+        mkdir -p "$(dirname "$export_path")"
+        export_tmp="$(mktemp "$(dirname "$export_path")/.${key_rel}.XXXXXX")"
+        # Exported whole, deliberately.  `export-minimal` drops every expired
+        # subkey — on the openvpn key that is 12 of 20, six of them signing
+        # subkeys covering releases from 2019 to mid-2026 — while keeping the
+        # revoked ones, so a retained rebuild of an older release would stop
+        # verifying.  Stripping only third-party signatures is not expressible
+        # here: `keep-expired-subkeys` does not exist in GnuPG 2.4, and
+        # `no-export-clean` cancels the minimisation outright, which is why the
+        # pair it was written with exported byte-for-byte what a plain export
+        # does.  A keyserver cannot exploit the fuller export: binding a subkey
+        # needs the primary's secret key, so it can pad the file but not add
+        # material the build would verify with.
+        if ! GNUPGHOME="$gnupg_tmp" "$GPG_BIN" --batch --armor \
+            --export "$pinned_fpr" > "$export_tmp"; then
+            rm -f "$export_tmp"
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"unavailable", proposed:false, reason:"key-export-unavailable", severity:"warn", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+        fi
+        # The exported file must carry the shape that was compared, not merely a
+        # key with the right primary: the same omission this check refuses from a
+        # keyserver would be just as damaging arriving from the export step.
+        if [[ ! -s "$export_tmp" ]] \
+            || ! exported_shape="$(key_shape_from_file "$export_tmp")" \
+            || ! exported_primary="$(awk -F: '$1 == "pub" {print $5; exit}' <<< "$exported_shape")" \
+            || [[ "$exported_primary" != "$pinned_fpr" ]] \
+            || [[ "$exported_shape" != "$fetched_shape" ]]; then
+            rm -f "$export_tmp"
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"unavailable", proposed:false, reason:"key-export-invalid", severity:"warn", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+        fi
+        if ! mv -f "$export_tmp" "$export_path"; then
+            rm -f "$export_tmp"
+            cleanup_refresh_tmp
+            jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" '
+              {status:"unavailable", proposed:false, reason:"key-install-unavailable", severity:"warn", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:[], removed:[]}}'
+            return 0
+        fi
+    fi
+
+    cleanup_refresh_tmp
+    jq -nc --arg primary_fpr "$fetched_primary" --arg pinned_fpr "$pinned_fpr" \
+        --argjson added "$added" --argjson removed "$removed" '
+      {status:"changed", proposed:true, reason:"shape-changed", severity:"none", primary_fpr:$primary_fpr, pinned_fpr:$pinned_fpr, delta:{added:$added, removed:$removed}}'
+}
+
+refresh_contract_alarm() {
+    local refresh="$1"
+    local primary_fpr pinned_fpr reason
+    primary_fpr="$(jq -r '.primary_fpr // "unknown"' <<< "$refresh")"
+    pinned_fpr="$(jq -r '.pinned_fpr // "unknown"' <<< "$refresh")"
+    reason="$(jq -r '.reason // "key-contract-mismatch"' <<< "$refresh")"
+
+    # Re-use the existing high-severity contract alarm path for this condition.
+    # It is deliberately not a refresh: its own reason describes why no key
+    # material is written for a PR.
+    jq -nc --arg primary_fpr "$primary_fpr" --arg pinned_fpr "$pinned_fpr" --arg reason "$reason" '
+      {status:"error", reason:$reason, severity:"high", primary_fpr:$primary_fpr, primary_keyid:null, primary_count:1, primary_validity:null, signing_capable:false, signing_usable:false, pinned_fpr:$pinned_fpr}'
 }
 
 rotation_config_unsupported() {
@@ -396,13 +651,15 @@ emit_warning_if_needed() {
     local dep="$2"
     local result="$3"
 
-    local expiry_status rotation_status contract_status expiry_reason rotation_reason contract_reason
+    local expiry_status rotation_status contract_status refresh_status expiry_reason rotation_reason contract_reason refresh_reason
     expiry_status="$(jq -r '.expiry.status' <<< "$result")"
     rotation_status="$(jq -r '.rotation.status' <<< "$result")"
     contract_status="$(jq -r '.contract.status // "ok"' <<< "$result")"
+    refresh_status="$(jq -r '.refresh.status // "not-checked"' <<< "$result")"
     expiry_reason="$(jq -r '.expiry.reason' <<< "$result")"
     rotation_reason="$(jq -r '.rotation.reason' <<< "$result")"
     contract_reason="$(jq -r '.contract.reason // "valid"' <<< "$result")"
+    refresh_reason="$(jq -r '.refresh.reason // "not-checked"' <<< "$result")"
 
     if [[ "$contract_status" != "ok" ]]; then
         printf '::warning::gpg-key-contract: %s\n' \
@@ -415,6 +672,10 @@ emit_warning_if_needed() {
     if [[ "$rotation_status" != "ok" ]]; then
         printf '::warning::gpg-key-rotation: %s\n' \
             "$(_gha_escape "${container}/${dep}: ${rotation_reason}")" >&2
+    fi
+    if [[ "$refresh_status" == "unavailable" ]]; then
+        printf '::warning::gpg-key-refresh: %s\n' \
+            "$(_gha_escape "${container}/${dep}: ${refresh_reason}")" >&2
     fi
     local config_finding config_reason config_value config_detail
     while IFS= read -r config_finding; do
@@ -543,6 +804,8 @@ check_dep() {
     local dep="$2"
     local config="$3"
     local cli_warn_days="$4"
+    local refresh_check="$5"
+    local refresh_dir="$6"
 
     local key_rel repo strip_v cfg_warn_days warn_days dep_type tag_pattern keyfile errors_json config_json fingerprint_arg pinned_fpr
     key_rel="$(YQ_DEP="$dep" yq -r '.dependency_sources[strenv(YQ_DEP)].gpg_key.file // ""' "$config")"
@@ -562,7 +825,8 @@ check_dep() {
     errors_json="[]"
     config_json="[]"
 
-    local expiry_json rotation_json contract_json report
+    local expiry_json rotation_json contract_json refresh_json report
+    refresh_json="$(empty_refresh)"
     if [[ -z "$fingerprint_arg" || "$fingerprint_arg" == "null" || -z "$pinned_fpr" || "$pinned_fpr" == "null" ]]; then
         local msg="${dep}: missing pinned gpg_key fingerprint build_arg"
         errors_json="$(jq -nc --arg msg "$msg" '[$msg]')"
@@ -593,6 +857,12 @@ check_dep() {
             contract_json="$(jq -nc --arg pinned_fpr "$pinned_fpr" '{status:"error", reason:"key-parse-error", severity:"high", primary_fpr:null, primary_keyid:null, primary_count:null, primary_validity:null, pinned_fpr:$pinned_fpr}')"
         else
             contract_json="$(contract_result "$report" "$pinned_fpr")"
+            if [[ "$refresh_check" == "true" ]]; then
+                refresh_json="$(refresh_result "$container" "$key_rel" "$keyfile" "$pinned_fpr" "$refresh_dir")"
+                if [[ "$(jq -r '.status' <<< "$refresh_json")" == "alarm" ]]; then
+                    contract_json="$(refresh_contract_alarm "$refresh_json")"
+                fi
+            fi
             if ! valid_warn_days "$warn_days"; then
                 local msg="${dep}: invalid gpg_key.expiry_warn_days: ${warn_days}"
                 errors_json="$(jq -nc --arg msg "$msg" --argjson errors "$errors_json" '$errors + [$msg]')"
@@ -634,16 +904,17 @@ check_dep() {
         --argjson expiry "$expiry_json" \
         --argjson rotation "$rotation_json" \
         --argjson contract "$contract_json" \
+        --argjson refresh "$refresh_json" \
         --argjson config "$config_json" \
         --argjson errors "$errors_json" \
-        '{container:$container, dependency:$dep, key_file:$key_file, expiry:$expiry, rotation:$rotation, contract:$contract, config:$config, errors:$errors}')"
+        '{container:$container, dependency:$dep, key_file:$key_file, expiry:$expiry, rotation:$rotation, contract:$contract, refresh:$refresh, config:$config, errors:$errors}')"
 
     emit_warning_if_needed "$container" "$dep" "$result"
     printf '%s\n' "$result"
 }
 
 main() {
-    local target="" json=false cli_warn_days=""
+    local target="" json=false cli_warn_days="" refresh_dir="" refresh_check=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -661,6 +932,19 @@ main() {
                     return 2
                 fi
                 cli_warn_days="$2"
+                shift 2
+                ;;
+            --refresh-check)
+                refresh_check=true
+                shift
+                ;;
+            --refresh-dir)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    usage
+                    return 2
+                fi
+                refresh_dir="$2"
+                refresh_check=true
                 shift 2
                 ;;
             -*)
@@ -732,7 +1016,7 @@ main() {
             if ! gpg_key_shape_valid "$config" "$dep"; then
                 result="$(gpg_key_shape_result "$container" "$dep")"
             else
-                result="$(check_dep "$container" "$dep" "$config" "$cli_warn_days")"
+                result="$(check_dep "$container" "$dep" "$config" "$cli_warn_days" "$refresh_check" "$refresh_dir")"
             fi
             results="$(jq -c --argjson item "$result" '. + [$item]' <<< "$results")"
         done <<< "$deps"
@@ -741,7 +1025,7 @@ main() {
     if [[ "$json" == "true" ]]; then
         jq -c '.' <<< "$results"
     else
-        jq -r '.[] | "\(.container)/\(.dependency): contract=\(.contract.status // "ok") expiry=\(.expiry.status) rotation=\(.rotation.status)"' <<< "$results"
+        jq -r '.[] | "\(.container)/\(.dependency): contract=\(.contract.status // "ok") expiry=\(.expiry.status) rotation=\(.rotation.status) refresh=\(.refresh.status // "not-checked")"' <<< "$results"
     fi
 }
 

--- a/tests/unit/check-gpg-keys.bats
+++ b/tests/unit/check-gpg-keys.bats
@@ -28,6 +28,9 @@ teardown() {
     unset FAKE_PRIMARY_FPR FAKE_PRIMARY_COUNT FAKE_PRIMARY_VALIDITY FAKE_SIGNING_FPR FAKE_SIGNING_USABLE FAKE_SIGNING_CAPABLE
     unset FAKE_CURL_LOG FAKE_CURL_ARGS_LOG FAKE_LATEST_ARGS_LOG
     unset GPG_KEYS_YQ_BIN GPG_KEYS_JQ_BIN
+    unset FAKE_GPG_REFRESH_MODE FAKE_GPG_REFRESH_LOG FAKE_REFRESH_PRIMARY_FPR FAKE_REFRESH_PRIMARY_VALIDITY
+    unset FAKE_VENDORED_SHAPE FAKE_FETCHED_SHAPE GPG_KEYS_REFRESH_TIMEOUT_SECONDS GPG_KEYS_REFRESH_KILL_AFTER_SECONDS
+    unset RUN_TIMEOUT_BIN FAKE_GPG_EXPORT_MODE FAKE_MV_MODE
 }
 
 write_project_files() {
@@ -140,10 +143,73 @@ esac
 EOF
     chmod +x "$TEST_PROJECT_ROOT/helpers/curl"
 
-    cat > "$TEST_PROJECT_ROOT/helpers/gpg" <<'EOF'
+cat > "$TEST_PROJECT_ROOT/helpers/gpg" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+default_shape() {
+  printf '%s\n' \
+    "pub:${FAKE_REFRESH_PRIMARY_VALIDITY:--}:2048:1:FAKEKEYID:0:0:::::scESC:" \
+    'fpr:::::::::MATCHFPR:' \
+    'sub:-:2048:1:FAKESUBKEY:0:0:::::s:' \
+    'fpr:::::::::FAKESUBFPR:'
+}
+
 for arg in "$@"; do
+  if [[ "$arg" == "--recv-keys" ]]; then
+    if [[ -n "${FAKE_GPG_REFRESH_LOG:-}" ]]; then
+      printf 'recv-keys\n' >> "$FAKE_GPG_REFRESH_LOG"
+    fi
+    case "${FAKE_GPG_REFRESH_MODE:-ok}" in
+      ok) ;;
+      fail) exit 2 ;;
+      hang) exec sleep 3600 ;;
+      hang-kill) trap '' TERM; exec sleep 3600 ;;
+      *) exit 99 ;;
+    esac
+    exit 0
+  fi
+  if [[ "$arg" == "--show-keys" ]]; then
+    # --show-keys is used on two different files: the vendored .asc, and the
+    # staged export, which mktemp names with a leading dot.  Reading the staged
+    # file must yield what was exported — the fetched shape — or the check that
+    # the export preserved that shape can never pass.
+    show_target="${*: -1}"
+    if [[ "$(basename -- "$show_target")" == .* ]]; then
+      if [[ -n "${FAKE_EXPORTED_SHAPE:-}" ]]; then
+        printf '%s\n' "$FAKE_EXPORTED_SHAPE"
+      elif [[ -n "${FAKE_FETCHED_SHAPE:-}" ]]; then
+        printf '%s\n' "$FAKE_FETCHED_SHAPE"
+      else
+        default_shape
+      fi
+    elif [[ -n "${FAKE_VENDORED_SHAPE:-}" ]]; then
+      printf '%s\n' "$FAKE_VENDORED_SHAPE"
+    else
+      default_shape
+    fi
+    exit 0
+  fi
+  if [[ "$arg" == "--list-keys" ]]; then
+    if [[ -n "${FAKE_FETCHED_SHAPE:-}" ]]; then
+      printf '%s\n' "$FAKE_FETCHED_SHAPE"
+    else
+      default_shape | sed "s/fpr:::::::::MATCHFPR:/fpr:::::::::${FAKE_REFRESH_PRIMARY_FPR:-MATCHFPR}:/"
+    fi
+    exit 0
+  fi
+  if [[ "$arg" == "--export" ]]; then
+    # The export is deliberately whole: any --export-options here would be a
+    # regression, so the fake reports which form it was called in.
+    if [[ "${FAKE_GPG_EXPORT_MODE:-ok}" == "empty" ]]; then
+      :
+    elif [[ " $* " == *" --export-options "* ]]; then
+      printf '%s\n' 'minimised export'
+    else
+      printf '%s\n' 'refreshed key material'
+    fi
+    exit 0
+  fi
   if [[ "$arg" == "--import" ]]; then
     exit 0
   fi
@@ -188,10 +254,32 @@ done
 exit 0
 EOF
     chmod +x "$TEST_PROJECT_ROOT/helpers/gpg"
+
+cat > "$TEST_PROJECT_ROOT/helpers/mktemp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# A failing mktemp is how the isolation boundary fails to be established.
+if [[ "${FAKE_MKTEMP_MODE:-ok}" == "fail" ]]; then
+    exit 1
+fi
+exec /usr/bin/mktemp "$@"
+EOF
+    chmod +x "$TEST_PROJECT_ROOT/helpers/mktemp"
+
+cat > "$TEST_PROJECT_ROOT/helpers/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FAKE_MV_MODE:-ok}" == "fail" ]]; then
+  exit 1
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "$TEST_PROJECT_ROOT/helpers/mv"
 }
 
 run_check() {
-    env GPG_KEYS_PROJECT_ROOT="$TEST_PROJECT_ROOT" \
+    env PATH="$TEST_PROJECT_ROOT/helpers:$PATH" \
+        GPG_KEYS_PROJECT_ROOT="$TEST_PROJECT_ROOT" \
         GPG_KEYS_GPG_BIN="${RUN_GPG_BIN:-$TEST_PROJECT_ROOT/helpers/gpg}" \
         GPG_KEYS_CURL_BIN="$TEST_PROJECT_ROOT/helpers/curl" \
         GPG_KEYS_LATEST_GH_RELEASE="$TEST_PROJECT_ROOT/helpers/latest-github-release" \
@@ -208,6 +296,18 @@ run_check() {
         FAKE_CURL_MODE="${FAKE_CURL_MODE:-ok}" \
         FAKE_CURL_ARGS_LOG="${FAKE_CURL_ARGS_LOG:-}" \
         FAKE_GPG_VERIFY_STATUS="${FAKE_GPG_VERIFY_STATUS:-validsig}" \
+        FAKE_GPG_REFRESH_MODE="${FAKE_GPG_REFRESH_MODE:-ok}" \
+        FAKE_GPG_REFRESH_LOG="${FAKE_GPG_REFRESH_LOG:-}" \
+        FAKE_REFRESH_PRIMARY_FPR="${FAKE_REFRESH_PRIMARY_FPR:-MATCHFPR}" \
+        FAKE_REFRESH_PRIMARY_VALIDITY="${FAKE_REFRESH_PRIMARY_VALIDITY:--}" \
+        FAKE_VENDORED_SHAPE="${FAKE_VENDORED_SHAPE:-}" \
+        FAKE_FETCHED_SHAPE="${FAKE_FETCHED_SHAPE:-}" \
+        GPG_KEYS_REFRESH_TIMEOUT_SECONDS="${GPG_KEYS_REFRESH_TIMEOUT_SECONDS:-30}" \
+        GPG_KEYS_REFRESH_KILL_AFTER_SECONDS="${GPG_KEYS_REFRESH_KILL_AFTER_SECONDS:-5}" \
+        GPG_KEYS_TIMEOUT_BIN="${RUN_TIMEOUT_BIN:-$(command -v timeout)}" \
+        FAKE_GPG_EXPORT_MODE="${FAKE_GPG_EXPORT_MODE:-ok}" \
+        FAKE_MV_MODE="${FAKE_MV_MODE:-ok}" \
+        FAKE_MKTEMP_MODE="${FAKE_MKTEMP_MODE:-ok}" \
         FAKE_LATEST_VERSION="${FAKE_LATEST_VERSION:-3.2.7}" \
         FAKE_LATEST_ARGS_LOG="${FAKE_LATEST_ARGS_LOG:-}" \
         EXPECT_GPG_KEYS_GPG_BIN="${EXPECT_GPG_KEYS_GPG_BIN:-}" \
@@ -414,6 +514,309 @@ require_live_gpg_keygen() {
     [ "$(jq -r '.[0].contract.signing_usable' <<< "$(json_output)")" = "true" ]
 }
 
+@test "unchanged trust shape with different armored bytes proposes no refresh" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unchanged" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "a changed primary or subkey trust shape proposes a refresh with its delta" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:r:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "changed" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "true" ]
+    [ "$(jq -r '.[0].refresh.delta.added[]' <<< "$(json_output)")" = "sub:r:0:s:FAKESUBFPR" ]
+    [ "$(jq -r '.[0].refresh.delta.removed[]' <<< "$(json_output)")" = "sub:-:0:s:FAKESUBFPR" ]
+    [ "$(cat "$refresh_dir/openvpn/easyrsa-signing-key.asc")" = "refreshed key material" ]
+}
+
+@test "a keyserver fetch failure warns and does not propose a refresh" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_GPG_REFRESH_MODE=fail
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"::warning::gpg-key-refresh: openvpn/EASYRSA_VERSION: keyserver-unavailable"* ]]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+}
+
+@test "a fetched primary fingerprint mismatch raises the anchor alarm and does not propose a refresh" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_REFRESH_PRIMARY_FPR=DIFFERENTFPR
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "alarm" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+    [ "$(jq -r '.[0].contract.status' <<< "$(json_output)")" = "error" ]
+    [ "$(jq -r '.[0].contract.reason' <<< "$(json_output)")" = "primary-fingerprint-mismatch" ]
+    [ "$(jq -r '.[0].contract.severity' <<< "$(json_output)")" = "high" ]
+}
+
+@test "a fetched key missing a vendored subkey raises an omission alarm and stages nothing" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "alarm" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "missing-key-fingerprints: FAKESUBFPR" ]
+    [ "$(jq -r '.[0].contract.reason' <<< "$(json_output)")" = "missing-key-fingerprints: FAKESUBFPR" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "the trust shape comparison ignores third-party signatures" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsig:::::::\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsig:::::::'
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unchanged" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+}
+
+@test "a subkey replacement is an omission alarm even when its metadata is identical" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "alarm" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "missing-key-fingerprints: FAKESUBFPR" ]
+}
+
+@test "a fetched revoked primary raises an alarm and stages nothing" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_REFRESH_PRIMARY_VALIDITY=r
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "alarm" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "primary-key-revoked" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+    [ "$(jq -r '.[0].contract.status' <<< "$(json_output)")" = "error" ]
+    [ "$(jq -r '.[0].contract.reason' <<< "$(json_output)")" = "primary-key-revoked" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "a fetched expired primary is unavailable while the vendored primary is valid" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_REFRESH_PRIMARY_VALIDITY=e
+    export FAKE_VENDORED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+    export FAKE_FETCHED_SHAPE=$'pub:e:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "fetched-primary-expired" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "an expired fetched primary still proposes when the vendored primary is also expired" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_REFRESH_PRIMARY_VALIDITY=e
+    export FAKE_VENDORED_SHAPE=$'pub:e:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+    export FAKE_FETCHED_SHAPE=$'pub:e:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "changed" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "true" ]
+    [ -f "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "a revoked subkey on a live primary is ordinary refresh work, not an alarm" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:r:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "changed" ]
+    [ "$(jq -r '.[0].contract.status' <<< "$(json_output)")" = "ok" ]
+}
+
+@test "a missing timeout binary fails preflight instead of reporting a keyserver outage" {
+    export RUN_TIMEOUT_BIN="$TEST_TEMP_DIR/missing-timeout"
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unable to resolve timeout; set GPG_KEYS_TIMEOUT_BIN"* ]]
+    [[ "$output" != *"keyserver-unavailable"* ]]
+}
+
+@test "a failed final move is unavailable rather than reported as changed" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+    export FAKE_MV_MODE=fail
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "key-install-unavailable" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "a zero-byte export is not installed" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+    export FAKE_GPG_EXPORT_MODE=empty
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "key-export-invalid" ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+}
+
+@test "a hanging keyserver becomes unavailable within the configured bound" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_GPG_REFRESH_MODE=hang
+    export GPG_KEYS_REFRESH_TIMEOUT_SECONDS=1
+    export GPG_KEYS_REFRESH_KILL_AFTER_SECONDS=1
+    local started elapsed
+    started="$(date +%s)"
+
+    run run_check openvpn --json --refresh-check
+    elapsed=$(( $(date +%s) - started ))
+
+    [ "$status" -eq 0 ]
+    [ "$elapsed" -lt 4 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "keyserver-timeout" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+}
+
+@test "a keyserver that ignores termination is killed and remains unavailable" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_GPG_REFRESH_MODE=hang-kill
+    export GPG_KEYS_REFRESH_TIMEOUT_SECONDS=1
+    export GPG_KEYS_REFRESH_KILL_AFTER_SECONDS=1
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "keyserver-timeout" ]
+    [ "$(jq -r '.[0].refresh.proposed' <<< "$(json_output)")" = "false" ]
+}
+
+@test "without refresh work requested, no keyserver call occurs and refresh is not-checked" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_GPG_REFRESH_LOG="$TEST_TEMP_DIR/refresh.log"
+
+    run run_check openvpn --json
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_GPG_REFRESH_LOG" ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "not-checked" ]
+}
+
+@test "a human-readable refresh check reports its refresh result" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+
+    run run_check openvpn --refresh-check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"refresh=unchanged"* ]]
+}
+
+@test "a workspace that cannot be created refuses instead of using the real keyring" {
+    # GNUPGHOME="" is not an isolated keyring, it is the caller's own, so a
+    # failing mktemp would make the fetch import into it.  The boundary that
+    # cannot be established must refuse rather than widen.
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_MKTEMP_MODE=fail
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"refresh-workspace-unavailable"* ]]
+    [[ "$output" != *'"proposed":true'* ]]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+    # The fetch must not have run at all.
+    [ ! -s "$TEST_PROJECT_ROOT/gpg-refresh.log" ] || \
+        ! grep -q 'recv-keys' "$TEST_PROJECT_ROOT/gpg-refresh.log"
+}
+
+@test "an export that lost a fetched subkey is not installed" {
+    # The same omission the fetch step refuses from a keyserver is just as
+    # damaging arriving from the export: a staged key carrying the right primary
+    # but fewer subkeys would replace the vendored file with an amputated one.
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::NEWSUBFPR:'
+    # The export drops the subkey the fetch had just gained.
+    export FAKE_EXPORTED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$refresh_dir/openvpn/easyrsa-signing-key.asc" ]
+    [[ "$output" == *"key-export-invalid"* ]]
+    [[ "$output" != *'"proposed":true'* ]]
+}
+
+@test "a refresh exports the whole key rather than a minimised one" {
+    # Measured on the real openvpn key: --export-options export-minimal keeps
+    # 8 subkeys of 20, dropping every expired one — six of them signing
+    # subkeys that signed releases between 2019 and mid-2026 — while keeping
+    # the revoked ones.  A retained rebuild of one of those releases would
+    # stop verifying, so minimisation must not come back.
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nfpr:::::::::MATCHFPR:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:\nsub:-:2048:1:NEWKEY:0:0:::::s:\nfpr:::::::::REPLACEDSUBFPR:'
+    local refresh_dir="$TEST_TEMP_DIR/refreshed"
+
+    run run_check openvpn --json --refresh-dir "$refresh_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$refresh_dir/openvpn/easyrsa-signing-key.asc")" = "refreshed key material" ]
+    [[ "$(cat "$refresh_dir/openvpn/easyrsa-signing-key.asc")" != *"minimised export"* ]]
+}
+
+@test "an unpaired pub/sub record is unavailable instead of comparing equal" {
+    export GPG_KEYS_NOW_TS=$((2000000000 - 100 * 86400))
+    export FAKE_FETCHED_SHAPE=$'pub:-:2048:1:FAKEKEYID:0:0:::::scESC:\nsub:-:2048:1:FAKESUBKEY:0:0:::::s:\nfpr:::::::::FAKESUBFPR:'
+
+    run run_check openvpn --json --refresh-check
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.[0].refresh.status' <<< "$(json_output)")" = "unavailable" ]
+    [ "$(jq -r '.[0].refresh.reason' <<< "$(json_output)")" = "key-shape-unavailable" ]
+}
+
 @test "workflow GPG gate treats config-only rows as findings" {
     local findings="$TEST_TEMP_DIR/findings.json"
     cat > "$findings" <<'EOF'
@@ -450,6 +853,30 @@ EOF
     [[ "$token_if" == *"github.ref == 'refs/heads/master'"* ]]
     [[ "$issue_if" == *"steps.gpg.outputs.has_findings == 'true'"* ]]
     [[ "$issue_if" == *"github.ref == 'refs/heads/master'"* ]]
+}
+
+@test "workflow fans changed GPG key shapes into one pinned create-pull-request matrix job" {
+    local wf="$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml"
+    local matrix pr_action add_paths
+    matrix="$(yq -r '.jobs."refresh-vendored-gpg-keys".strategy.matrix.include' "$wf")"
+    pr_action="$(yq -r '.jobs."refresh-vendored-gpg-keys".steps[] | select(.id == "create-pr") | .uses' "$wf")"
+    add_paths="$(yq -r '.jobs."refresh-vendored-gpg-keys".steps[] | select(.id == "create-pr") | .with."add-paths"' "$wf")"
+
+    [[ "$matrix" == *"fromJson(needs.check-gpg-keys.outputs.refresh_candidates)"* ]]
+    [ "$pr_action" = "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1" ]
+    [ "$add_paths" = '${{ matrix.key_file }}' ]
+}
+
+@test "workflow passes refresh matrix values into shell through environment variables" {
+    local wf="$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml"
+    local env_container env_dependency refresh_run
+    env_container="$(yq -r '.jobs."refresh-vendored-gpg-keys".steps[] | select(.id == "refresh") | .env.CONTAINER' "$wf")"
+    env_dependency="$(yq -r '.jobs."refresh-vendored-gpg-keys".steps[] | select(.id == "refresh") | .env.DEPENDENCY' "$wf")"
+    refresh_run="$(yq -r '.jobs."refresh-vendored-gpg-keys".steps[] | select(.id == "refresh") | .run' "$wf")"
+
+    [ "$env_container" = '${{ matrix.container }}' ]
+    [ "$env_dependency" = '${{ matrix.dependency }}' ]
+    [[ "$refresh_run" != *'${{ matrix.'* ]]
 }
 
 @test "trust contract mismatch is high when no signing-capable key exists" {


### PR DESCRIPTION
Three signing keys are vendored as `.asc` snapshots and nothing refreshed them, so
a revocation published upstream stayed invisible — to the build, and to the daily
check, which verifies with the same snapshot.

The daily check now fetches each key from a keyserver by its pinned fingerprint and
compares what comes back against the vendored file. When the trust-relevant shape
differs it opens a pull request per key.

## What is compared

Each primary and subkey with its validity, expiry, capability flags and full
fingerprint. Not the armored bytes: two of the three vendored keys already differ
byte-for-byte from the keyserver copy while nothing a build depends on has changed,
because signature sets drift as people sign a key. A byte trigger would have opened
two meaningless pull requests on its first run.

The fingerprint comes from the `fpr` record paired with its `pub` or `sub`, not the
64-bit key ID, so a signing subkey swapped for a different one with the same
metadata cannot compare equal.

## What is refused

A refresh may gain key material and never lose it. Pinning stops a keyserver forging
an addition — binding a subkey needs the primary's secret key — but not omission, and
an incomplete answer differs in shape exactly like a real update does. Every
fingerprint in the vendored key must still be present in the fetched one, and in the
staged export.

Revocation, a primary that does not match the pin, and a fetched primary that expired
while the vendored copy is still valid each go to the issue channel under their own
reason rather than opening a pull request. A revoked *subkey* is ordinary rotation.

A failed or timed-out fetch warns and proposes nothing: a keyserver outage must not
manufacture work.

## Why the export is whole

`export-minimal` keeps 8 subkeys of 20 on the openvpn key. It drops every expired
one — six of them signing subkeys covering releases from 2019 to mid-2026 — and keeps
the revoked ones, so a retained rebuild of one of those releases would stop verifying.
`keep-expired-subkeys` does not exist in GnuPG 2.4.

## Verification

- unit suite: 2460 collected, 0 failed
- `shellcheck -x -S warning`: clean
- `actionlint`: the same 20 pre-existing findings as master, none new
- run against the three real keys with the check requested: three `unchanged`,
  nothing proposed, no files written — which a byte-based implementation fails
- the whole-export decision, the fingerprint-loss refusal and the workspace refusal
  are each mutation-proven: breaking the guard turns its test red

Closes #1128
