### PR TITLE
fix(ci): stop duration consolidation reporting success after deleting its inputs

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -1857,12 +1857,54 @@ _consolidate_version_duration_file() {
     if [[ "$have_dur" == "true" ]] && [[ -n "$dur_source" ]]; then
         local max_dur
         max_dur=$(( dp_amd64 > dp_arm64 ? dp_amd64 : dp_arm64 ))
-        local tmp_dur
-        tmp_dur=$(mktemp)
-        jq --argjson dur "$max_dur" '. + {duration_seconds: $dur}' "$dur_source" \
-            > "$tmp_dur" && mv "$tmp_dur" "$dur_canonical" || rm -f "$tmp_dur"
-        rm -f "$dur_amd64" "$dur_arm64"
-        log_info "Duration consolidated (AX-3): $dur_canonical (amd64=${dp_amd64}s arm64=${dp_arm64}s max=${max_dur}s)"
+        local tmp_dur consolidation_status cleanup_status
+        # GNU mv -T prevents an existing directory from being treated as a
+        # destination directory.  A symlink to a directory needs an explicit
+        # refusal because -T would replace the symlink itself.
+        if [[ -L "$dur_canonical" && -d "$dur_canonical" ]]; then
+            log_error "Duration consolidation failed: canonical destination is a symlink to a directory: $dur_canonical"
+            return 1
+        fi
+
+        if ! tmp_dur=$(mktemp "${dur_canonical}.tmp.XXXXXX"); then
+            log_error "Duration consolidation failed: temporary file creation failed for $dur_canonical"
+            return 1
+        fi
+
+        if jq --argjson dur "$max_dur" '. + {duration_seconds: $dur}' "$dur_source" \
+            > "$tmp_dur"; then
+            :
+        else
+            consolidation_status=$?
+            if rm -f "$tmp_dur"; then
+                log_error "Duration consolidation failed: jq transformation failed for $dur_canonical (rc=$consolidation_status)"
+            else
+                cleanup_status=$?
+                log_error "Duration consolidation failed: jq transformation failed for $dur_canonical (rc=$consolidation_status); temporary file retained: $tmp_dur (cleanup rc=$cleanup_status)"
+            fi
+            return "$consolidation_status"
+        fi
+
+        if mv -fT "$tmp_dur" "$dur_canonical"; then
+            :
+        else
+            consolidation_status=$?
+            if rm -f "$tmp_dur"; then
+                log_error "Duration consolidation failed: canonical rename failed for $dur_canonical (rc=$consolidation_status)"
+            else
+                cleanup_status=$?
+                log_error "Duration consolidation failed: canonical rename failed for $dur_canonical (rc=$consolidation_status); temporary file retained: $tmp_dur (cleanup rc=$cleanup_status)"
+            fi
+            return "$consolidation_status"
+        fi
+
+        if rm -f "$dur_amd64" "$dur_arm64"; then
+            log_info "Duration consolidated (AX-3): $dur_canonical (amd64=${dp_amd64}s arm64=${dp_arm64}s max=${max_dur}s)"
+        else
+            cleanup_status=$?
+            log_error "Duration consolidation failed: source measurement cleanup did not complete for $dur_canonical (rc=$cleanup_status; source state may be partial)"
+            return "$cleanup_status"
+        fi
     fi
 }
 
