### PR TITLE
Let an extension build target a separate GHCR package

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -76,16 +76,95 @@ get_registry() {
     echo "${EXTENSION_REGISTRY:-ghcr.io}"
 }
 
+# validate_extension_package_suffix
+#
+# EXTENSION_PACKAGE_SUFFIX selects a separate GHCR package for an extension
+# build. It is deliberately a package-name component, not a tag suffix: a
+# value of -staging sends pg18-1.2.3 to ext-<name>-staging:pg18-1.2.3.
+#
+# An unset variable preserves the canonical production package. A set empty
+# value is rejected so a caller cannot accidentally request staging and fall
+# back to production. The accepted shape is a leading hyphen followed by
+# lowercase OCI repository-name components; it cannot introduce a path, tag,
+# digest, or whitespace separator into the assembled reference.
+validate_extension_package_suffix() {
+    # `${parameter+x}` is available on Bash 4.0; `[[ -v name ]]` is not
+    # available until Bash 4.2.
+    if [[ -z "${EXTENSION_PACKAGE_SUFFIX+x}" ]]; then
+        return 0
+    fi
+
+    local suffix="$EXTENSION_PACKAGE_SUFFIX"
+    if [[ "$suffix" =~ ^-[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+        return 0
+    fi
+
+    log_error "EXTENSION_PACKAGE_SUFFIX must be unset or match ^-[a-z0-9]+([._-][a-z0-9]+)*$"
+    return 1
+}
+
+# ext_package_name <extension>
+#
+# Generate the GHCR package component before any tag or buildcache qualifier.
+ext_package_name() {
+    local ext_name="$1"
+    validate_extension_package_suffix || return 1
+    printf 'ext-%s%s' "$ext_name" "${EXTENSION_PACKAGE_SUFFIX:-}"
+}
+
+# ext_image_repository <extension> [registry] [owner]
+#
+# Generate the repository portion of an extension image reference. Keep the
+# package suffix here so tag and digest consumers cannot accidentally bypass it.
+ext_image_repository() {
+    local ext_name="$1"
+    local registry="${2:-$(get_registry)}"
+    local owner="${3:-$(get_repo_owner)}"
+    local package
+
+    package=$(ext_package_name "$ext_name") || return 1
+    printf '%s/%s/%s' "$registry" "$owner" "$package"
+}
+
+# ext_canonical_image_repository <extension> [registry] [owner]
+#
+# Return the repository that legacy artifacts necessarily describe.  Before the
+# package-suffix axis existed, every digest was observed in this canonical,
+# unsuffixed package.
+ext_canonical_image_repository() {
+    local ext_name="$1"
+    local registry="${2:-$(get_registry)}"
+    local owner="${3:-$(get_repo_owner)}"
+
+    printf '%s/%s/ext-%s' "$registry" "$owner" "$ext_name"
+}
+
+# ext_buildcache_repository <extension> [registry] [owner]
+#
+# Cache is a sibling package of the selected extension package: the package
+# suffix belongs before its existing -buildcache qualifier.
+ext_buildcache_repository() {
+    local ext_name="$1"
+    local registry="${2:-$(get_registry)}"
+    local owner="${3:-$(get_repo_owner)}"
+    local package
+
+    package=$(ext_package_name "$ext_name") || return 1
+    printf '%s/%s/%s-buildcache' "$registry" "$owner" "$package"
+}
+
 # Generate extension image name
-# Format: ghcr.io/<owner>/ext-<name>:pg<version>-<ext_version>
+# Format: ghcr.io/<owner>/ext-<name><package_suffix>:pg<version>-<ext_version>
 ext_image_name() {
     local ext_name="$1"
     local ext_version="$2"
     local pg_major="$3"
     local registry="${4:-$(get_registry)}"
     local owner="${5:-$(get_repo_owner)}"
+    local repository
 
-    echo "${registry}/${owner}/ext-${ext_name}:pg${pg_major}-${ext_version}"
+    repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
+    printf '%s:pg%s-%s' "$repository" "$pg_major" "$ext_version"
 }
 
 # Generate local image name (for building)
@@ -319,7 +398,7 @@ tag_ext_image() {
     local_tag=$(ext_local_image_name "$ext_name" "$pg_major")
 
     local remote_tag
-    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major")
+    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major") || return 1
 
     log_info "Tagging $local_tag -> $remote_tag"
     if ! $DOCKER tag "$local_tag" "$remote_tag"; then
@@ -337,7 +416,7 @@ push_ext_image() {
     local pg_major="$3"
 
     local remote_tag
-    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major")
+    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major") || return 1
 
     log_info "Pushing $remote_tag"
     if ! $DOCKER push "$remote_tag"; then
@@ -500,7 +579,8 @@ _scoped_ext_ref() {
 #   rc 0  → prints the ref to use (canonical or pr-scoped).
 #   rc 1  → neither ref exists definitively (needs build or exclude).
 #           prints nothing.
-#   rc 2  → a probe returned transient ERROR, or the run scope is malformed
+#   rc 2  → a probe returned transient ERROR, the run scope is malformed, or
+#           reference construction failed
 #           → fail closed.
 #           prints nothing.
 #
@@ -551,7 +631,10 @@ ext_ref_resolve() {
 
     # Build canonical base: ext_image_name gives registry/owner/ext-<name>:pg<major>-<ver>
     # Append arch suffix when arch is non-empty.
-    canonical_ref=$(ext_image_name "$ext" "$version" "$major" "$registry" "$owner")
+    if ! canonical_ref=$(ext_image_name "$ext" "$version" "$major" "$registry" "$owner"); then
+        printf 'ERROR [ext_ref_resolve]: failed to construct reference\n' >&2
+        return 2
+    fi
     if [[ -n "$arch" ]]; then
         canonical_ref="${canonical_ref}-${arch}"
     fi
@@ -1071,6 +1154,24 @@ generate_dockerfile() {
                         > /dev/null 2>&1; then
                         _artifact_valid=1
                         printf '%s' "$_artifact_json" | jq -e 'has("version_digests")' > /dev/null 2>&1 && _artifact_has_version_digests=true
+                        # Digest-bearing artifacts record where their index digests
+                        # were observed. A missing identity is legacy provenance:
+                        # it means the canonical unsuffixed package, never the
+                        # package selected by the current caller.
+                        if [[ "$_artifact_has_version_digests" == "true" ]]; then
+                            local _artifact_digest_repository _expected_digest_repository
+                            if printf '%s' "$_artifact_json" | jq -e 'has("version_digests_repository")' > /dev/null 2>&1; then
+                                _artifact_digest_repository=$(printf '%s' "$_artifact_json" | jq -r '.version_digests_repository' 2>/dev/null || true)
+                            else
+                                _artifact_digest_repository=$(ext_canonical_image_repository "$ext_name" "$registry" "$owner") || return 1
+                            fi
+                            _expected_digest_repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
+                            if [[ "$_artifact_digest_repository" != "$_expected_digest_repository" ]]; then
+                                log_warning "generate_dockerfile: version_digests for $ext_name pg${pg_major} belong to $_artifact_digest_repository, not $_expected_digest_repository — treating artifact as absent, triggering self-heal"
+                                _artifact_valid=0
+                                _artifact_has_version_digests=false
+                            fi
+                        fi
                     fi
                 fi
             fi
@@ -1351,9 +1452,11 @@ generate_dockerfile() {
                                         log_error "generate_dockerfile: version_digests[$_art_ver] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_art_digest:-}" | head -c 80)")') — fail closed"
                                         return 1
                                     fi
-                                    _art_ref="${registry}/${owner}/ext-${ext_name}@${_art_digest}"
+                                    local _art_repository
+                                    _art_repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
+                                    _art_ref="${_art_repository}@${_art_digest}"
                                 else
-                                    _art_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner")
+                                    _art_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner") || return 1
                                 fi
                                 _ecs_ver_ref_list+="${_art_ver}	${_art_ref}"$'\n'
                             done <<< "$raw_versions"
@@ -1398,7 +1501,9 @@ generate_dockerfile() {
                     log_error "generate_dockerfile: version_digests[$ext_version] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_sv_digest:-}" | head -c 80)")') — fail closed"
                     return 1
                 fi
-                _sv_ref="${registry}/${owner}/ext-${ext_name}@${_sv_digest}"
+                local _sv_repository
+                _sv_repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
+                _sv_ref="${_sv_repository}@${_sv_digest}"
             elif [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
                 local _sv_rc=0
                 _sv_ref=$(ext_ref_resolve "$ext_name" "$ext_version" "$pg_major" "") || _sv_rc=$?
@@ -1411,8 +1516,9 @@ generate_dockerfile() {
                     return 1
                 fi
             else
-                # Push/dispatch: always emit canonical ref (unchanged from pre-consolidation behavior).
-                _sv_ref="${registry}/${owner}/ext-${ext_name}:pg${pg_major}-${ext_version}"
+                # Push/dispatch: emit the package selected by the independent
+                # package-suffix axis (canonical when it is unset).
+                _sv_ref=$(ext_image_name "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner") || return 1
             fi
             stages_block+="FROM ${_sv_ref} AS ext-${ext_name}"$'\n'
             copies_block+="COPY --from=ext-${ext_name} /output/extension/ /tmp/ext/${ext_name}/extension/"$'\n'
@@ -1579,7 +1685,7 @@ pull_ext_image() {
     local pg_major="$3"
 
     local remote_tag
-    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major")
+    remote_tag=$(ext_image_name "$ext_name" "$ext_version" "$pg_major") || return 1
 
     log_info "Pulling $remote_tag"
     if ! $DOCKER pull "$remote_tag"; then

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -123,7 +123,7 @@ build_ext_image() {
         # final consumer postgres image).  This diverges from the main-image
         # PR-skip policy intentionally.
         local _ver_image
-        _ver_image=$(ext_image_name "$ext_name" "$ext_version" "$pg_major")
+        _ver_image=$(ext_image_name "$ext_name" "$ext_version" "$pg_major") || return 1
         local _ver_tag
         # Per-arch tag carries both the arch suffix and the PR scope suffix (if any).
         # Format: <registry>/<owner>/ext-<name>:pg<major>-<ver>-<arch>${PR_TAG_SUFFIX}
@@ -135,7 +135,7 @@ build_ext_image() {
         # deriving the cache ref from REMOTE_CR would produce the wrong namespace
         # when REMOTE_CR is unset or set to a different registry by the caller.
         # Fix: derive owner from REPO_OWNER (env, set by CI) or get_repo_owner()
-        # and construct the cache ref as ghcr.io/<owner>/ext-<name>-buildcache:...
+        # and construct the cache ref as ghcr.io/<owner>/ext-<name><package-suffix>-buildcache:...
         #
         # supply-chain policy (operator-confirmed): PR cache exports append
         # PR_TAG_SUFFIX, so this implementation does not write master's
@@ -148,8 +148,10 @@ build_ext_image() {
         # importer is emitted. Master never imports a PR-scoped cache ref.
         local _cache_owner
         _cache_owner="${REPO_OWNER:-$(get_repo_owner)}"
+        local _cache_repository
+        _cache_repository=$(ext_buildcache_repository "$ext_name" "ghcr.io" "${_cache_owner}") || return 1
         local _cache_ref
-        _cache_ref="ghcr.io/${_cache_owner}/ext-${ext_name}-buildcache:pg${pg_major}-${ARCH_SUFFIX:-local}${PR_TAG_SUFFIX:-}"
+        _cache_ref="${_cache_repository}:pg${pg_major}-${ARCH_SUFFIX:-local}${PR_TAG_SUFFIX:-}"
 
         # Compute do_push for this build leg: true unless NO_PUSH or LOCAL_ONLY.
         local _do_push_ext=true
@@ -175,7 +177,7 @@ build_ext_image() {
         local _cache_flags=()
         if [[ "${NO_CACHE:-false}" != "true" ]]; then
             local _canonical_cache_ref
-            _canonical_cache_ref="ghcr.io/${_cache_owner}/ext-${ext_name}-buildcache:pg${pg_major}-${ARCH_SUFFIX:-local}"
+            _canonical_cache_ref="${_cache_repository}:pg${pg_major}-${ARCH_SUFFIX:-local}"
             _cache_flags=("--cache-from" "type=registry,ref=${_canonical_cache_ref}")
             if [[ "$_cache_ref" != "$_canonical_cache_ref" ]]; then
                 _cache_flags+=("--cache-from" "type=registry,ref=${_cache_ref}")
@@ -274,6 +276,9 @@ Options:
 
 Environment:
   EXTENSION_REGISTRY     Registry URL (default: ghcr.io)
+  EXTENSION_PACKAGE_SUFFIX
+                         Optional safe package suffix (e.g. -staging); sends
+                         extension images and build cache to ext-<name>-staging
 
 Examples:
   $(basename "$0") postgres                        # Build & push all missing
@@ -400,7 +405,7 @@ list_extension_status() {
         local ver
         while IFS= read -r ver; do
             local image
-            image=$(ext_image_name "$ext" "$ver" "$major_ver")
+            image=$(ext_image_name "$ext" "$ver" "$major_ver") || return 1
 
             local status
             if image_exists_in_registry "$image" 2>/dev/null; then
@@ -496,7 +501,7 @@ tag_extension() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         local image
-        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver")
+        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver") || return 1
         log_info "[DRY-RUN] Would tag $image"
         return 0
     fi
@@ -518,7 +523,7 @@ push_extension() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         local image
-        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver")
+        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver") || return 1
         log_info "[DRY-RUN] Would push $image"
         return 0
     fi
@@ -541,7 +546,7 @@ pull_extension() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         local image
-        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver")
+        image=$(ext_image_name "$ext_name" "$ext_version" "$major_ver") || return 1
         log_info "[DRY-RUN] Would pull $image"
         return 0
     fi
@@ -617,7 +622,7 @@ handle_pull_only_mode() {
         local ver
         while IFS= read -r ver; do
             local image
-            image=$(ext_image_name "$ext" "$ver" "$major_ver")
+            image=$(ext_image_name "$ext" "$ver" "$major_ver") || return 1
 
             if docker image inspect "$image" &>/dev/null && [[ "$FORCE" != "true" ]]; then
                 log_success "$ext $ver already exists locally"
@@ -737,7 +742,7 @@ _bundle_and_write_artifact() {
     local _cv
     while IFS= read -r _cv; do
         local _cv_image
-        _cv_image=$(ext_image_name "$ext" "$_cv" "$major_ver")
+        _cv_image=$(ext_image_name "$ext" "$_cv" "$major_ver") || return 1
 
         if [[ -n "${_btr_set[$_cv]:-}" ]]; then
             _confirmed_available+=("$_cv")
@@ -867,7 +872,6 @@ _bundle_and_write_artifact() {
     _available_json=$(printf '%s\n' "${_confirmed_available[@]+"${_confirmed_available[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
     _excluded_json="[$(IFS=,; echo "${_excluded_entries[*]+"${_excluded_entries[*]}"}")]"
     _resolved_json=$(echo "$version_set_json" | jq '.')
-
     if [[ "$_version_digests_json" == "null" ]]; then
         # No-push path: omit version_digests (local/no-push artifact).
         jq -nc \
@@ -882,6 +886,8 @@ _bundle_and_write_artifact() {
         log_info "Version-set lineage (build path, no-push — no version_digests): $_vs_lineage_file"
     else
         # Pushed path: include version_digests so consumer emits digest-pinned refs.
+        local _version_digests_repository
+        _version_digests_repository=$(ext_image_repository "$ext") || return 1
         jq -nc \
             --arg ext "$ext" \
             --arg pg_major "$major_ver" \
@@ -890,7 +896,8 @@ _bundle_and_write_artifact() {
             --argjson available "$_available_json" \
             --argjson excluded "$_excluded_json" \
             --argjson version_digests "$_version_digests_json" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests}' \
+            --arg version_digests_repository "$_version_digests_repository" \
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}' \
             > "$_vs_lineage_file"
         log_info "Version-set lineage (build path, pushed — with version_digests): $_vs_lineage_file"
     fi
@@ -1018,7 +1025,7 @@ build_tag_push_extensions() {
         local version
         while IFS= read -r version; do
             local ver_image
-            ver_image=$(ext_image_name "$ext" "$version" "$major_ver")
+            ver_image=$(ext_image_name "$ext" "$version" "$major_ver") || return 1
 
             # Skip already-available versions.
             # BF fix: on a PR (PR_TAG_SUFFIX non-empty), check the canonical arch tag
@@ -1136,7 +1143,7 @@ build_tag_push_extensions() {
             if [[ "$DRY_RUN" != "true" ]]; then
                 local _ver_duration=$(( SECONDS - _ver_start ))
                 local _ver_image
-                _ver_image=$(ext_image_name "$ext" "$version" "$major_ver")
+                _ver_image=$(ext_image_name "$ext" "$version" "$major_ver") || return 1
                 local _ver_safe="${version//[^a-zA-Z0-9.-]/_}"
                 local _ver_lineage_suffix=""
                 [[ -n "${ARCH_SUFFIX:-}" ]] && _ver_lineage_suffix="-${ARCH_SUFFIX}"
@@ -1455,7 +1462,7 @@ _should_build_extension() {
 
     local version image
     version=$(ext_config "$ext" "version" "$config_file")
-    image=$(ext_image_name "$ext" "$version" "$major_ver")
+    image=$(ext_image_name "$ext" "$version" "$major_ver") || return 2
 
     # Resolve the full version set (cached). A non-zero return from _resolve_cached
     # means the resolver script failed — NOT a no-resolver extension (which returns
@@ -1534,7 +1541,7 @@ _should_build_extension() {
     local ver
     while IFS= read -r ver; do
         local ver_image_mv
-        ver_image_mv=$(ext_image_name "$ext" "$ver" "$major_ver")
+        ver_image_mv=$(ext_image_name "$ext" "$ver" "$major_ver") || return 2
         local _check_ver_image_mv
         _check_ver_image_mv=$(_scoped_tag "$(_arch_suffix_tag "$ver_image_mv" "${ARCH_SUFFIX:-}")")
 
@@ -1764,7 +1771,7 @@ _emit_versionset_artifact() {
     local _probe_error=false
     while IFS= read -r ver; do
         local ver_image
-        ver_image=$(ext_image_name "$ext" "$ver" "$major_ver")
+        ver_image=$(ext_image_name "$ext" "$ver" "$major_ver") || return 1
 
         # Use 3-state probe to distinguish PRESENT / ABSENT / ERROR.
         # Versions in the built-this-run set are always PRESENT (propagation-lag guard).
@@ -2055,13 +2062,19 @@ finalize_multiarch_manifests() {
             # When both arch refs are absent (normal case: imagetools create hasn't run yet),
             # fall back to the computed scoped refs.
             if [[ -z "$_nr_src_amd64" ]]; then
-                _nr_src_amd64=$(_scoped_tag "$(_arch_suffix_tag "$(ext_image_name "$ext" "$ceiling" "$major_ver")" "amd64")")
+                local _nr_image
+                _nr_image=$(ext_image_name "$ext" "$ceiling" "$major_ver") || { _failed=true; continue; }
+                _nr_src_amd64=$(_scoped_tag "$(_arch_suffix_tag "$_nr_image" "amd64")")
             fi
             if [[ -z "$_nr_src_arm64" ]]; then
-                _nr_src_arm64=$(_scoped_tag "$(_arch_suffix_tag "$(ext_image_name "$ext" "$ceiling" "$major_ver")" "arm64")")
+                local _nr_image
+                _nr_image=$(ext_image_name "$ext" "$ceiling" "$major_ver") || { _failed=true; continue; }
+                _nr_src_arm64=$(_scoped_tag "$(_arch_suffix_tag "$_nr_image" "arm64")")
             fi
             if [[ -z "$_nr_target" ]]; then
-                _nr_target=$(_scoped_tag "$(ext_image_name "$ext" "$ceiling" "$major_ver")")
+                local _nr_image
+                _nr_image=$(ext_image_name "$ext" "$ceiling" "$major_ver") || { _failed=true; continue; }
+                _nr_target=$(_scoped_tag "$_nr_image")
             fi
 
             log_info "$ext $ceiling pg${major_ver}: imagetools create $_nr_target from $_nr_src_amd64 + $_nr_src_arm64 (non-resolver, stable suffixed tags)"
@@ -2224,7 +2237,9 @@ finalize_multiarch_manifests() {
             # Both arch tags confirmed PRESENT: create the multi-arch manifest.
             # Target is the scoped version ref (canonical on push, PR-scoped on PR).
             local ver_multiarch
-            ver_multiarch=$(_scoped_tag "$(ext_image_name "$ext" "$ver" "$major_ver")")
+            local _ver_image
+            _ver_image=$(ext_image_name "$ext" "$ver" "$major_ver") || { _ext_failed=true; break; }
+            ver_multiarch=$(_scoped_tag "$_ver_image")
 
             log_info "$ext $ver pg${major_ver}: imagetools create $ver_multiarch from $_ver_tag_amd64 + $_ver_tag_arm64"
             local _create_rc=0
@@ -2332,10 +2347,11 @@ finalize_multiarch_manifests() {
         local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
         mkdir -p "${ROOT_DIR}/.build-lineage"
 
-        local _available_json _excluded_json _resolved_json _version_digests_json
+        local _available_json _excluded_json _resolved_json _version_digests_json _version_digests_repository
         _available_json=$(printf '%s\n' "${_confirmed_available[@]+"${_confirmed_available[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
         _excluded_json="[$(IFS=,; echo "${_excluded_entries[*]+"${_excluded_entries[*]}"}")]"
         _resolved_json=$(echo "$version_set_json" | jq '.')
+        _version_digests_repository=$(ext_image_repository "$ext") || { _failed=true; continue; }
 
         # Build version_digests JSON object: {"<ver>":"sha256:..."}
         local _vd_args=()
@@ -2362,7 +2378,8 @@ finalize_multiarch_manifests() {
             --argjson available "$_available_json" \
             --argjson excluded "$_excluded_json" \
             --argjson version_digests "$_version_digests_json" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests}' \
+            --arg version_digests_repository "$_version_digests_repository" \
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}' \
             > "$_vs_lineage_file"
         log_success "Versionset artifact written: $_vs_lineage_file"
 
@@ -2376,6 +2393,10 @@ finalize_multiarch_manifests() {
 
 main() {
     parse_args "$@"
+
+    # Validate the optional package axis before any prerequisite, registry, or
+    # build action. A malformed suffix must never influence a reference.
+    validate_extension_package_suffix || return 1
 
     validate_prerequisites
 

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -730,6 +730,10 @@ _count_log_lines() {
     vd_present=$(jq -r 'if has("version_digests") then "yes" else "no" end' "$artifact")
     [ "$vd_present" = "yes" ]
 
+    local digest_repository
+    digest_repository=$(jq -r '.version_digests_repository // empty' "$artifact")
+    [ -n "$digest_repository" ]
+
     # version_digests must contain an entry for EVERY available version.
     local available_count vd_count
     available_count=$(jq '.available | length' "$artifact")
@@ -771,6 +775,13 @@ _count_log_lines() {
     local vd_present
     vd_present=$(jq -r 'if has("version_digests") then "yes" else "no" end' "$artifact")
     [ "$vd_present" = "no" ]
+
+    local digest_repository
+    digest_repository=$(jq -r 'has("version_digests_repository")' "$artifact")
+    [ "$digest_repository" = "false" ] || {
+        echo "FAIL: no-push artifact must not carry version_digests_repository without version_digests"
+        false
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -8661,6 +8672,10 @@ EOCFG
     local vd_2251
     vd_2251=$(jq -r '.version_digests["2.25.0"]' "$artifact" 2>/dev/null || echo "")
     [ "$vd_2251" = "sha256:cafebabe00000000000000000000000000000000000000000000000000000000" ]
+
+    local digest_repository
+    digest_repository=$(jq -r '.version_digests_repository // empty' "$artifact" 2>/dev/null || echo "")
+    [ -n "$digest_repository" ]
 
     # bundle_digest must NOT be present (replaced by version_digests).
     local has_bundle_digest

--- a/tests/unit/extension-package-suffix.bats
+++ b/tests/unit/extension-package-suffix.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+
+# Contract tests for EXTENSION_PACKAGE_SUFFIX, the package-name axis used by
+# rotation candidates. It is intentionally independent of PR_TAG_SUFFIX.
+
+load "../test_helper"
+
+_source_build_extensions() {
+    pushd "$SCRIPTS_DIR" > /dev/null 2>&1
+    # shellcheck disable=SC1091
+    source "./build-extensions.sh"
+    popd > /dev/null 2>&1
+}
+
+setup() {
+    setup_temp_dir
+    export EXTENSION_REGISTRY="ghcr.io"
+    export GITHUB_REPOSITORY_OWNER="testowner"
+    export FORCE=false LOCAL_ONLY=false NO_CACHE=false
+    unset EXTENSION_PACKAGE_SUFFIX PR_TAG_SUFFIX ARCH_SUFFIX BUILD_PLATFORM
+    _source_build_extensions
+}
+
+teardown() {
+    teardown_temp_dir
+    unset EXTENSION_REGISTRY GITHUB_REPOSITORY_OWNER EXTENSION_PACKAGE_SUFFIX
+    unset PR_TAG_SUFFIX ARCH_SUFFIX BUILD_PLATFORM FORCE LOCAL_ONLY NO_CACHE
+}
+
+@test "unset package suffix preserves origin/master literal constructor refs" {
+    local expected image cache
+    expected="ghcr.io/testowner/ext-pgvector:pg18-0.8.2"
+
+    image=$(ext_image_name "pgvector" "0.8.2" "18")
+    [ "$image" = "$expected" ] || {
+        echo "ASSERTION: unset package suffix must preserve ghcr.io/testowner/ext-pgvector:pg18-0.8.2"
+        false
+    }
+
+    cache=$(ext_buildcache_repository "pgvector" "ghcr.io" "testowner")
+    [ "$cache" = "ghcr.io/testowner/ext-pgvector-buildcache" ] || {
+        echo "ASSERTION: unset package suffix must preserve ghcr.io/testowner/ext-pgvector-buildcache"
+        false
+    }
+}
+
+@test "staging package suffix applies to per-arch, multi-arch, and buildcache refs with tag suffix" {
+    local docker_calls="$TEST_TEMP_DIR/docker-calls.log"
+    export EXTENSION_PACKAGE_SUFFIX="-staging"
+    export PR_TAG_SUFFIX="-rotation42"
+    export BUILD_PLATFORM="linux/amd64"
+    export ARCH_SUFFIX="amd64"
+    export REPO_OWNER="testowner"
+    export docker_calls
+
+    docker() {
+        printf 'DOCKER' >> "$docker_calls"
+        printf ' %s' "$@" >> "$docker_calls"
+        printf '\n' >> "$docker_calls"
+        return 0
+    }
+    export -f docker
+
+    run build_ext_image "pgvector" "0.8.2" "https://example.invalid/pgvector" "18" "/tmp/unused.Dockerfile" "/tmp"
+    [ "$status" -eq 0 ]
+
+    grep -Fxq \
+        "DOCKER buildx build --platform linux/amd64 -f /tmp/unused.Dockerfile -t ghcr.io/testowner/ext-pgvector-staging:pg18-0.8.2-amd64-rotation42 --load --cache-from type=registry,ref=ghcr.io/testowner/ext-pgvector-staging-buildcache:pg18-amd64 --cache-from type=registry,ref=ghcr.io/testowner/ext-pgvector-staging-buildcache:pg18-amd64-rotation42 --cache-to type=registry,ref=ghcr.io/testowner/ext-pgvector-staging-buildcache:pg18-amd64-rotation42,mode=max,ignore-error=true --build-arg REMOTE_CR=ghcr.io/oorabona --build-arg MAJOR_VERSION=18 --build-arg EXT_VERSION=0.8.2 --build-arg EXT_REPO=https://example.invalid/pgvector /tmp" \
+        "$docker_calls"
+    grep -Fxq "DOCKER push ghcr.io/testowner/ext-pgvector-staging:pg18-0.8.2-amd64-rotation42" "$docker_calls"
+
+    # FORCE retains the established preference for the run-scoped tag; the
+    # package suffix composes with that resolution rather than replacing it.
+    export FORCE=true
+    _image_registry_probe_3state() { return 0; }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve "pgvector" "0.8.2" "18" ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-pgvector-staging:pg18-0.8.2-rotation42" ] || {
+        echo "ASSERTION: multi-arch ref must carry the staging package and its independent tag suffix"
+        false
+    }
+}
+
+@test "malformed package suffix is refused before any build step" {
+    local suffix marker
+    marker="$TEST_TEMP_DIR/build-ran"
+
+    for suffix in '-/' '-:' '-@' '-has space' ''; do
+        rm -f "$marker"
+        run env EXTENSION_PACKAGE_SUFFIX="$suffix" BUILD_MARKER="$marker" \
+            bash -c '
+                source "'"$SCRIPTS_DIR"'/build-extensions.sh"
+                validate_prerequisites() { return 0; }
+                check_registry_auth() { return 0; }
+                list_extensions_by_priority() { echo pgvector; }
+                _should_build_extension() { return 0; }
+                build_tag_push_extensions() { touch "$BUILD_MARKER"; return 0; }
+                _emit_final_versionset_pass() { return 0; }
+                main postgres --major-version 18
+            '
+
+        [ ! -e "$marker" ] || {
+            echo "ASSERTION: malformed package suffix '$suffix' must stop before any build step"
+            false
+        }
+        [ "$status" -ne 0 ] || {
+            echo "ASSERTION: malformed package suffix '$suffix' must fail"
+            false
+        }
+        [[ "$output" == *"EXTENSION_PACKAGE_SUFFIX must be unset or match"* ]] || {
+            echo "ASSERTION: malformed package suffix '$suffix' must report the package-suffix boundary"
+            false
+        }
+    done
+}
+
+@test "invalid package suffix stops main when its caller uses ||" {
+    run env EXTENSION_PACKAGE_SUFFIX='' bash -c '
+        source "'"$SCRIPTS_DIR"'/build-extensions.sh"
+        validate_prerequisites() { echo PREREQUISITES_REACHED; }
+        list_extensions_by_priority() { echo LIST_REACHED; }
+        main postgres --list || true
+    '
+
+    [[ "$output" == *"EXTENSION_PACKAGE_SUFFIX must be unset or match"* ]] || {
+        echo "FAIL: invalid suffix must report the package-suffix boundary"
+        false
+    }
+    [[ "$output" != *"PREREQUISITES_REACHED"* ]] || {
+        echo "FAIL: invalid suffix must not reach prerequisites when main is called through ||"
+        false
+    }
+    [[ "$output" != *"LIST_REACHED"* ]] || {
+        echo "FAIL: invalid suffix must not reach listing when main is called through ||"
+        false
+    }
+}
+
+@test "failed package reference construction returns from ext_ref_resolve without a probe" {
+    local marker="$TEST_TEMP_DIR/probe-called"
+    export EXTENSION_PACKAGE_SUFFIX=''
+    export marker
+
+    _image_registry_probe_3state() {
+        touch "$marker"
+        return 0
+    }
+    export -f _image_registry_probe_3state
+
+    run ext_ref_resolve "pgvector" "0.8.2" "18" ""
+
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: failed reference construction must return ext_ref_resolve's documented error status"
+        false
+    }
+    [ ! -e "$marker" ] || {
+        echo "FAIL: failed reference construction must not reach _image_registry_probe_3state"
+        false
+    }
+    [[ "$output" == *"ERROR [ext_ref_resolve]: failed to construct reference"* ]] || {
+        echo "FAIL: failed reference construction must name ext_ref_resolve"
+        false
+    }
+}

--- a/tests/unit/generate-dockerfile-versionset.bats
+++ b/tests/unit/generate-dockerfile-versionset.bats
@@ -343,7 +343,7 @@ EOF
     ! grep -q "/tmp/ext/pgvector/0\." <<<"$output"
 }
 
-@test "single-version artifact with digest emits an immutable FROM ref" {
+@test "legacy single-version digest artifact without repository identity remains consumable" {
     cat > "$TEST_TEMP_DIR/.build-lineage/ext-pgvector-pg18-versionset.json" <<'EOF'
 {"ext":"pgvector","pg_major":"18","ceiling":"0.8.2","resolved":["0.8.2"],"available":["0.8.2"],"excluded":[],"version_digests":{"0.8.2":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
 EOF
@@ -357,6 +357,47 @@ EOF
     [ "$status" -eq 0 ]
     echo "$output" | grep -Fxq "FROM ghcr.io/testowner/ext-pgvector@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS ext-pgvector" || {
         echo "FAIL: valid declared version_digests must emit immutable FROM ref"
+        false
+    }
+}
+
+@test "digest artifact for another package is ignored and self-heals" {
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","2.27.1":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"version_digests_repository":"ghcr.io/testowner/ext-timescaledb-staging"}
+EOF
+    local probe_marker="$TEST_TEMP_DIR/self-heal-probes"
+    export probe_marker
+
+    resolve_version_set() {
+        echo '["2.25.0","2.27.1"]'
+    }
+    image_exists_in_registry() {
+        printf '%s\n' "$1" >> "$probe_marker"
+        return 0
+    }
+    export -f resolve_version_set image_exists_in_registry
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+    [ -s "$probe_marker" ] || {
+        echo "FAIL: mismatched digest package must trigger resolver/probe self-heal"
+        false
+    }
+    [[ "$output" == *"belong to ghcr.io/testowner/ext-timescaledb-staging, not ghcr.io/testowner/ext-timescaledb"* ]] || {
+        echo "FAIL: mismatched digest package must be refused with both identities"
+        false
+    }
+    ! grep -Fq '@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' <<<"$output" || {
+        echo "FAIL: mismatched digest package must not be emitted"
+        false
+    }
+    grep -Fxq 'COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/' <<<"$output" || {
+        echo "FAIL: self-heal must emit the current package tag"
         false
     }
 }
@@ -2644,6 +2685,57 @@ _write_versionset_with_malformed_ver_digest() {
     local pinned_count
     pinned_count=$(echo "$output" | grep -cxE "COPY --from=ghcr\.io/testowner/ext-timescaledb@sha256:[^[:space:]]+ /output/ /[0-9]+\.[0-9]+\.[0-9]+/" || true)
     [ "$pinned_count" -eq 2 ]
+}
+
+@test "legacy digest artifact remains canonical when package suffix is unset" {
+    # This fixture deliberately has no version_digests_repository: artifacts
+    # written before the identity field always refer to the canonical package.
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fxq "COPY --from=ghcr.io/testowner/ext-timescaledb@sha256:0000000000000000000000000000000000000000000000000000000000000001 /output/ /2.25.0/" || {
+        echo "FAIL: legacy digest artifact must remain consumable by the canonical package"
+        false
+    }
+}
+
+@test "legacy digest artifact with package suffix self-heals instead of pairing staging with canonical digest" {
+    _write_versionset_with_digests "timescaledb" "18" "2.25.0" "2.27.1"
+    export EXTENSION_PACKAGE_SUFFIX="-staging"
+    resolve_version_set() { echo '["2.25.0","2.27.1"]'; }
+    _image_registry_probe_3state() { return 0; }
+    export -f resolve_version_set _image_registry_probe_3state
+
+    run generate_dockerfile \
+        "$TEST_TEMP_DIR/extensions/config.yaml" \
+        "$TEST_TEMP_DIR/Dockerfile.template" \
+        "timeseries" "18" \
+        "ghcr.io" "testowner"
+
+    unset EXTENSION_PACKAGE_SUFFIX
+
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: legacy digest artifact under a package suffix must enter self-heal"
+        false
+    }
+    [[ "$output" == *"treating artifact as absent, triggering self-heal"* ]] || {
+        echo "FAIL: legacy digest artifact under a package suffix must be refused into self-heal"
+        false
+    }
+    ! grep -q "ext-timescaledb-staging@sha256:" <<<"$output" || {
+        echo "FAIL: staging repository must never be paired with a canonical legacy digest"
+        false
+    }
+    echo "$output" | grep -Fxq "COPY --from=ghcr.io/testowner/ext-timescaledb-staging:pg18-2.25.0 /output/ /2.25.0/" || {
+        echo "FAIL: self-heal must resolve the staging repository by tag"
+        false
+    }
 }
 
 @test "no version_digests in artifact → tag-based refs in collector" {


### PR DESCRIPTION
The scheduled rotation must compile a candidate, test it, and publish only if the test passes. Candidates cannot live in the production package, for two independent reasons.

A concurrent `auto-build` reaching stage B while the rotation is still testing sees the multi-arch target absent and both canonical arch tags present, and publishes an index built from untested images — and that is exactly the case the selector prioritises, since a pair with no canonical record ranks above every dated one. Separately, a run-scoped tag on the production package freezes its version record for ever: #1173 was closed after establishing that a record carrying a tag the pruner cannot parse can never be safely deleted, and at three runs a day the rotation would leave roughly a thousand of those a year.

`EXTENSION_PACKAGE_SUFFIX` names the package rather than the tag, so a build lands in `ext-<name>-staging` while the existing tag suffix keeps doing its own job. Unset, every reference is byte-identical to before — asserted as literal strings in default, local-only, force and no-cache modes, and answered hunk by hunk during review. A suffix carrying a path or tag separator is refused before any build starts, since a reference assembled from an unchecked string pushes somewhere nobody intended.

Three things the review changed, each of which the rotation would have walked into:

- **A digest now records which package it was observed in.** Building with the suffix set and generating with it unset emitted `ext-<name>@<staging-digest>`, a digest the production package does not carry. Every artifact writer records the repository; the reader refuses a mismatch and self-heals. An artifact written before this change is still consumed, since both shapes will exist during any rollout.
- **`ext_image_name` became fallible and twenty call sites did not.** With an empty suffix, `ext_ref_resolve` logged the error and then probed with an empty reference — reproduced as `PROBED_REF=<>`. All twenty propagate now, and `ext_ref_resolve` returns its documented error status without probing.
- **`[[ -v VAR ]]` needs Bash 4.2 against a documented 4.0 floor**, so an unset suffix reached a conditional-expression error and lost the whole extension command on the supported minimum. This was the second Bash-floor defect today; the other shipped in #1281.

Nothing sets the variable yet. The design it serves is on #1245: candidates build into staging, digests are frozen, amd64 runs the full postgres e2e and arm64 a native activation smoke, and promotion copies the frozen manifests to the canonical arch tags under the publishing lock before creating the index from the destination digests.

**Verification.** shellcheck `-x -S warning` clean; 2612 unit tests green through `tests/run-tests.sh`; each negative property ships with a test proven to fail under a named mutation. The Bash floor could not be exercised — only 5.2 is installed here — so that check was a source read for the constructs in question.

**Landed at its round budget.** Residue filed: #1286 (character-range validation is locale-dependent in three places), #1287 (a legacy artifact's digests are matched against a registry and owner it never recorded), #1288 (an empty owner builds `ghcr.io//ext-foo` and reports success), #1282 (staging and production share the local build tag and the lineage filename), #1283 (finalization discards a transient probe error as absence). Pre-existing and untouched: #1271, #1250, #1251, #1254, #1272, #1274, #1276, #1277, #1280.

Refs #1245
