### PR TITLE
Promote a tested extension candidate onto its canonical tags

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -14,6 +14,8 @@ HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -F log_info &>/dev/null; then
     source "$HELPERS_DIR/logging.sh"
 fi
+# shellcheck source=helpers/gha.sh
+source "$HELPERS_DIR/gha.sh"
 
 # shellcheck source=helpers/validate-extensions-schema.sh
 source "$HELPERS_DIR/validate-extensions-schema.sh"
@@ -464,6 +466,121 @@ is_valid_oci_digest() {
     # match the first line, silently accepting multi-line injections otherwise.
     [[ "$_d" == *$'\n'* ]] && return 1
     printf '%s' "$_d" | grep -Eqx 'sha256:[0-9a-f]{64}'
+}
+
+# extension_index_has_exact_digests <raw-index-json> <amd64-digest> <arm64-digest>
+#
+# Return success only for an index containing exactly one requested linux/amd64
+# descriptor and exactly one requested linux/arm64 descriptor.  The promotion
+# read-back and retry-recovery paths intentionally share this one predicate.
+extension_index_has_exact_digests() {
+    local raw_manifest="${1:-}"
+    local amd64_digest="${2:-}"
+    local arm64_digest="${3:-}"
+
+    jq -e --arg amd64_digest "$amd64_digest" --arg arm64_digest "$arm64_digest" '
+        .schemaVersion == 2 and
+        (.mediaType == "application/vnd.oci.image.index.v1+json" or
+         .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json") and
+        (.manifests | type == "array" and length == 2) and
+        ([.manifests[] |
+            select(.platform.os == "linux" and
+                   .platform.architecture == "amd64" and
+                   .digest == $amd64_digest)] | length == 1) and
+        ([.manifests[] |
+            select(.platform.os == "linux" and
+                   .platform.architecture == "arm64" and
+                   .digest == $arm64_digest)] | length == 1)
+    ' >/dev/null <<< "$raw_manifest"
+}
+
+# publish_extension_index_from_digests <target-tag-ref> <amd64-digest-ref> <arm64-digest-ref>
+#
+# Publish one extension multi-architecture index from two explicit, immutable
+# per-architecture digest references.  The target is intentionally a tag: it
+# is the canonical index consumers resolve.  Its children must be digest refs,
+# never mutable architecture tags.  On success, print the digest read back from
+# the published index. Returns 1 if creation itself failed and 2 if creation
+# succeeded but read-back verification failed, so callers do not claim the tag
+# was not written after a successful create.
+#
+# This is deliberately narrow so callers keep their own state-machine rules
+# (copying, conflict fences, and post-publication comparisons) while sharing
+# the one registry operation whose inputs must remain digest-pinned.
+publish_extension_index_from_digests() {
+    local target_ref="${1:-}"
+    local amd64_ref="${2:-}"
+    local arm64_ref="${3:-}"
+    local amd64_digest="${amd64_ref##*@}"
+    local arm64_digest="${arm64_ref##*@}"
+    local create_rc=0
+    local inspect_rc=0
+    local hash_rc=0
+    local raw_manifest
+    local raw_hash
+    local published_digest
+
+    if [[ -z "$target_ref" || "$amd64_ref" != *@* || "$arm64_ref" != *@* ]]; then
+        log_error "publish_extension_index_from_digests requires one target tag and two digest references"
+        return 1
+    fi
+
+    is_valid_oci_digest "$amd64_digest" || create_rc=$?
+    if [[ "$create_rc" -ne 0 ]]; then
+        log_error "Refusing to create extension index: amd64 source is not an explicit valid OCI digest reference"
+        return 1
+    fi
+
+    create_rc=0
+    is_valid_oci_digest "$arm64_digest" || create_rc=$?
+    if [[ "$create_rc" -ne 0 ]]; then
+        log_error "Refusing to create extension index: arm64 source is not an explicit valid OCI digest reference"
+        return 1
+    fi
+
+    create_rc=0
+    # Intentionally unquoted: logging.sh represents DRY_RUN commands as the
+    # two-word substitution "echo docker".
+    # shellcheck disable=SC2086
+    $DOCKER buildx imagetools create \
+        -t "$target_ref" \
+        "$amd64_ref" \
+        "$arm64_ref" || create_rc=$?
+    if [[ "$create_rc" -ne 0 ]]; then
+        log_error "Extension index creation outcome is unknown for $(_escape_gha_command "$target_ref") (rc=$create_rc); canonical state may have changed"
+        return 3
+    fi
+
+    raw_manifest=""
+    inspect_rc=0
+    # Intentionally unquoted; see the create invocation above.
+    # shellcheck disable=SC2086
+    raw_manifest=$($DOCKER buildx imagetools inspect "$target_ref" --raw 2>/dev/null) || inspect_rc=$?
+    if [[ "$inspect_rc" -ne 0 || -z "$raw_manifest" ]]; then
+        log_error "Could not read back the published extension index for $(_escape_gha_command "$target_ref")"
+        return 2
+    fi
+
+    if ! extension_index_has_exact_digests "$raw_manifest" "$amd64_digest" "$arm64_digest"; then
+        log_error "Published extension index for $(_escape_gha_command "$target_ref") did not contain exactly the requested linux/amd64 and linux/arm64 digests"
+        return 2
+    fi
+
+    raw_hash=""
+    raw_hash=$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}') || hash_rc=$?
+    if [[ "$hash_rc" -ne 0 || -z "$raw_hash" ]]; then
+        log_error "Could not calculate the read-back digest for $(_escape_gha_command "$target_ref")"
+        return 2
+    fi
+    published_digest="sha256:${raw_hash}"
+    inspect_rc=0
+    is_valid_oci_digest "$published_digest" || inspect_rc=$?
+    if [[ "$inspect_rc" -ne 0 ]]; then
+        log_error "Read-back digest for $(_escape_gha_command "$target_ref") was malformed"
+        return 2
+    fi
+
+    printf '%s' "$published_digest"
 }
 
 # validate_semver_set_json <json_array> <ceiling>

