### PR TITLE
fix(sbom): install a verified syft release instead of piping a script into sh

### DIFF
--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -5,13 +5,14 @@
 # Dependencies: jq (required), syft (installed on demand)
 # SBOM format: SPDX JSON (industry standard, supported by GitHub attestations)
 
-set -euo pipefail
-
 _SBOM_UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source logging if available
 if [[ -f "$_SBOM_UTILS_DIR/logging.sh" ]]; then
-    source "$_SBOM_UTILS_DIR/logging.sh"
+    if ! source "$_SBOM_UTILS_DIR/logging.sh"; then
+        echo "ERROR: Failed to load logging utilities" >&2
+        return 1
+    fi
 else
     log_info()    { echo "INFO: $*" >&2; }
     log_success() { echo "OK: $*" >&2; }
@@ -19,7 +20,10 @@ else
     log_warning() { echo "WARN: $*" >&2; }
 fi
 
-source "$_SBOM_UTILS_DIR/retry.sh"
+if ! source "$_SBOM_UTILS_DIR/retry.sh"; then
+    log_error "Failed to load retry utilities"
+    return 1
+fi
 
 # Install syft if not present
 # Downloads the latest release from Anchore's install script
@@ -31,22 +35,31 @@ install_syft() {
 
     local syft_version="v1.42.1"
     log_info "Installing syft ${syft_version}..."
-    if curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null; then
+    if (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null) \
+        && [[ -x /usr/local/bin/syft ]]; then
         log_success "syft ${syft_version} installed successfully"
-    elif curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null; then
+        return 0
+    elif (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null); then
         export PATH="$HOME/.local/bin:$PATH"
-        log_success "syft installed to ~/.local/bin"
-    else
-        log_error "Failed to install syft"
-        return 1
+        if command -v syft &>/dev/null; then
+            log_success "syft installed to ~/.local/bin"
+            return 0
+        fi
     fi
+
+    log_error "Failed to install syft"
+    return 1
 }
 
 # Generate SBOM from a registry image
 # Usage: generate_sbom <image_ref> <output_file>
 # image_ref: full image reference (e.g., ghcr.io/owner/repo:tag)
 # output_file: path for the SPDX JSON output
