### PR TITLE
Stop the extension prune reporting success after deciding nothing

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -73,6 +73,9 @@ jobs:
   cleanup-ext-images:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Deletion is authorised by the most recent successful re-read of that exact
+    # record. Nothing prevents a writer outside this workflow from changing it
+    # between that re-read and DELETE.
     # Independent lifecycle job — not in any build/consume path.
     # Runs monthly on schedule, or on operator dispatch with explicit opt-in.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/scripts/cleanup-ext-images.sh
+++ b/scripts/cleanup-ext-images.sh
@@ -21,6 +21,9 @@
 #   - If the window computation is empty/uncertain/errors for (ext, pg_major),
 #     tags for that major are treated as KEEP — never delete when the keep-set is unknown.
 #   - Every decision (keep / prune / skip) is logged.
+#   - Deletion is authorised by the most recent successful re-read of that exact
+#     record. Nothing prevents a writer outside this workflow from changing it
+#     between that re-read and DELETE.
 #
 # Required env vars: GH_TOKEN, OWNER
 # Optional env vars:
@@ -72,6 +75,16 @@ Environment:
   OWNER     (required)  GitHub owner/org (e.g. oorabona)
   EXT_CONFIG            Path to postgres/extensions/config.yaml
   PG_VERSIONS           Space-separated additional PG major versions
+
+Deletion guarantee:
+  Deletion is authorised by the most recent successful re-read of that exact
+  record. Nothing prevents a writer outside this workflow from changing it
+  between that re-read and DELETE.
+
+Exit status:
+  Returns non-zero if the invocation fails or if any record or coverage could
+  not be assessed completely, in both dry-run and execute modes. A non-zero
+  dry-run may therefore have made no deletions but is an incomplete audit.
 EOF
 }
 
@@ -125,13 +138,86 @@ _delete_ghcr_ext_version() {
     fi
 }
 
