### PR TITLE
Pin one extension version to a frozen digest at build time

### DIFF
--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -808,6 +808,113 @@ ext_ref_resolve() {
     esac
 }
 
+# ext_consumed_source_ref <extension> <version> <pg_major> <registry> <owner> <mode> [artifact_digest]
+#
+# Return the immutable or tag-based source reference a generated Dockerfile
+# consumes.  Keeping the candidate selector here means every generated FROM and
+# COPY --from reference has the same narrow, frozen-rotation escape hatch.
+ext_consumed_source_ref() {
+    local extension="${1:-}"
+    local version="${2:-}"
+    local pg_major="${3:-}"
+    local registry="${4:-}"
+    local owner="${5:-}"
+    local mode="${6:-}"
+    local artifact_digest="${7:-}"
+    local LC_ALL=C
+    local candidate="${ROTATION_CANDIDATE_REF:-}"
+    local candidate_left candidate_ref candidate_extension candidate_pg_major candidate_version
+    local candidate_repository candidate_digest candidate_suffix expected_repository
+    local repository candidate_prefix
+
+    if [[ -z "$extension" || -z "$version" || -z "$pg_major" || -z "$registry" || -z "$owner" || -z "$mode" ]]; then
+        log_error "ext_consumed_source_ref: extension, version, pg_major, registry, owner, and mode are required"
+        return 1
+    fi
+
+    # A requested frozen candidate must be completely understood before any
+    # fallback can run; otherwise a malformed rotation could test canonical bytes.
+    if [[ -n "$candidate" ]]; then
+        if [[ "$candidate" != *=* ]]; then
+            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
+            return 2
+        fi
+        candidate_left="${candidate%%=*}"
+        candidate_ref="${candidate#*=}"
+        if [[ "$candidate_ref" == *=* ]] || ! [[ "$candidate_left" =~ ^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$ ]]; then
+            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
+            return 2
+        fi
+        candidate_extension="${BASH_REMATCH[1]}"
+        candidate_pg_major="${BASH_REMATCH[2]}"
+        candidate_version="${BASH_REMATCH[3]}"
+
+        if ! [[ "$candidate_ref" =~ ^(.+)@([^@]+)$ ]]; then
+            log_error "ROTATION_CANDIDATE_REF must contain one pinned repository@sha256 digest reference"
+            return 2
+        fi
+        candidate_repository="${BASH_REMATCH[1]}"
+        candidate_digest="${BASH_REMATCH[2]}"
+        if ! is_valid_oci_digest "$candidate_digest"; then
+            log_error "ROTATION_CANDIDATE_REF must contain a valid pinned sha256 digest"
+            return 2
+        fi
+
+        candidate_prefix="${registry}/${owner}/ext-${candidate_extension}"
+        case "$candidate_repository" in
+            "$candidate_prefix") candidate_suffix="" ;;
+            "$candidate_prefix"-*) candidate_suffix="${candidate_repository#"$candidate_prefix"}" ;;
+            *)
+                log_error "ROTATION_CANDIDATE_REF repository must belong to this invocation's registry, owner, and extension"
+                return 2
+                ;;
+        esac
+
+        if [[ -n "$candidate_suffix" ]]; then
+            if ! EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" validate_extension_package_suffix; then
+                log_error "ROTATION_CANDIDATE_REF repository has an invalid package suffix"
+                return 2
+            fi
+            expected_repository=$(EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
+        else
+            expected_repository=$(unset EXTENSION_PACKAGE_SUFFIX; ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
+        fi
+        if [[ "$candidate_repository" != "$expected_repository" ]]; then
+            log_error "ROTATION_CANDIDATE_REF repository does not match the frozen candidate package"
+            return 2
+        fi
+
+        if [[ "$extension" == "$candidate_extension" && "$pg_major" == "$candidate_pg_major" && "$version" == "$candidate_version" ]]; then
+            printf '%s' "$candidate_ref"
+            return 0
+        fi
+    fi
+
+    case "$mode" in
+        pinned-digest)
+            if ! is_valid_oci_digest "$artifact_digest"; then
+                log_error "ext_consumed_source_ref: artifact digest for $extension $version pg${pg_major} is absent or malformed — fail closed"
+                return 1
+            fi
+            repository=$(ext_image_repository "$extension" "$registry" "$owner") || return 1
+            printf '%s@%s' "$repository" "$artifact_digest"
+            ;;
+        probe)
+            # ext_ref_resolve resolves registry and owner internally, unlike the
+            # other modes; forward this invocation's explicit identity once here.
+            EXTENSION_REGISTRY="$registry" GITHUB_REPOSITORY_OWNER="$owner" \
+                ext_ref_resolve "$extension" "$version" "$pg_major" ""
+            ;;
+        direct)
+            ext_image_name "$extension" "$version" "$pg_major" "$registry" "$owner"
+            ;;
+        *)
+            log_error "ext_consumed_source_ref: unsupported mode '$mode'"
+            return 1
+            ;;
+    esac
+}
+
 # Get list of extensions for a flavor, filtered by PG version compatibility
 # Excludes disabled extensions and those exceeding max_pg_version
 get_flavor_extensions() {
@@ -1350,8 +1457,8 @@ generate_dockerfile() {
                     return 1
                 fi
 
-                # Probe registry presence for each resolved version via ext_ref_resolve.
-                # ext_ref_resolve encapsulates canonical-first, PR-scoped fallback,
+                # Probe registry presence for each resolved version through the consumed
+                # source gateway. It preserves ext_ref_resolve's canonical-first, PR-scoped fallback,
                 # both force signals, and 3-state fail-closed in one call
                 # (arch="" = multi-arch tag).
                 # rc 0 → PRESENT (ref printed); rc 1 → ABSENT; rc 2 → transient ERROR (fail-closed).
@@ -1362,7 +1469,7 @@ generate_dockerfile() {
                 while IFS= read -r _sh_ver; do
                     [[ -z "$_sh_ver" ]] && continue
                     local _sh_resolved_ref _sh_rc=0
-                    _sh_resolved_ref=$(ext_ref_resolve "$ext_name" "$_sh_ver" "$pg_major" "") || _sh_rc=$?
+                    _sh_resolved_ref=$(ext_consumed_source_ref "$ext_name" "$_sh_ver" "$pg_major" "$registry" "$owner" probe) || _sh_rc=$?
                     case "$_sh_rc" in
                         0)
                             _sh_available+=("$_sh_ver")
@@ -1542,7 +1649,7 @@ generate_dockerfile() {
                         # sourced inside a function scope). Serializing as a string passes cleanly.
                         local _ecs_ver_ref_list=""
                         if [[ "$_versionset_from_selfheal" == "true" ]]; then
-                            # Self-heal path: refs already resolved by ext_ref_resolve above.
+                            # Self-heal path: refs already resolved by the source gateway above.
                             local _sh_mv
                             while IFS= read -r _sh_mv; do
                                 [[ -z "$_sh_mv" ]] && continue
@@ -1569,11 +1676,9 @@ generate_dockerfile() {
                                         log_error "generate_dockerfile: version_digests[$_art_ver] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_art_digest:-}" | head -c 80)")') — fail closed"
                                         return 1
                                     fi
-                                    local _art_repository
-                                    _art_repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
-                                    _art_ref="${_art_repository}@${_art_digest}"
+                                    _art_ref=$(ext_consumed_source_ref "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner" pinned-digest "$_art_digest") || return 1
                                 else
-                                    _art_ref=$(ext_image_name "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner") || return 1
+                                    _art_ref=$(ext_consumed_source_ref "$ext_name" "$_art_ver" "$pg_major" "$registry" "$owner" direct) || return 1
                                 fi
                                 _ecs_ver_ref_list+="${_art_ver}	${_art_ref}"$'\n'
                             done <<< "$raw_versions"
@@ -1618,12 +1723,10 @@ generate_dockerfile() {
                     log_error "generate_dockerfile: version_digests[$ext_version] for $ext_name pg${pg_major} is absent or malformed ('$(_sanitize_for_log "$(printf '%s' "${_sv_digest:-}" | head -c 80)")') — fail closed"
                     return 1
                 fi
-                local _sv_repository
-                _sv_repository=$(ext_image_repository "$ext_name" "$registry" "$owner") || return 1
-                _sv_ref="${_sv_repository}@${_sv_digest}"
+                _sv_ref=$(ext_consumed_source_ref "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner" pinned-digest "$_sv_digest") || return 1
             elif [[ -n "${PR_TAG_SUFFIX:-}" ]]; then
                 local _sv_rc=0
-                _sv_ref=$(ext_ref_resolve "$ext_name" "$ext_version" "$pg_major" "") || _sv_rc=$?
+                _sv_ref=$(ext_consumed_source_ref "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner" probe) || _sv_rc=$?
                 if [[ "$_sv_rc" -eq 2 ]]; then
                     log_error "generate_dockerfile: transient registry probe error resolving $ext_name $ext_version pg${pg_major} — fail closed"
                     return 1
@@ -1633,9 +1736,8 @@ generate_dockerfile() {
                     return 1
                 fi
             else
-                # Push/dispatch: emit the package selected by the independent
-                # package-suffix axis (canonical when it is unset).
-                _sv_ref=$(ext_image_name "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner") || return 1
+                # Push/dispatch remains direct so scheduled builds do not acquire a probe.
+                _sv_ref=$(ext_consumed_source_ref "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner" direct) || return 1
             fi
             stages_block+="FROM ${_sv_ref} AS ext-${ext_name}"$'\n'
             copies_block+="COPY --from=ext-${ext_name} /output/extension/ /tmp/ext/${ext_name}/extension/"$'\n'

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -724,6 +724,54 @@ _force_scoped_extension_ref() {
     return 1
 }
 
+# _parse_rotation_candidate_ref
+#
+# Parse ROTATION_CANDIDATE_REF's shared selector grammar.  The fixed
+# _rotation_candidate_ref_* globals are this function's deliberate multi-value
+# return channel: a caller-supplied output variable (and therefore a nameref)
+# could silently collide with a variable in a script that sources this file.
+#
+# Returns:
+#   0  ROTATION_CANDIDATE_REF is set, non-empty, and has a valid selector;
+#      _rotation_candidate_ref_extension, _rotation_candidate_ref_pg_major,
+#      _rotation_candidate_ref_version, and _rotation_candidate_ref_value are
+#      available to the caller.
+#   1  ROTATION_CANDIDATE_REF is unset or empty.
+#   2  ROTATION_CANDIDATE_REF is set and malformed.
+#
+# This helper owns only the left/right split and selector shape.  Its callers
+# retain validation of the pinned reference and its applicability.
+_parse_rotation_candidate_ref() {
+    local LC_ALL=C
+    local candidate candidate_left candidate_ref
+
+    _rotation_candidate_ref_extension=""
+    _rotation_candidate_ref_pg_major=""
+    _rotation_candidate_ref_version=""
+    _rotation_candidate_ref_value=""
+
+    if [[ -z "${ROTATION_CANDIDATE_REF+x}" ]]; then
+        return 1
+    fi
+    candidate="$ROTATION_CANDIDATE_REF"
+    [[ -n "$candidate" ]] || return 1
+
+    if [[ "$candidate" != *=* ]]; then
+        return 2
+    fi
+    candidate_left="${candidate%%=*}"
+    candidate_ref="${candidate#*=}"
+    if [[ "$candidate_ref" == *=* ]] || ! [[ "$candidate_left" =~ ^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$ ]]; then
+        return 2
+    fi
+
+    _rotation_candidate_ref_extension="${BASH_REMATCH[1]}"
+    _rotation_candidate_ref_pg_major="${BASH_REMATCH[2]}"
+    _rotation_candidate_ref_version="${BASH_REMATCH[3]}"
+    _rotation_candidate_ref_value="$candidate_ref"
+    return 0
+}
+
 ext_ref_resolve() {
     local ext="$1" version="$2" major="$3" arch="${4:-}"
     local registry owner canonical_ref pr_ref scope_rc=0
@@ -822,8 +870,8 @@ ext_consumed_source_ref() {
     local mode="${6:-}"
     local artifact_digest="${7:-}"
     local LC_ALL=C
-    local candidate="${ROTATION_CANDIDATE_REF:-}"
-    local candidate_left candidate_ref candidate_extension candidate_pg_major candidate_version
+    local candidate_rc=0
+    local candidate_ref candidate_extension candidate_pg_major candidate_version
     local candidate_repository candidate_digest candidate_suffix expected_repository
     local repository candidate_prefix
 
@@ -832,23 +880,47 @@ ext_consumed_source_ref() {
         return 1
     fi
 
+    # Keep the mode set closed even when a matching candidate would otherwise
+    # return before the fallback switch below.
+    case "$mode" in
+        pinned-digest|probe|direct) ;;
+        *)
+            log_error "ext_consumed_source_ref: unsupported mode '$mode'"
+            return 1
+            ;;
+    esac
+
     # A requested frozen candidate must be completely understood before any
     # fallback can run; otherwise a malformed rotation could test canonical bytes.
-    if [[ -n "$candidate" ]]; then
-        if [[ "$candidate" != *=* ]]; then
-            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
-            return 2
-        fi
-        candidate_left="${candidate%%=*}"
-        candidate_ref="${candidate#*=}"
-        if [[ "$candidate_ref" == *=* ]] || ! [[ "$candidate_left" =~ ^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$ ]]; then
-            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
-            return 2
-        fi
-        candidate_extension="${BASH_REMATCH[1]}"
-        candidate_pg_major="${BASH_REMATCH[2]}"
-        candidate_version="${BASH_REMATCH[3]}"
+    _parse_rotation_candidate_ref || candidate_rc=$?
+    case "$candidate_rc" in
+        0)
+            candidate_extension="$_rotation_candidate_ref_extension"
+            candidate_pg_major="$_rotation_candidate_ref_pg_major"
+            candidate_version="$_rotation_candidate_ref_version"
+            candidate_ref="$_rotation_candidate_ref_value"
 
+            # The producer uses this package axis to write a staging package. A
+            # consumer with a frozen candidate must not inherit it: its
+            # non-candidate versions would otherwise be redirected to that
+            # staging package.
+            if [[ -n "${EXTENSION_PACKAGE_SUFFIX+x}" && -n "$EXTENSION_PACKAGE_SUFFIX" ]]; then
+                log_error "ROTATION_CANDIDATE_REF cannot be consumed while EXTENSION_PACKAGE_SUFFIX is set"
+                return 2
+            fi
+            ;;
+        1) ;;
+        2)
+            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
+            return 2
+            ;;
+        *)
+            log_error "ROTATION_CANDIDATE_REF could not be parsed"
+            return 2
+            ;;
+    esac
+
+    if [[ "$candidate_rc" -eq 0 ]]; then
         if ! [[ "$candidate_ref" =~ ^(.+)@([^@]+)$ ]]; then
             log_error "ROTATION_CANDIDATE_REF must contain one pinned repository@sha256 digest reference"
             return 2
@@ -862,23 +934,22 @@ ext_consumed_source_ref() {
 
         candidate_prefix="${registry}/${owner}/ext-${candidate_extension}"
         case "$candidate_repository" in
-            "$candidate_prefix") candidate_suffix="" ;;
             "$candidate_prefix"-*) candidate_suffix="${candidate_repository#"$candidate_prefix"}" ;;
             *)