--- a/scripts/rotation-promote.sh
+++ b/scripts/rotation-promote.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# Promote a tested extension candidate from its staging package to canonical tags.
+#
+# This script is intentionally separate from build-extensions.sh: it consumes
+# frozen staging digests and a pre-test canonical baseline, whereas the ordinary
+# publish path discovers versions and can reuse tag-based state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../helpers/extension-utils.sh"
+
+# oci_tag_is_constructible <tag>
+#
+# OCI tags are capped at 128 characters and must begin with an alphanumeric or
+# underscore.  Check every constructed canonical tag before any registry call.
+oci_tag_is_constructible() {
+    local tag="${1:-}"
+    [[ "${#tag}" -le 128 && "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]
+}
+
+# canonical_index_has_requested_digests <reference> <amd64-digest> <arm64-digest>
+#
+# Read the canonical index under the caller-held lock and defer its exactness
+# decision to the shared helper used for post-publication validation.
+canonical_index_has_requested_digests() {
+    local index_ref="${1:-}"
+    local amd64_digest="${2:-}"
+    local arm64_digest="${3:-}"
+    local raw_manifest=""
+    local inspect_rc=0
+
+    # Intentionally unquoted: logging.sh represents DRY_RUN commands as the
+    # two-word substitution "echo docker".
+    # shellcheck disable=SC2086
+    raw_manifest=$($DOCKER buildx imagetools inspect "$index_ref" --raw 2>/dev/null) || inspect_rc=$?
+    [[ "$inspect_rc" -eq 0 && -n "$raw_manifest" ]] || return 1
+    extension_index_has_exact_digests "$raw_manifest" "$amd64_digest" "$arm64_digest"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: rotation-promote.sh --extension NAME --pg-major MAJOR --version VERSION \
+  (--baseline-digest DIGEST | --no-canonical-index) \
+  --amd64-digest DIGEST --arm64-digest DIGEST
+
+Promote the two tested staging manifests identified by DIGEST to the canonical
+extension architecture tags, then publish their canonical multi-arch index.
+The caller must declare exactly one pre-test canonical state: the canonical
+index digest observed before testing, or --no-canonical-index when it was
+confirmed absent. --no-canonical-index is a state flag, never a digest value.
+
+Promotion must be serialized per canonical (extension, pg major, version).
+This script does not acquire that lock: the caller must hold it before invoking
+the script and retain it through completion. The lock-time read below is a
+conflict fence, not a lock.
+EOF
+}
+
+# read_registry_digest <reference>
+#
+# Returns 0 and prints a digest when present, 1 when a successful tag listing
+# proves a tag reference absent, and 2 when it cannot determine either.
+# Callers that need a frozen object must reject both non-zero states; only the
+# canonical lock fence can accept the explicit ABSENT state.
+read_registry_digest() {
+    local ref="${1:-}"
+    local output=""
+    local inspect_rc=0
+
+    # Intentionally unquoted: logging.sh represents DRY_RUN commands as the
+    # two-word substitution "echo skopeo".
+    # shellcheck disable=SC2086
+    output=$($SKOPEO inspect --format '{{.Digest}}' "docker://${ref}" 2>&1) || inspect_rc=$?
+    if [[ "$inspect_rc" -ne 0 ]]; then
+        # Match ext_ref_resolve's PRESENT / ABSENT / INDETERMINATE contract:
+        # a failed manifest read is never itself evidence of absence. For a
+        # tag, a separate successful list-tags operation may prove its absence.
+        # Digest references have no tag listing that can establish absence.
+        if [[ "$ref" != *@* && "${ref##*/}" == *:* ]]; then
+            local repository="${ref%:*}"
+            local tag="${ref##*:}"
+            local tags_json=""
+            local tags_rc=0
+
+            # shellcheck disable=SC2086
+            tags_json=$($SKOPEO list-tags "docker://${repository}" 2>&1) || tags_rc=$?
+            if [[ "$tags_rc" -eq 0 ]] && jq -e --arg tag "$tag" '
+                ((.Tags // .tags) | type == "array") and
+                (((.Tags // .tags) | index($tag)) == null)
+            ' >/dev/null <<< "$tags_json"; then
+                return 1
+            fi
+        fi
+        log_error "Could not determine registry digest for $(_escape_gha_command "$ref") (inspect rc=$inspect_rc)"
+        return 2
+    fi
+
+    local digest_rc=0
+    is_valid_oci_digest "$output" || digest_rc=$?
+    if [[ "$digest_rc" -ne 0 ]]; then
+        log_error "Registry digest for $(_escape_gha_command "$ref") was malformed"
+        return 2
+    fi
+
+    printf '%s' "$output"
+}
+
+# verify_staging_manifest <reference> <architecture>
+#
+# Proves the frozen staging source is a single image manifest for linux/<arch>.
+# A manifest index is deliberately refused: skopeo copy --all would otherwise
+# copy every child beneath an architecture-specific canonical tag.
+verify_staging_manifest() {
+    local source_ref="${1:-}"
+    local architecture="${2:-}"
+    local raw_manifest=""
+    local config=""
+    local raw_rc=0
+    local config_rc=0
+
+    # shellcheck disable=SC2086
+    raw_manifest=$($SKOPEO inspect --raw "docker://${source_ref}" 2>&1) || raw_rc=$?
+    if [[ "$raw_rc" -ne 0 ]] || ! jq -e '
+        .schemaVersion == 2 and
+        (.mediaType == "application/vnd.oci.image.manifest.v1+json" or
+         .mediaType == "application/vnd.docker.distribution.manifest.v2+json") and
+        (.manifests | not)
+    ' >/dev/null <<< "$raw_manifest"; then
+        return 1
+    fi
+
+    # shellcheck disable=SC2086
+    config=$($SKOPEO inspect --config "docker://${source_ref}" 2>&1) || config_rc=$?
+    if [[ "$config_rc" -ne 0 ]] || ! jq -e --arg architecture "$architecture" '
+        .os == "linux" and .architecture == $architecture
+    ' >/dev/null <<< "$config"; then
+        return 1
+    fi
+}
+
+copy_staging_manifest() {
+    local source_ref="${1:-}"
+    local destination_ref="${2:-}"
+    local copy_rc=0
+
+    # shellcheck disable=SC2086
+    $SKOPEO copy --all --preserve-digests "docker://${source_ref}" "docker://${destination_ref}" || copy_rc=$?
+    if [[ "$copy_rc" -ne 0 ]]; then
+        log_error "Could not copy tested staging manifest $(_escape_gha_command "$source_ref") to $(_escape_gha_command "$destination_ref") (rc=$copy_rc)"
+        return 1
+    fi
+}
+
+# dry_run_command <command> [argument ...]
+#
+# Render a registry command without consulting the caller-overridable command
+# variables. Escape every rendered token so registry- and owner-derived
+# references cannot become GitHub Actions workflow commands in the log.
+dry_run_command() {
+    local argument
+
+    printf 'DRY RUN:'
+    for argument in "$@"; do
+        printf ' %s' "$(_escape_gha_command "$argument")"
+    done
+    printf '\n'
+}
+
+main() {
+    local extension=""
+    local pg_major=""
+    local version=""
+    local baseline_digest=""
+    local baseline_mode=""
+    local amd64_digest=""
+    local arm64_digest=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --extension|--pg-major|--version|--baseline-digest|--amd64-digest|--arm64-digest)
+                if [[ $# -lt 2 ]]; then
+                    log_error "Missing value for $(_escape_gha_command "$1")"
+                    return 1
+                fi
+                case "$1" in
+                    --extension) extension="$2" ;;
+                    --pg-major) pg_major="$2" ;;
+                    --version) version="$2" ;;
+                    --baseline-digest)
+                        if [[ -n "$baseline_mode" ]]; then
+                            log_error "Specify exactly one of --baseline-digest or --no-canonical-index"
+                            return 1
+                        fi
+                        baseline_digest="$2"
+                        baseline_mode="digest"
+                        ;;
+                    --amd64-digest) amd64_digest="$2" ;;
+                    --arm64-digest) arm64_digest="$2" ;;
+                esac
+                shift 2
+                ;;
+            --no-canonical-index)
+                if [[ -n "$baseline_mode" ]]; then
+                    log_error "Specify exactly one of --baseline-digest or --no-canonical-index"
+                    return 1
+                fi
+                baseline_mode="absent"
+                shift
+                ;;
+            -h|--help)
+                usage
+                return 0
+                ;;
+            *)
+                log_error "Unknown argument: $(_escape_gha_command "$1")"
+                usage >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [[ ! "$extension" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+        log_error "--extension must be a lowercase extension package component"
+        return 1
+    fi
+    if [[ ! "$pg_major" =~ ^[1-9][0-9]*$ ]]; then
+        log_error "--pg-major must be a positive integer"
+        return 1
+    fi
+    if [[ ! "$version" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+        log_error "--version must be a safe OCI tag component"
+        return 1
+    fi
+
+    if [[ -z "$baseline_mode" ]]; then
+        log_error "Specify exactly one of --baseline-digest or --no-canonical-index"
+        return 1
+    fi
+
+    local digest digest_rc=0
+    for digest in "$amd64_digest" "$arm64_digest"; do
+        digest_rc=0
+        is_valid_oci_digest "$digest" || digest_rc=$?
+        if [[ "$digest_rc" -ne 0 ]]; then
+            log_error "Promotion requires a valid baseline, amd64, and arm64 OCI digest"
+            return 1
+        fi
+    done
+    if [[ "$baseline_mode" == "digest" ]]; then
+        digest_rc=0
+        is_valid_oci_digest "$baseline_digest" || digest_rc=$?
+        if [[ "$digest_rc" -ne 0 ]]; then
+            log_error "Promotion requires a valid baseline, amd64, and arm64 OCI digest"
+            return 1
+        fi
+    fi
+    if [[ "$amd64_digest" == "$arm64_digest" ]]; then
+        log_error "Promotion requires distinct amd64 and arm64 OCI digests"
+        return 1
+    fi
+
+    # Package names are explicit here. EXTENSION_PACKAGE_SUFFIX is a global
+    # reference-construction axis, so changing it for this process cannot name
+    # the staging source and canonical destination at the same time.
+    local registry owner canonical_repo staging_repo registry_rc=0 owner_rc=0
+    registry=$(get_registry) || registry_rc=$?
+    owner=$(get_repo_owner) || owner_rc=$?
+    if [[ "$registry_rc" -ne 0 || "$owner_rc" -ne 0 || -z "$registry" || -z "$owner" ]]; then
+        log_error "Could not determine the extension registry and owner"
+        return 1
+    fi
+    canonical_repo="${registry}/${owner}/ext-${extension}"
+    staging_repo="${registry}/${owner}/ext-${extension}-staging"
+
+    local canonical_index_ref="${canonical_repo}:pg${pg_major}-${version}"
+    local staging_amd64_ref="${staging_repo}@${amd64_digest}"
+    local staging_arm64_ref="${staging_repo}@${arm64_digest}"
+    local canonical_amd64_tag="${canonical_repo}:pg${pg_major}-${version}-amd64"
+    local canonical_arm64_tag="${canonical_repo}:pg${pg_major}-${version}-arm64"
+
+    if ! oci_tag_is_constructible "pg${pg_major}-${version}" ||
+        ! oci_tag_is_constructible "pg${pg_major}-${version}-amd64" ||
+        ! oci_tag_is_constructible "pg${pg_major}-${version}-arm64"; then
+        log_error "Constructed canonical OCI tag exceeds the grammar or 128-character limit"
+        return 1
+    fi
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        dry_run_command skopeo inspect --format '{{.Digest}}' "docker://${staging_amd64_ref}"
+        dry_run_command skopeo inspect --raw "docker://${staging_amd64_ref}"
+        dry_run_command skopeo inspect --config "docker://${staging_amd64_ref}"
+        dry_run_command skopeo inspect --format '{{.Digest}}' "docker://${staging_arm64_ref}"
+        dry_run_command skopeo inspect --raw "docker://${staging_arm64_ref}"
+        dry_run_command skopeo inspect --config "docker://${staging_arm64_ref}"
+        dry_run_command skopeo inspect --format '{{.Digest}}' "docker://${canonical_index_ref}"
+        dry_run_command skopeo copy --all --preserve-digests "docker://${staging_amd64_ref}" "docker://${canonical_amd64_tag}"
+        dry_run_command skopeo inspect --format '{{.Digest}}' "docker://${canonical_amd64_tag}"
+        dry_run_command skopeo copy --all --preserve-digests "docker://${staging_arm64_ref}" "docker://${canonical_arm64_tag}"
+        dry_run_command skopeo inspect --format '{{.Digest}}' "docker://${canonical_arm64_tag}"
+        dry_run_command docker buildx imagetools create -t "$canonical_index_ref" "${canonical_repo}@${amd64_digest}" "${canonical_repo}@${arm64_digest}"
+        dry_run_command docker buildx imagetools inspect "$canonical_index_ref" --raw
+        log_success "Dry run completed promotion of $(_escape_gha_command "$extension") pg$(_escape_gha_command "$pg_major") $(_escape_gha_command "$version")"
+        return 0
+    fi
+
+    # Prove both frozen sources can be read before changing either canonical tag.
+    local source_amd64_digest="" source_arm64_digest="" source_amd64_rc=0 source_arm64_rc=0
+    source_amd64_digest=$(read_registry_digest "$staging_amd64_ref") || source_amd64_rc=$?
+    if [[ "$source_amd64_rc" -ne 0 ]] || [[ "$source_amd64_digest" != "$amd64_digest" ]]; then
+        log_error "Could not verify the frozen staging amd64 manifest; canonical tags remain unchanged"
+        return 1
+    fi
+    if ! verify_staging_manifest "$staging_amd64_ref" "amd64"; then
+        log_error "Frozen staging amd64 source was not a single linux/amd64 manifest; canonical tags remain unchanged"
+        return 1
+    fi
+    source_arm64_digest=$(read_registry_digest "$staging_arm64_ref") || source_arm64_rc=$?
+    if [[ "$source_arm64_rc" -ne 0 ]] || [[ "$source_arm64_digest" != "$arm64_digest" ]]; then
+        log_error "Could not verify the frozen staging arm64 manifest; canonical tags remain unchanged"
+        return 1
+    fi
+    if ! verify_staging_manifest "$staging_arm64_ref" "arm64"; then
+        log_error "Frozen staging arm64 source was not a single linux/arm64 manifest; canonical tags remain unchanged"
+        return 1
+    fi
+
+    # This is the lock-time conflict fence. A digest baseline must remain
+    # unchanged; an absent baseline must remain absent. Either a new index or a
+    # changed digest means another publisher acted while testing was in flight.
+    local locked_digest="" locked_rc=0
+    locked_digest=$(read_registry_digest "$canonical_index_ref") || locked_rc=$?
+    case "$locked_rc" in
+        0)
+            case "$baseline_mode" in
+                absent)
+                    if canonical_index_has_requested_digests "$canonical_index_ref" "$amd64_digest" "$arm64_digest"; then
+                        log_success "Recovered promotion: canonical index already contains the requested digests ($(_escape_gha_command "$locked_digest")); no write was needed"
+                        return 0
+                    fi
+                    log_error "Canonical index appeared since testing (caller declared no canonical index, found $(_escape_gha_command "$locked_digest")); refusing before any canonical copy"
+                    return 1
+                    ;;
+                digest)
+                    if [[ "$locked_digest" != "$baseline_digest" ]]; then
+                        if canonical_index_has_requested_digests "$canonical_index_ref" "$amd64_digest" "$arm64_digest"; then
+                            log_success "Recovered promotion: canonical index already contains the requested digests ($(_escape_gha_command "$locked_digest")); no write was needed"
+                            return 0
+                        fi
+                        log_error "Canonical index changed since testing (expected $(_escape_gha_command "$baseline_digest"), found $(_escape_gha_command "$locked_digest")); refusing before any canonical copy"
+                        return 1
+                    fi
+                    ;;
+            esac
+            ;;
+        1)
+            if [[ "$baseline_mode" == "digest" ]]; then
+                log_error "Canonical index disappeared since testing (expected $(_escape_gha_command "$baseline_digest")); refusing before any canonical copy"
+                return 1
+            fi
+            ;;
+        *)
+            log_error "Could not read the canonical index under the promotion lock; refusing to write"
+            return 1
+            ;;
+    esac
+
+    local copy_rc=0
+    copy_staging_manifest "$staging_amd64_ref" "$canonical_amd64_tag" || copy_rc=$?
+    if [[ "$copy_rc" -ne 0 ]]; then
+        return 1
+    fi
+
+    # This is an integrity tripwire for our own reference construction, not a
+    # security boundary: a party able to substitute this digest can write the
+    # canonical package directly and can rewrite the tag after this check.
+    local destination_amd64_digest="" destination_rc=0
+    destination_amd64_digest=$(read_registry_digest "$canonical_amd64_tag") || destination_rc=$?
+    if [[ "$destination_rc" -ne 0 ]] || [[ "$destination_amd64_digest" != "$amd64_digest" ]]; then
+        log_error "Canonical amd64 destination digest did not match the tested source (integrity tripwire); stopping before index publication"
+        return 1
+    fi
+
+    copy_rc=0
+    copy_staging_manifest "$staging_arm64_ref" "$canonical_arm64_tag" || copy_rc=$?
+    if [[ "$copy_rc" -ne 0 ]]; then
+        return 1
+    fi
+
+    local destination_arm64_digest=""
+    destination_rc=0
+    destination_arm64_digest=$(read_registry_digest "$canonical_arm64_tag") || destination_rc=$?
+    if [[ "$destination_rc" -ne 0 ]] || [[ "$destination_arm64_digest" != "$arm64_digest" ]]; then
+        log_error "Canonical arm64 destination digest did not match the tested source (integrity tripwire); stopping before index publication"
+        return 1
+    fi
+
+    local published_digest="" publish_rc=0
+    published_digest=$(publish_extension_index_from_digests \
+        "$canonical_index_ref" \
+        "${canonical_repo}@${destination_amd64_digest}" \
+        "${canonical_repo}@${destination_arm64_digest}") || publish_rc=$?
+    case "$publish_rc" in
+        0) ;;
+        2)
+            log_error "Canonical extension index was published but could not be verified"
+            return 1
+            ;;
+        3)
+            log_error "Canonical extension index publication outcome is unknown; canonical state may have changed"
+            return 1
+            ;;
+        *)
+            log_error "Canonical extension index was not published"
+            return 1
+            ;;
+    esac
+
+    # This is deliberately post-publication. An equal digest is not rolled
+    # back: the canonical tags already describe the same bytes. An absent
+    # baseline has no bytes to compare, so this check applies only to a digest
+    # baseline.
+    if [[ "$baseline_mode" == "digest" && "$published_digest" == "$baseline_digest" ]]; then
+        log_error "Promotion published an index identical to the pre-test baseline; reporting failed rotation without rollback"
+        return 1
+    fi
+
+    log_success "Promoted $(_escape_gha_command "$extension") pg$(_escape_gha_command "$pg_major") $(_escape_gha_command "$version"): $(_escape_gha_command "$published_digest")"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/unit/rotation-promote.bats
+++ b/tests/unit/rotation-promote.bats
@@ -1,0 +1,635 @@
+#!/usr/bin/env bats
+
+# Hermetic promotion tests. Registry commands are function stubs; no network or
+# containers are used. The call log distinguishes reads from canonical writes.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+    export OWNER="testowner"
+    export GITHUB_REPOSITORY_OWNER="$OWNER"
+    export EXTENSION_REGISTRY="ghcr.io"
+    export CALLS_FILE="$TEST_TEMP_DIR/registry-calls"
+    export AMD64_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    export ARM64_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    export RAW_MANIFEST="{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"digest\":\"$AMD64_DIGEST\",\"platform\":{\"os\":\"linux\",\"architecture\":\"amd64\"}},{\"digest\":\"$ARM64_DIGEST\",\"platform\":{\"os\":\"linux\",\"architecture\":\"arm64\"}}]}"
+    export BASELINE_DIGEST="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    export BASELINE_MODE="digest"
+    export CANONICAL_DIGEST="$BASELINE_DIGEST"
+    export SOURCE_AMD64_DIGEST="$AMD64_DIGEST"
+    export SOURCE_ARM64_DIGEST="$ARM64_DIGEST"
+    export DESTINATION_AMD64_DIGEST="$AMD64_DIGEST"
+    export DESTINATION_ARM64_DIGEST="$ARM64_DIGEST"
+    export DOCKER_MODE="success"
+    unset STATE_FILE
+    : > "$CALLS_FILE"
+}
+
+teardown() {
+    teardown_temp_dir
+    unset OWNER GITHUB_REPOSITORY_OWNER EXTENSION_REGISTRY CALLS_FILE RAW_MANIFEST AMD64_DIGEST ARM64_DIGEST BASELINE_DIGEST BASELINE_MODE
+    unset CANONICAL_DIGEST SOURCE_AMD64_DIGEST SOURCE_ARM64_DIGEST DESTINATION_AMD64_DIGEST DESTINATION_ARM64_DIGEST
+    unset SKOPEO_MODE DOCKER_MODE STATE_FILE
+}
+
+published_digest() {
+    printf 'sha256:%s' "$(printf '%s' "$RAW_MANIFEST" | sha256sum | awk '{print $1}')"
+}
+
+run_promotion() {
+    run env \
+        OWNER="$OWNER" \
+        GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" \
+        EXTENSION_REGISTRY="$EXTENSION_REGISTRY" \
+        CALLS_FILE="$CALLS_FILE" \
+        RAW_MANIFEST="$RAW_MANIFEST" \
+        AMD64_DIGEST="$AMD64_DIGEST" \
+        ARM64_DIGEST="$ARM64_DIGEST" \
+        BASELINE_DIGEST="$BASELINE_DIGEST" \
+        BASELINE_MODE="$BASELINE_MODE" \
+        CANONICAL_DIGEST="$CANONICAL_DIGEST" \
+        SOURCE_AMD64_DIGEST="$SOURCE_AMD64_DIGEST" \
+        SOURCE_ARM64_DIGEST="$SOURCE_ARM64_DIGEST" \
+        DESTINATION_AMD64_DIGEST="$DESTINATION_AMD64_DIGEST" \
+        DESTINATION_ARM64_DIGEST="$DESTINATION_ARM64_DIGEST" \
+        STATE_FILE="${STATE_FILE:-}" \
+        SKOPEO_MODE="${SKOPEO_MODE:-success}" \
+        DOCKER_MODE="${DOCKER_MODE:-success}" \
+        bash -c '
+            skopeo() {
+                local ref="${!#}"
+                if [[ "$1" == "copy" ]]; then
+                    printf "COPY %s\\n" "$*" >> "$CALLS_FILE"
+                    [[ "$SKOPEO_MODE" != "copy-fails" ]] || return 23
+                    return 0
+                fi
+                if [[ "$1" == "list-tags" ]]; then
+                    printf "LIST %s\\n" "$ref" >> "$CALLS_FILE"
+                    [[ "$SKOPEO_MODE" != "canonical-unknown-auth" && "$SKOPEO_MODE" != "canonical-inspect-fails" ]] || return 24
+                    cat <<EOF
+{"Tags":[]}
+EOF
+                    return 0
+                fi
+                printf "INSPECT %s\\n" "$ref" >> "$CALLS_FILE"
+                if [[ "$1" == "inspect" && "$2" == "--raw" ]]; then
+                    if [[ "$SKOPEO_MODE" == "amd64-index" && "$ref" == *"-staging@${AMD64_DIGEST}" ]]; then
+                        cat <<EOF
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}
+EOF
+                    else
+                        cat <<EOF
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}
+EOF
+                    fi
+                    return 0
+                fi
+                if [[ "$1" == "inspect" && "$2" == "--config" ]]; then
+                    if [[ "$SKOPEO_MODE" == "amd64-wrong-platform" && "$ref" == *"-staging@${AMD64_DIGEST}" ]]; then
+                        cat <<EOF
+{"os":"linux","architecture":"arm64"}
+EOF
+                    elif [[ "$ref" == *"-staging@${AMD64_DIGEST}" ]]; then
+                        cat <<EOF
+{"os":"linux","architecture":"amd64"}
+EOF
+                    else
+                        cat <<EOF
+{"os":"linux","architecture":"arm64"}
+EOF
+                    fi
+                    return 0
+                fi
+                [[ "$SKOPEO_MODE" != "inspect-fails" ]] || return 24
+                if [[ "$SKOPEO_MODE" == "amd64-inspect-fails" && "$ref" == *"-staging@${AMD64_DIGEST}" ]]; then
+                    return 24
+                fi
+                if [[ "$SKOPEO_MODE" == "amd64-absent" && "$ref" == *"-staging@${AMD64_DIGEST}" ]]; then
+                    printf "manifest unknown" >&2
+                    return 1
+                fi
+                if [[ "$SKOPEO_MODE" == "canonical-inspect-fails" && "$ref" != *"-staging@"* ]]; then
+                    return 24
+                fi
+                if [[ "$SKOPEO_MODE" == "canonical-unknown-auth" && "$ref" == *":pg17-0.8.6" ]]; then
+                    printf denied:\ upstream\ MANIFEST_UNKNOWN\ while\ auth\ unavailable >&2
+                    return 1
+                fi
+                if [[ "$SKOPEO_MODE" == "canonical-absent" && "$ref" == *":pg17-0.8.6" ]]; then
+                    printf "manifest unknown" >&2
+                    return 1
+                fi
+                if [[ "$SKOPEO_MODE" == "destination-amd64-absent" && "$ref" == *":pg17-0.8.6-amd64" ]]; then
+                    printf "manifest unknown" >&2
+                    return 1
+                fi
+                case "$ref" in
+                    *"-staging@${AMD64_DIGEST}") printf "%s" "$SOURCE_AMD64_DIGEST" ;;
+                    *"-staging@${ARM64_DIGEST}") printf "%s" "$SOURCE_ARM64_DIGEST" ;;
+                    *":pg17-0.8.6-amd64") printf "%s" "$DESTINATION_AMD64_DIGEST" ;;
+                    *":pg17-0.8.6-arm64") printf "%s" "$DESTINATION_ARM64_DIGEST" ;;
+                    *":pg17-0.8.6")
+                        if [[ -n "$STATE_FILE" && -s "$STATE_FILE" ]]; then
+                            cat "$STATE_FILE"
+                        else
+                            printf "%s" "$CANONICAL_DIGEST"
+                        fi
+                        ;;
+                    *) return 98 ;;
+                esac
+            }
+            docker() {
+                if [[ "$1 $2 $3" == "buildx imagetools create" ]]; then
+                    printf "CREATE %s\\n" "$*" >> "$CALLS_FILE"
+                    [[ "$DOCKER_MODE" != "create-fails" ]] || return 79
+                    if [[ "$DOCKER_MODE" == "commit-then-read-fails" ]]; then
+                        printf "sha256:%s" "$(printf "%s" "$RAW_MANIFEST" | sha256sum | awk "{print \$1}")" > "$STATE_FILE"
+                    fi
+                    return 0
+                fi
+                if [[ "$1 $2 $3" == "buildx imagetools inspect" ]]; then
+                    [[ "$DOCKER_MODE" != "index-read-fails" && "$DOCKER_MODE" != "commit-then-read-fails" ]] || return 77
+                    printf "%s" "$RAW_MANIFEST"
+                    return 0
+                fi
+                return 99
+            }
+            export -f skopeo docker
+            baseline_args=()
+            if [[ "$BASELINE_MODE" == "absent" ]]; then
+                baseline_args=(--no-canonical-index)
+            else
+                baseline_args=(--baseline-digest "$BASELINE_DIGEST")
+            fi
+            exec "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+                --extension pgvector --pg-major 17 --version 0.8.6 \
+                "${baseline_args[@]}" \
+                --amd64-digest "$AMD64_DIGEST" --arm64-digest "$ARM64_DIGEST"
+        '
+}
+
+@test "promotion copies frozen staging digests, verifies destinations, and creates a digest-pinned index" {
+    run_promotion
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Promoted pgvector pg17 0.8.6: $(published_digest)"* ]]
+    grep -Fqx "COPY copy --all --preserve-digests docker://ghcr.io/testowner/ext-pgvector-staging@${AMD64_DIGEST} docker://ghcr.io/testowner/ext-pgvector:pg17-0.8.6-amd64" "$CALLS_FILE" || {
+        echo "FAIL ASSERTION: staging copies must preserve the tested digest"
+        false
+    }
+    grep -Fqx "COPY copy --all --preserve-digests docker://ghcr.io/testowner/ext-pgvector-staging@${ARM64_DIGEST} docker://ghcr.io/testowner/ext-pgvector:pg17-0.8.6-arm64" "$CALLS_FILE"
+    grep -Fq "CREATE buildx imagetools create -t ghcr.io/testowner/ext-pgvector:pg17-0.8.6 ghcr.io/testowner/ext-pgvector@${AMD64_DIGEST} ghcr.io/testowner/ext-pgvector@${ARM64_DIGEST}" "$CALLS_FILE"
+}
+
+@test "a canonical index changed during testing refuses before any canonical write" {
+    export CANONICAL_DIGEST="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    export DOCKER_MODE="index-read-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: changed canonical index must refuse before any copy"
+        false
+    }
+    [[ "$output" == *"Canonical index changed since testing"* ]]
+    [[ ! -s "$CALLS_FILE" || "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: changed canonical index must refuse before any copy"
+        false
+    }
+}
+
+@test "a declared absent canonical index that remains absent permits first publication" {
+    export BASELINE_MODE="absent"
+    export SKOPEO_MODE="canonical-absent"
+
+    run_promotion
+
+    [ "$status" -eq 0 ] || {
+        echo "FAIL ASSERTION: a canonical index that remains absent must permit first publication"
+        false
+    }
+    [ "$(grep -c '^COPY ' "$CALLS_FILE")" -eq 2 ]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a canonical index appearing after the caller declared it absent refuses before any copy" {
+    export BASELINE_MODE="absent"
+    export DOCKER_MODE="index-read-fails"
+
+    run_promotion
+
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "FAIL ASSERTION: an appeared canonical index must refuse before any copy"
+        false
+    }
+    [[ "$output" == *"Canonical index appeared since testing"* ]]
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an appeared canonical index must refuse"
+        false
+    }
+}
+
+@test "an unreadable canonical index after the caller declared it absent refuses before any copy" {
+    export BASELINE_MODE="absent"
+    export SKOPEO_MODE="canonical-inspect-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: an unreadable canonical index must refuse before any copy"
+        false
+    }
+    [[ "$output" == *"Could not read the canonical index under the promotion lock"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: an unreadable canonical index must refuse before any copy"
+        false
+    }
+}
+
+@test "an ambiguous canonical error containing a not-found phrase refuses before any copy" {
+    export BASELINE_MODE="absent"
+    export SKOPEO_MODE="canonical-unknown-auth"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an ambiguous canonical error must refuse before any copy"
+        false
+    }
+    [[ "$output" == *"Could not read the canonical index under the promotion lock"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: an ambiguous canonical error must stop before any copy"
+        false
+    }
+}
+
+@test "an identical post-publication index is reported as a failed rotation without rollback" {
+    export BASELINE_DIGEST="$(published_digest)"
+    export CANONICAL_DIGEST="$BASELINE_DIGEST"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: identical published index must be reported as a failed rotation"
+        false
+    }
+    [[ "$output" == *"identical to the pre-test baseline; reporting failed rotation without rollback"* ]]
+    [ "$(grep -c '^COPY ' "$CALLS_FILE")" -eq 2 ]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a malformed supplied digest stops before any registry write" {
+    local malformed="sha256:not-a-digest"
+
+    run env \
+        OWNER="$OWNER" GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" EXTENSION_REGISTRY="$EXTENSION_REGISTRY" CALLS_FILE="$CALLS_FILE" \
+        bash -c '
+            skopeo() { printf "WRITE %s\\n" "$*" >> "$CALLS_FILE"; return 0; }
+            docker() { printf "WRITE %s\\n" "$*" >> "$CALLS_FILE"; return 0; }
+            export -f skopeo docker
+            exec "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+                --extension pgvector --pg-major 17 --version 0.8.6 \
+                --baseline-digest "$0" --amd64-digest "$0" --arm64-digest "$0"
+        ' "$malformed"
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: malformed digest must fail before any registry write"
+        false
+    }
+    [[ "$output" == *"Promotion requires a valid baseline, amd64, and arm64 OCI digest"* ]]
+    [[ ! -s "$CALLS_FILE" ]] || {
+        echo "ASSERTION: malformed digest must stop before any registry write"
+        false
+    }
+}
+
+@test "identical architecture digests stop before any registry write" {
+    export ARM64_DIGEST="$AMD64_DIGEST"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: identical architecture digests must stop before any registry write"
+        false
+    }
+    [[ "$output" == *"requires distinct amd64 and arm64 OCI digests"* ]]
+    [[ ! -s "$CALLS_FILE" ]] || {
+        echo "ASSERTION: identical architecture digests must stop before any registry write"
+        false
+    }
+}
+
+@test "an index passed as an amd64 input stops before any canonical write" {
+    export SKOPEO_MODE="amd64-index"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an index passed as amd64 must stop before any canonical write"
+        false
+    }
+    [[ "$output" == *"not a single linux/amd64 manifest"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: an index passed as amd64 must stop before any canonical write"
+        false
+    }
+}
+
+@test "a wrong-platform amd64 input stops before any canonical write" {
+    export SKOPEO_MODE="amd64-wrong-platform"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: a wrong-platform amd64 input must stop before any canonical write"
+        false
+    }
+    [[ "$output" == *"not a single linux/amd64 manifest"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: a wrong-platform amd64 input must stop before any canonical write"
+        false
+    }
+}
+
+@test "swapped architecture inputs stop before any canonical write" {
+    export SKOPEO_MODE="amd64-wrong-platform"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: swapped architecture inputs must stop before any canonical write"
+        false
+    }
+    [[ "$output" == *"not a single linux/amd64 manifest"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: swapped architecture inputs must stop before any canonical write"
+        false
+    }
+}
+
+@test "an unavailable frozen source stops before any canonical write" {
+    export SKOPEO_MODE="amd64-inspect-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: unavailable source probe must stop before any canonical write"
+        false
+    }
+    [[ "$output" == *"Could not verify the frozen staging amd64 manifest"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: unavailable source probe must stop before any canonical write"
+        false
+    }
+}
+
+@test "an absent frozen source stops before any canonical write" {
+    export SKOPEO_MODE="amd64-absent"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: an absent frozen source must stop before any canonical write"
+        false
+    }
+    [[ "$output" == *"Could not verify the frozen staging amd64 manifest"* ]]
+    [[ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE" || true)" -eq 0 ]] || {
+        echo "ASSERTION: an absent frozen source must stop before any canonical write"
+        false
+    }
+}
+
+@test "a mismatched canonical architecture destination stops before index publication" {
+    export DESTINATION_AMD64_DIGEST="sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+    run_promotion
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"integrity tripwire"* ]]
+    [ "$(grep -c '^COPY ' "$CALLS_FILE")" -eq 1 ]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE" || true)" -eq 0 ]
+}
+
+@test "an absent canonical destination after copy stops before index publication" {
+    export SKOPEO_MODE="destination-amd64-absent"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: an absent canonical destination must stop before index publication"
+        false
+    }
+    [[ "$output" == *"integrity tripwire"* ]]
+    [ "$(grep -c '^COPY ' "$CALLS_FILE")" -eq 1 ]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE" || true)" -eq 0 ]
+}
+
+@test "an empty read-back index is rejected after publication" {
+    export RAW_MANIFEST='{"schemaVersion":2,"manifests":[]}'
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an empty read-back index must be rejected after publication"
+        false
+    }
+    [[ "$output" == *"did not contain exactly the requested linux/amd64 and linux/arm64 digests"* ]]
+    [[ "$output" == *"was published but could not be verified"* ]]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a duplicate amd64 index without arm64 is rejected after publication" {
+    export RAW_MANIFEST="{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"digest\":\"$AMD64_DIGEST\",\"platform\":{\"os\":\"linux\",\"architecture\":\"amd64\"}},{\"digest\":\"$AMD64_DIGEST\",\"platform\":{\"os\":\"linux\",\"architecture\":\"amd64\"}}]}"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an index with duplicate amd64 and no arm64 must be rejected"
+        false
+    }
+    [[ "$output" == *"did not contain exactly the requested linux/amd64 and linux/arm64 digests"* ]] || {
+        echo "FAIL ASSERTION: duplicate amd64 must fail the exact-descriptor validator"
+        false
+    }
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a failed read after index creation says the index was published but could not be verified" {
+    export DOCKER_MODE="index-read-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: a failed post-write read must report publication with unverified state"
+        false
+    }
+    [[ "$output" == *"Canonical extension index was published but could not be verified"* ]]
+    [[ "$output" != *"Canonical extension index was not published"* ]]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a failed create reports an unknown canonical outcome rather than no publication" {
+    export DOCKER_MODE="create-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: a failed create must stop promotion"
+        false
+    }
+    [[ "$output" == *"publication outcome is unknown; canonical state may have changed"* ]]
+    [[ "$output" != *"Canonical extension index was not published" ]]
+    [ "$(grep -c '^CREATE ' "$CALLS_FILE")" -eq 1 ]
+}
+
+@test "a retry recovers a committed index without a further write" {
+    export STATE_FILE="$TEST_TEMP_DIR/canonical-state"
+    export DOCKER_MODE="commit-then-read-fails"
+
+    run_promotion
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: the simulated crash interval must leave the first invocation unverified"
+        false
+    }
+    [[ "$output" == *"was published but could not be verified"* ]]
+    [ -s "$STATE_FILE" ]
+    local writes_before
+    writes_before="$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE")"
+
+    export DOCKER_MODE="success"
+    run_promotion
+
+    [ "$status" -eq 0 ] || {
+        echo "FAIL ASSERTION: a retry whose canonical index already has both requested digests must recover"
+        false
+    }
+    [[ "$output" == *"Recovered promotion: canonical index already contains the requested digests"* ]]
+    [ "$(grep -cE '^(COPY|CREATE) ' "$CALLS_FILE")" -eq "$writes_before" ] || {
+        echo "ASSERTION: recovery must attempt no further canonical write"
+        false
+    }
+}
+
+@test "a constructed tag over 128 characters fails before any registry call" {
+    local too_long_version
+    too_long_version="$(printf 'a%.0s' {1..124})"
+
+    run env \
+        GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" EXTENSION_REGISTRY="$EXTENSION_REGISTRY" CALLS_FILE="$CALLS_FILE" \
+        bash -c '
+            skopeo() { printf "REGISTRY %s\\n" "$*" >> "$CALLS_FILE"; }
+            docker() { printf "REGISTRY %s\\n" "$*" >> "$CALLS_FILE"; }
+            export -f skopeo docker
+            exec "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+                --extension pgvector --pg-major 17 --version "$0" \
+                --baseline-digest "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" \
+                --amd64-digest "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                --arm64-digest "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ' "$too_long_version"
+
+    [ "$status" -ne 0 ] || {
+        echo "FAIL ASSERTION: an overlong constructed OCI tag must fail"
+        false
+    }
+    [[ "$output" == *"Constructed canonical OCI tag exceeds the grammar or 128-character limit"* ]] || {
+        echo "FAIL ASSERTION: constructed tag guard must reject before registry calls"
+        false
+    }
+    [[ ! -s "$CALLS_FILE" ]] || {
+        echo "ASSERTION: an overlong tag must stop before any registry call"
+        false
+    }
+}
+
+@test "an argument cannot inject a GitHub Actions workflow command into logs" {
+    local malicious_argument=$'--bad\n::add-mask::secret'
+
+    run env GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" EXTENSION_REGISTRY="$EXTENSION_REGISTRY" \
+        "$PROJECT_ROOT/scripts/rotation-promote.sh" "$malicious_argument"
+
+    [ "$status" -ne 0 ] || {
+        echo "ASSERTION: the malicious argument must remain an invalid argument"
+        false
+    }
+    [[ "$output" == *"%0A::add-mask::secret"* ]] || {
+        echo "FAIL ASSERTION: workflow command newline must be percent-escaped"
+        false
+    }
+    while IFS= read -r output_line; do
+        [[ "$output_line" != ::* ]] || {
+            echo "FAIL ASSERTION: no logged output line may begin with an unescaped workflow command"
+            false
+        }
+    done <<< "$output"
+}
+
+@test "DRY_RUN never invokes overridden registry clients" {
+    local sentinel="$TEST_TEMP_DIR/registry-client-sentinel"
+    local sentinel_calls="$TEST_TEMP_DIR/registry-client-sentinel-calls"
+
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "SENTINEL %s\\n" "$*" >> "$SENTINEL_CALLS"' \
+        'exit 97' > "$sentinel"
+    chmod +x "$sentinel"
+    : > "$sentinel_calls"
+
+    run env \
+        DRY_RUN=true SKOPEO="$sentinel" DOCKER="$sentinel" SENTINEL_CALLS="$sentinel_calls" \
+        GITHUB_REPOSITORY_OWNER=$'testowner\n::add-mask::owner' EXTENSION_REGISTRY=$'ghcr.io\n::notice::registry' \
+        "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+        --extension pgvector --pg-major 17 --version 0.8.6 \
+        --baseline-digest "$BASELINE_DIGEST" \
+        --amd64-digest "$AMD64_DIGEST" --arm64-digest "$ARM64_DIGEST"
+
+    [[ ! -s "$sentinel_calls" ]] || {
+        echo "FAIL ASSERTION: DRY_RUN must never invoke overridden registry clients" >&3
+        false
+    }
+    [ "$status" -eq 0 ] || {
+        echo "FAIL ASSERTION: DRY_RUN must complete without invoking overridden registry clients" >&3
+        false
+    }
+    [[ "$output" == *"skopeo inspect --format {{.Digest}}"* ]]
+    [[ "$output" == *"docker buildx imagetools create"* ]]
+    [[ "$output" == *"Dry run completed promotion"* ]]
+    [[ "$output" == *"ghcr.io%0A::notice::registry"* ]]
+    [[ "$output" == *"testowner%0A::add-mask::owner"* ]]
+    while IFS= read -r output_line; do
+        [[ "$output_line" != ::* ]] || {
+            echo "ASSERTION: DRY_RUN output must not contain an active workflow command"
+            false
+        }
+    done <<< "$output"
+}
+
+@test "DRY_RUN completes when SKOPEO is false" {
+    local sentinel="$TEST_TEMP_DIR/docker-client-sentinel"
+    local sentinel_calls="$TEST_TEMP_DIR/docker-client-sentinel-calls"
+
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "SENTINEL %s\\n" "$*" >> "$SENTINEL_CALLS"' \
+        'exit 97' > "$sentinel"
+    chmod +x "$sentinel"
+    : > "$sentinel_calls"
+
+    run env \
+        DRY_RUN=true SKOPEO=false DOCKER="$sentinel" SENTINEL_CALLS="$sentinel_calls" \
+        GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" EXTENSION_REGISTRY="$EXTENSION_REGISTRY" \
+        "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+        --extension pgvector --pg-major 17 --version 0.8.6 \
+        --baseline-digest "$BASELINE_DIGEST" \
+        --amd64-digest "$AMD64_DIGEST" --arm64-digest "$ARM64_DIGEST"
+
+    [[ ! -s "$sentinel_calls" ]] || {
+        echo "FAIL ASSERTION: DRY_RUN must not invoke DOCKER when SKOPEO=false" >&3
+        false
+    }
+    [ "$status" -eq 0 ] || {
+        echo "FAIL ASSERTION: DRY_RUN must complete when SKOPEO=false" >&3
+        false
+    }
+}


