### PR TITLE
refactor(openvpn): take pkcs11-helper from Alpine instead of compiling it

### DIFF
--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -5,15 +5,24 @@ FROM ${REMOTE_CR}/library/alpine:${OS_VERSION}
 
 ARG VERSION
 ARG UPSTREAM_VERSION
-ARG PKCS11_HELPER_VERSION
 ARG EASYRSA_VERSION
 ARG EASYRSA_KEY_FPR
 ARG OPENVPN_KEY_FPR
 ARG OVPN_SHA256
 ARG NPROC
+# Declared only to refuse it. pkcs11-helper now comes from the Alpine repository
+# (#957), so a caller who still pins a version here would get a different library
+# than the one they asked for. BuildKit does warn that the argument was not
+# consumed, and a warning in a build log is easy to miss, so stop instead.
+ARG PKCS11_HELPER_VERSION
 
 # Validate required build args
-RUN : "${VERSION:?required}" "${PKCS11_HELPER_VERSION:?required}" "${EASYRSA_VERSION:?required}" "${EASYRSA_KEY_FPR:?required}" "${OPENVPN_KEY_FPR:?required}" "${OVPN_SHA256:?required}" "${NPROC:?required}"
+RUN : "${VERSION:?required}" "${EASYRSA_VERSION:?required}" "${EASYRSA_KEY_FPR:?required}" "${OPENVPN_KEY_FPR:?required}" "${OVPN_SHA256:?required}" "${NPROC:?required}" \
+    && [ -z "${PKCS11_HELPER_VERSION:-}" ] || { \
+        echo "PKCS11_HELPER_VERSION is no longer honoured: pkcs11-helper comes from the Alpine repository (#957)." >&2; \
+        echo "Remove the build argument. Its version now follows OS_VERSION, and Alpine carries it from 3.24 only." >&2; \
+        exit 1; \
+    }
 
 # EasyRSA release signing key (Eric F Crist, the EasyRSA maintainer; fingerprint
 # 6F40 5682 1152 F03B 6B24 F2FC F848 9F83 9D73 67F3). Vendored as the trust
@@ -46,7 +55,7 @@ RUN set -ex \
     # `strip_v: true` in config.yaml governs the version monitor's comparison,
     # not this build argument.
     && RELEASE_VERSION="${DOWNLOAD_VERSION#v}" \
-    && apk add --update iptables bash ca-certificates curl linux-pam libselinux openssl nss gnutls gzip \
+    && apk add --update iptables bash ca-certificates curl linux-pam libselinux openssl nss gnutls gzip pkcs11-helper \
         google-authenticator libqrencode libcap-ng \
     && apk add --no-cache --virtual .build-deps \
         gcc \
@@ -55,17 +64,15 @@ RUN set -ex \
         coreutils \
         libconfig-dev \
         linux-headers \
-        autoconf \
-        libtool \
         openssl-dev \
         linux-pam-dev \
         libselinux-dev \
         nss-dev \
         gnutls-dev \
-        automake \
         make \
         libcap-ng-dev \
         libcap-dev \
+        pkcs11-helper-dev \
         gnupg \
     && cd /tmp \
     # Fetch the OpenVPN release artifact and its detached signature. The
@@ -111,20 +118,10 @@ RUN set -ex \
     # `tar | head -1` alone reports success when tar later hits a truncated
     # archive, because head exits 0 having read its line. Listing to a file first
     # lets tar's own status decide, so a corrupt archive stops here rather than
-    # after pkcs11-helper has been compiled.
+    # after the archive has been extracted.
     && tar tzf openvpn.tgz > /tmp/ovpn-members.txt \
     && [ "$(head -1 /tmp/ovpn-members.txt)" = "openvpn-${RELEASE_VERSION}/" ] \
     && rm -f /tmp/ovpn-members.txt \