+# Re-read one GHCR package version record by the same id used by DELETE.  A
+# listing is only a snapshot: a publisher may attach a retained tag after the
+# listing and before a destructive request is made.
+_get_ghcr_ext_version_record() {
+    local package_name="$1"   # e.g. ext-timescaledb
+    local version_id="$2"
+    local owner="${OWNER:?OWNER is required}"
+
+    gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/users/${owner}/packages/container/${package_name}/versions/${version_id}" 2>/dev/null \
+        | jq -ce --arg expected_version_id "$version_id" '
+          def record_tags:
+            (.metadata.container.tags // [])
+            | if type == "array" and all(.[]; type == "string") then .
+              else error("GHCR version record tags must be an array of strings")
+              end;
+          {
+            version_id: (if .id == null then error("GHCR version record has no id")
+                         elif (.id | tostring) != $expected_version_id then error("GHCR version record id does not match requested version id")
+                         else (.id | tostring)
+                         end),
+            tags: record_tags
+          }
+        '
+}
+
 # Check whether a version string is present in a JSON array of versions.
-# Returns 0 if in window, 1 if not.
+# Returns 0 if in window, 1 if definitely not, and 2 if membership could not
+# be computed.  Only the definite-not result may contribute to a deletion.
 _version_in_window() {
     local version="$1"
     local window_json="$2"
+    local jq_status
 
-    jq -e --arg v "$version" 'any(. == $v)' <<< "$window_json" >/dev/null 2>&1
+    if jq -e --arg v "$version" 'any(. == $v)' <<< "$window_json" >/dev/null 2>&1; then
+        return 0
+    else
+        jq_status=$?
+    fi
+    [[ "$jq_status" -eq 1 ]] && return 1
+    return 2
+}
+
+# Validate and normalize a resolver retention window.  The output variables are
+# set in the caller's dynamic scope.  Return 0 for valid, 1 for structurally
+# invalid, and 2 when validation itself could not be computed.
+_retention_window_is_valid() {
+    local window_json="$1"
+    local validation_result
+
+    validated_window_json=""
+    validated_window_count=""
+    validated_window_display=""
+
+    if ! validation_result=$(jq -cr '
+      if type == "array" and length > 0
+         and all(.[]; type == "string" and test("^[0-9]+([.][0-9]+)*$"))
+      then { valid: true, window: ., count: length, display: join(", ") }
+      else { valid: false }
+      end
+    ' <<< "$window_json"); then
+        return 2
+    fi
+
+    local window_is_valid
+    if ! window_is_valid=$(jq -r '.valid' <<< "$validation_result"); then
+        return 2
+    fi
+    [[ "$window_is_valid" == "true" ]] || return 1
+    if ! validated_window_json=$(jq -ce '.window' <<< "$validation_result"); then
+        return 2
+    fi
+    if ! validated_window_count=$(jq -er '.count' <<< "$validation_result"); then
+        return 2
+    fi
+    if ! validated_window_display=$(jq -er '.display' <<< "$validation_result"); then
+        return 2
+    fi
 }
 
 # Parse a managed extension tag.
@@ -191,6 +277,89 @@ _list_version_record_tags() {
           error("tag cannot be transported safely")
         end
     ' <<< "$record_json"
+}
+
+# Return 0 only when every tag on a record is managed and outside its known
+# retention window; return 1 for a definite keep, and 2 when classification
+# could not be computed. The two output variables are intentionally set in the
+# caller's dynamic scope so the log always names the exact tags assessed.
+_record_is_prunable() {
+    local record_json="$1"
+    local tag_count
+    local tags_file
+    local tag
+    local membership_status
+
+    record_tags_csv="(tag enumeration unavailable)"
+    record_keep_reason=""
+    if ! tag_count=$(jq -er '(.tags // []) | if type == "array" then length else error("record tags must be an array") end' <<< "$record_json"); then
+        record_keep_reason="tag count unknown; keeping record fail-closed"
+        return 2
+    fi
+    if [[ ! "$tag_count" =~ ^[0-9]+$ ]]; then
+        record_keep_reason="tag count unknown; keeping record fail-closed"
+        return 2
+    fi
+
+    if [[ "$tag_count" -eq 0 ]]; then
+        if ! record_tags_csv=$(_version_record_tags_csv "$record_json"); then
+            record_keep_reason="tag enumeration unknown; keeping record fail-closed"
+            return 2
+        fi
+        record_keep_reason="no tags on version record; fail-closed"
+        return 1
+    fi
+
+    if ! tags_file=$(mktemp "${TMPDIR:-/tmp}/cleanup-ext-images-record-tags.XXXXXX"); then
+        record_keep_reason="tag enumeration unavailable; keeping record fail-closed"
+        return 2
+    fi
+    if ! collect_lines "$tags_file" -- _list_version_record_tags "$record_json"; then
+        rm -f "$tags_file" || true
+        record_keep_reason="tag enumeration unknown; keeping record fail-closed"
+        return 2
+    fi
+
+    if ! record_tags_csv=$(_version_record_tags_csv "$record_json"); then
+        rm -f "$tags_file" || true
+        record_keep_reason="tag enumeration unknown; keeping record fail-closed"
+        return 2
+    fi
+    while IFS= read -r tag; do
+        local parsed
+        local tag_major
+        local tag_version
+        if ! parsed=$(_parse_ext_managed_tag "$tag"); then
+            rm -f "$tags_file" || true
+            printf -v record_keep_reason 'contains unmanaged/unparseable tag: %q' "$tag"
+            return 1
+        fi
+
+        IFS='|' read -r tag_major tag_version <<< "$parsed"
+        if [[ "${window_known_by_major[$tag_major]:-false}" != "true" ]]; then
+            rm -f "$tags_file" || true
+            record_keep_reason="window unknown for pg${tag_major}: ${tag}"
+            return 1
+        fi
+
+        if _version_in_window "$tag_version" "${window_by_major[$tag_major]}"; then
+            rm -f "$tags_file" || true
+            record_keep_reason="contains retained tag: ${tag}"
+            return 1
+        else
+            membership_status=$?
+        fi
+        if [[ "$membership_status" -eq 2 ]]; then
+            rm -f "$tags_file" || true
+            record_keep_reason="retention membership unknown for ${tag}; keeping record fail-closed"
+            return 2
+        fi
+    done < "$tags_file"
+    if ! rm -f "$tags_file"; then
+        record_keep_reason="tag enumeration cleanup failed; keeping record fail-closed"
+        return 2
+    fi
+    return 0
 }
 
 # ── Main entry point ─────────────────────────────────────────────────────────
@@ -285,6 +454,8 @@ main() {
     local total_delete_failures=0
     local total_skipped_pairs=0
     local total_listing_failures=0
+    local total_reread_failures=0
+    local total_analysis_failures=0
 
     if [[ "$dry_run" == "true" ]]; then
         log_warning "DRY-RUN MODE — no version records will be deleted (pass --execute to delete)"
@@ -373,23 +544,29 @@ main() {
                 continue
             fi
 
-            local window_count
-            window_count=$(jq 'if type=="array" and length>0 then length else 0 end' <<< "$window_json" 2>/dev/null || echo "0")
-            if [[ "${window_count}" -le 0 ]]; then
-                log_warning "  Resolver returned empty/non-array for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+            local window_validation_status
+            if _retention_window_is_valid "$window_json"; then
+                window_json="$validated_window_json"
+                window_by_major[$pg_major]="$window_json"
+                window_known_by_major[$pg_major]="true"
+                log_info "    Retention window (${validated_window_count} versions): ${validated_window_display}"
+            else
+                window_validation_status=$?
+                if [[ "$window_validation_status" -eq 1 ]]; then
+                    log_warning "  Resolver returned invalid window for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+                else
+                    log_warning "  Resolver window validation failed for ${ext_name}/pg${pg_major} — SKIPPING (fail-closed)"
+                fi
                 total_skipped_pairs=$((total_skipped_pairs + 1))
                 continue
             fi
-
-            window_json=$(jq -c '.' <<< "$window_json")
-            window_by_major[$pg_major]="$window_json"
-            window_known_by_major[$pg_major]="true"
-            log_info "    Retention window (${window_count} versions): $(jq -r 'join(", ")' <<< "$window_json")"
         done
 
         local kept_count=0
         local pruned_count=0
         local delete_failures=0
+        local reread_failures=0
+        local analysis_failures=0
         local record_json
         local records_file
 
@@ -410,68 +587,49 @@ main() {
             [[ -n "$record_json" ]] || continue
 
             local version_id
-            local tags_csv
-            local tag_count
             version_id=$(jq -r '.version_id' <<< "$record_json")
-            tags_csv="(tag enumeration unavailable)"
-            tag_count=$(jq '(.tags // []) | length' <<< "$record_json")
+            local record_tags_csv
+            local record_keep_reason
 
-            local should_delete="true"
-            local keep_reason=""
-
-            if [[ "$tag_count" -eq 0 ]]; then
-                should_delete="false"
-                keep_reason="no tags on version record; fail-closed"
-            fi
-
-            local tags_file
-            tags_file=$(mktemp "${TMPDIR:-/tmp}/cleanup-ext-images-record-tags.XXXXXX") || return 1
-            if ! collect_lines "$tags_file" -- _list_version_record_tags "$record_json"; then
-                should_delete="false"
-                keep_reason="tag enumeration unknown; keeping record fail-closed"
-            else
-                tags_csv=$(_version_record_tags_csv "$record_json")
-                local tag
-                while [[ "$should_delete" == "true" ]] && IFS= read -r tag; do
-                    local parsed
-                    local tag_major
-                    local tag_version
-                    if ! parsed=$(_parse_ext_managed_tag "$tag"); then
-                        should_delete="false"
-                        printf -v keep_reason 'contains unmanaged/unparseable tag: %q' "$tag"
-                        break
-                    fi
-
-                    IFS='|' read -r tag_major tag_version <<< "$parsed"
-                    if [[ "${window_known_by_major[$tag_major]:-false}" != "true" ]]; then
-                        should_delete="false"
-                        keep_reason="window unknown for pg${tag_major}: ${tag}"
-                        break
-                    fi
-
-                    if _version_in_window "$tag_version" "${window_by_major[$tag_major]}"; then
-                        should_delete="false"
-                        keep_reason="contains retained tag: ${tag}"
-                        break
-                    fi
-                done < "$tags_file"
-            fi
-            rm -f "$tags_file"
-
-            if [[ "$should_delete" == "true" ]]; then
-                log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${tags_csv}) — all managed tags outside window"
+            local record_classification_status
+            if _record_is_prunable "$record_json"; then
                 if [[ "$dry_run" == "true" ]]; then
-                    log_info "      [DRY-RUN] Would delete ${package_name} version_id=${version_id} (tags: ${tags_csv})"
+                    log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${record_tags_csv}) — all managed tags outside window"
+                    log_info "      [DRY-RUN] Would delete ${package_name} version_id=${version_id} (tags: ${record_tags_csv})"
                     pruned_count=$((pruned_count + 1))
                 else
-                    if _delete_ghcr_ext_version "$package_name" "$version_id" "$tags_csv"; then
-                        pruned_count=$((pruned_count + 1))
+                    local current_record_json
+                    log_info "    Candidate version_id=${version_id} (tags: ${record_tags_csv}) — re-reading before delete"
+                    if ! current_record_json=$(_get_ghcr_ext_version_record "$package_name" "$version_id"); then
+                        log_warning "    ✓ KEEP  version_id=${version_id} (tags: ${record_tags_csv}) — re-read before deletion failed; keeping record fail-closed"
+                        kept_count=$((kept_count + 1))
+                        reread_failures=$((reread_failures + 1))
+                    elif _record_is_prunable "$current_record_json"; then
+                        log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${record_tags_csv}) — all managed tags outside window"
+                        if _delete_ghcr_ext_version "$package_name" "$version_id" "$record_tags_csv"; then
+                            pruned_count=$((pruned_count + 1))
+                        else
+                            delete_failures=$((delete_failures + 1))
+                        fi
                     else
-                        delete_failures=$((delete_failures + 1))
+                        record_classification_status=$?
+                        if [[ "$record_classification_status" -eq 2 ]]; then
+                            log_warning "    ✓ KEEP  version_id=${version_id} (tags: ${record_tags_csv}) — re-read before deletion inconclusive: ${record_keep_reason}"
+                            analysis_failures=$((analysis_failures + 1))
+                        else
+                            log_info "    ✓ KEEP  version_id=${version_id} (tags: ${record_tags_csv}) — re-read before deletion: ${record_keep_reason}"
+                        fi
+                        kept_count=$((kept_count + 1))
                     fi
                 fi
             else
-                log_info "    ✓ KEEP  version_id=${version_id} (tags: ${tags_csv}) — ${keep_reason}"
+                record_classification_status=$?
+                if [[ "$record_classification_status" -eq 2 ]]; then
+                    log_warning "    ✓ KEEP  version_id=${version_id} (tags: ${record_tags_csv}) — analysis inconclusive: ${record_keep_reason}"
+                    analysis_failures=$((analysis_failures + 1))
+                else
+                    log_info "    ✓ KEEP  version_id=${version_id} (tags: ${record_tags_csv}) — ${record_keep_reason}"
+                fi
                 kept_count=$((kept_count + 1))
             fi
         done < "$records_file"
@@ -481,6 +639,8 @@ main() {
         total_kept=$((total_kept + kept_count))
         total_pruned=$((total_pruned + pruned_count))
         total_delete_failures=$((total_delete_failures + delete_failures))
+        total_reread_failures=$((total_reread_failures + reread_failures))
+        total_analysis_failures=$((total_analysis_failures + analysis_failures))
     done
 
     echo ""
@@ -492,6 +652,8 @@ main() {
     echo "  Delete failures: ${total_delete_failures}"
     echo "  (ext,major) pairs skipped (uncertain window): ${total_skipped_pairs}"
     echo "  Extensions skipped (listing failed): ${total_listing_failures}"
+    echo "  Candidate records kept (re-read failed): ${total_reread_failures}"
+    echo "  Candidate records kept (analysis inconclusive): ${total_analysis_failures}"
     if [[ "$dry_run" == "true" ]]; then
         echo "  Mode: DRY-RUN (no deletions performed)"
     else
@@ -499,7 +661,7 @@ main() {
     fi
     echo "========================================"
 
-    if [[ "$dry_run" != "true" && "$total_delete_failures" -gt 0 ]]; then
+    if [[ "$total_delete_failures" -gt 0 || "$total_skipped_pairs" -gt 0 || "$total_listing_failures" -gt 0 || "$total_reread_failures" -gt 0 || "$total_analysis_failures" -gt 0 ]]; then
         return 1
     fi
 }

--- a/tests/unit/cleanup-ext-images.bats
+++ b/tests/unit/cleanup-ext-images.bats
@@ -64,6 +64,8 @@ _run_cleanup_main_with_records() {
         CLEANUP_DELETE_MODE="$delete_mode" \
         CLEANUP_DELETE_CALLS_FILE="$delete_calls_file" \
         CLEANUP_LIST_MODE="$list_mode" \
+        CLEANUP_REREAD_RECORDS_FILE="${CLEANUP_REREAD_RECORDS_FILE:-$records_file}" \
+        CLEANUP_REREAD_MODE="${CLEANUP_REREAD_MODE:-success}" \
         bash -c '
             set -euo pipefail
             source "$PROJECT_ROOT/scripts/cleanup-ext-images.sh"
@@ -76,15 +78,47 @@ _run_cleanup_main_with_records() {
                 [[ -f "$window_file" ]] || return 1
                 cat "$window_file"
             }
-            gh() {
-                if [[ "$*" == *"--method DELETE"* ]]; then
+            jq() {
+                if [[ "${CLEANUP_JQ_MODE:-}" == "membership-fail" ]]; then
+                    local previous_arg=""
                     local arg
-                    local last_arg=""
                     for arg in "$@"; do
-                        last_arg="$arg"
+                        if [[ "$previous_arg" == "--arg" && "$arg" == "v" ]]; then
+                            return 2
+                        fi
+                        previous_arg="$arg"
                     done
+                fi
+                command jq "$@"
+            }
+            mktemp() {
+                if [[ "${CLEANUP_MKTEMP_MODE:-}" == "record-tags-fail" && "$*" == *"cleanup-ext-images-record-tags."* ]]; then
+                    return 1
+                fi
+                command mktemp "$@"
+            }
+            gh() {
+                local arg
+                local last_arg=""
+                for arg in "$@"; do
+                    last_arg="$arg"
+                done
+
+                if [[ "$*" == *"--method DELETE"* ]]; then
                     printf "DELETE:%s\n" "${last_arg##*/}" >> "$CLEANUP_DELETE_CALLS_FILE"
                     [[ "$CLEANUP_DELETE_MODE" != "fail" ]]
+                    return
+                fi
+
+                if [[ "$last_arg" == */versions/* ]]; then
+                    [[ "$CLEANUP_REREAD_MODE" != "fail" ]] || return 1
+                    if [[ "$CLEANUP_REREAD_MODE" == "mismatched-id" ]]; then
+                        jq -ce '.[0]' "$CLEANUP_REREAD_RECORDS_FILE"
+                        return
+                    fi
+                    jq -ce --arg version_id "${last_arg##*/}" \
+                        ".[] | select((.id | tostring) == \$version_id)" \
+                        "$CLEANUP_REREAD_RECORDS_FILE"
                     return
                 fi
 
@@ -195,7 +229,7 @@ EOF
     [[ ! -f "$delete_calls_file" ]]
 }
 
-@test "retired registry-derived major is kept fail-closed when its window cannot be computed" {
+@test "uncomputable resolver window is kept fail-closed and makes dry-run non-zero" {
     local records_file="$TEST_TEMP_DIR/retired-fail-records.json"
     local windows_dir="$TEST_TEMP_DIR/windows"
     local delete_calls_file="$TEST_TEMP_DIR/retired-fail-deletes"
@@ -209,11 +243,99 @@ EOF
 
     _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
 
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -ne 0 ]]
     [[ "$output" == *"Resolver failed for timescaledb/pg15"* ]]
     [[ "$output" == *"KEEP  version_id=311"* ]]
     [[ "$output" == *"window unknown for pg15: pg15-2.23.0"* ]]
     [[ "$output" == *"Summary: kept=1, pruned=0, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "jq membership failure keeps the record and makes execute mode non-zero" {
+    local records_file="$TEST_TEMP_DIR/jq-membership-fail-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/jq-membership-fail-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 321, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_JQ_MODE="membership-fail"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_JQ_MODE
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"KEEP  version_id=321"* ]]
+    [[ "$output" == *"retention membership unknown for pg17-2.23.0; keeping record fail-closed"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "structurally invalid [null] resolver window keeps records and makes execute mode non-zero" {
+    local records_file="$TEST_TEMP_DIR/null-window-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/null-window-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 331, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '[null]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Resolver returned invalid window for timescaledb/pg17"* ]]
+    [[ "$output" == *"KEEP  version_id=331"* ]]
+    [[ "$output" == *"window unknown for pg17: pg17-2.23.0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "structurally invalid [{}] resolver window keeps records and makes execute mode non-zero" {
+    local records_file="$TEST_TEMP_DIR/object-window-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/object-window-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 341, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '[{}]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Resolver returned invalid window for timescaledb/pg17"* ]]
+    [[ "$output" == *"KEEP  version_id=341"* ]]
+    [[ "$output" == *"window unknown for pg17: pg17-2.23.0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "classifier mktemp failure keeps the record and makes execute mode non-zero" {
+    local records_file="$TEST_TEMP_DIR/mktemp-fail-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/mktemp-fail-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 351, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_MKTEMP_MODE="record-tags-fail"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_MKTEMP_MODE
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"KEEP  version_id=351"* ]]
+    [[ "$output" == *"tag enumeration unavailable; keeping record fail-closed"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -286,12 +408,13 @@ EOF
 
     _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
 
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -ne 0 ]]
     [[ "$output" == *"KEEP  version_id=461"* ]]
     [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
     [[ "$output" != *"line-feed-quarantine-fragment"* ]]
     [[ "$output" != *"PRUNE version_id=461"* ]]
     [[ "$output" == *"Deleted ext-timescaledb version_id=462"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
     [[ -f "$delete_calls_file" ]]
     [[ "$(<"$delete_calls_file")" == "DELETE:462" ]]
 }
@@ -311,12 +434,13 @@ EOF
 
     _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
 
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -ne 0 ]]
     [[ "$output" == *"KEEP  version_id=471"* ]]
     [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
     [[ "$output" != *"nul-quarantine-fragment"* ]]
     [[ "$output" != *"PRUNE version_id=471"* ]]
     [[ "$output" == *"Deleted ext-timescaledb version_id=472"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
     [[ -f "$delete_calls_file" ]]
     [[ "$(<"$delete_calls_file")" == "DELETE:472" ]]
 }
@@ -341,11 +465,12 @@ EOF
 
     _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
 
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -ne 0 ]]
     [[ "$output" == *"KEEP  version_id=481"* ]]
     [[ "$output" == *"tag enumeration unknown; keeping record fail-closed"* ]]
     [[ "$output" != *"PRUNE version_id=481"* ]]
     [[ "$output" == *"Deleted ext-timescaledb version_id=482"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
     [[ -f "$delete_calls_file" ]]
     [[ "$(<"$delete_calls_file")" == "DELETE:482" ]]
 }
@@ -420,7 +545,7 @@ EOF
     [[ ! -f "$delete_calls_file" ]]
 }
 
-@test "GHCR version listing failure skips extension fail-closed" {
+@test "execute mode listing failure skips extension, deletes nothing, and exits non-zero" {
     local records_file="$TEST_TEMP_DIR/list-fail-records.json"
     local windows_dir="$TEST_TEMP_DIR/windows"
     local delete_calls_file="$TEST_TEMP_DIR/list-fail-calls"
@@ -428,12 +553,111 @@ EOF
     printf '[]\n' > "$records_file"
     _write_window "$windows_dir" "17" '["2.27.1"]'
 
-    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "fail"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "fail" --execute
 
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -ne 0 ]]
     [[ "$output" == *"GHCR version listing failed for ext-timescaledb"* ]]
     [[ "$output" == *"Extensions skipped (listing failed): 1"* ]]
     [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "execute mode keeps a record retagged into the retention window before deletion" {
+    local records_file="$TEST_TEMP_DIR/retagged-listing-records.json"
+    local reread_records_file="$TEST_TEMP_DIR/retagged-reread-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/retagged-delete-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 701, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    cat > "$reread_records_file" <<'EOF'
+[
+  { "id": 701, "metadata": { "container": { "tags": ["pg17-2.27.1"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_REREAD_RECORDS_FILE="$reread_records_file"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_REREAD_RECORDS_FILE
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Candidate version_id=701"* ]]
+    [[ "$output" == *"KEEP  version_id=701"* ]]
+    [[ "$output" == *"re-read before deletion: contains retained tag: pg17-2.27.1"* ]]
+    [[ "$output" != *"PRUNE version_id=701"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "execute mode re-read failure keeps its candidate and makes the run non-zero" {
+    local records_file="$TEST_TEMP_DIR/reread-fail-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/reread-fail-delete-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 702, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_REREAD_MODE="fail"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_REREAD_MODE
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"re-read before deletion failed; keeping record fail-closed"* ]]
+    [[ "$output" == *"Candidate records kept (re-read failed): 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "execute mode keeps a candidate when its re-read identifies a different record" {
+    local records_file="$TEST_TEMP_DIR/mismatched-reread-listing-records.json"
+    local reread_records_file="$TEST_TEMP_DIR/mismatched-reread-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/mismatched-reread-delete-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 701, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    cat > "$reread_records_file" <<'EOF'
+[
+  { "id": 702, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_REREAD_RECORDS_FILE="$reread_records_file"
+    export CLEANUP_REREAD_MODE="mismatched-id"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_REREAD_RECORDS_FILE CLEANUP_REREAD_MODE
+
+    [[ ! -f "$delete_calls_file" ]] || {
+        printf 'ASSERTION FAILED: no DELETE expected; observed %s\n' "$(<"$delete_calls_file")"
+        return 1
+    }
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Candidate version_id=701"* ]]
+    [[ "$output" == *"re-read before deletion failed; keeping record fail-closed"* ]]
+    [[ "$output" == *"Candidate records kept (re-read failed): 1"* ]]
+}
+
+@test "cleanup workflow does not share a concurrency group with publishers" {
+    local workflow="$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml"
+    local cleanup_job
+
+    cleanup_job=$(awk '
+      /^  cleanup-ext-images:$/ { in_job = 1; next }
+      in_job && /^  [[:alnum:]_-]+:$/ { exit }
+      in_job { print }
+    ' "$workflow")
+
+    [[ "$cleanup_job" != *"concurrency:"* ]]
+    [[ "$cleanup_job" != *"merge-extension-manifests-"* ]]
 }
 
 @test "--help flag exits 0 and prints usage" {


### PR DESCRIPTION
`cleanup-ext-images.sh` exited zero after inspecting none of the records it was
asked to prune, and it decided to delete a version from one API response then
deleted it by id from another.

Now every step that cannot conclude says so. Membership, window validation and
record classification each answer yes, no or could-not-tell, and only a definite
no supports a deletion — a `jq` that cannot run, a `[null]` or `[{}]` window, and
a failed `mktemp` inside the classifier all keep the record. Four counters feed
the exit status where one did before, so a run that skipped work returns
non-zero in both dry-run and `--execute`, which `--help` now states.

Before each DELETE the record is re-read by its id, and the response must carry
that same id. A response describing version 702 no longer authorises deleting
701.

Verified: 2612 unit tests green on this HEAD, `shellcheck` clean. Each negative
property was proven by removing it and observing the failure — dropping the id
comparison prints `no DELETE expected; observed DELETE:701`.

Known and not closed here: a publisher can still attach a retained tag between
the re-read and the DELETE (#1285), absent tag metadata is still read as an
authoritative empty tag set (#1291), a dry run still counts candidates as pruned
(#1292), and a record whose major has no window is recorded as assessed (#1295).
The two sibling pruners carry the same fail-open listing (#1284) and can delete
on absent metadata (#1294). Three tests here do not establish what their names
claim (#1296).

Closes #1250
Closes #1251
