### PR TITLE
Stop the runner SIGTERM test leaving a process writing 21 GB a day

### DIFF
--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -572,9 +572,11 @@ MOCK
 
     # The runner itself publishes readiness after a bounded delay.  It also
     # self-expires, so an abruptly killed Bats process leaves only a bounded
-    # child behind; this test deliberately creates no detached process group.
+    # child behind.  Its TERM marker proves the entrypoint's group signal
+    # reaches the runner, not just the entrypoint leader.
     cat > "$RUNNER_WORK/run.sh" <<MOCK
 #!/usr/bin/env bash
+trap 'touch "$WORK_DIR/runner-terminated"; exit 0' TERM INT
 command "$REAL_SLEEP" 0.1
 touch "$WORK_DIR/runner-started"
 command "$REAL_SLEEP" 5
@@ -592,8 +594,13 @@ exit 0
 MOCK
     chmod +x "$RUNNER_WORK/config.sh"
 
-    bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
+    command setsid bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
     local ep_pid=$!
+    RUNNER_PGID="$ep_pid"
+    if [[ -z "$RUNNER_PGID" ]]; then
+        _cleanup_runner_group "$ep_pid" || true
+        return 1
+    fi
 
     # Wait for runner to start (max 5s).
     local waited=0
@@ -603,11 +610,28 @@ MOCK
     done
     [[ -f "$WORK_DIR/runner-started" ]]
 
-    # This test covers entrypoint deregistration, not group cleanup.
-    kill -TERM "$ep_pid"
-    local entrypoint_status=0
-    wait "$ep_pid" || entrypoint_status=$?
-    [[ $entrypoint_status -eq 0 || $entrypoint_status -eq 143 ]]
+    # The entrypoint is the session and process-group leader, so its PID names
+    # the group.  Prove the group exists before signalling all its members.
+    if ! kill -0 -- "-$RUNNER_PGID"; then
+        _cleanup_runner_group "$RUNNER_PGID" || true
+        return 1
+    fi
+    kill -TERM -- "-$RUNNER_PGID"
+
+    # A leader-only signal leaves run.sh running until its self-expiry.  Check
+    # the runner's signal marker before the cleanup helper can signal it again.
+    local signal_waited=0
+    while [[ ! -f "$WORK_DIR/runner-terminated" ]] && [[ $signal_waited -lt 10 ]]; do
+        _real_sleep 0.1 || return 1
+        signal_waited=$((signal_waited + 1))
+    done
+    if [[ ! -f "$WORK_DIR/runner-terminated" ]]; then
+        _cleanup_runner_group "$RUNNER_PGID" || true
+        return 1
+    fi
+
+    # The helper bounds the wait and escalates if the group does not exit.
+    _cleanup_runner_group "$RUNNER_PGID"
 
     # Deregistration obtains a removal token and invokes config.sh remove.
     grep -q "repos/owner/repo/actions/runners/remove-token" "$WORK_DIR/curl-urls.log"
@@ -661,6 +685,22 @@ MOCK
     [[ $cleanup_status -ne 0 ]]
     [[ -d "$WORK_DIR" ]]
     grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
+}
+
+@test "teardown retains workspace when cleanup cannot prove group extinction" {
+    _write_mock_kill_sequence 'present'
+    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
+    RUNNER_PGID=424242
+
+    local teardown_status=0
+    teardown || teardown_status=$?
+
+    [[ $teardown_status -ne 0 ]]
+    [[ -d "$WORK_DIR" ]]
+
+    # Bats invokes teardown again after this test.  Clear the synthetic group
+    # only after observing that this teardown left the workspace intact.
+    RUNNER_PGID=""
 }
 
 @test "cleanup fails and retains workspace when a probe is unknown" {

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -11,6 +11,10 @@ setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     RUNNER_DIR="$(cd "$TEST_DIR/.." && pwd)"
     ENTRYPOINT="$RUNNER_DIR/entrypoint.sh"
+    # Resolve this before the mock directory shadows PATH.  type -P ignores
+    # shell functions, and the resulting pathname does not depend on PATH.
+    REAL_SLEEP="$(type -P sleep)"
+    RUNNER_PGID=""
 
     # Temp workspace — every test gets an isolated directory
     WORK_DIR="$(mktemp -d)"
@@ -97,6 +101,10 @@ MOCK
 }
 
 teardown() {
+    if [[ -n "${RUNNER_PGID:-}" ]]; then
+        kill -TERM -- "-$RUNNER_PGID" 2>/dev/null || true
+        wait "$RUNNER_PGID" 2>/dev/null || true
+    fi
     rm -rf "$WORK_DIR"
 }
 
