### PR TITLE
Stop a registry prune reporting success after seeing nothing

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cleanup old versions
+        id: cleanup_old_versions
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
@@ -50,12 +52,14 @@ jobs:
         run: ./scripts/cleanup-old-versions.sh
 
       - name: Install yq
-        if: github.event_name == 'schedule' || inputs.purge_obsolete == true
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.purge_obsolete == true) }}
         shell: bash
         run: yq --version
 
       - name: Purge obsolete images
-        if: github.event_name == 'schedule' || inputs.purge_obsolete == true
+        id: purge_obsolete_images
+        continue-on-error: true
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.purge_obsolete == true) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
@@ -68,6 +72,13 @@ jobs:
             ./scripts/cleanup-outdated-tags.sh "$CONTAINER_FILTER"
           else
             ./scripts/cleanup-outdated-tags.sh
+          fi
+
+      - name: Fail if registry cleanup failed
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.cleanup_old_versions.outcome }}" == "failure" || "${{ steps.purge_obsolete_images.outcome }}" == "failure" ]]; then
+            exit 1
           fi
 
   cleanup-ext-images:

--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -1,150 +1,251 @@
 #!/bin/bash
-# Age-based cleanup of GHCR container versions
-#
-# Applies retention rules in priority order:
-#   1. Keep versions with "latest" tag
-#   2. Keep top N most recent versions
-#   3. Keep latest of each major version
-#   4. Keep versions newer than cutoff date
+# Age-based cleanup of GHCR container versions.
 #
 # Required env vars: GH_TOKEN, OWNER
 # Optional env vars: DRY_RUN (default: false), KEEP_LATEST_COUNT (default: 10), KEEP_MONTHS (default: 6)
-#
-# Usage: cleanup-old-versions.sh [container...]
-#   If no containers specified, auto-discovers from Dockerfile directories.
 
