### PR TITLE
Keep every linter's output inert and its failures honest

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -8,7 +8,9 @@
 #     because they never interpret the workflow grammar.  actionlint does.
 #
 # (2) WHY SHELLCHECK_OPTS=--severity=error
-#     actionlint bundles shellcheck and runs it on every embedded `run:` block.
+#     actionlint discovers shellcheck on PATH and runs it on every embedded
+#     `run:` block. This job verifies that dependency first so the documented
+#     embedded-shell analysis cannot be silently skipped.
 #     At the default severity the repo has ~193 SC2086 (info) findings —
 #     intentional in GHA-controlled `run:` blocks where word-splitting is
 #     harmless.  At --severity=error those drop to 0 while the gate still
@@ -71,11 +73,42 @@ jobs:
           SHELLCHECK_OPTS: "--severity=error"
         run: |
           set -euo pipefail
+          shellcheck_status=0
+          shellcheck --version || shellcheck_status=$?
+          if [[ $shellcheck_status -ne 0 ]]; then
+            echo "::error::shellcheck tooling availability check failed (exit $shellcheck_status); actionlint cannot run embedded-shell analysis" >&2
+            exit "$shellcheck_status"
+          fi
+
+          # actionlint can reproduce repository-controlled workflow names and
+          # embedded shell text verbatim. Keep both streams inert while it runs.
+          run_with_workflow_commands_stopped() (
+            local stop_marker status
+            if ! stop_marker=$(uuidgen) || [[ -z "$stop_marker" ]]; then
+              echo "::error::could not mint a workflow command stop marker" >&2
+              return 1
+            fi
+            if ! printf '::stop-commands::%s\n' "$stop_marker"; then
+              echo "::error::could not write workflow command stop marker; refusing to run linter" >&2
+              return 1
+            fi
+            if "$@" 2>&1; then
+              status=0
+            else
+              status=$?
+            fi
+            if ! printf '\n::%s::\n' "$stop_marker"; then
+              echo "::error::could not write workflow command resume marker; refusing to report lint success" >&2
+              return 2
+            fi
+            return "$status"
+          )
+
           # No path args: actionlint auto-discovers all .github/workflows/*.{yaml,yml}
           # and excludes composite actions by location. See header note (3).
           # -config-file /dev/null: ignore any in-repo .github/actionlint.yaml so a
           # branch can't add `ignore:` patterns that silently weaken this gate
           # (a config-only change wouldn't even re-trigger this job). Wanting an
           # actionlint config later is a deliberate edit to THIS line, reviewed.
-          ./actionlint -no-color -config-file /dev/null
+          run_with_workflow_commands_stopped ./actionlint -no-color -config-file /dev/null
           echo "✅ actionlint: workflows compile clean" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -33,7 +33,13 @@ jobs:
 
       - name: Install shellcheck
         run: |
-          echo "shellcheck version: $(shellcheck --version | head -2)"
+          set -euo pipefail
+          shellcheck_status=0
+          shellcheck --version || shellcheck_status=$?
+          if [[ $shellcheck_status -ne 0 ]]; then
+            echo "::error::shellcheck tooling availability check failed (exit $shellcheck_status)" >&2
+            exit "$shellcheck_status"
+          fi
 
       - name: Check duplicate YAML mapping keys
         run: |
@@ -86,43 +92,70 @@ jobs:
           "$yamllint_venv/bin/yamllint" --version
 
           # A linter can reproduce repository-controlled text verbatim. Disable
-          # runner command parsing while it writes, and resume even if set -e
-          # exits the span because the linter fails.
+          # runner command parsing while it writes. Capture the child verdict
+          # so the resume marker is written before the wrapper returns it.
           run_with_workflow_commands_stopped() (
-            local stop_marker
+            local stop_marker status
             if ! stop_marker=$(uuidgen) || [[ -z "$stop_marker" ]]; then
               echo "::error::could not mint a workflow command stop marker" >&2
               return 1
             fi
-            trap 'printf "\n::%s::\n" "$stop_marker"' EXIT
-            printf '::stop-commands::%s\n' "$stop_marker"
-            "$@" 2>&1
+            if ! printf '::stop-commands::%s\n' "$stop_marker"; then
+              echo "::error::could not write workflow command stop marker; refusing to run linter" >&2
+              return 1
+            fi
+            if "$@" 2>&1; then
+              status=0
+            else
+              status=$?
+            fi
+            if ! printf '\n::%s::\n' "$stop_marker"; then
+              echo "::error::could not write workflow command resume marker; refusing to report lint success" >&2
+              return 2
+            fi
+            return "$status"
           )
 
           # Run yamllint only after this search has collected and validated every YAML pathname.
+          # The collector owns its annotation, so it must finish while runner
+          # command parsing is live before the linter span opens.
+          yaml_paths=$(mktemp)
+          trap 'rm -f "$yaml_paths"' EXIT
           ./scripts/collect-safe-paths.sh . -type f \( -name config.yaml -o -name variants.yaml \) \
