### PR TITLE
fix(sbom): install one verified syft release, locally and in CI

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1478,6 +1478,8 @@ jobs:
         id: install-syft
         if: matrix.build.os != 'windows' && steps.build.outputs.image_loaded == 'true' && matrix.arch == 'amd64' && github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
 
       - name: Generate SBOM
         id: sbom
@@ -1695,6 +1697,8 @@ jobs:
         id: install-syft-windows
         if: matrix.build.os == 'windows' && github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
 
       - name: Generate SBOM (Windows)
         id: sbom-windows
@@ -2127,6 +2131,8 @@ jobs:
         if: steps.bake-build.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
         continue-on-error: true
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
 
       - name: Generate SBOM and emit lineage (bake amd64)
         id: bake-sbom

--- a/.github/workflows/recreate-manifests.yaml
+++ b/.github/workflows/recreate-manifests.yaml
@@ -164,6 +164,8 @@ jobs:
       - name: Install syft
         if: inputs.generate_sboms == true
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
 
       - name: Generate SBOM
         id: sbom

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -2,13 +2,15 @@
 # SBOM (Software Bill of Materials) utilities
 # Provides functions for SBOM generation, comparison, and build history tracking.
 #
-# Dependencies: jq (required), syft (installed on demand)
+# Dependencies: jq (required); install_syft requires curl, uname, mktemp, tar, install, mv, mkdir, rm, head, and sha256sum or shasum; syft (installed on demand)
 # SBOM format: SPDX JSON (industry standard, supported by GitHub attestations)
 
 _SBOM_UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source logging if available
 if [[ -f "$_SBOM_UTILS_DIR/logging.sh" ]]; then
+    # shellcheck source=helpers/logging.sh
+    # shellcheck disable=SC1091
     if ! source "$_SBOM_UTILS_DIR/logging.sh"; then
         echo "ERROR: Failed to load logging utilities" >&2
         return 1
@@ -20,35 +22,145 @@ else
     log_warning() { echo "WARN: $*" >&2; }
 fi
 
+# shellcheck source=helpers/retry.sh
+# shellcheck disable=SC1091
 if ! source "$_SBOM_UTILS_DIR/retry.sh"; then
     log_error "Failed to load retry utilities"
     return 1
 fi
 
 # Install syft if not present
-# Downloads the latest release from Anchore's install script
 install_syft() {
     if command -v syft &>/dev/null; then
         log_info "syft already installed: $(syft version 2>/dev/null | head -1)"
         return 0
     fi
 
-    local syft_version="v1.42.1"
+    # Keep the version and release-asset digests together so updating this
+    # local convenience installer remains auditable.
+    local syft_version="1.51.0"
+    local syft_linux_amd64_sha256="2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f"
+    local syft_linux_arm64_sha256="6c0466811541ea03add5213a60a1562f0851e4c0b0ecfdee1a694a9455285900"
+    local syft_darwin_amd64_sha256="cddf9a044145caf0a1a3194d00d1dd51a1666f4814f2919cdb4768a0c062ad95"
+    local syft_darwin_arm64_sha256="4f37f4c7fefce0a68e4cf71ba3f5f9829a99e65d89b29f7ee41b8c2c10ea8c59"
+    local syft_asset syft_sha256
+    # This helper deliberately supports only the verified Linux and Darwin
+    # amd64/arm64 assets below; it is not a complete list of syft releases.
+    case "$(uname -s)-$(uname -m)" in
+        Linux-x86_64|Linux-amd64)
+            syft_asset="syft_${syft_version}_linux_amd64.tar.gz"
+            syft_sha256="$syft_linux_amd64_sha256"
+            ;;
+        Linux-aarch64|Linux-arm64)
+            syft_asset="syft_${syft_version}_linux_arm64.tar.gz"
+            syft_sha256="$syft_linux_arm64_sha256"
+            ;;
+        Darwin-x86_64|Darwin-amd64)
+            syft_asset="syft_${syft_version}_darwin_amd64.tar.gz"
+            syft_sha256="$syft_darwin_amd64_sha256"
+            ;;
+        Darwin-arm64)
+            syft_asset="syft_${syft_version}_darwin_arm64.tar.gz"
+            syft_sha256="$syft_darwin_arm64_sha256"
+            ;;
+        *)
+            log_error "No verified syft ${syft_version} release asset for $(uname -s)/$(uname -m)"
+            return 1
+            ;;
+    esac
+
+    local syft_tmp syft_archive syft_binary syft_destination syft_stage installed_version syft_version_output line syft_actual_sha256
+    local -a syft_checksum_command
+    syft_tmp=$(mktemp -d) || {
+        log_error "Failed to create temporary directory for syft download"
+        return 1
+    }
+    syft_archive="$syft_tmp/$syft_asset"
+    syft_binary="$syft_tmp/syft"
+
     log_info "Installing syft ${syft_version}..."
