### PR TITLE
Refuse a YAML pathname that yamllint's output would execute

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -84,8 +84,9 @@ jobs:
           install_package 'yamllint==1.37.1' "$yamllint_dir/requirements/yamllint.txt"
 
           "$yamllint_venv/bin/yamllint" --version
-          find . -type f \( -name config.yaml -o -name variants.yaml \) \
-            -not -path './.git/*' -print0 | xargs -0 "$yamllint_venv/bin/yamllint" -c .yamllint.yml
+          # Run yamllint only after this search has collected and validated every YAML pathname.
+          ./scripts/collect-safe-paths.sh . -type f \( -name config.yaml -o -name variants.yaml \) \
+            -not -path './.git/*' | xargs -r -0 "$yamllint_venv/bin/yamllint" -c .yamllint.yml
 
       - name: Run shellcheck on scripts
         run: |
@@ -93,44 +94,18 @@ jobs:
 
           scripts=()
 
-          # Discovery has to fail closed, and a find inside a process
-          # substitution does the opposite: it reports nothing when it fails,
-          # the reading loop then ends normally, and a scan that broke is
-          # indistinguishable from a repository holding no scripts — on which
-          # this job reports every one of them passing. Every collector
-          # therefore goes through here, where the search completes into a file
-          # whose pipeline status is checked, under pipefail, before a single
-          # path is added.
-          #
-          # Paths are carried NUL-delimited so a newline in one cannot split a
-          # single entry into several, and what may then be linted is confined
-          # to an allowlist of characters rather than escaped wherever it is
-          # later printed. The failure list is interpolated into the step
-          # summary as Markdown and into the log, so a backtick, a newline, a
-          # carriage return or a colon in a pathname can close a code span,
-          # forge a link, or open a workflow command in either sink. Escaping
-          # each sink means getting every sink right for ever; refusing the
-          # character set at the one point where a path enters means the sinks
-          # can only ever receive names that are inert in both.
+          # This collector covers pathnames produced by its searches; shellcheck -x sources and the project-root scripts appended below are outside this boundary.
           collect() {
-            local sorted f bad=
-            sorted=$(mktemp)
-            if ! find "$@" -print0 | sort -z > "$sorted"; then
-              rm -f "$sorted"
-              echo "::error::script discovery failed: find $*"
-              exit 1
+            local collected f
+            collected=$(mktemp)
+            if ! ./scripts/collect-safe-paths.sh "$@" > "$collected"; then
+              rm -f "$collected"
+              return 1
             fi
             while IFS= read -r -d '' f; do
-              case $f in
-                *[!A-Za-z0-9._/-]*) bad=$f; break ;;
-              esac
               scripts+=("$f")
-            done < "$sorted"
-            rm -f "$sorted"
-            if [[ -n $bad ]]; then
-              echo "::error::refusing to lint a path outside [A-Za-z0-9._/-]: $(printf '%q' "$bad")"
-              exit 1
-            fi
+            done < "$collected"
+            rm -f "$collected"
           }
 
           # Collect build-system shell scripts only (not container runtime scripts)

--- a/docs/WORKFLOW_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ARCHITECTURE.md
@@ -161,7 +161,7 @@ gh workflow run recreate-manifests.yaml -f container=postgres
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `shellcheck.yaml` | push, PR | Lint all `.sh` scripts with shellcheck |
+| `shellcheck.yaml` | push, PR | Lint the build-system, version and test shell scripts with shellcheck, and the YAML config files with yamllint. Container runtime scripts are deliberately excluded |
 | `validate-version-scripts.yaml` | PR (version.sh changes) | Validate version.sh scripts can run |
 | `sync-dockerhub-readme.yaml` | push (README changes) | Sync README.md to Docker Hub descriptions |
 | `cleanup-registry.yaml` | schedule (monthly) | Delete old GHCR images per retention policy |