-                log_error "ROTATION_CANDIDATE_REF repository must belong to this invocation's registry, owner, and extension"
+                log_error "ROTATION_CANDIDATE_REF repository must be a suffixed package belonging to this invocation's registry, owner, and extension"
                 return 2
                 ;;
         esac
 
-        if [[ -n "$candidate_suffix" ]]; then
-            if ! EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" validate_extension_package_suffix; then
-                log_error "ROTATION_CANDIDATE_REF repository has an invalid package suffix"
-                return 2
-            fi
-            expected_repository=$(EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
-        else
-            expected_repository=$(unset EXTENSION_PACKAGE_SUFFIX; ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
+        # A suffixed package prevents a rotation from testing bytes already in
+        # the canonical package. It does not establish that the suffix belongs
+        # to this rotation: an arbitrary ext-<name>-something is still accepted
+        # from the actor who supplies the workflow candidate.
+        if ! EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" validate_extension_package_suffix; then
+            log_error "ROTATION_CANDIDATE_REF repository has an invalid package suffix"
+            return 2
         fi
+        expected_repository=$(EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
         if [[ "$candidate_repository" != "$expected_repository" ]]; then
             log_error "ROTATION_CANDIDATE_REF repository does not match the frozen candidate package"
             return 2
@@ -907,10 +978,6 @@ ext_consumed_source_ref() {
             ;;
         direct)
             ext_image_name "$extension" "$version" "$pg_major" "$registry" "$owner"
-            ;;
-        *)
-            log_error "ext_consumed_source_ref: unsupported mode '$mode'"
-            return 1
             ;;
     esac
 }
@@ -1226,6 +1293,7 @@ generate_dockerfile() {
     local pg_major="$4"
     local registry="${5:-$(get_registry)}"
     local owner="${6:-$(get_repo_owner)}"
+    local LC_ALL=C
 
     if ! validate_extensions_schema "$config_file"; then
         log_error "generate_dockerfile: extensions schema validation failed for ${config_file}"
@@ -1285,6 +1353,34 @@ generate_dockerfile() {
     local stages_block=""
     local copies_block=""
     local all_runtime_deps=""
+    local candidate_rc=0
+    local candidate_ref candidate_extension candidate_pg_major
+    local candidate_applies=false
+
+    # The source gateway validates every candidate it reaches.  This render
+    # scope check covers the distinct valid-but-unconsumed case: only a
+    # candidate naming an extension emitted by this flavor and this PG major is
+    # required to appear in the assembled stage text.
+    _parse_rotation_candidate_ref || candidate_rc=$?
+    case "$candidate_rc" in
+        0)
+            candidate_extension="$_rotation_candidate_ref_extension"
+            candidate_pg_major="$_rotation_candidate_ref_pg_major"
+            candidate_ref="$_rotation_candidate_ref_value"
+            if [[ "$candidate_pg_major" == "$pg_major" ]] && grep -Fxq -- "$candidate_extension" <<< "$extensions"; then
+                candidate_applies=true
+            fi
+            ;;
+        1) ;;
+        2)
+            log_error "generate_dockerfile: ROTATION_CANDIDATE_REF is malformed — fail closed"
+            return 1
+            ;;
+        *)
+            log_error "generate_dockerfile: ROTATION_CANDIDATE_REF could not be parsed — fail closed"
+            return 1
+            ;;
+    esac
 
     if [[ -n "$extensions" ]]; then
         while IFS= read -r ext_name; do