-            -not -path './.git/*' | run_with_workflow_commands_stopped xargs -r -0 "$yamllint_venv/bin/yamllint" -c .yamllint.yml
+            -not -path './.git/*' > "$yaml_paths"
+          run_with_workflow_commands_stopped xargs -r -0 "$yamllint_venv/bin/yamllint" -c .yamllint.yml < "$yaml_paths"
 
       - name: Run shellcheck on scripts
         run: |
           set -euo pipefail
 
           # Keep linter diagnostics inert: they can reproduce untrusted file
-          # contents beginning with a GitHub Actions workflow command. The EXIT
-          # trap runs for success, a lint failure, and set -e or explicit exits.
-          run_with_workflow_commands_stopped() (
-            local stop_marker
+          # contents beginning with a GitHub Actions workflow command. Capture
+          # the child verdict so the resume marker is printed before set -e can
+          # leave the wrapper.
+          workflow_command_stop_marker_failed=0
+          run_with_workflow_commands_stopped() {
+            local stop_marker status
             if ! stop_marker=$(uuidgen) || [[ -z "$stop_marker" ]]; then
+              workflow_command_stop_marker_failed=1
               echo "::error::could not mint a workflow command stop marker" >&2
               return 1
             fi
-            trap 'printf "\n::%s::\n" "$stop_marker"' EXIT
-            printf '::stop-commands::%s\n' "$stop_marker"
-            "$@" 2>&1
-          )
-
-          run_shellcheck_counting_pass() {
-            shellcheck -x -S warning "$1" 2>/dev/null
+            if ! printf '::stop-commands::%s\n' "$stop_marker"; then
+              workflow_command_stop_marker_failed=1
+              echo "::error::could not write workflow command stop marker; refusing to run linter" >&2
+              return 1
+            fi
+            if "$@" 2>&1; then
+              status=0
+            else
+              status=$?
+            fi
+            if ! printf '\n::%s::\n' "$stop_marker"; then
+              echo "::error::could not write workflow command resume marker; refusing to report lint success" >&2
+              return 2
+            fi
+            return "$status"
           }
 
           scripts=()
@@ -170,11 +203,21 @@ jobs:
           failed_files=()
 
           for script in "${scripts[@]}"; do
-            if run_with_workflow_commands_stopped run_shellcheck_counting_pass "$script"; then
+            workflow_command_stop_marker_failed=0
+            if run_with_workflow_commands_stopped shellcheck -x -S warning "$script"; then
               passed=$((passed + 1))
             else
-              failed=$((failed + 1))
-              failed_files+=("$script")
+              status=$?
+              if [[ $workflow_command_stop_marker_failed -eq 1 ]]; then
+                status=2
+              fi
+              if [[ $status -eq 1 ]]; then
+                failed=$((failed + 1))
+                failed_files+=("$script")
+              else
+                echo "::error::shellcheck tooling failed for $script (exit $status); expected 0 or finding status 1" >&2
+                exit "$status"
+              fi
             fi
           done
 
@@ -197,14 +240,7 @@ jobs:
               done
             } >> "$GITHUB_STEP_SUMMARY"
 
-            echo ""
             echo "❌ $failed/$total scripts have shellcheck warnings"
-            echo ""
-            echo "Re-running failed scripts with details:"
-            for f in "${failed_files[@]}"; do
-              echo "--- $f ---"
-              run_with_workflow_commands_stopped shellcheck -x -S warning "$f" || true
-            done
             exit 1
           fi
 

