### PR TITLE
Make build-extensions.sh report what it actually did

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -251,6 +251,7 @@ FINALIZE_MULTIARCH=false
 NO_CACHE="${DOCKER_NO_CACHE:-false}"
 
 usage() {
+    local exit_code="${1:-0}"
     cat <<EOF
 Usage: $(basename "$0") <container> [options]
 
@@ -287,21 +288,40 @@ Examples:
   $(basename "$0") postgres --list                 # Show status
   $(basename "$0") postgres --local-only           # Build without push
 EOF
-    exit 0
+    exit "$exit_code"
 }
 
 # Parse arguments
 parse_args() {
+    # Command-line grammars are ASCII bytes, regardless of the caller locale.
+    local LC_ALL=C
+
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -h|--help)
-                usage
+                usage 0
                 ;;
             --major-version)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    log_error "Option --major-version requires a value"
+                    usage 2
+                fi
+                if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+                    log_error "Option --major-version must match ^[0-9]+$"
+                    usage 2
+                fi
                 MAJOR_VERSION="$2"
                 shift 2
                 ;;
             --extension)
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    log_error "Option --extension requires a value"
+                    usage 2
+                fi
+                if [[ ! "$2" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]]; then
+                    log_error "Option --extension must match ^[A-Za-z0-9_][A-Za-z0-9_-]*$"
+                    usage 2
+                fi
                 EXTENSION="$2"
                 shift 2
                 ;;
@@ -335,14 +355,14 @@ parse_args() {
                 ;;
             -*)
                 log_error "Unknown option: $1"
-                usage
+                usage 2
                 ;;
             *)
                 if [[ -z "$CONTAINER" ]]; then
                     CONTAINER="$1"
                 else
                     log_error "Unexpected argument: $1"
-                    usage
+                    usage 2
                 fi
                 shift
                 ;;
@@ -351,7 +371,17 @@ parse_args() {
 
     if [[ -z "$CONTAINER" ]]; then
         log_error "Container name required"
-        usage
+        usage 2
+    fi
+}
+
+log_dry_run_cache_mode() {
+    [[ "$DRY_RUN" == "true" ]] || return 0
+
+    if [[ "${NO_CACHE:-false}" == "true" ]]; then
+        log_info "[DRY-RUN] Cache mode: disabled"
+    else
+        log_info "[DRY-RUN] Cache mode: enabled"
     fi
 }
 
@@ -453,9 +483,6 @@ build_extension() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would build $ext_name $ext_version for $CONTAINER v$major_ver (REMOTE_CR=${REMOTE_CR})"
         log_info "[DRY-RUN]   --build-arg REMOTE_CR=${REMOTE_CR} --build-arg MAJOR_VERSION=$major_ver"
-        if [[ "${NO_CACHE:-false}" == "true" ]]; then
-            log_info "[DRY-RUN]   --no-cache (disables layer-result reuse and external registry cache imports and exports)"
-        fi
         return 0
     fi
 