-generate_sbom() {
+# The public SBOM operations retain their historical strict error handling in
+# subshells. This prevents their shell options from leaking into the scripts
+# that source this helper.
+generate_sbom() (
+    set -euo pipefail
     local image_ref="$1"
     local output_file="$2"
 
@@ -74,7 +87,7 @@ generate_sbom() {
         log_error "Failed to generate SBOM for $image_ref"
         return 1
     fi
-}
+)
 
 # Extract sorted package list from SBOM (for diffing)
 # Usage: extract_package_list <sbom_file>
@@ -83,7 +96,8 @@ generate_sbom() {
 # Extract SBOM summary (package counts by type)
 # Usage: extract_sbom_summary <sbom_file>
 # Output: JSON {"total": N, "apk": N, "pip": N, ...}
-extract_sbom_summary() {
+extract_sbom_summary() (
+    set -euo pipefail
     local sbom_file="$1"
 
     if [[ ! -f "$sbom_file" ]]; then
@@ -103,7 +117,7 @@ extract_sbom_summary() {
         from_entries |
         . + {total: $total}
     ' "$sbom_file" 2>/dev/null || echo '{"total": 0}'
-}
+)
 
 # Extract packages grouped by type (for dashboard drill-down)
 # Usage: extract_sbom_packages <sbom_file>
@@ -112,7 +126,8 @@ extract_sbom_summary() {
 # Compare two SBOMs and produce changelog JSON
 # Usage: compare_sboms <new_sbom> <old_sbom> <output_file>
 # Output: JSON with added/removed/updated arrays + summary counts
-compare_sboms() {
+compare_sboms() (
+    set -euo pipefail
     local new_sbom="$1"
     local old_sbom="$2"
     local output_file="$3"
@@ -197,7 +212,7 @@ compare_sboms() {
     removed=$(jq '.summary.removed' "$output_file")
     updated=$(jq '.summary.updated' "$output_file")
     log_info "Changelog: +$added -$removed ~$updated"
-}
+)
 
 _enrich_changelog_latest_results() {
     local queries_json="$1"
@@ -276,7 +291,8 @@ _enrich_changelog_add_enrichment() {
 
 # Enrich compare_sboms output with latest-version and freshness metadata.
 # Usage: enrich_changelog <changelog_file> [current_sbom_file]
-enrich_changelog() {
+enrich_changelog() (
+    set -euo pipefail
     local changelog_file="$1"
     : "${2:-}"
 
@@ -441,7 +457,7 @@ enrich_changelog() {
         log_warning "Dependency freshness enrichment failed; leaving changelog unchanged: $changelog_file"
         return 1
     fi
-}
+)
 
 # Append build metadata to history file (keeps last N entries)
 # Usage: append_build_history <lineage_file> <sbom_summary_json> <history_file> [max_entries] [changelog_file]
@@ -450,7 +466,8 @@ enrich_changelog() {
 # history_file: path to the history JSON file (created if missing)
 # max_entries: max entries to keep (default: 10)
 # changelog_file: path to changelog JSON (default: derived from history_file)
-append_build_history() {
+append_build_history() (
+    set -euo pipefail
     local lineage_file="$1"
     local sbom_summary="$2"
     local history_file="$3"
@@ -537,4 +554,4 @@ append_build_history() {
     ' > "$history_file"
 
     log_info "Build history updated: $history_file ($(jq 'length' "$history_file") entries)"
-}
+)

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -25,30 +25,132 @@ if ! source "$_SBOM_UTILS_DIR/retry.sh"; then
     return 1
 fi
 
+# Anchore syft release assets. Keep the version and release-asset digests together
+# so updating this local convenience installer remains auditable.
+SYFT_VERSION="1.42.1"
+SYFT_LINUX_AMD64_SHA256="989ded4e772810f93de6ccdc4512f79a6dabb5fb2dd2a9ffc72a80c955e6125a"
+SYFT_LINUX_ARM64_SHA256="dfc9ac5fffa8fea95b4f84b427e200dbb2bd9bd0bbf2760d1a9369715b60a91d"
+SYFT_DARWIN_AMD64_SHA256="1e52e39d24a4eaec94329e0f3283c448e2ee8f79dc03e5f1e405d324b7ae4e1c"
+SYFT_DARWIN_ARM64_SHA256="b83cdcbd1b4c55505abd359c25c5903d94b99be47e6f98572bf96927b7b47e45"
+
 # Install syft if not present
-# Downloads the latest release from Anchore's install script
 install_syft() {
     if command -v syft &>/dev/null; then
         log_info "syft already installed: $(syft version 2>/dev/null | head -1)"
         return 0
     fi
 
-    local syft_version="v1.42.1"
-    log_info "Installing syft ${syft_version}..."
-    if (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null) \
-        && [[ -x /usr/local/bin/syft ]]; then
-        log_success "syft ${syft_version} installed successfully"
-        return 0
-    elif (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null); then
-        export PATH="$HOME/.local/bin:$PATH"
-        if command -v syft &>/dev/null; then
-            log_success "syft installed to ~/.local/bin"
-            return 0
+    local syft_asset syft_sha256
+    case "$(uname -s)-$(uname -m)" in
+        Linux-x86_64|Linux-amd64)
+            syft_asset="syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+            syft_sha256="$SYFT_LINUX_AMD64_SHA256"
+            ;;
+        Linux-aarch64|Linux-arm64)
+            syft_asset="syft_${SYFT_VERSION}_linux_arm64.tar.gz"
+            syft_sha256="$SYFT_LINUX_ARM64_SHA256"
+            ;;
+        Darwin-x86_64|Darwin-amd64)
+            syft_asset="syft_${SYFT_VERSION}_darwin_amd64.tar.gz"
+            syft_sha256="$SYFT_DARWIN_AMD64_SHA256"
+            ;;
+        Darwin-arm64)
+            syft_asset="syft_${SYFT_VERSION}_darwin_arm64.tar.gz"
+            syft_sha256="$SYFT_DARWIN_ARM64_SHA256"
+            ;;
+        *)
+            log_error "No verified syft ${SYFT_VERSION} release asset for $(uname -s)/$(uname -m)"
+            return 1
+            ;;
+    esac
+
+    local syft_tmp syft_archive syft_binary syft_destination syft_stage installed_version syft_version_output line syft_actual_sha256
+    syft_tmp=$(mktemp -d) || {
+        log_error "Failed to create temporary directory for syft download"
+        return 1
+    }
+    syft_archive="$syft_tmp/$syft_asset"
+    syft_binary="$syft_tmp/syft"
+
+    log_info "Installing syft ${SYFT_VERSION}..."
+    if ! curl -fsSL --retry 3 --retry-delay 2 \
+        "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/${syft_asset}" \
+        -o "$syft_archive"; then
+        rm -rf "$syft_tmp"
+        log_error "Failed to download syft ${SYFT_VERSION}"
+        return 1
+    fi
+    if command -v sha256sum &>/dev/null; then
+        if ! printf '%s  %s\n' "$syft_sha256" "$syft_archive" | sha256sum -c - >/dev/null; then
+            rm -rf "$syft_tmp"
+            log_error "Downloaded syft ${SYFT_VERSION} failed SHA-256 verification"
+            return 1
         fi
+    elif command -v shasum &>/dev/null; then
+        if ! syft_actual_sha256=$(shasum -a 256 "$syft_archive"); then
+            rm -rf "$syft_tmp"
+            log_error "Downloaded syft ${SYFT_VERSION} failed SHA-256 verification"
+            return 1
+        fi
+        if [[ "${syft_actual_sha256%% *}" != "$syft_sha256" ]]; then
+            rm -rf "$syft_tmp"
+            log_error "Downloaded syft ${SYFT_VERSION} failed SHA-256 verification"
+            return 1
+        fi
+    else
+        rm -rf "$syft_tmp"
+        log_error "No SHA-256 checker available to verify syft ${SYFT_VERSION}"
+        return 1
+    fi
+    if ! tar -xzf "$syft_archive" -C "$syft_tmp" syft || [[ ! -f "$syft_binary" ]]; then
+        rm -rf "$syft_tmp"
+        log_error "Failed to extract verified syft ${SYFT_VERSION} archive"
+        return 1
     fi
 
-    log_error "Failed to install syft"
-    return 1
+    syft_destination="/usr/local/bin/syft"
+    if syft_stage=$(mktemp "${syft_destination}.tmp.XXXXXX") && install -m 0755 "$syft_binary" "$syft_stage"; then
+        :
+    else
+        [[ -n "$syft_stage" ]] && rm -f "$syft_stage"
+        local user_bin="$HOME/.local/bin"
+        syft_destination="$user_bin/syft"
+        if ! mkdir -p "$user_bin" || ! syft_stage=$(mktemp "${syft_destination}.tmp.XXXXXX") || ! install -m 0755 "$syft_binary" "$syft_stage"; then
+            [[ -n "$syft_stage" ]] && rm -f "$syft_stage"
+            rm -rf "$syft_tmp"
+            log_error "Failed to stage verified syft ${SYFT_VERSION}"
+            return 1
+        fi
+        export PATH="$user_bin:$PATH"
+    fi
+    rm -rf "$syft_tmp"
+
+    if ! syft_version_output=$("$syft_stage" version 2>/dev/null); then
+        rm -f "$syft_stage"
+        log_error "Installed syft did not report its version"
+        return 1
+    fi
+    installed_version=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^Version:[[:space:]]*(.+)$ ]]; then
+            installed_version="${BASH_REMATCH[1]}"
+            break
+        fi
+    done <<< "$syft_version_output"
+    if [[ -z "$installed_version" ]]; then
+        rm -f "$syft_stage"
+        log_error "Installed syft did not report its version"
+        return 1
+    fi
+
+    if ! mv -f "$syft_stage" "$syft_destination"; then
+        rm -f "$syft_stage"
+        log_error "Failed to install verified syft ${SYFT_VERSION}"
+        return 1
+    fi
+
+    log_success "syft ${installed_version} installed successfully" || :
+    return 0
 }
 
 # Generate SBOM from a registry image

--- a/make
+++ b/make
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# `make` is the entry point. Keep its error semantics independent of the
+# helpers it sources (sourced helpers must not set shell options for callers).
+set -euo pipefail
+
 # Establish a canonical PROJECT_ROOT from $0 BEFORE sourcing any helper.
 # This overrides any inherited/stale/malicious PROJECT_ROOT from the environment.
 # PROJECT_ROOT is a DATA-lookup variable (where .build-lineage / config.yaml live)
@@ -11,7 +15,7 @@ export PROJECT_ROOT
 export DOCKER_CLI_EXPERIMENTAL=enabled
 NPROC=$(nproc)
 export NPROC
-export DOCKERCOMPOSE="docker compose"
+export DOCKERCOMPOSE=""
 export DOCKEROPTS="${DOCKEROPTS:-}"
 
 # Source shared logging utilities
@@ -352,6 +356,7 @@ run() {
   fi
   local target=$1
   local wantedVersion=${2:-latest}
+  ensure_compose_provider || return $?
   pushd ${target}
   log_success "Running ${target} ${wantedVersion}"
   TAG=${wantedVersion} $DOCKERCOMPOSE run $DOCKEROPTS --rm ${target}
@@ -372,19 +377,6 @@ do_it() {
     # Then proceed with buildx (whether or not custom script existed)
     do_buildx "$op" "$registry"
     return $?
-  fi
-
-  # For other operations, check for custom scripts or use docker-compose
-  if [ -x "$op" ]; then
-    # shellcheck disable=SC1090
-    . "$op"
-    return $?
-  elif [ -r "docker-compose.yml" ]; then
-    $DOCKERCOMPOSE $op $DOCKEROPTS
-  elif [ -r "compose.yml" ]; then
-    $DOCKERCOMPOSE -f compose.yml $op $DOCKEROPTS
-  else
-    log_error "No ${op} script found in $PWD, aborting."
   fi
 }
 
@@ -558,7 +550,11 @@ check_updates() {
         local major_pattern
         major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
         local current_version
-        current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+        # No matching published tag is a normal lookup outcome. Keep the
+        # current-version field empty in that case, independently of pipefail.
+        if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+          current_version=""
+        fi
 
         # Latest upstream version for this major line
         local latest_version
@@ -614,10 +610,14 @@ check_updates() {
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
     local pattern
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     else
       # Fallback: try common version pattern
-      current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n' || echo "no-published-version")
+      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n'); then
+        current_version=""
+      fi
     fi
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
 
@@ -783,17 +783,30 @@ show_lineage() {
   fi
 }
 
-# If docker(-)compose is not found, just exit immediately
-if [ ! -x "$(command -v docker-compose)" ]; then
-  docker compose 2>/dev/null 1>&2
-  if [ $? -ne 0 ]; then
-    log_error "docker(-)compose is not installed, aborting."
+# Resolve a compose provider only on paths that will invoke one.  In
+# particular, discovery commands such as `list` must not require Docker.
+ensure_compose_provider() {
+  if command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="docker-compose"
+    log_success "Found 'docker-compose', continuing."
+    return 0
   fi
-  log_success "Found 'docker compose', continuing."
-  DOCKERCOMPOSE="docker compose"
-else
-  log_success "Found 'docker-compose', continuing."
-fi
+
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="docker compose"
+    log_success "Found 'docker compose', continuing."
+    return 0
+  fi
+
+  if command -v podman-compose >/dev/null 2>&1 && podman-compose version >/dev/null 2>&1; then
+    DOCKERCOMPOSE="podman-compose"
+    log_success "Found 'podman-compose', continuing."
+    return 0
+  fi
+
+  log_error "No compose provider found (looked for docker-compose, docker compose, and podman-compose)."
+  return 1
+}
 
 case "${1:-}" in
   build ) make "$@" ;;

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -682,7 +682,9 @@ build_container_variants() {
         log_info "$container has no variants, building single image..."
         local rc=0
         build_container "$container" "$major_version" "$major_version" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$major_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 
@@ -706,7 +708,9 @@ build_container_variants() {
         local dockerfile="${version_df:-Dockerfile}"
         local rc=0
         build_container "$container" "$base_image_version" "$base_image_version" "" "$dockerfile" || rc=$?
-        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"built\"}]"
+        local status="built"
+        [[ "$rc" -ne 0 ]] && status="failed"
+        echo "[{\"name\":\"default\",\"tag\":\"$base_image_version\",\"flavor\":\"\",\"status\":\"$status\"}]"
         return $rc
     fi
 

--- a/tests/unit/build-container.bats
+++ b/tests/unit/build-container.bats
@@ -34,6 +34,76 @@ teardown() {
     unset GITHUB_ACTIONS
 }
 
+assert_single_variant_result() {
+    local expected_tag="$1"
+    local expected_status="$2"
+    local result_lines
+    result_lines=$(sed -n '/^\[/p' <<< "$output")
+
+    [ "$(printf '%s\n' "$result_lines" | wc -l | tr -d ' ')" -eq 1 ]
+    jq -e --arg tag "$expected_tag" --arg status "$expected_status" \
+        '. == [{"name":"default","tag":$tag,"flavor":"","status":$status}]' \
+        <<< "$result_lines" >/dev/null
+}
+
+# =============================================================================
+# build_container_variants no-variants status tests
+# =============================================================================
+
+@test "build_container_variants reports failed when a container has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3" "failed"
+}
+
+@test "build_container_variants reports built when a container has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 1; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3" "built"
+}
+
+@test "build_container_variants reports failed when a version has no variants and its build fails" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 1; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 1 ]
+    assert_single_variant_result "1.2.3-alpine" "failed"
+}
+
+@test "build_container_variants reports built when a version has no variants and its build succeeds" {
+    source_build_script
+    export PROJECT_ROOT="$TEST_TEMP_DIR"
+    has_variants() { return 0; }
+    base_suffix() { printf '%s' '-alpine'; }
+    version_dockerfile() { printf '%s' 'Dockerfile.version'; }
+    list_variants() { :; }
+    build_container() { return 0; }
+
+    run build_container_variants sample 1.2.3
+
+    [ "$status" -eq 0 ]
+    assert_single_variant_result "1.2.3-alpine" "built"
+}
+
 # =============================================================================
 # check_multiplatform_support tests
 # =============================================================================

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -459,6 +459,12 @@ EOF
     cat > helpers/sbom-utils.sh <<'EOF'
 EOF
 
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
+EOF
+
     # check-version stub
     cat > scripts/check-version.sh <<'EOF'
 get_build_version() { echo "${2:-latest}"; return 0; }
@@ -542,6 +548,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'
@@ -663,6 +675,12 @@ has_dockerfile()  { return 0; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
+EOF
+
+    # dependency-graph stub: make sources it at startup, but check-updates
+    # does not use its graph API in this isolated fixture.
+    cat > helpers/dependency-graph.sh <<'EOF'
+return 0
 EOF
 
     cat > scripts/check-version.sh <<'EOF'

--- a/tests/unit/make-compose-provider.bats
+++ b/tests/unit/make-compose-provider.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+
+# Exercise the real `make` entry point with no compose provider on PATH.
+bats_require_minimum_version 1.5.0
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export COMPOSE_FREE_PATH="$TEST_TEMP_DIR/bin"
+    mkdir -p "$COMPOSE_FREE_PATH"
+
+    # `make` only needs these system utilities while loading and listing. Keep
+    # the controlled PATH free of docker, docker-compose, and podman-compose.
+    local command_name
+    for command_name in dirname nproc find sed cut sort ls; do
+        ln -s "$(command -v "$command_name")" "$COMPOSE_FREE_PATH/$command_name"
+    done
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+run_make_with_controlled_path() {
+    run --separate-stderr bash -c 'cd "$1" || exit 1; PATH="$2"; export PATH; shift 2; exec /bin/bash ./make "$@"' \
+        _ "$PROJECT_ROOT" "$COMPOSE_FREE_PATH" "$@"
+}
+
+@test "make list works without a compose provider" {
+    run_make_with_controlled_path list
+
+    [ "$status" -eq 0 ]
+    [ "$output" = $'ansible\ndebian\ngithub-runner\njekyll\nopenresty\nopenvpn\nphp\npostgres\nsslh\nterraform\ntor\nvector\nweb-shell\nwordpress' ]
+    [ -z "$stderr" ]
+}
+
+@test "make run refuses to proceed when no compose provider is available" {
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"docker-compose"* ]]
+    [[ "$stderr" == *"docker compose"* ]]
+    [[ "$stderr" == *"podman-compose"* ]]
+    [[ "$stderr" != *"Running ansible"* ]]
+}
+
+@test "make run accepts a docker-compose provider on PATH" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TEMP_DIR/docker-compose-args" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-compose-args")" = "<version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-compose-args")" = "<run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker-compose', continuing."* ]]
+    [[ "$stderr" != *"No compose provider found"* ]]
+}
+
+@test "make run accepts a docker compose provider and passes its exact arguments" {
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "make run accepts a podman-compose provider and passes its exact arguments" {
+    cat > "$COMPOSE_FREE_PATH/podman-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/podman-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/podman-compose-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/podman-compose"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/podman-compose-args")" = "<version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/podman-compose-args")" = "<run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'podman-compose', continuing."* ]]
+}
+
+@test "make run skips a provider whose probe fails and selects the next usable provider" {
+    cat > "$COMPOSE_FREE_PATH/docker-compose" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-compose-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-compose-args"
+exit 1
+EOF
+    cat > "$COMPOSE_FREE_PATH/docker" <<'EOF'
+#!/bin/sh
+printf '<%s>' "$@" >> "$TEST_TEMP_DIR/docker-args"
+printf '\n' >> "$TEST_TEMP_DIR/docker-args"
+EOF
+    chmod +x "$COMPOSE_FREE_PATH/docker-compose" "$COMPOSE_FREE_PATH/docker"
+
+    run_make_with_controlled_path run ansible
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_TEMP_DIR/docker-compose-args")" = "<version>" ]
+    [ "$(sed -n '1p' "$TEST_TEMP_DIR/docker-args")" = "<compose><version>" ]
+    [ "$(sed -n '2p' "$TEST_TEMP_DIR/docker-args")" = "<compose><run><--rm><ansible>" ]
+    [[ "$stderr" == *"Found 'docker compose', continuing."* ]]
+}
+
+@test "sourcing sbom-utils preserves the caller's shell options" {
+    run bash -c '
+        set +e
+        set -u
+        set -o pipefail
+        source "$1" || exit 1
+        case "$-" in *e*) exit 1 ;; esac
+        [[ "$(set -o | awk "\$1 == \"nounset\" { print \$2 }")" == on ]]
+        [[ "$(set -o | awk "\$1 == \"pipefail\" { print \$2 }")" == on ]]
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "sourcing sbom-utils fails when retry utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    run bash -c 'source "$1"' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load retry utilities"* ]]
+}
+
+@test "sourcing sbom-utils fails when logging utilities cannot be loaded" {
+    mkdir -p "$TEST_TEMP_DIR/helpers"
+    cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$PROJECT_ROOT/helpers/retry.sh" "$PROJECT_ROOT/helpers/logging.sh" \
+        "$TEST_TEMP_DIR/helpers/"
+    chmod 000 "$TEST_TEMP_DIR/helpers/logging.sh"
+
+    run bash -c '
+        log_error() { printf "caller log: %s\\n" "$*"; }
+        source "$1"
+    ' _ "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to load logging utilities"* ]]
+}
+
+@test "install_syft fails and does not claim success when its download fails" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    ln -s "$(command -v sh)" "$helper_bin/sh"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+exit 22
+EOF
+    chmod +x "$helper_bin/curl"
+
+    run bash -c 'PATH="$2"; export PATH; source "$1" || exit 1; install_syft' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to install syft"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}
+
+@test "install_syft does not download again after a successful system install outside PATH" {
+    local helper_bin="$TEST_TEMP_DIR/helper-bin"
+    local install_calls="$TEST_TEMP_DIR/install-calls"
+    mkdir -p "$helper_bin"
+    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' curl >> "$SYFT_INSTALL_CALLS"
+printf 'stub installer\n'
+EOF
+    cat > "$helper_bin/sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$4" >> "$SYFT_INSTALL_CALLS"
+if [ "$4" = /usr/local/bin ]; then
+    printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/syft
+    /bin/chmod +x /usr/local/bin/syft
+else
+    /bin/mkdir -p "$4"
+    printf '#!/bin/sh\nexit 0\n' > "$4/syft"
+    /bin/chmod +x "$4/syft"
+fi
+exit 0
+EOF
+    chmod +x "$helper_bin/curl" "$helper_bin/sh"
+
+    run unshare -Urnm bash -c '
+        mount -t tmpfs tmpfs /usr/local/bin || exit 1
+        PATH="$2"; export PATH
+        SYFT_INSTALL_CALLS="$3"; export SYFT_INSTALL_CALLS
+        HOME="$(dirname "$3")/home"; export HOME
+        source "$1" || exit 1
+        install_syft
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$install_calls"
+
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$install_calls")" -eq 2 ]
+    [ "$(sed -n '1p' "$install_calls")" = "curl" ]
+    [ "$(sed -n '2p' "$install_calls")" = "/usr/local/bin" ]
+    [[ "$output" == *"installed successfully"* ]]
+    [[ "$output" != *"installed to ~/.local/bin"* ]]
+}

