### PR TITLE
feat(ci): compile an extension whose recipe or declared version changed

### DIFF
--- a/.github/actions/detect-containers/action.yaml
+++ b/.github/actions/detect-containers/action.yaml
@@ -113,6 +113,9 @@ outputs:
   container_scopes:
     description: 'Normalized JSON map of per-container scopes, or empty for legacy callers'
     value: ${{ steps.find-containers.outputs.container_scopes }}
+  force_extension_builds:
+    description: 'Whether detected extension inputs require compilation instead of image reuse'
+    value: ${{ steps.find-containers.outputs.force_extension_builds }}
   carried_forward:
     description: |
       JSON array of container names that were newly appended to the build list
@@ -277,6 +280,8 @@ runs:
         containers_to_build=()
         containers_to_verify=()
         normalized_container_scopes=""
+        extension_config_base=""
+        force_extension_builds=false
 
         if [[ -n "${CONTAINER_SCOPES_INPUT:-}" ]]; then
           normalized_container_scopes=$(normalize_container_scopes "$CONTAINER_SCOPES_INPUT") || exit 1
@@ -359,6 +364,7 @@ runs:
 
             if [[ "$baseline_valid" == "true" ]]; then
               echo "Coverage checkpoint baseline: $baseline_sha"
+              extension_config_base="$baseline_sha"
               set +e
               changed_files=$(git diff --name-only --no-renames "$baseline_sha" "${{ github.sha }}" 2>/dev/null)
               diff_rc=$?
