### PR TITLE
fix(ci): stop the bake generator emitting an empty graph on a failed closure

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1798,8 +1798,10 @@ jobs:
   # ---------------------------------------------------------------------------
   # Bake pipeline (ADR-013 production cutover)
   #
-  # Routes the bake-managed containers (the set in helpers/bake-managed.sh)
-  # through `docker buildx bake` while the flat matrix above handles the rest.
+  # Routes eligible cells of bake-managed containers (the set in
+  # helpers/bake-managed.sh) through `docker buildx bake`. Windows cells always
+  # stay on the flat matrix; a retained cell reaches bake when its container is
+  # retained-eligible or declares build.always_all_versions.
   #
   # Architecture:
   #   bake-build-amd64 / bake-build-arm64  — Stage A: per-arch native builds

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1798,8 +1798,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Bake pipeline (ADR-013 production cutover)
   #
-  # Routes github-runner, web-shell, and wordpress through `docker buildx bake`
-  # while the flat matrix above continues to handle all other containers.
+  # Routes the bake-managed containers (the set in helpers/bake-managed.sh)
+  # through `docker buildx bake` while the flat matrix above handles the rest.
   #
   # Architecture:
   #   bake-build-amd64 / bake-build-arm64  — Stage A: per-arch native builds

--- a/helpers/bake-managed.sh
+++ b/helpers/bake-managed.sh
@@ -265,20 +265,17 @@ _bake_retained_eligible() {
 }
 
 # ---------------------------------------------------------------------------
-# partition_builds <builds_json> [<scope_active>] [<include_retained>]
+# partition_builds <builds_json> [<force_matrix>] [<include_retained>]
 #
 # Given the `builds` JSON array (cells with a `.container` field), prints a
 # compact JSON object:
 #   {"bake": [...cells routed to the bake engine...],
 #    "matrix": [...all remaining cells...]}
 #
-# When <scope_active> is "true" (second argument), bake is disabled for this
-# run: ALL cells route to .matrix.  This preserves per-cell scan/attest
-# fidelity for scoped dispatches (scope_versions / scope_flavors non-empty),
-# which build only a subset of a container's cells while bake would publish
-# the full container plan.
+# When <force_matrix> is "true" (second argument), ALL cells route to .matrix.
+# This flag disables bake routing for runs that require the flat matrix.
 #
-# When <scope_active> is absent or any value other than "true", per-cell
+# When <force_matrix> is absent or any value other than "true", per-cell
 # routing applies:
 #   A cell lands in .bake only when ALL of the following hold:
 #     1. Its .container is in the bake-managed set.
