### PR TITLE
Report which postgres extension recipes are overdue for a rebuild

### DIFF
--- a/helpers/ghcr-package-utils.sh
+++ b/helpers/ghcr-package-utils.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Shared read-only helpers for GHCR extension packages.
+#
+# This deliberately covers only ext-<name> package version records. The
+# container-wide readers in cleanup-outdated-tags.sh and cleanup-old-versions.sh
+# are deletion-path code with different reshapes, so keeping them separate
+# avoids widening this read helper into those destructive workflows.
+
+# List GHCR package version records for an extension package.
+# Output: compact JSON array of {version_id,name,tags[],updated_at} records.
+# Returns 1 when the API request fails; propagates jq's non-zero status when
+# the response cannot be normalized as a sequence of arrays.
+_list_ghcr_ext_version_records() {
+    local package_name="$1"   # e.g. ext-timescaledb
+    local owner="${OWNER:?OWNER is required}"
+
+    local raw_versions
+    raw_versions=$(gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/users/${owner}/packages/container/${package_name}/versions" \
+        --paginate 2>/dev/null) || return 1
+
+    jq -ce -s '
+      # A successful transport with no JSON document is incomplete, not an
+      # authoritative empty registry. A literal JSON [] remains one empty
+      # array in the slurped input and is therefore accepted below.
+      select(length > 0)
+      | def record_tags:
+        (.metadata.container.tags // [])
+        | if type == "array" and all(.[]; type == "string") then .
+          else error("GHCR version record tags must be an array of strings")
+          end;
+      if all(.[]; type == "array") then
+        [.[][] | {
+          version_id: (if .id == null then error("GHCR version record has no id") else (.id | tostring) end),
+          name: (if ((.name // "") | type) == "string" then (.name // "") else "" end),
+          tags: record_tags,
+          updated_at: (if .updated_at == null then "" elif (.updated_at | type) == "string" then .updated_at else "" end)
+        }]
+      else
+        error("GHCR package-versions response must contain JSON arrays")
+      end
+    ' <<< "$raw_versions"
+}

--- a/scripts/cleanup-ext-images.sh
+++ b/scripts/cleanup-ext-images.sh
@@ -43,6 +43,9 @@ source "${ROOT_DIR}/helpers/logging.sh"
 # shellcheck source=../helpers/collect-lines.sh
 source "${ROOT_DIR}/helpers/collect-lines.sh"
 
+# shellcheck source=../helpers/ghcr-package-utils.sh
+source "${ROOT_DIR}/helpers/ghcr-package-utils.sh"
+
 # shellcheck source=helpers/version-set-resolver.sh
 source "${ROOT_DIR}/helpers/version-set-resolver.sh"
 
@@ -89,34 +92,6 @@ _discover_resolver_extensions() {
 _discover_pg_versions() {
     local config_file="$1"
     yq -r '.pg_versions[]' "$config_file" 2>/dev/null
-}
-
-# List GHCR package version records for an extension package.
-# Output: compact JSON array of {version_id,name,tags[]} records.
-# Returns 1 on API error so callers can skip fail-closed.
-_list_ghcr_ext_version_records() {
-    local package_name="$1"   # e.g. ext-timescaledb
-    local owner="${OWNER:?OWNER is required}"
-
-    local raw_versions
-    raw_versions=$(gh api \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        "/users/${owner}/packages/container/${package_name}/versions" \
-        --paginate 2>/dev/null) || return 1
-
-    if [[ -z "$raw_versions" ]]; then
-        printf '[]\n'
-        return 0
-    fi
-
-    jq -c -s '
-      [.[][] | {
-        version_id: (.id | tostring),
-        name: (.name // ""),
-        tags: (.metadata.container.tags // [])
-      }]
-    ' <<< "$raw_versions"
 }
 
 # Discover every pg<major>- prefix present in GHCR version record tags.

--- a/scripts/rotation-select.sh
+++ b/scripts/rotation-select.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# Select the highest-priority PostgreSQL extension pair among the `full`
+# flavor's members. UNKNOWN freshness candidates rank first, then dated
+# overdue candidates by age; lexical extension|major|version order breaks ties.
+#
+# This is intentionally read-only: it lists GHCR version records and open
+# blocking issues, then writes its decision to stdout and (when set) GITHUB_OUTPUT.
+# The two listings are separate, non-atomic API observations. The workflow that
+# acts on a selected pair must recheck that pair immediately before acting.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=helpers/logging.sh
+source "${ROOT_DIR}/helpers/logging.sh"
+# shellcheck source=helpers/collect-lines.sh
+source "${ROOT_DIR}/helpers/collect-lines.sh"
+# shellcheck source=helpers/extension-utils.sh
+source "${ROOT_DIR}/helpers/extension-utils.sh"
+# shellcheck source=helpers/ghcr-package-utils.sh
+source "${ROOT_DIR}/helpers/ghcr-package-utils.sh"
+
+_write_selection() {
+    local selected="$1"
+    local extension="$2"
+    local major="$3"
+    local version="$4"
+
+    [[ -n "${GITHUB_OUTPUT:-}" ]] || return 0
+    {
+        printf 'selected=%s\n' "$selected"
+        printf 'extension=%s\n' "$extension"
+        printf 'major=%s\n' "$major"
+        printf 'version=%s\n' "$version"
+    } >> "$GITHUB_OUTPUT"
+}
+
+_list_rotation_blocking_issues() {
+    local repository="$1"
+
+    gh issue list \
+        --repo "$repository" \
+        --state open \
+        --label extension-rotation-blocked \
+        --json number,body \
+        --limit 1000
+}
+
+_rotation_repository() {
+    (
+        cd "$ROOT_DIR"
+        gh repo view --json nameWithOwner --jq .nameWithOwner
+    )
+}
+
+_valid_timestamp() {
+    local timestamp="$1"
+    [[ "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]]
+}
+
+_valid_staleness_days() {
+    local days="$1"
+    # Accept 1 through 9999 days.
+    [[ "$days" =~ ^[1-9][0-9]{0,3}$ ]]
+}
+
+_valid_extension_version() {
+    local version="$1"
+    [[ "$version" =~ ^[0-9]+([.][0-9]+)*$ ]]
+}
+
+_remove_rotation_temp_files() {
+    rm -f -- "$@"
+}
+
+_remove_rotation_temp_files_and_exit() {
+    local exit_status="$1"
+    shift
+    _remove_rotation_temp_files "$@"
+    trap - EXIT HUP INT TERM
+    exit "$exit_status"
+}
+
+# EXIT and signal traps evaluate their actions as shell source. Keep the
+# temporary paths in this global array and expand them only as quoted arguments
+# when the static trap action runs; a TMPDIR pathname must never become code.
+rotation_temp_files=()
+
+_print_table() {
+    local pairs_file="$1"
+    local ext_name
+    local pg_major
+    local version
+    local pair_key
+
+    printf 'EXTENSION\tMAJOR\tCEILING\tAGE_DAYS\tFRESHNESS\tELIGIBILITY\n'
+    while IFS=$'\t' read -r ext_name pg_major version; do
+        [[ -n "$ext_name" ]] || continue
+        pair_key="${ext_name}|${pg_major}|${version}"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$ext_name" "$pg_major" "$version" "${age_by_pair[$pair_key]}" \
+            "${freshness_by_pair[$pair_key]}" "${eligibility_by_pair[$pair_key]}"
+    done < "$pairs_file"
+}
+
+main() {
+    : "${GH_TOKEN:?GH_TOKEN is required}"
+    : "${OWNER:?OWNER is required}"
+    # Keep pair-key tie-breaking bytewise and independent of the runner locale.
+    local LC_ALL=C
+
+    local staleness_days="${STALENESS_DAYS:-30}"
+    if ! _valid_staleness_days "$staleness_days"; then
+        log_error "STALENESS_DAYS must be an integer from 1 through 9999 days (got: ${staleness_days})"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local ext_config="${EXT_CONFIG:-${ROOT_DIR}/postgres/extensions/config.yaml}"
+    if [[ ! -f "$ext_config" ]]; then
+        log_error "Extension config not found: ${ext_config}"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    if ! validate_extensions_schema "$ext_config"; then
+        log_error "Extension config failed schema validation: ${ext_config}"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local now_epoch
+    now_epoch=$(date +%s) || {
+        log_error "Could not read the current time"
+        _write_selection false "" "" ""
+        return 1
+    }
+
+    # Five minutes permits ordinary runner/GitHub clock skew. A timestamp any
+    # further ahead is impossible evidence of freshness and remains UNKNOWN.
+    local future_timestamp_tolerance_seconds=300
+
+    local pairs_file
+    pairs_file=$(mktemp "${TMPDIR:-/tmp}/rotation-select-pairs.XXXXXX") || return 1
+    local extensions_file
+    extensions_file=$(mktemp "${TMPDIR:-/tmp}/rotation-select-extensions.XXXXXX") || {
+        rm -f "$pairs_file"
+        return 1
+    }
+    local issues_file
+    issues_file=$(mktemp "${TMPDIR:-/tmp}/rotation-select-issues.XXXXXX") || {
+        rm -f "$pairs_file" "$extensions_file"
+        return 1
+    }
+    local majors_file
+    majors_file=$(mktemp "${TMPDIR:-/tmp}/rotation-select-majors.XXXXXX") || {
+        rm -f -- "$pairs_file" "$extensions_file" "$issues_file"
+        return 1
+    }
+    rotation_temp_files=("$pairs_file" "$extensions_file" "$issues_file" "$majors_file")
+    trap '_remove_rotation_temp_files "${rotation_temp_files[@]}"' EXIT
+    trap '_remove_rotation_temp_files_and_exit 129 "${rotation_temp_files[@]}"' HUP
+    trap '_remove_rotation_temp_files_and_exit 130 "${rotation_temp_files[@]}"' INT
+    trap '_remove_rotation_temp_files_and_exit 143 "${rotation_temp_files[@]}"' TERM
+    if ! collect_lines "$majors_file" -- yq -r '.pg_versions[]' "$ext_config"; then
+        rm -f "$majors_file"
+        log_error "Could not enumerate configured PostgreSQL majors"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local -A pair_seen=()
+    local pg_major
+    local ext_name
+    local version
+    while IFS= read -r pg_major; do
+        [[ "$pg_major" =~ ^[0-9]+$ ]] || {
+            rm -f "$majors_file"
+            log_error "Invalid PostgreSQL major in ${ext_config}: ${pg_major}"
+            _write_selection false "" "" ""
+            return 1
+        }
+        if ! collect_lines "$extensions_file" -- get_flavor_extensions "$ext_config" full "$pg_major"; then
+            rm -f "$majors_file"
+            log_error "Could not enumerate extensions for PostgreSQL ${pg_major}"
+            _write_selection false "" "" ""
+            return 1
+        fi
+        while IFS= read -r ext_name; do
+            [[ -n "$ext_name" ]] || continue
+            version=$(ext_name="$ext_name" yq -er '.extensions[strenv(ext_name)].version' "$ext_config") || {
+                rm -f "$majors_file"
+                log_error "Could not read ceiling version for ${ext_name}/pg${pg_major}"
+                _write_selection false "" "" ""
+                return 1
+            }
+            if [[ -z "$version" || "$version" == "null" ]]; then
+                rm -f "$majors_file"
+                log_error "Could not read ceiling version for ${ext_name}/pg${pg_major}"
+                _write_selection false "" "" ""
+                return 1
+            fi
+            if ! _valid_extension_version "$version"; then
+                rm -f "$majors_file"
+                log_error "Invalid ceiling version for ${ext_name}/pg${pg_major}; expected a numeric-dotted version"
+                _write_selection false "" "" ""
+                return 1
+            fi
+            local pair_key="${ext_name}|${pg_major}|${version}"
+            if [[ -z "${pair_seen[$pair_key]:-}" ]]; then
+                pair_seen[$pair_key]=1
+                printf '%s\t%s\t%s\n' "$ext_name" "$pg_major" "$version" >> "$pairs_file"
+            fi
+        done < "$extensions_file"
+    done < "$majors_file"
+    rm -f "$majors_file"
+
+    if [[ ! -s "$pairs_file" ]]; then
+        log_error "No extension/PostgreSQL pairs were found in ${ext_config}"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local rotation_repository
+    if ! rotation_repository=$(_rotation_repository) || [[ -z "$rotation_repository" ]]; then
+        log_error "Could not establish the repository for extension rotation; refusing to select from unknown issue scope"
+        _write_selection false "" "" ""
+        return 1
+    fi
+    if [[ "${rotation_repository%%/*}" != "$OWNER" ]]; then
+        log_error "OWNER (${OWNER}) does not match rotation repository owner (${rotation_repository%%/*}); refusing to combine different scopes"
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local -A records_by_extension=()
+    local -A listed_extension=()
+    local registry_failure=false
+    local records_json
+    while IFS=$'\t' read -r ext_name pg_major version; do
+        [[ -n "$ext_name" && -z "${listed_extension[$ext_name]:-}" ]] || continue
+        listed_extension[$ext_name]=1
+        if records_json=$(_list_ghcr_ext_version_records "ext-${ext_name}"); then
+            records_by_extension[$ext_name]="$records_json"
+        else
+            registry_failure=true
+            records_by_extension[$ext_name]='[]'
+            log_error "GHCR version listing failed for ext-${ext_name}; refusing to select from incomplete registry data"
+        fi
+    done < "$pairs_file"
+
+    if [[ "$registry_failure" == true ]]; then
+        printf 'No pair selected: registry state is incomplete; candidate set is unknown.\n'
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local -A blocked_pair=()
+    local issue_failure=false
+    if ! collect_lines "$issues_file" -- _list_rotation_blocking_issues "$rotation_repository"; then
+        issue_failure=true
+        log_error "Could not list open extension-rotation-blocked issues; refusing to select from incomplete issue data"
+    elif ! jq -e 'type == "array" and length < 1000 and all(.[]; type == "object" and (.number | type == "number") and ((.body == null) or (.body | type == "string")))' "$issues_file" >/dev/null; then
+        issue_failure=true
+        log_error "Open extension-rotation-blocked issue response was invalid or reached the 1000-issue cap; refusing to select"
+    else
+        local issue_records
+        if ! issue_records=$(jq -c '.[]' "$issues_file"); then
+            issue_failure=true
+            log_error "Could not enumerate open extension-rotation-blocked issues; refusing to select"
+        fi
+        local issue_json
+        while IFS= read -r issue_json; do
+            [[ -n "$issue_json" ]] || continue
+            local issue_number
+            local issue_body
+            issue_number=$(jq -r '.number' <<< "$issue_json")
+            issue_body=$(jq -r '.body // ""' <<< "$issue_json")
+            local marker
+            while IFS= read -r marker; do
+                # read removes LF but leaves CR from a CRLF-delimited GitHub body.
+                # Remove only that terminator; spaces or any other trailing text
+                # remain part of the marker and therefore fail the strict match.
+                marker="${marker%$'\r'}"
+                if [[ "$marker" =~ ^rotation-pair:\ ([a-zA-Z0-9_-]+)\ pg([0-9]+)\ ([0-9]+([.][0-9]+)*)$ ]]; then
+                    local marker_key="${BASH_REMATCH[1]}|${BASH_REMATCH[2]}|${BASH_REMATCH[3]}"
+                    if [[ -n "${pair_seen[$marker_key]:-}" ]]; then
+                        blocked_pair[$marker_key]=1
+                        log_info "Blocking marker #${issue_number}: ${marker} — matched current pair"
+                    else
+                        log_info "Blocking marker #${issue_number}: ${marker} — did not match a current pair"
+                    fi
+                fi
+            done <<< "$issue_body"
+        done <<< "$issue_records"
+    fi
+
+    if [[ "$issue_failure" == true ]]; then
+        printf 'No pair selected: blocking-issue state is incomplete; candidate set is unknown.\n'
+        _write_selection false "" "" ""
+        return 1
+    fi
+
+    local -A freshness_by_pair=()
+    local -A eligibility_by_pair=()
+    local -A age_by_pair=()
+    local selected_extension=""
+    local selected_major=""
+    local selected_version=""
+    local selected_age=-1
+    local selected_priority=-1
+    local selected_key=""
+    local canonical_tag
+    local record_json
+    local updated_at
+    local updated_epoch
+    local age_days
+    local pair_key
+    local blocked_candidate_count=0
+    local record_matches
+    local record_count
+
+    while IFS=$'\t' read -r ext_name pg_major version; do
+        pair_key="${ext_name}|${pg_major}|${version}"
+        canonical_tag="pg${pg_major}-${version}"
+        record_matches=$(jq -c --arg tag "$canonical_tag" '[.[] | select(any(.tags[]?; . == $tag))]' <<< "${records_by_extension[$ext_name]}")
+        record_count=$(jq -r 'length' <<< "$record_matches")
+        if [[ "$record_count" -ne 1 ]]; then
+            freshness_by_pair[$pair_key]=UNKNOWN
+            age_by_pair[$pair_key]=unknown
+            eligibility_by_pair[$pair_key]=$([[ -n "${blocked_pair[$pair_key]:-}" ]] && printf BLOCKED || printf ELIGIBLE)
+            [[ -z "${blocked_pair[$pair_key]:-}" ]] || ((blocked_candidate_count += 1))
+            # UNKNOWN has priority over dated pairs: an absent canonical record
+            # (or an inconsistent observation) means this pair was never built,
+            # was pruned, or cannot be judged. Ties use the lexical
+            # extension|major|version key, independent of config order.
+            if [[ -z "${blocked_pair[$pair_key]:-}" && ( "$selected_priority" -lt 2 || ( "$selected_priority" -eq 2 && "$pair_key" < "$selected_key" ) ) ]]; then
+                selected_extension="$ext_name"
+                selected_major="$pg_major"
+                selected_version="$version"
+                selected_age=-1
+                selected_priority=2
+                selected_key="$pair_key"
+            fi
+            continue
+        fi
+
+        record_json=$(jq -c '.[0]' <<< "$record_matches")
+
+        updated_at=$(jq -r '.updated_at // ""' <<< "$record_json")
+        if ! _valid_timestamp "$updated_at" || ! updated_epoch=$(date -d "$updated_at" +%s 2>/dev/null) || ((updated_epoch > now_epoch + future_timestamp_tolerance_seconds)); then
+            freshness_by_pair[$pair_key]=UNKNOWN
+            age_by_pair[$pair_key]=unknown
+            eligibility_by_pair[$pair_key]=$([[ -n "${blocked_pair[$pair_key]:-}" ]] && printf BLOCKED || printf ELIGIBLE)
+            [[ -z "${blocked_pair[$pair_key]:-}" ]] || ((blocked_candidate_count += 1))
+            # UNKNOWN has priority over dated pairs; lexical key breaks its tie.
+            if [[ -z "${blocked_pair[$pair_key]:-}" && ( "$selected_priority" -lt 2 || ( "$selected_priority" -eq 2 && "$pair_key" < "$selected_key" ) ) ]]; then
+                selected_extension="$ext_name"
+                selected_major="$pg_major"
+                selected_version="$version"
+                selected_age=-1
+                selected_priority=2
+                selected_key="$pair_key"
+            fi
+            continue
+        fi
+
+        age_days=$(( (now_epoch - updated_epoch) / 86400 ))
+        if [[ "$age_days" -lt 0 ]]; then
+            age_days=0
+        fi
+        age_by_pair[$pair_key]="$age_days"
+        if [[ -n "${blocked_pair[$pair_key]:-}" ]]; then
+            eligibility_by_pair[$pair_key]=BLOCKED
+            if [[ "$age_days" -ge "$staleness_days" ]]; then
+                freshness_by_pair[$pair_key]=OVERDUE
+                ((blocked_candidate_count += 1))
+            else
+                freshness_by_pair[$pair_key]=FRESH
+            fi
+        elif [[ "$age_days" -ge "$staleness_days" ]]; then
+            freshness_by_pair[$pair_key]=OVERDUE
+            eligibility_by_pair[$pair_key]=ELIGIBLE
+            # Among dated overdue pairs, age wins; equal ages use the same
+            # lexical extension|major|version key as UNKNOWN pairs.
+            if [[ "$selected_priority" -lt 1 || ( "$selected_priority" -eq 1 && ( "$age_days" -gt "$selected_age" || ( "$age_days" -eq "$selected_age" && "$pair_key" < "$selected_key" ) ) ) ]]; then
+                selected_extension="$ext_name"
+                selected_major="$pg_major"
+                selected_version="$version"
+                selected_age="$age_days"
+                selected_priority=1
+                selected_key="$pair_key"
+            fi
+        else
+            freshness_by_pair[$pair_key]=FRESH
+            eligibility_by_pair[$pair_key]=ELIGIBLE
+        fi
+    done < "$pairs_file"
+
+    _print_table "$pairs_file"
+
+    if [[ -n "$selected_extension" ]]; then
+        if [[ "$selected_priority" -eq 2 ]]; then
+            printf 'Selected pair: %s pg%s %s (freshness UNKNOWN)\n' \
+                "$selected_extension" "$selected_major" "$selected_version"
+        else
+            printf 'Selected pair: %s pg%s %s (%s days overdue)\n' \
+                "$selected_extension" "$selected_major" "$selected_version" "$((selected_age - staleness_days))"
+        fi
+        _write_selection true "$selected_extension" "$selected_major" "$selected_version"
+    elif ((blocked_candidate_count > 0)); then
+        printf 'No pair selected: every selection candidate is blocked.\n'
+        _write_selection false "" "" ""
+    else
+        printf 'Nothing is overdue.\n'
+        _write_selection false "" "" ""
+    fi
+}
+
+main "$@"

--- a/tests/unit/rotation-select.bats
+++ b/tests/unit/rotation-select.bats
@@ -1,0 +1,604 @@
+#!/usr/bin/env bats
+
+# End-to-end tests for the read-only extension rotation selector.  The real
+# config supplies the pair universe; gh is the only mocked process boundary.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export GH_TOKEN="test-token"
+    export OWNER="test-owner"
+    export EXT_CONFIG="$PROJECT_ROOT/postgres/extensions/config.yaml"
+    export GH_FIXTURE_DIR="$TEST_TEMP_DIR/ghcr"
+    export GH_ISSUES_JSON='[]'
+    export GH_API_MODE="success"
+    export GH_ISSUE_MODE="success"
+    export GH_REPO_MODE="success"
+    export GH_CALLS_FILE="$TEST_TEMP_DIR/gh-calls"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github-output"
+    export GH_STUB_PROBE=""
+    mkdir -p "$GH_FIXTURE_DIR"
+    : > "$GH_CALLS_FILE"
+    : > "$GITHUB_OUTPUT"
+    _write_fresh_registry
+}
+
+teardown() {
+    teardown_temp_dir
+    unset GH_TOKEN OWNER EXT_CONFIG GH_FIXTURE_DIR GH_ISSUES_JSON GH_API_MODE GH_ISSUE_MODE GH_REPO_MODE GH_CALLS_FILE GITHUB_OUTPUT GH_STUB_PROBE STALENESS_DAYS
+}
+
+_write_fresh_registry() {
+    local ext_name
+    local version
+    local pg_major
+    local records
+    local record
+    local fresh_updated_at
+
+    fresh_updated_at=$(date -u -d '7 days ago' +'%Y-%m-%dT%H:%M:%SZ')
+
+    while IFS=' ' read -r ext_name version; do
+        records='[]'
+        while IFS= read -r pg_major; do
+            record=$(jq -cn --arg tag "pg${pg_major}-${version}" --arg fresh_updated_at "$fresh_updated_at" '[{
+                id: 1,
+                name: "sha256:test",
+                updated_at: $fresh_updated_at,
+                metadata: {container: {tags: [$tag]}}
+            }]')
+            records=$(jq -c --argjson record "$record" '. + $record' <<< "$records")
+        done < <(yq -r '.pg_versions[]' "$EXT_CONFIG")
+        printf '%s\n' "$records" > "$GH_FIXTURE_DIR/ext-${ext_name}.json"
+    done < <(yq -r '.extensions | to_entries[] | .key + " " + .value.version' "$EXT_CONFIG")
+}
+
+_set_pair_updated_at() {
+    local ext_name="$1"
+    local pg_major="$2"
+    local version="$3"
+    local updated_at="$4"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq --arg tag "pg${pg_major}-${version}" --arg updated_at "$updated_at" '
+      map(if any(.metadata.container.tags[]; . == $tag) then .updated_at = $updated_at else . end)
+    ' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+}
+
+_remove_pair_updated_at() {
+    local ext_name="$1"
+    local pg_major="$2"
+    local version="$3"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq --arg tag "pg${pg_major}-${version}" '
+      map(if any(.metadata.container.tags[]; . == $tag) then del(.updated_at) else . end)
+    ' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+}
+
+_remove_canonical_record() {
+    local ext_name="$1"
+    local pg_major="$2"
+    local version="$3"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq --arg tag "pg${pg_major}-${version}" '
+      map(select(any(.metadata.container.tags[]; . == $tag) | not))
+    ' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+}
+
+_duplicate_canonical_record() {
+    local ext_name="$1"
+    local pg_major="$2"
+    local version="$3"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq --arg tag "pg${pg_major}-${version}" '
+      . as $records
+      | $records + [$records[] | select(any(.metadata.container.tags[]; . == $tag))]
+    ' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+}
+
+_expected_full_pairs() {
+    local pg_major
+    while IFS= read -r pg_major; do
+        pgver="$pg_major" yq -r '
+          . as $root
+          | .flavors.full[] as $ext_name
+          | select(
+              ($root.extensions[$ext_name].disabled == true | not) and
+              (($root.extensions[$ext_name].max_pg_version // 999) >= (strenv(pgver) | tonumber))
+            )
+          | [$ext_name, strenv(pgver), $root.extensions[$ext_name].version]
+          | @tsv
+        ' "$EXT_CONFIG"
+    done < <(yq -r '.pg_versions[]' "$EXT_CONFIG") | LC_ALL=C sort -u
+}
+
+_run_selector() {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        EXT_CONFIG="$EXT_CONFIG" \
+        GH_FIXTURE_DIR="$GH_FIXTURE_DIR" \
+        GH_ISSUES_JSON="$GH_ISSUES_JSON" \
+        GH_API_MODE="$GH_API_MODE" \
+        GH_ISSUE_MODE="$GH_ISSUE_MODE" \
+        GH_REPO_MODE="$GH_REPO_MODE" \
+        GH_CALLS_FILE="$GH_CALLS_FILE" \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        GH_STUB_PROBE="$GH_STUB_PROBE" \
+        STALENESS_DAYS="${STALENESS_DAYS:-}" \
+        bash -c '
+            gh() {
+                printf "%s\\n" "$*" >> "$GH_CALLS_FILE"
+                if [[ "${1:-}" == "api" && "$#" -eq 7 && "${2:-}" == "-H" && "${3:-}" == "Accept: application/vnd.github+json" && "${4:-}" == "-H" && "${5:-}" == "X-GitHub-Api-Version: 2022-11-28" && "${6:-}" == "/users/${OWNER}/packages/container/ext-"*"/versions" && "${7:-}" == "--paginate" ]]; then
+                    [[ "$GH_API_MODE" != "fail" ]] || return 1
+                    if [[ "$GH_API_MODE" == "empty-output" ]]; then
+                        return 0
+                    fi
+                    if [[ "$GH_API_MODE" == "invalid-json" ]]; then
+                        printf "{\\n"
+                        return 0
+                    fi
+                    local arg endpoint=""
+                    for arg in "$@"; do
+                        [[ "$arg" == /users/*/packages/container/*/versions ]] && endpoint="$arg"
+                    done
+                    local package_name="${endpoint%/versions}"
+                    package_name="${package_name##*/}"
+                    cat "$GH_FIXTURE_DIR/${package_name}.json"
+                    return
+                fi
+
+                if [[ "${1:-}" == "repo" && "$#" -eq 6 && "${2:-}" == "view" && "${3:-}" == "--json" && "${4:-}" == "nameWithOwner" && "${5:-}" == "--jq" && "${6:-}" == ".nameWithOwner" ]]; then
+                    [[ "$GH_REPO_MODE" != "fail" ]] || return 1
+                    printf "%s\\n" "test-owner/test-repository"
+                    return
+                fi
+
+                if [[ "${1:-}" == "issue" && "$#" -eq 12 && "${2:-}" == "list" && "${3:-}" == "--repo" && "${4:-}" == "test-owner/test-repository" && "${5:-}" == "--state" && "${6:-}" == "open" && "${7:-}" == "--label" && "${8:-}" == "extension-rotation-blocked" && "${9:-}" == "--json" && "${10:-}" == "number,body" && "${11:-}" == "--limit" && "${12:-}" == "1000" ]]; then
+                    [[ "$GH_ISSUE_MODE" != "fail" ]] || return 1
+                    printf "%s\\n" "$GH_ISSUES_JSON"
+                    return
+                fi
+
+                printf "%s\\n" "unexpected gh invocation: $*" >&2
+                return 98
+            }
+            export -f gh
+            case "$GH_STUB_PROBE" in
+                "") ;;
+                api-form) gh api -f data=one /users/test-owner/packages/container/ext-pgvector/versions; exit $? ;;
+                api-input) gh api --input payload.json /users/test-owner/packages/container/ext-pgvector/versions; exit $? ;;
+                api-graphql) gh api graphql -f query="query { viewer { login } }"; exit $? ;;
+                *) printf "%s\\n" "unknown gh stub probe: $GH_STUB_PROBE" >&2; exit 99 ;;
+            esac
+            exec "$PROJECT_ROOT/scripts/rotation-select.sh"
+        '
+}
+
+_output_value() {
+    local name="$1"
+    sed -n "s/^${name}=//p" "$GITHUB_OUTPUT" | tail -1
+}
+
+@test "all fresh pairs select nothing and emit all output keys" {
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Nothing is overdue."* ]]
+    [[ "$(awk -F '\t' 'NF == 6 && $1 != "EXTENSION" { count++ } END { print count + 0 }' <<< "$output")" -eq "$(wc -l < <(_expected_full_pairs))" ]]
+    [[ "$(_output_value selected)" == "false" ]]
+    [[ -z "$(_output_value extension)" ]]
+    [[ -z "$(_output_value major)" ]]
+    [[ -z "$(_output_value version)" ]]
+}
+
+@test "a single overdue pair is selected" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\t'*$'\tOVERDUE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6"* ]]
+    [[ "$(_output_value selected)" == "true" ]]
+    [[ "$(_output_value extension)" == "pgvector" ]]
+    [[ "$(_output_value major)" == "17" ]]
+    [[ "$(_output_value version)" == "0.8.6" ]]
+}
+
+@test "the oldest of two overdue pairs wins" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2021-01-01T00:00:00Z"
+    _set_pair_updated_at postgis 18 3.6.4 "2020-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Selected pair: postgis pg18 3.6.4"* ]]
+}
+
+@test "an absent canonical record selects ahead of a dated overdue pair" {
+    _remove_canonical_record pgvector 17 0.8.6
+    _set_pair_updated_at postgis 18 3.6.4 "2020-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+    [[ "$(_output_value selected)" == "true" ]]
+}
+
+@test "a recent amd64 sibling cannot make an old multi-arch record fresh" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+    local fixture="$GH_FIXTURE_DIR/ext-pgvector.json"
+    jq '. + [{
+      id: 99,
+      name: "sha256:amd64",
+      updated_at: "2099-01-01T00:00:00Z",
+      metadata: {container: {tags: ["pg17-0.8.6-amd64"]}}
+    }]' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\t'*$'\tOVERDUE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6"* ]]
+}
+
+@test "a record carrying only amd64 is UNKNOWN and is selected" {
+    local fixture="$GH_FIXTURE_DIR/ext-pgvector.json"
+    jq 'map(select(any(.metadata.container.tags[]; . != "pg17-0.8.6"))) + [{
+      id: 100,
+      name: "sha256:amd64-only",
+      updated_at: "2099-01-01T00:00:00Z",
+      metadata: {container: {tags: ["pg17-0.8.6-amd64"]}}
+    }]' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "missing updated_at is UNKNOWN and selects ahead of a dated overdue pair" {
+    _remove_pair_updated_at pgvector 17 0.8.6
+    _set_pair_updated_at postgis 18 3.6.4 "2020-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "malformed updated_at is UNKNOWN and selects ahead of a dated overdue pair" {
+    _set_pair_updated_at pgvector 17 0.8.6 "not-a-date"
+    _set_pair_updated_at postgis 18 3.6.4 "2020-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "a canonical record dated beyond five minutes in the future is UNKNOWN and a candidate" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2099-01-01T00:00:00Z"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "two canonical records do not yield a freshness verdict" {
+    _duplicate_canonical_record pgvector 17 0.8.6
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "GHCR API failure selects nothing and exits non-zero" {
+    export GH_API_MODE="fail"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"Selected pair:"* ]]
+    [[ "$output" == *"GHCR version listing failed"* ]]
+}
+
+@test "invalid GHCR JSON selects nothing and exits non-zero" {
+    export GH_API_MODE="invalid-json"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"Selected pair:"* ]]
+    [[ "$output" == *"GHCR version listing failed"* ]]
+}
+
+@test "a zero-byte GHCR response refuses instead of becoming an empty registry" {
+    export GH_API_MODE="empty-output"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"GHCR version listing failed"* ]]
+    [[ "$output" != *$'pgvector\t17\t0.8.6\tunknown'* ]]
+}
+
+@test "blocking issue query failure selects nothing and exits non-zero" {
+    export GH_ISSUE_MODE="fail"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"Selected pair:"* ]]
+    [[ "$output" == *"Could not list open extension-rotation-blocked issues"* ]]
+}
+
+@test "blocking issue listing is scoped to the configuration repository" {
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    grep -Fx -- 'repo view --json nameWithOwner --jq .nameWithOwner' "$GH_CALLS_FILE"
+    grep -Fx -- 'issue list --repo test-owner/test-repository --state open --label extension-rotation-blocked --json number,body --limit 1000' "$GH_CALLS_FILE"
+}
+
+@test "an unresolvable configuration repository selects nothing and exits non-zero" {
+    export GH_REPO_MODE="fail"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"Selected pair:"* ]]
+    [[ "$output" == *"Could not establish the repository for extension rotation"* ]]
+    ! grep -q '^issue list ' "$GH_CALLS_FILE"
+}
+
+@test "a current blocking issue moves selection to the next-oldest pair" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+    _set_pair_updated_at postgis 18 3.6.4 "2021-01-01T00:00:00Z"
+    export GH_ISSUES_JSON='[{"number": 1246, "body": "rotation-pair: pgvector pg17 0.8.6"}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Blocking marker #1246: rotation-pair: pgvector pg17 0.8.6 — matched current pair"* ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\t'*$'\tOVERDUE\tBLOCKED'* ]]
+    [[ "$output" == *"Selected pair: postgis pg18 3.6.4"* ]]
+}
+
+@test "a blocked UNKNOWN pair is distinguishable from an eligible UNKNOWN pair" {
+    _remove_pair_updated_at pgvector 17 0.8.6
+    _set_pair_updated_at postgis 18 3.6.4 "2020-01-01T00:00:00Z"
+    export GH_ISSUES_JSON='[{"number": 1248, "body": "rotation-pair: pgvector pg17 0.8.6"}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tBLOCKED'* ]]
+    [[ "$output" == *"Selected pair: postgis pg18 3.6.4"* ]]
+    [[ "$output" != *"Selected pair: pgvector pg17 0.8.6"* ]]
+}
+
+@test "two UNKNOWN pairs choose the lexical winner regardless configured order" {
+    _remove_pair_updated_at pgvector 17 0.8.6
+    _remove_pair_updated_at postgis 18 3.6.4
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+
+    local reversed_config="$TEST_TEMP_DIR/reversed-full-config.yaml"
+    yq '.flavors.full |= reverse' "$EXT_CONFIG" > "$reversed_config"
+    export EXT_CONFIG="$reversed_config"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (freshness UNKNOWN)"* ]]
+}
+
+@test "the selector uses only the documented gh read allowlist on a successful path" {
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "a stale-version blocking issue matches nothing" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+    export GH_ISSUES_JSON='[{"number": 1247, "body": "rotation-pair: pgvector pg17 0.8.5"}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Blocking marker #1247: rotation-pair: pgvector pg17 0.8.5 — did not match a current pair"* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6"* ]]
+}
+
+@test "an invalid STALENESS_DAYS is rejected before gh is called" {
+    export STALENESS_DAYS="0"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"STALENESS_DAYS must be an integer from 1 through 9999 days"* ]]
+    [[ ! -s "$GH_CALLS_FILE" ]]
+}
+
+@test "a non-digit STALENESS_DAYS is rejected before gh is called" {
+    export STALENESS_DAYS="thirty"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"STALENESS_DAYS must be an integer from 1 through 9999 days"* ]]
+    [[ ! -s "$GH_CALLS_FILE" ]]
+}
+
+@test "the largest accepted STALENESS_DAYS is accepted" {
+    export STALENESS_DAYS="9999"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Nothing is overdue."* ]]
+}
+
+@test "out-of-range STALENESS_DAYS values are rejected before gh is called" {
+    local days
+    for days in 10000 9223372036854775808; do
+        export STALENESS_DAYS="$days"
+
+        _run_selector
+
+        [[ "$status" -ne 0 ]]
+        [[ "$output" == *"STALENESS_DAYS must be an integer from 1 through 9999 days"* ]]
+        [[ ! -s "$GH_CALLS_FILE" ]]
+    done
+}
+
+@test "an extension config rejected by the shared schema validator is not read" {
+    local invalid_config="$TEST_TEMP_DIR/invalid-config.yaml"
+    cp "$EXT_CONFIG" "$invalid_config"
+    sed -i '0,/^  pgvector:/s//  "::warning::forged":/' "$invalid_config"
+    export EXT_CONFIG="$invalid_config"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Extension config failed schema validation"* ]]
+    [[ ! -s "$GH_CALLS_FILE" ]]
+}
+
+@test "a CRLF-terminated blocking marker blocks its pair" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+    _set_pair_updated_at postgis 18 3.6.4 "2021-01-01T00:00:00Z"
+    export GH_ISSUES_JSON=$'[{"number": 1250, "body": "rotation-pair: pgvector pg17 0.8.6\\r\\n"}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\t'*$'\tOVERDUE\tBLOCKED'* ]]
+    [[ "$output" == *"Selected pair: postgis pg18 3.6.4"* ]]
+}
+
+@test "a blocking marker with trailing text or spaces does not block its pair" {
+    _set_pair_updated_at pgvector 17 0.8.6 "2020-01-01T00:00:00Z"
+    export GH_ISSUES_JSON='[{"number": 1251, "body": "rotation-pair: pgvector pg17 0.8.6 trailing\nrotation-pair: pgvector pg17 0.8.6 "}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\t'*$'\tOVERDUE\tELIGIBLE'* ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6"* ]]
+}
+
+@test "a registry failure prints no per-pair status rows" {
+    export GH_API_MODE="fail"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *$'EXTENSION\tMAJOR\tCEILING\tAGE_DAYS'* ]]
+    [[ "$output" != *$'pgvector\t17\t0.8.6'* ]]
+}
+
+@test "an issue listing at the cap refuses to select" {
+    export GH_ISSUES_JSON
+    GH_ISSUES_JSON=$(jq -cn '[range(1; 1001) | {number: ., body: ""}]')
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"reached the 1000-issue cap"* ]]
+    [[ "$output" != *"Selected pair:"* ]]
+}
+
+@test "an OWNER different from the resolved repository owner refuses to select" {
+    export OWNER="upstream-owner"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"does not match rotation repository owner"* ]]
+    [[ "$output" != *"Selected pair:"* ]]
+    ! grep -q '^api ' "$GH_CALLS_FILE"
+}
+
+@test "every blocked candidate, including an undated one, is not reported as nothing overdue" {
+    _remove_pair_updated_at pgvector 17 0.8.6
+    export GH_ISSUES_JSON='[{"number": 1252, "body": "rotation-pair: pgvector pg17 0.8.6"}]'
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *$'pgvector\t17\t0.8.6\tunknown\tUNKNOWN\tBLOCKED'* ]]
+    [[ "$output" == *"every selection candidate is blocked"* ]]
+    [[ "$output" != *"Nothing is overdue."* ]]
+}
+
+@test "a carriage return in a version refuses before the pair stream or gh" {
+    local invalid_config="$TEST_TEMP_DIR/cr-version-config.yaml"
+    cp "$EXT_CONFIG" "$invalid_config"
+    local invalid_version=$'1.2.3\rselected=false'
+    invalid_version="$invalid_version" yq -i '.extensions.pgvector.version = strenv(invalid_version)' "$invalid_config"
+    export EXT_CONFIG="$invalid_config"
+
+    _run_selector
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Invalid ceiling version for pgvector/pg18; expected a numeric-dotted version"* ]]
+    [[ ! -s "$GH_CALLS_FILE" ]]
+    [[ "$(cat "$GITHUB_OUTPUT")" == $'selected=false\nextension=\nmajor=\nversion=' ]]
+}
+
+@test "a quote in TMPDIR cannot execute trap text" {
+    local trap_probe="$TEST_TEMP_DIR/trap-probe"
+    local quoted_tmpdir="${TEST_TEMP_DIR}/tmp'\$(touch ${trap_probe})'"
+    mkdir -p "$quoted_tmpdir"
+    export TMPDIR="$quoted_tmpdir"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ ! -e "$trap_probe" ]]
+}
+
+@test "the selected overdue count excludes the threshold" {
+    _set_pair_updated_at pgvector 17 0.8.6 "$(date -u -d '31 days ago' +'%Y-%m-%dT%H:%M:%SZ')"
+
+    _run_selector
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Selected pair: pgvector pg17 0.8.6 (1 days overdue)"* ]]
+}
+
+@test "the read-only gh allowlist rejects form, input, and GraphQL API calls" {
+    local probe
+    for probe in api-form api-input api-graphql; do
+        export GH_STUB_PROBE="$probe"
+        _run_selector
+        [[ "$status" -eq 98 ]]
+        [[ "$output" == *"unexpected gh invocation"* ]]
+    done
+}