@@ -1461,10 +1557,9 @@ generate_dockerfile() {
                 # source gateway. It preserves ext_ref_resolve's canonical-first, PR-scoped fallback,
                 # both force signals, and 3-state fail-closed in one call
                 # (arch="" = multi-arch tag).
-                # rc 0 → PRESENT (ref printed); rc 1 → ABSENT; rc 2 → transient ERROR (fail-closed).
+                # rc 0 → PRESENT (ref printed); rc 1 → ABSENT; rc 2 → consumed-source resolution failure (fail-closed).
                 local _sh_available=()
                 local -A _sh_emit_ref_map=()  # version → resolved emit ref (for lookup in emit loop)
-                local _sh_probe_error=false
                 local _sh_ver
                 while IFS= read -r _sh_ver; do
                     [[ -z "$_sh_ver" ]] && continue
@@ -1477,15 +1572,11 @@ generate_dockerfile() {
                             ;;
                         1)  ;;   # ABSENT — musl-failed / never-built / not yet pushed
                         *)
-                            log_error "generate_dockerfile: self-heal probe for $ext_name $pg_major $ext_version — registry probe for $_sh_ver returned an ambiguous error; cannot determine availability (fail-closed)"
-                            _sh_probe_error=true
+                            log_error "generate_dockerfile: consumed-source resolution failure for $ext_name $_sh_ver pg${pg_major} during self-heal — cannot determine availability (fail-closed)"
+                            return 1
                             ;;
                     esac
                 done < <(echo "$_sh_resolved_json" | jq -r '.[]' 2>/dev/null || true)
