### PR TITLE
fix(make): run discovery commands without a compose provider

### DIFF
--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -5,13 +5,14 @@
 # Dependencies: jq (required), syft (installed on demand)
 # SBOM format: SPDX JSON (industry standard, supported by GitHub attestations)
 
-set -euo pipefail
-
 _SBOM_UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source logging if available
 if [[ -f "$_SBOM_UTILS_DIR/logging.sh" ]]; then
-    source "$_SBOM_UTILS_DIR/logging.sh"
+    if ! source "$_SBOM_UTILS_DIR/logging.sh"; then
+        echo "ERROR: Failed to load logging utilities" >&2
+        return 1
+    fi
 else
     log_info()    { echo "INFO: $*" >&2; }
     log_success() { echo "OK: $*" >&2; }
@@ -19,7 +20,10 @@ else
     log_warning() { echo "WARN: $*" >&2; }
 fi
 
-source "$_SBOM_UTILS_DIR/retry.sh"
+if ! source "$_SBOM_UTILS_DIR/retry.sh"; then
+    log_error "Failed to load retry utilities"
+    return 1
+fi
 
 # Install syft if not present
 # Downloads the latest release from Anchore's install script
@@ -31,22 +35,31 @@ install_syft() {
 
     local syft_version="v1.42.1"
     log_info "Installing syft ${syft_version}..."
-    if curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null; then
+    if (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null) \
+        && [[ -x /usr/local/bin/syft ]]; then
         log_success "syft ${syft_version} installed successfully"
-    elif curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null; then
+        return 0
+    elif (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null); then
         export PATH="$HOME/.local/bin:$PATH"
-        log_success "syft installed to ~/.local/bin"
-    else
-        log_error "Failed to install syft"
-        return 1
+        if command -v syft &>/dev/null; then
+            log_success "syft installed to ~/.local/bin"
+            return 0
+        fi
     fi
+
+    log_error "Failed to install syft"
+    return 1
 }
 
 # Generate SBOM from a registry image
 # Usage: generate_sbom <image_ref> <output_file>
 # image_ref: full image reference (e.g., ghcr.io/owner/repo:tag)
 # output_file: path for the SPDX JSON output