--- a/tests/unit/make-compose-provider.bats
+++ b/tests/unit/make-compose-provider.bats
@@ -145,7 +145,7 @@ EOF
     mkdir -p "$TEST_TEMP_DIR/helpers"
     cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$PROJECT_ROOT/helpers/retry.sh" "$PROJECT_ROOT/helpers/logging.sh" \
         "$TEST_TEMP_DIR/helpers/"
-    chmod 000 "$TEST_TEMP_DIR/helpers/logging.sh"
+    printf 'return 1\n' > "$TEST_TEMP_DIR/helpers/logging.sh"
 
     run bash -c '
         log_error() { printf "caller log: %s\\n" "$*"; }
@@ -156,63 +156,393 @@ EOF
     [[ "$output" == *"Failed to load logging utilities"* ]]
 }
 
-@test "install_syft fails and does not claim success when its download fails" {
-    local helper_bin="$TEST_TEMP_DIR/helper-bin"
-    mkdir -p "$helper_bin"
-    ln -s "$(command -v dirname)" "$helper_bin/dirname"
-    ln -s "$(command -v sh)" "$helper_bin/sh"
-    cat > "$helper_bin/curl" <<'EOF'
+make_syft_archive() {
+    local archive="$1"
+    local reported_version="$2"
+    local version_status="${3:-0}"
+    local archive_dir="$TEST_TEMP_DIR/syft-archive"
+
+    mkdir -p "$archive_dir"
+    cat > "$archive_dir/syft" <<EOF
 #!/bin/sh
-exit 22
+if [ "\$1" = version ]; then
+    printf '%s\\n' 'Application: syft' 'Version: ${reported_version}'
+    exit ${version_status}
+fi
 EOF
-    chmod +x "$helper_bin/curl"
-
-    run bash -c 'PATH="$2"; export PATH; source "$1" || exit 1; install_syft' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Failed to install syft"* ]]
-    [[ "$output" != *"installed successfully"* ]]
-    [[ "$output" != *"installed to ~/.local/bin"* ]]
+    chmod +x "$archive_dir/syft"
+    tar --owner=0 --group=0 -czf "$archive" -C "$archive_dir" syft
+    sha256sum "$archive" | awk '{print $1}'
 }
 
-@test "install_syft does not download again after a successful system install outside PATH" {
+copy_sbom_utils_with_archive_digest() {
+    local archive_digest="$1"
+    local helper_dir="$TEST_TEMP_DIR/helpers"
+
+    mkdir -p "$helper_dir"
+    sed \
+        -e "s/989ded4e772810f93de6ccdc4512f79a6dabb5fb2dd2a9ffc72a80c955e6125a/${archive_digest}/" \
+        -e "s/dfc9ac5fffa8fea95b4f84b427e200dbb2bd9bd0bbf2760d1a9369715b60a91d/${archive_digest}/" \
+        -e "s/1e52e39d24a4eaec94329e0f3283c448e2ee8f79dc03e5f1e405d324b7ae4e1c/${archive_digest}/" \
+        -e "s/b83cdcbd1b4c55505abd359c25c5903d94b99be47e6f98572bf96927b7b47e45/${archive_digest}/" \
+        "$PROJECT_ROOT/helpers/sbom-utils.sh" > "$helper_dir/sbom-utils.sh"
+    cp "$PROJECT_ROOT/helpers/retry.sh" "$helper_dir/retry.sh"
+    printf '%s\n' "$helper_dir/sbom-utils.sh"
+}
+
+make_syft_helper_bin() {
     local helper_bin="$TEST_TEMP_DIR/helper-bin"
-    local install_calls="$TEST_TEMP_DIR/install-calls"
+    local command_name
+
     mkdir -p "$helper_bin"
-    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    for command_name in dirname uname mktemp rm sha256sum tar gzip install mkdir mv; do
+        ln -s "$(command -v "$command_name")" "$helper_bin/$command_name"
+    done
     cat > "$helper_bin/curl" <<'EOF'
 #!/bin/sh
-printf '%s\n' curl >> "$SYFT_INSTALL_CALLS"
-printf 'stub installer\n'
-EOF
-    cat > "$helper_bin/sh" <<'EOF'
-#!/bin/sh
-printf '%s\n' "$4" >> "$SYFT_INSTALL_CALLS"
-if [ "$4" = /usr/local/bin ]; then
-    printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/syft
-    /bin/chmod +x /usr/local/bin/syft
+destination=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        destination="$1"
+    fi
+    shift
+done
+if [ "${SYFT_ALTERED_BYTES:-false}" = true ]; then
+    /bin/cp "$SYFT_ALTERED_ARCHIVE" "$destination"
 else
-    /bin/mkdir -p "$4"
-    printf '#!/bin/sh\nexit 0\n' > "$4/syft"
-    /bin/chmod +x "$4/syft"
+    /bin/cp "$SYFT_TEST_ARCHIVE" "$destination"
 fi
-exit 0
 EOF
-    chmod +x "$helper_bin/curl" "$helper_bin/sh"
+    chmod +x "$helper_bin/curl"
+    printf '%s\n' "$helper_bin"
+}
+
+make_syft_platform_helper_bin() {
+    local helper_bin
+
+    helper_bin=$(make_syft_helper_bin)
+    rm "$helper_bin/sha256sum" "$helper_bin/tar" "$helper_bin/uname"
+    cat > "$helper_bin/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+    -s) printf '%s\n' "$SYFT_UNAME_S" ;;
+    -m) printf '%s\n' "$SYFT_UNAME_M" ;;
+    *) exit 1 ;;
+esac
+EOF
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+destination=""
+curl_args="$*"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        destination="$1"
+    fi
+    shift
+done
+printf '%s\n' "$curl_args" > "$SYFT_CURL_ARGS"
+: > "$destination"
+EOF
+    cat > "$helper_bin/sha256sum" <<'EOF'
+#!/bin/sh
+IFS= read -r digest_input
+printf '%s\n' "$digest_input" > "$SYFT_DIGEST_INPUT"
+EOF
+    cat > "$helper_bin/tar" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$helper_bin/uname" "$helper_bin/curl" "$helper_bin/sha256sum" "$helper_bin/tar"
+    printf '%s\n' "$helper_bin"
+}
+
+@test "install_syft selects the pinned asset and digest for every supported platform" {
+    local helper_bin os arch asset digest curl_args digest_input
+    helper_bin=$(make_syft_platform_helper_bin)
+
+    while IFS='|' read -r os arch asset digest; do
+        curl_args="$TEST_TEMP_DIR/${os}-${arch}-curl-args"
+        digest_input="$TEST_TEMP_DIR/${os}-${arch}-digest-input"
+
+        run bash -c '
+            PATH="$2"; export PATH
+            SYFT_UNAME_S="$3"; export SYFT_UNAME_S
+            SYFT_UNAME_M="$4"; export SYFT_UNAME_M
+            SYFT_CURL_ARGS="$5"; export SYFT_CURL_ARGS
+            SYFT_DIGEST_INPUT="$6"; export SYFT_DIGEST_INPUT
+            source "$1" || exit 1
+            install_syft
+        ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$os" "$arch" "$curl_args" "$digest_input"
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"Failed to extract verified syft"* ]]
+        grep -Fq "$asset" "$curl_args"
+        [ "$(awk '{print $1}' "$digest_input")" = "$digest" ]
+    done <<'EOF'
+Linux|x86_64|syft_1.42.1_linux_amd64.tar.gz|989ded4e772810f93de6ccdc4512f79a6dabb5fb2dd2a9ffc72a80c955e6125a
+Linux|arm64|syft_1.42.1_linux_arm64.tar.gz|dfc9ac5fffa8fea95b4f84b427e200dbb2bd9bd0bbf2760d1a9369715b60a91d
+Darwin|x86_64|syft_1.42.1_darwin_amd64.tar.gz|1e52e39d24a4eaec94329e0f3283c448e2ee8f79dc03e5f1e405d324b7ae4e1c
+Darwin|arm64|syft_1.42.1_darwin_arm64.tar.gz|b83cdcbd1b4c55505abd359c25c5903d94b99be47e6f98572bf96927b7b47e45
+EOF
+}
+
+@test "install_syft refuses an unsupported platform" {
+    local helper_bin
+    helper_bin=$(make_syft_platform_helper_bin)
+
+    run bash -c '
+        PATH="$2"; export PATH
+        SYFT_UNAME_S="FreeBSD"; export SYFT_UNAME_S
+        SYFT_UNAME_M="x86_64"; export SYFT_UNAME_M
+        source "$1" || exit 1
+        install_syft
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No verified syft 1.42.1 release asset for FreeBSD/x86_64"* ]]
+}
+
+@test "install_syft refuses altered bytes before installing anything" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local altered_archive="$TEST_TEMP_DIR/altered-syft.tar.gz"
+    local archive_digest helper helper_bin install_calls home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    make_syft_archive "$altered_archive" "9.9.8-altered" >/dev/null
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    install_calls="$TEST_TEMP_DIR/install-calls"
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+printf 'install called\n' > "$SYFT_INSTALL_CALLS"
+exit 1
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$6"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_ALTERED_ARCHIVE="$4"; export SYFT_ALTERED_ARCHIVE
+        SYFT_ALTERED_BYTES=true; export SYFT_ALTERED_BYTES
+        SYFT_INSTALL_CALLS="$5"; export SYFT_INSTALL_CALLS
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$altered_archive" "$install_calls" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$install_calls" ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [[ "$output" == *"failed SHA-256 verification"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+}
+
+@test "install_syft refuses altered bytes with the shasum fallback before installing anything" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local altered_archive="$TEST_TEMP_DIR/altered-syft.tar.gz"
+    local archive_digest helper helper_bin install_calls home_dir sha256sum_path
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    make_syft_archive "$altered_archive" "9.9.8-altered" >/dev/null
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    install_calls="$TEST_TEMP_DIR/install-calls"
+    home_dir="$TEST_TEMP_DIR/home"
+    sha256sum_path=$(command -v sha256sum)
+    rm "$helper_bin/sha256sum" "$helper_bin/install"
+    cat > "$helper_bin/shasum" <<EOF
+#!/bin/sh
+exec "${sha256sum_path}" "\$3"
+EOF
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+printf 'install called\n' > "$SYFT_INSTALL_CALLS"
+exit 1
+EOF
+    chmod +x "$helper_bin/shasum" "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$6"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_ALTERED_ARCHIVE="$4"; export SYFT_ALTERED_ARCHIVE
+        SYFT_ALTERED_BYTES=true; export SYFT_ALTERED_BYTES
+        SYFT_INSTALL_CALLS="$5"; export SYFT_INSTALL_CALLS
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$altered_archive" "$install_calls" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$install_calls" ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [[ "$output" == *"failed SHA-256 verification"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+}
+
+@test "install_syft logs the version reported by the verified installed binary" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
 
     run unshare -Urnm bash -c '
         mount -t tmpfs tmpfs /usr/local/bin || exit 1
         PATH="$2"; export PATH
-        SYFT_INSTALL_CALLS="$3"; export SYFT_INSTALL_CALLS
-        HOME="$(dirname "$3")/home"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        HOME="$4"; export HOME
         source "$1" || exit 1
         install_syft
-    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$install_calls"
+        test -x /usr/local/bin/syft
+    ' _ "$helper" "$helper_bin" "$archive" "$TEST_TEMP_DIR/home"
 
     [ "$status" -eq 0 ]
-    [ "$(wc -l < "$install_calls")" -eq 2 ]
-    [ "$(sed -n '1p' "$install_calls")" = "curl" ]
-    [ "$(sed -n '2p' "$install_calls")" = "/usr/local/bin" ]
-    [[ "$output" == *"installed successfully"* ]]
-    [[ "$output" != *"installed to ~/.local/bin"* ]]
+    [[ "$output" == *"syft 9.9.9-test installed successfully"* ]]
+    [[ "$output" != *"syft ${SYFT_VERSION:-1.42.1} installed successfully"* ]]
+}
+
+@test "install_syft falls back to the user directory and exports PATH when the system directory is unavailable" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+if [ "$destination" = /usr/local/bin/syft ]; then
+    exit 1
+fi
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft || exit 1
+        test -x "$HOME/.local/bin/syft"
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) ;;
+            *) exit 1 ;;
+        esac
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"syft 9.9.9-test installed successfully"* ]]
+}
+
+@test "install_syft leaves no new destination binary when validation fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test" 1)
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [ -z "$(find "$home_dir/.local/bin" -name 'syft.tmp.*' -print -quit 2>/dev/null)" ]
+    [[ "$output" == *"Installed syft did not report its version"* ]]
+}
+
+@test "install_syft preserves an existing destination binary when validation fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir destination
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test" 1)
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    destination="$home_dir/.local/bin/syft"
+    mkdir -p "$(dirname "$destination")"
+    printf '%s\n' 'previous syft bytes' > "$destination"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ "$(cat "$destination")" = 'previous syft bytes' ]
+    [ -z "$(find "$home_dir/.local/bin" -name 'syft.tmp.*' -print -quit 2>/dev/null)" ]
+}
+
+@test "install_syft succeeds when logging success fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        log_success() { return 1; }
+        install_syft
+        test -x "$HOME/.local/bin/syft"
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
`./make sbom` fetched an installer over the network and ran it directly, and logged syft v1.42.1 while passing no version to that installer — which treats an omitted tag as latest. The binary installed was whichever release was newest, and the log said otherwise.