-
-                if [[ "$_sh_probe_error" == "true" ]]; then
-                    return 1
-                fi
 
                 if [[ ${#_sh_available[@]} -eq 0 ]]; then
                     log_error "generate_dockerfile: self-heal for $ext_name pg${pg_major}: no resolved images are present in registry — cannot emit multi-version stages"
@@ -1728,7 +1819,7 @@ generate_dockerfile() {
                 local _sv_rc=0
                 _sv_ref=$(ext_consumed_source_ref "$ext_name" "$ext_version" "$pg_major" "$registry" "$owner" probe) || _sv_rc=$?
                 if [[ "$_sv_rc" -eq 2 ]]; then
-                    log_error "generate_dockerfile: transient registry probe error resolving $ext_name $ext_version pg${pg_major} — fail closed"
+                    log_error "generate_dockerfile: consumed-source resolution failure for $ext_name $ext_version pg${pg_major} — fail closed"
                     return 1
                 fi
                 if [[ "$_sv_rc" -ne 0 ]] || [[ -z "$_sv_ref" ]]; then
@@ -1750,6 +1841,14 @@ generate_dockerfile() {
                 all_runtime_deps+="${deps}"$'\n'
             fi
         done <<< "$extensions"
+    fi
+
+    # Decide from the exact stage text about to be emitted, not from an
+    # intention flag updated inside command substitutions. A candidate scoped
+    # to this render must have replaced one emitted source reference.
+    if [[ "$candidate_applies" == "true" ]] && ! grep -Fq -- "$candidate_ref" <<< "$stages_block"; then
+        log_error "generate_dockerfile: rotation candidate '$ROTATION_CANDIDATE_REF' was not consumed for ${candidate_extension} pg${pg_major} — fail closed"
+        return 1
     fi
 
     # Build runtime_deps block (deduplicated)

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -726,7 +726,7 @@ _force_scoped_extension_ref() {
 
 # _parse_rotation_candidate_ref
 #
-# Parse ROTATION_CANDIDATE_REF's shared selector grammar.  The fixed
+# Parse ROTATION_CANDIDATE_REF's promotion selector grammar.  The fixed
 # _rotation_candidate_ref_* globals are this function's deliberate multi-value
 # return channel: a caller-supplied output variable (and therefore a nameref)
 # could silently collide with a variable in a script that sources this file.
@@ -739,11 +739,12 @@ _force_scoped_extension_ref() {
 #   1  ROTATION_CANDIDATE_REF is unset or empty.
 #   2  ROTATION_CANDIDATE_REF is set and malformed.
 #
-# This helper owns only the left/right split and selector shape.  Its callers
-# retain validation of the pinned reference and its applicability.
+# This helper owns the left/right split and the three field grammars.  Keep
+# these expressions byte-for-byte equal to scripts/rotation-promote.sh:224-235
+# so a selector promotion would reject is malformed for the consumer too.
 _parse_rotation_candidate_ref() {
     local LC_ALL=C
-    local candidate candidate_left candidate_ref
+    local candidate candidate_left candidate_ref candidate_extra
 
     _rotation_candidate_ref_extension=""
     _rotation_candidate_ref_pg_major=""
@@ -761,14 +762,78 @@ _parse_rotation_candidate_ref() {
     fi
     candidate_left="${candidate%%=*}"
     candidate_ref="${candidate#*=}"
-    if [[ "$candidate_ref" == *=* ]] || ! [[ "$candidate_left" =~ ^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$ ]]; then
+    if [[ "$candidate_ref" == *=* ]] || [[ "$candidate_left" == *$'\n'* ]] || [[ "$candidate_left" == *$'\r'* ]]; then
+        return 2
+    fi
+    IFS=':' read -r _rotation_candidate_ref_extension _rotation_candidate_ref_pg_major \
+        _rotation_candidate_ref_version candidate_extra <<< "$candidate_left"
+    if [[ -z "$_rotation_candidate_ref_extension" || -z "$_rotation_candidate_ref_pg_major" ||
+        -z "$_rotation_candidate_ref_version" || -n "$candidate_extra" ]]; then
+        return 2
+    fi
+    if [[ ! "$_rotation_candidate_ref_extension" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] ||
+        [[ ! "$_rotation_candidate_ref_pg_major" =~ ^[1-9][0-9]*$ ]] ||
+        [[ ! "$_rotation_candidate_ref_version" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+        return 2
+    fi
+    _rotation_candidate_ref_value="$candidate_ref"
+    return 0
+}
+
+# _validate_rotation_candidate_context <registry> <owner>
+#
+# Validate every invariant shared by a frozen rotation candidate.  Keeping this
+# outside the per-extension gateway makes it unconditional for flavors with no
+# compiled extensions; the gateway calls it as well for direct callers.
+#
+# Returns 0 for a present, valid candidate; 1 when absent or empty; 2 when
+# present but malformed.  Parsed fields remain in the fixed parser globals.
+_validate_rotation_candidate_context() {
+    local LC_ALL=C
+    local registry="${1:-}" owner="${2:-}"
+    local candidate_rc=0
+    local candidate_ref candidate_repository candidate_digest expected_repository
+
+    _parse_rotation_candidate_ref || candidate_rc=$?
+    case "$candidate_rc" in
+        0) ;;
+        1) return 1 ;;
+        2)
+            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
+            return 2
+            ;;
+        *)
+            log_error "ROTATION_CANDIDATE_REF could not be parsed"
+            return 2
+            ;;
+    esac
+
+    # Definedness matters: a set-empty suffix is invalid just like every other
+    # explicit suffix request.  Check it before a matching candidate can return.
+    if [[ -n "${EXTENSION_PACKAGE_SUFFIX+x}" ]]; then
+        log_error "ROTATION_CANDIDATE_REF cannot be consumed while EXTENSION_PACKAGE_SUFFIX is set"
         return 2
     fi
 
-    _rotation_candidate_ref_extension="${BASH_REMATCH[1]}"
-    _rotation_candidate_ref_pg_major="${BASH_REMATCH[2]}"
-    _rotation_candidate_ref_version="${BASH_REMATCH[3]}"
-    _rotation_candidate_ref_value="$candidate_ref"
+    candidate_ref="$_rotation_candidate_ref_value"
+    if ! [[ "$candidate_ref" =~ ^(.+)@([^@]+)$ ]]; then
+        log_error "ROTATION_CANDIDATE_REF must contain one pinned repository@sha256 digest reference"
+        return 2
+    fi
+    candidate_repository="${BASH_REMATCH[1]}"
+    candidate_digest="${BASH_REMATCH[2]}"
+    if ! is_valid_oci_digest "$candidate_digest"; then
+        log_error "ROTATION_CANDIDATE_REF must contain a valid pinned sha256 digest"
+        return 2
+    fi
+
+    # This literal must stay equal to scripts/rotation-promote.sh:275: the
+    # package tested by this consumer is the package that promotion promotes.
+    expected_repository="${registry}/${owner}/ext-${_rotation_candidate_ref_extension}-staging"
+    if [[ "$candidate_repository" != "$expected_repository" ]]; then
+        log_error "ROTATION_CANDIDATE_REF repository must be this invocation's staging package"
+        return 2
+    fi
     return 0
 }
 
@@ -872,8 +937,7 @@ ext_consumed_source_ref() {
     local LC_ALL=C
     local candidate_rc=0
     local candidate_ref candidate_extension candidate_pg_major candidate_version
-    local candidate_repository candidate_digest candidate_suffix expected_repository
-    local repository candidate_prefix
+    local repository
 
     if [[ -z "$extension" || -z "$version" || -z "$pg_major" || -z "$registry" || -z "$owner" || -z "$mode" ]]; then
         log_error "ext_consumed_source_ref: extension, version, pg_major, registry, owner, and mode are required"
@@ -892,69 +956,19 @@ ext_consumed_source_ref() {
 
     # A requested frozen candidate must be completely understood before any
     # fallback can run; otherwise a malformed rotation could test canonical bytes.
-    _parse_rotation_candidate_ref || candidate_rc=$?
+    _validate_rotation_candidate_context "$registry" "$owner" || candidate_rc=$?
     case "$candidate_rc" in
         0)
             candidate_extension="$_rotation_candidate_ref_extension"
             candidate_pg_major="$_rotation_candidate_ref_pg_major"
             candidate_version="$_rotation_candidate_ref_version"
             candidate_ref="$_rotation_candidate_ref_value"
-
-            # The producer uses this package axis to write a staging package. A
-            # consumer with a frozen candidate must not inherit it: its
-            # non-candidate versions would otherwise be redirected to that
-            # staging package.
-            if [[ -n "${EXTENSION_PACKAGE_SUFFIX+x}" && -n "$EXTENSION_PACKAGE_SUFFIX" ]]; then
-                log_error "ROTATION_CANDIDATE_REF cannot be consumed while EXTENSION_PACKAGE_SUFFIX is set"
-                return 2
-            fi
             ;;
         1) ;;
-        2)
-            log_error "ROTATION_CANDIDATE_REF must match <extension>:<pg_major>:<version>=<repository>@<digest>"
-            return 2
-            ;;
-        *)
-            log_error "ROTATION_CANDIDATE_REF could not be parsed"
-            return 2
-            ;;
+        *) return 2 ;;
     esac
 
     if [[ "$candidate_rc" -eq 0 ]]; then
-        if ! [[ "$candidate_ref" =~ ^(.+)@([^@]+)$ ]]; then
-            log_error "ROTATION_CANDIDATE_REF must contain one pinned repository@sha256 digest reference"
-            return 2
-        fi
-        candidate_repository="${BASH_REMATCH[1]}"
-        candidate_digest="${BASH_REMATCH[2]}"
-        if ! is_valid_oci_digest "$candidate_digest"; then
-            log_error "ROTATION_CANDIDATE_REF must contain a valid pinned sha256 digest"
-            return 2
-        fi
-
-        candidate_prefix="${registry}/${owner}/ext-${candidate_extension}"
-        case "$candidate_repository" in
-            "$candidate_prefix"-*) candidate_suffix="${candidate_repository#"$candidate_prefix"}" ;;
-            *)
-                log_error "ROTATION_CANDIDATE_REF repository must be a suffixed package belonging to this invocation's registry, owner, and extension"
-                return 2
-                ;;
-        esac
-
-        # A suffixed package prevents a rotation from testing bytes already in
-        # the canonical package. It does not establish that the suffix belongs
-        # to this rotation: an arbitrary ext-<name>-something is still accepted
-        # from the actor who supplies the workflow candidate.
-        if ! EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" validate_extension_package_suffix; then
-            log_error "ROTATION_CANDIDATE_REF repository has an invalid package suffix"
-            return 2
-        fi
-        expected_repository=$(EXTENSION_PACKAGE_SUFFIX="$candidate_suffix" ext_image_repository "$candidate_extension" "$registry" "$owner") || return 2
-        if [[ "$candidate_repository" != "$expected_repository" ]]; then
-            log_error "ROTATION_CANDIDATE_REF repository does not match the frozen candidate package"
-            return 2
-        fi
-
         if [[ "$extension" == "$candidate_extension" && "$pg_major" == "$candidate_pg_major" && "$version" == "$candidate_version" ]]; then
             printf '%s' "$candidate_ref"
             return 0
@@ -1311,6 +1325,26 @@ generate_dockerfile() {
         export FORCE=true
     fi
 
+    # Validate frozen rotation context once for every render, including a base
+    # flavor that has no compiled extensions and therefore never reaches the
+    # consumed-source gateway below.
+    local candidate_rc=0
+    local candidate_ref candidate_extension candidate_pg_major candidate_version
+    _validate_rotation_candidate_context "$registry" "$owner" || candidate_rc=$?
+    case "$candidate_rc" in
+        0)
+            candidate_extension="$_rotation_candidate_ref_extension"
+            candidate_pg_major="$_rotation_candidate_ref_pg_major"
+            candidate_version="$_rotation_candidate_ref_version"
+            candidate_ref="$_rotation_candidate_ref_value"
+            ;;
+        1) ;;
+        *)
+            log_error "generate_dockerfile: ROTATION_CANDIDATE_REF is malformed — fail closed"
+            return 1
+            ;;
+    esac
+
     # Get filtered extension list for this flavor + PG version
     local extensions
     if ! extensions=$(get_flavor_extensions "$config_file" "$flavor" "$pg_major"); then
