### PR TITLE
fix(ci): build the postgres image against the extensions the run compiled

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -307,6 +307,10 @@ jobs:
       # same-repository PR, build-extensions and merge-extension-manifests
       # publish the PR-scoped extension images that this e2e build must consume.
       PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
+      # Dedicated resolver contract: extension names published successfully by
+      # this run. '*' preserves the detector's all-extensions scope. Skipped or
+      # failed extension stages publish no usable scoped refs, so force nothing.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -1154,6 +1158,9 @@ jobs:
       # this inlines the same expression that defines the workflow-level
       # REBUILD_MODE (see the top-level `env:`) rather than referencing it.
       REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
+      # Resolver contract: only extensions published successfully by this run.
+      # An empty value covers skipped or failed extension stages.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     runs-on: ${{ matrix.build.os == 'windows' && 'windows-latest' || matrix.runner }}
     timeout-minutes: ${{ matrix.build.os == 'windows' && 120 || 60 }}
     strategy:
@@ -1836,6 +1843,8 @@ jobs:
     timeout-minutes: 90
     env:
       CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+      # Resolver contract: only extensions published successfully by this run.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     permissions:
       contents: read
       packages: write
@@ -2328,6 +2337,8 @@ jobs:
     timeout-minutes: 90
     env:
       CONTAINER_SCOPES: ${{ needs.detect-containers.outputs.container_scopes }}