--- a/scripts/collect-safe-paths.sh
+++ b/scripts/collect-safe-paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Collect find results that are safe to pass to linters and to render in CI.
+#
+# Keep this decision in one executable instead of copying the allowlist into
+# workflow run blocks. A later linter must route pathnames it discovers by
+# search through this collector: it withholds every pathname until find has
+# succeeded and every result has passed the boundary, so its command cannot
+# start after a hostile pathname was found.
+
+set -euo pipefail
+
+# The pathname allowlist is ASCII bytes, regardless of the caller's locale or
+# Bash's range-expression behavior.
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+main() {
+    local paths_file path bad_path=
+
+    # Workflow callers use repository-relative find roots and predicates.
+    cd "$ROOT_DIR"
+
+    paths_file=$(mktemp)
+    # Do not put find in a process substitution: the consumer could see an
+    # empty list when find failed. With pipefail, the completed result is only
+    # considered usable after both find and sort have succeeded.
+    if ! find "$@" -print0 | sort -z > "$paths_file"; then
+        rm -f "$paths_file"
+        printf '%s\n' '::error::safe path discovery failed' >&2
+        return 1
+    fi
+
+    while IFS= read -r -d '' path; do
+        case $path in
+            *[!A-Za-z0-9._/-]*)
+                bad_path=$path
+                break
+                ;;
+        esac
+    done < "$paths_file"
+
+    if [[ -n $bad_path ]]; then
+        rm -f "$paths_file"
+        printf '%s\n' '::error::refusing to lint a path outside [A-Za-z0-9._/-]' >&2
+        printf 'rejected pathname: %q\n' "$bad_path" >&2
+        return 1
+    fi
+
+    if cat "$paths_file"; then
+        rm -f "$paths_file"
+    else
+        local status=$?
+        rm -f "$paths_file"
+        return "$status"
+    fi
+}
+
+main "$@"