-generate_sbom() {
+# The public SBOM operations retain their historical strict error handling in
+# subshells. This prevents their shell options from leaking into the scripts
+# that source this helper.
+generate_sbom() (
+    set -euo pipefail
     local image_ref="$1"
     local output_file="$2"
 
@@ -74,7 +87,7 @@ generate_sbom() {
         log_error "Failed to generate SBOM for $image_ref"
         return 1
     fi
-}
+)
 
 # Extract sorted package list from SBOM (for diffing)
 # Usage: extract_package_list <sbom_file>
@@ -83,7 +96,8 @@ generate_sbom() {
 # Extract SBOM summary (package counts by type)
 # Usage: extract_sbom_summary <sbom_file>
 # Output: JSON {"total": N, "apk": N, "pip": N, ...}
-extract_sbom_summary() {
+extract_sbom_summary() (
+    set -euo pipefail
     local sbom_file="$1"
 
     if [[ ! -f "$sbom_file" ]]; then
@@ -103,7 +117,7 @@ extract_sbom_summary() {
         from_entries |
         . + {total: $total}
     ' "$sbom_file" 2>/dev/null || echo '{"total": 0}'
-}
+)
 
 # Extract packages grouped by type (for dashboard drill-down)
 # Usage: extract_sbom_packages <sbom_file>
@@ -112,7 +126,8 @@ extract_sbom_summary() {
 # Compare two SBOMs and produce changelog JSON
 # Usage: compare_sboms <new_sbom> <old_sbom> <output_file>
 # Output: JSON with added/removed/updated arrays + summary counts
-compare_sboms() {
+compare_sboms() (
+    set -euo pipefail
     local new_sbom="$1"
     local old_sbom="$2"
     local output_file="$3"
@@ -197,7 +212,7 @@ compare_sboms() {
     removed=$(jq '.summary.removed' "$output_file")
     updated=$(jq '.summary.updated' "$output_file")
     log_info "Changelog: +$added -$removed ~$updated"
-}
+)
 
 _enrich_changelog_latest_results() {
     local queries_json="$1"
@@ -276,7 +291,8 @@ _enrich_changelog_add_enrichment() {
 
 # Enrich compare_sboms output with latest-version and freshness metadata.
 # Usage: enrich_changelog <changelog_file> [current_sbom_file]
-enrich_changelog() {
+enrich_changelog() (
+    set -euo pipefail
     local changelog_file="$1"
     : "${2:-}"
 
@@ -441,7 +457,7 @@ enrich_changelog() {
         log_warning "Dependency freshness enrichment failed; leaving changelog unchanged: $changelog_file"
         return 1
     fi
-}
+)
 
 # Append build metadata to history file (keeps last N entries)
 # Usage: append_build_history <lineage_file> <sbom_summary_json> <history_file> [max_entries] [changelog_file]
@@ -450,7 +466,8 @@ enrich_changelog() {
 # history_file: path to the history JSON file (created if missing)
 # max_entries: max entries to keep (default: 10)
 # changelog_file: path to changelog JSON (default: derived from history_file)
-append_build_history() {
+append_build_history() (
+    set -euo pipefail
     local lineage_file="$1"
     local sbom_summary="$2"
     local history_file="$3"
@@ -537,4 +554,4 @@ append_build_history() {
     ' > "$history_file"
 
     log_info "Build history updated: $history_file ($(jq 'length' "$history_file") entries)"
-}
+)

--- a/make
+++ b/make
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# `make` is the entry point. Keep its error semantics independent of the
+# helpers it sources (sourced helpers must not set shell options for callers).
+set -euo pipefail
+
 # Establish a canonical PROJECT_ROOT from $0 BEFORE sourcing any helper.
 # This overrides any inherited/stale/malicious PROJECT_ROOT from the environment.
 # PROJECT_ROOT is a DATA-lookup variable (where .build-lineage / config.yaml live)
@@ -11,7 +15,7 @@ export PROJECT_ROOT
 export DOCKER_CLI_EXPERIMENTAL=enabled
 NPROC=$(nproc)
 export NPROC
-export DOCKERCOMPOSE="docker compose"
+export DOCKERCOMPOSE=""
 export DOCKEROPTS="${DOCKEROPTS:-}"
 
 # Source shared logging utilities
@@ -352,6 +356,7 @@ run() {
   fi
   local target=$1
   local wantedVersion=${2:-latest}
+  ensure_compose_provider || return $?
   pushd ${target}
   log_success "Running ${target} ${wantedVersion}"
   TAG=${wantedVersion} $DOCKERCOMPOSE run $DOCKEROPTS --rm ${target}
@@ -372,19 +377,6 @@ do_it() {
     # Then proceed with buildx (whether or not custom script existed)
     do_buildx "$op" "$registry"
     return $?
-  fi
-
-  # For other operations, check for custom scripts or use docker-compose
-  if [ -x "$op" ]; then
-    # shellcheck disable=SC1090
-    . "$op"
-    return $?
-  elif [ -r "docker-compose.yml" ]; then
-    $DOCKERCOMPOSE $op $DOCKEROPTS
-  elif [ -r "compose.yml" ]; then
-    $DOCKERCOMPOSE -f compose.yml $op $DOCKEROPTS
-  else
-    log_error "No ${op} script found in $PWD, aborting."
   fi
 }
 
@@ -558,7 +550,11 @@ check_updates() {
         local major_pattern
         major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
         local current_version
-        current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+        # No matching published tag is a normal lookup outcome. Keep the
+        # current-version field empty in that case, independently of pipefail.
+        if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+          current_version=""
+        fi
 
         # Latest upstream version for this major line
         local latest_version
@@ -614,10 +610,14 @@ check_updates() {
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
     local pattern
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     else
       # Fallback: try common version pattern
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     fi
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
 
@@ -783,17 +783,24 @@ show_lineage() {
   fi
 }
 
-# If docker(-)compose is not found, just exit immediately
-if [ ! -x "$(command -v docker-compose)" ]; then
-  docker compose 2>/dev/null 1>&2
-  if [ $? -ne 0 ]; then
-    log_error "docker(-)compose is not installed, aborting."
+# Resolve a compose provider only on paths that will invoke one.  In
+# particular, discovery commands such as `list` must not require Docker.
+ensure_compose_provider() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="docker compose"
+    log_success "Found 'docker compose', continuing."
+    return 0
   fi
-  log_success "Found 'docker compose', continuing."
-  DOCKERCOMPOSE="docker compose"
-else
-  log_success "Found 'docker-compose', continuing."
-fi
+
+  if command -v podman-compose >/dev/null 2>&1 && podman-compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="podman-compose"
+    log_success "Found 'podman-compose', continuing."
+    return 0
+  fi
+
+  log_error "No compose provider found (looked for docker compose and podman-compose)."
+  return 1
+}
 
 case "${1:-}" in
   build ) make "$@" ;;

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -682,7 +682,9 @@ build_container_variants() {
         log_info "$container has no variants, building single image..."
         local rc=0
         build_container "$container" "$major_version" "$major_version" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 
@@ -706,7 +708,9 @@ build_container_variants() {
         local dockerfile="${version_df:-Dockerfile}"
         local rc=0
         build_container "$container" "$base_image_version" "$base_image_version" "" "$dockerfile" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -34,6 +34,76 @@ teardown() {
     unset GITHUB_ACTIONS
 }
 
+assert_single_variant_result() {
+    local expected_tag="$1"
+    local expected_status="$2"
+    local result_lines
+    result_lines=$(sed -n '/^\[/p' <<< "$output")
+
+    [ "$(printf '%s\n' "$result_lines" | wc -l | tr -d ' ')" -eq 1 ]
+    jq -e --arg tag "$expected_tag" --arg status "$expected_status" \
+        '. == [{"name":"default","tag":$tag,"flavor":"","status":$status}]' \
+        <<< "$result_lines" >/dev/null
+}
+
+# =============================================================================
+# build_container_variants no-variants status tests
+# =============================================================================
+
+@test "build_container_variants reports failed when a container has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3" "failed"
+}
+
+@test "build_container_variants reports built when a container has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3" "built"
+}
+
+@test "build_container_variants reports failed when a version has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3-alpine" "failed"
+}
+
+@test "build_container_variants reports built when a version has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3-alpine" "built"
+}
+
 # =============================================================================
 # check_multiplatform_support tests
 # =============================================================================

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -459,6 +459,12 @@ EOF
     cat > helpers/sbom-utils.sh <<'EOF'
 EOF
 
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
+EOF
+
     # check-version stub
     cat > scripts/check-version.sh <<'EOF'
 get_build_version() { echo "${2:-latest}"; return 0; }
@@ -542,6 +548,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'
@@ -663,6 +675,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'

--- a/tests/unit/make-compose-provider.bats
+++ b/tests/unit/make-compose-provider.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+
+# Exercise the real `make` entry point with no compose provider on PATH.
+bats_require_minimum_version 1.5.0
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export COMPOSE_FREE_PATH="$TEST_TEMP_DIR/bin"
+    mkdir -p "$COMPOSE_FREE_PATH"
+
+    # `make` only needs these system utilities while loading and listing. Keep
+    # the controlled PATH free of docker, docker-compose, and podman-compose.
+    local command_name
+    for command_name in dirname nproc find sed cut sort ls; do
+        ln -s "$(command -v "$command_name")" "$COMPOSE_FREE_PATH/$command_name"
+    done
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+run_make_with_controlled_path() {
+    run --separate-stderr bash -c 'cd "$1" || exit 1; PATH="$2"; export PATH; shift 2; exec /bin/bash ./make "$@"' \
+        _ "$PROJECT_ROOT" "$COMPOSE_FREE_PATH" "$@"
+}
+
+@test "make list works without a compose provider" {
+    run_make_with_controlled_path list
+
+    [ "$status" -eq 0 ]
+    [ "$output" = $'ansible\ndebian\ngithub-runner\njekyll\nopenresty\nopenvpn\nphp\npostgres\nsslh\nterraform\ntor\nvector\nweb-shell\nwordpress' ]
+    [ -z "$stderr" ]
+}
+
+@test "make run refuses to proceed when no compose provider is available" {
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"docker compose"* ]]
+    [[ "$stderr" == *"podman-compose"* ]]
+    [[ "$stderr" != *"docker-compose"* ]]
+    [[ "$stderr" != *"Running ansible"* ]]
+}
+
+@test "make run refuses a working docker-compose binary when no supported provider is available" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$TEST_TEMP_DIR/docker-compose-args" ]
+    [[ "$stderr" == *"No compose provider found"* ]]
+    [[ "$stderr" != *"docker-compose"* ]]
+}
+
+@test "make run selects docker compose over a working docker-compose binary" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+EOF
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose" "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_TEMP_DIR/docker-compose-args" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "make run accepts a podman-compose provider and passes its exact arguments" {
+    cat > "$COMPOSE_FREE_PATH/podman-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/podman-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/podman-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/podman-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/podman-compose-args")" = "<version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/podman-compose-args")" = "<run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'podman-compose', continuing."* ]]
+}
+
+@test "make run selects docker compose without executing an irrelevant docker-compose binary" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+exit 1
+EOF
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose" "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_TEMP_DIR/docker-compose-args" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "sourcing sbom-utils preserves the caller's shell options" {
+    run bash -c '
+        set +e
+        set -u
+        set -o pipefail
+        source "$1" || exit 1
+        case "$-" in *e*) exit 1 ;; esac
+        [[ "$(set -o | awk "\$1 == \"nounset\" { print \$2 }")" == on ]]
+        [[ "$(set -o | awk "\$1 == \"pipefail\" { print \$2 }")" == on ]]
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "sourcing sbom-utils fails when retry utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    run bash -c 'source "$1"' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load retry utilities"* ]]
+}
+
+@test "sourcing sbom-utils fails when logging utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$PROJECT_ROOT/helpers/retry.sh" "$PROJECT_ROOT/helpers/logging.sh" \
+        "$TEST_TEMP_DIR/helpers/"
+    chmod 000 "$TEST_TEMP_DIR/helpers/logging.sh"
+
+    run bash -c '
+        log_error() { printf "caller log: %s\\n" "$*"; }
+        source "$1"
+    ' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load logging utilities"* ]]
+}
+
+@test "install_syft fails and does not claim success when its download fails" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    ln -s "$(command -v sh)" "$helper_bin/sh"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+exit 22
+EOF
+    chmod +x "$helper_bin/curl"
+
+    run bash -c 'PATH="$2"; export PATH; source "$1" || exit 1; install_syft' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to install syft"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}
+
+@test "install_syft does not download again after a successful system install outside PATH" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    local install_calls="$TEST_TEMP_DIR/install-calls"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' curl >> "$SYFT_INSTALL_CALLS"
+printf 'stub installer\n'
+EOF
+    cat > "$helper_bin/sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$4" >> "$SYFT_INSTALL_CALLS"
+if [ "$4" = /usr/local/bin ]; then
+    printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/syft
+    /bin/chmod +x /usr/local/bin/syft
+else
+    /bin/mkdir -p "$4"
+    printf '#!/bin/sh\nexit 0\n' > "$4/syft"
+    /bin/chmod +x "$4/syft"
+fi
+exit 0
+EOF
+    chmod +x "$helper_bin/curl" "$helper_bin/sh"
+
+    if ! unshare -Urnm bash -c 'mount -t tmpfs tmpfs /usr/local/bin'; then
+        skip "user namespace with private mount not available"
+    fi
+
+    run unshare -Urnm bash -c '
+        mount -t tmpfs tmpfs /usr/local/bin || exit 1
+        PATH="$2"; export PATH
+        SYFT_INSTALL_CALLS="$3"; export SYFT_INSTALL_CALLS
+        HOME="$(dirname "$3")/home"; export HOME
+        source "$1" || exit 1
+        install_syft
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$install_calls"
+
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$install_calls")" -eq 2 ]
+    [ "$(sed -n '1p' "$install_calls")" = "curl" ]
+    [ "$(sed -n '2p' "$install_calls")" = "/usr/local/bin" ]
+    [[ "$output" == *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}


### PR DESCRIPTION
On a host with no compose provider, `./make list` exited 125 printing nothing at all: no list, no error, no diagnostic. Sixteen unit tests failed for a reason none of them named.

Three causes stacked. The provider guard ran before the `case` dispatch, so every operation paid for it even though `list`, `version` and `check-updates` never invoke compose. Its probe was silenced by `2>/dev/null`. And `make` declared no shell options of its own, inheriting `set -euo pipefail` from `helpers/sbom-utils.sh`, which turned that silenced probe into a wordless exit.

## What changed

- `make` declares its own shell options, so its behaviour under error no longer depends on which helper it sources or in what order.
- `helpers/sbom-utils.sh` keeps strict mode inside each public function rather than imposing it on its eight sourcing sites.
- The provider is resolved only on the paths that invoke it, and only after the candidate has been shown to run. A candidate that fails its probe falls through to the next.
- The two no-variants paths in `build_container_variants` reported a failed build as `"status":"built"`. The status now follows the result, as the variants path already did.
- An unreachable generic-operation branch in `do_it` is removed rather than guarded.

## Verification

2514 unit tests pass. `shellcheck -x -S warning` clean on `make`, `helpers/sbom-utils.sh` and `scripts/build-container.sh`. `./make list` returns its containers with no compose provider installed, and `./make build`, `./make push` and `./make run` dispatch unchanged. Three mutation proofs confirm the new tests fail when the behaviour they name is removed.

Eighteen tests in `latest-per-major.bats` had been exercising a mode production never had: their fixture writes an empty `sbom-utils.sh` stub, which silently disabled errexit inside the fixture. The fixture is completed and no assertion was weakened.

## Known gaps, filed separately

#1186, #1188 and #1191 describe failure paths in this area that predate this change and are not addressed here.