### PR TITLE
Let an extension build prove a compile, and be consumed by digest

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -1050,9 +1050,29 @@ generate_dockerfile() {
             # available:[] is necessarily stale → route to self-heal just like a
             # missing or truncated artifact.
             local _artifact_valid=0
-            if [[ -f "$versionset_file" ]] && command -v jq &>/dev/null; then
-                jq -e 'type == "object" and has("available") and (.available | type) == "array" and (.available | length) > 0' \
-                    "$versionset_file" > /dev/null 2>&1 && _artifact_valid=1
+            local _artifact_json=""
+            local _artifact_has_version_digests=false
+            if [[ -f "$versionset_file" ]]; then
+                # mapfile is a Bash builtin.  Unlike an assignment containing only
+                # a redirection, its failed file-open status is preserved when
+                # generate_dockerfile itself is invoked from an if condition.
+                local -a _artifact_lines=()
+                if ! mapfile -d '' _artifact_lines < "$versionset_file"; then
+                    log_error "generate_dockerfile: cannot read versionset artifact: $versionset_file"
+                    return 1
+                fi
+                _artifact_json="${_artifact_lines[0]-}"
+
+                if command -v jq &>/dev/null; then
+                    # Only a valid artifact may declare digest data for consumption.
+                    # A malformed artifact follows the existing self-heal/fallback path
+                    # and never supplies a digest through a fallback expression.
+                    if printf '%s' "$_artifact_json" | jq -e 'type == "object" and has("available") and (.available | type) == "array" and (.available | length) > 0' \
+                        > /dev/null 2>&1; then
+                        _artifact_valid=1
+                        printf '%s' "$_artifact_json" | jq -e 'has("version_digests")' > /dev/null 2>&1 && _artifact_has_version_digests=true
+                    fi
+                fi
             fi
 
             # _versionset_json holds the JSON source for the multi-version emission
@@ -1068,8 +1088,8 @@ generate_dockerfile() {
             local _versionset_json=""
             local _versionset_from_selfheal=false
 
-            if [[ -n "$_resolver_path" ]] && { [[ ! -f "$versionset_file" ]] || [[ "$_artifact_valid" -eq 0 ]]; }; then
-                if [[ "$_artifact_valid" -eq 0 ]] && [[ -f "$versionset_file" ]]; then
+            if [[ -n "$_resolver_path" ]] && [[ "$_artifact_valid" -eq 0 ]]; then
+                if [[ -n "$_artifact_json" ]]; then
                     log_error "generate_dockerfile: versionset artifact for $ext_name pg${pg_major} is malformed, missing .available array, or has empty available[] — treating as absent, triggering self-heal"
                 fi
                 # skopeo is required by the LIVE resolver path (skopeo list-tags docker.io).
@@ -1186,8 +1206,20 @@ generate_dockerfile() {
                 # Mark that this came from the self-heal path so the downstream
                 # emission block uses tag-based refs (no digest map available).
                 _versionset_from_selfheal=true
-            elif [[ -f "$versionset_file" ]] && [[ "$_artifact_valid" -eq 1 ]] && command -v jq &>/dev/null; then
-                _versionset_json=$(< "$versionset_file")
+            elif [[ "$_artifact_valid" -eq 1 ]] && command -v jq &>/dev/null; then
+                _versionset_json="$_artifact_json"
+            fi
+
+            # A legacy pushed artifact has the old bundle digest but no per-version
+            # digest map. Tag fallback is safe only for an artifact that was never
+            # pushed: the producer omits version_digests exactly for that case.
+            if [[ "$_artifact_valid" -eq 1 ]] && [[ "$_artifact_has_version_digests" == "false" ]]; then
+                local _legacy_bundle_digest
+                _legacy_bundle_digest=$(printf '%s' "$_artifact_json" | jq -r 'if has("bundle_digest") then "yes" else "no" end' 2>/dev/null || echo "no")
+                if [[ "$_legacy_bundle_digest" == "yes" ]]; then
+                    log_error "generate_dockerfile: $ext_name pg${pg_major} artifact has bundle_digest but no version_digests — this is a legacy pre-collector artifact; rebuild under the new schema to restore digest-pinned refs"
+                    return 1
+                fi
             fi
 
             if [[ -n "$_versionset_json" ]] && command -v jq &>/dev/null; then
@@ -1304,49 +1336,26 @@ generate_dockerfile() {
                                 _ecs_ver_ref_list+="${_sh_mv}	${_sh_mv_ref}"$'\n'
                             done <<< "$raw_versions"
                         else
-                            # Artifact-present path: use version_digests for digest-pinned refs.
-                            local _vd_field_present
-                            _vd_field_present=$(echo "$_versionset_json" | jq -r 'if has("version_digests") then "yes" else "no" end' 2>/dev/null || echo "no")
-
-                            # Guard: a legacy pushed artifact carries bundle_digest but no
-                            # version_digests.  Silently falling back to mutable tag refs for
-                            # such an artifact would regress the digest-pinned guarantee.
-                            # Fail closed so the operator rebuilds under the new schema.
-                            # The tag-fallback path is valid ONLY when neither key is present
-                            # (genuine local/no-push build — producer invariant).
-                            if [[ "$_vd_field_present" == "no" ]]; then
-                                local _bd_field_present
-                                _bd_field_present=$(echo "$_versionset_json" | jq -r 'if has("bundle_digest") then "yes" else "no" end' 2>/dev/null || echo "no")
-                                if [[ "$_bd_field_present" == "yes" ]]; then
-                                    log_error "generate_dockerfile: $ext_name pg${pg_major} artifact has bundle_digest but no version_digests — this is a legacy pre-collector artifact; rebuild under the new schema to restore digest-pinned refs"
-                                    return 1
-                                fi
-                            fi
-
+                            # Artifact-present path: the digest lookup is additive. It is
+                            # reached only for a valid artifact that declares
+                            # version_digests; tag-only artifacts retain the established
+                            # tag construction.
                             local _art_ver
                             while IFS= read -r _art_ver; do
                                 [[ -z "$_art_ver" ]] && continue
-                                if [[ "$_vd_field_present" == "yes" ]]; then
-                                    # Artifact has version_digests: require a valid digest per version.
+                                local _art_ref
+                                if [[ "$_artifact_has_version_digests" == "true" ]]; then
                                     local _art_digest
-                                    _art_digest=$(echo "$_versionset_json" | jq -r --arg v "$_art_ver" '.version_digests[$v] // empty' 2>/dev/null || true)
+                                    _art_digest=$(printf '%s' "$_artifact_json" | jq -r --arg v "$_art_ver" '.version_digests[$v] // empty' 2>/dev/null || true)
                                     if ! is_valid_oci_digest "$_art_digest"; then
                                         log_error "generate_dockerfile: version_digests[$_art_ver] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_art_digest:-}" | head -c 80)")') — fail closed"
                                         return 1
                                     fi
-                                    _ecs_ver_ref_list+="${_art_ver}	${registry}/${owner}/ext-${ext_name}@${_art_digest}"$'\n'
+                                    _art_ref="${registry}/${owner}/ext-${ext_name}@${_art_digest}"
                                 else
-                                    # Artifact lacks version_digests (LOCAL_ONLY / no-push build path):
-                                    # construct a tag-based ref using the caller's explicit registry/owner
-                                    # so the ref targets the correct repo even when the caller passed
-                                    # registry/owner overrides.
-                                    # This tag-fallback is correct ONLY for the not-pushed (local) case;
-                                    # a pushed artifact always has version_digests (producer invariant:
-                                    # version_digests absent ⟺ artifact was not pushed).
-                                    local _art_plain_ref
-                                    _art_plain_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner")
-                                    _ecs_ver_ref_list+="${_art_ver}	${_art_plain_ref}"$'\n'
+                                    _art_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner")
                                 fi
+                                _ecs_ver_ref_list+="${_art_ver}	${_art_ref}"$'\n'
                             done <<< "$raw_versions"
                         fi
 
@@ -1373,14 +1382,24 @@ generate_dockerfile() {
                 fi
             fi
 
-            # Single-version path (no versionset artifact, or jq unavailable):
+            # Single-version path (no multi-version collector needed):
+            # only a valid artifact that declares version_digests adds immutable
+            # consumption. All other cases retain the established tag resolution.
             # Route through ext_ref_resolve when in PR context (PR_TAG_SUFFIX set):
             #   canonical-first reuse (unchanged version) or PR-scoped (built this PR).
             #   rc 2 → fail closed; rc 1 → ceiling absent on both → fail closed.
             # On push/dispatch (PR_TAG_SUFFIX empty):
             #   emit canonical ref directly — no probe (image availability checked at docker build time).
             local _sv_ref
-            if [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
+            if [[ "$_artifact_valid" -eq 1 ]] && [[ "$_artifact_has_version_digests" == "true" ]]; then
+                local _sv_digest
+                _sv_digest=$(printf '%s' "$_artifact_json" | jq -r --arg v "$ext_version" '.version_digests[$v] // empty' 2>/dev/null || true)
+                if ! is_valid_oci_digest "$_sv_digest"; then
+                    log_error "generate_dockerfile: version_digests[$ext_version] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_sv_digest:-}" | head -c 80)")') — fail closed"
+                    return 1
+                fi
+                _sv_ref="${registry}/${owner}/ext-${ext_name}@${_sv_digest}"
+            elif [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
                 local _sv_rc=0
                 _sv_ref=$(ext_ref_resolve "$ext_name" "$ext_version" "$pg_major" "") || _sv_rc=$?
                 if [[ "$_sv_rc" -eq 2 ]]; then

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -97,6 +97,8 @@ build_ext_image() {
     local rust_version="${EXT_RUST_VERSION:-}"
     local _rust_args=()
     [[ -n "$rust_version" ]] && _rust_args=(--build-arg "RUST_VERSION=$rust_version")
+    local _no_cache_args=()
+    [[ "${NO_CACHE:-false}" == "true" ]] && _no_cache_args=(--no-cache)
 
     local local_tag
     local_tag=$(ext_local_image_name "$ext_name" "$pg_major")
@@ -162,21 +164,25 @@ build_ext_image() {
         # canonical cache still build normally. --cache-to writes when we have
         # GHCR write access (_do_push_ext=true);
         # omitting --cache-to on LOCAL_ONLY/NO_PUSH paths avoids attempting writes
-        # to a registry we cannot authenticate to in that context.
+        # to a registry we cannot authenticate to in that context. --no-cache
+        # disables layer-result reuse and omits external registry cache imports and exports.
         # The cache export must not be able to fail the build: a cache-to write
         # error (registry/auth/network) would otherwise surface as a non-zero
         # buildx exit and be misread as a compile/musl failure, silently dropping
         # a retained non-ceiling version. ignore-error=true makes the export
         # best-effort so only a genuine compile failure returns non-zero here;
         # real infra failures are caught by the separate push step (rc=2, fatal).
-        local _canonical_cache_ref
-        _canonical_cache_ref="ghcr.io/${_cache_owner}/ext-${ext_name}-buildcache:pg${pg_major}-${ARCH_SUFFIX:-local}"
-        local _cache_flags=("--cache-from" "type=registry,ref=${_canonical_cache_ref}")
-        if [[ "$_cache_ref" != "$_canonical_cache_ref" ]]; then
-            _cache_flags+=("--cache-from" "type=registry,ref=${_cache_ref}")
-        fi
-        if [[ "$_do_push_ext" == "true" ]]; then
-            _cache_flags+=("--cache-to" "type=registry,ref=${_cache_ref},mode=max,ignore-error=true")
+        local _cache_flags=()
+        if [[ "${NO_CACHE:-false}" != "true" ]]; then
+            local _canonical_cache_ref
+            _canonical_cache_ref="ghcr.io/${_cache_owner}/ext-${ext_name}-buildcache:pg${pg_major}-${ARCH_SUFFIX:-local}"
+            _cache_flags=("--cache-from" "type=registry,ref=${_canonical_cache_ref}")
+            if [[ "$_cache_ref" != "$_canonical_cache_ref" ]]; then
+                _cache_flags+=("--cache-from" "type=registry,ref=${_cache_ref}")
+            fi
+            if [[ "$_do_push_ext" == "true" ]]; then
+                _cache_flags+=("--cache-to" "type=registry,ref=${_cache_ref},mode=max,ignore-error=true")
+            fi
         fi
 
         if ! $DOCKER buildx build \
@@ -184,6 +190,7 @@ build_ext_image() {
             -f "$dockerfile" \
             -t "$_ver_tag" \
             --load \
+            "${_no_cache_args[@]}" \
             "${_cache_flags[@]}" \
             --build-arg REMOTE_CR="${REMOTE_CR}" \
             --build-arg MAJOR_VERSION="$pg_major" \
@@ -215,6 +222,7 @@ build_ext_image() {
     if ! $DOCKER build \
         -f "$dockerfile" \
         -t "$local_tag" \
+        "${_no_cache_args[@]}" \
         --build-arg REMOTE_CR="${REMOTE_CR}" \
         --build-arg MAJOR_VERSION="$pg_major" \
         --build-arg EXT_VERSION="$ext_version" \
@@ -238,6 +246,7 @@ LOCAL_ONLY=false
 PULL_ONLY=false
 DRY_RUN=false
 FINALIZE_MULTIARCH=false
+NO_CACHE="${DOCKER_NO_CACHE:-false}"
 
 usage() {
     cat <<EOF
@@ -256,6 +265,7 @@ Options:
   --force                Rebuild even if image already exists
   --list                 List extension status without building
   --local-only           Build locally without pushing to registry
+  --no-cache             Disable layer-result reuse and external registry cache imports and exports
   --pull-only            Pull images from registry (no build, no push)
   --dry-run              Show what would be done without executing
   --finalize-multiarch   Merge per-arch suffixed images into multi-arch manifests
@@ -300,6 +310,10 @@ parse_args() {
                 ;;
             --local-only)
                 LOCAL_ONLY=true
+                shift
+                ;;
+            --no-cache)
+                NO_CACHE=true
                 shift
                 ;;
             --dry-run)
@@ -434,6 +448,9 @@ build_extension() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would build $ext_name $ext_version for $CONTAINER v$major_ver (REMOTE_CR=${REMOTE_CR})"
         log_info "[DRY-RUN]   --build-arg REMOTE_CR=${REMOTE_CR} --build-arg MAJOR_VERSION=$major_ver"
+        if [[ "${NO_CACHE:-false}" == "true" ]]; then
+            log_info "[DRY-RUN]   --no-cache (disables layer-result reuse and external registry cache imports and exports)"
+        fi
         return 0
     fi
 

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -69,7 +69,7 @@ EOF
 
 teardown() {
     teardown_temp_dir
-    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR
+    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR NO_CACHE
 }
 
 # ---------------------------------------------------------------------------
@@ -1558,6 +1558,24 @@ _count_log_lines() {
 
     # No lineage dir or files must have been created.
     [ ! -d "$lineage_dir" ]
+}
+
+@test "dry-run --no-cache reports layer-result and external registry cache semantics" {
+    export DRY_RUN=true
+    NO_CACHE=false
+
+    run build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -eq 0 ]
+    local cached_output="$output"
+    ! grep -Fq -- "--no-cache (disables layer-result reuse and external registry cache imports and exports)" <<<"$cached_output"
+
+    NO_CACHE=true
+    run build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != "$cached_output" ]]
+    grep -Fq -- "--no-cache (disables layer-result reuse and external registry cache imports and exports)" <<<"$output"
 }
 
 # ---------------------------------------------------------------------------
@@ -12597,6 +12615,66 @@ EOF
             [[ "$buildx_line" != *"--cache-to"* ]]
         fi
     fi
+}
+
+@test "--no-cache disables layer-result reuse and external registry cache imports and exports" {
+    local docker_calls="$TEST_TEMP_DIR/no_cache_docker_calls.log"
+
+    # Re-source after setup's build_ext_image mock so this drives the real
+    # buildx invocation. parse_args is part of the contract: callers opt in
+    # with --no-cache rather than --force or --local-only implying it.
+    _source_build_extensions
+    DOCKER=docker
+    export DOCKER BUILD_PLATFORM=linux/amd64 ARCH_SUFFIX=amd64 REPO_OWNER=testowner
+    docker() {
+        printf '%s\n' "$*" >> "$docker_calls"
+        return 0
+    }
+
+    parse_args postgres --no-cache
+    [ "$NO_CACHE" = "true" ]
+    build_ext_image pgvector 0.8.2 https://github.com/pgvector/pgvector 18 Dockerfile .
+
+    local buildx_line
+    buildx_line=$(grep 'buildx build' "$docker_calls")
+    [[ "$buildx_line" == *"--no-cache"* ]] || { echo "FAIL: no-cache build must pass --no-cache"; false; }
+    [[ "$buildx_line" != *"--cache-from"* ]] || { echo "FAIL: no-cache build must not import registry cache"; false; }
+    [[ "$buildx_line" != *"--cache-to"* ]] || { echo "FAIL: no-cache build must not export registry cache"; false; }
+}
+
+@test "default cache flags remain enabled under local-only and force" {
+    local docker_calls="$TEST_TEMP_DIR/default_cache_docker_calls.log"
+
+    # Drive the real function twice: --local-only still imports its canonical
+    # cache, and --force changes only skip behaviour, not cache semantics.
+    unset DOCKER_NO_CACHE NO_CACHE
+    _source_build_extensions
+    DOCKER=docker
+    export DOCKER BUILD_PLATFORM=linux/amd64 ARCH_SUFFIX=amd64 REPO_OWNER=testowner
+    docker() {
+        printf '%s\n' "$*" >> "$docker_calls"
+        return 0
+    }
+
+    LOCAL_ONLY=true
+    FORCE=false
+    build_ext_image pgvector 0.8.2 https://github.com/pgvector/pgvector 18 Dockerfile .
+
+    LOCAL_ONLY=false
+    FORCE=true
+    build_ext_image pgvector 0.8.2 https://github.com/pgvector/pgvector 18 Dockerfile .
+
+    local -a buildx_lines
+    mapfile -t buildx_lines < <(grep 'buildx build' "$docker_calls")
+    [ "${#buildx_lines[@]}" -eq 2 ]
+
+    [[ "${buildx_lines[0]}" == *"--cache-from type=registry,ref=ghcr.io/testowner/ext-pgvector-buildcache:pg18-amd64"* ]] || { echo "FAIL: default local-only build must retain canonical cache import"; false; }
+    [[ "${buildx_lines[0]}" != *"--cache-to"* ]]
+    [[ "${buildx_lines[0]}" != *"--no-cache"* ]]
+
+    [[ "${buildx_lines[1]}" == *"--cache-from type=registry,ref=ghcr.io/testowner/ext-pgvector-buildcache:pg18-amd64"* ]] || { echo "FAIL: --force must retain canonical cache import by default"; false; }
+    [[ "${buildx_lines[1]}" == *"--cache-to type=registry,ref=ghcr.io/testowner/ext-pgvector-buildcache:pg18-amd64,mode=max,ignore-error=true"* ]]
+    [[ "${buildx_lines[1]}" != *"--no-cache"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -159,6 +159,54 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Artifact read failures are digest-authority failures, not self-heal inputs.
+# A failed command substitution is otherwise context-sensitive under errexit:
+# when generate_dockerfile is called from an if condition, it can continue with
+# an empty artifact snapshot and fall back to mutable tags.
+# ---------------------------------------------------------------------------
+
+@test "unreadable versionset artifact refuses when generate_dockerfile is called directly" {
+    _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
+    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    chmod 000 "$artifact"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    chmod 600 "$artifact"
+    [ "$status" -ne 0 ]
+    grep -Fq -- "cannot read versionset artifact: $artifact" <<<"$output"
+}
+
+@test "unreadable versionset artifact refuses when generate_dockerfile is called inside if" {
+    _write_versionset "timescaledb" "18" "2.25.0" "2.27.1"
+    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    chmod 000 "$artifact"
+
+    run bash -c '
+        source "$1"
+        export ROOT_DIR="$2"
+        get_registry() { echo "ghcr.io"; }
+        get_repo_owner() { echo "testowner"; }
+
+        if generate_dockerfile "$3" "$4" "timeseries" "18" "ghcr.io" "testowner"; then
+            echo "FAIL: unreadable versionset artifact was accepted inside if"
+            exit 0
+        fi
+
+        exit 1
+    ' bash "$HELPERS_DIR/extension-utils.sh" "$TEST_TEMP_DIR" \
+        "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template"
+
+    chmod 600 "$artifact"
+    [ "$status" -ne 0 ]
+    grep -Fq -- "cannot read versionset artifact: $artifact" <<<"$output"
+}
+
+# ---------------------------------------------------------------------------
 # Test 1: multi-version — 3 available → collector stage + ONE final-stage COPY
 # ---------------------------------------------------------------------------
 @test "multi-version: 3 available versions → FROM scratch AS ext_collect_timescaledb + 1 final COPY" {
@@ -293,6 +341,79 @@ EOF
 
     # Must NOT have version-subdirectory COPYs
     ! grep -q "/tmp/ext/pgvector/0\." <<<"$output"
+}
+
+@test "single-version artifact with digest emits an immutable FROM ref" {
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-pgvector-pg18-versionset.json" <<'EOF'
+{"ext":"pgvector","pg_major":"18","ceiling":"0.8.2","resolved":["0.8.2"],"available":["0.8.2"],"excluded":[],"version_digests":{"0.8.2":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
+EOF
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "vector" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fxq "FROM ghcr.io/testowner/ext-pgvector@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS ext-pgvector" || {
+        echo "FAIL: valid declared version_digests must emit immutable FROM ref"
+        false
+    }
+}
+
+@test "single-version artifact with a missing, empty, or malformed digest fails closed" {
+    local bad_digest
+    for bad_digest in '__MISSING__' '' 'sha256:not-a-digest'; do
+        if [[ "$bad_digest" == '__MISSING__' ]]; then
+            cat > "$TEST_TEMP_DIR/.build-lineage/ext-pgvector-pg18-versionset.json" <<'EOF'
+{"ext":"pgvector","pg_major":"18","ceiling":"0.8.2","resolved":["0.8.2"],"available":["0.8.2"],"excluded":[],"version_digests":{}}
+EOF
+        else
+            cat > "$TEST_TEMP_DIR/.build-lineage/ext-pgvector-pg18-versionset.json" <<EOF
+{"ext":"pgvector","pg_major":"18","ceiling":"0.8.2","resolved":["0.8.2"],"available":["0.8.2"],"excluded":[],"version_digests":{"0.8.2":"${bad_digest}"}}
+EOF
+        fi
+
+        run generate_dockerfile \
+            "$TEST_TEMP_DIR/extensions/config.yaml" \
+            "$TEST_TEMP_DIR/Dockerfile.template" \
+            "vector" "18" \
+            "ghcr.io" "testowner"
+
+        [ "$status" -ne 0 ] || { echo "FAIL: declared single-version digest must be valid and present"; false; }
+    done
+}
+
+@test "single-version extension without an artifact keeps its canonical tag" {
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "vector" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fxq "FROM ghcr.io/testowner/ext-pgvector:pg18-0.8.2 AS ext-pgvector"
+}
+
+@test "tag-only single-version artifact on forced PR → emits the PR-scoped ref" {
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-pgvector-pg18-versionset.json" <<'EOF'
+{"ext":"pgvector","pg_major":"18","ceiling":"0.8.2","resolved":["0.8.2"],"available":["0.8.2"],"excluded":[]}
+EOF
+    export PR_TAG_SUFFIX="-pr42"
+    export REBUILD="force"
+    _image_registry_probe_3state() { return 0; }
+    export -f _image_registry_probe_3state
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "vector" "18" \
+        "ghcr.io" "testowner"
+
+    unset PR_TAG_SUFFIX REBUILD
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fxq "FROM ghcr.io/testowner/ext-pgvector:pg18-0.8.2-pr42 AS ext-pgvector"
 }
 
 # ---------------------------------------------------------------------------
@@ -2326,6 +2447,69 @@ EOF
     [ "$per_ver_count" -eq 2 ]
 }
 
+@test "digest declaration and values are consumed from one artifact snapshot" {
+    local artifact_path="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json"
+    cat > "$artifact_path" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","2.27.1":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+EOF
+
+    export SNAPSHOT_ARTIFACT_PATH="$artifact_path"
+    jq() {
+        if [[ "$1" == "-e" && "$2" == 'type == "object" and has("available") and (.available | type) == "array" and (.available | length) > 0' ]] && [[ -z "${snapshot_fixture_replaced:-}" ]]; then
+            command jq "$@"
+            local jq_status=$?
+            snapshot_fixture_replaced=1
+            cat > "$SNAPSHOT_ARTIFACT_PATH" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[]}
+EOF
+            return "$jq_status"
+        fi
+        command jq "$@"
+    }
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    unset SNAPSHOT_ARTIFACT_PATH
+    unset -f jq
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fxq "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /output/ /2.25.0/" || {
+        echo "FAIL: digest declaration and digest values must come from the captured artifact snapshot"
+        false
+    }
+}
+
+@test "malformed artifact with version_digests does not supply a digest" {
+    # available:[] fails the artifact validity predicate. Its digest map must not
+    # leak into the self-heal fallback, which emits only resolved tag refs.
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":[],"excluded":[],"version_digests":{"2.25.0":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","2.27.1":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+EOF
+    resolve_version_set() { echo '["2.25.0","2.27.1"]'; }
+    _image_registry_probe_3state() { return 0; }
+    export -f resolve_version_set _image_registry_probe_3state
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: malformed artifact must follow self-heal instead of becoming digest-authoritative"
+        false
+    }
+    ! grep -q "@sha256:" <<<"$output" || {
+        echo "FAIL: malformed artifact must not supply a digest to self-heal"
+        false
+    }
+    echo "$output" | grep -Fxq "COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/"
+}
+
 # ---------------------------------------------------------------------------
 # AN-consumer: strict OCI digest validation at the consumer boundary.
 #
@@ -3382,7 +3566,10 @@ EOF
         "ghcr.io" "testowner"
 
     # Must fail closed — legacy artifact must not silently downgrade to tag refs.
-    [ "$status" -ne 0 ]
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: legacy bundle_digest artifact must fail closed"
+        false
+    }
 
     # No @sha256: in output (should be empty / no Dockerfile emitted).
     local digest_pin_count


### PR DESCRIPTION
Two things block the scheduled extension rotation, and this is both of them.

**A forced rebuild never recompiled.** `build_ext_image` always imported the canonical registry buildcache, on every path including `--local-only`, and no `--no-cache` reached it — `DOCKER_NO_CACHE` never got that far. A rotation run whose purpose is to prove a recipe still compiles would have restored cached layers and proved republication instead. `postgis` was unbuildable for months precisely because nothing ever compiled it.

`--no-cache` now omits both cache directions and passes the flag through. It disables reuse of layer results and the external registry cache; it does not empty a `RUN --mount=type=cache` and does not imply `--pull`, and the help, the comments and the dry-run output all say exactly that. Every existing caller keeps the flags it had.

**The postgres build could only consume a digest for one extension.** The digest path was gated on `version_set.resolver`, which only `timescaledb` declares; the other nine emitted a canonical tag, so a scheduled run's local test would have built against the previously published image. A valid artifact declaring `version_digests` now pins the generated `FROM` to `ext-<name>@sha256:…` for a single-version extension too, and a missing or malformed entry refuses rather than falling back to a tag.

A caller that does not supply such an artifact executes the code it executes on `master`. That was checked hunk by hunk, and the working tree contains no `ext_ref_resolve` difference against `master` at all.

Nothing calls either capability yet. The scheduled workflow is the next part of #1245.

**Verification.** shellcheck `-x -S warning` clean; 2600 unit tests green through `tests/run-tests.sh`; each negative property ships with a test proven to fail under a named mutation.

**Landed at its round budget.** Residue filed rather than fixed: #1275 (the artifact read should be the JSON parse — three rounds each found a different hole in the same six lines, and a fourth patch would find a fourth), #1276 (`--dry-run --no-cache` prints the cache mode from the helper, which the CLI path skips), #1277 (two tests rely on `chmod 000`, which root ignores). Pre-existing and untouched: #1271, #1272, #1273, #1274.

Refs #1245