--- a/tests/unit/collect-safe-paths.bats
+++ b/tests/unit/collect-safe-paths.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+load "../test_helper"
+
+setup() {
+    export TEST_TEMP_DIR
+    TEST_TEMP_DIR=$(mktemp -d)
+    COLLECTOR="$SCRIPTS_DIR/collect-safe-paths.sh"
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+    [[ -z ${COLLECTED_OUTPUT:-} ]] || rm -f "$COLLECTED_OUTPUT"
+}
+
+assert_constant_refusal() {
+    if [[ "$(grep '^::error::' <<<"$output")" != '::error::refusing to lint a path outside [A-Za-z0-9._/-]' ]]; then
+        echo "FAIL: rejected pathname entered a workflow-command line" >&3
+        return 1
+    fi
+}
+
+@test "accepts an ordinary pathname and emits it NUL-delimited" {
+    mkdir -p "$TEST_TEMP_DIR/ordinary"
+    touch "$TEST_TEMP_DIR/ordinary/config.yaml"
+
+    run bash -c 'set -o pipefail; "$1" "$2" -type f | tr "\\0" "\\n"' _ "$COLLECTOR" "$TEST_TEMP_DIR"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_TEMP_DIR/ordinary/config.yaml" ]
+}
+
+@test "emits two accepted pathnames with a NUL after each pathname" {
+    local collected expected
+    touch "$TEST_TEMP_DIR/alpha.yaml" "$TEST_TEMP_DIR/zeta.yaml"
+    collected=$(mktemp)
+    COLLECTED_OUTPUT=$collected
+    expected=$(printf '%s\0%s\0' "$TEST_TEMP_DIR/alpha.yaml" "$TEST_TEMP_DIR/zeta.yaml" | od -An -t x1 -v)
+
+    run bash -c '"$1" "$2" -maxdepth 1 -type f > "$3"; od -An -t x1 -v "$3"' _ \
+        "$COLLECTOR" "$TEST_TEMP_DIR" "$collected"
+
+    [ "$status" -eq 0 ]
+    if [[ "$output" != "$expected" ]]; then
+        echo "FAIL: collector output was not exactly two NUL-delimited pathnames" >&3
+        return 1
+    fi
+}
+
+@test "rejects a pathname containing a space before emitting paths" {
+    local collected
+    mkdir -p "$TEST_TEMP_DIR/bad path"
+    touch "$TEST_TEMP_DIR/bad path/config.yaml"
+    collected="$TEST_TEMP_DIR/collected"
+
+    run bash -c '"$1" "$2" -type f > "$3"' _ "$COLLECTOR" "$TEST_TEMP_DIR" "$collected"
+
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: unsafe pathname was accepted"
+        return 1
+    fi
+    [[ "$output" == *"::error::refusing to lint a path outside [A-Za-z0-9._/-]"* ]]
+    [[ "$output" == *"rejected pathname: "* ]]
+    [[ "$output" == *'bad\ path'* ]]
+    assert_constant_refusal
+    [ ! -s "$collected" ]
+}
+
+@test "rejects a pathname containing a newline before emitting paths" {
+    local collected newline_path
+    newline_path="${TEST_TEMP_DIR}/"$'bad\npath'
+    mkdir -p "$newline_path"
+    touch "$newline_path/config.yaml"
+    collected="$TEST_TEMP_DIR/collected"
+
+    run bash -c '"$1" "$2" -type f > "$3"' _ "$COLLECTOR" "$TEST_TEMP_DIR" "$collected"
+
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: unsafe pathname was accepted"
+        return 1
+    fi
+    [[ "$output" == *"::error::refusing to lint a path outside [A-Za-z0-9._/-]"* ]]
+    [[ "$output" == *"rejected pathname: "* ]]
+    [[ "$output" == *"\$'"* ]]
+    [[ "$output" == *"bad\\npath"* ]]
+    assert_constant_refusal
+    [ ! -s "$collected" ]
+}
+
+@test "rejects a pathname containing workflow-command colons" {
+    local collected
+    mkdir -p "$TEST_TEMP_DIR/bad::command"
+    touch "$TEST_TEMP_DIR/bad::command/config.yaml"
+    collected="$TEST_TEMP_DIR/collected"
+
+    run bash -c '"$1" "$2" -type f > "$3"' _ "$COLLECTOR" "$TEST_TEMP_DIR" "$collected"
+
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: unsafe pathname was accepted"
+        return 1
+    fi
+    [[ "$output" == *"::error::refusing to lint a path outside [A-Za-z0-9._/-]"* ]]
+    [[ "$output" == *"rejected pathname: "* ]]
+    [[ "$output" == *bad::command* ]]
+    assert_constant_refusal
+    [ ! -s "$collected" ]
+}
+
+@test "fails when find cannot search its target" {
+    local collected
+    collected="$TEST_TEMP_DIR/collected"
+
+    run bash -c '"$1" "$2" -type f > "$3"' _ "$COLLECTOR" "$TEST_TEMP_DIR/missing" "$collected"
+
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: failed find was accepted"
+        return 1
+    fi
+    [[ "$output" == *"::error::safe path discovery failed"* ]]
+    [ ! -s "$collected" ]
+}
+
+@test "does not start a downstream command for a rejected pathname" {
+    local marker
+    mkdir -p "$TEST_TEMP_DIR/bad::command"
+    touch "$TEST_TEMP_DIR/bad::command/config.yaml"
+    marker="$TEST_TEMP_DIR/downstream-started"
+
+    run bash -c 'set -o pipefail; "$1" "$2" -type f | xargs -r -0 touch "$3"' _ \
+        "$COLLECTOR" "$TEST_TEMP_DIR" "$marker"
+
+    if [[ -e $marker ]]; then
+        echo "FAIL: rejected pathname started downstream command"
+        return 1
+    fi
+    [ "$status" -ne 0 ]
+}
+
+@test "withholds a safe pathname sorted before a rejected pathname" {
+    local collected marker
+    mkdir -p "$TEST_TEMP_DIR/a-safe" "$TEST_TEMP_DIR/z-bad%0Aforged"
+    touch "$TEST_TEMP_DIR/a-safe/config.yaml" "$TEST_TEMP_DIR/z-bad%0Aforged/config.yaml"
+    collected="$TEST_TEMP_DIR/collected"
+    marker="$TEST_TEMP_DIR/downstream-started"
+
+    run bash -c 'set -o pipefail; "$1" "$2" -type f | tee "$3" | xargs -r -0 touch "$4"' _ \
+        "$COLLECTOR" "$TEST_TEMP_DIR" "$collected" "$marker"
+
+    [ "$status" -ne 0 ]
+    if [[ -s $collected ]]; then
+        echo "FAIL: collector emitted a validated path before all paths were accepted" >&3
+        return 1
+    fi
+    if [[ -e $marker ]]; then
+        echo "FAIL: collector started downstream before all paths were accepted"
+        return 1
+    fi
+}
+
+@test "withholds paths when a valid root precedes a missing root" {
+    local collected marker
+    mkdir -p "$TEST_TEMP_DIR/valid"
+    touch "$TEST_TEMP_DIR/valid/config.yaml"
+    collected="$TEST_TEMP_DIR/collected"
+    marker="$TEST_TEMP_DIR/downstream-started"
+
+    run bash -c 'set -o pipefail; "$1" "$2" "$3" -type f | tee "$4" | xargs -r -0 touch "$5"' _ \
+        "$COLLECTOR" "$TEST_TEMP_DIR/valid" "$TEST_TEMP_DIR/missing" "$collected" "$marker"
+
+    [ "$status" -ne 0 ]
+    if [[ -s $collected ]]; then
+        echo "FAIL: collector emitted a path before find completed successfully"
+        return 1
+    fi
+    if [[ -e $marker ]]; then
+        echo "FAIL: collector started downstream before find completed successfully"
+        return 1
+    fi
+}