@@ -1353,34 +1387,13 @@ generate_dockerfile() {
     local stages_block=""
     local copies_block=""
     local all_runtime_deps=""
-    local candidate_rc=0
-    local candidate_ref candidate_extension candidate_pg_major
     local candidate_applies=false
 
-    # The source gateway validates every candidate it reaches.  This render
-    # scope check covers the distinct valid-but-unconsumed case: only a
-    # candidate naming an extension emitted by this flavor and this PG major is
-    # required to appear in the assembled stage text.
-    _parse_rotation_candidate_ref || candidate_rc=$?
-    case "$candidate_rc" in
-        0)
-            candidate_extension="$_rotation_candidate_ref_extension"
-            candidate_pg_major="$_rotation_candidate_ref_pg_major"
-            candidate_ref="$_rotation_candidate_ref_value"
-            if [[ "$candidate_pg_major" == "$pg_major" ]] && grep -Fxq -- "$candidate_extension" <<< "$extensions"; then
-                candidate_applies=true
-            fi
-            ;;
-        1) ;;
-        2)
-            log_error "generate_dockerfile: ROTATION_CANDIDATE_REF is malformed — fail closed"
-            return 1
-            ;;
-        *)
-            log_error "generate_dockerfile: ROTATION_CANDIDATE_REF could not be parsed — fail closed"
-            return 1
-            ;;
-    esac
+    # A candidate naming an extension emitted by this flavor and PG major must
+    # replace that tuple's source reference in the stages about to be emitted.
+    if [[ "$candidate_rc" -eq 0 ]] && [[ "$candidate_pg_major" == "$pg_major" ]] && grep -Fxq -- "$candidate_extension" <<< "$extensions"; then
+        candidate_applies=true
+    fi
 
     if [[ -n "$extensions" ]]; then
         while IFS= read -r ext_name; do
