### PR TITLE
build(github-runner): pin the VS Build Tools bootstrapper to a fixed version

### DIFF
--- a/github-runner/Dockerfile.windows
+++ b/github-runner/Dockerfile.windows
@@ -139,8 +139,31 @@ RUN Expand-Archive -Path runner.zip -DestinationPath . -Force; \
 
 COPY entrypoint.ps1 C:\\entrypoint.ps1
 
-# VS Build Tools 2022 + Windows 11 SDK — direct Microsoft installer
-RUN Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vs_buildtools.exe' -OutFile C:\vs_buildtools.exe; \
+# VS Build Tools 2022 + Windows 11 SDK — pinned fixed-version bootstrapper.
+#
+# `aka.ms/vs/17/release/vs_buildtools.exe` floats: it serves whatever 17.x is
+# current, so two builds of the same commit installed different tooling. Measured
+# on 2026-08-09, it redirected to the same product GUID as the pin below but a
+# different build.
+#
+# Microsoft's release-history page publishes a fixed-version bootstrapper per
+# release, and each installs that exact release rather than the latest. The hash
+# segment of the URL is the file's own SHA-256 — verified: the 4459960-byte
+# download hashes to the value already in its path — so the URL carries its
+# integrity check and the assertion below restates it where a reader will see it.
+#
+# Bumping this means taking the next bootstrapper URL from the release history
+# and updating both the URL and the assertion.
+# The digest is a literal rather than an ARG: a Dockerfile ARG reaches the shell
+# through parser substitution, not as $env:, so an ARG here would compare against
+# an empty string and fail every build.
+RUN $expected = 'e0b8ea16494b4a79c68da26773131562aefecc8d87f1923c24d579c7a72e0575'; \
+    Invoke-WebRequest -Uri 'https://download.visualstudio.microsoft.com/download/pr/f7f5ecbc-83ca-4cf0-bdb2-aaf70efb6d97/e0b8ea16494b4a79c68da26773131562aefecc8d87f1923c24d579c7a72e0575/vs_BuildTools.exe' -OutFile C:\vs_buildtools.exe; \
+    $actual = (Get-FileHash -Path C:\vs_buildtools.exe -Algorithm SHA256).Hash.ToLower(); \
+    if ($actual -ne $expected) { \
+      Write-Error ('vs_BuildTools.exe digest mismatch: got ' + $actual + ', expected ' + $expected); \
+      exit 1; \
+    }; \
     Start-Process -Wait -FilePath C:\vs_buildtools.exe -ArgumentList \
       '--quiet', '--wait', '--norestart', \
       '--add', 'Microsoft.VisualStudio.Workload.VCTools', \
@@ -159,7 +182,13 @@ RUN $vsBase = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC
     Write-Host ('MSVC: ' + $msvcBin); \
     Write-Host ('SDK:  ' + $sdkBin); \
     $machPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); \
-    [System.Environment]::SetEnvironmentVariable('Path', ($machPath + ';' + $msvcBin + ';' + $sdkBin), 'Machine')
+    [System.Environment]::SetEnvironmentVariable('Path', ($machPath + ';' + $msvcBin + ';' + $sdkBin), 'Machine'); \
+    # Two lines, both true of this image: the toolset directory that was found,
+    # and the bootstrapper digest that produced it. The Windows SDK is not here
+    # because it is pinned by the component id in the install arguments above —
+    # restating it would put an assertion where the rest of the file holds
+    # observations.
+    Set-Content -Path C:\build-versions.txt -Encoding ascii -Value @( ('msvc_toolset=' + $msvcVer), 'vs_buildtools=e0b8ea16494b4a79c68da26773131562aefecc8d87f1923c24d579c7a72e0575' )
 
 LABEL org.opencontainers.image.description="GitHub Actions self-hosted runner (Windows ltsc2022 — dev)"
 LABEL org.opencontainers.image.source="https://github.com/oorabona/docker-containers"


### PR DESCRIPTION
`Dockerfile.windows` fetched `https://aka.ms/vs/17/release/vs_buildtools.exe`, a
redirector that serves whatever 17.x is current, so two builds of the same commit
installed different tooling and nothing in the image said which.

Measured on 2026-08-09: it redirected to the same product GUID as the pin below,
under a different build.

## The pin

Microsoft's release-history page publishes a fixed-version bootstrapper per
release, and each installs that exact release rather than the latest. The build
now takes one.

The hash segment of that URL is the file's own SHA-256 — the 4459960-byte download
hashes to the value already sitting in its path. The build asserts it anyway, as a
literal beside the URL, so the check is visible where the fetch happens and a
substituted artifact stops the build instead of being installed.

The digest is a literal rather than an `ARG`: a Dockerfile `ARG` reaches the shell
through parser substitution and not as `$env:`, so an `ARG` would have compared
against an empty string and failed every Windows build.

## What the image records

The PATH layer already discovers the MSVC toolset directory to build the path; it
now writes that and the bootstrapper digest to `C:\build-versions.txt`. The
Windows SDK is not there — it is pinned by the component id in the install
arguments, and restating it would put an assertion among observations.

## Bumping it

Take the next bootstrapper URL from the release history and update the URL, the
assertion and the recorded digest together.

## What was rescoped away

#801 also claimed the Rust toolchain was unpinned and that cargo-pgrx needed
monitoring. Neither holds: `rust_version: "1.96.0"` is declared and required, and
cargo-pgrx is derived at build time from ParadeDB's own `Cargo.toml`, which is
stronger than a pin this repository would maintain. The Rust toolchain is pinned
but unmonitored; the monitor writes only to `.extensions[NAME].version` and
`.build_args[NAME]`, and `rust_version` is neither, so wiring it would need a
third write path for a dependency that never leaves a build stage.

## Verification

Unit suite 2470 collected, 0 failed. This image is Windows and builds only in CI,
so the fetch, the digest assertion and the record file are verified there.

Closes #801