--- a/tests/unit/actionlint-stop-commands.bats
+++ b/tests/unit/actionlint-stop-commands.bats
@@ -1,0 +1,282 @@
+#!/usr/bin/env bats
+
+# Proves actionlint's repository-controlled diagnostics never reach the runner
+# while command parsing is live.
+
+load "../test_helper"
+
+setup() {
+    setup_temp_dir
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+_die() {
+    printf '%s\n' "$1" >&2
+    return 1
+}
+
+_actionlint_step() {
+    yq -r '.jobs.actionlint.steps[] | select(.name == "Run actionlint on workflows") | .run' \
+        "$PROJECT_ROOT/.github/workflows/actionlint.yaml"
+}
+
+_install_passing_actionlint() {
+    cat > "$TEST_TEMP_DIR/actionlint" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/actionlint"
+}
+
+_install_versioned_shellcheck() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+    printf '%s\n' 'ShellCheck - shell script analysis tool' 'version: 0.10.0'
+fi
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/shellcheck"
+}
+
+_install_uuidgen() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/uuidgen" <<'EOF'
+#!/bin/sh
+printf '%s\n' actionlint-test-marker
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/uuidgen"
+}
+
+_install_recording_linter() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/recording-linter" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' invoked >> "$LINTER_INVOCATIONS"
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/recording-linter"
+}
+
+_wrapper() {
+    awk '
+        /^run_with_workflow_commands_stopped\(\) \(/ { in_wrapper = 1 }
+        in_wrapper { print }
+        in_wrapper && /^\)$/ { exit }
+    '
+}
+
+_install_hostile_actionlint() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/hostile-actionlint" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '::warning::forged actionlint stdout'
+printf '%s\n' '::error::forged actionlint stderr' >&2
+printf '%s' '::stop-commands::forged-actionlint-token' >&2
+exit 1
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/hostile-actionlint"
+}
+
+_assert_forged_output_is_bracketed() {
+    local line active_marker outside=0 forged=0
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^::stop-commands::([[:alnum:]-]+)$ && "$line" != '::stop-commands::forged-actionlint-token' ]]; then
+            active_marker=${BASH_REMATCH[1]}
+        elif [[ -n ${active_marker:-} && "$line" == "::$active_marker::" ]]; then
+            active_marker=
+        elif [[ "$line" == '::warning::forged actionlint stdout' || "$line" == '::error::forged actionlint stderr' || "$line" == '::stop-commands::forged-actionlint-token' ]]; then
+            forged=$((forged + 1))
+            [[ -n ${active_marker:-} ]] || outside=$((outside + 1))
+        fi
+    done <<< "$output"
+
+    [ "$forged" -eq 3 ] || _die "the hostile actionlint stub did not emit all crafted output"
+    [ "$outside" -eq 0 ] || _die "a forged actionlint command reached the runner outside a stopped span"
+    [[ -z ${active_marker:-} ]] || _die "a stopped actionlint span remained open at end of output"
+}
+
+_assert_opening_write_failure_refuses_linter() {
+    local wrapper=$1
+
+    rm -f "$TEST_TEMP_DIR/invocations"
+    run bash -c 'set -euo pipefail
+        export PATH="$1:$PATH" LINTER_INVOCATIONS="$2"
+        eval "$3"
+        if run_with_workflow_commands_stopped recording-linter > /dev/full; then
+            printf "%s\n" WRAPPER_REPORTED_SUCCESS
+        fi' \
+        _ "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/invocations" "$wrapper"
+
+    [ "$status" -eq 0 ] || _die "a failed opening marker did not return failure from an errexit-exempt caller"
+    [ ! -e "$TEST_TEMP_DIR/invocations" ] \
+        || _die "a failed opening marker invoked the linter in an errexit-exempt caller"
+    [[ "$output" == *'::error::could not write workflow command stop marker; refusing to run linter'* ]] \
+        || _die "a failed opening marker did not name the refused linter launch"
+    [[ "$output" != *'WRAPPER_REPORTED_SUCCESS'* ]] \
+        || _die "a failed opening marker reported the linter as clean"
+}
+
+_assert_resume_write_failure_is_not_clean() {
+    local wrapper=$1
+
+    rm -f "$TEST_TEMP_DIR/invocations"
+    run bash -c 'set -euo pipefail
+        export PATH="$1:$PATH" LINTER_INVOCATIONS="$2"
+        eval "$3"
+        printf() {
+            if [[ ${1:-} == '\''\n::%s::\n'\'' ]]; then
+                return 1
+            fi
+            builtin printf "$@"
+        }
+        if run_with_workflow_commands_stopped recording-linter; then
+            printf "%s\n" WRAPPER_REPORTED_SUCCESS
+        fi' \
+        _ "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/invocations" "$wrapper"
+
+    [ "$status" -eq 0 ] || _die "a failed resume marker did not return failure from an errexit-exempt caller"
+    [ -e "$TEST_TEMP_DIR/invocations" ] \
+        || _die "a failed resume marker did not invoke the linter before closing the span"
+    [[ "$output" == *'::error::could not write workflow command resume marker; refusing to report lint success'* ]] \
+        || _die "a failed resume marker did not name the failed resume"
+    [[ "$output" != *'WRAPPER_REPORTED_SUCCESS'* ]] \
+        || _die "a failed resume marker reported the linter as clean"
+}
+
+_assert_shellcheck_probe_failure() {
+    local step=$1 expected_status=$2 failure_class=$3
+
+    rm -rf "$TEST_TEMP_DIR/probe-bin"
+    mkdir -p "$TEST_TEMP_DIR/probe-bin"
+    case "$failure_class" in
+        non-executable)
+            printf '#!/bin/sh\nexit 0\n' > "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            chmod -x "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            ;;
+        arbitrary)
+            printf '#!/bin/sh\nexit %s\n' "$expected_status" > "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            chmod +x "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            ;;
+        missing) ;;
+        *) _die "unknown ShellCheck probe failure class: $failure_class" ;;
+    esac
+
+    run /usr/bin/env PATH="$TEST_TEMP_DIR/probe-bin" /usr/bin/bash -c "$step"
+
+    [ "$status" -eq "$expected_status" ] \
+        || _die "the actionlint ShellCheck availability probe did not preserve exit $expected_status"
+    [[ "$output" == *"::error::shellcheck tooling availability check failed (exit $expected_status); actionlint cannot run embedded-shell analysis"* ]] \
+        || _die "the actionlint ShellCheck availability probe did not name exit $expected_status"
+}
+
+@test "actionlint output on both streams is bracketed and the span closes after a final write without newline" {
+    local step summary
+
+    _install_hostile_actionlint
+    step=$(_actionlint_step)
+    cp "$TEST_TEMP_DIR/bin/hostile-actionlint" "$TEST_TEMP_DIR/actionlint"
+    summary="$TEST_TEMP_DIR/summary"
+    : > "$summary"
+
+    run bash -c 'cd "$1"
+        GITHUB_STEP_SUMMARY="$2" bash -c "$3"' \
+        _ "$TEST_TEMP_DIR" "$summary" "$step"
+
+    [ "$status" -eq 1 ] || _die "the hostile actionlint failure did not keep the command verdict"
+    _assert_forged_output_is_bracketed
+}
+
+@test "the actionlint wrapper fails closed before opening a span" {
+    local step wrapper
+
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    printf '#!/usr/bin/env bash\nexit 70\n' > "$TEST_TEMP_DIR/bin/uuidgen"
+    chmod +x "$TEST_TEMP_DIR/bin/uuidgen"
+    step=$(_actionlint_step)
+    wrapper=$(_wrapper <<< "$step")
+
+    run bash -c 'set -euo pipefail
+        PATH="$1:$PATH"
+        eval "$2"
+        run_with_workflow_commands_stopped true' \
+        _ "$TEST_TEMP_DIR/bin" "$wrapper"
+
+    [ "$status" -eq 1 ] || _die "a failed actionlint marker did not fail closed"
+    [[ "$output" != *'::stop-commands::'* ]] || _die "a failed actionlint marker opened a stopped span"
+}
+
+@test "the actionlint wrapper refuses a failed opening write before invoking the linter in an errexit-exempt caller" {
+    local step wrapper
+
+    _install_uuidgen
+    _install_recording_linter
+    step=$(_actionlint_step)
+    wrapper=$(_wrapper <<< "$step")
+
+    _assert_opening_write_failure_refuses_linter "$wrapper"
+}
+
+@test "the actionlint wrapper fails when its resume write fails in an errexit-exempt caller" {
+    local step wrapper
+
+    _install_uuidgen
+    _install_recording_linter
+    step=$(_actionlint_step)
+    wrapper=$(_wrapper <<< "$step")
+
+    _assert_resume_write_failure_is_not_clean "$wrapper"
+}
+
+@test "actionlint fails naming shellcheck when embedded-shell analysis is unavailable" {
+    local step summary
+
+    _install_passing_actionlint
+    _install_uuidgen
+    step=$(_actionlint_step)
+    summary="$TEST_TEMP_DIR/summary"
+    : > "$summary"
+
+    run bash -c 'cd "$1"
+        PATH="$2" GITHUB_STEP_SUMMARY="$3"
+        eval "$4"' \
+        _ "$TEST_TEMP_DIR" "$TEST_TEMP_DIR/bin" "$summary" "$step"
+
+    [ "$status" -eq 127 ] || _die "the actionlint step did not preserve unavailable shellcheck status 127"
+    [[ "$output" == *'::error::shellcheck tooling availability check failed (exit 127); actionlint cannot run embedded-shell analysis'* ]] \
+        || _die "the actionlint failure did not name unavailable shellcheck embedded-shell analysis"
+}
+
+@test "actionlint preserves missing ShellCheck status 127" {
+    _assert_shellcheck_probe_failure "$(_actionlint_step)" 127 missing
+}
+
+@test "actionlint preserves non-executable ShellCheck status 126" {
+    _assert_shellcheck_probe_failure "$(_actionlint_step)" 126 non-executable
+}
+
+@test "actionlint preserves arbitrary ShellCheck tooling status" {
+    _assert_shellcheck_probe_failure "$(_actionlint_step)" 42 arbitrary
+}
+
+@test "actionlint records the ShellCheck version before its successful verdict" {
+    local step summary
+
+    _install_passing_actionlint
+    _install_versioned_shellcheck
+    step=$(_actionlint_step)
+    summary="$TEST_TEMP_DIR/summary"
+    : > "$summary"
+
+    run bash -c 'cd "$1"
+        PATH="$2:$PATH" GITHUB_STEP_SUMMARY="$3"
+        eval "$4"' \
+        _ "$TEST_TEMP_DIR" "$TEST_TEMP_DIR/bin" "$summary" "$step"
+
+    [ "$status" -eq 0 ] || _die "the actionlint step did not keep the successful verdict"
+    [[ "$output" == *'ShellCheck - shell script analysis tool'* && "$output" == *'version: 0.10.0'* ]] \
+        || _die "the successful actionlint step did not record the ShellCheck version"
+}

