### PR TITLE
docs(adr-015): record that build_deps is not yet an authoritative input

### DIFF
--- a/docs/adr/ADR-015-automated-extension-image-identity.md
+++ b/docs/adr/ADR-015-automated-extension-image-identity.md
@@ -60,6 +60,48 @@ Reuse: the identity-suffix **threading** through `ext_image_name` / `ext_ref_res
 5. Move `PGRX_VERSION` into config (a hashed input); strip `build_date`/timestamps from the output layer.
 6. The **periodic rebuild backstop** + the existing base-digest-drift cover residual apk drift.
 
+## Precondition: `build_deps` is not yet an authoritative input
+
+Step 1 of the plan hashes "normalized `build_deps`" among its declared inputs. That
+field is not today a faithful statement of what a build installs, in either
+direction:
+
+- no build path consumes or enforces it — it is documentation that generic YAML
+  reads pass over;
+- recipes install packages it does not declare (postgis: `autoconf`, `automake`,
+  `gettext-dev`, `git`, `icu-dev`, `libtool`, `pcre2-dev`, `perl`, plus the
+  PostgreSQL-major-derived `clang<N>`/`llvm<N>-dev`; paradedb: `curl`, `git`,
+  `pkgconf`);
+- it declares packages a recipe does not `apk add` — paradedb lists `rust` and
+  `cargo` while installing the toolchain through rustup;
+- and at least one declared package was absent from its recipe, which is how postgis
+  came to declare `bison` and `flex` under `build_deps` while its build could not
+  generate `lwin_wkt_parse.c`.
+
+This does not block step 1. The record it defines also carries the resolved,
+expanded Dockerfile bytes, so a recipe change moves the hash whether or not
+`build_deps` is faithful. What the mismatch blocks is treating `build_deps` itself
+as a build input: until it is authoritative, including it produces rebuilds that
+track the declaration rather than the build.
+
+**Making it authoritative needs a boundary, not a convention.** "The complete static
+`apk add` list" has to mean the direct arguments of the recipe's own static install,
+explicitly excluding packages derived at build time from the PostgreSQL major, and
+excluding the transitive closure. Migrating ten YAML lists without a validator or a
+generation mechanism that consumes them only creates a second convention free to
+drift again — which is the condition this section documents.
+
+**Ordering.** Take the identity change first: hash the expanded Dockerfile, source
+identity, resolved version, PG major and the build arguments actually consumed, with
+`build_deps` omitted. That alone gives automatic rebuild on any recipe change, which
+the ordinary prefilter does not (it decides on tag presence — `_image_needs_build`
+in `scripts/build-extensions.sh` — against a tag carrying no recipe input:
+`ghcr.io/<owner>/ext-<name>:pg<major>-<version>`, from `ext_image_name`; the
+main-container `compute_build_digest` is never called for extension images). `FORCE`
+and an absent tag or architecture still build, so a maintainer is not without
+recourse today; what is missing is that an edited recipe is picked up on its own.
+Make `build_deps` authoritative and enforced afterwards, and only then hash it.
+
 ## Consequences
 
 - No manual bump, no PR check (its whole problem surface is removed).


### PR DESCRIPTION
ADR-015's implementation plan hashes "normalized `build_deps`" among the declared
inputs of the extension build record. That field cannot yet carry that weight.

- No build path consumes or enforces it. Generic YAML reads pass over it; nothing
  selects on it.
- Recipes install packages it does not declare — postgis: `autoconf`, `automake`,
  `gettext-dev`, `git`, `icu-dev`, `libtool`, `pcre2-dev`, `perl`, plus the
  PostgreSQL-major-derived `clang<N>`/`llvm<N>-dev`; paradedb: `curl`, `git`,
  `pkgconf`.
- It declares packages a recipe never `apk add`s — paradedb lists `rust` and
  `cargo` while installing the toolchain through rustup.
- And a declared package was missing from its recipe, which is how postgis came to
  declare `bison` and `flex` while its build could not generate
  `lwin_wkt_parse.c` (#1168).

Hashing it as it stands would move the identity when the declaration changes and
sit still when the build changes.

## What this does not claim

Step 1 remains well defined. Its record also carries the resolved, expanded
Dockerfile bytes, so a recipe change moves the hash whether or not `build_deps` is
faithful. The mismatch blocks treating `build_deps` *itself* as an input, not the
step.

The ordering that follows: take the identity change first, with `build_deps`
omitted, which already gives automatic rebuild on any recipe change. Make the field
authoritative and enforced afterwards, and only then hash it.

## What it adds beyond the existing text

The ADR already explains that the prefilter keys on the tag, which is why option (B)
puts the hash in the tag suffix. This section does not restate that. It records the
source-of-truth mismatch, and one requirement the plan did not state: making
`build_deps` authoritative needs a boundary — the direct arguments of the static
install, excluding packages derived from the PostgreSQL major and excluding the
transitive closure — plus a validator or a generation mechanism that consumes it.
Migrating ten YAML lists with neither produces a second convention free to drift.

## Verification

Every factual anchor was checked against the source, and an adversarial review
corrected six claims in an earlier draft, including the extension tag format
(`ghcr.io/<owner>/ext-<name>:pg<major>-<version>`, from `ext_image_name`), the
absoluteness of "any same-version change is ignored" (`FORCE`, an absent tag and a
missing architecture all build), and the ordering claim, which was reversed. The
incident narrative that draft carried was cut: an ADR reader cannot verify it from
the repository.
