### PR TITLE
Stop a malformed tag from authorising its record's deletion

### DIFF
--- a/scripts/cleanup-ext-images.sh
+++ b/scripts/cleanup-ext-images.sh
@@ -172,13 +172,25 @@ _version_record_tags_csv() {
     ' <<< "$record_json"
 }
 
-# Emit all tags from one GHCR version record.  The caller collects this output
-# before making any delete/keep decision: a partial tag list is unknown, not an
-# empty list.
+# Emit all tags from one GHCR version record. The caller collects the complete
+# output before making a delete/keep decision: a malformed tag is rejected
+# before any tag is emitted, and a successful empty list emits nothing so the
+# caller's zero-tag decision remains in effect. This is intentionally a
+# newline-delimited transport, so registry tags containing LF or NUL cannot
+# round-trip and make the whole record malformed; the caller keeps it
+# fail-closed.
 _list_version_record_tags() {
     local record_json="$1"
 
-    jq -r '.tags[]?' <<< "$record_json"
+    jq -r '
+      (.tags // []) as $tags
+      | if ($tags | type) == "array" then
+          $tags
+          | if all(.[]; type == "string" and (contains("\n") | not) and (contains("\u0000") | not)) then .[] else error("tag cannot be transported safely") end
+        else
+          error("tag cannot be transported safely")
+        end
+    ' <<< "$record_json"
 }
 
 # ── Main entry point ─────────────────────────────────────────────────────────
@@ -401,7 +413,7 @@ main() {
             local tags_csv
             local tag_count
             version_id=$(jq -r '.version_id' <<< "$record_json")
-            tags_csv=$(_version_record_tags_csv "$record_json")
+            tags_csv="(tag enumeration unavailable)"
             tag_count=$(jq '(.tags // []) | length' <<< "$record_json")
 
             local should_delete="true"
@@ -418,16 +430,15 @@ main() {
                 should_delete="false"
                 keep_reason="tag enumeration unknown; keeping record fail-closed"
             else
+                tags_csv=$(_version_record_tags_csv "$record_json")
                 local tag
                 while [[ "$should_delete" == "true" ]] && IFS= read -r tag; do
-                    [[ -n "$tag" ]] || continue
-
                     local parsed
                     local tag_major
                     local tag_version
                     if ! parsed=$(_parse_ext_managed_tag "$tag"); then
                         should_delete="false"
-                        keep_reason="contains unmanaged/unparseable tag: ${tag}"
+                        printf -v keep_reason 'contains unmanaged/unparseable tag: %q' "$tag"
                         break
                     fi
 

--- a/tests/unit/cleanup-ext-images.bats
+++ b/tests/unit/cleanup-ext-images.bats
@@ -241,6 +241,115 @@ EOF
     [[ ! -f "$delete_calls_file" ]]
 }
 
+@test "empty tags protect their version records while all-canonical stale records still prune" {
+    local records_file="$TEST_TEMP_DIR/empty-tag-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/empty-tag-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 451, "metadata": { "container": { "tags": [] } } },
+  { "id": 452, "metadata": { "container": { "tags": ["pg17-2.23.0", ""] } } },
+  { "id": 453, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=451"* ]]
+    [[ "$output" == *"KEEP  version_id=451 (tags: (none)) — no tags on version record; fail-closed"* ]]
+    [[ "$output" != *"KEEP  version_id=451 (tags: (tag enumeration unavailable))"* ]]
+    [[ "$output" == *"KEEP  version_id=452"* ]]
+    [[ "$output" == *"contains unmanaged/unparseable tag: ''"* ]]
+    [[ "$output" != *"PRUNE version_id=451"* ]]
+    [[ "$output" != *"PRUNE version_id=452"* ]]
+    [[ "$output" == *"PRUNE version_id=453"* ]]
+    [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=453"* ]]
+    [[ "$output" == *"Summary: kept=2, pruned=1, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "line-feed tag makes enumeration unknown and keeps the whole record" {
+    local records_file="$TEST_TEMP_DIR/line-feed-tag-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/line-feed-tag-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 461, "metadata": { "container": { "tags": ["pg17-2.23.0\nline-feed-quarantine-fragment"] } } },
+  { "id": 462, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=461"* ]]
+    [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
+    [[ "$output" != *"line-feed-quarantine-fragment"* ]]
+    [[ "$output" != *"PRUNE version_id=461"* ]]
+    [[ "$output" == *"Deleted ext-timescaledb version_id=462"* ]]
+    [[ -f "$delete_calls_file" ]]
+    [[ "$(<"$delete_calls_file")" == "DELETE:462" ]]
+}
+
+@test "NUL tag makes enumeration unknown and keeps the whole record" {
+    local records_file="$TEST_TEMP_DIR/nul-tag-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/nul-tag-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 471, "metadata": { "container": { "tags": ["pg17-2.23.0\u0000nul-quarantine-fragment"] } } },
+  { "id": 472, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=471"* ]]
+    [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
+    [[ "$output" != *"nul-quarantine-fragment"* ]]
+    [[ "$output" != *"PRUNE version_id=471"* ]]
+    [[ "$output" == *"Deleted ext-timescaledb version_id=472"* ]]
+    [[ -f "$delete_calls_file" ]]
+    [[ "$(<"$delete_calls_file")" == "DELETE:472" ]]
+}
+
+@test "a later malformed tag keeps its record and emits none of its first tag" {
+    local records_file="$TEST_TEMP_DIR/later-malformed-tag-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/later-malformed-tag-deletes"
+
+    run _list_version_record_tags '{"tags":["pg17-2.24.0","bad\nlater-malformed-tag-fragment"]}'
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *"pg17-2.24.0"* ]]
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 481, "metadata": { "container": { "tags": ["pg17-2.24.0", "bad\nlater-malformed-tag-fragment"] } } },
+  { "id": 482, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=481"* ]]
+    [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
+    [[ "$output" != *"PRUNE version_id=481"* ]]
+    [[ "$output" == *"Deleted ext-timescaledb version_id=482"* ]]
+    [[ -f "$delete_calls_file" ]]
+    [[ "$(<"$delete_calls_file")" == "DELETE:482" ]]
+}
+
 @test "P2 execute mode: failed delete exits non-zero and is not counted as pruned" {
     local records_file="$TEST_TEMP_DIR/delete-failure-records.json"
     local windows_dir="$TEST_TEMP_DIR/windows"


### PR DESCRIPTION
`scripts/cleanup-ext-images.sh` keeps a version record whenever one of its tags fails to parse, because GHCR deletes records rather than tags and deleting one takes every tag on it. Three values bypassed that rule:

- an empty string was skipped before the parser saw it, so no flag was set and the record was deleted under the reason `all canonical managed tags outside window`;
- a tag carrying a line feed arrived through the newline-delimited transport as two lines, each of which parsed as a managed stale tag;
- `read` drops NUL, so a tag ending in one became a valid stale tag.

Each of the three authorised deleting a record whose real tag was unparseable and should have protected it.

Tags are now refused at `_list_version_record_tags`, before that transport, and the whole array is validated before any element is emitted — so the loop never sees a corrupted value, and the guarantee does not depend on the caller discarding a partial stream. `tags_csv` is built after enumeration succeeds, so a refused value never reaches the log.

Two things the review corrected along the way. `${tag@Q}` needs Bash 4.4 while `README.md` promises 4.0+, and on 4.0–4.3 it raised `bad substitution` on the exact path this change fixes; it is now `printf -v … %q`. And `jq -e` returns 4 when a filter emits nothing, so a record with `tags: []` — every per-arch child of a multi-arch index — was reported as malformed rather than untagged.

**Verification.** shellcheck `-x -S warning` clean; 2593 unit tests green through `tests/run-tests.sh`; each negative property ships with a test proven to fail under a named mutation, including the two that hold the ordering: rendering the log line before enumeration puts the malformed fragment back into the output, and emitting tags during validation leaks the first one.

Known and accepted: `tags_csv` prints accepted tag text verbatim, so a value carrying ESC or CR could affect terminal presentation; a registry tag cannot contain those. The Bash floor could not be exercised — only 5.2 is installed on the machine this was written on — so the check was a static read of the diff.

**Landed at its round budget**, with the terminal round finding nothing this branch introduced. Residue, all pre-existing: #1250, #1251, #1254, #1272, and #1280 (`_derive_ext_tag_window_version` has no caller).

#1173 asked for run-scoped tags to stop freezing their records and was closed instead of fixed: a GHCR record is a digest, its tags carry no per-tag time, and `updated_at` never differs from `created_at` across a hundred records, so nothing in the registry can say whether such a tag is still needed. The measurement is on that issue.

Closes #1279