@@ -2393,6 +2420,7 @@ finalize_multiarch_manifests() {
 
 main() {
     parse_args "$@"
+    log_dry_run_cache_mode
 
     # Validate the optional package axis before any prerequisite, registry, or
     # build action. A malformed suffix must never influence a reference.

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -1571,24 +1571,6 @@ _count_log_lines() {
     [ ! -d "$lineage_dir" ]
 }
 
-@test "dry-run --no-cache reports layer-result and external registry cache semantics" {
-    export DRY_RUN=true
-    NO_CACHE=false
-
-    run build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
-
-    [ "$status" -eq 0 ]
-    local cached_output="$output"
-    ! grep -Fq -- "--no-cache (disables layer-result reuse and external registry cache imports and exports)" <<<"$cached_output"
-
-    NO_CACHE=true
-    run build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
-
-    [ "$status" -eq 0 ]
-    [[ "$output" != "$cached_output" ]]
-    grep -Fq -- "--no-cache (disables layer-result reuse and external registry cache imports and exports)" <<<"$output"
-}
-
 # ---------------------------------------------------------------------------
 # P-malformed: resolver returns non-JSON → _resolve_cached must return non-zero
 # (fail-closed on publish path), NOT cache the bad value and silently skip builds.

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -81,6 +81,196 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# CLI entry-point behavior
+# ---------------------------------------------------------------------------
+
+@test "entry point refuses invalid invocations and accepts deliberate help" {
+    run "$SCRIPTS_DIR/build-extensions.sh" postgres --no-cach
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: unknown option must exit 2"
+        return 1
+    }
+
+    run "$SCRIPTS_DIR/build-extensions.sh" postgres extra
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: unexpected argument must exit 2"
+        return 1
+    }
+
+    run "$SCRIPTS_DIR/build-extensions.sh"
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: missing container must exit 2"
+        return 1
+    }
+
+    run "$SCRIPTS_DIR/build-extensions.sh" --help
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: deliberate --help must exit zero"
+        return 1
+    }
+}
+
+@test "entry point refuses missing and option-shaped option values" {
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --major-version with an option-shaped value must exit 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --major-version requires a value" || {
+        echo "FAIL: --major-version with an option-shaped value must name the option"
+        return 1
+    }
+    ! printf '%s' "$output" | grep -Fq "All extensions are up to date" || {
+        echo "FAIL: --major-version with an option-shaped value must not report a no-build success"
+        return 1
+    }
+
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --major-version without a value must exit 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --major-version requires a value" || {
+        echo "FAIL: --major-version without a value must name the option"
+        return 1
+    }
+
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --extension
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --extension without a value must exit 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --extension requires a value" || {
+        echo "FAIL: --extension without a value must name the option"
+        return 1
+    }
+
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --extension --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --extension with an option-shaped value must exit 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --extension requires a value" || {
+        echo "FAIL: --extension with an option-shaped value must name the option"
+        return 1
+    }
+}
+
+@test "entry point validates values consumed by options" {
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version 17x
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --major-version must refuse a non-decimal value with status 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --major-version must match ^[0-9]+$" || {
+        echo "FAIL: --major-version must explain its ASCII-digit grammar"
+        return 1
+    }
+
+    run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --extension 'pg/vector'
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --extension must refuse a non-name-shaped value with status 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --extension must match ^[A-Za-z0-9_][A-Za-z0-9_-]*$" || {
+        echo "FAIL: --extension must explain its command-line name grammar"
+        return 1
+    }
+}
+
+@test "entry point applies ASCII option grammars in a UTF-8 locale" {
+    run locale -a
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: locale -a must succeed before testing en_US.utf8"
+        return 1
+    }
+    printf '%s\n' "$output" | grep -Fxq 'en_US.utf8' || {
+        echo "FAIL: en_US.utf8 locale is required to test locale-independent ASCII option grammars"
+        return 1
+    }
+
+    run env LC_ALL=en_US.utf8 bash -c '[[ "$1" =~ ^[[:alpha:]]+$ ]]' _ 'É'
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: en_US.utf8 locale control must accept non-ASCII É with [[:alpha:]]"
+        return 1
+    }
+
+    run env LC_ALL=en_US.utf8 "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version '١' --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --major-version must reject Arabic-Indic digit ١ in en_US.utf8"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --major-version must match ^[0-9]+$" || {
+        echo "FAIL: --major-version must name its ASCII-digit grammar for ١"
+        return 1
+    }
+
+    run env LC_ALL=en_US.utf8 "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version '²' --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --major-version must reject superscript digit ² in en_US.utf8"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --major-version must match ^[0-9]+$" || {
+        echo "FAIL: --major-version must name its ASCII-digit grammar for ²"
+        return 1
+    }
+
+    run env LC_ALL=en_US.utf8 "$SCRIPTS_DIR/build-extensions.sh" postgres --extension 'É' --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --extension must reject É in en_US.utf8"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --extension must match ^[A-Za-z0-9_][A-Za-z0-9_-]*$" || {
+        echo "FAIL: --extension must name its ASCII grammar for É"
+        return 1
+    }
+}
+
+@test "entry point extension diagnostic names the accepted grammar" {
+    run env LC_ALL=en_US.utf8 "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version 17 --extension _pgvector-1 --dry-run
+    [ "$status" -eq 1 ] || {
+        echo "FAIL: --extension must parse _pgvector-1, which its diagnostic grammar describes"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Extension '_pgvector-1': no Dockerfile" || {
+        echo "FAIL: --extension must reach later validation after accepting _pgvector-1"
+        return 1
+    }
+
+    run "$SCRIPTS_DIR/build-extensions.sh" postgres --extension '-foo' --dry-run
+    [ "$status" -eq 2 ] || {
+        echo "FAIL: --extension -foo must exit 2"
+        return 1
+    }
+    printf '%s' "$output" | grep -Fq "Option --extension requires a value" || {
+        echo "FAIL: --extension -foo must remain option-shaped rather than grammar-valid"
+        return 1
+    }
+    ! [[ '-foo' =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]] || {
+        echo "FAIL: extension diagnostic grammar must not describe -foo as valid"
+        return 1
+    }
+}
+
+@test "dry-run entry point reports the requested cache mode" {
+    run "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version 17 --dry-run --no-cache --extension pgvector
+
+    [ "$status" -eq 0 ]
+    grep -Fq -- "[DRY-RUN] Cache mode: disabled" <<<"$output" || {
+        echo "FAIL: dry-run entry point must report disabled cache mode"
+        return 1
+    }
+
+    run env DOCKER_NO_CACHE=false "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version 17 --dry-run --extension pgvector
+
+    [ "$status" -eq 0 ]
+    grep -Fq -- "[DRY-RUN] Cache mode: enabled" <<<"$output" || {
+        echo "FAIL: dry-run entry point must report enabled cache mode"
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Default mock helpers — individual tests override as needed
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`usage()` ended with `exit 0` and every invalid-input branch called it, so
`./scripts/build-extensions.sh postgres --no-cach` compiled nothing and returned
0. `auto-build.yaml` invokes this script and then builds the postgres image
against whatever canonical extension images already existed — a green run with
stale extensions, which is the failure #1245 exists because of.

Refusals now exit 2 and a deliberate `--help` still exits 0. `--major-version`
and `--extension` refuse a missing or option-shaped value, naming the option,
and check the shape of a value that is present — `postgres --major-version
--dry-run` used to take `--dry-run` as the version and announce `All extensions
are up to date`.

Those checks are forced into ASCII with `local LC_ALL=C`, because a bash bracket
range is locale-dependent: under `en_US.utf8`, `^[0-9]+$` accepts the
Arabic-Indic `١`, which `yq` then cannot convert, and that failure is swallowed
by a process substitution (#1307) into the same false green. The regression test
fails explicitly on a host lacking the locale it needs rather than passing
vacuously there.

A dry run also states the cache mode it was asked for, from the entry point the
documented command uses. The test that covered this called `build_extension`
directly, so it passed while the documented invocation had no such behaviour;
its replacement drives the real entry point and asserts both modes.

Verified: 2617 unit tests green on this HEAD, `shellcheck` at its unchanged
baseline. Each property was proven by removing it and watching a test fail.

The CLI now forbids a leading hyphen in an extension name while the jq schema
still permits one — a fourth copy of one grammar, tracked in #1231 and #1286.

Known and not closed here: a failed extension enumeration is still
indistinguishable from having nothing to build (#1307), temporary directories are
still allocated before argument parsing (#1308), the container positional is
still dereferenced as a path (#1311), and the locale test's control checks a
different regex than production (#1316).

Closes #1272
Closes #1276