-    # Download pinned version of OpenSC pkcs11-helper
-    && curl -sSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 30 https://github.com/opensc/pkcs11-helper/archive/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.gz --output pkcs11-helper.tgz \
-    && tar zxvf pkcs11-helper.tgz \
-    && cd pkcs11-helper-pkcs11-helper-${PKCS11_HELPER_VERSION} \
-    && autoreconf -ivf \
-    # Note: --enable-pedantic removed - modern NSS headers use C++ comments incompatible with strict C90
-    && ./configure --enable-strict \
-    && make -j$NPROC \
-    && make install \
-    && cd /tmp \
     && tar zxvf openvpn.tgz && cd "openvpn-${RELEASE_VERSION}" \
     # Opinionated but lzo and lz4 are not required for OpenVPN to work
     # and subject to security issues.

--- a/openvpn/README.md
+++ b/openvpn/README.md
@@ -15,7 +15,7 @@ This is a simple `Alpine` based container with `OpenVPN` built from sources.
 ## Features
 
 - 🔐 Built from sources
-- Dependant library `pkcs11-helper` built from sources
+- Dependant library `pkcs11-helper` from the Alpine repository, signature-verified by `apk`
 - Embed `Google Authenticator` support
 
 ## Verify this image
@@ -184,7 +184,6 @@ Three variables control the container's lifecycle:
 ### Google Authenticator
 
 The container is configured to use the `google-authenticator` library to generate the OTP code.
-This library is based on the `pkcs11-helper` library which is built from sources.
 The generated QR code is stored in the container on a per user basis under the `/etc/openvpn/otp` directory.
 The QR code can be retrieved using the following command:
 
@@ -233,10 +232,10 @@ The following build arguments can be passed to customize the container build:
 |----------|---------|-------------|
 | `VERSION` | `latest` | OpenVPN version to build |
 | `UPSTREAM_VERSION` | (empty) | Fallback upstream version if `VERSION` is not specified |
-| `OS_VERSION` | `latest` | Alpine Linux version tag |
-| `PKCS11_HELPER_VERSION` | `1.31.0` | pkcs11-helper library version |
-| `EASYRSA_VERSION` | `3.2.2` | EasyRSA version for certificate management |
+| `OS_VERSION` | `latest` | Alpine Linux version tag — **3.24 or newer**, the releases carrying `pkcs11-helper` |
+| `EASYRSA_VERSION` | `3.2.6` | EasyRSA version for certificate management |
 | `NPROC` | `1` | Number of parallel processes for compilation |
+| `PKCS11_HELPER_VERSION` | — | **Refused.** The build stops if it is set: `pkcs11-helper` now comes from Alpine, so its version follows `OS_VERSION` |
 
 ## Build options
 
@@ -329,8 +328,12 @@ The following third-party dependencies are pinned and monitored for updates:
 
 | Dependency | Version | Source | Monitoring |
 |-----------|---------|--------|-----------|
-| pkcs11-helper | 1.31.0 | GitHub Release (opensc/pkcs11-helper) | Enabled |
-| EasyRSA | 3.2.2 | GitHub Release (OpenVPN/easy-rsa) | Enabled |
+| EasyRSA | 3.2.6 | GitHub Release (OpenVPN/easy-rsa) | Enabled |
+
+`pkcs11-helper` is deliberately absent from that table: it comes from the Alpine
+repository, so its version follows the base image and `apk` verifies its signature.
+Nothing here pins or monitors it. Alpine carries it in `main` from 3.24 onward, so
+`OS_VERSION` has that floor.
 
 ## References
 

--- a/openvpn/config.yaml
+++ b/openvpn/config.yaml
@@ -7,7 +7,6 @@ base_image_cache:
     tags: ["latest"]
 build_args:
   OS_VERSION: "latest"
-  PKCS11_HELPER_VERSION: "1.31.0"
   EASYRSA_VERSION: "3.2.6"
   # Pinned EasyRSA release-signing key fingerprint (primary). SINGLE SOURCE OF TRUTH:
   # consumed as a --build-arg by the Dockerfile bake (exactly-one-key + fingerprint