### PR DESCRIPTION
The scheduled rotation compiles a `(postgres extension, pg major)` candidate into
a separate staging package with no cache and tests it. This publishes the result
onto the canonical tags.

Nothing calls it yet — the workflow that selects, builds and tests is a separate
piece — so it is complete and covered on its own.

The order is: prove both frozen staging manifests read back as the digests that
were tested and are single-image manifests on the platforms their flags name;
read the canonical index again under the caller's lock and refuse if it is not
what the caller measured before testing; copy each architecture with
`--preserve-digests` and verify the destination; publish the index from the two
destination digests; compare the published digest against the baseline.

That second read is the conflict fence. The caller's lock covers only this
invocation, so an ordinary publish can update the canonical index while the tests
run; a pre-test baseline alone would let this overwrite a newer publication
having proved only that its result differs from a stale digest. `--help` states
that promotion must be serialized per canonical `(extension, pg major, version)`
and that this script acquires no lock.

Absence is established by a `skopeo list-tags` that succeeded and does not contain
the tag, never by matching text in an error — `--no-canonical-index` exists
because `rotation-select.sh` ranks a pair with no canonical record ahead of every
dated one. A retry after a crash that committed the index recognises it and
reports recovery without writing. `DRY_RUN=true` performs no registry operation
whatever `DOCKER` and `SKOPEO` hold.

Verified: 2637 unit tests green on this HEAD, `shellcheck` clean. Each negative
property was proven by removing it and watching a test fail — with both clients
pointed at a sentinel that records every call, a full dry run leaves its call
file empty, and disabling the dry-run branch makes the sentinel be invoked.

Known and not closed here: registry client output reaches stdout and the
workflow-command channel (#1314), extension and version names can collide with
the suffixes the reference scheme reserves (#1312), recovery verifies the index
without reading the architecture aliases and the index validator does not require
descriptor media types and sizes (#1313), and the ordinary publish path builds
the canonical index from mutable architecture references (#1304).

Refs #1245