--- a/tests/unit/shellcheck-stop-commands.bats
+++ b/tests/unit/shellcheck-stop-commands.bats
@@ -26,6 +26,10 @@ _workflow_step() {
         "$PROJECT_ROOT/.github/workflows/shellcheck.yaml"
 }
 
+_install_shellcheck_step() {
+    _workflow_step 'Install shellcheck'
+}
+
 _install_hostile_linter() {
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/hostile-linter" <<'EOF'
@@ -52,6 +56,15 @@ EOF
     chmod +x "$TEST_TEMP_DIR/bin/uuidgen"
 }
 
+_install_fixed_uuidgen() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/uuidgen" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' shellcheck-test-marker
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/uuidgen"
+}
+
 _install_recording_linter() {
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/recording-linter" <<'EOF'
@@ -65,16 +78,41 @@ _install_stderr_only_linter() {
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/shellcheck" <<'EOF'
 #!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+    printf '%s\n' 'ShellCheck - shell script analysis tool' 'version: 0.10.0'
+    exit 0
+fi
 printf '%s\n' 'counting-pass stderr must stay hidden' >&2
 EOF
     chmod +x "$TEST_TEMP_DIR/bin/shellcheck"
 }
 
+_install_broken_shellcheck() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+    exit 0
+fi
+exit 127
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/shellcheck"
+}
+
+_install_failing_find() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    cat > "$TEST_TEMP_DIR/bin/find" <<'EOF'
+#!/usr/bin/env bash
+exit 9
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/find"
+}
+
 _wrapper_from_step() {
     awk '
-        /^run_with_workflow_commands_stopped\(\) \(/ { in_wrapper = 1 }
+        /^run_with_workflow_commands_stopped\(\) (\(|\{)/ { in_wrapper = 1 }
         in_wrapper { print }
-        in_wrapper && /^\)$/ { exit }
+        in_wrapper && /^(\)|})$/ { exit }
     '
 }
 
