### PR TITLE
ci(shellcheck): install yamllint without reaching the Debian archive

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -38,10 +38,54 @@ jobs:
       - name: Check duplicate YAML mapping keys
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y yamllint
+          yamllint_dir="$RUNNER_TEMP/yamllint-1.37.1"
+          yamllint_venv="$yamllint_dir/venv"
+          mkdir -p "$yamllint_dir/requirements"
+
+          cat > "$yamllint_dir/requirements/PyYAML.txt" <<'EOF'
+          PyYAML==6.0.2 \
+            --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 \
+            --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 \
+            --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+            --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+            --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+            --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5
+          EOF
+          cat > "$yamllint_dir/requirements/pathspec.txt" <<'EOF'
+          pathspec==0.12.1 --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08
+          EOF
+          cat > "$yamllint_dir/requirements/yamllint.txt" <<'EOF'
+          yamllint==1.37.1 --hash=sha256:364f0d79e81409f591e323725e6a9f4504c8699ddf2d7263d8d2b539cd66a583
+          EOF
+
+          if ! python3 -m venv "$yamllint_venv"; then
+            echo "::error::yamllint installation failed: could not create isolated virtual environment at $yamllint_venv"
+            exit 1
+          fi
+
+          install_package() {
+            local package=$1 requirement_file=$2 status
+            timeout --kill-after=5s 60s "$yamllint_venv/bin/python" -m pip install \
+              --disable-pip-version-check --retries 2 --timeout 15 --no-deps --only-binary=:all: \
+              --force-reinstall --require-hashes -r "$requirement_file" || status=$?
+            if [[ -z ${status:-} ]]; then
+              return 0
+            fi
+            if [[ $status -eq 124 || $status -eq 137 ]]; then
+              echo "::error::yamllint installation timed out after 60 seconds while fetching or installing $package from PyPI"
+            else
+              echo "::error::yamllint installation could not fetch or install $package from PyPI (pip exited $status); see pip output above"
+            fi
+            return "$status"
+          }
+
+          install_package 'PyYAML==6.0.2' "$yamllint_dir/requirements/PyYAML.txt"
+          install_package 'pathspec==0.12.1' "$yamllint_dir/requirements/pathspec.txt"
+          install_package 'yamllint==1.37.1' "$yamllint_dir/requirements/yamllint.txt"
+
+          "$yamllint_venv/bin/yamllint" --version
           find . -type f \( -name config.yaml -o -name variants.yaml \) \
-            -not -path './.git/*' -print0 | xargs -0 yamllint -c .yamllint.yml
+            -not -path './.git/*' -print0 | xargs -0 "$yamllint_venv/bin/yamllint" -c .yamllint.yml
 
       - name: Run shellcheck on scripts
         run: |


### PR DESCRIPTION
The YAML duplicate-key step ran `sudo apt-get update` before installing yamllint, inside a job capped at ten minutes. When `azure.archive.ubuntu.com` stalls, the retries consume the whole budget and the job is cancelled — before yamllint runs, and before the shellcheck step below it starts at all.

Seen twice on 2026-08-18/19, on two unrelated pull requests, both at exactly 10m16s: seventeen `Ign: http://azure.archive.ubuntu.com/ubuntu …` lines then `##[error]The operation was canceled`. Both passed on re-run, so no diff was ever the cause. The cost is not the re-run — a red check with zero findings reads like a real lint failure, and sends you to the diff.

## What changes

yamllint 1.37.1 installs into a throwaway venv from hash-pinned PyPI requirements:

- **a preinstalled copy cannot win** — fresh venv, `--force-reinstall`, and the venv's absolute `yamllint` path used for both the version check and the lint;
- **no artifact names a CPython ABI** — `--require-hashes` with the hashes of the wheels pip may legitimately choose, so the runner may move to any Python the pinned releases cover;
- **nothing is built from source** — `--only-binary=:all:`, so pip's build isolation cannot fetch unpinned build dependencies and execute a build backend on the runner;
- **each package has its own 60s bound** with `--kill-after`, and a failure names the package and keeps pip's own diagnostics.

The linted file set, `.yamllint.yml`, the shellcheck steps below and `timeout-minutes` are unchanged.

## Verification

2538 unit tests pass; `actionlint` clean under CI's `SHELLCHECK_OPTS=--severity=error`.

The failure path was demonstrated rather than asserted: a deliberately wrong hash produced `::error::yamllint installation could not fetch or install PyYAML==6.0.2 from PyPI (pip exited 1)`, exit status 1, and neither of the two later installs ran.

## Not fixed here

#1239 — untrusted YAML pathnames reach yamllint's GitHub formatter unescaped, a class `collect()` already rejects one step below. #1240 — an empty file set fails the lint, and 137 is reported as a timeout when it also means an OOM kill. #1241 — the pinned wheels will stop covering the runner's Python and nothing watches for it. #1236 — the install still resolves through a mutable index, which can withhold though not substitute.

Closes #1220