@@ -298,7 +295,7 @@ _bake_retained_eligible() {
 # ---------------------------------------------------------------------------
 partition_builds() {
     local builds_json="$1"
-    local scope_active="${2:-false}"
+    local force_matrix="${2:-false}"
     local include_retained="${3:-false}"
 
     # Validate: must be a non-empty string
@@ -313,9 +310,8 @@ partition_builds() {
         return 1
     fi
 
-    # Scoped run or forced-matrix: bake disabled — all cells to matrix for full
-    # per-cell fidelity (scope_versions / scope_flavors / test routing).
-    if [[ "$scope_active" == "true" ]]; then
+    # Forced-matrix: bake disabled — all cells route to the flat matrix.
+    if [[ "$force_matrix" == "true" ]]; then
         echo "$builds_json" | jq -c '{bake: [], matrix: [.[]]}'
         return 0
     fi
@@ -414,22 +410,22 @@ main() {
     case "$cmd" in
         partition)
             if [[ $# -lt 2 ]]; then
-                printf 'Usage: %s partition <builds_json_or_@file> [scope_active] [include_retained]\n' \
+                printf 'Usage: %s partition <builds_json_or_@file> [force_matrix] [include_retained]\n' \
                     "$(basename "$0")" >&2
                 return 1
             fi
             local input="$2"
-            local scope_arg="${3:-false}"
+            local force_matrix_arg="${3:-false}"
             local include_retained_arg="${4:-false}"
             # Support @file syntax: @path reads from file
             if [[ "$input" == @* ]]; then
                 local filepath="${input#@}"
                 input="$(cat "$filepath")"
             fi
-            partition_builds "$input" "$scope_arg" "$include_retained_arg"
+            partition_builds "$input" "$force_matrix_arg" "$include_retained_arg"
             ;;
         *)
-            printf 'Usage: %s partition <builds_json_or_@file> [scope_active] [include_retained]\n' \
+            printf 'Usage: %s partition <builds_json_or_@file> [force_matrix] [include_retained]\n' \
                 "$(basename "$0")" >&2
             return 1
             ;;

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -65,6 +65,8 @@ source "${PROJECT_ROOT}/helpers/dependency-graph.sh"
 # build-args-utils provides build_args_json (config.yaml build_args as JSON).
 # shellcheck source=../helpers/logging.sh
 source "${PROJECT_ROOT}/helpers/logging.sh"
+# shellcheck source=../helpers/gha.sh
+source "${PROJECT_ROOT}/helpers/gha.sh"
 # shellcheck source=../helpers/build-args-utils.sh
 source "${PROJECT_ROOT}/helpers/build-args-utils.sh"
 # validate-base-cache-schema provides _vbc_validate_build_args_config — the
@@ -134,7 +136,7 @@ _list_all_containers() {
     local out stderr_file
     stderr_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-make-list.XXXXXX") || return 1
     if ! out=$({ cd "${PROJECT_ROOT}" && ./make list; } 2>"$stderr_file"); then
-        cat "$stderr_file" >&2
+        gha_error '%s' "$(<"$stderr_file")" >&2
         rm -f "$stderr_file"
         printf 'ERROR: ./make list failed\n' >&2
         return 1
@@ -863,10 +865,25 @@ _enumerate_cells_init() {
     fi
 
     _EC_closure_containers=()
+    local -A _closure_set=()
     while IFS= read -r c; do
-        [[ -n "$c" ]] && _EC_closure_containers+=("$c")
+        if [[ -n "$c" ]]; then
+            _EC_closure_containers+=("$c")
+            _closure_set["$c"]=1
+        fi
     done < "$closure_file"
     rm -f "$closure_file"
+
+    # Successful closure collection must retain every requested container.
+    # Dependencies may add entries, but absence is a fail-closed invariant:
+    # it covers an unreadable, truncated, removed, or replaced collected file.
+    for c in "${requested_containers[@]}"; do
+        if [[ -z "${_closure_set[$c]+set}" ]]; then
+            printf 'ERROR: collected closure is missing requested container %s — refusing to emit an incomplete bake graph\n' \
+                "$c" >&2
+            return 1
+        fi
+    done
 
     # Matrix enumeration + first-target-per-container for dep-context lookup
     # F4: use the caller-supplied include_all_retained flag (default false = latest-only).

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -131,11 +131,15 @@ EOF
 # Enumerate all containers from `./make list`, strictly filtered to container-
 # name characters to drop any diagnostic noise.
 _list_all_containers() {
-    local out
-    if ! out=$(cd "${PROJECT_ROOT}" && ./make list 2>/dev/null); then
+    local out stderr_file
+    stderr_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-make-list.XXXXXX") || return 1
+    if ! out=$({ cd "${PROJECT_ROOT}" && ./make list; } 2>"$stderr_file"); then
+        cat "$stderr_file" >&2
+        rm -f "$stderr_file"
         printf 'ERROR: ./make list failed\n' >&2
         return 1
     fi
+    rm -f "$stderr_file"
     printf '%s' "$out" | grep -E '^[a-z0-9_-]+$' || true
 }
 
@@ -848,11 +852,21 @@ _enumerate_cells_init() {
         fi
     done
 
-    # Determine containers to process: transitive dep closure of requested
+    # Determine containers to process: transitive dep closure of requested.
+    # collect_lines preserves _expand_closure's explicit failure status, which
+    # process substitution would otherwise discard and turn into an empty graph.
+    local closure_file
+    closure_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-closure.XXXXXX") || return 1
+    if ! collect_lines "$closure_file" -- _expand_closure "${requested_containers[@]}"; then
+        rm -f "$closure_file"
+        return 1
+    fi
+
     _EC_closure_containers=()
     while IFS= read -r c; do
         [[ -n "$c" ]] && _EC_closure_containers+=("$c")
-    done < <(_expand_closure "${requested_containers[@]}")
+    done < "$closure_file"
+    rm -f "$closure_file"
 
     # Matrix enumeration + first-target-per-container for dep-context lookup
     # F4: use the caller-supplied include_all_retained flag (default false = latest-only).

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -133,15 +133,35 @@ EOF
 # Enumerate all containers from `./make list`, strictly filtered to container-
 # name characters to drop any diagnostic noise.
 _list_all_containers() {
-    local out stderr_file
-    stderr_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-make-list.XXXXXX") || return 1
-    if ! out=$({ cd "${PROJECT_ROOT}" && ./make list; } 2>"$stderr_file"); then
-        gha_error '%s' "$(<"$stderr_file")" >&2
-        rm -f "$stderr_file"
+    local out stderr_file="" stderr_target="/dev/null"
+    # `./make list` writes to stderr on success too, so it is captured rather
+    # than left to the log, and replayed only when the command fails. The replay
+    # is bounded because it is loaded into a variable; gha.sh escapes it so a
+    # forged workflow command in that text cannot start a line.
+    #
+    # Capturing is best-effort: enumeration worked without a temporary file
+    # before the diagnostic existed, so unwritable temporary storage costs the
+    # diagnostic rather than the enumeration.
+    local stderr_replay_bytes=65536
+    if stderr_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-make-list.XXXXXX" 2>/dev/null); then
+        stderr_target="$stderr_file"
+    else
+        stderr_file=""
+    fi
+    if ! out=$({ cd "${PROJECT_ROOT}" && ./make list; } 2>"$stderr_target"); then
+        if [[ -n "$stderr_file" ]]; then
+            local replay
+            replay=$(head -c "$stderr_replay_bytes" "$stderr_file")
+            if (( $(wc -c < "$stderr_file") > stderr_replay_bytes )); then
+                replay+=$'\n'"[stderr truncated after ${stderr_replay_bytes} bytes]"
+            fi
+            gha_error '%s' "$replay" >&2
+            rm -f "$stderr_file"
+        fi
         printf 'ERROR: ./make list failed\n' >&2
         return 1
     fi
-    rm -f "$stderr_file"
+    [[ -n "$stderr_file" ]] && rm -f "$stderr_file"
     printf '%s' "$out" | grep -E '^[a-z0-9_-]+$' || true
 }
 
@@ -854,36 +874,19 @@ _enumerate_cells_init() {
         fi
     done
 
-    # Determine containers to process: transitive dep closure of requested.
-    # collect_lines preserves _expand_closure's explicit failure status, which
-    # process substitution would otherwise discard and turn into an empty graph.
-    local closure_file
-    closure_file=$(mktemp "${TMPDIR:-/tmp}/generate-bake-hcl-closure.XXXXXX") || return 1
-    if ! collect_lines "$closure_file" -- _expand_closure "${requested_containers[@]}"; then
-        rm -f "$closure_file"
+    # Determine containers to process: retain the complete closure in this
+    # process. Command substitution preserves an explicit producer failure.
+    local closure_newline
+    if ! closure_newline="$(_expand_closure "${requested_containers[@]}")"; then
         return 1
     fi
 
     _EC_closure_containers=()
-    local -A _closure_set=()
-    while IFS= read -r c; do
+    while IFS= read -r c || [[ -n "$c" ]]; do
         if [[ -n "$c" ]]; then
             _EC_closure_containers+=("$c")
-            _closure_set["$c"]=1
         fi
-    done < "$closure_file"
-    rm -f "$closure_file"
-
-    # Successful closure collection must retain every requested container.
-    # Dependencies may add entries, but absence is a fail-closed invariant:
-    # it covers an unreadable, truncated, removed, or replaced collected file.
-    for c in "${requested_containers[@]}"; do
-        if [[ -z "${_closure_set[$c]+set}" ]]; then
-            printf 'ERROR: collected closure is missing requested container %s — refusing to emit an incomplete bake graph\n' \
-                "$c" >&2
-            return 1
-        fi
-    done
+    done <<< "$closure_newline"
 
     # Matrix enumeration + first-target-per-container for dep-context lookup
     # F4: use the caller-supplied include_all_retained flag (default false = latest-only).

--- a/tests/unit/bake-managed.bats
+++ b/tests/unit/bake-managed.bats
@@ -611,10 +611,9 @@ ubuntu-1.0.0"
 }
 
 # ---------------------------------------------------------------------------
-# PR routing no longer forces matrix.  With force_matrix=false, bake-managed
-#         latest Linux cells route to .bake, while legacy-matrix/windows stay in .matrix
-#         through the normal partition gates.  PR Trivy coverage now runs inline in
-#         bake-build for those bake-managed cells.
+# With force_matrix=false, bake-managed latest Linux cells route to .bake,
+# while legacy-matrix and Windows cells stay in .matrix through the normal
+# partition gates.
 # Catches: PR routing accidentally preserving pull_request in force_matrix
 # ---------------------------------------------------------------------------
 @test "PR routing allows bake-managed Linux cells to bake" {

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1197,6 +1197,58 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
+# A successful collection is still only useful if it contains every requested
+# container. Exercise the build path after collection: an empty or replaced
+# file must not turn into an empty, successful bake document.
+# ---------------------------------------------------------------------------
+
+@test "generator emits no bake document when the collected closure is empty" {
+    # shellcheck disable=SC1090
+    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
+    _list_all_containers() { printf '%s\n' web-shell; }
+    collect_lines() { : > "$1"; }
+
+    run _build_bake_json web-shell
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"collected closure is missing requested container web-shell"* ]]
+    [[ "$output" != *'"target"'* ]]
+}
+
+@test "generator emits no bake document when the collected closure omits a requested container" {
+    # shellcheck disable=SC1090
+    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
+    _list_all_containers() { printf '%s\n' web-shell wordpress; }
+    collect_lines() { printf '%s\n' web-shell > "$1"; }
+
+    run _build_bake_json web-shell wordpress
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"collected closure is missing requested container wordpress"* ]]
+    [[ "$output" != *'"target"'* ]]
+}
+
+@test "generator safely annotates captured make list stderr" {
+    local fake_root
+    fake_root="${TEST_TEMP_DIR}/failing-make-list"
+    mkdir -p "$fake_root"
+    printf '#!/usr/bin/env bash\nprintf "untrusted\\n::warning::forged annotation\\n" >&2\nexit 1\n' \
+        > "${fake_root}/make"
+    chmod +x "${fake_root}/make"
+
+    # shellcheck disable=SC1090
+    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
+    PROJECT_ROOT="$fake_root"
+
+    run _list_all_containers
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'::error::'* ]]
+    [[ "$output" == *'::warning::forged annotation'* ]]
+    [[ "$output" != *$'\n::warning::forged annotation'* ]]
+}
+
+# ---------------------------------------------------------------------------
 # #595 — --cells objects include target_id field
 # Catches: omitting target_id from cells output → bake-buildresult cannot
 # correlate --metadata-file keys to cells.

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1196,38 +1196,6 @@ YAML
     [[ "$output" != *'"target"'* ]]
 }
 
-# ---------------------------------------------------------------------------
-# A successful collection is still only useful if it contains every requested
-# container. Exercise the build path after collection: an empty or replaced
-# file must not turn into an empty, successful bake document.
-# ---------------------------------------------------------------------------
-
-@test "generator emits no bake document when the collected closure is empty" {
-    # shellcheck disable=SC1090
-    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
-    _list_all_containers() { printf '%s\n' web-shell; }
-    collect_lines() { : > "$1"; }
-
-    run _build_bake_json web-shell
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"collected closure is missing requested container web-shell"* ]]
-    [[ "$output" != *'"target"'* ]]
-}
-
-@test "generator emits no bake document when the collected closure omits a requested container" {
-    # shellcheck disable=SC1090
-    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
-    _list_all_containers() { printf '%s\n' web-shell wordpress; }
-    collect_lines() { printf '%s\n' web-shell > "$1"; }
-
-    run _build_bake_json web-shell wordpress
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"collected closure is missing requested container wordpress"* ]]
-    [[ "$output" != *'"target"'* ]]
-}
-
 @test "generator safely annotates captured make list stderr" {
     local fake_root
     fake_root="${TEST_TEMP_DIR}/failing-make-list"
@@ -1246,6 +1214,25 @@ YAML
     [[ "$output" == *'::error::'* ]]
     [[ "$output" == *'::warning::forged annotation'* ]]
     [[ "$output" != *$'\n::warning::forged annotation'* ]]
+}
+
+@test "generator bounds and labels oversized make list stderr" {
+    local fake_root
+    fake_root="${TEST_TEMP_DIR}/noisy-make-list"
+    mkdir -p "$fake_root"
+    printf '#!/usr/bin/env bash\nhead -c 65537 /dev/zero | tr "\\0" x >&2\nexit 1\n' \
+        > "${fake_root}/make"
+    chmod +x "${fake_root}/make"
+
+    # shellcheck disable=SC1090
+    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
+    PROJECT_ROOT="$fake_root"
+
+    run _list_all_containers
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'[stderr truncated after 65536 bytes]'* ]]
+    [ "${#output}" -le 65700 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -1179,65 +1179,21 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# FIX S: fail-closed on dependency-graph errors
-# The generator must exit non-zero and emit ::error:: when _depgraph_get_deps_transitive
-# returns non-zero, rather than silently producing a bake graph with missing contexts.
+# Fail closed when transitive dependency resolution fails. Exercise the bake
+# generator path itself: a failure must not be converted into an empty document.
 # ---------------------------------------------------------------------------
 
-@test "FIX S — generator exits non-zero with ::error:: on depgraph failure" {
-    # Verify the fail-closed depgraph guard via a wrapper script that overrides
-    # _depgraph_get_deps_transitive to return non-zero.
-    # Strategy: write a caller script to $TEST_TEMP_DIR (allocated by setup()) that:
-    #   1. Sources all real generator helpers (variant-utils, dependency-graph, etc.)
-    #   2. Overrides the depgraph functions with stubs that return 1
-    #   3. Sources and re-defines the generator's internal functions by re-parsing the
-    #      generator body (with main() redefined as a no-op to prevent auto-execution)
-    #   4. Calls _expand_closure directly to trigger the fail-closed guard
-    # This avoids file-tree mirroring while still exercising the production code path.
-    local _tmpdir
-    _tmpdir=$(mktemp -d)
-    local wrapper="${_tmpdir}/gbh42_wrapper.sh"
-    printf '#!/usr/bin/env bash\n' > "$wrapper"
-    printf 'set -euo pipefail\n' >> "$wrapper"
-    printf 'export _DEPGRAPH_LINEAGE_DIR=/nonexistent\n' >> "$wrapper"
-    printf 'export GITHUB_ACTIONS=""\n' >> "$wrapper"
-    # Source real helpers
-    printf 'source "%s/helpers/variant-utils.sh"\n' "$PROJECT_ROOT" >> "$wrapper"
-    printf 'source "%s/helpers/dependency-graph.sh"\n' "$PROJECT_ROOT" >> "$wrapper"
-    printf 'source "%s/helpers/logging.sh"\n' "$PROJECT_ROOT" >> "$wrapper"
-    printf 'source "%s/helpers/build-args-utils.sh"\n' "$PROJECT_ROOT" >> "$wrapper"
-    printf 'source "%s/helpers/validate-base-cache-schema.sh"\n' "$PROJECT_ROOT" >> "$wrapper"
-    # Override depgraph functions to simulate failure
-    printf '_depgraph_get_deps_transitive() { return 1; }\n' >> "$wrapper"
-    printf '_depgraph_get_deps() { return 1; }\n' >> "$wrapper"
-    # Set PROJECT_ROOT so generator helpers resolve paths correctly
-    printf 'export PROJECT_ROOT="%s"\n' "$PROJECT_ROOT" >> "$wrapper"
-    # Source the generator internals by executing it in a subshell with a
-    # GENERATE_BAKE_TEST_SOURCING guard so main() is skipped.
-    # We do this by inlining just the functions we need to test.
-    # _expand_closure is the first fail-closed site; call it directly.
-    # Re-define it inline using the production code with the stubbed depgraph.
-    printf '_add_unique() { :; }\n' >> "$wrapper"
-    printf '_is_extension_container() { [[ -f "%s/$1/extensions/config.yaml" ]]; }\n' "$PROJECT_ROOT" >> "$wrapper"
-    printf '_expand_closure() {\n' >> "$wrapper"
-    printf '    local -a requested=("$@")\n' >> "$wrapper"
-    printf '    local c\n' >> "$wrapper"
-    printf '    for c in "${requested[@]}"; do\n' >> "$wrapper"
-    printf '        local deps\n' >> "$wrapper"
-    printf '        if ! deps="$(_depgraph_get_deps_transitive "$c")"; then\n' >> "$wrapper"
-    printf '            printf '"'"'::error::dependency-graph resolution failed for %%s\n'"'"' "$c" >&2\n' >> "$wrapper"
-    printf '            return 1\n' >> "$wrapper"
-    printf '        fi\n' >> "$wrapper"
-    printf '    done\n' >> "$wrapper"
-    printf '}\n' >> "$wrapper"
-    printf '_expand_closure debian || exit 1\n' >> "$wrapper"
-    printf 'exit 0\n' >> "$wrapper"
-    chmod +x "$wrapper"
+@test "generator emits no bake document when transitive dependency resolution fails" {
+    # shellcheck disable=SC1090
+    source "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh"
+    _list_all_containers() { printf '%s\n' web-shell; }
+    _depgraph_get_deps_transitive() { return 2; }
 
-    run bash "$wrapper" 2>&1
-    rm -rf "$_tmpdir"
+    run _build_bake_json web-shell
+
     [ "$status" -ne 0 ]
-    [[ "$output" == *"dependency-graph resolution failed"* ]]
+    [[ "$output" == *"dependency-graph resolution failed for web-shell"* ]]
+    [[ "$output" != *'"target"'* ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`scripts/generate-bake-hcl.sh` printed that it refused to emit an incomplete
build graph, then emitted a valid document with zero targets and exited 0. A
build job consuming that document has nothing to build, succeeds, and reports
green — the most dangerous shape a build definition can take, because nothing
distinguishes it from a run with nothing to do.

The container closure was read through a process substitution, whose exit status
nothing observes, so a dependency-graph failure became an empty closure and read
downstream as "nothing was requested". Reproduced on a tree without git
metadata, where owner resolution aborts the dependency scan:

```
$ ./scripts/generate-bake-hcl.sh web-shell > out.json 2> err.txt; echo "EXIT=$?"
EXIT=0
$ tail -1 err.txt
::error::dependency-graph resolution failed for web-shell — refusing to emit an incomplete bake graph
$ jq '.target | length' out.json
0
```

The closure is now obtained through a command substitution, which preserves the
producer's exit status and keeps the value in this process. A corrupted closure
is no longer expressible rather than being detected after the fact.

Two smaller items ride along because they live in the same two files. A failing
`./make list` now reaches the log with its stderr, bounded and emitted through
`helpers/gha.sh` so a forged workflow command in that text cannot start a line;
capturing it is best-effort, so unwritable temporary storage costs the
diagnostic and not the enumeration. And three comments were rewritten to
describe what the code does — routing is per cell, `partition_builds`' second
parameter is named for the flag its caller passes, and a fixture comment no
longer claims a per-pull-request scan that was intentionally dropped.

## Verified

- Full unit suite green, 2487 collected, 0 failed. `shellcheck` clean.
- The surviving test proved to discriminate: removing the status check makes
  exactly that test fail, restoring it makes the suite green.
- A successful run emits the same document as `master`, byte for byte
  (31895 bytes, compared with the previous script rooted in the repository).
- Enumeration still works with a read-only `TMPDIR`.

## Deliberately not changed

The 64 KiB bound applies to the replayed diagnostic, which is loaded into a
variable, and not to the captured file. Bounding the file needs a pipeline with
`PIPESTATUS` handling and a second temporary; the producer is this repository's
own `make`, so the cap sits where the risk is.

No signal or exit trap owns the temporary file. The runner is ephemeral, a
container list is not sensitive, and a shell-global trap installed by a library
function is its own defect.

## Filed rather than fixed here

- #1151 — a scope matching no cells emits an empty plan and exits 0. Same
  family, different path, present on `master`.
- #1150 — `_escape_gha_command` is defined twice with identical bodies. Both
  predate this branch, which only causes one file to source both.

Closes #1141
Refs #1143, #1148