-set -euo pipefail
+script_root() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+  cd "$script_dir/.." && pwd
+}
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-: "${GH_TOKEN:?GH_TOKEN is required}"
-: "${OWNER:?OWNER is required}"
-: "${DRY_RUN:=false}"
-: "${KEEP_LATEST_COUNT:=10}"
-: "${KEEP_MONTHS:=6}"
-
-CUTOFF_DATE=$(date -d "-${KEEP_MONTHS} months" +%Y-%m-%dT%H:%M:%SZ)
-
-echo "========================================"
-echo "GHCR Age-Based Cleanup"
-echo "========================================"
-echo "Owner: $OWNER"
-echo "Keep latest count: $KEEP_LATEST_COUNT"
-echo "Keep versions newer than: $CUTOFF_DATE"
-echo "Dry run: $DRY_RUN"
-echo "========================================"
-
-# Get containers to process
-if [[ $# -gt 0 ]]; then
-  CONTAINERS="$*"
-else
-  CONTAINERS=$(find "$ROOT_DIR" -maxdepth 2 -name "Dockerfile" -exec dirname {} \; | sed "s|^$ROOT_DIR/||" | sort)
-fi
-
-TOTAL_DELETED=0
-TOTAL_KEPT=0
-
-for CONTAINER in $CONTAINERS; do
-  echo ""
+print_banner() {
   echo "========================================"
-  echo "Processing: $CONTAINER"
+  echo "GHCR Age-Based Cleanup"
   echo "========================================"
+  echo "Owner: $OWNER"
+  echo "Keep latest count: $KEEP_LATEST_COUNT"
+  echo "Keep versions newer than: $CUTOFF_DATE"
+  echo "Dry run: $DRY_RUN"
+  echo "========================================"
+}
 
-  # Get all versions for this package
-  VERSIONS=$(gh api \
+# Write kept|deleted|delete_failures to stdout once a package was completely
+# assessed.  Its return status, rather than that record, communicates failure:
+# 10 listing failure, 11 processing failure, 12 one or more delete failures,
+# 13 a processing failure after deletion has started.
+purge_container() {
+  local container="$1"
+  local versions version_count versions_file="" deletions_file=""
+  local position=0 kept=0 deleted=0 delete_failures=0
+  local version_id tags created_at keep_reason tag major version_ts cutoff_ts processing_error=0
+  declare -A major_seen=()
+
+  if ! versions=$(gh api \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    "/users/${OWNER}/packages/container/${CONTAINER}/versions" \
-    --paginate 2>/dev/null || echo "[]")
-
-  if [ "$VERSIONS" = "[]" ] || [ -z "$VERSIONS" ]; then
-    echo "  No versions found (might be new or private)"
-    continue
+    "/users/${OWNER}/packages/container/${container}/versions" \
+    --paginate); then
+    echo "  ✗ Failed to list versions; skipping $container" >&2
+    return "$LISTING_FAILURE"
   fi
 
-  VERSION_COUNT=$(echo "$VERSIONS" | jq 'length')
-  echo "  Found $VERSION_COUNT versions"
+  if ! versions=$(jq -ce -s '
+    select(length > 0)
+    | if all(.[]; type == "array") then [.[][]]
+      else error("GHCR package-versions response must contain JSON arrays")
+      end
+  ' <<< "$versions"); then
+    echo "  ✗ Version listing was not a JSON array; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
 
-  VERSIONS_FILE=$(mktemp)
-  echo "$VERSIONS" | jq -r '.[] | "\(.id)|\(.metadata.container.tags // [] | join(","))|\(.created_at)"' > "$VERSIONS_FILE"
-
-  declare -A MAJOR_SEEN=()
-  POSITION=0
-  KEPT=0
-  DELETED=0
-
-  while IFS='|' read -r VERSION_ID TAGS CREATED_AT; do
-    POSITION=$((POSITION + 1))
-    [ -z "$VERSION_ID" ] && continue
-
-    KEEP_REASON=""
-
-    # Rule 1: Keep "latest" tag
-    if grep -q ",latest," <<< ",$TAGS,"; then
-      KEEP_REASON="has 'latest' tag"
+  if ! version_count=$(jq -er 'length' <<< "$versions"); then
+    echo "  ✗ Failed to count versions; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  echo "  Found $version_count versions" >&2
+  if [[ "$version_count" -eq 0 ]]; then
+    echo "  No versions found (might be new or private)" >&2
+    if ! printf '%s\n' "0|0|0"; then
+      return "$PROCESSING_FAILURE"
     fi
+    return 0
+  fi
 
-    # Rule 2: Keep top N most recent
-    if [ -z "$KEEP_REASON" ] && [ "$POSITION" -le "$KEEP_LATEST_COUNT" ]; then
-      KEEP_REASON="in top $KEEP_LATEST_COUNT recent"
-    fi
+  if ! cutoff_ts=$(date -d "$CUTOFF_DATE" +%s); then
+    echo "  ✗ Failed to parse cutoff date; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  if ! versions_file=$(mktemp) || ! deletions_file=$(mktemp); then
+    rm -f "$versions_file" "$deletions_file"
+    echo "  ✗ Failed to create cleanup work files; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  if ! jq -er '.[] | "\(.id)|\(.metadata.container.tags // [] | join(","))|\(.created_at)"' \
+      <<< "$versions" > "$versions_file"; then
+    rm -f "$versions_file" "$deletions_file"
+    echo "  ✗ Failed to prepare version list; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  if [[ ! -r "$versions_file" ]]; then
+    rm -f "$versions_file" "$deletions_file"
+    echo "  ✗ Failed to read version list; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
 
-    # Rule 3: Keep latest of each major version
-    if [ -z "$KEEP_REASON" ]; then
-      for TAG in $(echo "$TAGS" | tr ',' ' '); do
-        if [[ "$TAG" =~ ^v?([0-9]+)\.[0-9] ]]; then
-          MAJOR="${BASH_REMATCH[1]}"
-          if [ -z "${MAJOR_SEEN[$MAJOR]:-}" ]; then
-            MAJOR_SEEN[$MAJOR]=1
-            KEEP_REASON="latest of major v$MAJOR"
+  # Decide every record before deleting any of them.  A malformed date in a
+  # later record must leave earlier obsolete records untouched.
+  while IFS='|' read -r version_id tags created_at; do
+    [[ -z "$version_id" ]] && continue
+    position=$((position + 1))
+    keep_reason=""
+
+    if grep -q ",latest," <<< ",$tags,"; then
+      keep_reason="has 'latest' tag"
+    elif [[ "$position" -le "$KEEP_LATEST_COUNT" ]]; then
+      keep_reason="in top $KEEP_LATEST_COUNT recent"
+    else
+      for tag in $(tr ',' ' ' <<< "$tags"); do
+        if [[ "$tag" =~ ^v?([0-9]+)\.[0-9] ]]; then
+          major="${BASH_REMATCH[1]}"
+          if [[ -z "${major_seen[$major]:-}" ]]; then
+            major_seen[$major]=1
+            keep_reason="latest of major v$major"
           fi
           break
         fi
       done
     fi
 
-    # Rule 4: Keep if newer than cutoff
-    if [ -z "$KEEP_REASON" ]; then
-      VERSION_TS=$(date -d "$CREATED_AT" +%s 2>/dev/null || echo "0")
-      CUTOFF_TS=$(date -d "$CUTOFF_DATE" +%s)
-      if [ "$VERSION_TS" -gt "$CUTOFF_TS" ]; then
-        KEEP_REASON="newer than $KEEP_MONTHS months"
+    if [[ -z "$keep_reason" ]]; then
+      if ! version_ts=$(date -d "$created_at" +%s 2>/dev/null); then
+        echo "  ✗ Failed to parse version date; skipping $container" >&2
+        processing_error=1
+        break
+      fi
+      if [[ "$version_ts" -gt "$cutoff_ts" ]]; then
+        keep_reason="newer than $KEEP_MONTHS months"
       fi
     fi
 
-    if [ -n "$KEEP_REASON" ]; then
-      echo "  ✓ Keep #$POSITION (tags: ${TAGS:-untagged}) - $KEEP_REASON"
-      KEPT=$((KEPT + 1))
+    if [[ -n "$keep_reason" ]]; then
+      echo "  ✓ Keep #$position (tags: ${tags:-untagged}) - $keep_reason" >&2
+      kept=$((kept + 1))
+    elif ! printf '%s|%s|%s\n' "$position" "$version_id" "$tags" >> "$deletions_file"; then
+      echo "  ✗ Failed to prepare deletion list; skipping $container" >&2
+      processing_error=1
+      break
+    fi
+  done < "$versions_file"
+
+  if [[ "$processing_error" -ne 0 ]]; then
+    rm -f "$versions_file" "$deletions_file"
+    return "$PROCESSING_FAILURE"
+  fi
+
+  if ! rm -f "$versions_file"; then
+    rm -f "$deletions_file"
+    echo "  ✗ Failed to remove version list; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+
+  while IFS='|' read -r position version_id tags; do
+    [[ -z "$version_id" ]] && continue
+    echo "  ✗ Delete #$position (tags: ${tags:-untagged})" >&2
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "    [DRY RUN] Would delete version $version_id" >&2
+    elif gh api --method DELETE \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/users/${OWNER}/packages/container/${container}/versions/${version_id}"; then
+      echo "    ✓ Deleted" >&2
+      deleted=$((deleted + 1))
     else
-      echo "  ✗ Delete #$POSITION (tags: ${TAGS:-untagged}, created: $CREATED_AT)"
-      if [ "$DRY_RUN" = "true" ]; then
-        echo "    [DRY RUN] Would delete version $VERSION_ID"
-      else
-        if gh api \
-          --method DELETE \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "/users/${OWNER}/packages/container/${CONTAINER}/versions/${VERSION_ID}" 2>/dev/null; then
-          echo "    ✓ Deleted"
-          DELETED=$((DELETED + 1))
-        else
-          echo "    ✗ Failed to delete"
-        fi
-      fi
+      echo "    ✗ Failed to delete" >&2
+      delete_failures=$((delete_failures + 1))
     fi
-  done < "$VERSIONS_FILE"
+  done < "$deletions_file"
 
-  rm -f "$VERSIONS_FILE"
-  TOTAL_KEPT=$((TOTAL_KEPT + KEPT))
-  TOTAL_DELETED=$((TOTAL_DELETED + DELETED))
-  echo "  Summary: kept=$KEPT, deleted=$DELETED"
-done
+  if ! printf '%s\n' "$kept|$deleted|$delete_failures"; then
+    return "$PROCESSING_FAILURE"
+  fi
+  if ! rm -f "$deletions_file"; then
+    echo "  ✗ Failed to remove deletion list after cleanup" >&2
+    return "$POST_DELETE_PROCESSING_FAILURE"
+  fi
+  if [[ "$delete_failures" -gt 0 ]]; then
+    return "$DELETE_FAILURE"
+  fi
+}
 
-echo ""
-echo "========================================"
-echo "Cleanup Summary"
-echo "========================================"
-echo "Versions kept: $TOTAL_KEPT"
-echo "Versions deleted: $TOTAL_DELETED"
-echo "========================================"
+main() {
+  set -euo pipefail
+
+  : "${GH_TOKEN:?GH_TOKEN is required}"
+  : "${OWNER:?OWNER is required}"
+  : "${DRY_RUN:=false}"
+  : "${KEEP_LATEST_COUNT:=10}"
+  : "${KEEP_MONTHS:=6}"
+
+  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13
+  local root_dir containers container result status
+  local kept deleted delete_failures
+  root_dir=$(script_root) || return 1
+  CUTOFF_DATE=$(date -d "-${KEEP_MONTHS} months" +%Y-%m-%dT%H:%M:%SZ) || return 1
+  print_banner
+
+  if [[ $# -gt 0 ]]; then
+    containers="$*"
+  else
+    containers=$(find "$root_dir" -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed "s|^$root_dir/||" | sort) || return 1
+  fi
+
+  local total_deleted=0 total_kept=0 total_assessed=0
+  local total_listing_failures=0 total_processing_failures=0 total_delete_failures=0
+  for container in $containers; do
+    echo ""
+    echo "========================================"
+    echo "Processing: $container"
+    echo "========================================"
+
+    if result=$(purge_container "$container"); then
+      status=0
+    else
+      status=$?
+    fi
+
+    case "$status" in
+      0|"$DELETE_FAILURE"|"$POST_DELETE_PROCESSING_FAILURE")
+        if ! IFS='|' read -r kept deleted delete_failures <<< "$result"; then
+          echo "  ✗ Failed to read cleanup result; skipping $container"
+          total_processing_failures=$((total_processing_failures + 1))
+          continue
+        fi
+        total_assessed=$((total_assessed + 1))
+        total_kept=$((total_kept + kept))
+        total_deleted=$((total_deleted + deleted))
+        total_delete_failures=$((total_delete_failures + delete_failures))
+        echo "  Summary: kept=$kept, deleted=$deleted, delete_failures=$delete_failures"
+        [[ "$status" -ne "$POST_DELETE_PROCESSING_FAILURE" ]] || total_processing_failures=$((total_processing_failures + 1))
+        ;;
+      "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
+      "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
+      *)
+        echo "  ✗ Unexpected cleanup status $status; skipping $container"
+        total_processing_failures=$((total_processing_failures + 1))
+        ;;
+    esac
+  done
+
+  echo ""
+  echo "========================================"
+  echo "Cleanup Summary"
+  echo "========================================"
+  echo "Packages assessed: $total_assessed"
+  echo "Packages skipped (listing failed): $total_listing_failures"
+  echo "Packages skipped (processing failed): $total_processing_failures"
+  echo "Versions kept: $total_kept"
+  echo "Versions deleted: $total_deleted"
+  echo "Delete failures: $total_delete_failures"
+  echo "========================================"
+
+  if [[ "$total_listing_failures" -gt 0 || "$total_processing_failures" -gt 0 || "$total_delete_failures" -gt 0 ]]; then
+    return 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -1,405 +1,330 @@
 #!/bin/bash
 # Purge container images whose tags are not in the current valid build set.
-#
-# Uses ./make list-builds to determine valid tags, then:
-#   Phase 1: Classify GHCR versions as kept/obsolete by tag matching
-#   Phase 2: Resolve manifest list children to build protected digest set
-#   Phase 3: Delete obsolete tagged versions + untagged orphans from GHCR
-#   Phase 4: Delete obsolete tags from Docker Hub (if credentials provided)
-#
 # Required env vars: GH_TOKEN, OWNER
-# Optional env vars:
-#   DRY_RUN (default: false)
-#   DOCKERHUB_USERNAME, DOCKERHUB_TOKEN — if set, also cleans Docker Hub
-#
-# Usage: cleanup-outdated-tags.sh [container...]
-#   If no containers specified, processes all containers from ./make list.
 
-set -euo pipefail
+script_root() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+  cd "$script_dir/.." && pwd
+}
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-: "${GH_TOKEN:?GH_TOKEN is required}"
-: "${OWNER:?OWNER is required}"
-: "${DRY_RUN:=false}"
-: "${DOCKERHUB_USERNAME:=}"
-: "${DOCKERHUB_TOKEN:=}"
-
-# Get containers to process
-if [[ $# -gt 0 ]]; then
-  CONTAINERS="$*"
-else
-  CONTAINERS=$("$ROOT_DIR/make" list)
-fi
-
-TOTAL_KEPT=0
-TOTAL_OBSOLETE=0
-TOTAL_ORPHANS=0
-TOTAL_DH_DELETED=0
-
-# ── Helper: build valid tag set for a container ──
 build_valid_tags() {
-  local container="$1"
-  local builds_json
-
-  builds_json=$("$ROOT_DIR/make" list-builds "$container" 2>/dev/null) || return 1
-
-  if [[ -z "$builds_json" || "$builds_json" == "[]" ]]; then
+  local container="$1" builds_json tags variant_tags
+  if ! builds_json=$("$ROOT_DIR/make" list-builds "$container" 2>/dev/null); then
     return 1
   fi
-
-  # Tags from builds + latest + buildcache + latest-{variant}
-  # buildcache        — flat-matrix per-container registry cache (mode=max)
-  # buildcache-*      — bake per-target registry cache (keyed by container+tag+arch)
-  local tags
-  tags=$(echo "$builds_json" | jq -r '.[].tag')
-  tags+=$'\n'"latest"
-  tags+=$'\n'"buildcache"
-
-  local variant_tags
-  variant_tags=$(echo "$builds_json" | jq -r '
-    .[] | select(.variant != "" and .is_latest_version == true) |
-    "latest-" + .variant
-  ' | sort -u)
+  if ! jq -e 'type == "array" and length > 0' >/dev/null <<< "$builds_json"; then
+    return 1
+  fi
+  if ! tags=$(jq -r '.[].tag' <<< "$builds_json"); then
+    return 1
+  fi
+  tags+=$'\nlatest\nbuildcache'
+  if ! variant_tags=$(jq -r '.[] | select(.variant != "" and .is_latest_version == true) | "latest-" + .variant' <<< "$builds_json" | sort -u); then
+    return 1
+  fi
   if [[ -n "$variant_tags" ]]; then
     tags+=$'\n'"$variant_tags"
   fi
-
-  # Deduplicate
-  echo "$tags" | sort -u
+  printf '%s\n' "$tags" | sort -u
 }
 
-# ── Helper: check if a tag is valid (exact match or arch-specific of a valid tag) ──
 is_valid_tag() {
-  local tag="$1"
-  local valid_tags="$2"
-
-  # Direct match
-  if grep -qxF "$tag" <<< "$valid_tags"; then
-    return 0
-  fi
-
-  # Arch-specific suffix of a valid tag (e.g., 1.7.7-amd64, 1.7.7-alpine-arm64)
-  local base_tag
+  local tag="$1" valid_tags="$2" base_tag remainder cache_base_tag
+  if grep -qxF "$tag" <<< "$valid_tags"; then return 0; fi
   base_tag="${tag%-amd64}"
   base_tag="${base_tag%-arm64}"
-  if [[ "$base_tag" != "$tag" ]] && grep -qxF "$base_tag" <<< "$valid_tags"; then
-    return 0
-  fi
-
-  # Bake per-target registry cache tags: buildcache-<base-tag>-{amd64,arm64}
-  # (e.g. buildcache-2.334.0-amd64, buildcache-2.334.0-dev-arm64).
-  # A bake cache tag is valid IFF its underlying base tag is itself valid.
-  # This prevents stale cache entries for rotated-out versions from accumulating.
-  # Bare "buildcache" (flat-matrix cache, no arch suffix) is already covered by
-  # the direct-match path above (it's emitted into valid_tags by build_valid_tags).
+  if [[ "$base_tag" != "$tag" ]] && grep -qxF "$base_tag" <<< "$valid_tags"; then return 0; fi
   if [[ "$tag" == buildcache-* ]]; then
-    # Strip the "buildcache-" prefix to get the remainder
-    local remainder="${tag#buildcache-}"
-
-    # Guard against malformed double-prefix (buildcache-buildcache-...)
-    if [[ "$remainder" == buildcache-* || -z "$remainder" ]]; then
-      return 1
-    fi
-
-    # Strip exactly the arch suffix (anchored to end) to recover the base tag
-    local cache_base_tag="$remainder"
+    remainder="${tag#buildcache-}"
+    [[ "$remainder" == buildcache-* || -z "$remainder" ]] && return 1
+    cache_base_tag="$remainder"
     if [[ "$cache_base_tag" == *-amd64 ]]; then
       cache_base_tag="${cache_base_tag%-amd64}"
     elif [[ "$cache_base_tag" == *-arm64 ]]; then
       cache_base_tag="${cache_base_tag%-arm64}"
     else
-      # No recognised arch suffix — not a bake cache tag we manage; treat as invalid
       return 1
     fi
-
-    # Base tag must be non-empty after stripping
-    if [[ -z "$cache_base_tag" ]]; then
-      return 1
-    fi
-
-    # The cache tag is valid iff its underlying base tag is currently valid
+    [[ -n "$cache_base_tag" ]] || return 1
     is_valid_tag "$cache_base_tag" "$valid_tags"
     return $?
   fi
-
   return 1
 }
 
-# ── Helper: purge GHCR obsolete images for one container ──
 purge_ghcr() {
-  local container="$1"
-  local valid_tags="$2"
-  local kept=0 obsolete=0 orphans=0
+  local container="$1" valid_tags="$2"
+  local versions version_count versions_file="" obsolete_file="" protected_file=""
+  local version_id digest tags tag has_valid kept=0 obsolete=0 orphans=0 delete_failures=0
+  local protected_digests="" ghcr_token manifest children
+  local -a kept_digests=()
 
-  # Fetch all GHCR versions
-  local versions
-  versions=$(gh api \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "/users/${OWNER}/packages/container/${container}/versions" \
-    --paginate 2>/dev/null || echo "[]")
+  cleanup_files() { rm -f "$versions_file" "$obsolete_file" "$protected_file"; }
 
-  if [[ "$versions" == "[]" || -z "$versions" ]]; then
-    echo "  No GHCR versions found"
-    echo "0|0|0"
-    return
+  if ! versions=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/users/${OWNER}/packages/container/${container}/versions" --paginate); then
+    echo "  ✗ Failed to list GHCR versions; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! versions=$(jq -ce -s '
+    select(length > 0)
+    | if all(.[]; type == "array") then [.[][]]
+      else error("GHCR package-versions response must contain JSON arrays")
+      end
+  ' <<< "$versions"); then
+    echo "  ✗ GHCR version listing was not a JSON array; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! version_count=$(jq -er 'length' <<< "$versions"); then
+    echo "  ✗ Failed to count GHCR versions; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  echo "  Found $version_count GHCR versions" >&2
+  if [[ "$version_count" -eq 0 ]]; then
+    echo "  No GHCR versions found" >&2
+    if ! printf '%s\n' "0|0|0|0"; then
+      return "$PROCESSING_FAILURE"
+    fi
+    return 0
+  fi
+  if ! versions_file=$(mktemp) || ! obsolete_file=$(mktemp); then
+    cleanup_files
+    echo "  ✗ Failed to create GHCR work files; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  if ! jq -er '.[] | "\(.id)|\(.name)|\(.metadata.container.tags // [] | join(","))"' <<< "$versions" > "$versions_file"; then
+    cleanup_files
+    echo "  ✗ Failed to prepare GHCR version list; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+  if [[ ! -r "$versions_file" || ! -r "$obsolete_file" || ! -w "$obsolete_file" ]]; then
+    cleanup_files
+    echo "  ✗ Failed to access GHCR work files; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
   fi
 
-  local version_count
-  version_count=$(echo "$versions" | jq 'length')
-  echo "  Found $version_count GHCR versions" >&2
-
-  # Save to temp file: id|digest|tags
-  local versions_file
-  versions_file=$(mktemp)
-  echo "$versions" | jq -r '.[] | "\(.id)|\(.name)|\(.metadata.container.tags // [] | join(","))"' > "$versions_file"
-
-  # ── Phase 1: Classify tagged versions ──
-  local kept_digests=()
-  local obsolete_file
-  obsolete_file=$(mktemp)
-
   while IFS='|' read -r version_id digest tags; do
-    [[ -z "$version_id" ]] && continue
-    [[ -z "$tags" ]] && continue
-
-    local has_valid=false
-    for tag in $(echo "$tags" | tr ',' ' '); do
-      if is_valid_tag "$tag" "$valid_tags"; then
-        has_valid=true
-        break
-      fi
+    [[ -z "$version_id" || -z "$tags" ]] && continue
+    has_valid=false
+    for tag in $(tr ',' ' ' <<< "$tags"); do
+      if is_valid_tag "$tag" "$valid_tags"; then has_valid=true; break; fi
     done
-
-    if [[ "$has_valid" == "true" ]]; then
+    if [[ "$has_valid" == true ]]; then
       echo "  ✓ Keep (tags: $tags)" >&2
-      kept=$((kept + 1))
-      kept_digests+=("$digest")
+      kept=$((kept + 1)); kept_digests+=("$digest")
+    elif ! printf '%s|%s|%s\n' "$version_id" "$digest" "$tags" >> "$obsolete_file"; then
+      cleanup_files
+      echo "  ✗ Failed to write GHCR obsolete list; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
     else
       echo "  ? Obsolete candidate (tags: $tags)" >&2
-      echo "$version_id|$digest|$tags" >> "$obsolete_file"
     fi
   done < "$versions_file"
 
-  # ── Phase 2: Resolve manifest list children ──
-  local protected_digests=""
-  local resolve_ok=false
-
   if [[ ${#kept_digests[@]} -gt 0 ]]; then
-    echo "" >&2
     echo "  Resolving manifest references for ${#kept_digests[@]} kept images..." >&2
-
-    local ghcr_token
-    ghcr_token=$(curl -sf \
-      -u "_:${GH_TOKEN}" \
-      "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${container}:pull" \
-      | jq -r '.token' 2>/dev/null || echo "")
-
-    if [[ -z "$ghcr_token" ]]; then
-      echo "  ⚠ Failed to get GHCR token, skipping all deletions for safety" >&2
-    else
-      local protected_file
-      protected_file=$(mktemp)
-      printf '%s\n' "${kept_digests[@]}" > "$protected_file"
-
-      local fetch_failures=0
-      for digest in "${kept_digests[@]}"; do
-        local manifest
-        manifest=$(curl -sf \
-          -H "Authorization: Bearer $ghcr_token" \
-          -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json" \
-          "https://ghcr.io/v2/${OWNER}/${container}/manifests/${digest}" 2>/dev/null || echo "")
-
-        if [[ -z "$manifest" ]]; then
-          fetch_failures=$((fetch_failures + 1))
-          echo "  ⚠ Failed to fetch manifest for ${digest:0:19}..." >&2
-          continue
-        fi
-
-        local children
-        children=$(echo "$manifest" | jq -r '.manifests[]?.digest // empty' 2>/dev/null || true)
-        if [[ -n "$children" ]]; then
-          echo "$children" >> "$protected_file"
-        fi
-      done
-
-      if [[ "$fetch_failures" -gt 0 ]]; then
-        echo "  ⚠ $fetch_failures manifest fetch(es) failed, skipping all deletions for safety" >&2
-      else
-        protected_digests=$(sort -u "$protected_file")
-        local protected_count
-        protected_count=$(echo "$protected_digests" | wc -l)
-        echo "  Protected digests: $protected_count (${#kept_digests[@]} manifests + children)" >&2
-        resolve_ok=true
-      fi
-
-      rm -f "$protected_file"
+    if ! ghcr_token=$(curl -sf -u "_:${GH_TOKEN}" \
+        "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${container}:pull" | jq -er '.token'); then
+      cleanup_files
+      echo "  ✗ Failed to get GHCR token; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
     fi
-  else
-    resolve_ok=true
+    if ! protected_file=$(mktemp) || ! printf '%s\n' "${kept_digests[@]}" > "$protected_file"; then
+      cleanup_files
+      echo "  ✗ Failed to prepare protected-digest list; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
+    fi
+    for digest in "${kept_digests[@]}"; do
+      if ! manifest=$(curl -sf -H "Authorization: Bearer $ghcr_token" \
+        -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json" \
+        "https://ghcr.io/v2/${OWNER}/${container}/manifests/${digest}"); then
+        cleanup_files
+        echo "  ✗ Failed to fetch manifest for ${digest:0:19}; skipping $container" >&2
+        return "$PROCESSING_FAILURE"
+      fi
+      if ! jq -e 'type == "object"' >/dev/null <<< "$manifest"; then
+        cleanup_files
+        echo "  ✗ Failed to parse manifest for ${digest:0:19}; skipping $container" >&2
+        return "$PROCESSING_FAILURE"
+      fi
+      if ! children=$(jq -r '.manifests[]?.digest // empty' <<< "$manifest"); then
+        cleanup_files
+        echo "  ✗ Failed to read manifest for ${digest:0:19}; skipping $container" >&2
+        return "$PROCESSING_FAILURE"
+      fi
+      if [[ -n "$children" ]] && ! printf '%s\n' "$children" >> "$protected_file"; then
+        cleanup_files
+        echo "  ✗ Failed to write protected-digest list; skipping $container" >&2
+        return "$PROCESSING_FAILURE"
+      fi
+    done
+    if ! protected_digests=$(sort -u "$protected_file"); then
+      cleanup_files
+      echo "  ✗ Failed to read protected-digest list; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
+    fi
   fi
 
-  # ── Phase 3: Delete obsolete tagged + untagged orphans ──
-  if [[ "$resolve_ok" == "true" ]]; then
-    # Delete obsolete tagged versions
-    while IFS='|' read -r version_id digest tags; do
-      [[ -z "$version_id" ]] && continue
-
-      if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
-        echo "  ✓ Keep (tags: $tags) — digest is manifest child" >&2
-        kept=$((kept + 1))
+  while IFS='|' read -r version_id digest tags; do
+    [[ -z "$version_id" ]] && continue
+    if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
+      echo "  ✓ Keep (tags: $tags) — digest is manifest child" >&2; kept=$((kept + 1))
+    else
+      echo "  ✗ Obsolete (tags: $tags)" >&2
+      if [[ "$DRY_RUN" == true ]]; then
+        echo "    [DRY RUN] Would delete version $version_id" >&2
+      elif gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/users/${OWNER}/packages/container/${container}/versions/${version_id}"; then
+        echo "    ✓ Deleted" >&2
       else
-        echo "  ✗ Obsolete (tags: $tags)" >&2
-        if [[ "$DRY_RUN" == "true" ]]; then
-          echo "    [DRY RUN] Would delete version $version_id" >&2
-        else
-          if gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/users/${OWNER}/packages/container/${container}/versions/${version_id}" 2>/dev/null; then
-            echo "    ✓ Deleted" >&2
-          else
-            echo "    ✗ Failed to delete" >&2
-          fi
-        fi
-        obsolete=$((obsolete + 1))
+        echo "    ✗ Failed to delete" >&2; delete_failures=$((delete_failures + 1))
       fi
-    done < "$obsolete_file"
+      obsolete=$((obsolete + 1))
+    fi
+  done < "$obsolete_file"
 
-    # Delete untagged orphans
-    while IFS='|' read -r version_id digest tags; do
-      [[ -z "$version_id" ]] && continue
-      [[ -n "$tags" ]] && continue
-
-      if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
-        kept=$((kept + 1))
+  while IFS='|' read -r version_id digest tags; do
+    [[ -z "$version_id" || -n "$tags" ]] && continue
+    if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
+      kept=$((kept + 1))
+    else
+      echo "  ✗ Orphan (digest: ${digest:0:19}...)" >&2
+      if [[ "$DRY_RUN" == true ]]; then
+        echo "    [DRY RUN] Would delete version $version_id" >&2
+      elif gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/users/${OWNER}/packages/container/${container}/versions/${version_id}"; then
+        echo "    ✓ Deleted" >&2
       else
-        echo "  ✗ Orphan (digest: ${digest:0:19}...)" >&2
-        if [[ "$DRY_RUN" == "true" ]]; then
-          echo "    [DRY RUN] Would delete version $version_id" >&2
-        else
-          if gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/users/${OWNER}/packages/container/${container}/versions/${version_id}" 2>/dev/null; then
-            echo "    ✓ Deleted" >&2
-          else
-            echo "    ✗ Failed to delete" >&2
-          fi
-        fi
-        orphans=$((orphans + 1))
+        echo "    ✗ Failed to delete" >&2; delete_failures=$((delete_failures + 1))
       fi
-    done < "$versions_file"
+      orphans=$((orphans + 1))
+    fi
+  done < "$versions_file"
+  if ! printf '%s\n' "$kept|$obsolete|$orphans|$delete_failures"; then
+    return "$PROCESSING_FAILURE"
   fi
-
-  rm -f "$obsolete_file" "$versions_file"
-  echo "$kept|$obsolete|$orphans"
+  if ! cleanup_files; then
+    echo "  ✗ Failed to remove GHCR work files after cleanup" >&2
+    return "$POST_DELETE_PROCESSING_FAILURE"
+  fi
+  [[ "$delete_failures" -eq 0 ]] || return "$DELETE_FAILURE"
 }
 
-# ── Helper: purge Docker Hub obsolete tags for one container ──
+# stdout is assessed|deleted.  No configured Docker Hub credentials means it
+# was not attempted (0|0); a returned non-zero status is always a real failure.
 purge_dockerhub() {
-  local container="$1"
-  local valid_tags="$2"
-  local dh_deleted=0 dh_kept=0
-
+  local container="$1" valid_tags="$2" dh_jwt response dh_tags tag dh_kept=0 dh_deleted=0 delete_failures=0
   if [[ -z "$DOCKERHUB_USERNAME" || -z "$DOCKERHUB_TOKEN" ]]; then
-    echo "0"
-    return
+    printf '%s\n' "0|0" || return "$PROCESSING_FAILURE"
+    return 0
   fi
-
-  echo "" >&2
   echo "  Docker Hub cleanup for $container..." >&2
-
-  # Authenticate
-  local dh_jwt
-  dh_jwt=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"$DOCKERHUB_USERNAME\",\"password\":\"$DOCKERHUB_TOKEN\"}" \
-    | jq -r '.token // empty' 2>/dev/null || echo "")
-
-  if [[ -z "$dh_jwt" ]]; then
-    echo "  ⚠ Failed to authenticate to Docker Hub, skipping" >&2
-    echo "0"
-    return
+  if ! dh_jwt=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" -H "Content-Type: application/json" \
+      -d "{\"username\":\"$DOCKERHUB_USERNAME\",\"password\":\"$DOCKERHUB_TOKEN\"}" | jq -er '.token'); then
+    echo "  ✗ Failed to authenticate to Docker Hub; skipping $container" >&2; return "$PROCESSING_FAILURE"
   fi
-
-  # List all tags
-  local dh_tags
-  dh_tags=$(curl -sf \
-    -H "Authorization: Bearer $dh_jwt" \
-    "https://hub.docker.com/v2/repositories/$DOCKERHUB_USERNAME/$container/tags?page_size=100" \
-    | jq -r '.results[].name // empty' 2>/dev/null || echo "")
-
-  if [[ -z "$dh_tags" ]]; then
-    echo "  No Docker Hub tags found (repo may not exist)" >&2
-    echo "0"
-    return
+  if ! response=$(curl -sf -H "Authorization: Bearer $dh_jwt" \
+      "https://hub.docker.com/v2/repositories/$DOCKERHUB_USERNAME/$container/tags?page_size=100"); then
+    echo "  ✗ Failed to list Docker Hub tags; skipping $container" >&2; return "$LISTING_FAILURE"
   fi
-
+  if ! jq -e '.results | type == "array"' >/dev/null <<< "$response"; then
+    echo "  ✗ Docker Hub tag listing was not a JSON array; skipping $container" >&2; return "$LISTING_FAILURE"
+  fi
+  if ! dh_tags=$(jq -r '.results[].name // empty' <<< "$response"); then
+    echo "  ✗ Failed to read Docker Hub tag listing; skipping $container" >&2; return "$PROCESSING_FAILURE"
+  fi
   while IFS= read -r tag; do
     [[ -z "$tag" ]] && continue
-
-    if is_valid_tag "$tag" "$valid_tags"; then
-      dh_kept=$((dh_kept + 1))
+    if is_valid_tag "$tag" "$valid_tags"; then dh_kept=$((dh_kept + 1)); continue; fi
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "    [DRY RUN] Would delete Docker Hub tag: $tag" >&2
+    elif curl -sf -X DELETE -H "Authorization: Bearer $dh_jwt" \
+        "https://hub.docker.com/v2/repositories/$DOCKERHUB_USERNAME/$container/tags/$tag/" >/dev/null; then
+      echo "    ✓ Deleted Docker Hub tag: $tag" >&2
     else
-      if [[ "$DRY_RUN" == "true" ]]; then
-        echo "    [DRY RUN] Would delete Docker Hub tag: $tag" >&2
-      else
-        if curl -sf -X DELETE \
-          -H "Authorization: Bearer $dh_jwt" \
-          "https://hub.docker.com/v2/repositories/$DOCKERHUB_USERNAME/$container/tags/$tag/" >/dev/null 2>&1; then
-          echo "    ✓ Deleted Docker Hub tag: $tag" >&2
-        else
-          echo "    ✗ Failed to delete Docker Hub tag: $tag" >&2
-        fi
-      fi
-      dh_deleted=$((dh_deleted + 1))
+      echo "    ✗ Failed to delete Docker Hub tag: $tag" >&2; delete_failures=$((delete_failures + 1))
     fi
+    dh_deleted=$((dh_deleted + 1))
   done <<< "$dh_tags"
-
   echo "  Docker Hub: kept=$dh_kept, deleted=$dh_deleted" >&2
-  echo "$dh_deleted"
+  if ! printf '%s\n' "1|$dh_deleted"; then
+    return "$PROCESSING_FAILURE"
+  fi
+  [[ "$delete_failures" -eq 0 ]] || return "$DELETE_FAILURE"
 }
 
-# ── Main loop ──
-for CONTAINER in $CONTAINERS; do
-  echo ""
+main() {
+  set -euo pipefail
+  : "${GH_TOKEN:?GH_TOKEN is required}"
+  : "${OWNER:?OWNER is required}"
+  : "${DRY_RUN:=false}"
+  : "${DOCKERHUB_USERNAME:=}"
+  : "${DOCKERHUB_TOKEN:=}"
+  ROOT_DIR=$(script_root) || return 1
+  export ROOT_DIR
+
+  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13
+  local containers container valid_tags valid_count result ghcr_status dh_result dh_status
+  local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed
+  local total_assessed=0 total_build_failures=0 total_listing_failures=0 total_processing_failures=0 total_ghcr_delete_failures=0 total_dh_delete_failures=0
+  local total_kept=0 total_obsolete=0 total_orphans=0 total_dh_deleted=0
+  if [[ $# -gt 0 ]]; then containers="$*"; else containers=$("$ROOT_DIR/make" list) || return 1; fi
+
+  for container in $containers; do
+    echo ""; echo "========================================"; echo "Purging obsolete images: $container"; echo "========================================"
+    if ! valid_tags=$(build_valid_tags "$container"); then
+      echo "  Failed to get builds for $container, skipping"; total_build_failures=$((total_build_failures + 1)); continue
+    fi
+    valid_count=$(wc -l <<< "$valid_tags")
+    echo "  Valid tags ($valid_count total):"; printf '    %s\n' "${valid_tags//$'\n'/$'\n    '}"
+    package_assessed=false
+
+    if result=$(purge_ghcr "$container" "$valid_tags"); then ghcr_status=0; else ghcr_status=$?; fi
+    case "$ghcr_status" in
+      0|"$DELETE_FAILURE"|"$POST_DELETE_PROCESSING_FAILURE")
+        if ! IFS='|' read -r kept obsolete orphans delete_failures <<< "$result"; then
+          echo "  ✗ Failed to read GHCR cleanup result; skipping $container"; total_processing_failures=$((total_processing_failures + 1))
+        else
+          package_assessed=true; total_kept=$((total_kept + kept)); total_obsolete=$((total_obsolete + obsolete)); total_orphans=$((total_orphans + orphans)); total_ghcr_delete_failures=$((total_ghcr_delete_failures + delete_failures))
+          echo "  GHCR summary: kept=$kept, obsolete=$obsolete, orphans=$orphans, delete_failures=$delete_failures"
+          [[ "$ghcr_status" -ne "$POST_DELETE_PROCESSING_FAILURE" ]] || total_processing_failures=$((total_processing_failures + 1))
+        fi ;;
+      "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
+      "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
+      *) echo "  ✗ Unexpected GHCR cleanup status $ghcr_status; skipping $container"; total_processing_failures=$((total_processing_failures + 1)) ;;
+    esac
+
+    if dh_result=$(purge_dockerhub "$container" "$valid_tags"); then dh_status=0; else dh_status=$?; fi
+    case "$dh_status" in
+      0|"$DELETE_FAILURE")
+        if ! IFS='|' read -r dh_assessed dh_deleted <<< "$dh_result"; then
+          echo "  ✗ Failed to read Docker Hub cleanup result; skipping $container"; total_processing_failures=$((total_processing_failures + 1))
+        else
+          [[ "$package_assessed" == true || "$dh_assessed" -eq 0 ]] || package_assessed=true
+          total_dh_deleted=$((total_dh_deleted + dh_deleted))
+          [[ "$dh_status" -eq 0 ]] || total_dh_delete_failures=$((total_dh_delete_failures + 1))
+        fi ;;
+      "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
+      "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
+      *) total_processing_failures=$((total_processing_failures + 1)) ;;
+    esac
+    [[ "$package_assessed" == true ]] && total_assessed=$((total_assessed + 1))
+  done
+
+  echo ""; echo "========================================"; echo "Purge Summary"; echo "========================================"
+  echo "Packages assessed: $total_assessed"
+  echo "Packages skipped (build listing failed): $total_build_failures"
+  echo "Registry listing failures: $total_listing_failures"
+  echo "Packages skipped (processing failed): $total_processing_failures"
+  echo "GHCR — kept: $total_kept, obsolete: $total_obsolete, orphans: $total_orphans"
+  echo "GHCR — delete failures: $total_ghcr_delete_failures"
+  [[ -n "$DOCKERHUB_USERNAME" ]] && echo "Docker Hub — delete failures: $total_dh_delete_failures"
+  [[ -n "$DOCKERHUB_USERNAME" ]] && echo "Docker Hub — deleted: $total_dh_deleted"
   echo "========================================"
-  echo "Purging obsolete images: $CONTAINER"
-  echo "========================================"
+  [[ "$total_build_failures" -eq 0 && "$total_listing_failures" -eq 0 && "$total_processing_failures" -eq 0 && "$total_ghcr_delete_failures" -eq 0 && "$total_dh_delete_failures" -eq 0 ]]
+}
 
-  VALID_TAGS=$(build_valid_tags "$CONTAINER") || {
-    echo "  Failed to get builds for $CONTAINER, skipping"
-    continue
-  }
-
-  VALID_COUNT=$(echo "$VALID_TAGS" | wc -l)
-  echo "  Valid tags ($VALID_COUNT total):"
-  echo "$VALID_TAGS" | sed 's/^/    /'
-
-  # GHCR cleanup
-  GHCR_RESULT=$(purge_ghcr "$CONTAINER" "$VALID_TAGS")
-  IFS='|' read -r KEPT OBSOLETE ORPHANS <<< "$GHCR_RESULT"
-  TOTAL_KEPT=$((TOTAL_KEPT + KEPT))
-  TOTAL_OBSOLETE=$((TOTAL_OBSOLETE + OBSOLETE))
-  TOTAL_ORPHANS=$((TOTAL_ORPHANS + ORPHANS))
-  echo "  GHCR summary: kept=$KEPT, obsolete=$OBSOLETE, orphans=$ORPHANS"
-
-  # Docker Hub cleanup
-  DH_DELETED=$(purge_dockerhub "$CONTAINER" "$VALID_TAGS")
-  TOTAL_DH_DELETED=$((TOTAL_DH_DELETED + DH_DELETED))
-done
-
-echo ""
-echo "========================================"
-echo "Purge Summary"
-echo "========================================"
-echo "GHCR — kept: $TOTAL_KEPT, obsolete: $TOTAL_OBSOLETE, orphans: $TOTAL_ORPHANS"
-if [[ -n "$DOCKERHUB_USERNAME" ]]; then
-  echo "Docker Hub — deleted: $TOTAL_DH_DELETED"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-echo "========================================"

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/cleanup-old-versions.sh fail-closed registry handling.
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    STUB_DIR="$(mktemp -d)"
+    export GH_LOG="$STUB_DIR/gh.log"
+
+    cat > "$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"--method DELETE"* ]]; then
+    printf 'DELETE:%s\n' "$*" >> "$GH_LOG"
+    if [[ "${GH_MODE:-}" == "delete-failure" ]]; then
+        echo "gh: delete denied" >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+if [[ "${GH_MODE:-}" == "listing-failure" && "$*" == *"/container/broken/versions"* ]]; then
+    echo "gh: API rate limit exceeded" >&2
+    exit 1
+fi
+
+if [[ "${GH_MODE:-}" == "malformed-listing" && "$*" == *"/container/broken/versions"* ]]; then
+    printf '%s\n' 'not-json'
+    exit 0
+fi
+
+if [[ "${GH_MODE:-}" == "empty-listing" && "$*" == *"/container/broken/versions"* ]]; then
+    exit 0
+fi
+
+if [[ "${GH_MODE:-}" == "malformed-record" && "$*" == *"/container/broken/versions"* ]]; then
+    printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":"not-an-array"}},"created_at":"2000-01-01T00:00:00Z"}]'
+    exit 0
+fi
+
+if [[ "${GH_MODE:-}" == "delete-failure" || "${GH_MODE:-}" == "cleanup-failure" ]]; then
+    printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+else
+    printf '%s\n' '[]'
+fi
+EOF
+    chmod +x "$STUB_DIR/gh"
+}
+
+assert_executable() {
+    local script_path="$1"
+    if [[ ! -x "$script_path" ]]; then
+        echo "ASSERTION FAILED: expected executable script: $script_path" >&2
+        return 1
+    fi
+}
+
+assert_no_delete_attempts() {
+    local log_file="$1"
+    if [[ -s "$log_file" ]]; then
+        echo "ASSERTION FAILED: expected no DELETE attempt after an invalid later date" >&2
+        return 1
+    fi
+}
+
+assert_output_reports_invalid_date() {
+    if [[ "$output" != *"Failed to parse version date; skipping stale"* ]]; then
+        echo "ASSERTION FAILED: expected invalid later date to stop the package before DELETE" >&2
+        return 1
+    fi
+}
+
+assert_summary_reports_successful_deletion() {
+    if [[ "$output" != *"Summary: kept=0, deleted=1, delete_failures=0"* ]]; then
+        echo "ASSERTION FAILED: expected summary to report the successful deletion after cleanup failure" >&2
+        return 1
+    fi
+}
+
+@test "workflow-executed registry pruners are executable" {
+    assert_executable "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+    assert_executable "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+}
+
+@test "a zero-status malformed listing is unassessed, while a later package is assessed" {
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="malformed-listing" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken healthy
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Processing: healthy"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+}
+
+@test "a zero-byte successful listing is rejected rather than treated as an empty array" {
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="empty-listing" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+}
+
+@test "two paginated version arrays are flattened so a second-page version is classified" {
+    cat > "$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+printf '%s\n' '[{"id":102,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+EOF
+    chmod +x "$STUB_DIR/gh"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        KEEP_LATEST_COUNT="1" \
+        KEEP_MONTHS="0" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" stale
+
+    [[ "$status" -eq 0 ]]
+    if [[ "$output" != *"Would delete version 102"* ]]; then
+        echo "ASSERTION FAILED: expected second-page version 102 to be classified" >&2
+        return 1
+    fi
+    [[ "$output" == *"Found 2 versions"* ]]
+}
+
+@test "a non-array first paginated page is rejected even when a later page is valid" {
+    cat > "$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' '{}'
+printf '%s\n' '[]'
+EOF
+    chmod +x "$STUB_DIR/gh"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+}
+
+@test "a JSON record that jq cannot prepare is unassessed, cleans its temporary file, and does not abandon later packages" {
+    cat > "$STUB_DIR/mktemp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PRUNER_TEMP_FILE:?}"
+: > "$PRUNER_TEMP_FILE"
+printf '%s\n' "$PRUNER_TEMP_FILE"
+EOF
+    chmod +x "$STUB_DIR/mktemp"
+    local temp_file="$STUB_DIR/version-list"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="malformed-record" \
+        GH_LOG="$GH_LOG" \
+        PRUNER_TEMP_FILE="$temp_file" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken healthy
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Failed to prepare version list; skipping broken"* ]]
+    [[ "$output" == *"Processing: healthy"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ ! -e "$temp_file" ]]
+}
+
+@test "sourcing is inert and script_root uses BASH_SOURCE rather than the caller directory" {
+    run env -u GH_TOKEN -u OWNER bash -c '
+        set -e
+        before=$(set +o)
+        cd /
+        source "$1"
+        after=$(set +o)
+        [[ "$before" == "$after" ]]
+        [[ "$(script_root)" == "$2" ]]
+    ' _ "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" "$PROJECT_ROOT"
+
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+teardown() {
+    rm -rf "$STUB_DIR"
+}
+
+@test "listing failure is skipped, reported, and makes the run fail after later packages are assessed" {
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="listing-failure" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken healthy
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"gh: API rate limit exceeded"* ]]
+    [[ "$output" == *"Failed to list versions; skipping broken"* ]]
+    [[ "$output" == *"Processing: healthy"* ]]
+    [[ "$output" == *"No versions found (might be new or private)"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+    [[ "$output" == *"Delete failures: 0"* ]]
+}
+
+@test "failed deletion is counted and makes the completed run fail" {
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="delete-failure" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" stale
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"gh: delete denied"* ]]
+    [[ "$output" == *"Failed to delete"* ]]
+    [[ "$output" == *"Summary: kept=0, deleted=0, delete_failures=1"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 0"* ]]
+    [[ "$output" == *"Delete failures: 1"* ]]
+    [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
+}
+
+@test "an invalid later date attempts no DELETE for the package" {
+    cat > "$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"--method DELETE"* ]]; then
+    printf 'DELETE:%s\n' "$*" >> "$GH_LOG"
+    exit 0
+fi
+
+printf '%s\n' '[
+  {"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},
+  {"id":102,"metadata":{"container":{"tags":[]}},"created_at":"not-a-date"}
+]'
+EOF
+    chmod +x "$STUB_DIR/gh"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" stale
+
+    assert_no_delete_attempts "$GH_LOG"
+    [[ "$status" -eq 1 ]]
+    assert_output_reports_invalid_date
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+}
+
+@test "a failed post-delete cleanup still reports successful deletions" {
+    cat > "$STUB_DIR/rm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${RM_CALLS:-}" ]]; then
+    exec /bin/rm "$@"
+fi
+
+calls=0
+[[ -f "$RM_CALLS" ]] && calls=$(<"$RM_CALLS")
+calls=$((calls + 1))
+printf '%s\n' "$calls" > "$RM_CALLS"
+[[ "$calls" -eq 1 ]]
+EOF
+    chmod +x "$STUB_DIR/rm"
+    local rm_calls="$STUB_DIR/rm-calls"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        GH_MODE="cleanup-failure" \
+        GH_LOG="$GH_LOG" \
+        RM_CALLS="$rm_calls" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" stale
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Failed to remove deletion list after cleanup"* ]]
+    assert_summary_reports_successful_deletion
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ "$output" == *"Versions deleted: 1"* ]]
+    [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
+}

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -3,31 +3,25 @@
 # Unit tests for scripts/cleanup-outdated-tags.sh
 # Focus: is_valid_tag — bake cache tag validity derived from underlying base tag
 
-# Source is_valid_tag from the script.
-# The script has top-level guards (GH_TOKEN, OWNER) and a main loop; we set
-# dummy env vars and an empty CONTAINERS so the loop is a no-op on source.
-# We do NOT use bats `run` for is_valid_tag since that would re-execute the
-# main loop in the subshell.  Instead we call the function directly and check
-# the return code.
+# Source is_valid_tag from the script.  Sourcing is intentionally inert: it
+# defines functions only, so these tests do not need to arrange a fake main.
 
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    ORIGINAL_PATH="$PATH"
 
     export GH_TOKEN="test-token"
     export OWNER="test-owner"
     export DRY_RUN="true"
-    # Empty CONTAINERS prevents the main loop from iterating anything
-    export CONTAINERS=""
-
-    # Create a stub make so the script doesn't call the real one
+    # Keep a stub make available for tests that invoke main.
     _STUB_DIR="$(mktemp -d)"
     mkdir -p "$_STUB_DIR"
     printf '#!/bin/bash\necho ""\n' > "$_STUB_DIR/make"
     chmod +x "$_STUB_DIR/make"
     export PATH="$_STUB_DIR:$PATH"
 
-    # Source the script; the main loop runs but CONTAINERS="" → no iterations
+    # Source the script without triggering validation, output, or main.
     # shellcheck source=/dev/null
     source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" 2>/dev/null || true
 
@@ -35,8 +29,10 @@ setup() {
 }
 
 teardown() {
+    PATH="$ORIGINAL_PATH"
+    export PATH
     rm -rf "${_STUB_DIR:-}"
-    unset GH_TOKEN OWNER DRY_RUN CONTAINERS _STUB_DIR
+    unset GH_TOKEN OWNER DRY_RUN _STUB_DIR ORIGINAL_PATH
 }
 
 # ---------------------------------------------------------------------------
@@ -183,4 +179,252 @@ make_valid_tags() {
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
     is_valid_tag "buildcache-amd64" "$valid_tags"
+}
+
+@test "purge_ghcr listing failure is counted and makes the completed run fail" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                echo "gh: API rate limit exceeded" >&2
+                return 1
+            }
+            main broken
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"gh: API rate limit exceeded"* ]]
+    [[ "$output" == *"Failed to list GHCR versions; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Registry listing failures: 1"* ]]
+    [[ "$output" == *"GHCR — delete failures: 0"* ]]
+}
+
+@test "purge_ghcr treats a zero-status non-JSON body as a listing failure and leaves the package unassessed" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() { printf "%s\\n" "not-json"; }
+            main broken
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"GHCR version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Registry listing failures: 1"* ]]
+}
+
+@test "purge_ghcr rejects a zero-byte successful listing rather than treating it as an empty array" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() { return 0; }
+            main broken
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"GHCR version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Registry listing failures: 1"* ]]
+}
+
+@test "purge_ghcr flattens two paginated version arrays and classifies a second-page version" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            purge_dockerhub() { printf "%s\\n" "0|0"; }
+            gh() {
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:first\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}}]"
+                printf "%s\\n" "[{\"id\":102,\"name\":\"sha256:second\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Found 2 GHCR versions"* ]]
+    [[ "$output" == *"Would delete version 102"* ]]
+}
+
+@test "purge_ghcr rejects a non-array first paginated page even when a later page is valid" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() { printf "%s\\n" "{}" "[]"; }
+            main broken
+        '
+
+    if [[ "$status" -ne 1 ]]; then
+        echo "ASSERTION FAILED: expected a non-array first page to refuse the listing" >&2
+        return 1
+    fi
+    [[ "$output" == *"GHCR version listing was not a JSON array; skipping broken"* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Registry listing failures: 1"* ]]
+}
+
+@test "a successful Docker Hub assessment counts when GHCR listing fails" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() { return 1; }
+            purge_dockerhub() { printf "%s\\n" "1|0"; }
+            main broken
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Registry listing failures: 1"* ]]
+}
+
+@test "sourcing is inert and script_root uses BASH_SOURCE rather than the caller directory" {
+    run env -u GH_TOKEN -u OWNER bash -c '
+        set -e
+        before=$(set +o)
+        cd /
+        source "$1"
+        after=$(set +o)
+        [[ "$before" == "$after" ]]
+        [[ "$(script_root)" == "$2" ]]
+    ' _ "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" "$PROJECT_ROOT"
+
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "workflow attempts both registry pruners and fails after either failure" {
+    local workflow purge_step
+    workflow=$(<"$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml")
+    purge_step=$(sed -n '/- name: Purge obsolete images/,/- name: Fail if registry cleanup failed/p' "$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml")
+
+    [[ "$workflow" == *"id: cleanup_old_versions"* ]]
+    [[ "$workflow" == *"id: purge_obsolete_images"* ]]
+    [[ "$purge_step" == *"continue-on-error: true"* ]]
+    [[ "$purge_step" == *"always() && (github.event_name == 'schedule' || inputs.purge_obsolete == true)"* ]]
+    [[ "$workflow" == *"steps.cleanup_old_versions.outcome }}\" == \"failure\" || \"\${{ steps.purge_obsolete_images.outcome"* ]]
+
+    # This is the failure path that GitHub Actions evaluates: continue-on-error
+    # preserves the age-pruner outcome while always() still starts the second
+    # pruner, then the final gate fails the job.
+    run bash -c '
+        printf "%s\\n" "Cleanup old versions ran (failure)"
+        [[ "$1" == *"continue-on-error: true"* ]]
+        [[ "$2" == *"always() && (github.event_name == '\''schedule'\'' || inputs.purge_obsolete == true)"* ]]
+        printf "%s\\n" "Purge obsolete images ran"
+        [[ "$1" == *"steps.cleanup_old_versions.outcome }}\" == \"failure\" || \"\${{ steps.purge_obsolete_images.outcome"* ]]
+    ' _ "$workflow" "$purge_step"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Cleanup old versions ran (failure)"* ]]
+    [[ "$output" == *"Purge obsolete images ran"* ]]
+}
+
+@test "purge_ghcr delete failure is counted and returned as a failed completed run" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    echo "gh: delete denied" >&2
+                    return 1
+                fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:stale\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"gh: delete denied"* ]]
+    [[ "$output" == *"Failed to delete"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphans=0, delete_failures=1"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Registry listing failures: 0"* ]]
+    [[ "$output" == *"GHCR — delete failures: 1"* ]]
+}
+
+@test "a failed post-delete GHCR cleanup still reports successful deletions" {
+    cat > "$_STUB_DIR/rm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${RM_CALLS:-}" ]]; then
+    exec /bin/rm "$@"
+fi
+
+calls=0
+[[ -f "$RM_CALLS" ]] && calls=$(<"$RM_CALLS")
+calls=$((calls + 1))
+printf '%s\n' "$calls" > "$RM_CALLS"
+exit 1
+EOF
+    chmod +x "$_STUB_DIR/rm"
+    local rm_calls="$_STUB_DIR/rm-calls"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        PATH="$_STUB_DIR:$PATH" \
+        RM_CALLS="$rm_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    return 0
+                fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:stale\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Failed to remove GHCR work files after cleanup"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphans=0, delete_failures=0"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ "$output" == *"GHCR — kept: 0, obsolete: 1, orphans: 0"* ]]
 }