@@ -200,6 +208,12 @@ MOCK
 _run_entrypoint() {
     # Run entrypoint from RUNNER_WORK so relative ./config.sh and ./run.sh work
     run bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE"
+}
+
+# Use the real sleep binary for test timing.  entrypoint.sh must still resolve
+# its retry backoff through the mocked sleep on PATH.
+_real_sleep() {
+    command "$REAL_SLEEP" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -442,37 +456,70 @@ MOCK
     export GITHUB_TOKEN="ghp_pattoken"
     export GITHUB_REPOSITORY="owner/repo"
 
-    # Make run.sh block until signalled, then exit
+    # Make run.sh block until signalled, then exit.  The readiness delay makes
+    # the assertion below discriminate between real and mocked test sleeps.
     cat > "$RUNNER_WORK/run.sh" <<MOCK
 #!/usr/bin/env bash
+# Delay without resolving any binary through PATH.
+coproc readiness_blocker { while IFS= read -r _; do :; done; }
+read -r -t 0.2 _ <&"\${readiness_blocker[0]}" || true
+kill "\$readiness_blocker_PID"
+wait "\$readiness_blocker_PID" 2>/dev/null || true
 # Signal the parent that we've started
 touch "$WORK_DIR/runner-started"
-# Block until killed
-while true; do sleep 0.1; done
+# Block without polling or resolving a binary through PATH.  The coprocess
+# waits on the pipe held open by this shell, and this shell waits on it.
+trap 'exit 0' TERM INT
+coproc runner_blocker { while IFS= read -r _; do :; done; }
+wait "\$runner_blocker_PID"
 MOCK
     chmod +x "$RUNNER_WORK/run.sh"
 
-    # Run entrypoint in background
-    bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
-    local ep_pid=$!
+    # Record config.sh remove invocations so this test proves deregistration,
+    # not merely that its log contains a generic runner-related message.
+    cat > "$RUNNER_WORK/config.sh" <<MOCK
+#!/usr/bin/env bash
+if [[ "\$1" == "remove" ]]; then
+    touch "$WORK_DIR/runner-deregistered"
+fi
+exit 0
+MOCK
+    chmod +x "$RUNNER_WORK/config.sh"
+
+    # Run entrypoint in its own process group so its runner child can receive
+    # the same signal.  With setsid, the leader PID is also the process group.
+    command setsid bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
+    RUNNER_PGID=$!
+    local ep_pid=$RUNNER_PGID
 
     # Wait for runner to start (max 5s)
     local waited=0
     while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -lt 50 ]]; do
-        sleep 0.1
+        _real_sleep 0.1
         waited=$((waited + 1))
     done
+    [[ -f "$WORK_DIR/runner-started" ]]
+    [[ $waited -lt 50 ]]
 
-    # Send SIGTERM to the entrypoint process group
-    kill -SIGTERM "$ep_pid" 2>/dev/null || true
+    # Signal and reap the whole entrypoint process group.
+    kill -TERM -- "-$ep_pid" 2>/dev/null || true
     wait "$ep_pid" 2>/dev/null || true
+    if kill -0 -- "-$ep_pid" 2>/dev/null; then
+        false
+    fi
+    RUNNER_PGID=""
 