-    if (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b /usr/local/bin 2>/dev/null) \
-        && [[ -x /usr/local/bin/syft ]]; then
-        log_success "syft ${syft_version} installed successfully"
-        return 0
-    elif (set -o pipefail; curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${syft_version}/install.sh" | sh -s -- -b "$HOME/.local/bin" 2>/dev/null); then
-        export PATH="$HOME/.local/bin:$PATH"
-        if command -v syft &>/dev/null; then
-            log_success "syft installed to ~/.local/bin"
-            return 0
-        fi
+    if ! curl -fsSL --retry 3 --retry-delay 2 \
+        "https://github.com/anchore/syft/releases/download/v${syft_version}/${syft_asset}" \
+        -o "$syft_archive"; then
+        rm -rf "$syft_tmp"
+        log_error "Failed to download syft ${syft_version}"
+        return 1
+    fi
+    if command -v sha256sum &>/dev/null; then
+        syft_checksum_command=(sha256sum)
+    elif command -v shasum &>/dev/null; then
+        syft_checksum_command=(shasum -a 256)
+    else
+        rm -rf "$syft_tmp"
+        log_error "No SHA-256 checker available to verify syft ${syft_version}"
+        return 1
+    fi
+    if ! syft_actual_sha256=$("${syft_checksum_command[@]}" "$syft_archive"); then
+        rm -rf "$syft_tmp"
+        log_error "Downloaded syft ${syft_version} failed SHA-256 verification"
+        return 1
+    fi
+    syft_actual_sha256="${syft_actual_sha256#\\}"
+    if [[ "${syft_actual_sha256%% *}" != "$syft_sha256" ]]; then
+        rm -rf "$syft_tmp"
+        log_error "Downloaded syft ${syft_version} failed SHA-256 verification"
+        return 1
+    fi
+    if ! tar -xzf "$syft_archive" -C "$syft_tmp" syft || [[ ! -f "$syft_binary" ]]; then
+        rm -rf "$syft_tmp"
+        log_error "Failed to extract verified syft ${syft_version} archive"
+        return 1
     fi
 
-    log_error "Failed to install syft"
-    return 1
+    syft_destination="/usr/local/bin/syft"
+    if syft_stage=$(mktemp "${syft_destination}.tmp.XXXXXX") && install -m 0755 "$syft_binary" "$syft_stage"; then
+        :
+    else
+        [[ -n "$syft_stage" ]] && rm -f "$syft_stage"
+        local user_bin="$HOME/.local/bin"
+        syft_destination="$user_bin/syft"
+        if ! mkdir -p "$user_bin" || ! syft_stage=$(mktemp "${syft_destination}.tmp.XXXXXX") || ! install -m 0755 "$syft_binary" "$syft_stage"; then
+            [[ -n "$syft_stage" ]] && rm -f "$syft_stage"
+            rm -rf "$syft_tmp"
+            log_error "Failed to stage verified syft ${syft_version}"
+            return 1
+        fi
+        export PATH="$user_bin:$PATH"
+    fi
+    rm -rf "$syft_tmp"
+
+    if ! syft_version_output=$("$syft_stage" version 2>/dev/null); then
+        rm -f "$syft_stage"
+        log_error "Installed syft did not report its version"
+        return 1
+    fi
+    installed_version=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^Version:[[:space:]]*(.+)$ ]]; then
+            installed_version="${BASH_REMATCH[1]}"
+            break
+        fi
+    done <<< "$syft_version_output"
+    if [[ -z "$installed_version" ]]; then
+        rm -f "$syft_stage"
+        log_error "Installed syft did not report its version"
+        return 1
+    fi
+    if [[ "${installed_version#v}" != "$syft_version" ]]; then
+        rm -f "$syft_stage"
+        log_error "Installed syft reported version ${installed_version}, expected ${syft_version}"
+        return 1
+    fi
+    installed_version="${installed_version#v}"
+
+    if ! mv -f "$syft_stage" "$syft_destination"; then
+        rm -f "$syft_stage"
+        log_error "Failed to install verified syft ${syft_version}"
+        return 1
+    fi
+
+    log_success "syft ${installed_version} installed successfully" || :
+    return 0
 }
 
 # Generate SBOM from a registry image
