### PR TITLE
Report a prune's failures instead of losing them

### DIFF
--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -24,12 +24,14 @@ print_banner() {
 # Write kept|deleted|delete_failures to stdout once a package was completely
 # assessed.  Its return status, rather than that record, communicates failure:
 # 10 listing failure, 11 processing failure, 12 one or more delete failures,
-# 13 a processing failure after deletion has started.
+# and 13 a failure after every record was assessed.  Deletion-plan replay is
+# execution, not assessment, so a replay failure also returns 13.
 purge_container() {
   local container="$1"
   local versions version_count versions_file="" deletions_file=""
   local position=0 kept=0 deleted=0 delete_failures=0
-  local version_id tags created_at keep_reason tag major version_ts cutoff_ts processing_error=0
+  local version_id tags created_at keep_reason tag tag_list major version_ts cutoff_ts processing_error=0 deletion_read_error=0
+  local record_b64 record_json
   declare -A major_seen=()
 
   if ! versions=$(gh api \
@@ -73,7 +75,7 @@ purge_container() {
     echo "  ✗ Failed to create cleanup work files; skipping $container" >&2
     return "$PROCESSING_FAILURE"
   fi
-  if ! jq -er '.[] | "\(.id)|\(.metadata.container.tags // [] | join(","))|\(.created_at)"' \
+  if ! jq -er '.[] | {id: (.id | tostring), tags: (.metadata.container.tags // []), created_at: .created_at} | @base64' \
       <<< "$versions" > "$versions_file"; then
     rm -f "$versions_file" "$deletions_file"
     echo "  ✗ Failed to prepare version list; skipping $container" >&2
@@ -87,8 +89,16 @@ purge_container() {
 
   # Decide every record before deleting any of them.  A malformed date in a
   # later record must leave earlier obsolete records untouched.
-  while IFS='|' read -r version_id tags created_at; do
-    [[ -z "$version_id" ]] && continue
+  while IFS= read -r record_b64; do
+    [[ -z "$record_b64" ]] && continue
+    if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
+      || ! version_id=$(jq -er '.id' <<< "$record_json") \
+      || ! tags=$(jq -er '.tags | join(",")' <<< "$record_json") \
+      || ! created_at=$(jq -er '.created_at' <<< "$record_json"); then
+      echo "  ✗ Failed to read version record; skipping $container" >&2
+      processing_error=1
+      break
+    fi
     position=$((position + 1))
     keep_reason=""
 
@@ -97,7 +107,12 @@ purge_container() {
     elif [[ "$position" -le "$KEEP_LATEST_COUNT" ]]; then
       keep_reason="in top $KEEP_LATEST_COUNT recent"
     else
-      for tag in $(tr ',' ' ' <<< "$tags"); do
+      if ! tag_list=$(jq -r '.tags[]' <<< "$record_json"); then
+        echo "  ✗ Failed to read version tags; skipping $container" >&2
+        processing_error=1
+        break
+      fi
+      while IFS= read -r tag; do
         if [[ "$tag" =~ ^v?([0-9]+)\.[0-9] ]]; then
           major="${BASH_REMATCH[1]}"
           if [[ -z "${major_seen[$major]:-}" ]]; then
@@ -106,7 +121,7 @@ purge_container() {
           fi
           break
         fi
-      done
+      done <<< "$tag_list"
     fi
 
     if [[ -z "$keep_reason" ]]; then
@@ -123,7 +138,7 @@ purge_container() {
     if [[ -n "$keep_reason" ]]; then
       echo "  ✓ Keep #$position (tags: ${tags:-untagged}) - $keep_reason" >&2
       kept=$((kept + 1))
-    elif ! printf '%s|%s|%s\n' "$position" "$version_id" "$tags" >> "$deletions_file"; then
+    elif ! printf '%s|%s\n' "$position" "$record_b64" >> "$deletions_file"; then
       echo "  ✗ Failed to prepare deletion list; skipping $container" >&2
       processing_error=1
       break
@@ -141,8 +156,15 @@ purge_container() {
     return "$PROCESSING_FAILURE"
   fi
 
-  while IFS='|' read -r position version_id tags; do
-    [[ -z "$version_id" ]] && continue
+  while IFS='|' read -r position record_b64; do
+    [[ -z "$record_b64" ]] && continue
+    if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
+      || ! version_id=$(jq -er '.id' <<< "$record_json") \
+      || ! tags=$(jq -er '.tags | join(",")' <<< "$record_json"); then
+      echo "  ✗ Failed to read prepared deletion record; skipping $container" >&2
+      deletion_read_error=1
+      break
+    fi
     echo "  ✗ Delete #$position (tags: ${tags:-untagged})" >&2
     if [[ "$DRY_RUN" == "true" ]]; then
       echo "    [DRY RUN] Would delete version $version_id" >&2
@@ -157,6 +179,15 @@ purge_container() {
       delete_failures=$((delete_failures + 1))
     fi
   done < "$deletions_file"
+
+  if [[ "$deletion_read_error" -ne 0 ]]; then
+    if ! printf '%s\n' "$kept|$deleted|$delete_failures"; then
+      rm -f "$deletions_file"
+      return "$PROCESSING_FAILURE"
+    fi
+    rm -f "$deletions_file"
+    return "$POST_DELETE_PROCESSING_FAILURE"
+  fi
 
   if ! printf '%s\n' "$kept|$deleted|$delete_failures"; then
     return "$PROCESSING_FAILURE"
@@ -179,7 +210,7 @@ main() {
   : "${KEEP_LATEST_COUNT:=10}"
   : "${KEEP_MONTHS:=6}"
 
-  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13
+  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 INCOMPLETE_DELETION_FAILURE=16
   local root_dir containers container result status
   local kept deleted delete_failures
   root_dir=$(script_root) || return 1
@@ -222,6 +253,20 @@ main() {
         ;;
       "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
       "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
+      # Reserved: planning is complete before deletion begins, so this script
+      # does not produce 16.  Keep it fail-closed for an explicit future
+      # partial-assessment producer rather than treating it as execution.
+      "$INCOMPLETE_DELETION_FAILURE")
+        if ! IFS='|' read -r kept deleted delete_failures <<< "$result"; then
+          echo "  ✗ Failed to read incomplete cleanup result; skipping $container"
+        else
+          total_kept=$((total_kept + kept))
+          total_deleted=$((total_deleted + deleted))
+          total_delete_failures=$((total_delete_failures + delete_failures))
+          echo "  Summary: kept=$kept, deleted=$deleted, delete_failures=$delete_failures"
+        fi
+        total_processing_failures=$((total_processing_failures + 1))
+        ;;
       *)
         echo "  ✗ Unexpected cleanup status $status; skipping $container"
         total_processing_failures=$((total_processing_failures + 1))

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -54,9 +54,13 @@ is_valid_tag() {
 }
 
 purge_ghcr() {
+  # 10 listing failure, 11 processing failure, 12 delete failure, 13 failure
+  # after complete assessment, and 15 protection failure.  Replaying either
+  # completed deletion list is execution, so a replay failure returns 13.
   local container="$1" valid_tags="$2"
   local versions version_count versions_file="" obsolete_file="" protected_file=""
-  local version_id digest tags tag has_valid kept=0 obsolete=0 orphans=0 delete_failures=0
+  local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0
+  local record_b64 record_json
   local protected_digests="" ghcr_token manifest children
   local -a kept_digests=()
 
@@ -93,7 +97,7 @@ purge_ghcr() {
     echo "  ✗ Failed to create GHCR work files; skipping $container" >&2
     return "$PROCESSING_FAILURE"
   fi
-  if ! jq -er '.[] | "\(.id)|\(.name)|\(.metadata.container.tags // [] | join(","))"' <<< "$versions" > "$versions_file"; then
+  if ! jq -er '.[] | {id: (.id | tostring), digest: .name, tags: (.metadata.container.tags // [])} | @base64' <<< "$versions" > "$versions_file"; then
     cleanup_files
     echo "  ✗ Failed to prepare GHCR version list; skipping $container" >&2
     return "$PROCESSING_FAILURE"
@@ -104,16 +108,30 @@ purge_ghcr() {
     return "$PROCESSING_FAILURE"
   fi
 
-  while IFS='|' read -r version_id digest tags; do
-    [[ -z "$version_id" || -z "$tags" ]] && continue
+  while IFS= read -r record_b64; do
+    [[ -z "$record_b64" ]] && continue
+    if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
+      || ! version_id=$(jq -er '.id' <<< "$record_json") \
+      || ! digest=$(jq -er '.digest' <<< "$record_json") \
+      || ! tags=$(jq -er '.tags | join(",")' <<< "$record_json"); then
+      cleanup_files
+      echo "  ✗ Failed to read GHCR version record; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
+    fi
+    [[ -z "$tags" ]] && continue
     has_valid=false
-    for tag in $(tr ',' ' ' <<< "$tags"); do
+    if ! tag_list=$(jq -r '.tags[]' <<< "$record_json"); then
+      cleanup_files
+      echo "  ✗ Failed to read GHCR version tags; skipping $container" >&2
+      return "$PROCESSING_FAILURE"
+    fi
+    while IFS= read -r tag; do
       if is_valid_tag "$tag" "$valid_tags"; then has_valid=true; break; fi
-    done
+    done <<< "$tag_list"
     if [[ "$has_valid" == true ]]; then
       echo "  ✓ Keep (tags: $tags)" >&2
       kept=$((kept + 1)); kept_digests+=("$digest")
-    elif ! printf '%s|%s|%s\n' "$version_id" "$digest" "$tags" >> "$obsolete_file"; then
+    elif ! printf '%s\n' "$record_b64" >> "$obsolete_file"; then
       cleanup_files
       echo "  ✗ Failed to write GHCR obsolete list; skipping $container" >&2
       return "$PROCESSING_FAILURE"
@@ -128,12 +146,12 @@ purge_ghcr() {
         "https://ghcr.io/token?service=ghcr.io&scope=repository:${OWNER}/${container}:pull" | jq -er '.token'); then
       cleanup_files
       echo "  ✗ Failed to get GHCR token; skipping $container" >&2
-      return "$PROCESSING_FAILURE"
+      return "$PROTECTION_FAILURE"
     fi
     if ! protected_file=$(mktemp) || ! printf '%s\n' "${kept_digests[@]}" > "$protected_file"; then
       cleanup_files
       echo "  ✗ Failed to prepare protected-digest list; skipping $container" >&2
-      return "$PROCESSING_FAILURE"
+      return "$PROTECTION_FAILURE"
     fi
     for digest in "${kept_digests[@]}"; do
       if ! manifest=$(curl -sf -H "Authorization: Bearer $ghcr_token" \
@@ -141,33 +159,41 @@ purge_ghcr() {
         "https://ghcr.io/v2/${OWNER}/${container}/manifests/${digest}"); then
         cleanup_files
         echo "  ✗ Failed to fetch manifest for ${digest:0:19}; skipping $container" >&2
-        return "$PROCESSING_FAILURE"
+        return "$PROTECTION_FAILURE"
       fi
       if ! jq -e 'type == "object"' >/dev/null <<< "$manifest"; then
         cleanup_files
         echo "  ✗ Failed to parse manifest for ${digest:0:19}; skipping $container" >&2
-        return "$PROCESSING_FAILURE"
+        return "$PROTECTION_FAILURE"
       fi
       if ! children=$(jq -r '.manifests[]?.digest // empty' <<< "$manifest"); then
         cleanup_files
         echo "  ✗ Failed to read manifest for ${digest:0:19}; skipping $container" >&2
-        return "$PROCESSING_FAILURE"
+        return "$PROTECTION_FAILURE"
       fi
       if [[ -n "$children" ]] && ! printf '%s\n' "$children" >> "$protected_file"; then
         cleanup_files
         echo "  ✗ Failed to write protected-digest list; skipping $container" >&2
-        return "$PROCESSING_FAILURE"
+        return "$PROTECTION_FAILURE"
       fi
     done
     if ! protected_digests=$(sort -u "$protected_file"); then
       cleanup_files
       echo "  ✗ Failed to read protected-digest list; skipping $container" >&2
-      return "$PROCESSING_FAILURE"
+      return "$PROTECTION_FAILURE"
     fi
   fi
 
-  while IFS='|' read -r version_id digest tags; do
-    [[ -z "$version_id" ]] && continue
+  while IFS= read -r record_b64; do
+    [[ -z "$record_b64" ]] && continue
+    if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
+      || ! version_id=$(jq -er '.id' <<< "$record_json") \
+      || ! digest=$(jq -er '.digest' <<< "$record_json") \
+      || ! tags=$(jq -er '.tags | join(",")' <<< "$record_json"); then
+      echo "  ✗ Failed to read prepared GHCR deletion record; skipping $container" >&2
+      deletion_read_error=1
+      break
+    fi
     if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
       echo "  ✓ Keep (tags: $tags) — digest is manifest child" >&2; kept=$((kept + 1))
     else
@@ -184,8 +210,26 @@ purge_ghcr() {
     fi
   done < "$obsolete_file"
 
-  while IFS='|' read -r version_id digest tags; do
-    [[ -z "$version_id" || -n "$tags" ]] && continue
+  if [[ "$deletion_read_error" -ne 0 ]]; then
+    if ! printf '%s\n' "$kept|$obsolete|$orphans|$delete_failures"; then
+      cleanup_files
+      return "$PROCESSING_FAILURE"
+    fi
+    cleanup_files
+    return "$POST_DELETE_PROCESSING_FAILURE"
+  fi
+
+  while IFS= read -r record_b64; do
+    [[ -z "$record_b64" ]] && continue
+    if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
+      || ! version_id=$(jq -er '.id' <<< "$record_json") \
+      || ! digest=$(jq -er '.digest' <<< "$record_json") \
+      || ! tags=$(jq -er '.tags | join(",")' <<< "$record_json"); then
+      echo "  ✗ Failed to read GHCR version record; skipping $container" >&2
+      deletion_read_error=1
+      break
+    fi
+    [[ -n "$tags" ]] && continue
     if [[ -n "$protected_digests" ]] && grep -qxF "$digest" <<< "$protected_digests"; then
       kept=$((kept + 1))
     else
@@ -201,6 +245,14 @@ purge_ghcr() {
       orphans=$((orphans + 1))
     fi
   done < "$versions_file"
+  if [[ "$deletion_read_error" -ne 0 ]]; then
+    if ! printf '%s\n' "$kept|$obsolete|$orphans|$delete_failures"; then
+      cleanup_files
+      return "$PROCESSING_FAILURE"
+    fi
+    cleanup_files
+    return "$POST_DELETE_PROCESSING_FAILURE"
+  fi
   if ! printf '%s\n' "$kept|$obsolete|$orphans|$delete_failures"; then
     return "$PROCESSING_FAILURE"
   fi
@@ -264,9 +316,13 @@ main() {
   ROOT_DIR=$(script_root) || return 1
   export ROOT_DIR
 
-  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13
+  # 14 is reserved for a distinct uninterpretable-record producer.  Current
+  # decoding failures are processing failures (11).  16 is reserved for a
+  # future partial-assessment producer; this plan-then-delete implementation
+  # deliberately has none, and replay failures are post-complete (13).
+  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15 INCOMPLETE_DELETION_FAILURE=16
   local containers container valid_tags valid_count result ghcr_status dh_result dh_status
-  local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed
+  local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed skip_dockerhub
   local total_assessed=0 total_build_failures=0 total_listing_failures=0 total_processing_failures=0 total_ghcr_delete_failures=0 total_dh_delete_failures=0
   local total_kept=0 total_obsolete=0 total_orphans=0 total_dh_deleted=0
   if [[ $# -gt 0 ]]; then containers="$*"; else containers=$("$ROOT_DIR/make" list) || return 1; fi
@@ -279,21 +335,38 @@ main() {
     valid_count=$(wc -l <<< "$valid_tags")
     echo "  Valid tags ($valid_count total):"; printf '    %s\n' "${valid_tags//$'\n'/$'\n    '}"
     package_assessed=false
+    skip_dockerhub=false
 
     if result=$(purge_ghcr "$container" "$valid_tags"); then ghcr_status=0; else ghcr_status=$?; fi
     case "$ghcr_status" in
       0|"$DELETE_FAILURE"|"$POST_DELETE_PROCESSING_FAILURE")
         if ! IFS='|' read -r kept obsolete orphans delete_failures <<< "$result"; then
-          echo "  ✗ Failed to read GHCR cleanup result; skipping $container"; total_processing_failures=$((total_processing_failures + 1))
+          echo "  ✗ Failed to read GHCR cleanup result; skipping $container"; total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true
         else
           package_assessed=true; total_kept=$((total_kept + kept)); total_obsolete=$((total_obsolete + obsolete)); total_orphans=$((total_orphans + orphans)); total_ghcr_delete_failures=$((total_ghcr_delete_failures + delete_failures))
           echo "  GHCR summary: kept=$kept, obsolete=$obsolete, orphans=$orphans, delete_failures=$delete_failures"
           [[ "$ghcr_status" -ne "$POST_DELETE_PROCESSING_FAILURE" ]] || total_processing_failures=$((total_processing_failures + 1))
         fi ;;
-      "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
-      "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
-      *) echo "  ✗ Unexpected GHCR cleanup status $ghcr_status; skipping $container"; total_processing_failures=$((total_processing_failures + 1)) ;;
+      "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)); skip_dockerhub=true ;;
+      "$PROCESSING_FAILURE"|"$UNINTERPRETABLE_RECORD_FAILURE"|"$PROTECTION_FAILURE") total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true ;;
+      # Reserved fail-closed status; see the declaration above.  A status 16
+      # caller has not supplied a completed assessment, so Docker Hub stays off.
+      "$INCOMPLETE_DELETION_FAILURE")
+        if ! IFS='|' read -r kept obsolete orphans delete_failures <<< "$result"; then
+          echo "  ✗ Failed to read incomplete GHCR cleanup result; skipping $container"
+        else
+          total_kept=$((total_kept + kept)); total_obsolete=$((total_obsolete + obsolete)); total_orphans=$((total_orphans + orphans)); total_ghcr_delete_failures=$((total_ghcr_delete_failures + delete_failures))
+          echo "  GHCR summary: kept=$kept, obsolete=$obsolete, orphans=$orphans, delete_failures=$delete_failures"
+        fi
+        total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true
+        ;;
+      *) echo "  ✗ Unexpected GHCR cleanup status $ghcr_status; skipping $container"; total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true ;;
     esac
+
+    if [[ "$skip_dockerhub" == true ]]; then
+      echo "  Docker Hub cleanup skipped: GHCR safety assessment was incomplete"
+      continue
+    fi
 
     if dh_result=$(purge_dockerhub "$container" "$valid_tags"); then dh_status=0; else dh_status=$?; fi
     case "$dh_status" in

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -79,6 +79,21 @@ assert_summary_reports_successful_deletion() {
     fi
 }
 
+assert_tag_decode_failure_stops_before_delete() {
+    local log_file="$1"
+    if [[ "$status" -ne 1 || -s "$log_file" || "$output" != *"Failed to read version tags; skipping protected"* ]]; then
+        echo "ASSERTION FAILED: tag decode failure must stop the package before DELETE" >&2
+        return 1
+    fi
+}
+
+assert_prepared_decode_preserves_delete_totals() {
+    if [[ "$output" != *"Summary: kept=0, deleted=1, delete_failures=0"* || "$output" != *"Packages assessed: 1"* ]]; then
+        echo "ASSERTION FAILED: a completed deletion plan must keep successful deletes in the totals and assess the package" >&2
+        return 1
+    fi
+}
+
 @test "workflow-executed registry pruners are executable" {
     assert_executable "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
     assert_executable "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
@@ -189,7 +204,7 @@ EOF
         bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken healthy
 
     [[ "$status" -eq 1 ]]
-    [[ "$output" == *"Failed to prepare version list; skipping broken"* ]]
+    [[ "$output" == *"Failed to read version record; skipping broken"* ]]
     [[ "$output" == *"Processing: healthy"* ]]
     [[ "$output" == *"Packages assessed: 1"* ]]
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
@@ -328,4 +343,65 @@ EOF
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
     [[ "$output" == *"Versions deleted: 1"* ]]
     [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
+}
+
+@test "a tag decode failure stops a protecting version before DELETE" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"metadata\":{\"container\":{\"tags\":[\"v1.2.3\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            jq() {
+                if [[ "${!#}" == ".tags[]" ]]; then echo "jq: tag decode exhausted" >&2; return 1; fi
+                command jq "$@"
+            }
+            main protected
+        '
+
+    assert_tag_decode_failure_stops_before_delete "$GH_LOG"
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+}
+
+@test "a prepared deletion decode failure assesses the completed plan and still reports an earlier DELETE" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        BASE64_CALLS="$STUB_DIR/base64-calls" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            base64() {
+                calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")
+                calls=$((calls + 1)); printf "%s\\n" "$calls" > "$BASE64_CALLS"
+                [[ "$calls" -lt 4 ]] || { echo "base64: prepared record lost" >&2; return 1; }
+                command base64 "$@"
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
+    [[ "$(<"$GH_LOG")" != *"/versions/102"* ]]
+    assert_prepared_decode_preserves_delete_totals
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
 }

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -42,6 +42,37 @@ make_valid_tags() {
     printf '%s\n' "$@"
 }
 
+assert_tag_decode_failure_stops_before_delete() {
+    local log_file="$1"
+    if [[ "$status" -ne 1 || -s "$log_file" || "$output" != *"Failed to read GHCR version tags; skipping protected"* ]]; then
+        echo "ASSERTION FAILED: tag decode failure must stop the package before DELETE" >&2
+        return 1
+    fi
+}
+
+assert_preplan_failure_is_unassessed_and_skips_dockerhub() {
+    local call_file="$1"
+    if [[ "$output" != *"Packages assessed: 0"* || -s "$call_file" ]]; then
+        echo "ASSERTION FAILED: a pre-plan failure must stay unassessed and Docker Hub must not run" >&2
+        return 1
+    fi
+}
+
+assert_prepared_decode_preserves_delete_totals() {
+    if [[ "$output" != *"GHCR summary: kept=0, obsolete=1, orphans=0, delete_failures=0"* || "$output" != *"Packages assessed: 1"* ]]; then
+        echo "ASSERTION FAILED: a completed GHCR plan must keep successful deletes in the totals and assess the package" >&2
+        return 1
+    fi
+}
+
+assert_dockerhub_called_after_complete_ghcr_plan() {
+    local call_file="$1"
+    if [[ ! -s "$call_file" ]]; then
+        echo "ASSERTION FAILED: Docker Hub must run after a completed GHCR plan even when its execution fails" >&2
+        return 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Direct-match tests (regression: existing behaviour must be preserved)
 # ---------------------------------------------------------------------------
@@ -292,9 +323,12 @@ make_valid_tags() {
     [[ "$output" == *"Registry listing failures: 1"* ]]
 }
 
-@test "a successful Docker Hub assessment counts when GHCR listing fails" {
+@test "Docker Hub is called only after every GHCR assessment status is complete" {
+    local dockerhub_calls="$_STUB_DIR/dockerhub-calls"
+
     run env \
         PROJECT_ROOT="$PROJECT_ROOT" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
         GH_TOKEN="$GH_TOKEN" \
         OWNER="$OWNER" \
         DRY_RUN="true" \
@@ -302,14 +336,37 @@ make_valid_tags() {
             set -euo pipefail
             source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
             build_valid_tags() { printf "%s\\n" "latest"; }
-            gh() { return 1; }
-            purge_dockerhub() { printf "%s\\n" "1|0"; }
-            main broken
+            purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
+            for expectation in success:0:complete:success listing:10:incomplete:failure processing:11:incomplete:failure delete:12:complete:failure post-complete:13:complete:failure uninterpretable:14:incomplete:failure protection:15:incomplete:failure incomplete-delete:16:incomplete:failure unexpected:99:incomplete:failure; do
+                name=${expectation%%:*}; remainder=${expectation#*:}; stub_ghcr_status=${remainder%%:*}; remainder=${remainder#*:}; assessment=${remainder%%:*}; expected_run=${remainder#*:}
+                : > "$DOCKERHUB_CALLS"
+                purge_ghcr() {
+                    if [[ "$stub_ghcr_status" -eq 12 ]]; then printf "%s\\n" "0|0|0|1"; else printf "%s\\n" "0|0|0|0"; fi
+                    return "$stub_ghcr_status"
+                }
+                if main stale; then main_result=success; else main_result=failure; fi
+                if [[ "$main_result" != "$expected_run" ]]; then
+                    echo "ASSERTION FAILED: GHCR $name status returned $main_result instead of $expected_run" >&2
+                    exit 1
+                fi
+                if [[ "$assessment" == incomplete && -s "$DOCKERHUB_CALLS" ]]; then
+                    echo "ASSERTION FAILED: Docker Hub was called while GHCR $name protection was incomplete" >&2
+                    exit 1
+                fi
+                if [[ "$assessment" == complete && ! -s "$DOCKERHUB_CALLS" ]]; then
+                    echo "ASSERTION FAILED: Docker Hub was not called after complete GHCR $name assessment" >&2
+                    exit 1
+                fi
+            done
+            exit 0
         '
 
-    [[ "$status" -eq 1 ]]
-    [[ "$output" == *"Packages assessed: 1"* ]]
-    [[ "$output" == *"Registry listing failures: 1"* ]]
+    if [[ "$status" -ne 0 ]]; then
+        echo "ASSERTION FAILED: Docker Hub completion guard test exited unexpectedly" >&2
+        echo "$output" >&2
+        return 1
+    fi
+    [[ "$output" == *"Docker Hub cleanup skipped: GHCR safety assessment was incomplete"* ]]
 }
 
 @test "sourcing is inert and script_root uses BASH_SOURCE rather than the caller directory" {
@@ -427,4 +484,75 @@ EOF
     [[ "$output" == *"Packages assessed: 1"* ]]
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
     [[ "$output" == *"GHCR — kept: 0, obsolete: 1, orphans: 0"* ]]
+}
+
+@test "a tag decode failure stops a protecting GHCR version before DELETE" {
+    local gh_log="$_STUB_DIR/gh.log"
+    local dockerhub_calls="$_STUB_DIR/dockerhub-calls"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$gh_log" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:protected\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}}]"
+            }
+            jq() {
+                if [[ "${!#}" == ".tags[]" ]]; then echo "jq: tag decode exhausted" >&2; return 1; fi
+                command jq "$@"
+            }
+            main protected
+        '
+
+    assert_tag_decode_failure_stops_before_delete "$gh_log"
+    assert_preplan_failure_is_unassessed_and_skips_dockerhub "$dockerhub_calls"
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+}
+
+@test "a prepared GHCR deletion decode failure assesses the completed plan, reports the DELETE, and runs Docker Hub" {
+    local gh_log="$_STUB_DIR/gh.log"
+    local base64_calls="$_STUB_DIR/base64-calls"
+    local dockerhub_calls="$_STUB_DIR/dockerhub-calls"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$gh_log" \
+        BASE64_CALLS="$base64_calls" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:first\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}},{\"id\":102,\"name\":\"sha256:second\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
+            }
+            base64() {
+                calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")
+                calls=$((calls + 1)); printf "%s\\n" "$calls" > "$BASE64_CALLS"
+                [[ "$calls" -lt 4 ]] || { echo "base64: prepared record lost" >&2; return 1; }
+                command base64 "$@"
+            }
+            main stale
+        '
+
+    assert_dockerhub_called_after_complete_ghcr_plan "$dockerhub_calls"
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/102"* ]]
+    assert_prepared_decode_preserves_delete_totals
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
 }


### PR DESCRIPTION
The container pruners lost track of what happened.

The tag loops read `jq` through process substitution, where bash discards the
producer's exit status, so a failed `.tags[]` looked like a record with no tags:
the age cleaner never saw the tag that would have preserved the latest major of
its version and put it in the deletion plan, and the obsolete-tag cleaner left
`has_valid` false and classified a currently valid image obsolete. Both loops use
checked captures now and no `< <(…)` remains.

A decode failure after earlier deletions returned the pre-delete status with no
result record, so successful deletions vanished from the totals and a mutated
package was reported skipped.

And an incomplete GHCR assessment did not stop the Docker Hub pass. Every status
now says which of the two it is — the plan did not complete, or its execution
failed — and assessed and Docker Hub move together in every row:

| Status | Assessed | Docker Hub |
|---|---|---|
| 0 | yes | runs |
| 10 listing failure | no | suppressed |
| 11 processing failure | no | suppressed |
| 12 delete failure after complete assessment | yes | runs |
| 13 post-complete failure | yes | runs |
| 14, 16 | no | suppressed — reserved, documented |
| 15 protection failure | no | suppressed |

The cross-registry test could not fail before this: its inner script ended with
`exit 1` while the assertion expected Bats status 1, so an `ASSERTION FAILED`
was indistinguishable from the expected outcome — which is why that guard was
wrong in three consecutive reviews of the predecessor. It exits 0 only after its
observations succeed, with a spy standing in for `purge_dockerhub`.

Verified: 2683 unit tests green on this HEAD, `shellcheck` clean. The
plan-completed case was proven red-then-green against the unmodified scripts.

This is one half of a split; `fix/1300-prune-input-validation` carries the record
schema, framing, digest canonicalisation and configuration bounds. The
predecessor is tagged `split-base-1300-2026-08-21`.

Known and not closed here: an orphan-pass decode failure still reports the
package assessed and lets Docker Hub run, because that classification is a second
phase by design (#1335); a DELETE response body can reach the result record and
its arithmetic (#1336); Docker Hub counts attempts as deletions and stops at 100
tags (#1302); age retention protects whichever versions GHCR listed first
(#1301).

Closes #1309