@@ -2020,7 +2062,10 @@ finalize_multiarch_manifests() {
             fi
             # AX-3: consolidate per-arch duration files so the summer counts the
             # ceiling once (MAX), not once per arch.
-            _consolidate_version_duration_file "$ext" "$major_ver" "$ceiling"
+            if ! _consolidate_version_duration_file "$ext" "$major_ver" "$ceiling"; then
+                log_error "$ext $ceiling pg${major_ver}: duration consolidation failed — see preceding diagnostic"
+                _failed=true
+            fi
             continue
         fi
 
@@ -2049,7 +2094,10 @@ finalize_multiarch_manifests() {
         local _dur_ver_pre
         while IFS= read -r _dur_ver_pre; do
             [[ -z "$_dur_ver_pre" ]] && continue
-            _consolidate_version_duration_file "$ext" "$major_ver" "$_dur_ver_pre"
+            if ! _consolidate_version_duration_file "$ext" "$major_ver" "$_dur_ver_pre"; then
+                log_error "$ext $_dur_ver_pre pg${major_ver}: duration consolidation failed — see preceding diagnostic"
+                _failed=true
+            fi
         done < <(echo "$version_set_json" | jq -r '.[]')
 
         # Step 1: compute AVAILABLE set via ext_ref_resolve (unified resolver).

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -10608,6 +10608,290 @@ EOF
     }
 }
 