-    # The cleanup function should have called curl for a removal token
-    # Check the log for deregistration message
-    grep -q "deregistering" "$LOG_FILE" || \
-    grep -q "shutdown" "$LOG_FILE" || \
-    grep -q "SIGTERM\|signal" "$LOG_FILE" || \
-    grep -q "runner" "$LOG_FILE"
+    # Deregistration obtains a removal token and invokes config.sh remove.
+    grep -q "repos/owner/repo/actions/runners/remove-token" "$WORK_DIR/curl-urls.log"
+    [[ -f "$WORK_DIR/runner-deregistered" ]]
+    grep -q "Runner deregistered\." "$LOG_FILE"
+
+    # The teardown must reap the process group before it removes its files.
+    local teardown_wait_line teardown_remove_line
+    teardown_wait_line=$(declare -f teardown | grep -n 'wait "$RUNNER_PGID"' | cut -d: -f1)
+    teardown_remove_line=$(declare -f teardown | grep -n 'rm -rf "$WORK_DIR"' | cut -d: -f1)
+    [[ -n "$teardown_wait_line" && -n "$teardown_remove_line" ]]
+    [[ $teardown_wait_line -lt $teardown_remove_line ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -500,8 +547,8 @@ MOCK
     # First invocation
     bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>/dev/null || true
 
-    # Brief pause to ensure timestamp differs — bypass mock sleep with real binary
-    /usr/bin/sleep 1 2>/dev/null || /bin/sleep 1 2>/dev/null || true
+    # Brief pause to ensure timestamp differs.
+    _real_sleep 1
 
     # Second invocation
     bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>/dev/null || true

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -212,45 +212,122 @@ _run_entrypoint() {
 # Use the real sleep binary for test timing.  entrypoint.sh must still resolve
 # its retry backoff through the mocked sleep on PATH.
 _real_sleep() {
-    command "$REAL_SLEEP" "$@"
+    command "${RUNNER_REAL_SLEEP:-$REAL_SLEEP}" "$@"
+}
+
+# Return one of three states for a process group: 0 present, 1 absent, or 2
+# unknown.  A failed signal probe alone is never evidence of extinction: an
+# EPERM result has the same shell status as ESRCH.  /proc is available on the
+# Linux-only test host, so membership in the process group is the authoritative
+# answer when the normal probe has a conventional result.
+_runner_group_state() {
+    local pgid="${1:-}"
+    local probe_status=0
+    local stat_file stat_line state ppid stat_pgid ignored rest
+
+    [[ "$pgid" =~ ^[1-9][0-9]*$ ]] || return 2
+
+    # Use env so the decision table can mock kill in BIN_DIR despite Bash's
+    # kill builtin taking precedence over PATH.
+    env kill -0 -- "-$pgid" 2>/dev/null || probe_status=$?
+    [[ $probe_status -eq 0 ]] && return 0
+    # GNU/procps kill uses 1 for the expected ESRCH/EPERM outcomes.  Anything
+    # else is an unexpected probe failure and must retain the workspace.
+    [[ $probe_status -eq 1 ]] || return 2
+    [[ -d "${RUNNER_PROC_ROOT:-/proc}" ]] || return 2
+
+    for stat_file in "${RUNNER_PROC_ROOT:-/proc}"/[0-9]*/stat; do
+        [[ -e "$stat_file" ]] || continue
+        stat_line=$(<"$stat_file") || return 2
+        # Fields after the final ')' are: state (3), ppid (4), pgrp (5), ... .
+        rest="${stat_line##*) }"
+        read -r state ppid stat_pgid ignored <<<"$rest"
+        [[ "$state" =~ ^[A-Z]$ && "$ppid" =~ ^[0-9]+$ && "$stat_pgid" =~ ^[0-9]+$ && -n "$ignored" ]] || return 2
+        [[ "$stat_pgid" == "$pgid" ]] && return 0
+    done
+
+    return 1
+}
+
+# A group proven absent cannot contain a running leader, so wait can only reap
+# the already-dead child.  The watchdog makes that invariant an actual one-
+# second deadline rather than relying on wait's expected immediate return.
+_reap_absent_runner_leader() {
+    local pgid="$1"
+    local timed_out=0
+    local parent_pid="$BASHPID"
+    local watchdog_pid
+    local saved_usr1_trap
+
+    saved_usr1_trap=$(trap -p USR1 || true)
+    trap 'timed_out=1' USR1
+    ( command "$REAL_SLEEP" 1 && kill -USR1 "$parent_pid" 2>/dev/null ) &
+    watchdog_pid=$!
+
+    wait "$pgid" 2>/dev/null || true
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    if [[ -n "$saved_usr1_trap" ]]; then
+        eval "$saved_usr1_trap"
+    else
+        trap - USR1
+    fi
+
+    [[ $timed_out -eq 0 ]]
 }
 
 # Stop a runner session without deleting its workspace while a descendant may
 # still be using it.  The six-second TERM grace exceeds the five-second
-# readiness window and covers the mocked entrypoint's deregistration path; the
-# one-second KILL confirmation remains well below the
-# outer test timeout if a process stops responding.
+# readiness window; KILL confirmation is limited to one second.
 _cleanup_runner_group() {
     local pgid="${1:-}"
     local term_waited=0
     local kill_waited=0
+    local group_state=0
+    local grace_failed=0
 
-    # An unset, invalid, or already-extinct group needs no cleanup.
-    if [[ -z "$pgid" ]] || ! kill -0 -- "-$pgid" 2>/dev/null; then
-        return 0
+    [[ -z "$pgid" ]] && return 0
+
+    if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
+    if [[ $group_state -eq 1 ]]; then
+        _reap_absent_runner_leader "$pgid"
+        return $?
     fi
+    [[ $group_state -eq 0 ]] || return 1
 
-    kill -TERM -- "-$pgid" 2>/dev/null || true
-    while kill -0 -- "-$pgid" 2>/dev/null && [[ $term_waited -lt 60 ]]; do
-        _real_sleep 0.1
+    env kill -TERM -- "-$pgid" 2>/dev/null || true
+    while [[ $term_waited -lt 60 ]]; do
+        if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
+        [[ $group_state -eq 1 ]] && break
+        [[ $group_state -eq 0 ]] || return 1
+        if ! _real_sleep 0.1; then
+            grace_failed=1
+            break
+        fi
         term_waited=$((term_waited + 1))
     done
 
-    if kill -0 -- "-$pgid" 2>/dev/null; then
-        kill -KILL -- "-$pgid" 2>/dev/null || true
-        while kill -0 -- "-$pgid" 2>/dev/null && [[ $kill_waited -lt 10 ]]; do
-            _real_sleep 0.1
-            kill_waited=$((kill_waited + 1))
-        done
+    if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
+    if [[ $grace_failed -eq 1 || $group_state -ne 1 ]]; then
+        env kill -KILL -- "-$pgid" 2>/dev/null || true
     fi
 
-    if kill -0 -- "-$pgid" 2>/dev/null; then
-        return 1
-    fi
+    while [[ $kill_waited -lt 10 ]]; do
+        if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
+        [[ $group_state -eq 1 ]] && break
+        [[ $group_state -eq 0 ]] || return 1
+        if ! _real_sleep 0.1; then
+            grace_failed=1
+            break
+        fi
+        kill_waited=$((kill_waited + 1))
+    done
 
-    # The group is already absent, so this wait can only collect the leader's
-    # cached status; it cannot block on a surviving process.
-    wait "$pgid" 2>/dev/null || true
+    if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
+    [[ $group_state -eq 1 ]] || return 1
+    _reap_absent_runner_leader "$pgid" || return 1
+
+    [[ $grace_failed -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -493,24 +570,14 @@ MOCK
     export GITHUB_TOKEN="ghp_pattoken"
     export GITHUB_REPOSITORY="owner/repo"
 
-    # Make run.sh block until signalled, then exit.  The readiness delay makes
-    # the assertion below discriminate between real and mocked test sleeps.
+    # The runner itself publishes readiness after a bounded delay.  It also
+    # self-expires, so an abruptly killed Bats process leaves only a bounded
+    # child behind; this test deliberately creates no detached process group.
     cat > "$RUNNER_WORK/run.sh" <<MOCK
 #!/usr/bin/env bash
-# Delay without resolving any binary through PATH.
-coproc readiness_blocker { while IFS= read -r _; do :; done; }
-read -r -t 0.2 _ <&"\${readiness_blocker[0]}" || true
-kill "\$readiness_blocker_PID"
-wait "\$readiness_blocker_PID" 2>/dev/null || true
-# Block without polling or resolving a binary through PATH.  The coprocess
-# waits on the pipe held open by this shell, and this shell waits on it.
-trap 'exit 0' TERM INT
-coproc runner_blocker { while IFS= read -r _; do :; done; }
-# A killed Bats process never reaches teardown.  This kernel-blocking read
-# limits that otherwise detached mock to thirty seconds without using PATH.
-read -r -t 30 _ <&"\${runner_blocker[0]}" || true
-kill "\$runner_blocker_PID" 2>/dev/null || true
-wait "\$runner_blocker_PID" 2>/dev/null || true
+command "$REAL_SLEEP" 0.1
+touch "$WORK_DIR/runner-started"
+command "$REAL_SLEEP" 5
 MOCK
     chmod +x "$RUNNER_WORK/run.sh"
 
@@ -525,34 +592,22 @@ exit 0
 MOCK
     chmod +x "$RUNNER_WORK/config.sh"
 
-    # Run entrypoint in its own process group so its runner child can receive
-    # the same signal.  With setsid, the leader PID is also the process group.
-    command setsid bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
-    RUNNER_PGID=$!
-    local ep_pid=$RUNNER_PGID
-
-    # Make the marker arrive on the final permitted poll.  The marker itself,
-    # not the counter after observing it, is the readiness evidence.
-    local readiness_polls=0
-    _real_sleep() {
-        command "$REAL_SLEEP" "$@"
-        readiness_polls=$((readiness_polls + 1))
-        if [[ $readiness_polls -eq 50 ]]; then
-            touch "$WORK_DIR/runner-started"
-        fi
-    }
+    bash -c "cd '$RUNNER_WORK' && bash '$ENTRYPOINT'" 2>"$LOG_FILE" &
+    local ep_pid=$!
 
     # Wait for runner to start (max 5s).
-    local waited=1
-    while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -le 50 ]]; do
-        _real_sleep 0.1
+    local waited=0
+    while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -lt 50 ]]; do
+        _real_sleep 0.1 || return 1
         waited=$((waited + 1))
     done
     [[ -f "$WORK_DIR/runner-started" ]]
 
-    # Signal, prove extinction, and reap the whole entrypoint process group.
-    _cleanup_runner_group "$ep_pid"
-    RUNNER_PGID=""
+    # This test covers entrypoint deregistration, not group cleanup.
+    kill -TERM "$ep_pid"
+    local entrypoint_status=0
+    wait "$ep_pid" || entrypoint_status=$?
+    [[ $entrypoint_status -eq 0 || $entrypoint_status -eq 143 ]]
 
     # Deregistration obtains a removal token and invokes config.sh remove.
     grep -q "repos/owner/repo/actions/runners/remove-token" "$WORK_DIR/curl-urls.log"
@@ -561,63 +616,79 @@ MOCK
 
 }
 
-@test "process-group cleanup waits for group extinction before returning" {
-    # The leader exits before its TERM-resistant descendant.  A leader-only
-    # probe would treat that live group as already gone.
-    command setsid bash -c "bash -c 'trap \"\" TERM INT; exec $REAL_SLEEP 1' & exec $REAL_SLEEP 0.1" &
-    local pgid=$!
-    _real_sleep 0.2
+# The decision table below exercises cleanup state transitions without real
+# processes.  End-to-end orchestration covers actual survivor and disk-growth
+# behaviour, where it is observable without making each fixture a leak/race.
+_write_mock_kill_sequence() {
+    local states="$1"
 
-    _cleanup_runner_group "$pgid"
+    cat > "$BIN_DIR/kill" <<MOCK
+#!/usr/bin/env bash
+if [[ "\$1" == "-0" ]]; then
+    count_file="$WORK_DIR/kill-probe-count"
+    count=\$(cat "\$count_file" 2>/dev/null || echo 0)
+    state=\$(printf '%s\\n' '$states' | sed -n "\$((count + 1))p")
+    [[ -n "\$state" ]] || state=\$(printf '%s\\n' '$states' | tail -n 1)
+    echo \$((count + 1)) > "\$count_file"
+    case "\$state" in
+        present) exit 0 ;;
+        absent) exit 1 ;;
+        unknown) exit 2 ;;
+    esac
+fi
+echo "\$1" >> "$WORK_DIR/kill-signals.log"
+exit 0
+MOCK
+    chmod +x "$BIN_DIR/kill"
+}
+
+@test "cleanup succeeds when probes change from present to absent" {
+    _write_mock_kill_sequence $'present\nabsent'
+
+    _cleanup_runner_group 424242
 
     [[ -d "$WORK_DIR" ]]
-    ! kill -0 -- "-$pgid" 2>/dev/null
+    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
 }
 