@@ -1844,11 +1857,18 @@ generate_dockerfile() {
     fi
 
     # Decide from the exact stage text about to be emitted, not from an
-    # intention flag updated inside command substitutions. A candidate scoped
-    # to this render must have replaced one emitted source reference.
-    if [[ "$candidate_applies" == "true" ]] && ! grep -Fq -- "$candidate_ref" <<< "$stages_block"; then
-        log_error "generate_dockerfile: rotation candidate '$ROTATION_CANDIDATE_REF' was not consumed for ${candidate_extension} pg${pg_major} — fail closed"
-        return 1
+    # intention flag updated inside command substitutions.  A whole source-line
+    # match proves this candidate tuple consumed the reference: the collector
+    # path pins its version in the destination path and the single-version path
+    # pins its extension in the stage alias.
+    if [[ "$candidate_applies" == "true" ]]; then
+        local candidate_collector_line="COPY --from=${candidate_ref} /output/ /${candidate_version}/"
+        local candidate_stage_line="FROM ${candidate_ref} AS ext-${candidate_extension}"
+        if ! grep -Fxq -- "$candidate_collector_line" <<< "$stages_block" &&
+            ! grep -Fxq -- "$candidate_stage_line" <<< "$stages_block"; then
+            log_error "generate_dockerfile: rotation candidate '$ROTATION_CANDIDATE_REF' was not consumed for ${candidate_extension} pg${pg_major} — fail closed"
+            return 1
+        fi
     fi
 
     # Build runtime_deps block (deduplicated)

--- a/tests/unit/ext-consumed-source-ref.bats
+++ b/tests/unit/ext-consumed-source-ref.bats
@@ -1,0 +1,367 @@
+#!/usr/bin/env bats
+
+# The consumed-source gateway owns generated Dockerfile source references.  The
+# checks below cover its three modes plus the narrow frozen rotation selector.
+
+bats_require_minimum_version 1.5.0
+
+load "../test_helper"
+
+_source_extension_utils() {
+    # shellcheck disable=SC1091
+    source "$HELPERS_DIR/extension-utils.sh"
+}
+
+_digest() {
+    printf 'sha256:%064d' "${1:-0}"
+}
+
+# shellcheck disable=SC2317
+setup() {
+    setup_temp_dir
+    _source_extension_utils
+    get_registry() { printf 'ghcr.io'; }
+    get_repo_owner() { printf 'testowner'; }
+    unset ROTATION_CANDIDATE_REF EXTENSION_PACKAGE_SUFFIX PR_TAG_SUFFIX
+}
+
+teardown() {
+    unset ROTATION_CANDIDATE_REF EXTENSION_PACKAGE_SUFFIX PR_TAG_SUFFIX
+    teardown_temp_dir
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "matching frozen candidate wins pinned-digest, probe, and direct modes" {
+    local digest candidate
+    digest=$(_digest 42)
+    candidate="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export ROTATION_CANDIDATE_REF="$candidate"
+
+    ext_ref_resolve() { printf 'probe-must-not-run'; return 0; }
+
+    run ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner pinned-digest "$(_digest 1)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-pgvector-staging@${digest}" ]
+
+    run ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner probe
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-pgvector-staging@${digest}" ]
+
+    run ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-pgvector-staging@${digest}" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "non-matching frozen candidate keeps retained and other extensions canonical" {
+    local digest
+    digest=$(_digest 43)
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+
+    run ext_consumed_source_ref pgvector 0.8.1 18 ghcr.io testowner direct
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-pgvector:pg18-0.8.1" ]
+
+    run ext_consumed_source_ref postgis 0.8.2 18 ghcr.io testowner direct
+    [ "$status" -eq 0 ]
+    [ "$output" = "ghcr.io/testowner/ext-postgis:pg18-0.8.2" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "malformed frozen candidates fail closed without a source reference" {
+    local digest short_digest upper_digest invalid
+    digest=$(_digest 44)
+    short_digest="sha256:$(printf '%063d' 0)"
+    upper_digest="sha256:A$(printf '%063d' 0)"
+    local -a invalid=(
+        "pgvector:18:0.8.2"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${digest}=extra"
+        "pgvector:18:=ghcr.io/testowner/ext-pgvector@${digest}"
+        "pgvector:18abc:0.8.2=ghcr.io/testowner/ext-pgvector@${digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${short_digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${upper_digest}"
+        "pgvector:18:0.8.2=ghcr.io/not-testowner/ext-pgvector@${digest}"
+        "pgvector:18:0.8.2=registry.example/testowner/ext-pgvector@${digest}"
+    )
+
+    for invalid in "${invalid[@]}"; do
+        export ROTATION_CANDIDATE_REF="$invalid"
+        run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+        [ "$status" -eq 2 ]
+        [ -z "$output" ]
+    done
+}
+
+@test "pinned-digest rejects malformed digests rather than emitting a tag" {
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner pinned-digest "sha256:bad"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "caller registry and owner reach direct, pinned-digest, and probe modes" {
+    export EXTENSION_REGISTRY=environment.example
+    export GITHUB_REPOSITORY_OWNER=environment-owner
+    get_registry() { printf '%s' "$EXTENSION_REGISTRY"; }
+    get_repo_owner() { printf '%s' "$GITHUB_REPOSITORY_OWNER"; }
+
+    run ext_consumed_source_ref pgvector 0.8.2 18 custom.io customowner direct
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom.io/customowner/ext-pgvector:pg18-0.8.2" ]
+
+    local digest
+    digest=$(_digest 59)
+    run ext_consumed_source_ref pgvector 0.8.2 18 custom.io customowner pinned-digest "$digest"
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom.io/customowner/ext-pgvector@${digest}" ]
+
+    # ext_ref_resolve derives its identity internally, so probe proves the
+    # gateway's one temporary environment forwarding point.
+    _image_registry_probe_3state() { return 0; }
+    run ext_consumed_source_ref pgvector 0.8.2 18 custom.io customowner probe
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom.io/customowner/ext-pgvector:pg18-0.8.2" ]
+}
+
+@test "empty registry or owner is refused without a source reference" {
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 "" customowner direct
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 custom.io "" direct
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "generated direct path stays unprobed and the frozen candidate preserves COPY count" {
+    mkdir -p "$TEST_TEMP_DIR/extensions"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    priority: 1
+    initdb:
+      mode: create
+flavors:
+  vector:
+    - pgvector
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    export ROOT_DIR="$TEST_TEMP_DIR"
+    export EXT_CONSUMED_PROBE_LOG="$TEST_TEMP_DIR/probe.log"
+    : > "$EXT_CONSUMED_PROBE_LOG"
+    # shellcheck disable=SC2317
+    _image_registry_probe_3state() { printf '%s\n' "$1" >> "$EXT_CONSUMED_PROBE_LOG"; return 0; }
+
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    local canonical_output="$output"
+    [ ! -s "$EXT_CONSUMED_PROBE_LOG" ]
+    [[ "$canonical_output" == *"FROM ghcr.io/testowner/ext-pgvector:pg18-0.8.2 AS ext-pgvector"* ]]
+
+    local digest candidate canonical_copy_count candidate_copy_count
+    digest=$(_digest 45)
+    candidate="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export ROTATION_CANDIDATE_REF="$candidate"
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FROM ghcr.io/testowner/ext-pgvector-staging@${digest} AS ext-pgvector"* ]]
+    canonical_copy_count=$(grep -c '^COPY --from=' <<<"$canonical_output" || true)
+    candidate_copy_count=$(grep -c '^COPY --from=' <<<"$output" || true)
+    [ "$candidate_copy_count" -eq "$canonical_copy_count" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "generated collector keeps an older retained version canonical beside the frozen candidate" {
+    mkdir -p "$TEST_TEMP_DIR/extensions" "$TEST_TEMP_DIR/.build-lineage"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  timescaledb:
+    version: "2.27.1"
+    repo: "timescale/timescaledb"
+    priority: 1
+    initdb:
+      mode: create
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+flavors:
+  timeseries:
+    - timescaledb
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    local older_digest ceiling_digest frozen_digest
+    older_digest=$(_digest 51)
+    ceiling_digest=$(_digest 52)
+    frozen_digest=$(_digest 53)
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<EOF
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[],"version_digests":{"2.25.0":"${older_digest}","2.27.1":"${ceiling_digest}"}}
+EOF
+    export ROOT_DIR="$TEST_TEMP_DIR"
+
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" timeseries 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    local canonical_output="$output"
+    [[ "$canonical_output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb@${older_digest} /output/ /2.25.0/"* ]]
+    [[ "$canonical_output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb@${ceiling_digest} /output/ /2.27.1/"* ]]
+
+    export ROTATION_CANDIDATE_REF="timescaledb:18:2.27.1=ghcr.io/testowner/ext-timescaledb-staging@${frozen_digest}"
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" timeseries 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb@${older_digest} /output/ /2.25.0/"* ]]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb-staging@${frozen_digest} /output/ /2.27.1/"* ]]
+    [ "$(grep -c '^COPY --from=' <<<"$output" || true)" -eq "$(grep -c '^COPY --from=' <<<"$canonical_output" || true)" ]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "generated self-heal collector routes its probe map through the frozen candidate" {
+    mkdir -p "$TEST_TEMP_DIR/extensions" "$TEST_TEMP_DIR/.build-lineage"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  timescaledb:
+    version: "2.27.1"
+    repo: "timescale/timescaledb"
+    priority: 1
+    initdb:
+      mode: create
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+flavors:
+  timeseries:
+    - timescaledb
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    export ROOT_DIR="$TEST_TEMP_DIR"
+    resolve_version_set() { printf '["2.25.0","2.27.1"]'; }
+    # shellcheck disable=SC2317
+    _image_registry_probe_3state() { return 0; }
+    local frozen_digest
+    frozen_digest=$(_digest 54)
+    export ROTATION_CANDIDATE_REF="timescaledb:18:2.27.1=ghcr.io/testowner/ext-timescaledb-staging@${frozen_digest}"
+
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" timeseries 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/"* ]]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb-staging@${frozen_digest} /output/ /2.27.1/"* ]]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "generated tag-only collector and both single-version modes honor the frozen candidate" {
+    mkdir -p "$TEST_TEMP_DIR/extensions" "$TEST_TEMP_DIR/.build-lineage"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  timescaledb:
+    version: "2.27.1"
+    repo: "timescale/timescaledb"
+    priority: 1
+    initdb:
+      mode: create
+    version_set:
+      resolver: "scripts/resolvers/timescaledb-ha.sh"
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    priority: 2
+    initdb:
+      mode: create
+flavors:
+  timeseries:
+    - timescaledb
+  vector:
+    - pgvector
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<'EOF'
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.25.0","2.27.1"],"available":["2.25.0","2.27.1"],"excluded":[]}
+EOF
+    export ROOT_DIR="$TEST_TEMP_DIR"
+    local tag_digest pinned_digest probe_digest
+    tag_digest=$(_digest 55)
+    pinned_digest=$(_digest 56)
+    probe_digest=$(_digest 57)
+
+    export ROTATION_CANDIDATE_REF="timescaledb:18:2.27.1=ghcr.io/testowner/ext-timescaledb-staging@${tag_digest}"
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" timeseries 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb:pg18-2.25.0 /output/ /2.25.0/"* ]]
+    [[ "$output" == *"COPY --from=ghcr.io/testowner/ext-timescaledb-staging@${tag_digest} /output/ /2.27.1/"* ]]
+
+    cat > "$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg18-versionset.json" <<EOF
+{"ext":"timescaledb","pg_major":"18","ceiling":"2.27.1","resolved":["2.27.1"],"available":["2.27.1"],"excluded":[],"version_digests":{"2.27.1":"$(_digest 58)"}}
+EOF
+    export ROTATION_CANDIDATE_REF="timescaledb:18:2.27.1=ghcr.io/testowner/ext-timescaledb-staging@${pinned_digest}"
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" timeseries 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FROM ghcr.io/testowner/ext-timescaledb-staging@${pinned_digest} AS ext-timescaledb"* ]]
+
+    export PR_TAG_SUFFIX=-pr42
+    # shellcheck disable=SC2317
+    _image_registry_probe_3state() { return 0; }
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${probe_digest}"
+    run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FROM ghcr.io/testowner/ext-pgvector-staging@${probe_digest} AS ext-pgvector"* ]]
+}
+
+@test "generate_dockerfile has no consumed-reference bypass" {
+    # This lint catches a newly added bypass; it is not proof that none exists.
+    # The sole ext_image_repository allowance compares artifact provenance; it
+    # does not emit a consumed reference.
+    local body non_provenance_body
+    body=$(awk '/^generate_dockerfile\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
+    non_provenance_body=$(awk '
+        /^[[:space:]]*#/ { next }
+        /_expected_digest_repository=\$\(ext_image_repository "\$ext_name" "\$registry" "\$owner"\) \|\| return 1/ { next }
+        { print }
+    ' <<<"$body")
+    if grep -Eq '(^|[^[:alnum:]_])(ext_image_name|ext_image_repository|ext_ref_resolve)[[:space:]]+' <<<"$non_provenance_body"; then
+        echo "generate_dockerfile bypasses ext_consumed_source_ref"
+        return 1
+    fi
+    if grep -Eq '"\$\{[^}]+\}@\$\{[^}]+\}"' <<<"$body"; then
+        echo "generate_dockerfile assembles a digest reference directly"
+        return 1
+    fi
+}

--- a/tests/unit/ext-consumed-source-ref.bats
+++ b/tests/unit/ext-consumed-source-ref.bats
@@ -30,6 +30,28 @@ teardown() {
     teardown_temp_dir
 }
 
+# shellcheck disable=SC2154 # shared parser output globals
+@test "rotation candidate parser distinguishes valid, absent, and malformed values" {
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@sha256:reference"
+    local parser_rc=0
+    _parse_rotation_candidate_ref || parser_rc=$?
+    [ "$parser_rc" -eq 0 ]
+    [ "$_rotation_candidate_ref_extension" = "pgvector" ]
+    [ "$_rotation_candidate_ref_pg_major" = "18" ]
+    [ "$_rotation_candidate_ref_version" = "0.8.2" ]
+    [ "$_rotation_candidate_ref_value" = "ghcr.io/testowner/ext-pgvector-staging@sha256:reference" ]
+
+    unset ROTATION_CANDIDATE_REF
+    parser_rc=0
+    _parse_rotation_candidate_ref || parser_rc=$?
+    [ "$parser_rc" -eq 1 ]
+
+    export ROTATION_CANDIDATE_REF="pgvector:18broken:0.8.2=reference"
+    parser_rc=0
+    _parse_rotation_candidate_ref || parser_rc=$?
+    [ "$parser_rc" -eq 2 ]
+}
+
 # shellcheck disable=SC2030,SC2031
 @test "matching frozen candidate wins pinned-digest, probe, and direct modes" {
     local digest candidate
@@ -50,6 +72,32 @@ teardown() {
     run ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
     [ "$status" -eq 0 ]
     [ "$output" = "ghcr.io/testowner/ext-pgvector-staging@${digest}" ]
+}
+
+@test "unsupported mode is refused before a matching frozen candidate" {
+    local digest
+    digest=$(_digest 41)
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner typo
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"unsupported mode 'typo'"* ]]
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "frozen candidate refuses an ambient package suffix" {
+    local digest
+    digest=$(_digest 42)
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export EXTENSION_PACKAGE_SUFFIX="-staging"
+
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"cannot be consumed while EXTENSION_PACKAGE_SUFFIX is set"* ]]
 }
 
 # shellcheck disable=SC2030,SC2031
