### PR TITLE
Stop the extension prune claiming certainty it does not have

### DIFF
--- a/helpers/ghcr-package-utils.sh
+++ b/helpers/ghcr-package-utils.sh
@@ -7,7 +7,11 @@
 # avoids widening this read helper into those destructive workflows.
 
 # List GHCR package version records for an extension package.
-# Output: compact JSON array of {version_id,name,tags[],updated_at} records.
+# Output: compact JSON array of {version_id,name,tags,tags_observed,updated_at}
+# records. `tags` is always an array of strings. `tags_observed` is true only
+# when GitHub returned the tags array (including an authoritative empty array);
+# it is false when tag metadata was absent or null, so callers can distinguish
+# an observed empty set from an incomplete observation.
 # Returns 1 when the API request fails; propagates jq's non-zero status when
 # the response cannot be normalized as a sequence of arrays.
 _list_ghcr_ext_version_records() {
@@ -27,17 +31,23 @@ _list_ghcr_ext_version_records() {
       # array in the slurped input and is therefore accepted below.
       select(length > 0)
       | def record_tags:
-        (.metadata.container.tags // [])
-        | if type == "array" and all(.[]; type == "string") then .
-          else error("GHCR version record tags must be an array of strings")
-          end;
+        if ((.metadata? | type) == "object"
+            and (.metadata.container? | type) == "object"
+            and (.metadata.container | has("tags") and .tags != null)) then
+          .metadata.container.tags
+          | if type == "array" and all(.[]; type == "string") then .
+            else error("GHCR version record tags must be an array of strings")
+            end
+          | { tags: ., tags_observed: true }
+        else { tags: [], tags_observed: false }
+        end;
       if all(.[]; type == "array") then
-        [.[][] | {
+        [.[][] | ({
           version_id: (if .id == null then error("GHCR version record has no id") else (.id | tostring) end),
-          name: (if ((.name // "") | type) == "string" then (.name // "") else "" end),
-          tags: record_tags,
+          name: (if ((.name // "") | type) == "string" then (.name // "") else "" end)
+        } + record_tags + {
           updated_at: (if .updated_at == null then "" elif (.updated_at | type) == "string" then .updated_at else "" end)
-        }]
+        })]
       else
         error("GHCR package-versions response must contain JSON arrays")
       end

--- a/scripts/cleanup-ext-images.sh
+++ b/scripts/cleanup-ext-images.sh
@@ -152,17 +152,22 @@ _get_ghcr_ext_version_record() {
         "/users/${owner}/packages/container/${package_name}/versions/${version_id}" 2>/dev/null \
         | jq -ce --arg expected_version_id "$version_id" '
           def record_tags:
-            (.metadata.container.tags // [])
-            | if type == "array" and all(.[]; type == "string") then .
-              else error("GHCR version record tags must be an array of strings")
-              end;
-          {
+            if ((.metadata? | type) == "object"
+                and (.metadata.container? | type) == "object"
+                and (.metadata.container | has("tags") and .tags != null)) then
+              .metadata.container.tags
+              | if type == "array" and all(.[]; type == "string") then .
+                else error("GHCR version record tags must be an array of strings")
+                end
+              | { tags: ., tags_observed: true }
+            else { tags: [], tags_observed: false }
+            end;
+          ({
             version_id: (if .id == null then error("GHCR version record has no id")
                          elif (.id | tostring) != $expected_version_id then error("GHCR version record id does not match requested version id")
                          else (.id | tostring)
                          end),
-            tags: record_tags
-          }
+          } + record_tags)
         '
 }
 
@@ -235,26 +240,15 @@ _parse_ext_managed_tag() {
     printf '%s|%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
 }
 
-# Extract the resolver version from a managed extension tag for a specific major.
-_derive_ext_tag_window_version() {
-    local tag="$1"
-    local pg_major="$2"
-    local parsed
-    local parsed_major
-    local version
-
-    parsed=$(_parse_ext_managed_tag "$tag") || return 1
-    IFS='|' read -r parsed_major version <<< "$parsed"
-    [[ "$parsed_major" == "$pg_major" ]] || return 1
-    printf '%s\n' "$version"
-}
-
 _version_record_tags_csv() {
     local record_json="$1"
 
     jq -r '
-      (.tags // []) as $tags
-      | if ($tags | length) > 0 then ($tags | join(",")) else "(none)" end
+      .tags as $tags
+      | if ($tags | type) == "array" then
+          if ($tags | length) > 0 then ($tags | join(",")) else "(none)" end
+        else error("record tags must be an array")
+        end
     ' <<< "$record_json"
 }
 
@@ -269,7 +263,7 @@ _list_version_record_tags() {
     local record_json="$1"
 
     jq -r '
-      (.tags // []) as $tags
+      .tags as $tags
       | if ($tags | type) == "array" then
           $tags
           | if all(.[]; type == "string" and (contains("\n") | not) and (contains("\u0000") | not)) then .[] else error("tag cannot be transported safely") end
@@ -292,7 +286,16 @@ _record_is_prunable() {
 
     record_tags_csv="(tag enumeration unavailable)"
     record_keep_reason=""
-    if ! tag_count=$(jq -er '(.tags // []) | if type == "array" then length else error("record tags must be an array") end' <<< "$record_json"); then
+    local tags_observed
+    if ! tags_observed=$(jq -r '.tags_observed | if type == "boolean" then . else error("record tags_observed must be boolean") end' <<< "$record_json"); then
+        record_keep_reason="tag observation unknown; keeping record fail-closed"
+        return 2
+    fi
+    if [[ "$tags_observed" != "true" ]]; then
+        record_keep_reason="tags were not observed; keeping record fail-closed"
+        return 2
+    fi
+    if ! tag_count=$(jq -er '.tags | if type == "array" then length else error("record tags must be an array") end' <<< "$record_json"); then
         record_keep_reason="tag count unknown; keeping record fail-closed"
         return 2
     fi
@@ -339,7 +342,7 @@ _record_is_prunable() {
         if [[ "${window_known_by_major[$tag_major]:-false}" != "true" ]]; then
             rm -f "$tags_file" || true
             record_keep_reason="window unknown for pg${tag_major}: ${tag}"
-            return 1
+            return 2
         fi
 
         if _version_in_window "$tag_version" "${window_by_major[$tag_major]}"; then
@@ -450,7 +453,8 @@ main() {
     fi
 
     local total_kept=0
-    local total_pruned=0
+    local total_would_delete=0
+    local total_deleted=0
     local total_delete_failures=0
     local total_skipped_pairs=0
     local total_listing_failures=0
@@ -474,6 +478,7 @@ main() {
 
         if ! version_records_json=$(_list_ghcr_ext_version_records "$package_name"); then
             log_warning "  GHCR version listing failed for ${package_name} — SKIPPING extension (fail-closed)"
+            log_warning "    Summary: kept=0, would_delete=0, deleted=0, failed=1 (delete_failures=0, reread_failures=0, analysis_inconclusive=0, listing_failures=1)"
             total_listing_failures=$((total_listing_failures + 1))
             continue
         fi
@@ -484,6 +489,7 @@ main() {
 
         if [[ "$version_record_count" -eq 0 ]]; then
             log_info "  No GHCR version records found — nothing to prune"
+            log_info "    Summary: kept=0, would_delete=0, deleted=0, failed=0 (delete_failures=0, reread_failures=0, analysis_inconclusive=0, listing_failures=0)"
             continue
         fi
 
@@ -519,13 +525,11 @@ main() {
             log_info "  No pg<major>- tags found in registry records"
         fi
 
-        if [[ ${#pg_majors[@]} -eq 0 ]]; then
-            log_info "  No PG majors to resolve — nothing to prune"
-            continue
-        fi
-
         local -A window_by_major=()
         local -A window_known_by_major=()
+        if [[ ${#pg_majors[@]} -eq 0 ]]; then
+            log_info "  No PG majors to resolve — classifying records without retention windows"
+        fi
         for pg_major in "${pg_majors[@]}"; do
             echo ""
             log_step "  PG major: ${pg_major}"
@@ -563,7 +567,8 @@ main() {
         done
 
         local kept_count=0
-        local pruned_count=0
+        local would_delete_count=0
+        local deleted_count=0
         local delete_failures=0
         local reread_failures=0
         local analysis_failures=0
@@ -596,7 +601,7 @@ main() {
                 if [[ "$dry_run" == "true" ]]; then
                     log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${record_tags_csv}) — all managed tags outside window"
                     log_info "      [DRY-RUN] Would delete ${package_name} version_id=${version_id} (tags: ${record_tags_csv})"
-                    pruned_count=$((pruned_count + 1))
+                    would_delete_count=$((would_delete_count + 1))
                 else
                     local current_record_json
                     log_info "    Candidate version_id=${version_id} (tags: ${record_tags_csv}) — re-reading before delete"
@@ -607,7 +612,7 @@ main() {
                     elif _record_is_prunable "$current_record_json"; then
                         log_warning "    ✗ PRUNE version_id=${version_id} (tags: ${record_tags_csv}) — all managed tags outside window"
                         if _delete_ghcr_ext_version "$package_name" "$version_id" "$record_tags_csv"; then
-                            pruned_count=$((pruned_count + 1))
+                            deleted_count=$((deleted_count + 1))
                         else
                             delete_failures=$((delete_failures + 1))
                         fi
@@ -635,9 +640,11 @@ main() {
         done < "$records_file"
         rm -f "$records_file"
 
-        log_info "    Summary: kept=${kept_count}, pruned=${pruned_count}, failed=${delete_failures}"
+        local extension_failures=$((delete_failures + reread_failures + analysis_failures))
+        log_info "    Summary: kept=${kept_count}, would_delete=${would_delete_count}, deleted=${deleted_count}, failed=${extension_failures} (delete_failures=${delete_failures}, reread_failures=${reread_failures}, analysis_inconclusive=${analysis_failures}, listing_failures=0)"
         total_kept=$((total_kept + kept_count))
-        total_pruned=$((total_pruned + pruned_count))
+        total_would_delete=$((total_would_delete + would_delete_count))
+        total_deleted=$((total_deleted + deleted_count))
         total_delete_failures=$((total_delete_failures + delete_failures))
         total_reread_failures=$((total_reread_failures + reread_failures))
         total_analysis_failures=$((total_analysis_failures + analysis_failures))
@@ -648,7 +655,8 @@ main() {
     echo "Extension image cleanup summary"
     echo "========================================"
     echo "  Version records kept  : ${total_kept}"
-    echo "  Version records pruned: ${total_pruned}"
+    echo "  Version records that would be deleted: ${total_would_delete}"
+    echo "  Version records deleted: ${total_deleted}"
     echo "  Delete failures: ${total_delete_failures}"
     echo "  (ext,major) pairs skipped (uncertain window): ${total_skipped_pairs}"
     echo "  Extensions skipped (listing failed): ${total_listing_failures}"

--- a/scripts/rotation-select.sh
+++ b/scripts/rotation-select.sh
@@ -244,6 +244,10 @@ main() {
         listed_extension[$ext_name]=1
         if records_json=$(_list_ghcr_ext_version_records "ext-${ext_name}"); then
             records_by_extension[$ext_name]="$records_json"
+            if ! jq -e 'all(.[]; .tags_observed == true)' <<< "$records_json" >/dev/null; then
+                registry_failure=true
+                log_error "GHCR version listing for ext-${ext_name} has unobserved tags; refusing to select from incomplete registry data"
+            fi
         else
             registry_failure=true
             records_by_extension[$ext_name]='[]'

--- a/tests/unit/cleanup-ext-images.bats
+++ b/tests/unit/cleanup-ext-images.bats
@@ -143,6 +143,23 @@ _run_cleanup_main_with_records() {
     ! _parse_ext_managed_tag "other-image-tag"
 }
 
+@test "GHCR record contract keeps tags as an array and exposes whether they were observed" {
+    gh() {
+        printf '%s\n' '[{"id":1,"metadata":{"container":{"tags":[]}}},{"id":2,"metadata":{"container":{"tags":null}}}]'
+    }
+
+    run _list_ghcr_ext_version_records "ext-timescaledb"
+    unset -f gh
+
+    [[ "$status" -eq 0 ]]
+    command jq -e '
+      . == [
+        {version_id: "1", name: "", tags: [], tags_observed: true, updated_at: ""},
+        {version_id: "2", name: "", tags: [], tags_observed: false, updated_at: ""}
+      ]
+    ' <<< "$output" >/dev/null
+}
+
 @test "mixed-tag version record is kept; separate all-stale record is selected" {
     local records_file="$TEST_TEMP_DIR/mixed-records.json"
     local windows_dir="$TEST_TEMP_DIR/windows"
@@ -172,7 +189,7 @@ EOF
     [[ "$output" != *"Would delete ext-timescaledb version_id=101"* ]]
     [[ "$output" == *"PRUNE version_id=102"* ]]
     [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=102"* ]]
-    [[ "$output" == *"Summary: kept=1, pruned=1, failed=0"* ]]
+    [[ "$output" == *"Summary: kept=1, would_delete=1, deleted=0, failed=0"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -202,7 +219,7 @@ EOF
     [[ "$output" != *"PRUNE version_id=203"* ]]
     [[ "$output" == *"PRUNE version_id=204"* ]]
     [[ "$output" == *"PRUNE version_id=205"* ]]
-    [[ "$output" == *"Summary: kept=3, pruned=2, failed=0"* ]]
+    [[ "$output" == *"Summary: kept=3, would_delete=2, deleted=0, failed=0"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -225,7 +242,8 @@ EOF
     [[ "$output" == *"Registry PG majors: 15"* ]]
     [[ "$output" == *"PG major: 15"* ]]
     [[ "$output" == *"PRUNE version_id=301"* ]]
-    [[ "$output" == *"Version records pruned: 1"* ]]
+    [[ "$output" == *"Version records that would be deleted: 1"* ]]
+    [[ "$output" == *"Version records deleted: 0"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -247,7 +265,14 @@ EOF
     [[ "$output" == *"Resolver failed for timescaledb/pg15"* ]]
     [[ "$output" == *"KEEP  version_id=311"* ]]
     [[ "$output" == *"window unknown for pg15: pg15-2.23.0"* ]]
-    [[ "$output" == *"Summary: kept=1, pruned=0, failed=0"* ]]
+    if [[ "$output" != *"Candidate records kept (analysis inconclusive): 1"* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: a record with no computed major window must be counted as inconclusive'
+        return 1
+    fi
+    if [[ "$output" != *"Summary: kept=1, would_delete=0, deleted=0, failed=1 (delete_failures=0, reread_failures=0, analysis_inconclusive=1, listing_failures=0)"* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: per-extension summary must count an inconclusive record as a failure'
+        return 1
+    fi
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -359,7 +384,7 @@ EOF
     [[ "$output" == *"contains unmanaged/unparseable tag: pg17-latest"* ]]
     [[ "$output" == *"KEEP  version_id=402"* ]]
     [[ "$output" == *"contains unmanaged/unparseable tag: latest"* ]]
-    [[ "$output" == *"Summary: kept=2, pruned=0, failed=0"* ]]
+    [[ "$output" == *"Summary: kept=2, would_delete=0, deleted=0, failed=0"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -389,7 +414,75 @@ EOF
     [[ "$output" != *"PRUNE version_id=452"* ]]
     [[ "$output" == *"PRUNE version_id=453"* ]]
     [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=453"* ]]
-    [[ "$output" == *"Summary: kept=2, pruned=1, failed=0"* ]]
+    [[ "$output" == *"Summary: kept=2, would_delete=1, deleted=0, failed=0"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "listing record without metadata.container tags is inconclusive and makes dry-run non-zero" {
+    local records_file="$TEST_TEMP_DIR/missing-list-tags-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/missing-list-tags-deletes"
+
+    printf '%s\n' '[{"id":701}]' > "$records_file"
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+
+    if [[ "$status" -eq 0 || "$output" != *"Candidate records kept (analysis inconclusive): 1"* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: absent tag metadata must make the run non-zero with the record counted as inconclusive'
+        return 1
+    fi
+    [[ "$output" == *"KEEP  version_id=701 (tags: (tag enumeration unavailable)) — analysis inconclusive: tags were not observed; keeping record fail-closed"* ]]
+    [[ "$output" == *"Version records kept  : 1"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "invalid PG_VERSIONS still classifies a record whose tags were not observed" {
+    local records_file="$TEST_TEMP_DIR/no-major-unobserved-tags-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/no-major-unobserved-tags-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 701, "metadata": { "container": { "tags": null } } }
+]
+EOF
+
+    export PG_VERSIONS=x
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+    unset PG_VERSIONS
+
+    if [[ "$status" -eq 0 \
+        || "$output" != *"Summary: kept=1, would_delete=0, deleted=0, failed=1 (delete_failures=0, reread_failures=0, analysis_inconclusive=1, listing_failures=0)"* \
+        || "$output" != *"Candidate records kept (analysis inconclusive): 1"* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: PG_VERSIONS=x with an unobserved tag record must exit non-zero and count the record as analysis inconclusive'
+        return 1
+    fi
+    [[ "$output" == *"No PG majors to resolve — classifying records without retention windows"* ]]
+    [[ "$output" == *"KEEP  version_id=701 (tags: (tag enumeration unavailable)) — analysis inconclusive: tags were not observed; keeping record fail-closed"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "no resolvable PG major still definitely keeps observed empty and foreign tag records" {
+    local records_file="$TEST_TEMP_DIR/no-major-observed-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/no-major-observed-deletes"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 711, "metadata": { "container": { "tags": [] } } },
+  { "id": 712, "metadata": { "container": { "tags": ["latest"] } } }
+]
+EOF
+
+    export PG_VERSIONS=x
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success"
+    unset PG_VERSIONS
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"KEEP  version_id=711 (tags: (none)) — no tags on version record; fail-closed"* ]]
+    [[ "$output" == *"KEEP  version_id=712 (tags: latest) — contains unmanaged/unparseable tag: latest"* ]]
+    [[ "$output" == *"Summary: kept=2, would_delete=0, deleted=0, failed=0 (delete_failures=0, reread_failures=0, analysis_inconclusive=0, listing_failures=0)"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -494,8 +587,8 @@ EOF
     grep -q "DELETE:501" "$delete_calls_file"
     [[ "$output" == *"PRUNE version_id=501"* ]]
     [[ "$output" == *"Failed to delete ext-timescaledb version_id=501"* ]]
-    [[ "$output" == *"Summary: kept=0, pruned=0, failed=1"* ]]
-    [[ "$output" == *"Version records pruned: 0"* ]]
+    [[ "$output" == *"Summary: kept=0, would_delete=0, deleted=0, failed=1"* ]]
+    [[ "$output" == *"Version records deleted: 0"* ]]
     [[ "$output" == *"Delete failures: 1"* ]]
 }
 
@@ -518,8 +611,8 @@ EOF
     grep -q "DELETE:502" "$delete_calls_file"
     [[ "$output" == *"PRUNE version_id=502"* ]]
     [[ "$output" == *"Deleted ext-timescaledb version_id=502"* ]]
-    [[ "$output" == *"Summary: kept=0, pruned=1, failed=0"* ]]
-    [[ "$output" == *"Version records pruned: 1"* ]]
+    [[ "$output" == *"Summary: kept=0, would_delete=0, deleted=1, failed=0"* ]]
+    [[ "$output" == *"Version records deleted: 1"* ]]
     [[ "$output" == *"Delete failures: 0"* ]]
 }
 
@@ -541,7 +634,11 @@ EOF
     [[ "$output" == *"DRY-RUN MODE"* ]]
     [[ "$output" == *"PRUNE version_id=601"* ]]
     [[ "$output" == *"[DRY-RUN] Would delete ext-timescaledb version_id=601"* ]]
-    [[ "$output" == *"Version records pruned: 1"* ]]
+    if [[ "$output" != *"Version records deleted: 0"* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: dry-run summary must report zero deleted records'
+        return 1
+    fi
+    [[ "$output" == *"Version records that would be deleted: 1"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 
@@ -588,6 +685,30 @@ EOF
     [[ "$output" == *"KEEP  version_id=701"* ]]
     [[ "$output" == *"re-read before deletion: contains retained tag: pg17-2.27.1"* ]]
     [[ "$output" != *"PRUNE version_id=701"* ]]
+    [[ ! -f "$delete_calls_file" ]]
+}
+
+@test "execute mode treats a re-read without metadata.container tags as inconclusive" {
+    local records_file="$TEST_TEMP_DIR/missing-reread-tags-listing-records.json"
+    local reread_records_file="$TEST_TEMP_DIR/missing-reread-tags-records.json"
+    local windows_dir="$TEST_TEMP_DIR/windows"
+    local delete_calls_file="$TEST_TEMP_DIR/missing-reread-tags-delete-calls"
+
+    cat > "$records_file" <<'EOF'
+[
+  { "id": 701, "metadata": { "container": { "tags": ["pg17-2.23.0"] } } }
+]
+EOF
+    printf '%s\n' '[{"id":701}]' > "$reread_records_file"
+    _write_window "$windows_dir" "17" '["2.27.1"]'
+
+    export CLEANUP_REREAD_RECORDS_FILE="$reread_records_file"
+    _run_cleanup_main_with_records "$records_file" "$windows_dir" "success" "$delete_calls_file" "success" --execute
+    unset CLEANUP_REREAD_RECORDS_FILE
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"KEEP  version_id=701 (tags: (tag enumeration unavailable)) — re-read before deletion inconclusive: tags were not observed; keeping record fail-closed"* ]]
+    [[ "$output" == *"Candidate records kept (analysis inconclusive): 1"* ]]
     [[ ! -f "$delete_calls_file" ]]
 }
 

--- a/tests/unit/rotation-select.bats
+++ b/tests/unit/rotation-select.bats
@@ -104,6 +104,31 @@ _duplicate_canonical_record() {
     mv "$fixture.next" "$fixture"
 }
 
+_replace_with_unobserved_record() {
+    local ext_name="$1"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq -cn '[{
+      id: 100,
+      name: "sha256:unobserved",
+      updated_at: "2020-01-01T00:00:00Z",
+      metadata: {container: {tags: null}}
+    }]' > "$fixture"
+}
+
+_append_unobserved_record() {
+    local ext_name="$1"
+    local fixture="$GH_FIXTURE_DIR/ext-${ext_name}.json"
+
+    jq '. + [{
+      id: 100,
+      name: "sha256:unobserved",
+      updated_at: "2020-01-01T00:00:00Z",
+      metadata: {container: {tags: null}}
+    }]' "$fixture" > "$fixture.next"
+    mv "$fixture.next" "$fixture"
+}
+
 _expected_full_pairs() {
     local pg_major
     while IFS= read -r pg_major; do
@@ -342,6 +367,48 @@ _output_value() {
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"GHCR version listing failed"* ]]
     [[ "$output" != *$'pgvector\t17\t0.8.6\tunknown'* ]]
+}
+
+@test "an extension listing whose only record has unobserved tags selects nothing and exits non-zero" {
+    _replace_with_unobserved_record pgvector
+
+    _run_selector
+
+    if [[ "$status" -eq 0 \
+        || "$output" == *"Selected pair:"* \
+        || "$(_output_value selected)" != "false" ]]; then
+        printf '%s\n' 'ASSERTION FAILED: an extension listing whose only record has unobserved tags must exit non-zero and select no pair'
+        return 1
+    fi
+    [[ "$output" == *"GHCR version listing for ext-pgvector has unobserved tags"* ]]
+}
+
+@test "an unobserved record alongside a canonical tag selects nothing and exits non-zero" {
+    _append_unobserved_record pgvector
+
+    _run_selector
+
+    if [[ "$status" -eq 0 \
+        || "$output" == *"Selected pair:"* \
+        || "$(_output_value selected)" != "false" ]]; then
+        printf '%s\n' 'ASSERTION FAILED: an unobserved record alongside a canonical tag must exit non-zero and select no pair'
+        return 1
+    fi
+    [[ "$output" == *"GHCR version listing for ext-pgvector has unobserved tags"* ]]
+}
+
+@test "unobserved tags are a registry failure rather than an UNKNOWN pair" {
+    _replace_with_unobserved_record pgvector
+
+    _run_selector
+
+    if [[ "$status" -eq 0 \
+        || "$output" == *"Selected pair:"* \
+        || "$output" == *$'EXTENSION\tMAJOR\tCEILING\tAGE_DAYS'* ]]; then
+        printf '%s\n' 'ASSERTION FAILED: unobserved tags must be a registry failure, not an UNKNOWN pair'
+        return 1
+    fi
+    [[ "$(_output_value selected)" == "false" ]]
 }
 
 @test "blocking issue query failure selects nothing and exits non-zero" {


### PR DESCRIPTION
The extension prune reported certainties it had not established.

An absent `metadata.container.tags` was normalised to `[]`, so a response shaped
`{id: 701}` classified as genuinely untagged — the state that authorises
deletion — while the script's own promise is that a record it could not assess
makes the run non-zero. `tags` stays an array and a separate `tags_observed`
carries the distinction, so a caller reading the documented contract can act on
it.

The rotation selector is the third consumer of that record and needed it: it
matched on `.tags[]?` alone, so a listing with one ordinary record plus one whose
tags were never observed still reported exact freshness and exited zero. Any
unobserved record now fails that extension's listing closed before pair
classification — a failure, not an UNKNOWN pair, because UNKNOWN ranks ahead of
every dated pair and would steer the rotation toward exactly the data that could
not be read.

Every listed record now reaches a classification even when no PostgreSQL major is
resolvable; an early `continue` used to skip the classifier entirely and exit
zero. A dry run counts candidates separately from deletions, where one counter
printed `Version records pruned: 1` seven lines above `Mode: DRY-RUN (no
deletions performed)` on the job's default mode. A record whose major has no
window reaches the inconclusive state rather than a definite keep. Per-extension
summaries distinguish deletion, re-read, analysis and listing failures. The
unreachable `_derive_ext_tag_window_version` is gone.

Verified: 2662 unit tests green on this HEAD, `shellcheck` at its baseline. Each
property was proven by removing it and watching a named test fail.

Known and not closed here: the per-extension `failed` count grows a case at a
time and still misses a resolver failure (#1323); the help says OWNER may be an
organization while every package call is built as `/users/` (#1247); two tests in
this file do not establish what their names claim (#1296); the window between the
re-read and the DELETE (#1285).

Closes #1291
Closes #1292
Closes #1295
Closes #1280
