### PR TITLE
docs(postgres): note why hypopg's hypothetical indexes are useful

### DIFF
--- a/postgres/extensions/build/hypopg.Dockerfile
+++ b/postgres/extensions/build/hypopg.Dockerfile
@@ -2,7 +2,8 @@
 # https://github.com/HypoPG/hypopg
 #
 # HypoPG allows creating hypothetical indexes to test query plans
-# without actually creating the indexes
+# without actually creating the indexes, so a planner change can be assessed
+# before paying for the index.
 
 ARG REMOTE_CR=ghcr.io/oorabona
 ARG MAJOR_VERSION


### PR DESCRIPTION
A comment-only edit to `postgres/extensions/build/hypopg.Dockerfile`, opened to
verify #1170 end to end.

Before #1170, a pull request touching an extension recipe reused the published
image and compiled nothing — #1168's extension jobs finished in one minute. This
pull request is the same shape, so its extension jobs are the measurement.

## Pass criteria

| Signal | Reused (the old defect) | Compiled (what #1170 must produce) |
|---|---|---|
| `Build PostgreSQL Extensions` duration | ~1 min | 5–7 min |
| detect-containers log | no expanded scope line | `forced extension scope: hypopg` |
| build log | no hypopg compile | hypopg compiled for majors 16, 17, 18 |

hypopg declares one version, which is why it was chosen: it is the cheapest
extension to force.

The classifier's local prediction for this diff is `hypopg`:

```
$ source helpers/container-scopes.sh
$ extension_scope_for_changes "postgres/extensions/build/hypopg.Dockerfile" "" "postgres/extensions/config.yaml"
hypopg
```

If the jobs finish in a minute, #1170 does not force under real conditions and
the scheduled rotation that builds on its signal must not be written yet.

The comment itself is true and worth keeping either way.