### PR DESCRIPTION
`postgis` could not be compiled for months. The extension reuse predicate is tag presence, which carries no recipe input, so a recipe nobody edits is never exercised — and nothing here could answer "when was pgvector for PostgreSQL 17 last built?".

`scripts/rotation-select.sh` prints the age of every `(extension, major)` pair from the GHCR version record carrying that pair's canonical multi-arch tag, and names the single most overdue one. It builds nothing, writes nothing outside stdout and `$GITHUB_OUTPUT`, and no workflow calls it yet. It is the first of three parts of #1245; the second adds the no-cache compile and the digest-pinned consume contract, the third the scheduled workflow and its publish step.

Design decisions worth stating:

- **Freshness comes from the multi-arch record alone.** The `-amd64` and `-arm64` tags are rewritten before any test verdict exists, so reading their timestamp would call a failed build fresh.
- **A pair with no record, or an undated one, is selected first** rather than treated as an error. It is the pair most in need of a build; making it fatal would let one pruned record stop rotation for ever.
- **Only an unreadable registry or issue listing refuses to select.** With an incomplete candidate set, "most overdue" has no meaning.
- **A pair named by an open `extension-rotation-blocked` issue is skipped**, so one failing pair cannot win every run and starve the other twenty-nine. The marker carries the ceiling version, so a version bump cannot stay blocked by an issue about the version before it.

`helpers/ghcr-package-utils.sh` becomes the one reader of the GHCR package-versions API for `ext-*` packages; `cleanup-ext-images.sh` loses its private copy. One behaviour changes there: a malformed API response now fails that path closed instead of yielding records built from it.

**Verification.** shellcheck `-x -S warning` clean; 2580 unit tests green through `tests/run-tests.sh`; each negative property ships with a test proven to fail under a named mutation.

**Landed at its round budget.** Residue filed rather than fixed: #1252 (tests coupled to live extension versions), #1254 (three tests that do not establish what their names claim), #1255 (whole-day truncation in the tie-break, and the accepted spelling of the threshold), #1256 (failure paths that skip the output record). Pre-existing and untouched: #1247, #1248, #1250, #1251.

Refs #1245