@@ -381,6 +387,7 @@ runs:
               changed_files=$(git diff --name-only --no-renames 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.sha }}" 2>/dev/null)
             else
               changed_files=$(git diff --name-only --no-renames "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null)
+              extension_config_base="${{ github.event.before }}"
             fi
             diff_rc=$?
             set -e
@@ -398,6 +405,10 @@ runs:
                 "building all containers with retained version expansion"
               coverage_fallback=true
               changed_files=""
+            else
+              extension_config_base=$(git merge-base \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}" 2>/dev/null || true)
             fi
           else
             # For manual triggers (workflow_dispatch)
@@ -457,6 +468,44 @@ runs:
             fi
             # TODO: Shared-helper fanout (helpers/*.sh change affecting all images)
             # is a broader policy; tracked as follow-up to avoid over-engineering here.
+          fi
+
+          # Extension artifacts are normally reused by tag.  When their recipe,
+          # declared version, resolver, or helper changed, derive a postgres
+          # extension scope and separately signal that reuse must be bypassed.
+          # This runs for both pull_request and post-merge push diffs.
+          if [[ -n "$changed_files" ]]; then
+            extension_config_base_file=""
+            if grep -Fxq "postgres/extensions/config.yaml" <<< "$changed_files" &&
+               [[ -n "$extension_config_base" ]]; then
+              extension_config_base_file=$(mktemp "${RUNNER_TEMP}/extension-config-base.XXXXXX")
+              if ! git show "${extension_config_base}:postgres/extensions/config.yaml" \
+                  > "$extension_config_base_file" 2>/dev/null; then
+                rm -f "$extension_config_base_file"
+                extension_config_base_file=""
+              fi
+            fi
+
+            extension_scope=$(extension_scope_for_changes \
+              "$changed_files" \
+              "$extension_config_base_file" \
+              "$GITHUB_WORKSPACE/postgres/extensions/config.yaml")
+            [[ -z "$extension_config_base_file" ]] || rm -f "$extension_config_base_file"
+
+            if [[ -n "$extension_scope" ]]; then
+              force_extension_builds=true
+              if [[ "$extension_scope" == "all" ]]; then
+                normalized_container_scopes='{"postgres":{}}'
+              else
+                normalized_container_scopes=$(jq -cn --arg extensions "$extension_scope" \
+                  '{postgres: {extensions: $extensions}}')
+              fi
+              if echo "$valid_containers" | grep -qx "postgres" &&
+                 [[ " ${containers_to_build[*]} " != *" postgres "* ]]; then
+                echo "🔧 Extension build input changed — adding postgres with forced extension scope: $extension_scope"
+                containers_to_build+=("postgres")
+              fi
+            fi
           fi
 
         if [[ -n "$changed_files" ]]; then
@@ -613,6 +662,7 @@ runs:
 
         # Create outputs (CSV first, then JSON for matrix compatibility)
         echo "container_scopes=$normalized_container_scopes" >> $GITHUB_OUTPUT
+        echo "force_extension_builds=$force_extension_builds" >> $GITHUB_OUTPUT
         if [ ${#containers_to_verify_only[@]} -eq 0 ]; then
           echo "containers_to_verify=[]" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -251,6 +251,7 @@ jobs:
       bake_final_builds: ${{ steps.detect.outputs.bake_final_builds }}
       postgres_matrix_builds: ${{ steps.detect.outputs.postgres_matrix_builds }}
       container_scopes: ${{ steps.detect.outputs.container_scopes }}
+      force_extension_builds: ${{ steps.detect.outputs.force_extension_builds }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -553,6 +554,7 @@ jobs:
           SCOPE_EXTENSIONS: ${{ github.event.inputs.scope_extensions || inputs.scope_extensions }}
           CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
           REBUILD: ${{ env.REBUILD_MODE }}
+          FORCE_EXTENSION_BUILDS: ${{ needs.detect-containers.outputs.force_extension_builds }}
           VERSIONS_MAP: ${{ steps.ext-versions.outputs.versions_map }}
           # USE_BASE_CACHE mirrors the use_base_cache gate in build-container: true only for
           # non-fork push/dispatch events (where GHCR write access and sync-base-images ran).
@@ -585,7 +587,7 @@ jobs:
           # documented override in scope_extensions actually bypasses the
           # registry-skip path.
           force_arg=()
-          if [[ "$REBUILD" == "force" || "$REBUILD" == "all" ]]; then
+          if [[ "$REBUILD" == "force" || "$REBUILD" == "all" || "$FORCE_EXTENSION_BUILDS" == "true" ]]; then
             force_arg=(--force)
           fi
 
@@ -846,13 +848,14 @@ jobs:
           # thread the same rebuild/force signal as stage A so --finalize-multiarch
           # knows to skip canonical-first reuse and merge from freshly-built PR-scoped tags.
           REBUILD: ${{ env.REBUILD_MODE }}
+          FORCE_EXTENSION_BUILDS: ${{ needs.detect-containers.outputs.force_extension_builds }}
         run: |
           chmod +x scripts/build-extensions.sh helpers/extension-utils.sh
 
           # mirror stage A's --force logic so finalize skips canonical-first
           # reuse for versions that were explicitly rebuilt by stage A this run.
           force_arg=()
-          if [[ "$REBUILD" == "force" || "$REBUILD" == "all" ]]; then
+          if [[ "$REBUILD" == "force" || "$REBUILD" == "all" || "$FORCE_EXTENSION_BUILDS" == "true" ]]; then
             force_arg=(--force)
           fi
 

--- a/helpers/container-scopes.sh
+++ b/helpers/container-scopes.sh
@@ -72,6 +72,121 @@ container_scope_field() {
     printf '%s' "$container_scopes" | jq -r --arg c "$container" --arg f "$field" '.[$c][$f] // ""'
 }
 
+# Classify extension build inputs in a changed-files list.  The result is either
+# an empty string (no compilation required), a comma-separated list of known
+# extension names, or the literal "all".  "all" is deliberately fail-closed:
+# callers must compile every extension when the config cannot be safely
+# attributed to individual extension version fields.
+extension_scope_for_changes() {
+    local changed_files="${1:-}"
+    local previous_config="${2:-}"
+    local current_config="${3:-postgres/extensions/config.yaml}"
+    local config_changed=false
+    local shared_input_changed=false
+    local file ext
+    local -a recipe_extensions=()
+
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        case "$file" in
+            postgres/extensions/build/*.Dockerfile)
+                ext="${file#postgres/extensions/build/}"
+                ext="${ext%.Dockerfile}"
+                recipe_extensions+=("$ext")
+                ;;
+            postgres/extensions/config.yaml)
+                config_changed=true
+                ;;
+            scripts/resolvers/*|helpers/extension-*.sh)
+                shared_input_changed=true
+                ;;
+        esac
+    done <<< "$changed_files"
+
+    if [[ "$shared_input_changed" == "true" ]]; then
+        printf 'all\n'
+        return 0
+    fi
+
+    if [[ ${#recipe_extensions[@]} -eq 0 && "$config_changed" != "true" ]]; then
+        printf ''
+        return 0
+    fi
+
+    local current_json previous_json known_extensions
+    if ! current_json=$(yq -o=json '.' "$current_config" 2>/dev/null) ||
+       ! jq -e '
+         type == "object" and
+         (.extensions | type == "object") and
+         (.extensions | length > 0) and
+         all(.extensions[];
+           type == "object" and
+           (.version | type == "string") and
+           (.rust_version == null or (.rust_version | type == "string")))
+       ' <<< "$current_json" >/dev/null 2>&1; then
+        printf 'all\n'
+        return 0
+    fi
+
+    known_extensions=$(jq -r '.extensions | keys[]' <<< "$current_json")
+    for ext in "${recipe_extensions[@]}"; do
+        if [[ -z "$ext" ]] || ! grep -Fxq "$ext" <<< "$known_extensions"; then
+            printf 'all\n'
+            return 0
+        fi
+    done
+
+    local -a scoped_extensions=("${recipe_extensions[@]}")
+    if [[ "$config_changed" == "true" ]]; then
+        if [[ -z "$previous_config" ]] ||
+           ! previous_json=$(yq -o=json '.' "$previous_config" 2>/dev/null) ||
+           ! jq -e '
+             type == "object" and
+             (.extensions | type == "object") and
+             (.extensions | length > 0) and
+             all(.extensions[];
+               type == "object" and
+               (.version | type == "string") and
+               (.rust_version == null or (.rust_version | type == "string")))
+           ' <<< "$previous_json" >/dev/null 2>&1; then
+            printf 'all\n'
+            return 0
+        fi
+
+        # Adding/removing/renaming extensions, changing any shared config, or
+        # changing an extension field other than version/rust_version cannot be
+        # attributed safely.  Flavor composition is intentionally excluded: it
+        # changes final images but does not require recompiling extensions.
+        if ! jq -e --argjson previous "$previous_json" '
+          (.extensions | keys) == ($previous.extensions | keys) and
+          del(.extensions, .flavors) == ($previous | del(.extensions, .flavors)) and
+          (.extensions | with_entries(.value |= del(.version, .rust_version))) ==
+            ($previous.extensions | with_entries(.value |= del(.version, .rust_version)))
+        ' <<< "$current_json" >/dev/null 2>&1; then
+            printf 'all\n'
+            return 0
+        fi
+
+        while IFS= read -r ext; do
+            [[ -z "$ext" ]] && continue
+            scoped_extensions+=("$ext")
+        done < <(jq -r --argjson previous "$previous_json" '
+          .extensions | keys[] as $name |
+          select(
+            (.[$name].version // null) != ($previous.extensions[$name].version // null) or
+            (.[$name].rust_version // null) != ($previous.extensions[$name].rust_version // null)
+          ) | $name
+        ' <<< "$current_json")
+    fi
+
+    if [[ ${#scoped_extensions[@]} -eq 0 ]]; then
+        printf ''
+        return 0
+    fi
+
+    printf '%s\n' "${scoped_extensions[@]}" | sort -u | paste -sd, -
+}
+
 filter_builds_by_version_flavor_scope() {
     local container_builds="$1"
     local scope_versions="${2:-}"
@@ -173,4 +288,5 @@ expand_variants_for_containers() {
 }
 
 export -f normalize_container_scopes container_scope_keys validate_container_scope_keys
-export -f container_scope_field filter_builds_by_version_flavor_scope expand_variants_for_containers
+export -f container_scope_field extension_scope_for_changes
+export -f filter_builds_by_version_flavor_scope expand_variants_for_containers

--- a/tests/unit/detect-containers.bats
+++ b/tests/unit/detect-containers.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export CONTAINER_SCOPES_INPUT=""
+}
+
+teardown() {
+    unset BASELINE_FAILED BASELINE_VALID CONTAINER_SCOPES_INPUT GITHUB_ACTION_PATH GITHUB_OUTPUT GITHUB_WORKSPACE RUNNER_TEMP TEST_BASE_SHA TEST_HEAD_SHA TEST_CHANGED_FILES
+    teardown_temp_dir
+}
+
+make_classifier_workspace() {
+    CLASSIFIER_WORKSPACE="$TEST_TEMP_DIR/workspace"
+    local workspace="$CLASSIFIER_WORKSPACE"
+    mkdir -p "$workspace"
+    cp "$PROJECT_ROOT/make" "$workspace/"
+    cp -a "$PROJECT_ROOT/helpers" "$PROJECT_ROOT/scripts" "$workspace/"
+    mkdir -p "$workspace/postgres/extensions"
+    cp "$PROJECT_ROOT/postgres/Dockerfile" "$workspace/postgres/"
+    cp "$PROJECT_ROOT/postgres/variants.yaml" "$workspace/postgres/"
+    cp -a "$PROJECT_ROOT/postgres/extensions/config.yaml" "$workspace/postgres/extensions/"
+
+    git -C "$workspace" init -q
+    git -C "$workspace" config user.email tests@example.invalid
+    git -C "$workspace" config user.name tests
+    git -C "$workspace" add .
+    git -C "$workspace" commit -qm baseline
+    export TEST_BASE_SHA
+    TEST_BASE_SHA=$(git -C "$workspace" rev-parse HEAD)
+    export TEST_HEAD_SHA="$TEST_BASE_SHA"
+}
+
+run_find_containers_step() {
+    local changed_files="$1"
+    local workspace="$2"
+    local script="$TEST_TEMP_DIR/find-containers.sh"
+
+    yq -r '.runs.steps[] | select(.id == "find-containers") | .run' \
+        "$PROJECT_ROOT/.github/actions/detect-containers/action.yaml" > "$script"
+
+    # Render the pull-request context and substitute the diff provider with the
+    # changed-files fixture.  The temporary workspace is a real git repository,
+    # so the classifier compares its baseline config with the working-tree one.
+    perl -0pi -e '
+        s/\$\{\{ github\.event_name \}\}/pull_request/g;
+        s/\$\{\{ github\.event\.pull_request\.base\.sha \}\}/\$TEST_BASE_SHA/g;
+        s/\$\{\{ github\.event\.pull_request\.head\.sha \}\}/\$TEST_HEAD_SHA/g;
+        s/\$\{\{ inputs\.container \}\}//g;
+        s|(source "\$\{GITHUB_ACTION_PATH\}/\.\./\.\./\.\./helpers/pr-changed-files\.sh")|$1\npr_changed_files() { printf "%s\\n" "\${TEST_CHANGED_FILES}"; }|;
+    ' "$script"
+
+    # Used only for the requested discrimination proof: the production source
+    # remains untouched while this generated classifier script has attribution
+    # removed, making its refusal assertions fail.
+    if [[ "${DISABLE_EXTENSION_ATTRIBUTION:-false}" == "true" ]]; then
+        perl -0pi -e 's/extension_scope=\$\(extension_scope_for_changes \\\n+\s+"\$changed_files" \\\n+\s+"\$extension_config_base_file" \\\n+\s+"\$GITHUB_WORKSPACE\/postgres\/extensions\/config\.yaml"\)/extension_scope=""/g' "$script"
+    fi
+
+    export BASELINE_FAILED="[]"
+    export BASELINE_VALID="false"
+    export GITHUB_ACTION_PATH="$PROJECT_ROOT/.github/actions/detect-containers"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
+    export GITHUB_WORKSPACE="$workspace"
+    export RUNNER_TEMP="$TEST_TEMP_DIR"
+    export TEST_CHANGED_FILES="$changed_files"
+
+    run bash -c 'cd "$1" || exit 1; exec bash "$2"' _ "$workspace" "$script"
+}
+
+output_value() {
+    local name="$1"
+    sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
+}
+
+assert_extension_scope() {
+    local changed_files="$1"
+    local expected_scope="$2"
+    local expected_force="$3"
+    local workspace="${4:-}"
+    if [[ -z "$workspace" ]]; then
+        make_classifier_workspace
+        workspace="$CLASSIFIER_WORKSPACE"
+    fi
+
+    run_find_containers_step "$changed_files" "$workspace"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = '["postgres"]' ]
+    [ "$(output_value force_extension_builds)" = "$expected_force" ]
+    if [[ "$expected_scope" == "all" ]]; then
+        [ "$(output_value container_scopes)" = '{"postgres":{}}' ]
+    else
+        [ "$(output_value container_scopes | jq -r '.postgres.extensions // ""')" = "$expected_scope" ]
+    fi
+}
+
+@test "changed extension recipe emits hypopg scope and forces compilation" {
+    assert_extension_scope "postgres/extensions/build/hypopg.Dockerfile" "hypopg" "true"
+}
+
+@test "changed declared extension version scopes and forces that extension" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    yq -i '.extensions.hypopg.version = "1.4.4"' "$workspace/postgres/extensions/config.yaml"
+    run_find_containers_step "postgres/extensions/config.yaml" "$workspace"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value container_scopes | jq -r '.postgres.extensions')" = "hypopg" ]
+    [ "$(output_value force_extension_builds)" = "true" ]
+}
+
+@test "changed declared rust version scopes and forces that extension" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    yq -i '.extensions.paradedb.rust_version = "1.96.1"' "$workspace/postgres/extensions/config.yaml"
+    run_find_containers_step "postgres/extensions/config.yaml" "$workspace"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value container_scopes | jq -r '.postgres.extensions')" = "paradedb" ]
+    [ "$(output_value force_extension_builds)" = "true" ]
+}
+
+@test "changed shared extension config fans out and forces every extension" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    yq -i '.base_variant = "debian"' "$workspace/postgres/extensions/config.yaml"
+    assert_extension_scope "postgres/extensions/config.yaml" "all" "true" "$workspace"
+}
+
+@test "changed resolver fans out and forces every extension" {
+    assert_extension_scope "scripts/resolvers/timescaledb-ha.sh" "all" "true"
+}
+
+@test "changed extension helper fans out and forces every extension" {
+    assert_extension_scope "helpers/extension-utils.sh" "all" "true"
+}
+
+@test "flavor-only extension config change rebuilds postgres without forced compilation" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    yq -i '.flavors.vector += ["hypopg"]' "$workspace/postgres/extensions/config.yaml"
+    run_find_containers_step "postgres/extensions/config.yaml" "$workspace"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = '["postgres"]' ]
+    [ -z "$(output_value container_scopes)" ]
+    [ "$(output_value force_extension_builds)" = "false" ]
+}
+
+@test "unparseable extension config fails closed to every extension" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    printf '\ninvalid: [\n' >> "$workspace/postgres/extensions/config.yaml"
+    assert_extension_scope "postgres/extensions/config.yaml" "all" "true" "$workspace"
+}
+
+@test "unexpected extension config shape fails closed to every extension" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    yq -i '.extensions = []' "$workspace/postgres/extensions/config.yaml"
+    assert_extension_scope "postgres/extensions/config.yaml" "all" "true" "$workspace"
+}
+
+@test "unknown extension recipe fails closed to every extension" {
+    assert_extension_scope "postgres/extensions/build/not-a-known-extension.Dockerfile" "all" "true"
+}
+
+@test "unrelated postgres README emits neither extension scope nor force signal" {
+    make_classifier_workspace
+    workspace="$CLASSIFIER_WORKSPACE"
+    run_find_containers_step "postgres/README.md" "$workspace"
+
+    [ "$status" -eq 0 ]
+    [ "$(output_value containers)" = "[]" ]
+    [ -z "$(output_value container_scopes)" ]
+    [ "$(output_value force_extension_builds)" = "false" ]
+}


### PR DESCRIPTION
Extension images are reused by tag presence — `_image_needs_build`
(`scripts/build-extensions.sh`) skips when `ext-<name>:pg<major>-<version>` exists,
and that tag carries no recipe input. So a pull request editing an extension's
Dockerfile compiles nothing, and the merge that follows compiles nothing either.
The change is neither verified nor applied.

That is how postgis stayed unbuildable for months while its config declared the
`bison` and `flex` it was missing (#1168), and why #1168's own extension jobs
finished in one minute.

## What changes

The classifier derives two things from the changed-file list: which extensions
must be compiled, and a signal that bypasses reuse. Both apply on the pull request
and on the push that follows the merge — a pull-request-only force would publish
suffixed candidate refs and then let the merge run skip on the canonical tag,
leaving the fix proved and unapplied.

| Changed path | Extensions compiled |
|---|---|
| `postgres/extensions/build/<ext>.Dockerfile` | that extension |
| an extension's `version` or `rust_version` in `config.yaml` | that extension |
| anything else in `config.yaml` | all |
| a shared resolver or extension helper | all |
| flavour composition only | none — the final image rebuilds, no recompilation |
| config unreadable, base unreadable, name unrecognised | **all** |

A declared version is attributed by reading the config and its base revision with
`yq` and comparing, never by matching diff text — which cannot distinguish an
extension's `version` from a flavour's.

The build machinery is unchanged. `scripts/build-extensions.sh` already accepted
`--extension` and `--force`; this only decides when to pass them.

## Fail-closed

Every ambiguity compiles all ten extensions. An unreadable base revision produces
an empty comparison file and lands in that branch. Building too much costs runner
time; building too little restores the defect this exists to remove.

## Verified

- Full unit suite green, 2499 collected, 0 failed. `shellcheck` clean.
- 11 new classifier tests, one per row above plus the negative case.
- Discrimination proved independently: neutering the classifier turns 9 of the 11
  red; the 2 that survive are the two rows expecting an empty scope, which a
  neutered classifier satisfies by accident. Restored, 11 green again.
- Exercised on real inputs: a diff touching `hypopg`'s recipe and `debian/Dockerfile`
  scopes to `hypopg` alone and leaves debian unfiltered — a container absent from
  the scope map is passed through, not dropped.

`actionlint` on `auto-build.yaml` exceeds ten minutes locally; CI runs it.

## Cost

Forcing one single-version extension across majors 16, 17 and 18 measured 5 min
(arm64) and 7 min (amd64). Nine of the ten declare one version. `timescaledb` is
resolver-backed and expands to twelve, so a change touching it costs roughly an
hour — inside the job's 180-minute timeout, worth watching.

Refs #666