+      # Resolver contract: only extensions published successfully by this run.
+      FORCE_SCOPED_EXTENSION_REFS: ${{ needs.build-extensions.result == 'success' && needs.merge-extension-manifests.result == 'success' && needs.detect-containers.outputs.force_extension_builds == 'true' && (fromJSON(needs.detect-containers.outputs.container_scopes || '{}').postgres.extensions || '*') || '' }}
     permissions:
       contents: read
       packages: write

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -459,8 +459,8 @@ _scoped_ext_ref() {
 # ext_ref_resolve <ext> <version> <major> <arch>
 #
 # SINGLE SOURCE OF TRUTH for per-version extension image reference resolution.
-# Encapsulates all five axes: canonical-vs-PR-scoped, arch suffix, FORCE,
-# 3-state fail-closed, PR suffix.
+# Encapsulates all six axes: canonical-vs-PR-scoped, arch suffix, FORCE,
+# FORCE_SCOPED_EXTENSION_REFS scope membership, 3-state fail-closed, PR suffix.
 #
 # Parameters:
 #   <ext>     extension name (e.g. timescaledb)
@@ -472,6 +472,12 @@ _scoped_ext_ref() {
 # Reads env:
 #   PR_TAG_SUFFIX  (PR scoping, may be empty)
 #   FORCE          (true|false, defaults false)
+#   FORCE_SCOPED_EXTENSION_REFS
+#                  (comma-separated extension names, "*" for all, or empty;
+#                  a run-scoped contract set only after this run published the
+#                  named extension images. Only a named extension uses its
+#                  freshly-published PR-scoped ref. Empty values force nothing;
+#                  malformed non-empty values fail closed.)
 #
 # Ref construction (registry/owner from get_registry/get_repo_owner):
 #   canonical  = ext_image_name(ext,ver,major)[+"-"<arch>]
@@ -483,7 +489,10 @@ _scoped_ext_ref() {
 #   FORCE=true AND PR_TAG_SUFFIX set:
 #     → prefer PR-scoped (freshly rebuilt this run); do NOT reuse canonical.
 #     Probe PR-scoped only (canonical is stale for this version).
-#   else (not FORCE, or no PR_TAG_SUFFIX):
+#   FORCE_SCOPED_EXTENSION_REFS names ext AND PR_TAG_SUFFIX set:
+#     → prefer PR-scoped (freshly rebuilt this run); do NOT reuse canonical.
+#     Probe PR-scoped only (canonical is stale for this version).
+#   else (neither force signal, or no PR_TAG_SUFFIX):
 #     → prefer canonical when PRESENT (read-only reuse for unchanged versions).
 #     If canonical ABSENT and PR_TAG_SUFFIX set → probe PR-scoped.
 #
@@ -491,14 +500,52 @@ _scoped_ext_ref() {
 #   rc 0  → prints the ref to use (canonical or pr-scoped).
 #   rc 1  → neither ref exists definitively (needs build or exclude).
 #           prints nothing.
-#   rc 2  → a probe returned transient ERROR → fail closed.
+#   rc 2  → a probe returned transient ERROR, or the run scope is malformed
+#           → fail closed.
 #           prints nothing.
 #
 # On push/dispatch (PR_TAG_SUFFIX empty): only canonical is considered;
 # behavior is identical to the current canonical path.
+_force_scoped_extension_ref() {
+    local ext="$1" scope="${FORCE_SCOPED_EXTENSION_REFS:-}" scoped_ext
+    local -a scoped_exts
+
+    # "*" is the explicit all-extensions scope. Every other non-empty value
+    # must be a complete comma-separated extension-name list. This mirrors the
+    # schema validator's name_shaped rule, ^[A-Za-z0-9_-]+$, so a schema-valid
+    # extension name has the same meaning in this run-scoped contract.
+    case "$scope" in
+        '*') return 0 ;;
+        '') return 1 ;;
+    esac
+    [[ "$scope" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]] || return 2
+
+    IFS=',' read -ra scoped_exts <<< "$scope"
+    for scoped_ext in "${scoped_exts[@]}"; do
+        [[ "$ext" == "$scoped_ext" ]] && return 0
+    done
+    return 1
+}
+
 ext_ref_resolve() {
     local ext="$1" version="$2" major="$3" arch="${4:-}"
-    local registry owner canonical_ref pr_ref
+    local registry owner canonical_ref pr_ref scope_rc=0
+
+    # The run scope can only affect a PR-scoped reference.  On push/dispatch,
+    # leave it completely unconsulted so this remains the canonical-only path.
+    if [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
+        # A corrupt non-empty run scope must not silently select canonical images.
+        # Keep rc 2 for this fail-closed resolution error, matching probe failures.
+        _force_scoped_extension_ref "$ext" || scope_rc=$?
+        case "$scope_rc" in
+            0|1) ;;
+            *)
+                printf 'ERROR [ext_ref_resolve]: invalid FORCE_SCOPED_EXTENSION_REFS scope\n' >&2
+                return 2
+                ;;
+        esac
+    fi
+
     registry=$(get_registry)
     owner=$(get_repo_owner)
 
@@ -517,8 +564,9 @@ ext_ref_resolve() {
     fi
 
     # On push/dispatch (PR_TAG_SUFFIX empty), pr_ref == canonical_ref.
-    # Handle FORCE + PR: prefer pr-scoped (do not reuse canonical stale ref).
-    if [[ "${FORCE:-false}" == "true" ]] && [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
+    # A forced rebuild, or a scope that names this extension, must prefer the
+    # PR-scoped ref and never reuse the canonical stale ref.
+    if { [[ "${FORCE:-false}" == "true" ]] || [[ "$scope_rc" -eq 0 ]]; } && [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
         # Probe the PR-scoped ref only.
         local _rc=0
         _image_registry_probe_3state "$pr_ref" || _rc=$?
@@ -529,7 +577,7 @@ ext_ref_resolve() {
         esac
     fi
 
-    # Normal path (not FORCE+PR, or push/dispatch):
+    # Normal path (neither force signal + PR, or push/dispatch):
     # Probe canonical first (read-only reuse for unchanged versions).
     local _can_rc=0
     _image_registry_probe_3state "$canonical_ref" || _can_rc=$?
@@ -880,8 +928,9 @@ generate_dockerfile() {
     # Derive FORCE from REBUILD env so a forced PR run prefers freshly-rebuilt
     # PR-scoped refs over stale canonical refs for non-resolver/single-version
     # extensions.  This mirrors the --force logic in build-extensions.sh and
-    # merge-extension-manifests.  ext_ref_resolve reads FORCE from env; the
-    # build-and-push job exports REBUILD from env.REBUILD_MODE.
+    # merge-extension-manifests.  ext_ref_resolve also reads the separate
+    # FORCE_SCOPED_EXTENSION_REFS run contract.  The build-and-push job exports
+    # REBUILD from env.REBUILD_MODE.
     # Pre-existing FORCE=true is preserved (e.g. LOCAL_ONLY builds).
     if [[ "${REBUILD:-}" == "force" || "${REBUILD:-}" == "all" ]]; then
         export FORCE=true
@@ -1065,7 +1114,8 @@ generate_dockerfile() {
 
                 # Probe registry presence for each resolved version via ext_ref_resolve.
                 # ext_ref_resolve encapsulates canonical-first, PR-scoped fallback,
-                # FORCE, and 3-state fail-closed in one call (arch="" = multi-arch tag).
+                # both force signals, and 3-state fail-closed in one call
+                # (arch="" = multi-arch tag).
                 # rc 0 → PRESENT (ref printed); rc 1 → ABSENT; rc 2 → transient ERROR (fail-closed).
                 local _sh_available=()
                 local -A _sh_emit_ref_map=()  # version → resolved emit ref (for lookup in emit loop)

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -69,7 +69,7 @@ EOF
 
 teardown() {
     teardown_temp_dir
-    unset FORCE LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR
+    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR
 }
 
 # ---------------------------------------------------------------------------
@@ -174,6 +174,281 @@ _setup_default_mocks() {
 
     # jq: pass through (real jq required)
     # log_* pass-through (already sourced from extension-utils.sh chain)
+}
+
+# ---------------------------------------------------------------------------
+# ext_ref_resolve — run-scoped forced extension refs
+#
+# The resolver, rather than a caller, decides whether a consumer uses canonical
+# or this run's scoped extension image.  These tests stub the underlying
+# three-state registry probe, not ext_ref_resolve itself.
+# ---------------------------------------------------------------------------
+
+@test "run-scoped forced extension refs prefer scoped ref when both refs are present" {
+    local probe_log="$TEST_TEMP_DIR/scoped-present-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+@test "without run-scoped forced extension refs canonical stays preferred when both refs are present" {
+    local probe_log="$TEST_TEMP_DIR/canonical-present-probes.log"
+    export FORCE=false
+    unset FORCE_SCOPED_EXTENSION_REFS
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64" ]
+}
+
+@test "run-scoped forced extension refs absent means needs build without canonical fallback" {
+    local probe_log="$TEST_TEMP_DIR/scoped-absent-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 1
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+@test "run-scoped forced extension ref probe error fails closed" {
+    local probe_log="$TEST_TEMP_DIR/scoped-error-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='*'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 2
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve timescaledb 2.27.1 18 amd64
+
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-timescaledb:pg18-2.27.1-amd64-pr42" ]
+}
+
+# Keep the empty-PR_TAG_SUFFIX tests: valid and malformed scopes prove scope is
+# not consulted without a suffix, preserving byte-for-byte canonical resolution.
+
+@test "malformed run-scoped extension ref scope is ignored without a PR suffix" {
+    local probe_log="$TEST_TEMP_DIR/malformed-empty-suffix-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS="hypopg,,pgvector"
+    export PR_TAG_SUFFIX=""
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+}
+
+@test "valid run-scoped extension ref scope is ignored without a PR suffix" {
+    local probe_log="$TEST_TEMP_DIR/valid-empty-suffix-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS=hypopg
+    export PR_TAG_SUFFIX=""
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+}
+
+@test "run-scoped forced extension refs scope only the extension this run rebuilt" {
+    local probe_log="$TEST_TEMP_DIR/scoped-membership-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS=hypopg
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64-pr42" ]
+
+    run ext_ref_resolve pgvector 0.8.2 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-pgvector:pg18-0.8.2-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(sed -n '1p' "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64-pr42" ]
+    [ "$(sed -n '2p' "$probe_log")" = "ghcr.io/test/ext-pgvector:pg18-0.8.2-amd64" ]
+}
+
+@test "empty or absent run-scoped extension ref scope forces nothing" {
+    local probe_log="$TEST_TEMP_DIR/empty-scope-probes.log"
+    export FORCE=false
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    unset FORCE_SCOPED_EXTENSION_REFS
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+
+    export FORCE_SCOPED_EXTENSION_REFS=""
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(grep -cv -- '-pr42' "$probe_log" || true)" -eq 2 ]
+}
+
+@test "run-scoped forced extension refs match a schema-valid name outside the former matcher grammar" {
+    local probe_log="$TEST_TEMP_DIR/schema-valid-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS='-hypopg'
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve -hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext--hypopg:pg18-1.4.3-amd64-pr42" ]
+    [ "$(wc -l < "$probe_log")" -eq 1 ]
+    [ "$(< "$probe_log")" = "ghcr.io/test/ext--hypopg:pg18-1.4.3-amd64-pr42" ]
+}
+
+@test "run-scoped forced extension ref scope true matches only an extension named true" {
+    local probe_log="$TEST_TEMP_DIR/literal-true-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS=true
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve true 1.0.0 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-true:pg18-1.0.0-amd64-pr42" ]
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+    [ "$(wc -l < "$probe_log")" -eq 2 ]
+    [ "$(sed -n '1p' "$probe_log")" = "ghcr.io/test/ext-true:pg18-1.0.0-amd64-pr42" ]
+    [ "$(sed -n '2p' "$probe_log")" = "ghcr.io/test/ext-hypopg:pg18-1.4.3-amd64" ]
+}
+
+@test "malformed run-scoped extension ref scope fails closed before probing" {
+    local probe_log="$TEST_TEMP_DIR/malformed-scope-probes.log"
+    export FORCE=false
+    export FORCE_SCOPED_EXTENSION_REFS="hypopg,,pgvector"
+    export PR_TAG_SUFFIX="-pr42"
+    export probe_log
+
+    _image_present_3state() {
+        printf '%s\n' "$1" >> "$probe_log"
+        return 0
+    }
+    export -f _image_present_3state
+    _image_registry_probe_3state() { _image_present_3state "$@"; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve hypopg 1.4.3 18 amd64
+
+    [ "$status" -eq 2 ]
+    [ "$output" = "ERROR [ext_ref_resolve]: invalid FORCE_SCOPED_EXTENSION_REFS scope" ]
+    [ ! -s "$probe_log" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A pull request editing an extension recipe compiled that extension and published it under a run-scoped tag, and every image built later in the same run still resolved the canonical tag. The compile was verified; the artifact never ran.

Run [31820830910](https://github.com/oorabona/docker-containers/actions/runs/31820830910): the extension job pushed `ext-hypopg:pg18-1.4.3-pr1171`, and the e2e in the same run built postgres `FROM ghcr.io/oorabona/ext-hypopg:pg18-1.4.3`, unsuffixed.

## What changed

`ext_ref_resolve` preferred the scoped reference only under a flag derived from `REBUILD`, which is `none` on an ordinary pull request, so the signal naming the recompiled extensions never left the two extension jobs.

`FORCE_SCOPED_EXTENSION_REFS` is now a contract of its own, documented in the resolver header and carried to the four jobs that consume extension references. It transports the extension scope rather than a boolean: an extension the run rebuilt resolves to its scoped reference, one it did not rebuild resolves to canonical. It is set only when the extension jobs actually published, so a run with `skip_extensions` forces nothing. `*` is the only all-extensions sentinel. Names are matched against the same grammar the extensions schema describes, but by a second Bash implementation rather than a shared one, and the two disagree on non-ASCII input under a UTF-8 locale (#1231).

Without a `PR_TAG_SUFFIX` the scope is not consulted at all, so push, dispatch and local builds resolve exactly as they did before this change. With a suffix, a scope value that cannot be parsed stops resolution instead of silently reusing canonical.

`REBUILD` and `FORCE` keep their existing meanings.

## Verification

2525 unit tests pass; `actionlint` and `shellcheck -x -S warning` clean. Mutation proofs confirm the tests fail when the behaviours they name are removed, including a two-extension case proving an unchanged extension still resolves to canonical, and an empty-suffix case proving an irrelevant scope value cannot affect a push build.

## Known gaps, filed separately

#1207 — an explicit `container_scopes` dispatch publishes scoped images that consumers still ignore, because the signal is derived from change detection alone.
#1196 — extension tags are shared across runs of the same pull request.
#1206 — a scoped image can be missing while the build reports success.
#1197 — a malformed scope is reported as a transient registry error and one caller still falls back on it.

These four share one root: consumers re-derive what the producer already knows. Worth deciding once, across all of them.

Closes #1172