### PR DESCRIPTION
Under Actions, yamllint selects its GitHub formatter and interpolates the filename into `::group::` and `::error` lines without escaping. NUL delimiters keep a discovered path intact through `xargs`; they do not survive that output. A pull request adding a file whose path carries a newline followed by `::add-mask::` gets that line executed as a workflow command — forged annotations, manipulated grouping, masked log content.

The shellcheck step already refused any path outside `[A-Za-z0-9._/-]`, for the reason its comment gives: escaping each sink means getting every sink right for ever, while refusing the character set where a path enters means the sinks can only receive names that are inert. The YAML path never had that treatment.

That boundary now lives in `scripts/collect-safe-paths.sh` and both lint steps go through it, so a third linter cannot be added without it. `xargs -r` keeps yamllint from starting on an empty or withheld stream.

Two things the review changed after the first implementation:

- **The refusal message reproduced the hole.** It printed the rejected pathname through `printf '%q'`, which quotes real control characters and leaves a literal `%0A` alone — and `%` is outside the boundary, so the hostile name was refused and still reached the command channel. The `::error::` line is now constant and the pathname goes on an ordinary log line.
- **The allowlist depended on the locale.** `[A-Za-z]` are range expressions; under a UTF-8 locale with `globasciiranges` off, `é` collates inside them. `LC_ALL=C` now precedes the matching, and the mutation removing it was proven red in exactly that environment rather than on a host where a compiled-in default hides the property.

**Verification.** actionlint with `SHELLCHECK_OPTS=--severity=error`; shellcheck `-x -S warning`; 2553 unit tests green through `tests/run-tests.sh`; the collector returns the same 33 YAML paths the old discovery did. Each negative property ships with a test proven to fail under a named mutation.

**Landed at its round budget.** Residue filed rather than fixed: #1258 (the ASCII guarantee has no committed test, two tests can pass over a failure, and a zero-argument call scans the whole checkout) and #1259 (three different lint scopes stated in the architecture document). Pre-existing and untouched: #1253 — shellcheck and yamllint reproduce contributor source text on stdout, which needs the `::stop-commands::` protocol and is independent of pathnames.

Closes #1239
