### PR TITLE
perf(ci): let a PR's extension build reuse master's cache

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -448,7 +448,9 @@ jobs:
     # Fork PRs are excluded: they have read-only GITHUB_TOKEN and cannot push
     # to GHCR regardless. TimescaleDB bumps arrive via same-repo auto-update PRs
     # only; same-repo PRs push (packages:write is explicitly granted below) so
-    # the smoke validates end-to-end and master reuses the cache.
+    # the smoke validates end-to-end. A PR imports master's canonical cache but exports
+    # only its PR-scoped cache; master imports only the canonical cache, so newly changed
+    # extension work recompiles at merge before master refreshes the canonical cache.
     if: |
       always() &&
       needs.detect-containers.outputs.count > 0 &&
@@ -568,11 +570,14 @@ jobs:
           # merge-extension-manifests (stage B) fuses them into multi-arch manifests.
           ARCH_SUFFIX: ${{ matrix.arch }}
           BUILD_PLATFORM: ${{ matrix.platform }}
-          # supply-chain: same-repo PRs publish PR-scoped tags only so unreviewed
-          # code never overwrites canonical production-consumed refs.  On push/dispatch
-          # (master) PR_TAG_SUFFIX is empty → canonical refs published.
-          # The shared registry build-cache lets master reuse the PR's compiled layers
-          # (cache hit, no recompile) — safe because forks are excluded by the job if:.
+          # supply-chain: as written, same-repo PRs publish only PR-scoped tags, so they
+          # do not overwrite canonical production-consumed refs by accident. A PR author
+          # who changes the executed script is outside what this suffix constrains.
+          # On push/dispatch (master) PR_TAG_SUFFIX is empty → canonical refs published.
+          # The registry build-cache flow is asymmetric: a same-repo PR imports the
+          # canonical cache and exports only its PR-scoped cache, while master imports
+          # only canonical. Changed extension work therefore recompiles at merge before
+          # the canonical cache is refreshed.
           # BE-1: only set the suffix for same-repo PRs (where the -pr<N> images were
           # actually built).  Fork PRs are excluded by the job if: clause above, so this
           # path is only reached by push/dispatch (empty suffix → canonical) and same-repo

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -54,15 +54,16 @@ _arch_suffix_tag() {
 # Appends ${PR_TAG_SUFFIX} to <base_ref> when PR_TAG_SUFFIX is non-empty;
 # returns <base_ref> unchanged when PR_TAG_SUFFIX is empty (push/dispatch path).
 #
-# supply-chain policy (operator-confirmed option 2): image tags AND the
-# registry build-cache are both PR-scoped.  On a same-repo pull_request, the
+# supply-chain policy (operator-confirmed option 2): image tags and registry
+# build-cache export refs are PR-scoped. On a same-repo pull_request, the
 # build-extensions leg publishes per-arch images and the stage-B merge publishes
 # multi-arch manifests and the bundle — all carrying the -pr<N> suffix.
-# The build-cache ref also carries the PR suffix (see the supply-chain comment in
-# build_ext_image) so an unmerged PR cannot influence master's canonical build
-# via a shared cache entry.  Master recompiles the bumped version on merge;
-# the prefilter skips already-canonical versions so only the newly bumped
-# version recompiles — bounded, accepted waste.
+# A PR imports both the canonical cache and its own scoped cache, but exports
+# only to its scoped ref (see the supply-chain comment in build_ext_image). This
+# prevents this implementation from writing master's canonical cache during a
+# PR run, while letting it reuse master's work. The PR author controls the
+# scripts running in this job, so the suffix is not a security boundary; it is
+# a rollback/audit convenience. Master never imports a PR-scoped cache ref.
 # Forks are excluded at the job if: clause so only trusted same-repo PRs write
 # to the GHCR namespace.
 #
@@ -82,7 +83,7 @@ _scoped_tag() {
 
 
 # Override build_ext_image from extension-utils.sh for the CI buildx per-arch
-# path: explicit --platform builds, PR-scoped cache refs, separate compile/push
+# path: explicit --platform builds, asymmetric cache refs, separate compile/push
 # handling, and rc=2 for push failures. It also injects REMOTE_CR into extension
 # builder stages. Do not delete this override merely by upstreaming REMOTE_CR;
 # extension-utils.sh would need the whole buildx/cache/push path first.
@@ -112,9 +113,9 @@ build_ext_image() {
         #     ceiling AND non-ceiling, because it is not a compile incompatibility).
         #
         # BA-1: pushing extension images from same-repo PRs is a deliberate
-        # accepted trade-off.  Extensions require native compilation (musl/glibc),
-        # so rebuilding from scratch on the master merge leg would waste minutes of
-        # compile time per version per arch.  A single-maintainer repo with
+        # accepted trade-off. PR-scoped images let the PR's own smoke consume and
+        # validate them; recompiling at merge is the accepted cost of keeping master
+        # independent of PR-scoped cache entries. A single-maintainer repo with
         # serialized auto-update PRs makes this safe: the trust boundary is the PR
         # author, and the push is scoped to extension sub-images only (not the
         # final consumer postgres image).  This diverges from the main-image
@@ -134,14 +135,15 @@ build_ext_image() {
         # Fix: derive owner from REPO_OWNER (env, set by CI) or get_repo_owner()
         # and construct the cache ref as ghcr.io/<owner>/ext-<name>-buildcache:...
         #
-        # supply-chain policy (operator-confirmed): the cache ref is PR-scoped
-        # by appending PR_TAG_SUFFIX so an unmerged PR cannot influence master's
-        # canonical build via a shared cache entry.  On a same-repo PR the ref ends
-        # in pg<N>-<arch>-pr<N>; on push/dispatch (master) PR_TAG_SUFFIX is empty
-        # and the ref ends in pg<N>-<arch>.  There are no shared PR<->master refs.
-        # Master recompiles the bumped version on merge; the prefilter skips
-        # already-canonical versions so only the newly bumped version recompiles —
-        # bounded, accepted waste relative to the supply-chain guarantee.
+        # supply-chain policy (operator-confirmed): PR cache exports append
+        # PR_TAG_SUFFIX, so this implementation does not write master's
+        # canonical cache during a PR run. The PR author controls the scripts
+        # running in this job, so the suffix is not a security boundary; it is
+        # a rollback/audit convenience. A same-repo PR imports both the
+        # canonical pg<N>-<arch> cache and its pg<N>-<arch>-pr<N> cache, but
+        # exports only to the latter. On push/dispatch PR_TAG_SUFFIX is empty,
+        # so both read refs resolve to the same canonical ref and only one
+        # importer is emitted. Master never imports a PR-scoped cache ref.
         local _cache_owner
         _cache_owner="${REPO_OWNER:-$(get_repo_owner)}"
         local _cache_ref
@@ -154,10 +156,11 @@ build_ext_image() {
 
         # Step 1: compile — always use --load (loads image into the local docker
         # store of the native runner).  rc=1 on failure (compile / musl error).
-        # the cache is PR-scoped (see comment above); --cache-from on a PR
-        # reads ONLY that PR's own scoped cache across re-pushes.  On push/dispatch
-        # (master) the ref has no suffix so master reads/writes only its own cache.
-        # --cache-to writes when we have GHCR write access (_do_push_ext=true);
+        # Cache imports are intentionally asymmetric: a PR reads the canonical
+        # cache plus its own scoped cache, while its export remains PR-scoped.
+        # A missing importer is non-fatal to buildx, so extensions with no
+        # canonical cache still build normally. --cache-to writes when we have
+        # GHCR write access (_do_push_ext=true);
         # omitting --cache-to on LOCAL_ONLY/NO_PUSH paths avoids attempting writes
         # to a registry we cannot authenticate to in that context.
         # The cache export must not be able to fail the build: a cache-to write
@@ -166,7 +169,12 @@ build_ext_image() {
         # a retained non-ceiling version. ignore-error=true makes the export
         # best-effort so only a genuine compile failure returns non-zero here;
         # real infra failures are caught by the separate push step (rc=2, fatal).
-        local _cache_flags=("--cache-from" "type=registry,ref=${_cache_ref}")
+        local _canonical_cache_ref
+        _canonical_cache_ref="ghcr.io/${_cache_owner}/ext-${ext_name}-buildcache:pg${pg_major}-${ARCH_SUFFIX:-local}"
+        local _cache_flags=("--cache-from" "type=registry,ref=${_canonical_cache_ref}")
+        if [[ "$_cache_ref" != "$_canonical_cache_ref" ]]; then
+            _cache_flags+=("--cache-from" "type=registry,ref=${_cache_ref}")
+        fi
         if [[ "$_do_push_ext" == "true" ]]; then
             _cache_flags+=("--cache-to" "type=registry,ref=${_cache_ref},mode=max,ignore-error=true")
         fi

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -12041,22 +12041,76 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# build cache ref must carry PR_TAG_SUFFIX on PR builds,
-# and no suffix on push/dispatch (canonical) builds.
+# build cache exports must carry PR_TAG_SUFFIX on PR builds,
+# while cache imports read both canonical and PR-scoped refs on a PR.
 #
-# Supply-chain policy (operator-confirmed): the build cache is PR-scoped so an
-# unmerged PR cannot influence master's canonical build via a shared cache.
-# Master recompiles the bumped version (the prefilter skips already-canonical
-# versions, so only the new version recompiles — bounded, accepted waste).
-# No shared PR<->master refs.
+# Supply-chain export invariant (pre-existing): PR cache exports are scoped, so
+# this implementation does not write master's canonical cache during a PR run.
+# The PR author controls the scripts running in this job, so the suffix is not a
+# security boundary; it is a rollback/audit convenience. A PR may safely import
+# the canonical cache and its own scoped cache; master imports canonical only
+# and never imports a PR-scoped ref.
 #
-# RED before fix: cache ref is ..:pg18-amd64 regardless of PR_TAG_SUFFIX —
-#   a PR run writes to the same ref as master, enabling cross-scope influence.
+# RED before this fix: a PR imported only its own PR-scoped ref. On that PR's
+# first run, the ref did not exist, so it missed master's canonical cache and
+# rebuilt cold.
 # GREEN after fix:
-#   PR_TAG_SUFFIX=-pr42  → --cache-from/--cache-to ref ends in pg18-amd64-pr42
-#   PR_TAG_SUFFIX empty  → --cache-from/--cache-to ref ends in pg18-amd64 (no suffix)
+#   PR_TAG_SUFFIX=-pr42  → --cache-from has canonical and scoped refs; --cache-to is scoped
+#   PR_TAG_SUFFIX empty  → one canonical --cache-from and canonical --cache-to
 # ---------------------------------------------------------------------------
-@test "PR_TAG_SUFFIX=-pr42 → cache ref is ...buildcache:pg18-amd64-pr42" {
+_cache_refs_from_buildx_args() {
+    local direction="$1"
+    shift
+    local args=("$@")
+    local index cache_option cache_part cache_ref
+    local cache_parts=()
+    CACHE_REFS=()
+
+    for ((index = 0; index < ${#args[@]}; index++)); do
+        [[ "${args[$index]}" == "$direction" ]] || continue
+        cache_option="${args[$((index + 1))]:-}"
+        cache_ref=""
+        IFS=',' read -r -a cache_parts <<< "$cache_option"
+        for cache_part in "${cache_parts[@]}"; do
+            if [[ "$cache_part" == ref=* ]]; then
+                if [[ -n "$cache_ref" ]]; then
+                    echo "$direction cache option has multiple refs: $cache_option" >&2
+                    return 1
+                fi
+                cache_ref="${cache_part#ref=}"
+            fi
+        done
+        if [[ -z "$cache_ref" ]]; then
+            echo "$direction cache option has no ref: $cache_option" >&2
+            return 1
+        fi
+        CACHE_REFS+=("$cache_ref")
+    done
+}
+
+_assert_cache_refs() {
+    local direction="$1"
+    shift
+    local expected=("$@")
+    local expected_ref actual_ref matches
+
+    if [[ ${#CACHE_REFS[@]} -ne ${#expected[@]} ]]; then
+        echo "$direction must name exactly: ${expected[*]}; got: ${CACHE_REFS[*]}" >&2
+        return 1
+    fi
+    for expected_ref in "${expected[@]}"; do
+        matches=0
+        for actual_ref in "${CACHE_REFS[@]}"; do
+            [[ "$actual_ref" == "$expected_ref" ]] && matches=$((matches + 1))
+        done
+        if [[ "$matches" -ne 1 ]]; then
+            echo "$direction must name exactly: ${expected[*]}; got: ${CACHE_REFS[*]}" >&2
+            return 1
+        fi
+    done
+}
+
+@test "PR cache reads canonical and scoped refs but writes only the scoped ref" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bd1_pr_docker_calls.log"
@@ -12100,7 +12154,9 @@ EOF
         export -f image_exists_in_registry
 
         docker() {
-            echo "DOCKER $*" >> "$docker_calls"
+            printf "DOCKER" >> "$docker_calls"
+            printf "\t%s" "$@" >> "$docker_calls"
+            printf "\n" >> "$docker_calls"
             return 0
         }
         export -f docker
@@ -12129,20 +12185,25 @@ EOF
     [ -f "$docker_calls" ]
 
     local buildx_line
-    buildx_line=$(grep 'buildx build' "$docker_calls" | grep -- '--load' || true)
+    buildx_line=$(grep -F $'\tbuildx\tbuild\t' "$docker_calls" | grep -F $'\t--load\t' || true)
     [ -n "$buildx_line" ]
 
-    # The cache ref (both --cache-from and --cache-to) must carry the PR suffix.
-    # PR_TAG_SUFFIX=-pr42 → ref must end in pg18-amd64-pr42, NOT pg18-amd64.
-    [[ "$buildx_line" == *"ext-timescaledb-buildcache:pg18-amd64-pr42"* ]]
+    local buildx_args
+    IFS=$'\t' read -r -a buildx_args <<< "$buildx_line"
 
-    # The un-scoped (canonical) cache ref must NOT appear.
-    local unscoped_count
-    unscoped_count=$(echo "$buildx_line" | grep -c 'buildcache:pg18-amd64[^-]' || true)
-    [ "$unscoped_count" -eq 0 ]
+    # A PR imports exactly the canonical and its scoped cache refs.
+    _cache_refs_from_buildx_args "--cache-from" "${buildx_args[@]}"
+    _assert_cache_refs "PR cache imports" \
+        "ghcr.io/testowner/ext-timescaledb-buildcache:pg18-amd64" \
+        "ghcr.io/testowner/ext-timescaledb-buildcache:pg18-amd64-pr42"
+
+    # A PR exports exactly its scoped ref; an additional canonical exporter fails.
+    _cache_refs_from_buildx_args "--cache-to" "${buildx_args[@]}"
+    _assert_cache_refs "PR cache exports" \
+        "ghcr.io/testowner/ext-timescaledb-buildcache:pg18-amd64-pr42"
 }
 
-@test "PR_TAG_SUFFIX empty (push) → canonical cache ref (no suffix)" {
+@test "master cache reads the canonical ref exactly once" {
     local tmpd="$TEST_TEMP_DIR"
     local sd="$SCRIPTS_DIR"
     local docker_calls="$tmpd/bd1_push_docker_calls.log"
@@ -12186,7 +12247,9 @@ EOF
         export -f image_exists_in_registry
 
         docker() {
-            echo "DOCKER $*" >> "$docker_calls"
+            printf "DOCKER" >> "$docker_calls"
+            printf "\t%s" "$@" >> "$docker_calls"
+            printf "\n" >> "$docker_calls"
             return 0
         }
         export -f docker
@@ -12215,16 +12278,20 @@ EOF
     [ -f "$docker_calls" ]
 
     local buildx_line
-    buildx_line=$(grep 'buildx build' "$docker_calls" | grep -- '--load' || true)
+    buildx_line=$(grep -F $'\tbuildx\tbuild\t' "$docker_calls" | grep -F $'\t--load\t' || true)
     [ -n "$buildx_line" ]
 
-    # Canonical cache ref: ends in pg18-amd64 with no PR suffix.
-    [[ "$buildx_line" == *"ext-timescaledb-buildcache:pg18-amd64"* ]]
+    local buildx_args
+    IFS=$'\t' read -r -a buildx_args <<< "$buildx_line"
 
-    # The ref must NOT contain -pr<N> (no PR suffix on canonical builds).
-    local pr_count
-    pr_count=$(echo "$buildx_line" | grep -c 'buildcache:pg18-amd64-pr' || true)
-    [ "$pr_count" -eq 0 ]
+    # Master imports and exports exactly the canonical ref once.
+    _cache_refs_from_buildx_args "--cache-from" "${buildx_args[@]}"
+    _assert_cache_refs "master cache imports" \
+        "ghcr.io/testowner/ext-timescaledb-buildcache:pg18-amd64"
+
+    _cache_refs_from_buildx_args "--cache-to" "${buildx_args[@]}"
+    _assert_cache_refs "master cache exports" \
+        "ghcr.io/testowner/ext-timescaledb-buildcache:pg18-amd64"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The extension buildcache ref carried `PR_TAG_SUFFIX` in both directions, so a pull request that actually rebuilds extensions could only ever import a cache that does not exist yet.

Measured on #1208, which touches `helpers/extension-utils.sh` and therefore forces every extension to recompile:

```
#6 ERROR: failed to configure registry cache importer:
   ghcr.io/…/ext-paradedb-buildcache:pg16-amd64-pr1208: not found
```

arm64 finished at 2h43m; amd64 hit the job's 180-minute timeout and took `e2e-gate` with it. The same jobs on a PR that does not touch an extension build input finish in 1–2 minutes, because they reuse published manifests rather than building.

## What changes

The reason for scoping the ref is the write direction — an unmerged PR must not write the cache master consumes. Reading it is safe, because master never imports a PR-scoped ref. So the import side widens and the export side does not move:

- a PR imports the canonical ref **and** its own scoped ref, and exports only to its own;
- master imports the canonical ref exactly once, and exports to it as before;
- a missing canonical cache stays non-fatal, so an extension nobody has built yet still builds.

Master does not consume what a PR produced, so changed extension work still recompiles at merge. That is deliberate, and the comments now say so — several of them previously promised the opposite.

## Verification

- 2527 unit tests pass; `shellcheck -x -S warning` and `actionlint` clean under CI's severity.
- The two cache tests compare the complete set of refs each direction names, rather than substrings of a flattened command. Both were mutation-proven with at-HEAD controls: a second exporter naming the canonical ref with its options reordered passed the old test and fails the new one, and an importer naming a different architecture did the same.

## Not fixed here

Pre-existing, in code this branch does not change: #1222, #1223, #1224, #1225.