### PR DESCRIPTION
Both container pruners turned a failed GHCR listing into an empty list and exited
zero whatever happened, so a rate-limited monthly run looked like a clean one and
registry growth continued unnoticed.

They now tell an empty answer from no answer, count listing, processing and
deletion failures separately, finish every container they can still read, and
exit non-zero. `purge_ghcr` signals its cause on the return status instead of
leaving the caller to guess from an empty stdout. Validation of every
retention-relevant record completes before any DELETE, so a package is never
mutated and then reported as skipped. `gh`'s stderr survives on the failing
paths.

Two things the review caught that nothing local could. Both scripts had lost
their executable bit while the workflow invokes them directly — a test now
asserts `-x` rather than trusting the mode to survive a rewrite. And
`gh api --paginate` emits one JSON document per page, which both scripts read as
one: the count became `100\n23`, the array check passed on whichever page came
last, and only page one was ever classified. They slurp now, like
`helpers/trivy-utils.sh` and `helpers/ghcr-package-utils.sh` already did.

The two pruners run as separate steps of one job; making the first fail would
have skipped the second, so both now run under `continue-on-error` with a final
step failing the job if either did.

Verified: 2633 unit tests green on this HEAD, `shellcheck` and `actionlint`
clean. Each negative property was proven by removing it and watching a test fail
— weakening the page check to `(.[-1] | type == "array")`, which is the old
behaviour, turns `expected a non-array first page to refuse the listing` red.

Known and not closed here: uninterpretable input still authorises deletion at
five sites (#1300), retention still protects whichever versions GHCR listed first
(#1301), Docker Hub cleanup still reports work it skipped (#1302), `DRY_RUN=TRUE`
still deletes for real (#1305), and a post-delete cleanup failure reports a
package as both assessed and skipped (#1309).

Closes #1284
