### PR TITLE
Stop pinning identity tests to a version the next bump evicts

### DIFF
--- a/tests/unit/image-identity.bats
+++ b/tests/unit/image-identity.bats
@@ -124,9 +124,21 @@ versions:
 }
 
 @test "resolves terraform's retained empty-suffix full variant as a variant cell" {
-    resolve "$PROJECT_ROOT/terraform" "ghcr.io/oorabona/terraform:1.15.6-alpine"
+    local terraform_tag terraform_version
+    terraform_tag=$(yq -r '[.versions[] | select(([.variants[] | select((.name == "full") and (.suffix == "") and (.flavor == "full"))] | length) > 0) | .tag] | .[0] // ""' \
+        "$PROJECT_ROOT/terraform/variants.yaml") || {
+        echo "terraform/variants.yaml could not be read to find a full variant with an empty suffix" >&2
+        return 1
+    }
+    if [[ -z "$terraform_tag" || "$terraform_tag" == "null" || "$terraform_tag" != *-alpine ]]; then
+        echo "terraform/variants.yaml does not declare an -alpine version with a full variant with an empty suffix" >&2
+        return 1
+    fi
+    terraform_version="${terraform_tag%-alpine}"
+
+    resolve "$PROJECT_ROOT/terraform" "ghcr.io/oorabona/terraform:$terraform_tag"
     [ "$status" -eq 0 ]
-    [ "$(jq -r '.component_version + ":" + .kind + ":" + .variant + ":" + .flavor' <<<"$output")" = "1.15.6:variant:full:full" ]
+    [ "$(jq -r '.component_version + ":" + .kind + ":" + .variant + ":" + .flavor' <<<"$output")" = "$terraform_version:variant:full:full" ]
 }
 
 @test "mirrors generator coercions for version, suffix, and empty flavor" {
@@ -157,26 +169,51 @@ versions:
 }
 
 @test "resolves web-shell ubuntu but rejects a typo instead of falling back to debian" {
-    resolve "$PROJECT_ROOT/web-shell" "web-shell:1.7.7-ubuntu"
+    local web_shell_version
+    web_shell_version=$(yq -r '[.versions[] | select(([.variants[] | select((.name == "ubuntu") and (.suffix == "-ubuntu") and (.flavor == "ubuntu"))] | length) > 0) | select(([.variants[] | select((.name == "typo") or (.suffix == "-typo"))] | length) == 0) | .tag] | .[0] // ""' \
+        "$PROJECT_ROOT/web-shell/variants.yaml") || {
+        echo "web-shell/variants.yaml could not be read to find an ubuntu variant without a typo suffix" >&2
+        return 1
+    }
+    if [[ -z "$web_shell_version" || "$web_shell_version" == "null" ]]; then
+        echo "web-shell/variants.yaml does not declare an ubuntu variant without a typo suffix" >&2
+        return 1
+    fi
+
+    resolve "$PROJECT_ROOT/web-shell" "web-shell:$web_shell_version-ubuntu"
     [ "$status" -eq 0 ]
     [ "$(jq -r '.variant' <<<"$output")" = "ubuntu" ]
 
-    resolve "$PROJECT_ROOT/web-shell" "web-shell:1.7.7-typo"
+    resolve "$PROJECT_ROOT/web-shell" "web-shell:$web_shell_version-typo"
     [ "$status" -ne 0 ]
     [[ "$output" == *"does not name a declared cell"* ]]
 }
 
 @test "uses the longest github-runner suffix and preserves the distinct variant name" {
-    resolve "$PROJECT_ROOT/github-runner" "github-runner:2.336.0-debian-trixie-dev"
+    local github_runner_version
+    github_runner_version=$(yq -r '[.versions[] | select(([.variants[] | select((.name == "debian-trixie-dev") and (.suffix == "-debian-trixie-dev") and (.flavor == "debian-trixie"))] | length) > 0) | select(([.variants[] | select((.name == "ubuntu-2404-dev") and (.suffix == "-dev") and (.flavor == "ubuntu-2404"))] | length) > 0) | .tag] | .[0] // ""' \
+        "$PROJECT_ROOT/github-runner/variants.yaml") || {
+        echo "github-runner/variants.yaml could not be read to find debian-trixie-dev and dev suffixes" >&2
+        return 1
+    }
+    if [[ -z "$github_runner_version" || "$github_runner_version" == "null" ]]; then
+        echo "github-runner/variants.yaml does not declare debian-trixie-dev and dev suffixes" >&2
+        return 1
+    fi
+
+    resolve "$PROJECT_ROOT/github-runner" "github-runner:$github_runner_version-debian-trixie-dev"
     [ "$status" -eq 0 ]
     [ "$(jq -r '.variant + ":" + .flavor' <<<"$output")" = "debian-trixie-dev:debian-trixie" ]
 
-    resolve "$PROJECT_ROOT/github-runner" "github-runner:2.336.0-dev"
+    resolve "$PROJECT_ROOT/github-runner" "github-runner:$github_runner_version-dev"
     [ "$status" -eq 0 ]
     [ "$(jq -r '.variant + ":" + .flavor' <<<"$output")" = "ubuntu-2404-dev:ubuntu-2404" ]
 }
 
 @test "accepts only postgres's generated base-before-variant tag order" {
+    # 17 is a long-lived major stream (always_all_versions: true), and this
+    # assertion requires that major to declare vector. Deriving it would trade
+    # this stable pin for a fragile choice among supported majors.
     resolve "$PROJECT_ROOT/postgres" "postgres:17-alpine-vector"
     [ "$status" -eq 0 ]
     [ "$(jq -r '.variant' <<<"$output")" = "vector" ]


### PR DESCRIPTION
Three tests in `tests/unit/image-identity.bats` resolve against a live container directory
and hardcoded the upstream version in the reference they passed. Each named the **oldest
retained** entry — precisely the one a routine bump evicts.

`resolves terraform's retained empty-suffix full variant as a variant cell` is the only
failing check on #1262 for that reason: terraform declares `1.15.8 / 1.15.7 / 1.15.6`, the
test asks for `1.15.6-alpine`, and the bump to `1.15.9` drops it. web-shell `1.7.7` and
github-runner `2.336.0` are the same shape and break on their next bumps.

They now read a version from that container's own `variants.yaml`, choosing one that declares
the variant the assertion is about, and fail with a message naming what they could not find
rather than skipping.

They still read live configuration on purpose. The neighbouring tests build a synthetic
container with `make_container`, which is right when the property is about the resolver's
grammar; these three assert that the resolver agrees with this repository's real
configuration, which a fixture cannot check.

The two postgres tests keep their literal `17`. `postgres/variants.yaml` sets
`always_all_versions: true` — a major is a long-lived release stream here, not a release —
and the assertion depends on that major declaring a `vector` variant. Deriving it would
trade a stable pin for a fragile choice among majors.

## Verification

`bats -j 8 tests/unit/*.bats` — 2752 collected, 0 failed.

Rewrote `terraform/variants.yaml` to the exact window #1262 produces (`1.15.9`, `1.15.8`,
`1.15.7`, checked duplicate-free) and ran the terraform test against it: passes. The file was
restored byte-identically afterwards. An earlier attempt at that check produced a duplicate
tag and failed — the resolver was right to reject it, and the probe was wrong.

The github-runner test was shown still failing when the resolver's longest-suffix rule is
mutated to first-match, so deriving the version did not cost the assertion its teeth.

Unblocks #1262.