CI is unaffected throughout: both workflows install syft through `anchore/sbom-action/download-syft` pinned to a full SHA and never reach this function. This is the local developer path.

## What changed

- The release asset for the pinned version is downloaded and checked against a digest recorded next to the version, per platform. A mismatch installs nothing and returns non-zero; a platform with no recorded digest is refused rather than installed unverified.
- The binary is staged beside its destination, validated there, and renamed only after it passes, so a failed validation leaves nothing behind and an existing installation survives untouched.
- The version reported comes from the installed binary rather than from the constant.
- macOS keeps working: `amd64` and `arm64` assets are pinned too, and the digest check prefers `sha256sum` and falls back to `shasum -a 256`.

All four digests were read from the checksums file Anchore publishes for v1.42.1.

## Verification

2521 unit tests pass. `shellcheck -x -S warning` clean. Mutation proofs confirm the tests fail when the behaviours they name are removed: neutralising the digest check, reporting the constant instead of the binary version, and neutralising the fallback comparison each turn a test red.

The macOS path is proven through a stubbed `uname`, not through execution — no macOS host was available.

## Known gaps, filed separately

#1199 collects the residue: publishing `PATH` after a successful install so the caller can find the binary, validating an existing `syft` before trusting it, rejecting a directory destination, curl timeouts, and restoring a download-failure test that was lost when the install flow was restructured.

Closes #1187
Closes #1192
Closes #1193

Targets `fix/make-guard-and-build-status` (#1195); retarget to master once that merges.