### PR TITLE
Recompile and retest one extension pair on a schedule

### DIFF
--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -96,6 +96,24 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate push input
+      shell: bash
+      env:
+        PUSH: ${{ inputs.push }}
+      run: |
+        set -euo pipefail
+        case "$PUSH" in
+          true|false) ;;
+          *)
+            # Use the repository's workflow-command escaper before logging an
+            # arbitrary caller value.
+            source ./helpers/logging.sh
+            safe_push=$(_escape_gha_command "$PUSH")
+            printf '::error::Invalid push input %s; expected true or false\n' "$safe_push" >&2
+            exit 1
+            ;;
+        esac
+
     - name: Log in to GitHub Container Registry
       if: runner.os != 'Windows'
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/actions/build-container/action.yaml
+++ b/.github/actions/build-container/action.yaml
@@ -53,6 +53,10 @@ inputs:
     description: Enable Trivy vulnerability scanning (true/false)
     required: false
     default: 'true'
+  push:
+    description: Whether to publish the built image. 'false' builds and loads only.
+    required: false
+    default: 'true'
   vulnerability_severity:
     description: 'Severities surfaced in SARIF + dashboard (advisory). Build is never blocked — Trivy runs continue-on-error.'
     required: false
@@ -711,7 +715,7 @@ runs:
     # GHCR Push - PRIMARY REGISTRY (required)
     # Push the already-built image with platform suffix for multi-arch manifest creation
     - name: Push to GHCR (primary)
-      if: ${{ steps.build.outputs.image_loaded == 'true' && github.event_name != 'pull_request' }}
+      if: ${{ steps.build.outputs.image_loaded == 'true' && inputs.push == 'true' && github.event_name != 'pull_request' }}
       id: push-ghcr
       shell: bash
       run: |
@@ -748,7 +752,7 @@ runs:
     # Docker Hub Push - SECONDARY REGISTRY (optional, can fail)
     # Tag and push the already-built image with platform suffix
     - name: Push to Docker Hub (secondary)
-      if: ${{ steps.build.outputs.image_loaded == 'true' && github.event_name != 'pull_request' && (steps.dockerhub-login.outcome == 'success' || steps.dockerhub-login-windows.outcome == 'success') }}
+      if: ${{ steps.build.outputs.image_loaded == 'true' && inputs.push == 'true' && github.event_name != 'pull_request' && (steps.dockerhub-login.outcome == 'success' || steps.dockerhub-login-windows.outcome == 'success') }}
       id: push-dockerhub
       shell: bash
       run: |
@@ -913,8 +917,12 @@ runs:
           fi
         fi
 
-    - name: Skip push for pull request
-      if: ${{ steps.build.outputs.image_loaded == 'true' && github.event_name == 'pull_request' }}
+    - name: Skip push for pull request or disabled publishing
+      if: ${{ steps.build.outputs.image_loaded == 'true' && (github.event_name == 'pull_request' || inputs.push != 'true') }}
       shell: bash
       run: |
-        echo "::notice::Skipping push (pull request - test build only)"
+        if [[ "${{ inputs.push }}" != "true" ]]; then
+          echo "::notice::Skipping push (push input is false - test build only)"
+        else
+          echo "::notice::Skipping push (pull request - test build only)"
+        fi

--- a/.github/workflows/rotation.yaml
+++ b/.github/workflows/rotation.yaml
@@ -5,7 +5,9 @@ name: Extension Rotation
 # avoids maintaining a second, weaker validation path.
 on:
   schedule:
-    - cron: '17 4 * * *'
+    - cron: '17 1 * * *'
+    - cron: '17 9 * * *'
+    - cron: '17 17 * * *'
   workflow_dispatch:
     inputs:
       extension:
@@ -79,6 +81,24 @@ jobs:
             exit 1
           fi
           if [[ "$supplied" -eq 2 ]]; then
