### PR TITLE
fix(postgres): install the parser generators postgis needs to build

### DIFF
--- a/postgres/extensions/build/postgis.Dockerfile
+++ b/postgres/extensions/build/postgis.Dockerfile
@@ -28,6 +28,12 @@ ARG MAJOR_VERSION
 RUN : "${EXT_VERSION:?required}" "${EXT_REPO:?required}"
 
 # Install build dependencies.
+# bison (yacc) and flex (lex) generate lwin_wkt_parse.c / lwin_wkt_lex.c. The
+# source below is a git checkout driven by autogen.sh, which does not ship the
+# pre-generated files a release tarball would, so both are required here. Their
+# absence surfaces only on a real compile — a cached extension image hides it —
+# and reads as "No yacc found, cannot build parser".
+#
 # PGXS hardcodes a specific clang-N for JIT bitcode (with_llvm=yes). Derive that
 # major from the postgres base's Makefile.global and install exactly it, so the
 # toolchain tracks the base instead of being re-pinned (the clang19→clang21 drift).
@@ -38,6 +44,8 @@ RUN set -eux \
         automake \
         libtool \
         gettext-dev \
+        bison \
+        flex \
         git \
         icu-dev \
         geos-dev \


### PR DESCRIPTION
postgis cannot be compiled. Forcing a rebuild today failed on both
architectures, after two hours:

```
No yacc found, cannot build parser
make[1]: *** [Makefile:238: lwin_wkt_parse.c] Error 1
ERROR: failed to build: process "/bin/sh -c gettextize && ./autogen.sh && ./configure --enable-lto && make -j$(nproc) && make install DESTDIR=/install" did not complete successfully: exit code: 2
```

The source is a git checkout driven by `autogen.sh`, which does not ship the
pre-generated `lwin_wkt_parse.c` and `lwin_wkt_lex.c` that a release tarball
carries. `bison` and `flex` generate them, and neither was installed.

`extensions/config.yaml` already declares both under `postgis.build_deps`, and
its comment already names this exact error. Nothing reads `build_deps`, so the
declaration and the Dockerfile drifted apart with no signal. postgis is the only
extension where the two disagreed; `pgvector` and `paradedb` looked like gaps to
a first extraction and are not.

## This fix is correct and currently inert

An extension image's identity is `<extension>:<version>-pg<major>`. Reuse is
decided by probing that ref in the registry, and **nothing hashes the extension
Dockerfile**. Changing this recipe therefore does not invalidate the published
`postgis:3.6.4-pg16`, and the extension jobs on this pull request completed in
one minute each by reusing it — they did not compile anything.

So merging this does not by itself rebuild postgis. The fix takes effect the
next time postgis is genuinely built: a version bump, or a digest-ignoring
rebuild. Until then the published image keeps working; what was broken is the
ability to reproduce it.

That gap is the subject of ADR-015 (*Automated (content-addressed) postgres
extension image identity*), which is accepted as a design with implementation
deferred. Its plan hashes, among other inputs, the normalized `build_deps` and
the resolved Dockerfile bytes — exactly the two things whose divergence caused
this. Wiring `build_deps` into the builds before that hash exists would be inert
in the same way.

## Verification

The unit suite is green (2487 collected, 0 failed) and does not exercise a
compile. The failing compile above is the evidence for the diagnosis; the
evidence that the fix works will come from the first real postgis build after
this merges.