+@test "duration consolidation fails on jq error without deleting per-arch inputs or reporting success" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local canonical_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1.json"
+
+    mkdir -p "$lineage_dir"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    jq() {
+        if [[ "$1" == "--argjson" ]]; then
+            echo "forced jq failure" >&2
+            return 71
+        fi
+        command jq "$@"
+    }
+
+    run _consolidate_version_duration_file timescaledb 18 2.27.1
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: jq consolidation failure returned success"
+        false
+    }
+    [[ "$output" == *"jq transformation failed"* ]] || {
+        echo "FAIL: jq consolidation failure was not named in output: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated"* ]] || {
+        echo "FAIL: jq consolidation failure reported success: $output"
+        false
+    }
+    [ -f "$amd64_dur" ] || {
+        echo "FAIL: amd64 input was deleted after jq consolidation failure"
+        false
+    }
+    [ -f "$arm64_dur" ] || {
+        echo "FAIL: arm64 input was deleted after jq consolidation failure"
+        false
+    }
+    [ ! -f "$canonical_dur" ] || {
+        echo "FAIL: canonical duration file was written after jq consolidation failure"
+        false
+    }
+}
+
+@test "duration consolidation fails on rename error without deleting per-arch inputs or reporting success" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local canonical_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1.json"
+
+    mkdir -p "$lineage_dir"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    mv() {
+        if [[ "$3" == "$canonical_dur" ]]; then
+            echo "forced mv failure" >&2
+            return 72
+        fi
+        command mv "$@"
+    }
+
+    run _consolidate_version_duration_file timescaledb 18 2.27.1
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: rename consolidation failure returned success"
+        false
+    }
+    [[ "$output" == *"canonical rename failed"* ]] || {
+        echo "FAIL: rename consolidation failure was not named in output: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated"* ]] || {
+        echo "FAIL: rename consolidation failure reported success: $output"
+        false
+    }
+    [ -f "$amd64_dur" ] || {
+        echo "FAIL: amd64 input was deleted after rename consolidation failure"
+        false
+    }
+    [ -f "$arm64_dur" ] || {
+        echo "FAIL: arm64 input was deleted after rename consolidation failure"
+        false
+    }
+    [ ! -f "$canonical_dur" ] || {
+        echo "FAIL: canonical duration file was written after rename consolidation failure"
+        false
+    }
+}
+
+@test "duration consolidation refuses a canonical directory without deleting sources or reporting success" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local canonical_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1.json"
+
+    mkdir -p "$canonical_dur"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    run _consolidate_version_duration_file timescaledb 18 2.27.1
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: canonical directory destination unexpectedly succeeded"
+        false
+    }
+    [[ "$output" == *"canonical rename failed"* ]] || {
+        echo "FAIL: canonical directory destination was not named in output: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated (AX-3)"* ]] || {
+        echo "FAIL: canonical directory destination reported success: $output"
+        false
+    }
+    [ -f "$amd64_dur" ] || {
+        echo "FAIL: amd64 input was deleted after canonical directory refusal"
+        false
+    }
+    [ -f "$arm64_dur" ] || {
+        echo "FAIL: arm64 input was deleted after canonical directory refusal"
+        false
+    }
+}
+
+@test "duration consolidation refuses a canonical symlink to a directory without deleting sources" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local canonical_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1.json"
+    local canonical_target="$lineage_dir/canonical-target"
+
+    mkdir -p "$canonical_target"
+    ln -s "$canonical_target" "$canonical_dur"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    run _consolidate_version_duration_file timescaledb 18 2.27.1
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: canonical symlink-to-directory destination unexpectedly succeeded"
+        false
+    }
+    [[ "$output" == *"symlink to a directory"* ]] || {
+        echo "FAIL: canonical symlink-to-directory refusal was not named in output: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated (AX-3)"* ]] || {
+        echo "FAIL: canonical symlink-to-directory destination reported success: $output"
+        false
+    }
+    [ -f "$amd64_dur" ] || {
+        echo "FAIL: amd64 input was deleted after canonical symlink-to-directory refusal"
+        false
+    }
+    [ -f "$arm64_dur" ] || {
+        echo "FAIL: arm64 input was deleted after canonical symlink-to-directory refusal"
+        false
+    }
+}
+
+@test "finalize fails when source duration cleanup fails under its if-not caller, without logging consolidation success" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local canonical_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1.json"
+
+    cat > "$CONFIG_FILE" <<'EOF'
+extensions:
+  timescaledb:
+    version: "2.27.1"
+    repo: "https://github.com/timescale/timescaledb"
+    priority: 1
+EOF
+    mkdir -p "$lineage_dir"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    export FORCE=true
+    list_extensions_by_priority() { echo "timescaledb"; }
+    docker() { return 0; }
+    rm() {
+        if [[ "${1:-}" == "-f" && "${2:-}" == "${amd64_dur:-}" && "${3:-}" == "${arm64_dur:-}" && -n "${amd64_dur:-}" ]]; then
+            echo "forced source cleanup failure" >&2
+            return 73
+        fi
+        command rm "$@"
+    }
+
+    # Exercise the production `if ! _consolidate_version_duration_file` caller in
+    # finalize_multiarch_manifests, where errexit is disabled for the helper body.
+    run finalize_multiarch_manifests "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: finalize reported success after source duration cleanup failed"
+        false
+    }
+    [[ "$output" == *"duration consolidation failed — see preceding diagnostic"* ]] || {
+        echo "FAIL: finalize did not direct readers to the helper diagnostic: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated (AX-3)"* ]] || {
+        echo "FAIL: source cleanup failure logged consolidation success: $output"
+        false
+    }
+    [ -f "$canonical_dur" ] || {
+        echo "FAIL: canonical duration file was not written before the source cleanup failure"
+        false
+    }
+    [ -f "$amd64_dur" ] || {
+        echo "FAIL: failing source cleanup unexpectedly removed amd64 measurement"
+        false
+    }
+    [ -f "$arm64_dur" ] || {
+        echo "FAIL: failing source cleanup unexpectedly removed arm64 measurement"
+        false
+    }
+}
+
+@test "jq failure with temporary cleanup failure reports residual path and preserves jq status" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local amd64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-amd64.json"
+    local arm64_dur="$lineage_dir/ext-timescaledb-pg18-2.27.1-arm64.json"
+    local caller_log="$TEST_TEMP_DIR/duration-caller.log"
+    local tmp_dur
+
+    mkdir -p "$lineage_dir"
+    printf '{"duration_seconds":100}\n' > "$amd64_dur"
+    printf '{"duration_seconds":140}\n' > "$arm64_dur"
+
+    jq() {
+        if [[ "$1" == "--argjson" ]]; then
+            echo "forced jq failure" >&2
+            return 71
+        fi
+        command jq "$@"
+    }
+    rm() {
+        if [[ "${1:-}" == "-f" && "${2:-}" == *".tmp."* ]]; then
+            echo "forced temporary cleanup failure" >&2
+            return 74
+        fi
+        command rm "$@"
+    }
+
+    # The same `if !` shape used by finalize must still receive a failure.
+    local caller_rc=0
+    if ! _consolidate_version_duration_file timescaledb 18 2.27.1 > "$caller_log" 2>&1; then
+        caller_rc=1
+    fi
+    [ "$caller_rc" -eq 1 ] || {
+        echo "FAIL: if-not caller did not see the jq consolidation failure"
+        false
+    }
+
+    tmp_dur=$(compgen -G "$lineage_dir/ext-timescaledb-pg18-2.27.1.json.tmp.*" | head -n 1)
+    [ -f "$tmp_dur" ] || {
+        echo "FAIL: expected residual temporary file was not left behind"
+        false
+    }
+    [[ "$(< "$caller_log")" == *"temporary file retained: $tmp_dur"* ]] || {
+        echo "FAIL: residual temporary path was not reported: $(< "$caller_log")"
+        false
+    }
+
+    # `if !` inverts the helper's status, so invoke it directly to prove the
+    # original jq failure (71), rather than the cleanup failure (74), is returned.
+    run _consolidate_version_duration_file timescaledb 18 2.27.1
+
+    [ "$status" -eq 71 ] || {
+        echo "FAIL: temporary cleanup failure replaced jq status; got $status"
+        false
+    }
+    [[ "$output" == *"temporary file retained:"* ]] || {
+        echo "FAIL: direct jq failure did not report a retained temporary path: $output"
+        false
+    }
+    [[ "$output" != *"Duration consolidated (AX-3)"* ]] || {
+        echo "FAIL: temporary cleanup failure logged consolidation success: $output"
+        false
+    }
+}
+
 # ---------------------------------------------------------------------------
 # SIMP-cached-version-merged: a CACHED non-ceiling version (its -amd64/-arm64
 # suffixed tags exist in the registry from a prior run, NOT rebuilt this run)