+            [[ "$DISPATCH_EXTENSION" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || {
+              echo 'Invalid extension name' >&2
+              exit 1
+            }
+            [[ "$DISPATCH_MAJOR" =~ ^[0-9]+$ ]] || {
+              echo 'Invalid PostgreSQL major' >&2
+              exit 1
+            }
+            if ! yq -r '.pg_versions[]' postgres/extensions/config.yaml | grep -Fx -- "$DISPATCH_MAJOR" >/dev/null; then
+              echo "PostgreSQL major is not configured: $DISPATCH_MAJOR" >&2
+              exit 1
+            fi
+            source helpers/extension-utils.sh
+            full_extensions=$(get_flavor_extensions postgres/extensions/config.yaml full "$DISPATCH_MAJOR")
+            if ! printf '%s\n' "$full_extensions" | grep -Fx -- "$DISPATCH_EXTENSION" >/dev/null; then
+              echo "Extension is not in the full flavor for PostgreSQL $DISPATCH_MAJOR: $DISPATCH_EXTENSION" >&2
+              exit 1
+            fi
             version=$(DISPATCH_EXTENSION="$DISPATCH_EXTENSION" yq -er \
               '.extensions[strenv(DISPATCH_EXTENSION)].version' postgres/extensions/config.yaml)
             [[ "$version" =~ ^[0-9]+([.][0-9]+)*$ ]] || {
@@ -122,11 +142,10 @@ jobs:
           fi
 
       - name: Record no eligible pair
-        id: no-selection
         if: steps.select.outputs.selected != 'true'
         shell: bash
         run: |
-          printf 'selected=false\n' >> "$GITHUB_OUTPUT"
+          printf 'No eligible extension rotation pair was selected\n'
 
   build:
     needs: select
@@ -360,6 +379,13 @@ jobs:
           push: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fail attributable candidate image build result
+        if: steps.build-e2e-image.outcome == 'failure'
+        shell: bash
+        run: |
+          printf 'true\n' > rotation-artifacts/test-amd64
+          exit 1
+
       - name: Resolve loaded e2e image ID
         shell: bash
         env:
@@ -382,12 +408,7 @@ jobs:
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
-      - name: Fail attributable build or suite result
-        # build-container is production-oriented and attempts a post-build push
-        # on scheduled/dispatch events. This job intentionally has packages:read;
-        # a failed post-build push is harmless once the exact loaded image was
-        # resolved below. A missing image-ID remains infrastructure, not a pair
-        # quarantine signal; the suite verdict is the attributable test result.
+      - name: Fail attributable e2e suite result
         if: steps.e2e.outcome == 'failure'
         shell: bash
         run: |
@@ -442,6 +463,13 @@ jobs:
           push: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fail attributable candidate image build result
+        if: steps.build-e2e-image.outcome == 'failure'
+        shell: bash
+        run: |
+          printf 'true\n' > rotation-artifacts/test-arm64
+          exit 1
+
       - name: Resolve loaded e2e image ID
         shell: bash
         env:
@@ -464,9 +492,7 @@ jobs:
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
-      - name: Fail attributable build or suite result
-        # See the amd64 leg: packages:read makes build-container's post-build
-        # push advisory here once the loaded image has been resolved.
+      - name: Fail attributable e2e suite result
         if: steps.e2e.outcome == 'failure'
         shell: bash
         run: |
@@ -615,7 +641,6 @@ jobs:
           TEST_ARM64_RESULT: ${{ needs.test-arm64.result }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
           attributable=false
           expected_statuses=(build-amd64 build-arm64)
           if [[ "$TEST_AMD64_RESULT" == success || "$TEST_AMD64_RESULT" == failure ]]; then
@@ -677,13 +702,34 @@ jobs:
             printf -v line 'arm64 digest: %s\n' "$ARM64_DIGEST"
             body+="$line"
           fi
+          issues=$(gh issue list --repo "$REPOSITORY" --state open \
+            --label extension-rotation-blocked --json number,body --limit 1000)
+          jq -e 'type == "array" and length < 1000 and all(.[]; type == "object" and (.number | type == "number") and ((.body == null) or (.body | type == "string")))' \
+            >/dev/null <<< "$issues"
+          marker="rotation-pair: ${EXTENSION} pg${PG_MAJOR} ${VERSION}"
+          existing_issue=''
+          while IFS= read -r issue; do
+            issue_number=$(jq -er '.number' <<< "$issue")
+            while IFS= read -r line; do
+              line="${line%$'\r'}"
+              if [[ "$line" == "$marker" ]]; then
+                existing_issue="$issue_number"
+                break 2
+              fi
+            done < <(jq -r '.body // ""' <<< "$issue")
+          done < <(jq -c '.[]' <<< "$issues")
+          if [[ -n "$existing_issue" ]]; then
+            body+=$'\nA marker already existed immediately before quarantine creation; commented instead of creating a duplicate. This removes ordinary rerun duplicates and cannot remove a simultaneous external creator, since GitHub Issues has no uniqueness constraint.\n'
+            gh issue comment --repo "$REPOSITORY" "$existing_issue" --body "$body"
+            exit 0
+          fi
           gh issue create --repo "$REPOSITORY" \
             --title "Extension rotation blocked: ${EXTENSION} pg${PG_MAJOR} ${VERSION}" \
             --label extension-rotation-blocked --body "$body"
 
   cleanup-staging:
     needs: [select, promote, promote-dry-run]
-    if: always() && needs.select.outputs.selected == 'true' && needs.promote.result != 'failure'
+    if: always() && needs.select.outputs.selected == 'true' && needs.promote.result != 'failure' && needs.promote.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -702,11 +748,15 @@ jobs:
           set -euo pipefail
           failed=0
           for package in "ext-${EXTENSION}-staging" "ext-${EXTENSION}-staging-buildcache"; do
-            output=''
+            response=''
             rc=0
-            output=$(gh api --method DELETE "/users/${OWNER}/packages/container/${package}" 2>&1) || rc=$?
-            if [[ "$rc" -ne 0 && "$output" != *404* ]]; then
-              printf '%s\n' "$output" >&2
+            response=$(gh api --include --method DELETE "/users/${OWNER}/packages/container/${package}" 2>&1) || rc=$?
+            status=$(sed -nE 's#^HTTP/[0-9.]+ ([0-9]{3})( |$).*#\1#p' <<< "$response" | tail -n 1)
+            if [[ "$status" == 404 ]]; then
+              continue
+            fi
+            if [[ -z "$status" || "$rc" -ne 0 || ! "$status" =~ ^2[0-9]{2}$ ]]; then
+              printf '%s\n' "$response" >&2
               failed=1
             fi
           done

--- a/.github/workflows/rotation.yaml
+++ b/.github/workflows/rotation.yaml
@@ -9,15 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       extension:
-        description: Extension package component (set all three pair inputs to override selection)
+        description: Extension package component (set both pair inputs to override selection)
         required: false
         type: string
       pg_major:
-        description: PostgreSQL major (set all three pair inputs to override selection)
-        required: false
-        type: string
-      version:
-        description: Extension version (set all three pair inputs to override selection)
+        description: PostgreSQL major (set both pair inputs to override selection)
         required: false
         type: string
       dry_run:
@@ -53,13 +49,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Require the default branch
+        shell: bash
+        env:
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF" != "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            printf '::error::Extension rotation only runs on the default branch (%s); ref %s would not share the auto-build promotion lock\n' "$DEFAULT_BRANCH" "$REF"
+            exit 1
+          fi
+
       - name: Select rotation pair
         id: select
         shell: bash
         env:
           DISPATCH_EXTENSION: ${{ inputs.extension }}
           DISPATCH_MAJOR: ${{ inputs.pg_major }}
-          DISPATCH_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
         run: |
@@ -67,19 +74,22 @@ jobs:
           supplied=0
           [[ -n "$DISPATCH_EXTENSION" ]] && supplied=$((supplied + 1))
           [[ -n "$DISPATCH_MAJOR" ]] && supplied=$((supplied + 1))
-          [[ -n "$DISPATCH_VERSION" ]] && supplied=$((supplied + 1))
-          if [[ "$supplied" -ne 0 && "$supplied" -ne 3 ]]; then
-            echo 'All of extension, pg_major, and version must be supplied together' >&2
+          if [[ "$supplied" -ne 0 && "$supplied" -ne 2 ]]; then
+            echo 'Both extension and pg_major must be supplied together' >&2
             exit 1
           fi
-          if [[ "$supplied" -eq 3 ]]; then
-            # A maintainer-selected pair is an operator action. Do not let the
-            # selector's blocking marker override this explicit dispatch.
+          if [[ "$supplied" -eq 2 ]]; then
+            version=$(DISPATCH_EXTENSION="$DISPATCH_EXTENSION" yq -er \
+              '.extensions[strenv(DISPATCH_EXTENSION)].version' postgres/extensions/config.yaml)
+            [[ "$version" =~ ^[0-9]+([.][0-9]+)*$ ]] || {
+              echo "Configured extension version is invalid: $version" >&2
+              exit 1
+            }
             {
               printf 'selected=true\n'
               printf 'extension=%s\n' "$DISPATCH_EXTENSION"
               printf 'major=%s\n' "$DISPATCH_MAJOR"
-              printf 'version=%s\n' "$DISPATCH_VERSION"
+              printf 'version=%s\n' "$version"
             } >> "$GITHUB_OUTPUT"
           else
             scripts/rotation-select.sh
@@ -146,9 +156,11 @@ jobs:
 
       - name: Initialize failure attribution
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          mkdir -p .rotation
-          printf 'false\n' > .rotation/attributable
+          mkdir -p rotation-artifacts
+          printf 'false\n' > "rotation-artifacts/build-${ARCH}"
 
       - name: Install yq
         shell: bash
@@ -189,6 +201,29 @@ jobs:
         with:
           driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
 
+      - name: Recheck rotation block before compiling
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+        run: |
+          set -euo pipefail
+          issues=$(gh issue list --repo "$REPOSITORY" --state open \
+            --label extension-rotation-blocked --json number,body --limit 1000)
+          jq -e 'type == "array" and length < 1000 and all(.[]; type == "object" and (.number | type == "number") and ((.body == null) or (.body | type == "string")))' \
+            >/dev/null <<< "$issues"
+          marker="rotation-pair: ${EXTENSION} pg${PG_MAJOR} ${VERSION}"
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            if [[ "$line" == "$marker" ]]; then
+              printf '::error::Refusing to compile %s: an open extension-rotation-blocked issue now names this pair\n' "$marker"
+              exit 1
+            fi
+          done < <(jq -r '.[] | .body // ""' <<< "$issues")
+
       - name: Compile and push cacheless staging extension
         id: compile
         continue-on-error: true
@@ -198,7 +233,6 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           EXTENSION: ${{ needs.select.outputs.extension }}
           PG_MAJOR: ${{ needs.select.outputs.major }}
-          VERSION: ${{ needs.select.outputs.version }}
         run: |
           set -euo pipefail
           EXTENSION_PACKAGE_SUFFIX=-staging ARCH_SUFFIX="$ARCH" BUILD_PLATFORM="$PLATFORM" \
@@ -207,8 +241,10 @@ jobs:
       - name: Fail an attributable extension compile
         if: steps.compile.outcome == 'failure'
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          printf 'true\n' > .rotation/attributable
+          printf 'true\n' > "rotation-artifacts/build-${ARCH}"
           exit 1
 
       - name: Freeze and validate staging manifest digest
@@ -235,7 +271,7 @@ jobs:
           ' >/dev/null <<< "$raw"
           config=$(skopeo inspect --config "docker://${ref}")
           jq -e --arg arch "$ARCH" '.os == "linux" and .architecture == $arch' >/dev/null <<< "$config"
-          printf '%s\n' "$digest" > .rotation/digest
+          printf '%s\n' "$digest" > rotation-artifacts/digest
           printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload frozen staging digest
@@ -243,16 +279,16 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: rotation-digest-${{ matrix.arch }}
-          path: .rotation/digest
-          if-no-files-found: ignore
+          path: rotation-artifacts/digest
+          if-no-files-found: error
 
       - name: Upload build attribution
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: rotation-status-build-${{ matrix.arch }}
-          path: .rotation/attributable
-          if-no-files-found: ignore
+          path: rotation-artifacts/build-${{ matrix.arch }}
+          if-no-files-found: error
 
   freeze-digests:
     needs: [select, build]
@@ -269,7 +305,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: rotation-digest-*
-          path: .rotation/digests
+          path: rotation-artifacts/digests
 
       - name: Read frozen staging digests
         id: read
@@ -277,8 +313,8 @@ jobs:
         run: |
           set -euo pipefail
           export LC_ALL=C
-          amd64_digest=$(<.rotation/digests/rotation-digest-amd64/digest)
-          arm64_digest=$(<.rotation/digests/rotation-digest-arm64/digest)
+          amd64_digest=$(<rotation-artifacts/digests/rotation-digest-amd64/digest)
+          arm64_digest=$(<rotation-artifacts/digests/rotation-digest-arm64/digest)
           [[ "$amd64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
           [[ "$arm64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
           [[ "$amd64_digest" != "$arm64_digest" ]]
@@ -303,8 +339,8 @@ jobs:
       - name: Initialize failure attribution
         shell: bash
         run: |
-          mkdir -p .rotation
-          printf 'false\n' > .rotation/attributable
+          mkdir -p rotation-artifacts
+          printf 'false\n' > rotation-artifacts/test-amd64
 
       - name: Build loadable PostgreSQL full image
         id: build-e2e-image
@@ -338,6 +374,11 @@ jobs:
         id: e2e
         continue-on-error: true
         shell: bash
+        env:
+          E2E_BUILD_TAG: ${{ format('{0}-full-alpine', needs.select.outputs.major) }}
+          E2E_BUILD_VERSION: ${{ needs.select.outputs.major }}
+          E2E_BUILD_VARIANT: full
+          E2E_BUILD_FLAVOR: full
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
@@ -350,7 +391,7 @@ jobs:
         if: steps.e2e.outcome == 'failure'
         shell: bash
         run: |
-          printf 'true\n' > .rotation/attributable
+          printf 'true\n' > rotation-artifacts/test-amd64
           exit 1
 
       - name: Upload test attribution
@@ -358,8 +399,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: rotation-status-test-amd64
-          path: .rotation/attributable
-          if-no-files-found: ignore
+          path: rotation-artifacts/test-amd64
+          if-no-files-found: error
 
   test-arm64:
     needs: [select, freeze-digests]
@@ -380,8 +421,8 @@ jobs:
       - name: Initialize failure attribution
         shell: bash
         run: |
-          mkdir -p .rotation
-          printf 'false\n' > .rotation/attributable
+          mkdir -p rotation-artifacts
+          printf 'false\n' > rotation-artifacts/test-arm64
 
       - name: Build loadable PostgreSQL full image
         id: build-e2e-image
@@ -415,6 +456,11 @@ jobs:
         id: e2e
         continue-on-error: true
         shell: bash
+        env:
+          E2E_BUILD_TAG: ${{ format('{0}-full-alpine', needs.select.outputs.major) }}
+          E2E_BUILD_VERSION: ${{ needs.select.outputs.major }}
+          E2E_BUILD_VARIANT: full
+          E2E_BUILD_FLAVOR: full
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
@@ -424,7 +470,7 @@ jobs:
         if: steps.e2e.outcome == 'failure'
         shell: bash
         run: |
-          printf 'true\n' > .rotation/attributable
+          printf 'true\n' > rotation-artifacts/test-arm64
           exit 1
 
       - name: Upload test attribution
@@ -432,8 +478,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: rotation-status-test-arm64
-          path: .rotation/attributable
-          if-no-files-found: ignore
+          path: rotation-artifacts/test-arm64
+          if-no-files-found: error
 
   promote:
     needs: [select, build, freeze-digests, test-amd64, test-arm64]
@@ -558,22 +604,47 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: rotation-status-*
-          path: .rotation/status
+          path: rotation-artifacts/status
           merge-multiple: true
-        continue-on-error: true
 
       - name: Decide whether a failure is attributable
         id: attribution
         shell: bash
+        env:
+          TEST_AMD64_RESULT: ${{ needs.test-amd64.result }}
+          TEST_ARM64_RESULT: ${{ needs.test-arm64.result }}
         run: |
+          set -euo pipefail
           shopt -s nullglob
           attributable=false
-          for status_file in .rotation/status/*; do
-            if [[ $(<"$status_file") == true ]]; then
+          expected_statuses=(build-amd64 build-arm64)
+          if [[ "$TEST_AMD64_RESULT" == success || "$TEST_AMD64_RESULT" == failure ]]; then
+            expected_statuses+=(test-amd64)
+          fi
+          if [[ "$TEST_ARM64_RESULT" == success || "$TEST_ARM64_RESULT" == failure ]]; then
+            expected_statuses+=(test-arm64)
+          fi
+          failed_statuses=()
+          for status_name in "${expected_statuses[@]}"; do
+            status_file="rotation-artifacts/status/${status_name}"
+            if [[ ! -f "$status_file" ]]; then
+              printf '::error::Missing failure attribution from completed producer: %s\n' "$status_name" >&2
+              exit 1
+            fi
+            status=$(<"$status_file")
+            if [[ "$status" != true && "$status" != false ]]; then
+              printf '::error::Invalid failure attribution from %s: %s\n' "$status_name" "$status" >&2
+              exit 1
+            fi
+            if [[ "$status" == true ]]; then
               attributable=true
+              failed_statuses+=("$status_name")
             fi
           done
+          IFS=,
+          printf -v failed_statuses_csv '%s' "${failed_statuses[*]}"
           printf 'create=%s\n' "$attributable" >> "$GITHUB_OUTPUT"
+          printf 'failed_statuses=%s\n' "$failed_statuses_csv" >> "$GITHUB_OUTPUT"
 
       - name: Quarantine failing extension pair
         if: steps.attribution.outputs.create == 'true'
@@ -587,14 +658,24 @@ jobs:
           AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
           ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
           RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+          FAILED_STATUSES: ${{ steps.attribution.outputs.failed_statuses }}
         run: |
           set -euo pipefail
-          body=$(printf 'rotation-pair: %s pg%s %s\n\nFailed run: %s\n' "$EXTENSION" "$PG_MAJOR" "$VERSION" "$RUN_URL")
+          printf -v body 'rotation-pair: %s pg%s %s\n\nFailed run: %s\n' "$EXTENSION" "$PG_MAJOR" "$VERSION" "$RUN_URL"
+          IFS=, read -r -a failed_statuses <<< "$FAILED_STATUSES"
+          for status_name in "${failed_statuses[@]}"; do
+            phase="${status_name%%-*}"
+            arch="${status_name#*-}"
+            printf -v line 'Failed phase: %s; architecture: %s\n' "$phase" "$arch"
+            body+="$line"
+          done
           if [[ -n "$AMD64_DIGEST" ]]; then
-            body+=$(printf 'amd64 digest: %s\n' "$AMD64_DIGEST")
+            printf -v line 'amd64 digest: %s\n' "$AMD64_DIGEST"
+            body+="$line"
           fi
           if [[ -n "$ARM64_DIGEST" ]]; then
-            body+=$(printf 'arm64 digest: %s\n' "$ARM64_DIGEST")
+            printf -v line 'arm64 digest: %s\n' "$ARM64_DIGEST"
+            body+="$line"
           fi
           gh issue create --repo "$REPOSITORY" \
             --title "Extension rotation blocked: ${EXTENSION} pg${PG_MAJOR} ${VERSION}" \
@@ -602,16 +683,16 @@ jobs:
 
   cleanup-staging:
     needs: [select, promote, promote-dry-run]
-    if: always() && needs.select.outputs.selected == 'true'
+    if: always() && needs.select.outputs.selected == 'true' && needs.promote.result != 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - name: Delete staging packages
-        # Cleanup failure is not a failed rotation: staging is unreachable from
-        # production, so leave a visible cleanup error without quarantining it.
-        continue-on-error: true
+        # A deletion failure must remain visible in the workflow result. It is
+        # not attributable to the extension pair, so quarantine does not act on
+        # it, but a successful rotation cannot claim staging was cleaned up.
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -630,3 +711,27 @@ jobs:
             fi
           done
           exit "$failed"
+
+  retain-staging-after-promotion-failure:
+    needs: [select, promote, freeze-digests]
+    if: always() && needs.select.outputs.selected == 'true' && needs.promote.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Record retained staging packages
+        shell: bash
+        env:
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
+        run: |
+          set -euo pipefail
+          {
+            printf '## Staging packages retained after promotion failure\n\n'
+            printf -- "- \`ext-%s-staging\`\n" "$EXTENSION"
+            printf -- "- \`ext-%s-staging-buildcache\`\n\n" "$EXTENSION"
+            printf 'Retry inputs:\n\n'
+            printf -- "- amd64 digest: \`%s\`\n" "$AMD64_DIGEST"
+            printf -- "- arm64 digest: \`%s\`\n" "$ARM64_DIGEST"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rotation.yaml
+++ b/.github/workflows/rotation.yaml
@@ -1,0 +1,632 @@
+name: Extension Rotation
+
+# The arm64 leg deliberately runs the same full e2e harness as amd64. This is
+# stronger than the issue's originally proposed arm64 activation smoke and
+# avoids maintaining a second, weaker validation path.
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      extension:
+        description: Extension package component (set all three pair inputs to override selection)
+        required: false
+        type: string
+      pg_major:
+        description: PostgreSQL major (set all three pair inputs to override selection)
+        required: false
+        type: string
+      version:
+        description: Extension version (set all three pair inputs to override selection)
+        required: false
+        type: string
+      dry_run:
+        description: Render promotion commands without changing canonical tags
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: extension-rotation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      packages: read
+    outputs:
+      selected: ${{ steps.select.outputs.selected }}
+      extension: ${{ steps.select.outputs.extension }}
+      major: ${{ steps.select.outputs.major }}
+      version: ${{ steps.select.outputs.version }}
+      baseline_digest: ${{ steps.baseline.outputs.digest }}
+      no_canonical_index: ${{ steps.baseline.outputs.absent }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Select rotation pair
+        id: select
+        shell: bash
+        env:
+          DISPATCH_EXTENSION: ${{ inputs.extension }}
+          DISPATCH_MAJOR: ${{ inputs.pg_major }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          supplied=0
+          [[ -n "$DISPATCH_EXTENSION" ]] && supplied=$((supplied + 1))
+          [[ -n "$DISPATCH_MAJOR" ]] && supplied=$((supplied + 1))
+          [[ -n "$DISPATCH_VERSION" ]] && supplied=$((supplied + 1))
+          if [[ "$supplied" -ne 0 && "$supplied" -ne 3 ]]; then
+            echo 'All of extension, pg_major, and version must be supplied together' >&2
+            exit 1
+          fi
+          if [[ "$supplied" -eq 3 ]]; then
+            # A maintainer-selected pair is an operator action. Do not let the
+            # selector's blocking marker override this explicit dispatch.
+            {
+              printf 'selected=true\n'
+              printf 'extension=%s\n' "$DISPATCH_EXTENSION"
+              printf 'major=%s\n' "$DISPATCH_MAJOR"
+              printf 'version=%s\n' "$DISPATCH_VERSION"
+            } >> "$GITHUB_OUTPUT"
+          else
+            scripts/rotation-select.sh
+          fi
+
+      - name: Install skopeo for canonical index read
+        if: steps.select.outputs.selected == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y skopeo
+
+      - name: Read pre-test canonical index
+        id: baseline
+        if: steps.select.outputs.selected == 'true'
+        shell: bash
+        env:
+          EXTENSION: ${{ steps.select.outputs.extension }}
+          PG_MAJOR: ${{ steps.select.outputs.major }}
+          VERSION: ${{ steps.select.outputs.version }}
+        run: |
+          set -euo pipefail
+          baseline=$(scripts/rotation-promote.sh --read-canonical-index \
+            --extension "$EXTENSION" --pg-major "$PG_MAJOR" --version "$VERSION")
+          if [[ "$baseline" == absent ]]; then
+            printf 'digest=\nabsent=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'digest=%s\nabsent=false\n' "$baseline" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record no eligible pair
+        id: no-selection
+        if: steps.select.outputs.selected != 'true'
+        shell: bash
+        run: |
+          printf 'selected=false\n' >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: select
+    if: needs.select.outputs.selected == 'true'
+    name: Build ${{ matrix.arch }} staging extension
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize failure attribution
+        shell: bash
+        run: |
+          mkdir -p .rotation
+          printf 'false\n' > .rotation/attributable
+
+      - name: Install yq
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_${ARCH}"
+          case "$ARCH" in
+            amd64) echo '0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /usr/local/bin/yq' | sha256sum -c - ;;
+            arm64) echo '4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d  /usr/local/bin/yq' | sha256sum -c - ;;
+            *) exit 1 ;;
+          esac
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Install skopeo
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y skopeo
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Compile and push cacheless staging extension
+        id: compile
+        continue-on-error: true
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          PLATFORM: ${{ matrix.platform }}
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+        run: |
+          set -euo pipefail
+          EXTENSION_PACKAGE_SUFFIX=-staging ARCH_SUFFIX="$ARCH" BUILD_PLATFORM="$PLATFORM" \
+            scripts/build-extensions.sh postgres --major-version "$PG_MAJOR" --extension "$EXTENSION" --force --no-cache
+
+      - name: Fail an attributable extension compile
+        if: steps.compile.outcome == 'failure'
+        shell: bash
+        run: |
+          printf 'true\n' > .rotation/attributable
+          exit 1
+
+      - name: Freeze and validate staging manifest digest
+        id: freeze
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          ref="ghcr.io/${OWNER}/ext-${EXTENSION}-staging:pg${PG_MAJOR}-${VERSION}-${ARCH}"
+          digest=$(skopeo inspect --format '{{.Digest}}' "docker://${ref}")
+          [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]
+          raw=$(skopeo inspect --raw "docker://${ref}")
+          jq -e '
+            .schemaVersion == 2 and
+            (.mediaType == "application/vnd.oci.image.manifest.v1+json" or
+             .mediaType == "application/vnd.docker.distribution.manifest.v2+json") and
+            (.manifests | not)
+          ' >/dev/null <<< "$raw"
+          config=$(skopeo inspect --config "docker://${ref}")
+          jq -e --arg arch "$ARCH" '.os == "linux" and .architecture == $arch' >/dev/null <<< "$config"
+          printf '%s\n' "$digest" > .rotation/digest
+          printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Upload frozen staging digest
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: rotation-digest-${{ matrix.arch }}
+          path: .rotation/digest
+          if-no-files-found: ignore
+
+      - name: Upload build attribution
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: rotation-status-build-${{ matrix.arch }}
+          path: .rotation/attributable
+          if-no-files-found: ignore
+
+  freeze-digests:
+    needs: [select, build]
+    if: needs.select.outputs.selected == 'true' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      amd64_digest: ${{ steps.read.outputs.amd64_digest }}
+      arm64_digest: ${{ steps.read.outputs.arm64_digest }}
+    steps:
+      - name: Download frozen staging digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: rotation-digest-*
+          path: .rotation/digests
+
+      - name: Read frozen staging digests
+        id: read
+        shell: bash
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          amd64_digest=$(<.rotation/digests/rotation-digest-amd64/digest)
+          arm64_digest=$(<.rotation/digests/rotation-digest-arm64/digest)
+          [[ "$amd64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
+          [[ "$arm64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
+          [[ "$amd64_digest" != "$arm64_digest" ]]
+          printf 'amd64_digest=%s\narm64_digest=%s\n' "$amd64_digest" "$arm64_digest" >> "$GITHUB_OUTPUT"
+
+  test-amd64:
+    needs: [select, freeze-digests]
+    if: needs.select.outputs.selected == 'true' && needs.freeze-digests.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    env:
+      ROTATION_CANDIDATE_REF: ${{ format('{0}:{1}:{2}=ghcr.io/{3}/ext-{0}-staging@{4}', needs.select.outputs.extension, needs.select.outputs.major, needs.select.outputs.version, github.repository_owner, needs.freeze-digests.outputs.amd64_digest) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize failure attribution
+        shell: bash
+        run: |
+          mkdir -p .rotation
+          printf 'false\n' > .rotation/attributable
+
+      - name: Build loadable PostgreSQL full image
+        id: build-e2e-image
+        continue-on-error: true
+        uses: ./.github/actions/build-container
+        with:
+          container: postgres
+          version: ${{ needs.select.outputs.major }}
+          tag: ${{ format('{0}-full-alpine', needs.select.outputs.major) }}
+          flavor: full
+          variant: full
+          platform: linux/amd64
+          rebuild_mode: force
+          docker_no_cache: 'true'
+          scan_vulnerabilities: 'false'
+          # This image exists to be tested against a candidate that has not been promoted.
+          push: 'false'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve loaded e2e image ID
+        shell: bash
+        env:
+          IMAGE: ${{ format('ghcr.io/{0}/postgres:{1}-full-alpine', github.repository_owner, needs.select.outputs.major) }}
+        run: |
+          set -euo pipefail
+          image_id=$(timeout -k 2 10 docker image inspect --format '{{.Id}}' "$IMAGE")
+          test -n "$image_id"
+          echo "E2E_IMAGE_ID=$image_id" >> "$GITHUB_ENV"
+
+      - name: Run e2e suite
+        id: e2e
+        continue-on-error: true
+        shell: bash
+        run: |
+          E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
+
+      - name: Fail attributable build or suite result
+        # build-container is production-oriented and attempts a post-build push
+        # on scheduled/dispatch events. This job intentionally has packages:read;
+        # a failed post-build push is harmless once the exact loaded image was
+        # resolved below. A missing image-ID remains infrastructure, not a pair
+        # quarantine signal; the suite verdict is the attributable test result.
+        if: steps.e2e.outcome == 'failure'
+        shell: bash
+        run: |
+          printf 'true\n' > .rotation/attributable
+          exit 1
+
+      - name: Upload test attribution
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: rotation-status-test-amd64
+          path: .rotation/attributable
+          if-no-files-found: ignore
+
+  test-arm64:
+    needs: [select, freeze-digests]
+    if: needs.select.outputs.selected == 'true' && needs.freeze-digests.result == 'success'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    env:
+      ROTATION_CANDIDATE_REF: ${{ format('{0}:{1}:{2}=ghcr.io/{3}/ext-{0}-staging@{4}', needs.select.outputs.extension, needs.select.outputs.major, needs.select.outputs.version, github.repository_owner, needs.freeze-digests.outputs.arm64_digest) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize failure attribution
+        shell: bash
+        run: |
+          mkdir -p .rotation
+          printf 'false\n' > .rotation/attributable
+
+      - name: Build loadable PostgreSQL full image
+        id: build-e2e-image
+        continue-on-error: true
+        uses: ./.github/actions/build-container
+        with:
+          container: postgres
+          version: ${{ needs.select.outputs.major }}
+          tag: ${{ format('{0}-full-alpine', needs.select.outputs.major) }}
+          flavor: full
+          variant: full
+          platform: linux/arm64
+          rebuild_mode: force
+          docker_no_cache: 'true'
+          scan_vulnerabilities: 'false'
+          # This image exists to be tested against a candidate that has not been promoted.
+          push: 'false'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve loaded e2e image ID
+        shell: bash
+        env:
+          IMAGE: ${{ format('ghcr.io/{0}/postgres:{1}-full-alpine', github.repository_owner, needs.select.outputs.major) }}
+        run: |
+          set -euo pipefail
+          image_id=$(timeout -k 2 10 docker image inspect --format '{{.Id}}' "$IMAGE")
+          test -n "$image_id"
+          echo "E2E_IMAGE_ID=$image_id" >> "$GITHUB_ENV"
+
+      - name: Run e2e suite
+        id: e2e
+        continue-on-error: true
+        shell: bash
+        run: |
+          E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
+
+      - name: Fail attributable build or suite result
+        # See the amd64 leg: packages:read makes build-container's post-build
+        # push advisory here once the loaded image has been resolved.
+        if: steps.e2e.outcome == 'failure'
+        shell: bash
+        run: |
+          printf 'true\n' > .rotation/attributable
+          exit 1
+
+      - name: Upload test attribution
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: rotation-status-test-arm64
+          path: .rotation/attributable
+          if-no-files-found: ignore
+
+  promote:
+    needs: [select, build, freeze-digests, test-amd64, test-arm64]
+    if: |
+      needs.select.outputs.selected == 'true' &&
+      needs.build.result == 'success' &&
+      needs.freeze-digests.result == 'success' &&
+      needs.test-amd64.result == 'success' &&
+      needs.test-arm64.result == 'success' &&
+      (github.event_name != 'workflow_dispatch' || inputs.dry_run != true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: merge-extension-manifests-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install skopeo
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y skopeo
+
+      - name: Log in to container registries
+        uses: ./.github/actions/docker-login
+        with:
+          ghcr_username: ${{ github.actor }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight BuildKit image
+        uses: ./.github/actions/preflight-buildkit
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: image=ghcr.io/${{ github.repository_owner }}/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
+
+      - name: Promote frozen staging digests
+        shell: bash
+        env:
+          DRY_RUN: 'false'
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+          BASELINE_DIGEST: ${{ needs.select.outputs.baseline_digest }}
+          NO_CANONICAL_INDEX: ${{ needs.select.outputs.no_canonical_index }}
+          AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
+        run: |
+          set -euo pipefail
+          baseline_args=()
+          if [[ "$NO_CANONICAL_INDEX" == true ]]; then
+            baseline_args=(--no-canonical-index)
+          else
+            baseline_args=(--baseline-digest "$BASELINE_DIGEST")
+          fi
+          scripts/rotation-promote.sh --extension "$EXTENSION" --pg-major "$PG_MAJOR" --version "$VERSION" \
+            "${baseline_args[@]}" --amd64-digest "$AMD64_DIGEST" --arm64-digest "$ARM64_DIGEST"
+
+  promote-dry-run:
+    needs: [select, build, freeze-digests, test-amd64, test-arm64]
+    if: |
+      needs.select.outputs.selected == 'true' &&
+      needs.build.result == 'success' &&
+      needs.freeze-digests.result == 'success' &&
+      needs.test-amd64.result == 'success' &&
+      needs.test-arm64.result == 'success' &&
+      github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Render frozen staging promotion
+        shell: bash
+        env:
+          DRY_RUN: 'true'
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+          BASELINE_DIGEST: ${{ needs.select.outputs.baseline_digest }}
+          NO_CANONICAL_INDEX: ${{ needs.select.outputs.no_canonical_index }}
+          AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
+        run: |
+          set -euo pipefail
+          baseline_args=()
+          if [[ "$NO_CANONICAL_INDEX" == true ]]; then
+            baseline_args=(--no-canonical-index)
+          else
+            baseline_args=(--baseline-digest "$BASELINE_DIGEST")
+          fi
+          scripts/rotation-promote.sh --extension "$EXTENSION" --pg-major "$PG_MAJOR" --version "$VERSION" \
+            "${baseline_args[@]}" --amd64-digest "$AMD64_DIGEST" --arm64-digest "$ARM64_DIGEST"
+
+  quarantine:
+    needs: [select, build, freeze-digests, test-amd64, test-arm64]
+    if: always() && needs.select.outputs.selected == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - name: Download failure attribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: rotation-status-*
+          path: .rotation/status
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Decide whether a failure is attributable
+        id: attribution
+        shell: bash
+        run: |
+          shopt -s nullglob
+          attributable=false
+          for status_file in .rotation/status/*; do
+            if [[ $(<"$status_file") == true ]]; then
+              attributable=true
+            fi
+          done
+          printf 'create=%s\n' "$attributable" >> "$GITHUB_OUTPUT"
+
+      - name: Quarantine failing extension pair
+        if: steps.attribution.outputs.create == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          EXTENSION: ${{ needs.select.outputs.extension }}
+          PG_MAJOR: ${{ needs.select.outputs.major }}
+          VERSION: ${{ needs.select.outputs.version }}
+          AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
+          RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+        run: |
+          set -euo pipefail
+          body=$(printf 'rotation-pair: %s pg%s %s\n\nFailed run: %s\n' "$EXTENSION" "$PG_MAJOR" "$VERSION" "$RUN_URL")
+          if [[ -n "$AMD64_DIGEST" ]]; then
+            body+=$(printf 'amd64 digest: %s\n' "$AMD64_DIGEST")
+          fi
+          if [[ -n "$ARM64_DIGEST" ]]; then
+            body+=$(printf 'arm64 digest: %s\n' "$ARM64_DIGEST")
+          fi
+          gh issue create --repo "$REPOSITORY" \
+            --title "Extension rotation blocked: ${EXTENSION} pg${PG_MAJOR} ${VERSION}" \
+            --label extension-rotation-blocked --body "$body"
+
+  cleanup-staging:
+    needs: [select, promote, promote-dry-run]
+    if: always() && needs.select.outputs.selected == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete staging packages
+        # Cleanup failure is not a failed rotation: staging is unreachable from
+        # production, so leave a visible cleanup error without quarantining it.
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          EXTENSION: ${{ needs.select.outputs.extension }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for package in "ext-${EXTENSION}-staging" "ext-${EXTENSION}-staging-buildcache"; do
+            output=''
+            rc=0
+            output=$(gh api --method DELETE "/users/${OWNER}/packages/container/${package}" 2>&1) || rc=$?
+            if [[ "$rc" -ne 0 && "$output" != *404* ]]; then
+              printf '%s\n' "$output" >&2
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/scripts/rotation-promote.sh
+++ b/scripts/rotation-promote.sh
@@ -45,6 +45,9 @@ Usage: rotation-promote.sh --extension NAME --pg-major MAJOR --version VERSION \
   (--baseline-digest DIGEST | --no-canonical-index) \
   --amd64-digest DIGEST --arm64-digest DIGEST
 
+       rotation-promote.sh --read-canonical-index --extension NAME \
+  --pg-major MAJOR --version VERSION
+
 Promote the two tested staging manifests identified by DIGEST to the canonical
 extension architecture tags, then publish their canonical multi-arch index.
 The caller must declare exactly one pre-test canonical state: the canonical
@@ -55,6 +58,10 @@ Promotion must be serialized per canonical (extension, pg major, version).
 This script does not acquire that lock: the caller must hold it before invoking
 the script and retain it through completion. The lock-time read below is a
 conflict fence, not a lock.
+
+--read-canonical-index only reads the current canonical index state. It prints
+the index digest when present, or "absent" when a successful tag listing proves
+the tag absent. It cannot be combined with promotion flags.
 EOF
 }
 
@@ -176,6 +183,8 @@ main() {
     local baseline_mode=""
     local amd64_digest=""
     local arm64_digest=""
+    local read_canonical_index=false
+    local promotion_flag=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -189,6 +198,7 @@ main() {
                     --pg-major) pg_major="$2" ;;
                     --version) version="$2" ;;
                     --baseline-digest)
+                        promotion_flag="$1"
                         if [[ -n "$baseline_mode" ]]; then
                             log_error "Specify exactly one of --baseline-digest or --no-canonical-index"
                             return 1
@@ -196,17 +206,28 @@ main() {
                         baseline_digest="$2"
                         baseline_mode="digest"
                         ;;
-                    --amd64-digest) amd64_digest="$2" ;;
-                    --arm64-digest) arm64_digest="$2" ;;
+                    --amd64-digest)
+                        promotion_flag="$1"
+                        amd64_digest="$2"
+                        ;;
+                    --arm64-digest)
+                        promotion_flag="$1"
+                        arm64_digest="$2"
+                        ;;
                 esac
                 shift 2
                 ;;
             --no-canonical-index)
+                promotion_flag="$1"
                 if [[ -n "$baseline_mode" ]]; then
                     log_error "Specify exactly one of --baseline-digest or --no-canonical-index"
                     return 1
                 fi
                 baseline_mode="absent"
+                shift
+                ;;
+            --read-canonical-index)
+                read_canonical_index=true
                 shift
                 ;;
             -h|--help)
@@ -221,6 +242,11 @@ main() {
         esac
     done
 
+    if [[ "$read_canonical_index" == true && -n "$promotion_flag" ]]; then
+        log_error "--read-canonical-index cannot be combined with promotion flag $(_escape_gha_command "$promotion_flag")"
+        return 1
+    fi
+
     if [[ ! "$extension" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
         log_error "--extension must be a lowercase extension package component"
         return 1
@@ -232,6 +258,42 @@ main() {
     if [[ ! "$version" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
         log_error "--version must be a safe OCI tag component"
         return 1
+    fi
+
+    # This read uses the same registry-state contract as the promotion lock
+    # fence. It is deliberately before all promotion-only validation and does
+    # not acquire a lock or mutate a registry record.
+    if [[ "$read_canonical_index" == true ]]; then
+        local read_registry read_owner read_registry_rc=0 read_owner_rc=0
+        read_registry=$(get_registry) || read_registry_rc=$?
+        read_owner=$(get_repo_owner) || read_owner_rc=$?
+        if [[ "$read_registry_rc" -ne 0 || "$read_owner_rc" -ne 0 || -z "$read_registry" || -z "$read_owner" ]]; then
+            log_error "Could not determine the extension registry and owner"
+            return 1
+        fi
+
+        local read_canonical_index_ref="${read_registry}/${read_owner}/ext-${extension}:pg${pg_major}-${version}"
+        if ! oci_tag_is_constructible "pg${pg_major}-${version}"; then
+            log_error "Constructed canonical OCI tag exceeds the grammar or 128-character limit"
+            return 1
+        fi
+
+        local read_digest="" read_rc=0
+        read_digest=$(read_registry_digest "$read_canonical_index_ref") || read_rc=$?
+        case "$read_rc" in
+            0)
+                printf '%s\n' "$read_digest"
+                return 0
+                ;;
+            1)
+                printf 'absent\n'
+                return 0
+                ;;
+            *)
+                log_error "Could not read the canonical index state"
+                return 1
+                ;;
+        esac
     fi
 
     if [[ -z "$baseline_mode" ]]; then

--- a/tests/unit/build-container-push-guard.bats
+++ b/tests/unit/build-container-push-guard.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# Composite-action wiring is not executable by Bats. Read its YAML shape with
+# yq so both registry pushes and both rotation test callers stay covered.
+
+load "../test_helper"
+
+@test "every build-container push step requires the push input" {
+    local name condition count=0
+
+    run yq -r '.runs.steps[] | [.name, .if] | @tsv' \
+        "$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+
+    [ "$status" -eq 0 ]
+    while IFS=$'\t' read -r name condition; do
+        [[ "$name" == 'Push to'* ]] || continue
+        [[ "$condition" == *"inputs.push == 'true'"* ]]
+        count=$((count + 1))
+    done <<< "$output"
+    [ "$count" -eq 2 ]
+}
+
+@test "rotation test jobs disable publishing for their candidate images" {
+    local job
+
+    for job in test-amd64 test-arm64; do
+        run yq -r ".jobs.\"$job\".steps[] | select(.uses == \"./.github/actions/build-container\") | .with.push" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+        [ "$status" -eq 0 ]
+        [ "$output" = 'false' ]
+    done
+}

--- a/tests/unit/rotation-promote.bats
+++ b/tests/unit/rotation-promote.bats
@@ -169,6 +169,106 @@ EOF
         '
 }
 
+run_canonical_index_read() {
+    run env \
+        OWNER="$OWNER" \
+        GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" \
+        EXTENSION_REGISTRY="$EXTENSION_REGISTRY" \
+        CALLS_FILE="$CALLS_FILE" \
+        CANONICAL_DIGEST="$CANONICAL_DIGEST" \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        SKOPEO_MODE="${SKOPEO_MODE:-read-present}" \
+        bash -c '
+            skopeo() {
+                local ref="${!#}"
+                printf "%s\\n" "$*" >> "$CALLS_FILE"
+                if [[ "$1" == "inspect" ]]; then
+                    [[ "$SKOPEO_MODE" == "read-present" ]] || return 24
+                    printf "%s" "$CANONICAL_DIGEST"
+                    return 0
+                fi
+                if [[ "$1" == "list-tags" ]]; then
+                    [[ "$SKOPEO_MODE" != "read-indeterminate" ]] || return 25
+                    printf "{\\\"Tags\\\":[]}\\n"
+                    return 0
+                fi
+                return 98
+            }
+            export -f skopeo
+            exec "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+                --read-canonical-index --extension pgvector --pg-major 17 --version 0.8.6 "$@"
+        ' bash "$@"
+}
+
+@test "read-canonical-index prints a resolved canonical digest" {
+    run_canonical_index_read
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$CANONICAL_DIGEST" ]
+    grep -Fqx 'inspect --format {{.Digest}} docker://ghcr.io/testowner/ext-pgvector:pg17-0.8.6' "$CALLS_FILE"
+}
+
+@test "read-canonical-index prints absent only after a successful tag listing" {
+    export SKOPEO_MODE="read-absent"
+
+    run_canonical_index_read
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "absent" ]
+    grep -Fqx 'list-tags docker://ghcr.io/testowner/ext-pgvector' "$CALLS_FILE"
+}
+
+@test "read-canonical-index leaves stdout empty for an indeterminate registry read" {
+    local stdout_file="$TEST_TEMP_DIR/read-stdout"
+    export SKOPEO_MODE="read-indeterminate"
+
+    run env \
+        OWNER="$OWNER" GITHUB_REPOSITORY_OWNER="$GITHUB_REPOSITORY_OWNER" EXTENSION_REGISTRY="$EXTENSION_REGISTRY" \
+        CALLS_FILE="$CALLS_FILE" CANONICAL_DIGEST="$CANONICAL_DIGEST" SKOPEO_MODE="$SKOPEO_MODE" \
+        PROJECT_ROOT="$PROJECT_ROOT" READ_STDOUT="$stdout_file" \
+        bash -c '
+            skopeo() {
+                printf "%s\\n" "$*" >> "$CALLS_FILE"
+                [[ "$1" != "inspect" ]] || return 24
+                # A failed listing may still emit parseable stale data. Only a
+                # successful list-tags response can establish absence.
+                printf "{\\\"Tags\\\":[]}\\n"
+                return 25
+            }
+            export -f skopeo
+            "$PROJECT_ROOT/scripts/rotation-promote.sh" \
+                --read-canonical-index --extension pgvector --pg-major 17 --version 0.8.6 > "$READ_STDOUT"
+        '
+
+    [ "$status" -ne 0 ]
+    [ ! -s "$stdout_file" ]
+    [[ "$output" == *"Could not read the canonical index state"* ]]
+}
+
+@test "read-canonical-index refuses every promotion flag before a registry call" {
+    local flag
+    local value
+
+    for flag in --amd64-digest --arm64-digest --baseline-digest --no-canonical-index; do
+        : > "$CALLS_FILE"
+        if [[ "$flag" == "--no-canonical-index" ]]; then
+            run_canonical_index_read "$flag"
+        else
+            value="$AMD64_DIGEST"
+            run_canonical_index_read "$flag" "$value"
+        fi
+        [ "$status" -ne 0 ] || {
+            echo "ASSERTION: $flag must be refused with --read-canonical-index"
+            false
+        }
+        [[ "$output" == *"cannot be combined with promotion flag $flag"* ]]
+        [[ ! -s "$CALLS_FILE" ]] || {
+            echo "ASSERTION: $flag must be refused before any registry call"
+            false
+        }
+    done
+}
+
 @test "promotion copies frozen staging digests, verifies destinations, and creates a digest-pinned index" {
     run_promotion
 

--- a/tests/unit/rotation-workflow-guards.bats
+++ b/tests/unit/rotation-workflow-guards.bats
@@ -83,11 +83,23 @@ load "../test_helper"
     [[ "$validation" == *'Invalid push input'* ]]
 }
 
-@test "rotation cleanup retains staging after a failed promotion" {
+@test "rotation schedules three daily runs with enough room for a long run" {
+    run yq -r '.on.schedule | length' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 3 ]
+
+    run yq -r '.on.schedule[].cron' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'17 1 * * *\n17 9 * * *\n17 17 * * *' ]
+}
+
+@test "rotation cleanup retains staging after failed or cancelled promotion" {
     run yq -r '.jobs."cleanup-staging".if' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"needs.promote.result != 'failure'"* ]]
+    [[ "$output" == *"needs.promote.result != 'cancelled'"* ]]
     [ "$output" != 'always()' ]
 
     run yq -r '.jobs."retain-staging-after-promotion-failure".if' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
@@ -100,7 +112,7 @@ load "../test_helper"
     [ "$output" = false ]
 }
 
-@test "rotation derives a dispatch version and rechecks blocks before compiling" {
+@test "rotation validates a dispatch pair and rechecks blocks before compiling" {
     local select_run recheck_index compile_index
 
     run yq -r '.on.workflow_dispatch.inputs | has("version")' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
@@ -112,6 +124,11 @@ load "../test_helper"
     [ "$status" -eq 0 ]
     select_run="$output"
     [[ "$select_run" == *'.extensions[strenv(DISPATCH_EXTENSION)].version'* ]]
+    [[ "$select_run" == *'[[ "$DISPATCH_EXTENSION" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]'* ]]
+    [[ "$select_run" == *'[[ "$DISPATCH_MAJOR" =~ ^[0-9]+$ ]]'* ]]
+    [[ "$select_run" == *".pg_versions[]"* ]]
+    [[ "$select_run" == *'get_flavor_extensions postgres/extensions/config.yaml full "$DISPATCH_MAJOR"'* ]]
+    [[ "$select_run" == *"printf 'selected=true\\n'"* ]]
 
     run yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Recheck rotation block before compiling") | .key' \
         "$PROJECT_ROOT/.github/workflows/rotation.yaml"
@@ -122,4 +139,35 @@ load "../test_helper"
     [ "$status" -eq 0 ]
     compile_index="$output"
     [ "$compile_index" -eq $((recheck_index + 1)) ]
+}
+
+@test "rotation attributes a failed candidate image build on both architectures" {
+    local build_condition suite_condition
+
+    for job in test-amd64 test-arm64; do
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail attributable candidate image build result\") | .if" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+        [ "$status" -eq 0 ]
+        build_condition="$output"
+        [ "$build_condition" = "steps.build-e2e-image.outcome == 'failure'" ]
+
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail attributable e2e suite result\") | .if" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+        [ "$status" -eq 0 ]
+        suite_condition="$output"
+        [ "$suite_condition" = "steps.e2e.outcome == 'failure'" ]
+    done
+}
+
+@test "rotation test-job push comments do not claim a post-build push" {
+    local comment
+
+    for job in test-amd64 test-arm64; do
+        run yq -r ".jobs.\"$job\".steps[] | select(.id == \"build-e2e-image\") | .with | to_entries[] | select(.key == \"push\") | (.key | headComment)" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+        [ "$status" -eq 0 ]
+        [[ "$output" != *'post-build push'* ]]
+    done
 }

--- a/tests/unit/rotation-workflow-guards.bats
+++ b/tests/unit/rotation-workflow-guards.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+
+# Workflow wiring is declarative. Inspect it as YAML rather than grepping a
+# serialization whose indentation and quoting are not part of the contract.
+
+load "../test_helper"
+
+@test "rotation uploads use visible paths and fail empty matches" {
+    local path policy count=0
+
+    run yq -r '
+      .jobs[] | .steps[]?
+      | select(.uses == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+      | [.with.path, .with."if-no-files-found"] | @tsv
+    ' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+    [ "$status" -eq 0 ]
+    while IFS=$'\t' read -r path policy; do
+        [[ "/$path/" != */.*/* ]]
+        [ "$policy" = error ]
+        count=$((count + 1))
+    done <<< "$output"
+    [ "$count" -eq 4 ]
+}
+
+@test "rotation e2e suites identify the exact full build cell" {
+    local job expected
+
+    expected="\${{ format('{0}-full-alpine', needs.select.outputs.major) }}"$'\t'"\${{ needs.select.outputs.major }}"$'\tfull\tfull'
+    for job in test-amd64 test-arm64; do
+        run yq -r ".jobs.\"$job\".steps[] | select(.id == \"e2e\") | [.env.E2E_BUILD_TAG, .env.E2E_BUILD_VERSION, .env.E2E_BUILD_VARIANT, .env.E2E_BUILD_FLAVOR] | @tsv" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+        [ "$status" -eq 0 ]
+        [ "$output" = "$expected" ]
+    done
+}
+
+@test "rotation status artifacts keep producer-specific names" {
+    local names build_path
+
+    run yq -r '
+      .jobs[] | .steps[]?
+      | select(.uses == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+      | select(.with.name | test("^rotation-status-"))
+      | .with.name
+    ' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+    [ "$status" -eq 0 ]
+    names="$output"
+    [ "$(printf '%s\n' "$names" | sort -u | wc -l)" -eq 3 ]
+    [[ "$names" == *'rotation-status-build-${{ matrix.arch }}'* ]]
+    [[ "$names" == *'rotation-status-test-amd64'* ]]
+    [[ "$names" == *'rotation-status-test-arm64'* ]]
+
+    run yq -r '.jobs.build.steps[] | select(.name == "Upload build attribution") | .with.path' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" = 'rotation-artifacts/build-${{ matrix.arch }}' ]
+
+    run yq -r '.jobs.quarantine.steps[] | select(.id == "attribution") | .run' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'expected_statuses=(build-amd64 build-arm64)'* ]]
+    [[ "$output" == *'Missing failure attribution from completed producer'* ]]
+}
+
+@test "build-container accepts only literal boolean push values" {
+    local validation
+
+    run yq -r '.runs.steps[] | select(.name == "Validate push input") | .env.PUSH' \
+        "$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '${{ inputs.push }}' ]
+
+    run yq -r '.runs.steps[] | select(.name == "Validate push input") | .run' \
+        "$PROJECT_ROOT/.github/actions/build-container/action.yaml"
+    [ "$status" -eq 0 ]
+    validation="$output"
+    [[ "$validation" == *$'case "$PUSH" in\n  true|false) ;;'* ]]
+    [[ "$validation" == *'_escape_gha_command "$PUSH"'* ]]
+    [[ "$validation" == *'Invalid push input'* ]]
+}
+
+@test "rotation cleanup retains staging after a failed promotion" {
+    run yq -r '.jobs."cleanup-staging".if' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"needs.promote.result != 'failure'"* ]]
+    [ "$output" != 'always()' ]
+
+    run yq -r '.jobs."retain-staging-after-promotion-failure".if' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"needs.promote.result == 'failure'"* ]]
+
+    run yq -r '.jobs."cleanup-staging".steps[] | select(.name == "Delete staging packages") | ."continue-on-error" // false' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" = false ]
+}
+
+@test "rotation derives a dispatch version and rechecks blocks before compiling" {
+    local select_run recheck_index compile_index
+
+    run yq -r '.on.workflow_dispatch.inputs | has("version")' "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" = false ]
+
+    run yq -r '.jobs.select.steps[] | select(.id == "select") | .run' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    select_run="$output"
+    [[ "$select_run" == *'.extensions[strenv(DISPATCH_EXTENSION)].version'* ]]
+
+    run yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Recheck rotation block before compiling") | .key' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    recheck_index="$output"
+    run yq -r '.jobs.build.steps | to_entries[] | select(.value.id == "compile") | .key' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    compile_index="$output"
+    [ "$compile_index" -eq $((recheck_index + 1)) ]
+}


### PR DESCRIPTION
Extension images were reused whenever their tag existed, and a tag carries no record of the
recipe that made it. `postgis` was therefore unbuildable for months without anything
noticing. #1245 asks that every `(extension, pg major)` pair be recompiled from its current
recipe and runtime-tested within 30 days; this is the workflow that does it.

A run picks the stalest pair, compiles it with no cache into `ext-<name>-staging`, freezes
both per-architecture manifest digests, builds the postgres `full` image against each frozen
digest on its own architecture, runs the full e2e suite against it, and only then promotes —
copying the tested manifests to the canonical architecture tags and publishing the index from
those digests while holding the same lock `auto-build` uses for the same writes.

It runs three times a day, the cadence #1245 costed its arguments against; 30 eligible pairs
against 90 slots leaves room for an outage.

A failure the run can attribute to the extension — the compile, or the generated image, or
the suite — opens an issue carrying the marker line `rotation-select.sh` parses, so a
deterministically broken pair stops winning every run. A runner, registry or harness failure
fails the run without one.

`rotation-promote.sh` gains `--read-canonical-index` so the pre-test baseline is read by the
script that owns those three-state registry semantics rather than by workflow YAML.
`build-container` gains a `push` input, default `'true'`: the rotation's test image is built
from bytes that have not been promoted and must not be published.

## Verification

`bats -j 8 tests/unit/*.bats` — 2752 collected, 0 failed. `actionlint` and
`shellcheck -S warning` clean.

Each guard is covered by a test that was shown failing under a mutation: the three crons, the
cleanup condition excluding both `failure` and `cancelled`, attribution on a failed image
build, artifact paths that are neither hidden nor allowed to be empty, the four `E2E_BUILD_*`
identity fields, distinct per-producer status files, `push` accepting only `true` or `false`,
and no comment claiming a post-build push.

The workflow itself has not been run: `actionlint` is the only mechanical check available
before it exists on the default branch. The first scheduled run is the real verification, and
its dry-run dispatch input exists for that.

## Follow-ups

Filed rather than folded in: #1351 #1352 #1353 #1354 #1355 #1356. #1351 and #1352 are settled
decisions on #1245 that this review re-argued; #1353 is the one worth doing next, since a
registry outage can currently quarantine a healthy pair for 30 days.

Closes #1245.
