### PR TITLE
docs(ci): say what the cache guard and the concurrency group actually do

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -1133,10 +1133,10 @@ jobs:
       (needs.build-extensions.result == 'success' || needs.build-extensions.result == 'skipped') &&
       (needs.merge-extension-manifests.result == 'success' || needs.merge-extension-manifests.result == 'skipped') &&
       (needs.sync-base-images.result == 'success' || needs.sync-base-images.result == 'skipped')
-    # NOTE: No job-level concurrency here — caused unexpected mid-build cancellations
-    # (observed 2026-04-23). Workflow-level concurrency is already removed so
-    # different-container runs parallelize. Same-container races are rare in practice
-    # (upstream-monitor serializes PR merges via concurrency on its own workflow).
+    # NOTE: Per-ref concurrency is active at the workflow level. No additional
+    # job-level group is used here because it caused unexpected mid-build cancellations
+    # (observed 2026-04-23). The workflow-level boundary prevents conflicting runs,
+    # while different-container jobs within a run still parallelize.
     env:
       # export PR_TAG_SUFFIX so generate_dockerfile (called by ./make build postgres)
       # PR-scopes the non-resolver/single-version extension FROM refs and self-heal
@@ -2014,7 +2014,9 @@ jobs:
           #   true  → real publish path (push/dispatch): emit cache-to so master builds
           #           write to the canonical buildcache refs.
           #   false → PR build-only (IS_PR=true) or DRY_RUN: emit cache-from only;
-          #           the HCL has no cache-to → PR code cannot poison canonical buildcache.
+          #           as written, the HCL has no cache-to and writes no canonical buildcache.
+          #           The PR author controls the scripts running in the job, so this is
+          #           a rollback/audit convenience, not a security boundary.
           # This is the only correct place to set it: the generator reads it at HCL-
           # generation time, before the three-way DRY_RUN/IS_PR/push branch below.
           bake_cache_export="false"

--- a/tests/unit/syft-version-parity.bats
+++ b/tests/unit/syft-version-parity.bats
@@ -1,8 +1,10 @@
 #!/usr/bin/env bats
 
-# Guarantees that local SBOM generation and every download-syft workflow step
-# use one explicit release. The structural workflow query finds every action use,
-# so moved steps still participate and a new call site cannot be silently skipped.
+# Verifies the on-demand installer's explicit Syft pin matches every download-syft
+# workflow step. The structural workflow query finds every action use, so moved
+# steps still participate and a new call site cannot be silently skipped. This
+# does not cover local SBOM generation: a syft already on PATH is used without a
+# version check (#1209).
 load "../test_helper"
 
 syft_workflow_sites() {


### PR DESCRIPTION
Three comments described mechanisms they did not match. No executable line changes — `git diff -U0 | grep '^[+-]' | grep -v '^[+-][+-]'` yields only `#` lines.

**#1225** — the bake path said that because the generated HCL has no `cache-to`, PR code cannot poison the canonical buildcache. A same-repo PR runs with `packages: write` and checks out its own branch, so its author can edit the workflow or `scripts/generate-bake-hcl.sh`. `auto-build.yaml` already states this correctly where it grants that permission: the suffix is a rollback and audit convenience, not a security boundary. This was the third and last occurrence of the framing; the other two were corrected in #1226.

**#1232** — the build job said workflow-level concurrency was removed, while the workflow declares a top-level group. That comment is the evidence someone would cite for deleting the group, which would reopen the extension-tag race it prevents.

**#1217** — the syft parity test claimed it guarantees local SBOM generation and every `download-syft` step use one release. It compares `install_syft`'s pin against the workflow inputs and says nothing about local generation, because `install_syft` returns early when `command -v syft` resolves. That early return is #1209.

## Why the three together

Correcting one comment about a mechanism makes every other sentence describing it wrong by contrast. On two branches this week, fixing them one at a time cost a full review round per sentence.

## Deliberately left

`auto-build.yaml:303` says PR-built layers "can't land" in the canonical buildcache. That describes `BUILD_CACHE_EXPORT: 'false'` on a job that exports nothing, so it is true of the implementation rather than a claim about what a PR author is prevented from doing.

## Verification

2538 unit tests pass. `actionlint` clean under CI's `SHELLCHECK_OPTS=--severity=error`.

Closes #1225
Closes #1232
Closes #1217