@@ -140,6 +178,80 @@ _run_hostile_linter_through_wrapper() {
     _assert_no_command_span_is_left_open
 }
 
+_assert_opening_write_failure_refuses_linter() {
+    local wrapper=$1
+
+    rm -f "$TEST_TEMP_DIR/invocations"
+    run bash -c 'set -euo pipefail
+        export PATH="$1:$PATH" LINTER_INVOCATIONS="$2"
+        eval "$3"
+        if run_with_workflow_commands_stopped recording-linter > /dev/full; then
+            printf "%s\n" WRAPPER_REPORTED_SUCCESS
+        fi' \
+        _ "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/invocations" "$wrapper"
+
+    [ "$status" -eq 0 ] || _die "a failed opening marker did not return failure from an errexit-exempt caller"
+    [ ! -e "$TEST_TEMP_DIR/invocations" ] \
+        || _die "a failed opening marker invoked the linter in an errexit-exempt caller"
+    [[ "$output" == *'::error::could not write workflow command stop marker; refusing to run linter'* ]] \
+        || _die "a failed opening marker did not name the refused linter launch"
+    [[ "$output" != *'WRAPPER_REPORTED_SUCCESS'* ]] \
+        || _die "a failed opening marker reported the linter as clean"
+}
+
+_assert_resume_write_failure_is_not_clean() {
+    local wrapper=$1
+
+    rm -f "$TEST_TEMP_DIR/invocations"
+    run bash -c 'set -euo pipefail
+        export PATH="$1:$PATH" LINTER_INVOCATIONS="$2"
+        eval "$3"
+        printf() {
+            if [[ ${1:-} == '\''\n::%s::\n'\'' ]]; then
+                return 1
+            fi
+            builtin printf "$@"
+        }
+        if run_with_workflow_commands_stopped recording-linter; then
+            printf "%s\n" WRAPPER_REPORTED_SUCCESS
+        fi' \
+        _ "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/invocations" "$wrapper"
+
+    [ "$status" -eq 0 ] || _die "a failed resume marker did not return failure from an errexit-exempt caller"
+    [ -e "$TEST_TEMP_DIR/invocations" ] \
+        || _die "a failed resume marker did not invoke the linter before closing the span"
+    [[ "$output" == *'::error::could not write workflow command resume marker; refusing to report lint success'* ]] \
+        || _die "a failed resume marker did not name the failed resume"
+    [[ "$output" != *'WRAPPER_REPORTED_SUCCESS'* ]] \
+        || _die "a failed resume marker reported the linter as clean"
+}
+
+_assert_shellcheck_probe_failure() {
+    local step=$1 expected_status=$2 failure_class=$3
+
+    rm -rf "$TEST_TEMP_DIR/probe-bin"
+    mkdir -p "$TEST_TEMP_DIR/probe-bin"
+    case "$failure_class" in
+        non-executable)
+            printf '#!/bin/sh\nexit 0\n' > "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            chmod -x "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            ;;
+        arbitrary)
+            printf '#!/bin/sh\nexit %s\n' "$expected_status" > "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            chmod +x "$TEST_TEMP_DIR/probe-bin/shellcheck"
+            ;;
+        missing) ;;
+        *) _die "unknown ShellCheck probe failure class: $failure_class" ;;
+    esac
+
+    run /usr/bin/env PATH="$TEST_TEMP_DIR/probe-bin" /usr/bin/bash -c "$step"
+
+    [ "$status" -eq "$expected_status" ] \
+        || _die "the ShellCheck availability probe did not preserve exit $expected_status"
+    [[ "$output" == *"::error::shellcheck tooling availability check failed (exit $expected_status)"* ]] \
+        || _die "the ShellCheck availability probe did not name exit $expected_status"
+}
+
 @test "shellcheck failure is bracketed by a stopped and resumed command span" {
     local script summary
 
@@ -190,11 +302,51 @@ _run_hostile_linter_through_wrapper() {
             || _die "linter span does not reject a failed or empty marker"
         [[ "$wrapper" == *'return 1'* ]] \
             || _die "linter span does not stop before opening a span when marker minting fails"
-        [[ "$wrapper" == *"trap 'printf \"\\n::%s::\\n\" \"\$stop_marker\"' EXIT"* ]] \
+        [[ "$wrapper" == *"trap 'printf \"\\n::%s::\\n\" \"\$stop_marker\"' EXIT"* || "$wrapper" == *"printf '\\n::%s::\\n' \"\$stop_marker\""* ]] \
             || _die "linter span does not force the resume marker onto a new line"
         [[ "$wrapper" == *'"$@" 2>&1'* ]] \
             || _die "linter wrapper does not merge stderr into its stdout descriptor"
     done
+}
+
+@test "a marker-mint failure is fatal tooling, not two shellcheck findings" {
+    local script summary project
+
+    _install_failing_uuidgen
+    _install_recording_linter
+    ln -s recording-linter "$TEST_TEMP_DIR/bin/shellcheck"
+    script=$(_workflow_step 'Run shellcheck on scripts')
+    summary="$TEST_TEMP_DIR/summary"
+    project="$TEST_TEMP_DIR/project"
+    mkdir -p "$project/scripts" "$project/helpers"
+    : > "$project/a"
+    : > "$project/b"
+    : > "$summary"
+    cat > "$project/scripts/collect-safe-paths.sh" <<'EOF'
+#!/usr/bin/env bash
+if [[ $1 == ./scripts ]]; then
+    printf './a\0'
+elif [[ $1 == . ]]; then
+    printf './b\0'
+fi
+EOF
+    chmod +x "$project/scripts/collect-safe-paths.sh"
+
+    run bash -c 'cd "$1"
+        PATH="$2:$PATH" LINTER_INVOCATIONS="$3" GITHUB_STEP_SUMMARY="$4" bash -c "$5"' \
+        _ "$project" "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/invocations" "$summary" "$script"
+
+    [[ "$output" == *'::error::could not mint a workflow command stop marker'* ]] \
+        || _die "the marker-mint failure diagnostic was not emitted"
+    [ ! -e "$TEST_TEMP_DIR/invocations" ] \
+        || _die "the marker-mint failure invoked shellcheck"
+    [[ $(< "$summary") != *'./a'* && $(< "$summary") != *'./b'* ]] \
+        || _die "the marker-mint failure added a script to the failed list"
+    [[ "$output" != *'scripts have shellcheck warnings'* ]] \
+        || _die "the marker-mint failure was counted as a shellcheck finding"
+    [[ "$output" == *'::error::shellcheck tooling failed for ./a (exit 2); expected 0 or finding status 1'* ]] \
+        || _die "the marker-mint failure did not name the tooling failure"
+    [ "$status" -eq 2 ] || _die "the marker-mint failure did not reach the tooling failure path"
 }
 
 @test "hostile commands on both linter streams are inside one stopped span" {
@@ -238,6 +390,36 @@ _run_hostile_linter_through_wrapper() {
     done
 }
 
+@test "both linter wrappers refuse a failed opening write before invoking the linter in errexit-exempt callers" {
+    local yaml_step shellcheck_step step wrapper
+
+    _install_fixed_uuidgen
+    _install_recording_linter
+    yaml_step=$(_workflow_step 'Check duplicate YAML mapping keys')
+    shellcheck_step=$(_workflow_step 'Run shellcheck on scripts')
+
+    for step in "$yaml_step" "$shellcheck_step"; do
+        wrapper=$(_wrapper_from_step <<< "$step")
+        [ -n "$wrapper" ] || _die "could not extract the linter command span"
+        _assert_opening_write_failure_refuses_linter "$wrapper"
+    done
+}
+
+@test "both linter wrappers fail when their resume write fails in errexit-exempt callers" {
+    local yaml_step shellcheck_step step wrapper
+
+    _install_fixed_uuidgen
+    _install_recording_linter
+    yaml_step=$(_workflow_step 'Check duplicate YAML mapping keys')
+    shellcheck_step=$(_workflow_step 'Run shellcheck on scripts')
+
+    for step in "$yaml_step" "$shellcheck_step"; do
+        wrapper=$(_wrapper_from_step <<< "$step")
+        [ -n "$wrapper" ] || _die "could not extract the linter command span"
+        _assert_resume_write_failure_is_not_clean "$wrapper"
+    done
+}
+
 @test "a hostile final write without a newline still closes both stopped command spans" {
     local yaml_step shellcheck_step
 
@@ -249,10 +431,79 @@ _run_hostile_linter_through_wrapper() {
     _run_hostile_linter_through_wrapper "$shellcheck_step" false
 }
 
-@test "shellcheck counting pass keeps its stderr suppressed inside the stopped span" {
-    local script summary
+@test "shellcheck prints each finding once inside the stopped span" {
+    local script summary project line active_marker
+    local findings_inside=0 findings_outside=0
 
     _install_stderr_only_linter
+    script=$(_workflow_step 'Run shellcheck on scripts')
+    summary="$TEST_TEMP_DIR/summary"
+    project="$TEST_TEMP_DIR/project"
+    mkdir -p "$project/scripts" "$project/helpers"
+    : > "$summary"
+    cat > "$project/scripts/collect-safe-paths.sh" <<'EOF'
+#!/usr/bin/env bash
+if [[ $1 == ./scripts ]]; then
+    printf './a\0'
+fi
+EOF
+    chmod +x "$project/scripts/collect-safe-paths.sh"
+
+    run bash -c 'cd "$1"
+        PATH="$2:$PATH" GITHUB_STEP_SUMMARY="$3" bash -c "$4"' \
+        _ "$project" "$TEST_TEMP_DIR/bin" "$summary" "$script"
+
+    [ "$status" -eq 0 ] || _die "the all-passing shellcheck run did not keep the step verdict"
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^::stop-commands::([[:alnum:]-]+)$ ]]; then
+            active_marker=${BASH_REMATCH[1]}
+        elif [[ -n ${active_marker:-} && "$line" == "::$active_marker::" ]]; then
+            active_marker=
+        elif [[ "$line" == 'counting-pass stderr must stay hidden' ]]; then
+            if [[ -n ${active_marker:-} ]]; then
+                findings_inside=$((findings_inside + 1))
+            else
+                findings_outside=$((findings_outside + 1))
+            fi
+        fi
+    done <<< "$output"
+
+    [ "$findings_inside" -eq 1 ] \
+        || _die "the shellcheck diagnostic was printed $findings_inside times inside stopped spans, expected 1"
+    [ "$findings_outside" -eq 0 ] \
+        || _die "the shellcheck diagnostic was printed outside stopped spans"
+}
+
+@test "the ShellCheck availability probe records its version" {
+    local step
+
+    _install_stderr_only_linter
+    step=$(_install_shellcheck_step)
+
+    run bash -c 'PATH="$1:$PATH" bash -c "$2"' \
+        _ "$TEST_TEMP_DIR/bin" "$step"
+
+    [ "$status" -eq 0 ] || _die "the ShellCheck availability probe did not keep the successful verdict"
+    [[ "$output" == *'ShellCheck - shell script analysis tool'* && "$output" == *'version: 0.10.0'* ]] \
+        || _die "the ShellCheck availability probe did not record the linter version output"
+}
+
+@test "the ShellCheck availability probe preserves missing-binary status 127" {
+    _assert_shellcheck_probe_failure "$(_install_shellcheck_step)" 127 missing
+}
+
+@test "the ShellCheck availability probe preserves non-executable status 126" {
+    _assert_shellcheck_probe_failure "$(_install_shellcheck_step)" 126 non-executable
+}
+
+@test "the ShellCheck availability probe preserves arbitrary tooling status" {
+    _assert_shellcheck_probe_failure "$(_install_shellcheck_step)" 42 arbitrary
+}
+
+@test "a shellcheck tooling failure is not counted as a lint finding" {
+    local script summary
+
+    _install_broken_shellcheck
     script=$(_workflow_step 'Run shellcheck on scripts')
     summary="$TEST_TEMP_DIR/summary"
     : > "$summary"
@@ -261,9 +512,43 @@ _run_hostile_linter_through_wrapper() {
         PATH="$2:$PATH" GITHUB_STEP_SUMMARY="$3" bash -c "$4"' \
         _ "$PROJECT_ROOT" "$TEST_TEMP_DIR/bin" "$summary" "$script"
 
-    [ "$status" -eq 0 ] || _die "the all-passing shellcheck counting pass did not keep the step verdict"
-    [[ "$output" != *'counting-pass stderr must stay hidden'* ]] \
-        || _die "the shellcheck counting pass leaked diagnostics that its 2>/dev/null must suppress"
+    [ "$status" -eq 127 ] || _die "the shellcheck tooling status did not abort the workflow step"
+    [[ "$output" == *'::error::shellcheck tooling failed for '*'(exit 127); expected 0 or finding status 1'* ]] \
+        || _die "the shellcheck tooling failure did not name exit 127"
+    [[ "$output" != *'scripts have shellcheck warnings'* ]] \
+        || _die "the shellcheck tooling failure was counted as a lint finding"
+}
+
+@test "a collector failure reaches the runner before any stopped linter span" {
+    local yaml_step wrapper collector_block
+
+    _install_failing_find
+    yaml_step=$(_workflow_step 'Check duplicate YAML mapping keys')
+    wrapper=$(_wrapper_from_step <<< "$yaml_step")
+    [ -n "$wrapper" ] || _die "could not extract the yamllint command span"
+    [[ "$yaml_step" == *'yaml_paths=$(mktemp)'* ]] \
+        || _die "the collector must finish before the stopped yamllint span opens"
+    [[ "$yaml_step" == *'> "$yaml_paths"'* ]] \
+        || _die "the collector must write its validated paths before yamllint starts"
+    collector_block=$(awk '
+        /yaml_paths=\$\(mktemp\)/ { in_block = 1 }
+        in_block { print }
+        /< "\$yaml_paths"/ { exit }
+    ' <<< "$yaml_step")
+    [ -n "$collector_block" ] || _die "could not extract the collector and yamllint sequence"
+
+    run bash -c 'set -euo pipefail
+        cd "$1"
+        PATH="$2:$PATH"
+        eval "$3"
+        eval "$4"' \
+        _ "$PROJECT_ROOT" "$TEST_TEMP_DIR/bin" "$wrapper" "$collector_block"
+
+    [ "$status" -eq 1 ] || _die "the collector failure did not keep the workflow step verdict"
+    [[ "$output" == *'::error::safe path discovery failed'* ]] \
+        || _die "the collector diagnostic was not emitted"
+    [[ "$output" != *'::stop-commands::'* ]] \
+        || _die "the collector diagnostic was emitted inside a stopped linter span"
 }
 
 @test "recognised explicit linter launch shapes are wrapped" {
@@ -295,6 +580,6 @@ _run_hostile_linter_through_wrapper() {
         [[ "$invocation" == *'run_with_workflow_commands_stopped '* ]] \
             || _die "a recognised explicit linter launch is not wrapped: $invocation"
     done
-    [ "${#invocations[@]}" -eq 3 ] \
-        || _die "expected three recognised explicit linter launch shapes, found ${#invocations[@]}"
+    [ "${#invocations[@]}" -eq 2 ] \
+        || _die "expected two recognised explicit linter launch shapes, found ${#invocations[@]}"
 }


### PR DESCRIPTION
actionlint runs ShellCheck over the `run:` blocks of every workflow and streamed
its output straight to the runner. The value it reproduces is a **filename**: a
tracked file named `.github/workflows/safe<LF>::error::forged.yaml` with a syntax
error makes actionlint print the name across the break, and the runner executes
the rest as a workflow command. No message-format escaping could have closed
that. It runs inside the same fail-closed stop-commands bracket as the other two
linters now.

Two ways the ShellCheck job lied about its own work are gone. Its availability
check ran `echo "…$(shellcheck --version)"`, so the status belonged to `echo` and
a missing binary passed the step that exists to verify it. And every non-zero
status counted as a lint finding, so a run where ShellCheck never executed
reported that every script had warnings — including when the stop-marker mint
failed, which was that same defect one door along. Only ShellCheck's finding
status is a finding; every other status, and a wrapper setup failure, take the
fatal tooling path and add no file.

actionlint's header claimed it bundles shellcheck. It finds one on `PATH`, so
with none present the embedded-shell checks were silently skipped and the step
passed — shown by emptying `PATH`. Both workflows now require it, name it when
absent, preserve its exit status so 126, 127 and a crash stay distinguishable,
and log the version that produced the verdict.

The path collector's own `::error::` was emitted inside the stopped span, so a
`find` failure or an allowlist violation went red without the annotation
explaining why. Paths are collected before the span opens.

Verified: 2672 unit tests green on this HEAD, `actionlint` clean on both
workflows. Each property was proven by removing it and watching a named test
fail — `144s/if ! printf/if printf/` turns `a failed opening marker invoked the
linter in an errexit-exempt caller` red.

Known and not closed here: a signal between the opening marker and the explicit
resume leaves the span open for the rest of the job (#1325); the exactly-once
test counts output from a run ShellCheck called clean (#1326); the lint verdict
still depends on whichever ShellCheck `ubuntu-latest` carries (#1322). Four
copies of the wrapper exist and nothing prevents a fifth linter appearing without
one — that question stayed open across three reviews and is not decided here.

Closes #1290
Closes #1293
Closes #1298