@@ -81,6 +129,7 @@ teardown() {
         "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector"
         "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${short_digest}"
         "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${upper_digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${digest}"
         "pgvector:18:0.8.2=ghcr.io/not-testowner/ext-pgvector@${digest}"
         "pgvector:18:0.8.2=registry.example/testowner/ext-pgvector@${digest}"
     )
@@ -135,7 +184,7 @@ teardown() {
 }
 
 # shellcheck disable=SC2030,SC2031
-@test "generated direct path stays unprobed and the frozen candidate preserves COPY count" {
+@test "generated canonical direct path stays unprobed and the frozen candidate preserves COPY count" {
     mkdir -p "$TEST_TEMP_DIR/extensions"
     cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
 extensions:
@@ -145,9 +194,16 @@ extensions:
     priority: 1
     initdb:
       mode: create
+  postgis:
+    version: "3.5.1"
+    repo: "postgis/postgis"
+    priority: 2
+    initdb:
+      mode: create
 flavors:
   vector:
     - pgvector
+    - postgis
 EOF
     cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
 ARG VERSION
@@ -179,9 +235,31 @@ EOF
     run generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
     [ "$status" -eq 0 ]
     [[ "$output" == *"FROM ghcr.io/testowner/ext-pgvector-staging@${digest} AS ext-pgvector"* ]]
+    [ "$(grep -Foc -- "ghcr.io/testowner/ext-pgvector-staging@${digest}" <<<"$output" || true)" -eq 1 ]
+    [[ "$output" != *"ghcr.io/testowner/ext-pgvector:pg18-0.8.2"* ]]
+    [[ "$output" == *"FROM ghcr.io/testowner/ext-postgis:pg18-3.5.1 AS ext-postgis"* ]]
     canonical_copy_count=$(grep -c '^COPY --from=' <<<"$canonical_output" || true)
     candidate_copy_count=$(grep -c '^COPY --from=' <<<"$output" || true)
     [ "$candidate_copy_count" -eq "$canonical_copy_count" ]
+
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.1=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    run --separate-stderr generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"rotation candidate 'pgvector:18:0.8.1="*"was not consumed"* ]]
+
+    export ROTATION_CANDIDATE_REF="pgvector:18broken:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    # Isolate the render guard from the gateway's separate fail-closed check:
+    # if the render treats parser rc 2 as absent, this canonical source would
+    # otherwise let it assemble a Dockerfile.
+    # shellcheck disable=SC2317
+    ext_consumed_source_ref() { printf 'ghcr.io/testowner/ext-%s:pg%s-%s' "$1" "$3" "$2"; }
+    run --separate-stderr generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"ROTATION_CANDIDATE_REF is malformed"* ]]
 }
 
 # shellcheck disable=SC2030,SC2031
@@ -345,8 +423,10 @@ EOF
     [[ "$output" == *"FROM ghcr.io/testowner/ext-pgvector-staging@${probe_digest} AS ext-pgvector"* ]]
 }
 