@@ -308,6 +420,7 @@ enrich_changelog() (
     if ! declare -F _freshness_resolver_for >/dev/null 2>&1; then
         if [[ -f "${_SBOM_UTILS_DIR}/dependency-freshness.sh" ]]; then
             # shellcheck source=helpers/dependency-freshness.sh
+            # shellcheck disable=SC1091
             source "${_SBOM_UTILS_DIR}/dependency-freshness.sh"
         else
             log_warning "dependency-freshness helper unavailable; skipping enrichment"

--- a/tests/unit/make-compose-provider.bats
+++ b/tests/unit/make-compose-provider.bats
@@ -135,6 +135,18 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "sourcing sbom-utils does not assign syft pin variables in the caller" {
+    run bash -c '
+        unset SYFT_VERSION SYFT_LINUX_AMD64_SHA256 SYFT_LINUX_ARM64_SHA256 \
+            SYFT_DARWIN_AMD64_SHA256 SYFT_DARWIN_ARM64_SHA256
+        source "$1" || exit 1
+        ! [[ -v SYFT_VERSION || -v SYFT_LINUX_AMD64_SHA256 || -v SYFT_LINUX_ARM64_SHA256 \
+            || -v SYFT_DARWIN_AMD64_SHA256 || -v SYFT_DARWIN_ARM64_SHA256 ]]
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "sourcing sbom-utils fails when retry utilities cannot be loaded" {
     mkdir -p "$TEST_TEMP_DIR/helpers"
     cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$TEST_TEMP_DIR/helpers/sbom-utils.sh"
@@ -149,7 +161,7 @@ EOF
     mkdir -p "$TEST_TEMP_DIR/helpers"
     cp "$PROJECT_ROOT/helpers/sbom-utils.sh" "$PROJECT_ROOT/helpers/retry.sh" "$PROJECT_ROOT/helpers/logging.sh" \
         "$TEST_TEMP_DIR/helpers/"
-    chmod 000 "$TEST_TEMP_DIR/helpers/logging.sh"
+    printf 'return 1\n' > "$TEST_TEMP_DIR/helpers/logging.sh"
 
     run bash -c '
         log_error() { printf "caller log: %s\\n" "$*"; }
@@ -160,67 +172,592 @@ EOF
     [[ "$output" == *"Failed to load logging utilities"* ]]
 }
 
-@test "install_syft fails and does not claim success when its download fails" {
-    local helper_bin="$TEST_TEMP_DIR/helper-bin"
-    mkdir -p "$helper_bin"
-    ln -s "$(command -v dirname)" "$helper_bin/dirname"
-    ln -s "$(command -v sh)" "$helper_bin/sh"
-    cat > "$helper_bin/curl" <<'EOF'
+make_syft_archive() {
+    local archive="$1"
+    local reported_version="$2"
+    local version_status="${3:-0}"
+    local archive_dir="$TEST_TEMP_DIR/syft-archive"
+
+    mkdir -p "$archive_dir"
+    cat > "$archive_dir/syft" <<EOF
 #!/bin/sh
-exit 22
+if [ "\$1" = version ]; then
+    printf '%s\\n' 'Application: syft' 'Version: ${reported_version}'
+    exit ${version_status}
+fi
 EOF
-    chmod +x "$helper_bin/curl"
-
-    run bash -c 'PATH="$2"; export PATH; source "$1" || exit 1; install_syft' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Failed to install syft"* ]]
-    [[ "$output" != *"installed successfully"* ]]
-    [[ "$output" != *"installed to ~/.local/bin"* ]]
+    chmod +x "$archive_dir/syft"
+    tar -czf "$archive" -C "$archive_dir" syft
+    sha256sum "$archive" | awk '{print $1}'
 }
 
-@test "install_syft does not download again after a successful system install outside PATH" {
+copy_sbom_utils_with_archive_digest() {
+    local archive_digest="$1"
+    local helper_dir="$TEST_TEMP_DIR/helpers"
+
+    mkdir -p "$helper_dir"
+    sed \
+        -e "s/2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f/${archive_digest}/" \
+        -e "s/6c0466811541ea03add5213a60a1562f0851e4c0b0ecfdee1a694a9455285900/${archive_digest}/" \
+        -e "s/cddf9a044145caf0a1a3194d00d1dd51a1666f4814f2919cdb4768a0c062ad95/${archive_digest}/" \
+        -e "s/4f37f4c7fefce0a68e4cf71ba3f5f9829a99e65d89b29f7ee41b8c2c10ea8c59/${archive_digest}/" \
+        "$PROJECT_ROOT/helpers/sbom-utils.sh" > "$helper_dir/sbom-utils.sh"
+    cp "$PROJECT_ROOT/helpers/retry.sh" "$helper_dir/retry.sh"
+    printf '%s\n' "$helper_dir/sbom-utils.sh"
+}
+
+make_syft_helper_bin() {
     local helper_bin="$TEST_TEMP_DIR/helper-bin"
-    local install_calls="$TEST_TEMP_DIR/install-calls"
+    local command_name mktemp_path mv_path
+
     mkdir -p "$helper_bin"
-    ln -s "$(command -v dirname)" "$helper_bin/dirname"
+    for command_name in dirname uname rm sha256sum tar gzip install mkdir; do
+        ln -s "$(command -v "$command_name")" "$helper_bin/$command_name"
+    done
+    mktemp_path=$(command -v mktemp)
+    mv_path=$(command -v mv)
+    cat > "$helper_bin/mktemp" <<EOF
+#!/bin/sh
+case "\$1" in
+    /usr/local/bin/syft.tmp.*)
+        echo 'refusing test system staging path' >&2
+        exit 1
+        ;;
+    /usr/local/bin/*)
+        exec "${mktemp_path}" "\${TMPDIR:-/tmp}/syft-system-stage.XXXXXX"
+        ;;
+    *)
+        exec "${mktemp_path}" "\$@"
+        ;;
+esac
+EOF
+    cat > "$helper_bin/mv" <<EOF
+#!/bin/sh
+source_path=""
+destination=""
+for argument in "\$@"; do
+    case "\$argument" in
+        -*) ;;
+        *) source_path="\$destination"; destination="\$argument" ;;
+    esac
+done
+if [ "\$destination" = /usr/local/bin/syft ]; then
+    if [ -n "\${SYFT_SYSTEM_DESTINATION:-}" ]; then
+        if [ -n "\${SYFT_SYSTEM_MV_DESTINATION:-}" ]; then
+            printf '%s\\n' "\$destination" > "\$SYFT_SYSTEM_MV_DESTINATION"
+        fi
+        exec "${mv_path}" "\$source_path" "\$SYFT_SYSTEM_DESTINATION"
+    fi
+    echo 'refusing test write to /usr/local/bin/syft' >&2
+    exit 1
+fi
+exec "${mv_path}" "\$@"
+EOF
     cat > "$helper_bin/curl" <<'EOF'
 #!/bin/sh
-printf '%s\n' curl >> "$SYFT_INSTALL_CALLS"
-printf 'stub installer\n'
-EOF
-    cat > "$helper_bin/sh" <<'EOF'
-#!/bin/sh
-printf '%s\n' "$4" >> "$SYFT_INSTALL_CALLS"
-if [ "$4" = /usr/local/bin ]; then
-    printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/syft
-    /bin/chmod +x /usr/local/bin/syft
-else
-    /bin/mkdir -p "$4"
-    printf '#!/bin/sh\nexit 0\n' > "$4/syft"
-    /bin/chmod +x "$4/syft"
-fi
-exit 0
-EOF
-    chmod +x "$helper_bin/curl" "$helper_bin/sh"
-
-    if ! unshare -Urnm bash -c 'mount -t tmpfs tmpfs /usr/local/bin'; then
-        skip "user namespace with private mount not available"
+destination=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        destination="$1"
     fi
+    shift
+done
+if [ -n "${SYFT_CURL_CALLS:-}" ]; then
+    printf 'curl\n' >> "$SYFT_CURL_CALLS"
+fi
+if [ "${SYFT_ALTERED_BYTES:-false}" = true ]; then
+    /bin/cp "$SYFT_ALTERED_ARCHIVE" "$destination"
+elif [ "${SYFT_CURL_FAIL:-false}" = true ]; then
+    exit 1
+else
+    /bin/cp "$SYFT_TEST_ARCHIVE" "$destination"
+fi
+EOF
+    chmod +x "$helper_bin/mktemp" "$helper_bin/mv" "$helper_bin/curl"
+    printf '%s\n' "$helper_bin"
+}
 
-    run unshare -Urnm bash -c '
-        mount -t tmpfs tmpfs /usr/local/bin || exit 1
+@test "make_syft_helper_bin refuses a default system staging path without returning one" {
+    local helper_bin
+    helper_bin=$(make_syft_helper_bin)
+
+    run --separate-stderr "$helper_bin/mktemp" /usr/local/bin/syft.tmp.XXXXXX
+
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    [[ "$stderr" != *"/usr/local/bin/"* ]]
+    [[ "$stderr" == *"refusing test system staging path"* ]]
+}
+
+make_syft_platform_helper_bin() {
+    local helper_bin
+
+    helper_bin=$(make_syft_helper_bin)
+    rm "$helper_bin/sha256sum" "$helper_bin/tar" "$helper_bin/uname"
+    cat > "$helper_bin/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+    -s) printf '%s\n' "$SYFT_UNAME_S" ;;
+    -m) printf '%s\n' "$SYFT_UNAME_M" ;;
+    *) exit 1 ;;
+esac
+EOF
+    cat > "$helper_bin/curl" <<'EOF'
+#!/bin/sh
+destination=""
+curl_args="$*"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        destination="$1"
+    fi
+    shift
+done
+printf '%s\n' "$curl_args" > "$SYFT_CURL_ARGS"
+: > "$destination"
+EOF
+    cat > "$helper_bin/sha256sum" <<'EOF'
+#!/bin/sh
+case "$1" in
+    *linux_amd64*) digest="2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f" ;;
+    *linux_arm64*) digest="6c0466811541ea03add5213a60a1562f0851e4c0b0ecfdee1a694a9455285900" ;;
+    *darwin_amd64*) digest="cddf9a044145caf0a1a3194d00d1dd51a1666f4814f2919cdb4768a0c062ad95" ;;
+    *darwin_arm64*) digest="4f37f4c7fefce0a68e4cf71ba3f5f9829a99e65d89b29f7ee41b8c2c10ea8c59" ;;
+    *) exit 1 ;;
+esac
+printf '%s  %s\n' "$digest" "$1" > "$SYFT_DIGEST_INPUT"
+printf '%s  %s\n' "$digest" "$1"
+EOF
+    cat > "$helper_bin/tar" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$helper_bin/uname" "$helper_bin/curl" "$helper_bin/sha256sum" "$helper_bin/tar"
+    printf '%s\n' "$helper_bin"
+}
+
+@test "install_syft selects the pinned asset and digest for every platform this helper accepts" {
+    local helper_bin os arch asset digest curl_args digest_input
+    helper_bin=$(make_syft_platform_helper_bin)
+
+    while IFS='|' read -r os arch asset digest; do
+        curl_args="$TEST_TEMP_DIR/${os}-${arch}-curl-args"
+        digest_input="$TEST_TEMP_DIR/${os}-${arch}-digest-input"
+
+        run bash -c '
+            PATH="$2"; export PATH
+            SYFT_UNAME_S="$3"; export SYFT_UNAME_S
+            SYFT_UNAME_M="$4"; export SYFT_UNAME_M
+            SYFT_CURL_ARGS="$5"; export SYFT_CURL_ARGS
+            SYFT_DIGEST_INPUT="$6"; export SYFT_DIGEST_INPUT
+            source "$1" || exit 1
+            install_syft
+        ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$os" "$arch" "$curl_args" "$digest_input"
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"Failed to extract verified syft"* ]]
+        grep -Fq "$asset" "$curl_args"
+        [ "$(awk '{print $1}' "$digest_input")" = "$digest" ]
+    done <<'EOF'
+Linux|x86_64|syft_1.51.0_linux_amd64.tar.gz|2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f
+Linux|amd64|syft_1.51.0_linux_amd64.tar.gz|2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f
+Linux|aarch64|syft_1.51.0_linux_arm64.tar.gz|6c0466811541ea03add5213a60a1562f0851e4c0b0ecfdee1a694a9455285900
+Linux|arm64|syft_1.51.0_linux_arm64.tar.gz|6c0466811541ea03add5213a60a1562f0851e4c0b0ecfdee1a694a9455285900
+Darwin|x86_64|syft_1.51.0_darwin_amd64.tar.gz|cddf9a044145caf0a1a3194d00d1dd51a1666f4814f2919cdb4768a0c062ad95
+Darwin|amd64|syft_1.51.0_darwin_amd64.tar.gz|cddf9a044145caf0a1a3194d00d1dd51a1666f4814f2919cdb4768a0c062ad95
+Darwin|arm64|syft_1.51.0_darwin_arm64.tar.gz|4f37f4c7fefce0a68e4cf71ba3f5f9829a99e65d89b29f7ee41b8c2c10ea8c59
+EOF
+}
+
+@test "install_syft refuses an unsupported platform" {
+    local helper_bin
+    helper_bin=$(make_syft_platform_helper_bin)
+
+    run bash -c '
         PATH="$2"; export PATH
-        SYFT_INSTALL_CALLS="$3"; export SYFT_INSTALL_CALLS
-        HOME="$(dirname "$3")/home"; export HOME
+        SYFT_UNAME_S="FreeBSD"; export SYFT_UNAME_S
+        SYFT_UNAME_M="x86_64"; export SYFT_UNAME_M
         source "$1" || exit 1
         install_syft
-    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin" "$install_calls"
+    ' _ "$PROJECT_ROOT/helpers/sbom-utils.sh" "$helper_bin"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No verified syft 1.51.0 release asset for FreeBSD/x86_64"* ]]
+}
+
+@test "install_syft refuses altered bytes before installing anything" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local altered_archive="$TEST_TEMP_DIR/altered-syft.tar.gz"
+    local archive_digest helper helper_bin install_calls home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    make_syft_archive "$altered_archive" "9.9.8-altered" >/dev/null
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    install_calls="$TEST_TEMP_DIR/install-calls"
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+printf 'install called\n' > "$SYFT_INSTALL_CALLS"
+exit 1
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$6"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_ALTERED_ARCHIVE="$4"; export SYFT_ALTERED_ARCHIVE
+        SYFT_ALTERED_BYTES=true; export SYFT_ALTERED_BYTES
+        SYFT_INSTALL_CALLS="$5"; export SYFT_INSTALL_CALLS
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$altered_archive" "$install_calls" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$install_calls" ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [[ "$output" == *"failed SHA-256 verification"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+}
+
+@test "install_syft refuses altered bytes with the shasum fallback before installing anything" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local altered_archive="$TEST_TEMP_DIR/altered-syft.tar.gz"
+    local archive_digest helper helper_bin install_calls home_dir sha256sum_path
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    make_syft_archive "$altered_archive" "9.9.8-altered" >/dev/null
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    install_calls="$TEST_TEMP_DIR/install-calls"
+    home_dir="$TEST_TEMP_DIR/home"
+    sha256sum_path=$(command -v sha256sum)
+    rm "$helper_bin/sha256sum" "$helper_bin/install"
+    cat > "$helper_bin/shasum" <<EOF
+#!/bin/sh
+exec "${sha256sum_path}" "\$3"
+EOF
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+printf 'install called\n' > "$SYFT_INSTALL_CALLS"
+exit 1
+EOF
+    chmod +x "$helper_bin/shasum" "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$6"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_ALTERED_ARCHIVE="$4"; export SYFT_ALTERED_ARCHIVE
+        SYFT_ALTERED_BYTES=true; export SYFT_ALTERED_BYTES
+        SYFT_INSTALL_CALLS="$5"; export SYFT_INSTALL_CALLS
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$altered_archive" "$install_calls" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$install_calls" ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [[ "$output" == *"failed SHA-256 verification"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+}
+
+@test "install_syft refuses a verified binary reporting an unpinned version without replacing destinations" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir destination existing
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    for existing in false true; do
+        destination="$home_dir/.local/bin/syft"
+        rm -f "$destination"
+        if [ "$existing" = true ]; then
+            mkdir -p "$(dirname "$destination")"
+            printf '%s\n' 'previous syft bytes' > "$destination"
+        fi
+
+        run bash -c '
+        PATH="$2"; export PATH
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        HOME="$4"; export HOME
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$TEST_TEMP_DIR/home"
+
+        [ "$status" -ne 0 ]
+        if [ "$existing" = true ]; then
+            [ "$(cat "$destination")" = 'previous syft bytes' ]
+        else
+            [ ! -e "$destination" ]
+        fi
+        [ -z "$(find "$home_dir/.local/bin" -name 'syft.tmp.*' -print -quit 2>/dev/null)" ]
+        [[ "$output" == *"reported version 9.9.9-test, expected 1.51.0"* ]]
+        [[ "$output" != *"installed successfully"* ]]
+    done
+}
+
+@test "install_syft returns failure without installing or logging success when download fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir system_destination system_mv_destination
+    archive_digest=$(make_syft_archive "$archive" "1.51.0")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    system_destination="$TEST_TEMP_DIR/system-bin/syft"
+    system_mv_destination="$TEST_TEMP_DIR/system-mv-destination"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_CURL_FAIL=true; export SYFT_CURL_FAIL
+        SYFT_SYSTEM_DESTINATION="$5"; export SYFT_SYSTEM_DESTINATION
+        SYFT_SYSTEM_MV_DESTINATION="$6"; export SYFT_SYSTEM_MV_DESTINATION
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir" "$system_destination" "$system_mv_destination"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [ ! -e "$system_destination" ]
+    [ ! -e "$system_mv_destination" ]
+    [[ "$output" == *"Failed to download syft 1.51.0"* ]]
+    [[ "$output" != *"installed successfully"* ]]
+}
+
+@test "install_syft falls back to the user directory and exports PATH when the system directory is unavailable" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "1.51.0")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft || exit 1
+        test -x "$HOME/.local/bin/syft"
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) ;;
+            *) exit 1 ;;
+        esac
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
 
     [ "$status" -eq 0 ]
-    [ "$(wc -l < "$install_calls")" -eq 2 ]
-    [ "$(sed -n '1p' "$install_calls")" = "curl" ]
-    [ "$(sed -n '2p' "$install_calls")" = "/usr/local/bin" ]
-    [[ "$output" == *"installed successfully"* ]]
-    [[ "$output" != *"installed to ~/.local/bin"* ]]
+    [[ "$output" == *"syft 1.51.0 installed successfully"* ]]
+}
+
+@test "install_syft installs a verified binary at the requested system destination" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir system_destination system_mv_destination mktemp_path curl_calls
+    archive_digest=$(make_syft_archive "$archive" "1.51.0")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    system_destination="$TEST_TEMP_DIR/system-bin/syft"
+    system_mv_destination="$TEST_TEMP_DIR/system-mv-destination"
+    curl_calls="$TEST_TEMP_DIR/curl-calls"
+    mktemp_path=$(command -v mktemp)
+    mkdir -p "$(dirname "$system_destination")"
+    cat > "$helper_bin/mktemp" <<EOF
+#!/bin/sh
+case "\$1" in
+    /usr/local/bin/syft.tmp.*) exec "${mktemp_path}" "${TEST_TEMP_DIR}/system-stage.XXXXXX" ;;
+    *) exec "${mktemp_path}" "\$@" ;;
+esac
+EOF
+    chmod +x "$helper_bin/mktemp"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        SYFT_SYSTEM_DESTINATION="$5"; export SYFT_SYSTEM_DESTINATION
+        SYFT_SYSTEM_MV_DESTINATION="$6"; export SYFT_SYSTEM_MV_DESTINATION
+        SYFT_CURL_CALLS="$7"; export SYFT_CURL_CALLS
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir" "$system_destination" "$system_mv_destination" "$curl_calls"
+
+    [ "$status" -eq 0 ]
+    [ -x "$system_destination" ]
+    [ "$("$system_destination" version | awk '/^Version:/ { print $2 }')" = 1.51.0 ]
+    [ "$(cat "$system_mv_destination")" = /usr/local/bin/syft ]
+    [ "$(wc -l < "$curl_calls")" -eq 1 ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+}
+
+@test "install_syft verifies a correct archive in a TMPDIR containing a backslash" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir tmpdir
+    archive_digest=$(make_syft_archive "$archive" "1.51.0")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    tmpdir="$TEST_TEMP_DIR/tmp\\dir"
+    mkdir -p "$tmpdir"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        TMPDIR="$5"; export TMPDIR
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir" "$tmpdir"
+
+    [ "$status" -eq 0 ]
+    [ -x "$home_dir/.local/bin/syft" ]
+    [[ "$output" == *"syft 1.51.0 installed successfully"* ]]
+}
+
+@test "install_syft leaves no new destination binary when validation fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test" 1)
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$home_dir/.local/bin/syft" ]
+    [ -z "$(find "$home_dir/.local/bin" -name 'syft.tmp.*' -print -quit 2>/dev/null)" ]
+    [[ "$output" == *"Installed syft did not report its version"* ]]
+}
+
+@test "install_syft preserves an existing destination binary when validation fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir destination
+    archive_digest=$(make_syft_archive "$archive" "9.9.9-test" 1)
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    destination="$home_dir/.local/bin/syft"
+    mkdir -p "$(dirname "$destination")"
+    printf '%s\n' 'previous syft bytes' > "$destination"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        install_syft
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -ne 0 ]
+    [ "$(cat "$destination")" = 'previous syft bytes' ]
+    [ -z "$(find "$home_dir/.local/bin" -name 'syft.tmp.*' -print -quit 2>/dev/null)" ]
+}
+
+@test "install_syft succeeds when logging success fails" {
+    local archive="$TEST_TEMP_DIR/syft.tar.gz"
+    local archive_digest helper helper_bin home_dir
+    archive_digest=$(make_syft_archive "$archive" "v1.51.0")
+    helper=$(copy_sbom_utils_with_archive_digest "$archive_digest")
+    helper_bin=$(make_syft_helper_bin)
+    home_dir="$TEST_TEMP_DIR/home"
+    rm "$helper_bin/install"
+    cat > "$helper_bin/install" <<'EOF'
+#!/bin/sh
+destination=""
+for argument in "$@"; do
+    destination="$argument"
+done
+case "$destination" in
+    /usr/local/bin/syft.tmp.*) exit 1 ;;
+esac
+exec /usr/bin/install "$@"
+EOF
+    chmod +x "$helper_bin/install"
+
+    run bash -c '
+        PATH="$2"; export PATH
+        HOME="$4"; export HOME
+        SYFT_TEST_ARCHIVE="$3"; export SYFT_TEST_ARCHIVE
+        source "$1" || exit 1
+        log_success() { return 1; }
+        install_syft
+        test -x "$HOME/.local/bin/syft"
+    ' _ "$helper" "$helper_bin" "$archive" "$home_dir"
+
+    [ "$status" -eq 0 ]
 }

--- a/tests/unit/syft-version-parity.bats
+++ b/tests/unit/syft-version-parity.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+# Guarantees that local SBOM generation and every download-syft workflow step
+# use one explicit release. The structural workflow query finds every action use,
+# so moved steps still participate and a new call site cannot be silently skipped.
+load "../test_helper"
+
+syft_workflow_sites() {
+    local workflow_file="$1"
+
+    yq -r '
+        .jobs
+        | to_entries[]
+        | .key as $job
+        | .value.steps[]?
+        | select((.uses // "" | downcase) | test("^anchore/sbom-action/download-syft@"))
+        | [$job, (.name // "unnamed step"), (.with."syft-version" // "")]
+        | @tsv
+    ' "$workflow_file"
+}
+
+@test "syft helper and every download-syft workflow site pin the same explicit release" {
+    local helper_version expected_workflow_version site version workflow_file workflow_output job step
+    local workflows_dir="${SYFT_WORKFLOWS_DIR:-$PROJECT_ROOT/.github/workflows}"
+    local nullglob_was_set=false discovered_sites
+    local -a workflow_files workflow_sites
+
+    helper_version="$(sed -nE 's/^[[:space:]]*local syft_version="([^"]+)"$/\1/p' "$PROJECT_ROOT/helpers/sbom-utils.sh")"
+    if [ -z "$helper_version" ]; then
+        printf 'helpers/sbom-utils.sh does not declare local syft_version\n' >&2
+        return 1
+    fi
+    if [ "$(printf '%s\n' "$helper_version" | wc -l)" -ne 1 ]; then
+        printf 'helpers/sbom-utils.sh declares multiple local syft_version values\n' >&2
+        return 1
+    fi
+    expected_workflow_version="v${helper_version}"
+
+    if [ ! -d "$workflows_dir" ]; then
+        printf 'syft workflow discovery failed: %s is not a directory\n' "$workflows_dir" >&2
+        return 1
+    fi
+
+    if shopt -q nullglob; then
+        nullglob_was_set=true
+    fi
+    shopt -s nullglob
+    workflow_files=("$workflows_dir"/*.yaml "$workflows_dir"/*.yml)
+    if [ "$nullglob_was_set" = false ]; then
+        shopt -u nullglob
+    fi
+    if [ "${#workflow_files[@]}" -eq 0 ]; then
+        printf 'syft workflow discovery failed: no workflow files found in %s\n' "$workflows_dir" >&2
+        return 1
+    fi
+
+    for workflow_file in "${workflow_files[@]}"; do
+        if ! workflow_output="$(syft_workflow_sites "$workflow_file")"; then
+            printf 'syft workflow discovery failed: yq could not query %s\n' "$workflow_file" >&2
+            return 1
+        fi
+        while IFS=$'\t' read -r job step version; do
+            [ -n "$job" ] || continue
+            workflow_sites+=("$(basename "$workflow_file"):$job:$step"$'\t'"$version")
+        done <<< "$workflow_output"
+    done
+
+    if [ "${#workflow_sites[@]}" -ne 4 ]; then
+        if [ "${#workflow_sites[@]}" -eq 0 ]; then
+            discovered_sites='none'
+        else
+            discovered_sites=''
+            for site in "${workflow_sites[@]}"; do
+                discovered_sites+="${discovered_sites:+, }${site%%$'\t'*}"
+            done
+        fi
+        printf 'expected exactly four download-syft workflow sites, found %s; discovered: %s\n' \
+            "${#workflow_sites[@]}" "$discovered_sites" >&2
+        return 1
+    fi
+    for site in "${workflow_sites[@]}"; do
+        version="${site##*$'\t'}"
+        if [ -z "$version" ]; then
+            printf 'syft version parity mismatch at %s: missing syft-version; expected %s\n' "${site%%$'\t'*}" "$expected_workflow_version" >&2
+            return 1
+        fi
+        if [ "$version" != "$expected_workflow_version" ]; then
+            printf 'syft version parity mismatch at %s: expected %s, got %s\n' "${site%%$'\t'*}" "$expected_workflow_version" "$version" >&2
+            return 1
+        fi
+    done
+}


### PR DESCRIPTION
`./make sbom` fetched an installer over the network and piped it into `sh`. It passed no version to that installer, which treats an omitted tag as latest, so it logged `v1.42.1` and installed whichever release was newest.

CI had the mirror-image problem. All four `anchore/sbom-action/download-syft` steps passed no `syft-version`, and the action falls back to a version compiled into it — `v1.42.3` at the pinned SHA. So local and CI generated SBOMs with different scanners, neither of which anyone had chosen, and bumping the action SHA would have moved CI's silently.

## What changes

`install_syft` downloads the pinned 1.51.0 release asset and verifies it against a per-architecture SHA-256 digest recorded beside the version. Before anything is moved into place it runs the staged binary and requires the version it reports to equal the pin, normalising only a leading `v` — so a digest paired with the wrong version installs nothing and leaves an existing destination untouched.

The four workflow steps now pass `syft-version: v1.51.0` explicitly. `tests/unit/syft-version-parity.bats` discovers every workflow, queries `download-syft` steps structurally, and fails when any site is missing its version, carries a different one, or when discovery itself cannot run.

The pin and the four digests are function-local, so sourcing the helper no longer assigns `SYFT_VERSION` or the `SYFT_*_SHA256` names into the caller.

## Verification

- 2527 unit tests pass.
- `shellcheck` clean; `actionlint` clean under CI's `SHELLCHECK_OPTS=--severity=error`.
- The four digests were diffed against Anchore's published `syft_1.51.0_checksums.txt` and are byte-identical.
- Mutation-proven: removing the version comparison, returning success from the download-failure branch, deleting a platform arm, skipping the system move, reverting digest verification to checksum-file syntax, restoring the unsafe staging stub, and adding a fifth workflow site each turn a named test red.

## Not fixed here

`install_syft` has failure modes that predate this change or need a host this project's CI does not have: #1209, #1210, #1211, #1212, #1213, #1214, #1215, #1217, #1218. Monitoring the pin the way every other dependency here is monitored is #1216 — the daily check's unit is a container directory, and syft is repository tooling.

Closes #1187
Closes #1192
Closes #1193
