### PR TITLE
fix(ci): build the postgres image against the extensions the run compiled

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -307,6 +307,10 @@ jobs:
       # same-repository PR, build-extensions and merge-extension-manifests
       # publish the PR-scoped extension images that this e2e build must consume.
       PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
+      # Dedicated resolver contract: extension names published successfully by
+      # this run. '*' preserves the detector's all-extensions scope. Skipped or
+      # failed extension stages publish no usable scoped refs, so force nothing.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -1149,6 +1153,9 @@ jobs:
       # this inlines the same expression that defines the workflow-level
       # REBUILD_MODE (see the top-level `env:`) rather than referencing it.
       REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
+      # Resolver contract: only extensions published successfully by this run.
+      # An empty value covers skipped or failed extension stages.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     runs-on: ${{ matrix.build.os == 'windows' && 'windows-latest' || matrix.runner }}
     timeout-minutes: ${{ matrix.build.os == 'windows' && 120 || 60 }}
     strategy:
@@ -1827,6 +1834,8 @@ jobs:
     timeout-minutes: 90
     env:
       CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+      # Resolver contract: only extensions published successfully by this run.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     permissions:
       contents: read
       packages: write
@@ -2317,6 +2326,8 @@ jobs:
     timeout-minutes: 90
     env:
       CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+      # Resolver contract: only extensions published successfully by this run.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     permissions:
       contents: read
       packages: write

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -459,8 +459,8 @@ _scoped_ext_ref() {
 # ext_ref_resolve <ext> <version> <major> <arch>
 #
 # SINGLE SOURCE OF TRUTH for per-version extension image reference resolution.
-# Encapsulates all five axes: canonical-vs-PR-scoped, arch suffix, FORCE,
-# 3-state fail-closed, PR suffix.
+# Encapsulates all six axes: canonical-vs-PR-scoped, arch suffix, FORCE,
+# FORCE_SCOPED_EXTENSION_REFS scope membership, 3-state fail-closed, PR suffix.
 #
 # Parameters:
 #   <ext>     extension name (e.g. timescaledb)
@@ -472,6 +472,12 @@ _scoped_ext_ref() {
 # Reads env:
 #   PR_TAG_SUFFIX  (PR scoping, may be empty)
 #   FORCE          (true|false, defaults false)
+#   FORCE_SCOPED_EXTENSION_REFS
+#                  (comma-separated extension names, "*" for all, or empty;
+#                  a run-scoped contract set only after this run published the
+#                  named extension images. Only a named extension uses its
+#                  freshly-published PR-scoped ref. Empty values force nothing;
+#                  malformed non-empty values fail closed.)
 #
 # Ref construction (registry/owner from get_registry/get_repo_owner):
 #   canonical  = ext_image_name(ext,ver,major)[+"-"<arch>]
@@ -483,7 +489,10 @@ _scoped_ext_ref() {
 #   FORCE=true AND PR_TAG_SUFFIX set:
 #     → prefer PR-scoped (freshly rebuilt this run); do NOT reuse canonical.
 #     Probe PR-scoped only (canonical is stale for this version).
-#   else (not FORCE, or no PR_TAG_SUFFIX):
+#   FORCE_SCOPED_EXTENSION_REFS names ext AND PR_TAG_SUFFIX set:
+#     → prefer PR-scoped (freshly rebuilt this run); do NOT reuse canonical.
+#     Probe PR-scoped only (canonical is stale for this version).
+#   else (neither force signal, or no PR_TAG_SUFFIX):
 #     → prefer canonical when PRESENT (read-only reuse for unchanged versions).
 #     If canonical ABSENT and PR_TAG_SUFFIX set → probe PR-scoped.
 #
@@ -491,14 +500,48 @@ _scoped_ext_ref() {
 #   rc 0  → prints the ref to use (canonical or pr-scoped).
 #   rc 1  → neither ref exists definitively (needs build or exclude).
 #           prints nothing.
-#   rc 2  → a probe returned transient ERROR → fail closed.
+#   rc 2  → a probe returned transient ERROR, or the run scope is malformed
+#           → fail closed.
 #           prints nothing.
 #
 # On push/dispatch (PR_TAG_SUFFIX empty): only canonical is considered;
 # behavior is identical to the current canonical path.
+_force_scoped_extension_ref() {
+    local ext="$1" scope="${FORCE_SCOPED_EXTENSION_REFS:-}" scoped_ext
+    local -a scoped_exts
+
+    # "*" is the explicit all-extensions scope. Every other non-empty value
+    # must be a complete comma-separated extension-name list. This mirrors the
+    # schema validator's name_shaped rule, ^[A-Za-z0-9_-]+$, so a schema-valid
+    # extension name has the same meaning in this run-scoped contract.
+    case "$scope" in
+        '*') return 0 ;;
+        '') return 1 ;;
+    esac
+    [[ "$scope" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]] || return 2
+
+    IFS=',' read -ra scoped_exts <<< "$scope"
+    for scoped_ext in "${scoped_exts[@]}"; do
+        [[ "$ext" == "$scoped_ext" ]] && return 0
+    done
+    return 1
+}
+
 ext_ref_resolve() {
     local ext="$1" version="$2" major="$3" arch="${4:-}"
-    local registry owner canonical_ref pr_ref
+    local registry owner canonical_ref pr_ref scope_rc=0
+
+    # A corrupt non-empty run scope must not silently select canonical images.
+    # Keep rc 2 for this fail-closed resolution error, matching probe failures.
+    _force_scoped_extension_ref "$ext" || scope_rc=$?
+    case "$scope_rc" in
+        0|1) ;;
+        *)
+            printf 'ERROR [ext_ref_resolve]: invalid FORCE_SCOPED_EXTENSION_REFS scope\n' >&2
+            return 2
+            ;;
+    esac
+
     registry=$(get_registry)
     owner=$(get_repo_owner)
 
@@ -517,8 +560,9 @@ ext_ref_resolve() {
     fi
 
     # On push/dispatch (PR_TAG_SUFFIX empty), pr_ref == canonical_ref.
-    # Handle FORCE + PR: prefer pr-scoped (do not reuse canonical stale ref).
-    if [[ "${FORCE:-false}" == "true" ]] && [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
+    # A forced rebuild, or a scope that names this extension, must prefer the
+    # PR-scoped ref and never reuse the canonical stale ref.
+    if { [[ "${FORCE:-false}" == "true" ]] || [[ "$scope_rc" -eq 0 ]]; } && [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
         # Probe the PR-scoped ref only.
         local _rc=0
         _image_registry_probe_3state "$pr_ref" || _rc=$?
@@ -529,7 +573,7 @@ ext_ref_resolve() {
         esac
     fi
 
-    # Normal path (not FORCE+PR, or push/dispatch):
+    # Normal path (neither force signal + PR, or push/dispatch):
     # Probe canonical first (read-only reuse for unchanged versions).
     local _can_rc=0
     _image_registry_probe_3state "$canonical_ref" || _can_rc=$?
@@ -880,8 +924,9 @@ generate_dockerfile() {
     # Derive FORCE from REBUILD env so a forced PR run prefers freshly-rebuilt
     # PR-scoped refs over stale canonical refs for non-resolver/single-version
     # extensions.  This mirrors the --force logic in build-extensions.sh and
-    # merge-extension-manifests.  ext_ref_resolve reads FORCE from env; the
-    # build-and-push job exports REBUILD from env.REBUILD_MODE.
+    # merge-extension-manifests.  ext_ref_resolve also reads the separate
+    # FORCE_SCOPED_EXTENSION_REFS run contract.  The build-and-push job exports
+    # REBUILD from env.REBUILD_MODE.
     # Pre-existing FORCE=true is preserved (e.g. LOCAL_ONLY builds).
     if [[ "${REBUILD:-}" == "force" || "${REBUILD:-}" == "all" ]]; then
         export FORCE=true
@@ -1065,7 +1110,8 @@ generate_dockerfile() {
 
                 # Probe registry presence for each resolved version via ext_ref_resolve.
                 # ext_ref_resolve encapsulates canonical-first, PR-scoped fallback,
-                # FORCE, and 3-state fail-closed in one call (arch="" = multi-arch tag).
+                # both force signals, and 3-state fail-closed in one call
+                # (arch="" = multi-arch tag).
                 # rc 0 → PRESENT (ref printed); rc 1 → ABSENT; rc 2 → transient ERROR (fail-closed).
                 local _sh_available=()
                 local -A _sh_emit_ref_map=()  # version → resolved emit ref (for lookup in emit loop)

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -5,13 +5,14 @@
 # Dependencies: jq (required), syft (installed on demand)
 # SBOM format: SPDX JSON (industry standard, supported by GitHub attestations)
 
-set -euo pipefail
-
 _SBOM_UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source logging if available
 if [[ -f "$_SBOM_UTILS_DIR/logging.sh" ]]; then
-    source "$_SBOM_UTILS_DIR/logging.sh"
+    if ! source "$_SBOM_UTILS_DIR/logging.sh"; then
+        echo "ERROR: Failed to load logging utilities" >&2
+        return 1
+    fi
 else
     log_info()    { echo "INFO: $*" >&2; }
     log_success() { echo "OK: $*" >&2; }
@@ -19,7 +20,10 @@ else
     log_warning() { echo "WARN: $*" >&2; }
 fi
 
-source "$_SBOM_UTILS_DIR/retry.sh"
+if ! source "$_SBOM_UTILS_DIR/retry.sh"; then
+    log_error "Failed to load retry utilities"
+    return 1
+fi
 
 # Install syft if not present
 # Downloads the latest release from Anchore's install script
@@ -31,22 +35,31 @@ install_syft() {
 
     local syft_version="v1.42.1"
     log_info "Installing syft ${syft_version}..."
-    if curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null; then
+    if (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null) \
+        && [[ -x /usr/local/bin/syft ]]; then
         log_success "syft ${syft_version} installed successfully"
-    elif curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null; then
+        return 0
+    elif (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null); then
         export PATH="$HOME/.local/bin:$PATH"
-        log_success "syft installed to ~/.local/bin"
-    else
-        log_error "Failed to install syft"
-        return 1
+        if command -v syft &>/dev/null; then
+            log_success "syft installed to ~/.local/bin"
+            return 0
+        fi
     fi
+
+    log_error "Failed to install syft"
+    return 1
 }
 
 # Generate SBOM from a registry image
 # Usage: generate_sbom <image_ref> <output_file>
 # image_ref: full image reference (e.g., ghcr.io/owner/repo:tag)
 # output_file: path for the SPDX JSON output
-generate_sbom() {
+# The public SBOM operations retain their historical strict error handling in
+# subshells. This prevents their shell options from leaking into the scripts
+# that source this helper.
+generate_sbom() (
+    set -euo pipefail
     local image_ref="$1"
     local output_file="$2"
 
@@ -74,7 +87,7 @@ generate_sbom() {
         log_error "Failed to generate SBOM for $image_ref"
         return 1
     fi
-}
+)
 
 # Extract sorted package list from SBOM (for diffing)
 # Usage: extract_package_list <sbom_file>
@@ -83,7 +96,8 @@ generate_sbom() {
 # Extract SBOM summary (package counts by type)
 # Usage: extract_sbom_summary <sbom_file>
 # Output: JSON {"total": N, "apk": N, "pip": N, ...}
-extract_sbom_summary() {
+extract_sbom_summary() (
+    set -euo pipefail
     local sbom_file="$1"
 
     if [[ ! -f "$sbom_file" ]]; then
@@ -103,7 +117,7 @@ extract_sbom_summary() {
         from_entries |
         . + {total: $total}
     ' "$sbom_file" 2>/dev/null || echo '{"total": 0}'
-}
+)
 
 # Extract packages grouped by type (for dashboard drill-down)
 # Usage: extract_sbom_packages <sbom_file>
@@ -112,7 +126,8 @@ extract_sbom_summary() {
 # Compare two SBOMs and produce changelog JSON
 # Usage: compare_sboms <new_sbom> <old_sbom> <output_file>
 # Output: JSON with added/removed/updated arrays + summary counts
-compare_sboms() {
+compare_sboms() (
+    set -euo pipefail
     local new_sbom="$1"
     local old_sbom="$2"
     local output_file="$3"
@@ -197,7 +212,7 @@ compare_sboms() {
     removed=$(jq '.summary.removed' "$output_file")
     updated=$(jq '.summary.updated' "$output_file")
     log_info "Changelog: +$added -$removed ~$updated"
-}
+)
 
 _enrich_changelog_latest_results() {
     local queries_json="$1"
@@ -276,7 +291,8 @@ _enrich_changelog_add_enrichment() {
 
 # Enrich compare_sboms output with latest-version and freshness metadata.
 # Usage: enrich_changelog <changelog_file> [current_sbom_file]
-enrich_changelog() {
+enrich_changelog() (
+    set -euo pipefail
     local changelog_file="$1"
     : "${2:-}"
 
@@ -441,7 +457,7 @@ enrich_changelog() {
         log_warning "Dependency freshness enrichment failed; leaving changelog unchanged: $changelog_file"
         return 1
     fi
-}
+)
 
 # Append build metadata to history file (keeps last N entries)
 # Usage: append_build_history <lineage_file> <sbom_summary_json> <history_file> [max_entries] [changelog_file]
@@ -450,7 +466,8 @@ enrich_changelog() {
 # history_file: path to the history JSON file (created if missing)
 # max_entries: max entries to keep (default: 10)
 # changelog_file: path to changelog JSON (default: derived from history_file)
-append_build_history() {
+append_build_history() (
+    set -euo pipefail
     local lineage_file="$1"
     local sbom_summary="$2"
     local history_file="$3"
@@ -537,4 +554,4 @@ append_build_history() {
     ' > "$history_file"
 
     log_info "Build history updated: $history_file ($(jq 'length' "$history_file") entries)"
-}
+)

--- a/make
+++ b/make
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# `make` is the entry point. Keep its error semantics independent of the
+# helpers it sources (sourced helpers must not set shell options for callers).
+set -euo pipefail
+
 # Establish a canonical PROJECT_ROOT from $0 BEFORE sourcing any helper.
 # This overrides any inherited/stale/malicious PROJECT_ROOT from the environment.
 # PROJECT_ROOT is a DATA-lookup variable (where .build-lineage / config.yaml live)
@@ -11,7 +15,7 @@ export PROJECT_ROOT
 export DOCKER_CLI_EXPERIMENTAL=enabled
 NPROC=$(nproc)
 export NPROC
-export DOCKERCOMPOSE="docker compose"
+export DOCKERCOMPOSE=""
 export DOCKEROPTS="${DOCKEROPTS:-}"
 
 # Source shared logging utilities
@@ -352,6 +356,7 @@ run() {
   fi
   local target=$1
   local wantedVersion=${2:-latest}
+  ensure_compose_provider || return $?
   pushd ${target}
   log_success "Running ${target} ${wantedVersion}"
   TAG=${wantedVersion} $DOCKERCOMPOSE run $DOCKEROPTS --rm ${target}
@@ -372,19 +377,6 @@ do_it() {
     # Then proceed with buildx (whether or not custom script existed)
     do_buildx "$op" "$registry"
     return $?
-  fi
-
-  # For other operations, check for custom scripts or use docker-compose
-  if [ -x "$op" ]; then
-    # shellcheck disable=SC1090
-    . "$op"
-    return $?
-  elif [ -r "docker-compose.yml" ]; then
-    $DOCKERCOMPOSE $op $DOCKEROPTS
-  elif [ -r "compose.yml" ]; then
-    $DOCKERCOMPOSE -f compose.yml $op $DOCKEROPTS
-  else
-    log_error "No ${op} script found in $PWD, aborting."
   fi
 }
 
@@ -558,7 +550,11 @@ check_updates() {
         local major_pattern
         major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
         local current_version
-        current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+        # No matching published tag is a normal lookup outcome. Keep the
+        # current-version field empty in that case, independently of pipefail.
+        if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+          current_version=""
+        fi
 
         # Latest upstream version for this major line
         local latest_version
@@ -614,10 +610,14 @@ check_updates() {
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
     local pattern
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     else
       # Fallback: try common version pattern
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     fi
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
 
@@ -783,17 +783,30 @@ show_lineage() {
   fi
 }
 
-# If docker(-)compose is not found, just exit immediately
-if [ ! -x "$(command -v docker-compose)" ]; then
-  docker compose 2>/dev/null 1>&2
-  if [ $? -ne 0 ]; then
-    log_error "docker(-)compose is not installed, aborting."
+# Resolve a compose provider only on paths that will invoke one.  In
+# particular, discovery commands such as `list` must not require Docker.
+ensure_compose_provider() {
+  if command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="docker-compose"
+    log_success "Found 'docker-compose', continuing."
+    return 0
   fi
-  log_success "Found 'docker compose', continuing."
-  DOCKERCOMPOSE="docker compose"
-else
-  log_success "Found 'docker-compose', continuing."
-fi
+
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="docker compose"
+    log_success "Found 'docker compose', continuing."
+    return 0
+  fi
+
+  if command -v podman-compose >/dev/null 2>&1 && podman-compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="podman-compose"
+    log_success "Found 'podman-compose', continuing."
+    return 0
+  fi
+
+  log_error "No compose provider found (looked for docker-compose, docker compose, and podman-compose)."
+  return 1
+}
 
 case "${1:-}" in
   build ) make "$@" ;;

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -682,7 +682,9 @@ build_container_variants() {
         log_info "$container has no variants, building single image..."
         local rc=0
         build_container "$container" "$major_version" "$major_version" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 
@@ -706,7 +708,9 @@ build_container_variants() {
         local dockerfile="${version_df:-Dockerfile}"
         local rc=0
         build_container "$container" "$base_image_version" "$base_image_version" "" "$dockerfile" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -34,6 +34,76 @@ teardown() {
     unset GITHUB_ACTIONS
 }
 
+assert_single_variant_result() {
+    local expected_tag="$1"
+    local expected_status="$2"
+    local result_lines
+    result_lines=$(sed -n '/^\[/p' <<< "$output")
+
+    [ "$(printf '%s\n' "$result_lines" | wc -l | tr -d ' ')" -eq 1 ]
+    jq -e --arg tag "$expected_tag" --arg status "$expected_status" \
+        '. == [{"name":"default","tag":$tag,"flavor":"","status":$status}]' \
+        <<< "$result_lines" >/dev/null
+}
+
+# =============================================================================
+# build_container_variants no-variants status tests
+# =============================================================================
+
+@test "build_container_variants reports failed when a container has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3" "failed"
+}
+
+@test "build_container_variants reports built when a container has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3" "built"
+}
+
+@test "build_container_variants reports failed when a version has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3-alpine" "failed"
+}
+
+@test "build_container_variants reports built when a version has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3-alpine" "built"
+}
+
 # =============================================================================
 # check_multiplatform_support tests
 # =============================================================================

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -69,7 +69,7 @@ EOF
 
 teardown() {
     teardown_temp_dir
-    unset FORCE LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR
+    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR
 }
 
 # ---------------------------------------------------------------------------
@@ -174,6 +174,236 @@ _setup_default_mocks() {
 
     # jq: pass through (real jq required)
     # log_* pass-through (already sourced from extension-utils.sh chain)
+}
+
+# ---------------------------------------------------------------------------
+# ext_ref_resolve — run-scoped forced extension refs
+#
+# The resolver, rather than a caller, decides whether a consumer uses canonical
+# or this run's scoped extension image.  These tests stub the underlying
+# three-state registry probe, not ext_ref_resolve itself.
+# ---------------------------------------------------------------------------
+
+@test "run-scoped forced extension refs prefer scoped ref when both refs are present" {
+    local probe_log="$TEST_TEMP_DIR/scoped-present-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+@test "without run-scoped forced extension refs canonical stays preferred when both refs are present" {
+    local probe_log="$TEST_TEMP_DIR/canonical-present-probes.log"
+    export FORCE=false
+    unset FORCE_SCOPED_EXTENSION_REFS
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64" ]
+}
+
+@test "run-scoped forced extension refs absent means needs build without canonical fallback" {
+    local probe_log="$TEST_TEMP_DIR/scoped-absent-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 1
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+@test "run-scoped forced extension ref probe error fails closed" {
+    local probe_log="$TEST_TEMP_DIR/scoped-error-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 2
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+# No empty-PR_TAG_SUFFIX test: helpers/extension-utils.sh assigns
+# pr_ref="$canonical_ref", so the forced and canonical branches converge. A
+# test for this case would pass whatever the forced-branch condition does.
+
+@test "run-scoped forced extension refs scope only the extension this run rebuilt" {
+    local probe_log="$TEST_TEMP_DIR/scoped-membership-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS=hypopg
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64-pr42" ]
+
+    run ext_ref_resolve pgvector 0.8.2 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-pgvector:pg18-0.8.2-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(sed -n '1p' "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64-pr42" ]
+    [ "$(sed -n '2p' "$probe_log")" = "ghcr.io/test/ext-pgvector:pg18-0.8.2-amd64" ]
+}
+
+@test "empty or absent run-scoped extension ref scope forces nothing" {
+    local probe_log="$TEST_TEMP_DIR/empty-scope-probes.log"
+    export FORCE=false
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    unset FORCE_SCOPED_EXTENSION_REFS
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+
+    export FORCE_SCOPED_EXTENSION_REFS=""
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(grep -cv -- '-pr42' "$probe_log" || true)" -eq 2 ]
+}
+
+@test "run-scoped forced extension refs match a schema-valid name outside the former matcher grammar" {
+    local probe_log="$TEST_TEMP_DIR/schema-valid-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='-hypopg'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve -hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext--hypopg:pg18-1.4.3-amd64-pr42" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext--hypopg:pg18-1.4.3-amd64-pr42" ]
+}
+
+@test "run-scoped forced extension ref scope true matches only an extension named true" {
+    local probe_log="$TEST_TEMP_DIR/literal-true-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS=true
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve true 1.0.0 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-true:pg18-1.0.0-amd64-pr42" ]
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(sed -n '1p' "$probe_log")" = "ghcr.io/test/ext-true:pg18-1.0.0-amd64-pr42" ]
+    [ "$(sed -n '2p' "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+}
+
+@test "malformed run-scoped extension ref scope fails closed before probing" {
+    local probe_log="$TEST_TEMP_DIR/malformed-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS="hypopg,,pgvector"
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 2 ]
+    [ "$output" = "ERROR [ext_ref_resolve]: invalid FORCE_SCOPED_EXTENSION_REFS scope" ]
+    [ ! -s "$probe_log" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -459,6 +459,12 @@ EOF
     cat > helpers/sbom-utils.sh <<'EOF'
 EOF
 
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
+EOF
+
     # check-version stub
     cat > scripts/check-version.sh <<'EOF'
 get_build_version() { echo "${2:-latest}"; return 0; }
@@ -542,6 +548,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'
@@ -663,6 +675,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'

--- a/tests/unit/make-compose-provider.bats
+++ b/tests/unit/make-compose-provider.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+
+# Exercise the real `make` entry point with no compose provider on PATH.
+bats_require_minimum_version 1.5.0
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export COMPOSE_FREE_PATH="$TEST_TEMP_DIR/bin"
+    mkdir -p "$COMPOSE_FREE_PATH"
+
+    # `make` only needs these system utilities while loading and listing. Keep
+    # the controlled PATH free of docker, docker-compose, and podman-compose.
+    local command_name
+    for command_name in dirname nproc find sed cut sort ls; do
+        ln -s "$(command -v "$command_name")" "$COMPOSE_FREE_PATH/$command_name"
+    done
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+run_make_with_controlled_path() {
+    run --separate-stderr bash -c 'cd "$1" || exit 1; PATH="$2"; export PATH; shift 2; exec /bin/bash ./make "$@"' \
+        _ "$PROJECT_ROOT" "$COMPOSE_FREE_PATH" "$@"
+}
+
+@test "make list works without a compose provider" {
+    run_make_with_controlled_path list
+
+    [ "$status" -eq 0 ]
+    [ "$output" = $'ansible\ndebian\ngithub-runner\njekyll\nopenresty\nopenvpn\nphp\npostgres\nsslh\nterraform\ntor\nvector\nweb-shell\nwordpress' ]
+    [ -z "$stderr" ]
+}
+
+@test "make run refuses to proceed when no compose provider is available" {
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"docker-compose"* ]]
+    [[ "$stderr" == *"docker compose"* ]]
+    [[ "$stderr" == *"podman-compose"* ]]
+    [[ "$stderr" != *"Running ansible"* ]]
+}
+
+@test "make run accepts a docker-compose provider on PATH" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TEMP_DIR/docker-compose-args" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-compose-args")" = "<version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-compose-args")" = "<run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker-compose', continuing."* ]]
+    [[ "$stderr" != *"No compose provider found"* ]]
+}
+
+@test "make run accepts a docker compose provider and passes its exact arguments" {
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "make run accepts a podman-compose provider and passes its exact arguments" {
+    cat > "$COMPOSE_FREE_PATH/podman-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/podman-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/podman-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/podman-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/podman-compose-args")" = "<version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/podman-compose-args")" = "<run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'podman-compose', continuing."* ]]
+}
+
+@test "make run skips a provider whose probe fails and selects the next usable provider" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+exit 1
+EOF
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose" "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_TEMP_DIR/docker-compose-args")" = "<version>" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "sourcing sbom-utils preserves the caller's shell options" {
+    run bash -c '
+        set +e
+        set -u
+        set -o pipefail
+        source "$1" || exit 1
+        case "$-" in *e*) exit 1 ;; esac
+        [[ "$(set -o | awk "\$1 == \"nounset\" { print \$2 }")" == on ]]
+        [[ "$(set -o | awk "\$1 == \"pipefail\" { print \$2 }")" == on ]]
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "sourcing sbom-utils fails when retry utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    run bash -c 'source "$1"' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load retry utilities"* ]]
+}
+
+@test "sourcing sbom-utils fails when logging utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$PROJECT_ROOT/helpers/retry.sh" "$PROJECT_ROOT/helpers/logging.sh" \
+        "$TEST_TEMP_DIR/helpers/"
+    chmod 000 "$TEST_TEMP_DIR/helpers/logging.sh"
+
+    run bash -c '
+        log_error() { printf "caller log: %s\\n" "$*"; }
+        source "$1"
+    ' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load logging utilities"* ]]
+}
+
+@test "install_syft fails and does not claim success when its download fails" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    ln -s "$(command -v sh)" "$helper_bin/sh"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+exit 22
+EOF
+    chmod +x "$helper_bin/curl"
+
+    run bash -c 'PATH="$2"; export PATH; source "$1" || exit 1; install_syft' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to install syft"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}
+
+@test "install_syft does not download again after a successful system install outside PATH" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    local install_calls="$TEST_TEMP_DIR/install-calls"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' curl >> "$SYFT_INSTALL_CALLS"
+printf 'stub installer\n'
+EOF
+    cat > "$helper_bin/sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$4" >> "$SYFT_INSTALL_CALLS"
+if [ "$4" = /usr/local/bin ]; then
+    printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/syft
+    /bin/chmod +x /usr/local/bin/syft
+else
+    /bin/mkdir -p "$4"
+    printf '#!/bin/sh\nexit 0\n' > "$4/syft"
+    /bin/chmod +x "$4/syft"
+fi
+exit 0
+EOF
+    chmod +x "$helper_bin/curl" "$helper_bin/sh"
+
+    run unshare -Urnm bash -c '
+        mount -t tmpfs tmpfs /usr/local/bin || exit 1
+        PATH="$2"; export PATH
+        SYFT_INSTALL_CALLS="$3"; export SYFT_INSTALL_CALLS
+        HOME="$(dirname "$3")/home"; export HOME
+        source "$1" || exit 1
+        install_syft
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$install_calls"
+
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$install_calls")" -eq 2 ]
+    [ "$(sed -n '1p' "$install_calls")" = "curl" ]
+    [ "$(sed -n '2p' "$install_calls")" = "/usr/local/bin" ]
+    [[ "$output" == *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}


### PR DESCRIPTION
A pull request editing an extension recipe compiled that extension and published it under a run-scoped tag. Every image built later in the same run still resolved the canonical tag, so the freshly compiled extension was pushed and never executed.

Run [31820830910](https://github.com/oorabona/docker-containers/actions/runs/31820830910) shows it end to end: the extension job pushed `ext-hypopg:pg18-1.4.3-pr1171`, and the e2e in the same run built postgres `FROM ghcr.io/oorabona/ext-hypopg:pg18-1.4.3`, unsuffixed. The compile was verified; the artifact never ran.

## What changed

`ext_ref_resolve` preferred the scoped reference only under a force flag derived from `REBUILD`, which is `none` on an ordinary pull request. The signal saying which extensions this run recompiled never left the two extension jobs.

`FORCE_SCOPED_EXTENSION_REFS` is now a contract of its own, documented in the resolver header and carried to the four jobs that consume extension references. It transports the extension scope rather than a boolean, so an extension the run rebuilt resolves to its scoped reference while an extension it did not rebuild resolves to canonical. It is set only when the extension jobs actually published, so a run with `skip_extensions` forces nothing. A scope value that cannot be parsed stops resolution instead of silently reusing canonical. Names are matched with the grammar the extensions schema itself defines.

`REBUILD` and `FORCE` keep their existing meanings, and resolution is unchanged wherever the new signal is absent.

## Verification

2523 unit tests pass. `actionlint` and `shellcheck -x -S warning` clean. Mutation proofs confirm the tests fail when the behaviours they name are removed, including a two-extension case proving an unchanged extension still resolves to canonical.

The empty-suffix case has no test on purpose: with no suffix the resolver assigns `pr_ref="$canonical_ref"`, so both branches converge and a test written for it would pass whatever the condition does. A mutation demonstrated exactly that, and the reason is recorded beside the tests.

## Known gaps, filed separately

#1196 — extension tags are shared across runs of the same pull request, so a rerun can overwrite what another run consumes. This predates the change and shapes how candidate references should be identified.
#1197 — a malformed scope is reported as a transient registry error and one caller still falls back on it.

Closes #1172

Targets `fix/make-guard-and-build-status` (#1195); retarget to master once that merges.