@@ -57,12 +56,6 @@ dependency_sources:
       release_asset_template: "openvpn-{version}.tar.gz"
       release_tag_template: "v{version}"
       signature_suffix: ".asc"
-  PKCS11_HELPER_VERSION:
-    lifecycle: tracked
-    type: github-release
-    repo: opensc/pkcs11-helper
-    strip_v: false
-    tag_pattern: "(?<=pkcs11-helper-)\\d+\\.\\d+\\.\\d+"
   EASYRSA_VERSION:
     lifecycle: tracked
     type: github-release


### PR DESCRIPTION
The build fetched OpenSC pkcs11-helper over TLS and compiled it, with no
verification of any kind. #957 asked for a digest-pinning approach. Measuring what
upstream publishes says the answer is to stop compiling it.

## Why a digest was the wrong instrument

OpenSC signs nothing: five consecutive releases publish exactly one asset each, a
`.tar.bz2`, with no `.asc` and no `.sig`. The tag is lightweight, so there is no
tag object to sign either.

A digest of our own would not have closed that. The precedent here is
`OVPN_SHA256`, and it works because its dependency is `lifecycle: untracked` — a
human moves the version and the digest together. `PKCS11_HELPER_VERSION` was
`tracked`, so the monitor bumped it unattended and a pin would have gone stale on
every bump. A pin the same automation maintains and consumes locks bytes that were
already observed; it does not authenticate them.

We were also not downloading what upstream publishes. The build took GitHub's
auto-generated archive (125650 bytes, no `./configure`) rather than the release
asset (424487 bytes, ships `./configure`) — which is why it ran `autoreconf`.

## What replaces it

Alpine `main` carries `pkcs11-helper-1.31.0-r0`, the version this build compiled,
and `apk` verifies repository signatures by default. That is an independent signed
trust root, which is what the issue was reaching for.

Gone with the source build: the unverified download, `autoreconf`, the `autoconf`
/ `automake` / `libtool` packages, and this dependency's version tracking.
OpenVPN's own source stays a GPG-verified release tarball, compiled here as before.

`PKCS11_HELPER_VERSION` is now declared only to refuse it. BuildKit does warn that
an unconsumed build argument was passed, and a warning in a build log is easy to
miss, so a caller who still pins a version gets a build that stops and says why
rather than a different library than the one they asked for.

## The trade, stated plainly

Version selection moves to Alpine. Today there is no lag — upstream's latest
release is 1.31.0 and Alpine ships 1.31.0-r0 — but a rebuild of the same commit
now picks up whatever Alpine has published since, and an Alpine package revision
reaches the image without review here.

**Alpine carries `pkcs11-helper` from 3.24 onward**, absent from 3.19 through
3.23, so `OS_VERSION` has a floor it did not have before. The repository builds
`latest`, so nothing breaks; the constraint is documented where the argument is.

If Alpine ever trails a security fix, the source build returns — with the
published release asset rather than the GitHub archive it used to take.

## Verification

On the built image: `/usr/lib/libpkcs11-helper.so.1` is owned by
`pkcs11-helper-1.31.0-r0`, no self-built copy remains under `/usr/local/lib`,
`openvpn --version` reports `[PKCS11]`, and the binary links the Alpine library.

The lifecycle e2e passes against it, including the handshake and revocation phases
added in #965 — so PKCS#11 support is exercised through a real connection rather
than inferred from a compile flag.

Also measured, both directions: a normal build succeeds, and a build passing
`PKCS11_HELPER_VERSION` stops at the guard with its message.

Unit suite: 2460 collected, 0 failed.

Two documentation values were stale before this branch and are corrected while
here: both tables said EasyRSA 3.2.2 where `config.yaml` says 3.2.6. They duplicate
a version the monitor bumps, so they will drift again; worth folding into
`config.yaml` as the single source if it recurs.

Closes #957