### PR DESCRIPTION
Duration consolidation was:

```bash
jq … "$dur_source" > "$tmp_dur" && mv "$tmp_dur" "$dur_canonical" || rm -f "$tmp_dur"
```

`||` binds to the whole `&&` chain, so a failure of `jq` or of `mv` lands on the `rm`, which succeeds, and the chain's status is the `rm`'s. The next two lines delete both per-architecture duration files and log `Duration consolidated`. A full filesystem, malformed JSON, a permissions failure or a cross-filesystem `mv` therefore produced no canonical file, no per-arch files, and a success message — and those files are the only copies of those measurements.

This runs on every extension build.

## What changes

Each step is checked separately and names itself in the error. The temporary is created as a sibling of the destination, so the rename is same-filesystem and atomic, and it uses `mv -fT` so a directory at the canonical path cannot swallow it — with an explicit refusal for a symlink-to-directory, which `-T` would replace rather than refuse. The per-arch inputs are removed only after the rename succeeds, and both call sites in `finalize_multiarch_manifests` propagate the failure into `_failed`, which the finalizer already returns.

A consolidation failure now fails the stage rather than warning: losing a dashboard input silently is what this set out to stop.

## Verification

2544 unit tests pass; `shellcheck -x -S warning` clean.

Mutation-proven, with the first run by hand rather than reported: replacing `return "$consolidation_status"` with `return 0` turned both failure tests red at `FAIL: jq consolidation failure returned success` and `FAIL: rename consolidation failure returned success`. Later rounds added proofs for the source-deletion path exercised through the production `if !` caller shape, and for the directory destination.

## Not fixed here

#1234 — a malformed measurement becomes zero via `jq … || echo 0`, so an unreadable arm64 file yields a wrong maximum and both inputs are then deleted. #1237 — two paths leave canonical and per-arch files together so the summer double-counts: a `continue` that skips consolidation, and process death between the rename and the deletion. #1235 — the read-then-delete is not a transaction against concurrent writers. #1238 — a killed run leaves a temporary the stale sweep's `.json` glob does not match. #1243 — `mv -T` is a GNU requirement this mode does not declare, and a comment saying non-ceiling failures are tolerated now contradicts the code.

Closes #1222