-@test "generate_dockerfile has no consumed-reference bypass" {
-    # This lint catches a newly added bypass; it is not proof that none exists.
+@test "lint detects direct consumed-reference constructors in generate_dockerfile" {
+    # This is a lint, not behavioral proof. It cannot detect a bypass written as
+    # either `printf -v _art_ref '%s@%s' "$repository" "$digest"` or
+    # `_art_ref="$repository@$digest"`; those are the known gap.
     # The sole ext_image_repository allowance compares artifact provenance; it
     # does not emit a consumed reference.
     local body non_provenance_body
@@ -362,6 +442,20 @@ EOF
     fi
     if grep -Eq '"\$\{[^}]+\}@\$\{[^}]+\}"' <<<"$body"; then
         echo "generate_dockerfile assembles a digest reference directly"
+        return 1
+    fi
+}
+
+@test "lint keeps ROTATION_CANDIDATE_REF triple parsing in its shared helper" {
+    local parser_body gateway_body render_body triple_pattern
+    triple_pattern='^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$'
+    parser_body=$(awk '/^_parse_rotation_candidate_ref\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
+    gateway_body=$(awk '/^ext_consumed_source_ref\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
+    render_body=$(awk '/^generate_dockerfile\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
+
+    grep -Fq -- "$triple_pattern" <<<"$parser_body"
+    if grep -Fq -- "$triple_pattern" <<<"$gateway_body" || grep -Fq -- "$triple_pattern" <<<"$render_body"; then
+        echo "ROTATION_CANDIDATE_REF triple parsing must stay in _parse_rotation_candidate_ref"
         return 1
     fi
 }

--- a/tests/unit/ext-consumed-source-ref.bats
+++ b/tests/unit/ext-consumed-source-ref.bats
@@ -142,6 +142,149 @@ teardown() {
     done
 }
 
+@test "rotation candidate accepts only the staging package promotion promotes" {
+    local digest invalid
+    digest=$(_digest 46)
+    local -a invalid=(
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-old@${digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-rotation42@${digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector@${digest}"
+        "pgvector:18:0.8.2=ghcr.io/testowner/ext-postgis-staging@${digest}"
+    )
+
+    for invalid in "${invalid[@]}"; do
+        export ROTATION_CANDIDATE_REF="$invalid"
+        run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+        [ "$status" -eq 2 ]
+        [ -z "$output" ]
+        # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+        [[ "$stderr" == *"staging package"* ]]
+    done
+}
+
+@test "rotation selector uses promotion's extension pg-major and version grammars" {
+    local digest invalid parser_rc=0
+    digest=$(_digest 47)
+    local -a invalid=(
+        "pgvector:018:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+        "pgvector:0:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+        "Pgvector:18:0.8.2=ghcr.io/testowner/ext-Pgvector-staging@${digest}"
+        "_pgvector:18:0.8.2=ghcr.io/testowner/ext-_pgvector-staging@${digest}"
+        "pgvector:18:0.8. 2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+        $'pgvector:18:0.8.2\nbad=ghcr.io/testowner/ext-pgvector-staging@'"${digest}"
+        "pgvector:18:0.8/2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    )
+
+    for invalid in "${invalid[@]}"; do
+        export ROTATION_CANDIDATE_REF="$invalid"
+        parser_rc=0
+        _parse_rotation_candidate_ref || parser_rc=$?
+        [ "$parser_rc" -eq 2 ]
+        run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+        [ "$status" -eq 2 ]
+        [ -z "$output" ]
+    done
+}
+
+# shellcheck disable=SC2030,SC2031
+@test "base flavor refuses any defined package suffix with a rotation candidate" {
+    mkdir -p "$TEST_TEMP_DIR/extensions"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions: {}
+flavors:
+  base: []
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    local digest
+    digest=$(_digest 48)
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export EXTENSION_PACKAGE_SUFFIX="-staging"
+
+    run --separate-stderr generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" base 18 ghcr.io testowner
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"EXTENSION_PACKAGE_SUFFIX is set"* ]]
+}
+
+@test "set-empty package suffix is refused before a matching candidate returns" {
+    local digest
+    digest=$(_digest 49)
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export EXTENSION_PACKAGE_SUFFIX=""
+
+    run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner direct
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"EXTENSION_PACKAGE_SUFFIX is set"* ]]
+}
+
+# shellcheck disable=SC2030,SC2031,SC2317
+@test "a sibling stage containing candidate bytes does not prove candidate consumption" {
+    mkdir -p "$TEST_TEMP_DIR/extensions"
+    cat > "$TEST_TEMP_DIR/extensions/config.yaml" <<'EOF'
+extensions:
+  pgvector:
+    version: "0.8.2"
+    repo: "pgvector/pgvector"
+    priority: 1
+    initdb:
+      mode: create
+  postgis:
+    version: "3.5.1"
+    repo: "postgis/postgis"
+    priority: 2
+    initdb:
+      mode: create
+flavors:
+  vector:
+    - pgvector
+    - postgis
+EOF
+    cat > "$TEST_TEMP_DIR/Dockerfile.template" <<'EOF'
+ARG VERSION
+# @@EXTENSION_STAGES@@
+FROM postgres:${VERSION}
+# @@FLAVOR_ARG@@
+# @@EXTENSION_COPIES@@
+# @@EXTENSION_INSTALLS@@
+# @@BUILTIN_INITDB@@
+# @@FLAVOR_INITDB@@
+# @@RUNTIME_DEPS@@
+EOF
+    local digest candidate_ref
+    digest=$(_digest 50)
+    candidate_ref="ghcr.io/testowner/ext-pgvector-staging@${digest}"
+    export ROTATION_CANDIDATE_REF="pgvector:18:0.8.2=${candidate_ref}"
+
+    # Model a wrong gateway result: only the sibling stage contains candidate
+    # bytes.  A substring proof would accept it; the tuple-line proof must not.
+    ext_consumed_source_ref() {
+        if [[ "$1" == "postgis" ]]; then
+            printf '%s' "$candidate_ref"
+        else
+            printf 'ghcr.io/testowner/ext-%s:pg%s-%s' "$1" "$3" "$2"
+        fi
+    }
+
+    run --separate-stderr generate_dockerfile "$TEST_TEMP_DIR/extensions/config.yaml" "$TEST_TEMP_DIR/Dockerfile.template" vector 18 ghcr.io testowner
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # shellcheck disable=SC2154 # Bats --separate-stderr result variable
+    [[ "$stderr" == *"was not consumed"* ]]
+}
+
 @test "pinned-digest rejects malformed digests rather than emitting a tag" {
     run --separate-stderr ext_consumed_source_ref pgvector 0.8.2 18 ghcr.io testowner pinned-digest "sha256:bad"
     [ "$status" -eq 1 ]
@@ -446,16 +589,22 @@ EOF
     fi
 }
 
-@test "lint keeps ROTATION_CANDIDATE_REF triple parsing in its shared helper" {
-    local parser_body gateway_body render_body triple_pattern
-    triple_pattern='^([A-Za-z0-9_-]+):([0-9]+):([^:=]+)$'
+@test "lint keeps promotion selector grammars in the shared parser" {
+    local parser_body gateway_body render_body extension_pattern pg_major_pattern version_pattern
+    extension_pattern='^[a-z0-9]+([._-][a-z0-9]+)*$'
+    pg_major_pattern='^[1-9][0-9]*$'
+    version_pattern='^[A-Za-z0-9][A-Za-z0-9_.-]*$'
     parser_body=$(awk '/^_parse_rotation_candidate_ref\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
     gateway_body=$(awk '/^ext_consumed_source_ref\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
     render_body=$(awk '/^generate_dockerfile\(\) \{/{inside=1} inside {print} /^}$/ && inside {exit}' "$HELPERS_DIR/extension-utils.sh")
 
-    grep -Fq -- "$triple_pattern" <<<"$parser_body"
-    if grep -Fq -- "$triple_pattern" <<<"$gateway_body" || grep -Fq -- "$triple_pattern" <<<"$render_body"; then
-        echo "ROTATION_CANDIDATE_REF triple parsing must stay in _parse_rotation_candidate_ref"
+    grep -Fq -- "$extension_pattern" <<<"$parser_body"
+    grep -Fq -- "$pg_major_pattern" <<<"$parser_body"
+    grep -Fq -- "$version_pattern" <<<"$parser_body"
+    if grep -Fq -- "$extension_pattern" <<<"$gateway_body" || grep -Fq -- "$extension_pattern" <<<"$render_body" ||
+        grep -Fq -- "$pg_major_pattern" <<<"$gateway_body" || grep -Fq -- "$pg_major_pattern" <<<"$render_body" ||
+        grep -Fq -- "$version_pattern" <<<"$gateway_body" || grep -Fq -- "$version_pattern" <<<"$render_body"; then
+        echo "ROTATION_CANDIDATE_REF promotion grammars must stay in _parse_rotation_candidate_ref"
         return 1
     fi
 }


### PR DESCRIPTION
A generated postgres Dockerfile built its extension source references at six places, three
of which never went through `ext_ref_resolve`. There was nowhere to say "this one extension
version comes from this exact manifest digest" while every other stage — including retained
older versions of that same extension — stays canonical, which is what the scheduled
rotation in #1245 needs before it can test a freshly compiled candidate.

`ext_consumed_source_ref` is now the only function `generate_dockerfile` uses to obtain a
consumed reference. It reads `ROTATION_CANDIDATE_REF` in the form
`<extension>:<pg_major>:<version>=<registry>/<owner>/ext-<extension>-staging@sha256:<64 hex>`
and refuses rather than falls back:

- the repository must be exactly the staging package `scripts/rotation-promote.sh:275`
  builds, so the bytes tested are the bytes promoted;
- the three field grammars are the ones promotion applies, so a value promotion would reject
  is malformed here instead of parsing as a candidate that matches nothing;
- a valid candidate naming an extension and major this render emits must appear in the
  emitted stages, matched on the whole `COPY --from=… /output/ /<version>/` or
  `FROM … AS ext-<extension>` line, or the render fails;
- a candidate and a defined `EXTENSION_PACKAGE_SUFFIX` are refused together, validated once
  per render so a flavour with no compiled extensions is covered too.

Existing behaviour is preserved where it differs: the push/dispatch single-version path
still emits its reference without a registry probe, and every mode carries the caller's
registry and owner, which `tests/unit/generate-dockerfile-versionset.bats:707` locks.

## Verification

`git ls-files 'tests/unit/*.bats' | xargs bats -j 8` — 2737 collected, 0 failed.
`shellcheck -S warning` clean on both changed files.

Each refusal above was shown failing under a mutation with
`~/.claude/scripts/mutation-proof.sh`, and the candidate acceptance was probed directly:
`-old`, a bare canonical repository, another extension's staging package, a zero-padded
major, major `0`, an uppercase extension name and a version containing a slash are each
refused; only the staging package for the named extension is accepted.

The two container-backed suites that fail on this host (`running as root without
ALLOW_ROOT`, and the openresty PCRE2 pair under `-j 8`) fail the same way on `master`.

## Follow-ups

Filed rather than folded in: #1344 #1345 #1346 #1347 #1348 #1349. #1346 and #1347 are
pre-existing on `master`.

Part of #1245; the rotation workflow that sets `ROTATION_CANDIDATE_REF` follows separately.
