### PR TITLE
ci(sync-dockerhub-readme): scope the workflow token to contents:read

### DIFF
--- a/.github/workflows/sync-dockerhub-readme.yaml
+++ b/.github/workflows/sync-dockerhub-readme.yaml
@@ -12,6 +12,12 @@ on:
         required: false
         type: string
 
+# Both jobs read the checkout and push to Docker Hub with Docker Hub
+# credentials; nothing here uses GITHUB_TOKEN for a write. Declared so the
+# repository default cannot widen it.
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`sync-dockerhub-readme.yaml` was the only workflow in the repository declaring
no `permissions` block, at the top level or per job. Workflows without one get
the repository default, which is currently write:

```
$ gh api repos/oorabona/docker-containers/actions/permissions/workflow \
    --jq '.default_workflow_permissions'
write
```

So the one workflow that needs the least ran with the broadest token. It checks
out, reads `README.md` files, and pushes them to Docker Hub with Docker Hub
credentials. Nothing in it uses `GITHUB_TOKEN` for a write:

```
$ grep -nE "gh (pr|issue|api|release)|git (push|commit|tag)|GITHUB_TOKEN|github-script|upload-artifact|attest" \
    .github/workflows/sync-dockerhub-readme.yaml
(no matches)
```

Nobody outside the repository can reach it — its triggers are `push` and
`workflow_dispatch`, both write-access only. What the scope buys is the case
where a third-party action in this workflow is compromised: it then holds a
read-only token instead of a write-all one.

With this, all fifteen workflows declare their own scope:

```
$ for f in .github/workflows/*.y*ml; do
    top=$(yq -r '.permissions // ""' "$f"); perjob=$(grep -c '^    permissions:' "$f")
    [[ -z "$top" && "$perjob" -eq 0 ]] && echo "MISSING: $f"
  done
(no output)
```

That is the precondition for lowering the repository default to read, which
turns a future omission into a fail-closed default rather than a silent
write-all grant. The setting change follows this merge.