-@test "process-group cleanup escalates an unresponsive member within its deadline" {
-    command setsid bash -c '
-        trap "" TERM INT
-        coproc blocker { trap "" TERM INT; while IFS= read -r _; do :; done; }
-        while :; do read -r -t 30 _ <&"${blocker[0]}" || true; done
-    ' &
-    local pgid=$!
-    _real_sleep 0.1
-    local started=$SECONDS
+@test "cleanup fails and retains workspace when probes stay present" {
+    _write_mock_kill_sequence 'present'
+    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
 
-    _cleanup_runner_group "$pgid"
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
 
-    (( SECONDS - started < 8 ))
-    ! kill -0 -- "-$pgid" 2>/dev/null
+    [[ $cleanup_status -ne 0 ]]
+    [[ -d "$WORK_DIR" ]]
+    grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
-@test "teardown keeps the workspace when group extinction cannot be proven" {
-    command setsid bash -c '
-        trap "" TERM INT
-        coproc blocker { trap "" TERM INT; while IFS= read -r _; do :; done; }
-        while :; do read -r -t 30 _ <&"${blocker[0]}" || true; done
-    ' &
-    RUNNER_PGID=$!
-    _real_sleep 0.1
+@test "cleanup fails and retains workspace when a probe is unknown" {
+    _write_mock_kill_sequence 'unknown'
 
-    # Simulate a group that remains observable after KILL.  This lets teardown
-    # exercise its failure branch without needing an unkillable test process.
-    kill() {
-        if [[ "$1" == "-0" ]]; then
-            return 0
-        fi
-        builtin kill "$@"
-    }
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
 
-    local teardown_status=0
-    teardown || teardown_status=$?
-    local workspace_status=0
-    [[ -d "$WORK_DIR" ]] || workspace_status=$?
+    [[ $cleanup_status -ne 0 ]]
+    [[ -d "$WORK_DIR" ]]
+    [[ ! -f "$WORK_DIR/kill-signals.log" ]]
+}
 
-    unset -f kill
-    RUNNER_PGID=""
+@test "cleanup fails after a failed grace period even when KILL proves absence" {
+    _write_mock_kill_sequence $'present\npresent\nabsent'
+    cat > "$BIN_DIR/failing-real-sleep" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$BIN_DIR/failing-real-sleep"
+    RUNNER_REAL_SLEEP="$BIN_DIR/failing-real-sleep"
 
-    [[ $teardown_status -ne 0 ]]
-    [[ $workspace_status -eq 0 ]]
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
+
+    [[ $cleanup_status -ne 0 ]]
+    [[ -d "$WORK_DIR" ]]
+    grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
 # ---------------------------------------------------------------------------

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -101,9 +101,8 @@ MOCK
 }
 
 teardown() {
-    if [[ -n "${RUNNER_PGID:-}" ]]; then
-        kill -TERM -- "-$RUNNER_PGID" 2>/dev/null || true
-        wait "$RUNNER_PGID" 2>/dev/null || true
+    if ! _cleanup_runner_group "${RUNNER_PGID:-}"; then
+        return 1
     fi
     rm -rf "$WORK_DIR"
 }
@@ -214,6 +213,44 @@ _run_entrypoint() {
 # its retry backoff through the mocked sleep on PATH.
 _real_sleep() {
     command "$REAL_SLEEP" "$@"
+}
+
+# Stop a runner session without deleting its workspace while a descendant may
+# still be using it.  The six-second TERM grace exceeds the five-second
+# readiness window and covers the mocked entrypoint's deregistration path; the
+# one-second KILL confirmation remains well below the
+# outer test timeout if a process stops responding.
+_cleanup_runner_group() {
+    local pgid="${1:-}"
+    local term_waited=0
+    local kill_waited=0
+
+    # An unset, invalid, or already-extinct group needs no cleanup.
+    if [[ -z "$pgid" ]] || ! kill -0 -- "-$pgid" 2>/dev/null; then
+        return 0
+    fi
+
+    kill -TERM -- "-$pgid" 2>/dev/null || true
+    while kill -0 -- "-$pgid" 2>/dev/null && [[ $term_waited -lt 60 ]]; do
+        _real_sleep 0.1
+        term_waited=$((term_waited + 1))
+    done
+
+    if kill -0 -- "-$pgid" 2>/dev/null; then
+        kill -KILL -- "-$pgid" 2>/dev/null || true
+        while kill -0 -- "-$pgid" 2>/dev/null && [[ $kill_waited -lt 10 ]]; do
+            _real_sleep 0.1
+            kill_waited=$((kill_waited + 1))
+        done
+    fi
+
+    if kill -0 -- "-$pgid" 2>/dev/null; then
+        return 1
+    fi
+
+    # The group is already absent, so this wait can only collect the leader's
+    # cached status; it cannot block on a surviving process.
+    wait "$pgid" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -465,13 +502,15 @@ coproc readiness_blocker { while IFS= read -r _; do :; done; }
 read -r -t 0.2 _ <&"\${readiness_blocker[0]}" || true
 kill "\$readiness_blocker_PID"
 wait "\$readiness_blocker_PID" 2>/dev/null || true
-# Signal the parent that we've started
-touch "$WORK_DIR/runner-started"
 # Block without polling or resolving a binary through PATH.  The coprocess
 # waits on the pipe held open by this shell, and this shell waits on it.
 trap 'exit 0' TERM INT
 coproc runner_blocker { while IFS= read -r _; do :; done; }
-wait "\$runner_blocker_PID"
+# A killed Bats process never reaches teardown.  This kernel-blocking read
+# limits that otherwise detached mock to thirty seconds without using PATH.
+read -r -t 30 _ <&"\${runner_blocker[0]}" || true
+kill "\$runner_blocker_PID" 2>/dev/null || true
+wait "\$runner_blocker_PID" 2>/dev/null || true
 MOCK
     chmod +x "$RUNNER_WORK/run.sh"
 
@@ -492,21 +531,27 @@ MOCK
     RUNNER_PGID=$!
     local ep_pid=$RUNNER_PGID
 
-    # Wait for runner to start (max 5s)
-    local waited=0
-    while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -lt 50 ]]; do
+    # Make the marker arrive on the final permitted poll.  The marker itself,
+    # not the counter after observing it, is the readiness evidence.
+    local readiness_polls=0
+    _real_sleep() {
+        command "$REAL_SLEEP" "$@"
+        readiness_polls=$((readiness_polls + 1))
+        if [[ $readiness_polls -eq 50 ]]; then
+            touch "$WORK_DIR/runner-started"
+        fi
+    }
+
+    # Wait for runner to start (max 5s).
+    local waited=1
+    while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -le 50 ]]; do
         _real_sleep 0.1
         waited=$((waited + 1))
     done
     [[ -f "$WORK_DIR/runner-started" ]]
-    [[ $waited -lt 50 ]]
 
-    # Signal and reap the whole entrypoint process group.
-    kill -TERM -- "-$ep_pid" 2>/dev/null || true
-    wait "$ep_pid" 2>/dev/null || true
-    if kill -0 -- "-$ep_pid" 2>/dev/null; then
-        false
-    fi
+    # Signal, prove extinction, and reap the whole entrypoint process group.
+    _cleanup_runner_group "$ep_pid"
     RUNNER_PGID=""
 
     # Deregistration obtains a removal token and invokes config.sh remove.
@@ -514,12 +559,65 @@ MOCK
     [[ -f "$WORK_DIR/runner-deregistered" ]]
     grep -q "Runner deregistered\." "$LOG_FILE"
 
-    # The teardown must reap the process group before it removes its files.
-    local teardown_wait_line teardown_remove_line
-    teardown_wait_line=$(declare -f teardown | grep -n 'wait "$RUNNER_PGID"' | cut -d: -f1)
-    teardown_remove_line=$(declare -f teardown | grep -n 'rm -rf "$WORK_DIR"' | cut -d: -f1)
-    [[ -n "$teardown_wait_line" && -n "$teardown_remove_line" ]]
-    [[ $teardown_wait_line -lt $teardown_remove_line ]]
+}
+
+@test "process-group cleanup waits for group extinction before returning" {
+    # The leader exits before its TERM-resistant descendant.  A leader-only
+    # probe would treat that live group as already gone.
+    command setsid bash -c "bash -c 'trap \"\" TERM INT; exec $REAL_SLEEP 1' & exec $REAL_SLEEP 0.1" &
+    local pgid=$!
+    _real_sleep 0.2
+
+    _cleanup_runner_group "$pgid"
+
+    [[ -d "$WORK_DIR" ]]
+    ! kill -0 -- "-$pgid" 2>/dev/null
+}
+
+@test "process-group cleanup escalates an unresponsive member within its deadline" {
+    command setsid bash -c '
+        trap "" TERM INT
+        coproc blocker { trap "" TERM INT; while IFS= read -r _; do :; done; }
+        while :; do read -r -t 30 _ <&"${blocker[0]}" || true; done
+    ' &
+    local pgid=$!
+    _real_sleep 0.1
+    local started=$SECONDS
+
+    _cleanup_runner_group "$pgid"
+
+    (( SECONDS - started < 8 ))
+    ! kill -0 -- "-$pgid" 2>/dev/null
+}
+
+@test "teardown keeps the workspace when group extinction cannot be proven" {
+    command setsid bash -c '
+        trap "" TERM INT
+        coproc blocker { trap "" TERM INT; while IFS= read -r _; do :; done; }
+        while :; do read -r -t 30 _ <&"${blocker[0]}" || true; done
+    ' &
+    RUNNER_PGID=$!
+    _real_sleep 0.1
+
+    # Simulate a group that remains observable after KILL.  This lets teardown
+    # exercise its failure branch without needing an unkillable test process.
+    kill() {
+        if [[ "$1" == "-0" ]]; then
+            return 0
+        fi
+        builtin kill "$@"
+    }
+
+    local teardown_status=0
+    teardown || teardown_status=$?
+    local workspace_status=0
+    [[ -d "$WORK_DIR" ]] || workspace_status=$?
+
+    unset -f kill
+    RUNNER_PGID=""
+
+    [[ $teardown_status -ne 0 ]]
+    [[ $workspace_status -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Running the `github-runner` bats suite left a process behind that wrote into a file it had
already lost. Measured on `origin/master`, extracted into a temporary directory and run there:

```
    PID    PPID    PGID ELAPSED
 161391       1  160506     638 bash ./run.sh
/proc/161391/cwd  -> /tmp/tmp.FLWgZv03Eh/actions-runner (deleted)
/proc/161391/fd/2 -> /tmp/tmp.FLWgZv03Eh/entrypoint.log (deleted)
stderr 150607383 -> 153132258 bytes (+2524875 in 10s)
```

21.8 GB per day per survivor, invisible to `du`, reclaimed only when the process dies. Three of
them filled a 61 GB root filesystem twice (#1369).

Four defects chained. Test 10 signalled one pid where its comment said process group, so the
`run.sh` grandchild survived and was reparented to init. `teardown()` deleted the workspace it
was still using. The mock `run.sh` polled, and the global no-op `sleep` mock turned that poll
into a busy loop — the same mock also made the test's own readiness wait complete in
microseconds instead of five seconds, so the signal could be sent before the runner started.

Now: the entrypoint runs in its own session, the group is signalled, and one bounded helper
proves the group gone before anything is removed — sending TERM, establishing absence from
`/proc` membership rather than inferring it from a non-zero `kill -0`, escalating to KILL, and
returning failure when it cannot conclude, in which case the workspace is kept. The mock blocks
in the kernel and self-expires, so an abruptly killed bats process leaves a bounded leak. Every
wait in the file reaches the real `sleep` through one helper.

Test 10 no longer passes on a log merely containing the word "runner": it asserts the group is
gone, the removal-token endpoint was called, and `config.sh remove` ran.

## Verification

`bats github-runner/tests/test-runner-linux.bats` — 21 passed, 1 failed. The failure,
`running as root without ALLOW_ROOT exits 1`, fails identically on `origin/master`; #1374
explains why it always will until its claim is narrowed.

A full run followed by an immediate scan and again after eight seconds leaves no process
matching the test workspace, and 40 KB of root growth. The probe was rebuilt for this: an
earlier version waited ten seconds before scanning, which the mock's own self-expiry had made
non-discriminating.

Two properties were mutation-proved by hand rather than only by the agent: emptying
`RUNNER_PGID` and reverting the signal to `kill -TERM "$ep_pid"` each turn the suite red.

## Follow-ups

Landed on capped evidence at the declared budget plus its one bought round. Residue: #1370
#1372 #1373 #1374 #1375. **#1370 first** — `$!` is the group id only while job control is off,
which is true of bats today and one `set -m` away from silently naming a dead pid.

Closes #1369.
