### PR TITLE
Quarantine a rotation pair only on evidence a producer stands behind

### DIFF
--- a/.github/workflows/rotation.yaml
+++ b/.github/workflows/rotation.yaml
@@ -173,13 +173,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Initialize failure attribution
+      - name: Initialize build producer state
         shell: bash
         env:
           ARCH: ${{ matrix.arch }}
         run: |
           mkdir -p rotation-artifacts
-          printf 'false\n' > "rotation-artifacts/build-${ARCH}"
+          printf 'infra\n' > "rotation-artifacts/build-${ARCH}"
 
       - name: Install yq
         shell: bash
@@ -252,18 +252,16 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           EXTENSION: ${{ needs.select.outputs.extension }}
           PG_MAJOR: ${{ needs.select.outputs.major }}
+          ROTATION_STATUS_FILE: rotation-artifacts/build-${{ matrix.arch }}
         run: |
           set -euo pipefail
           EXTENSION_PACKAGE_SUFFIX=-staging ARCH_SUFFIX="$ARCH" BUILD_PLATFORM="$PLATFORM" \
             scripts/build-extensions.sh postgres --major-version "$PG_MAJOR" --extension "$EXTENSION" --force --no-cache
 
-      - name: Fail an attributable extension compile
+      - name: Fail extension build result
         if: steps.compile.outcome == 'failure'
         shell: bash
-        env:
-          ARCH: ${{ matrix.arch }}
         run: |
-          printf 'true\n' > "rotation-artifacts/build-${ARCH}"
           exit 1
 
       - name: Freeze and validate staging manifest digest
@@ -355,12 +353,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Initialize failure attribution
-        shell: bash
-        run: |
-          mkdir -p rotation-artifacts
-          printf 'false\n' > rotation-artifacts/test-amd64
-
       - name: Build loadable PostgreSQL full image
         id: build-e2e-image
         continue-on-error: true
@@ -379,12 +371,10 @@ jobs:
           push: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail attributable candidate image build result
+      - name: Fail candidate image build result
         if: steps.build-e2e-image.outcome == 'failure'
         shell: bash
-        run: |
-          printf 'true\n' > rotation-artifacts/test-amd64
-          exit 1
+        run: exit 1
 
       - name: Resolve loaded e2e image ID
         shell: bash
@@ -408,20 +398,10 @@ jobs:
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
-      - name: Fail attributable e2e suite result
+      - name: Fail e2e suite result
         if: steps.e2e.outcome == 'failure'
         shell: bash
-        run: |
-          printf 'true\n' > rotation-artifacts/test-amd64
-          exit 1
-
-      - name: Upload test attribution
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        with:
-          name: rotation-status-test-amd64
-          path: rotation-artifacts/test-amd64
-          if-no-files-found: error
+        run: exit 1
 
   test-arm64:
     needs: [select, freeze-digests]
@@ -438,12 +418,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Initialize failure attribution
-        shell: bash
-        run: |
-          mkdir -p rotation-artifacts
-          printf 'false\n' > rotation-artifacts/test-arm64
 
       - name: Build loadable PostgreSQL full image
         id: build-e2e-image
@@ -463,12 +437,10 @@ jobs:
           push: 'false'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail attributable candidate image build result
+      - name: Fail candidate image build result
         if: steps.build-e2e-image.outcome == 'failure'
         shell: bash
-        run: |
-          printf 'true\n' > rotation-artifacts/test-arm64
-          exit 1
+        run: exit 1
 
       - name: Resolve loaded e2e image ID
         shell: bash
@@ -492,20 +464,10 @@ jobs:
         run: |
           E2E_IMAGE="$E2E_IMAGE_ID" tests/e2e-test.sh postgres
 
-      - name: Fail attributable e2e suite result
+      - name: Fail e2e suite result
         if: steps.e2e.outcome == 'failure'
         shell: bash
-        run: |
-          printf 'true\n' > rotation-artifacts/test-arm64
-          exit 1
-
-      - name: Upload test attribution
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        with:
-          name: rotation-status-test-arm64
-          path: rotation-artifacts/test-arm64
-          if-no-files-found: error
+        run: exit 1
 
   promote:
     needs: [select, build, freeze-digests, test-amd64, test-arm64]
@@ -633,43 +595,90 @@ jobs:
           path: rotation-artifacts/status
           merge-multiple: true
 
-      - name: Decide whether a failure is attributable
+      - name: Decide whether producer evidence warrants quarantine
         id: attribution
         shell: bash
-        env:
-          TEST_AMD64_RESULT: ${{ needs.test-amd64.result }}
-          TEST_ARM64_RESULT: ${{ needs.test-arm64.result }}
         run: |
           set -euo pipefail
-          attributable=false
-          expected_statuses=(build-amd64 build-arm64)
-          if [[ "$TEST_AMD64_RESULT" == success || "$TEST_AMD64_RESULT" == failure ]]; then
-            expected_statuses+=(test-amd64)
-          fi
-          if [[ "$TEST_ARM64_RESULT" == success || "$TEST_ARM64_RESULT" == failure ]]; then
-            expected_statuses+=(test-arm64)
-          fi
-          failed_statuses=()
-          for status_name in "${expected_statuses[@]}"; do
-            status_file="rotation-artifacts/status/${status_name}"
+          # A missing, damaged, or unknown producer record is absence of
+          # evidence, not evidence that the pair is broken.  The destructive
+          # action below therefore defaults every such record to infra.
+          remove_canonical_file() {
+            local canonical_file="$1"
+            if ! rm -f -- "$canonical_file"; then
+              printf '::warning::Could not remove temporary producer-state file; continuing with the determined state\n' >&2
+            fi
+          }
+
+          read_rotation_status() {
+            local status_name="$1"
+            local status_file="rotation-artifacts/status/${status_name}"
+            local state canonical_file
+
             if [[ ! -f "$status_file" ]]; then
-              printf '::error::Missing failure attribution from completed producer: %s\n' "$status_name" >&2
-              exit 1
+              printf '::warning::Missing producer state from %s; treating it as infra\n' "$status_name" >&2
+              printf 'infra\n'
+              return 0
             fi
-            status=$(<"$status_file")
-            if [[ "$status" != true && "$status" != false ]]; then
-              printf '::error::Invalid failure attribution from %s: %s\n' "$status_name" "$status" >&2
-              exit 1
+            canonical_file=$(mktemp) || {
+              printf '::warning::Could not validate producer state from %s; treating it as infra\n' "$status_name" >&2
+              printf 'infra\n'
+              return 0
+            }
+            for state in success build-failed infra; do
+              if ! printf '%s\n' "$state" > "$canonical_file"; then
+                remove_canonical_file "$canonical_file"
+                printf '::warning::Could not validate producer state from %s; treating it as infra\n' "$status_name" >&2
+                printf 'infra\n'
+                return 0
+              fi
+              if cmp -s "$canonical_file" "$status_file"; then
+                remove_canonical_file "$canonical_file"
+                printf 'Producer state %s=%s\n' "$status_name" "$state" >&2
+                printf '%s\n' "$state"
+                return 0
+              fi
+            done
+            remove_canonical_file "$canonical_file"
+            printf '::warning::Invalid producer state from %s; treating it as infra\n' "$status_name" >&2
+            printf 'infra\n'
+          }
+
+          status_names=(build-amd64 build-arm64)
+          declare -A states=()
+          for status_name in "${status_names[@]}"; do
+            states["$status_name"]=$(read_rotation_status "$status_name")
+          done
+
+          quarantine_evidence_warrants_action() {
+            create=false
+            reasons=()
+            # buildx itself cannot distinguish a rejected recipe from a pull,
+            # fetch, clone, or compilation failure. Independent runners both
+            # exhausting retries is the cheapest available discriminator.
+            if [[ "${states[build-amd64]}" == build-failed && "${states[build-arm64]}" == build-failed ]]; then
+              create=true
+              reasons+=("both architectures exhausted their build retries")
             fi
-            if [[ "$status" == true ]]; then
-              attributable=true
-              failed_statuses+=("$status_name")
-            fi
+            # A test failure cannot quarantine: the shared full suite names
+            # the suite, not the candidate. Cost: an extension that compiles
+            # then fails runtime checks is not quarantined automatically.
+          }
+
+          quarantine_evidence_warrants_action
+
+          state_lines=()
+          for status_name in "${status_names[@]}"; do
+            state_lines+=("${status_name}=${states[$status_name]}")
           done
           IFS=,
-          printf -v failed_statuses_csv '%s' "${failed_statuses[*]}"
-          printf 'create=%s\n' "$attributable" >> "$GITHUB_OUTPUT"
-          printf 'failed_statuses=%s\n' "$failed_statuses_csv" >> "$GITHUB_OUTPUT"
+          printf -v state_lines_csv '%s' "${state_lines[*]}"
+          printf -v reasons_csv '%s' "${reasons[*]}"
+          {
+            printf 'create=%s\n' "$create"
+            printf 'states=%s\n' "$state_lines_csv"
+            printf 'reasons=%s\n' "$reasons_csv"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Quarantine failing extension pair
         if: steps.attribution.outputs.create == 'true'
@@ -683,17 +692,25 @@ jobs:
           AMD64_DIGEST: ${{ needs.freeze-digests.outputs.amd64_digest }}
           ARM64_DIGEST: ${{ needs.freeze-digests.outputs.arm64_digest }}
           RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
-          FAILED_STATUSES: ${{ steps.attribution.outputs.failed_statuses }}
+          PRODUCER_STATES: ${{ steps.attribution.outputs.states }}
+          QUARANTINE_REASONS: ${{ steps.attribution.outputs.reasons }}
         run: |
           set -euo pipefail
           printf -v body 'rotation-pair: %s pg%s %s\n\nFailed run: %s\n' "$EXTENSION" "$PG_MAJOR" "$VERSION" "$RUN_URL"
-          IFS=, read -r -a failed_statuses <<< "$FAILED_STATUSES"
-          for status_name in "${failed_statuses[@]}"; do
-            phase="${status_name%%-*}"
-            arch="${status_name#*-}"
-            printf -v line 'Failed phase: %s; architecture: %s\n' "$phase" "$arch"
+          body+=$'\nProducer states:\n'
+          IFS=, read -r -a producer_states <<< "$PRODUCER_STATES"
+          for producer_state in "${producer_states[@]}"; do
+            printf -v line -- '- %s\n' "$producer_state"
             body+="$line"
           done
+          IFS=, read -r -a quarantine_reasons <<< "$QUARANTINE_REASONS"
+          if [[ ${#quarantine_reasons[@]} -gt 0 ]]; then
+            body+=$'\nQuarantine evidence:\n'
+            for quarantine_reason in "${quarantine_reasons[@]}"; do
+              printf -v line -- '- %s\n' "$quarantine_reason"
+              body+="$line"
+            done
+          fi
           if [[ -n "$AMD64_DIGEST" ]]; then
             printf -v line 'amd64 digest: %s\n' "$AMD64_DIGEST"
             body+="$line"

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -83,7 +83,7 @@ _scoped_tag() {
 
 
 # Override build_ext_image from extension-utils.sh for the CI buildx per-arch
-# path: explicit --platform builds, asymmetric cache refs, separate compile/push
+# path: explicit --platform builds, asymmetric cache refs, separate build-phase/push
 # handling, and rc=2 for push failures. It also injects REMOTE_CR into extension
 # builder stages. Do not delete this override merely by upstreaming REMOTE_CR;
 # extension-utils.sh would need the whole buildx/cache/push path first.
@@ -107,12 +107,11 @@ build_ext_image() {
 
     if [[ -n "${BUILD_PLATFORM:-}" ]]; then
         # CI per-arch leg: build for the specific platform using buildx.
-        # Build and push are intentionally SEPARATE steps so their failure modes
-        # are distinguishable:
-        #   - compile (--load) failure → rc=1 (musl incompatibility tolerated for
-        #     non-ceiling versions by the caller).
-        #   - push failure (infra/auth/network) → rc=2 (FATAL for ALL versions,
-        #     ceiling AND non-ceiling, because it is not a compile incompatibility).
+        # A successful local build is pushed separately, so a push failure is
+        # rc=2.  A buildx --load failure is rc=1, but is an ambiguous build-phase
+        # result: it can be a rejected recipe, a FROM pull, an apk fetch, a git
+        # clone, or compilation.  Rotation attributes rc=1 only when both
+        # independent architecture legs agree.
         #
         # BA-1: pushing extension images from same-repo PRs is a deliberate
         # accepted trade-off. PR-scoped images let the PR's own smoke consume and
@@ -158,8 +157,8 @@ build_ext_image() {
         [[ "${NO_PUSH:-false}" == "true" ]] && _do_push_ext=false
         [[ "${LOCAL_ONLY:-false}" == "true" ]] && _do_push_ext=false
 
-        # Step 1: compile — always use --load (loads image into the local docker
-        # store of the native runner).  rc=1 on failure (compile / musl error).
+        # Step 1: build — always use --load (loads image into the local docker
+        # store of the native runner).  rc=1 is an ambiguous build-phase failure.
         # Cache imports are intentionally asymmetric: a PR reads the canonical
         # cache plus its own scoped cache, while its export remains PR-scoped.
         # A missing importer is non-fatal to buildx, so extensions with no
@@ -170,10 +169,9 @@ build_ext_image() {
         # disables layer-result reuse and omits external registry cache imports and exports.
         # The cache export must not be able to fail the build: a cache-to write
         # error (registry/auth/network) would otherwise surface as a non-zero
-        # buildx exit and be misread as a compile/musl failure, silently dropping
-        # a retained non-ceiling version. ignore-error=true makes the export
-        # best-effort so only a genuine compile failure returns non-zero here;
-        # real infra failures are caught by the separate push step (rc=2, fatal).
+        # buildx exit with the same ambiguous rc=1 as a rejected recipe, pull,
+        # fetch, clone, or compilation. ignore-error=true makes the export
+        # best-effort; the later push still reports its own rc=2 failure.
         local _cache_flags=()
         if [[ "${NO_CACHE:-false}" != "true" ]]; then
             local _canonical_cache_ref
@@ -200,8 +198,8 @@ build_ext_image() {
             --build-arg EXT_REPO="$ext_repo" \
             "${_rust_args[@]}" \
             "$context_dir"; then
-            log_error "Docker buildx build (compile) failed for $ext_name $ext_version (pg${pg_major})"
-            return 1  # compile failure
+            log_error "Docker buildx build failed for $ext_name $ext_version (pg${pg_major})"
+            return 1  # ambiguous build-phase failure
         fi
 
         if [[ "$_do_push_ext" == "false" ]]; then
@@ -209,8 +207,8 @@ build_ext_image() {
             return 0
         fi
 
-        # Step 2: push — separate from compile so push/auth/network failures are
-        # distinct from musl compile incompatibilities.  rc=2 on failure (infra).
+        # Step 2: push a successful local build. rc=2 is an infra/auth/network
+        # failure; it does not make rc=1 a compiler diagnosis.
         if ! $DOCKER push "$_ver_tag"; then
             log_error "Docker push failed for $ext_name $ext_version (pg${pg_major}) — infra/auth/network error"
             return 2  # push failure (infra — FATAL for all versions, not just ceiling)
@@ -249,6 +247,102 @@ PULL_ONLY=false
 DRY_RUN=false
 FINALIZE_MULTIARCH=false
 NO_CACHE="${DOCKER_NO_CACHE:-false}"
+
+# ROTATION_STATUS_FILE is an optional producer-owned status channel used by the
+# scheduled extension rotation.  An unset variable keeps every other caller on
+# its historical boolean-only exit-code contract.  A set empty path is refused:
+# it is almost certainly a caller that meant to request attribution but would
+# otherwise silently lose it.
+_rotation_status_file_is_valid() {
+    if [[ -z "${ROTATION_STATUS_FILE+x}" ]]; then
+        return 0
+    fi
+    if [[ -z "$ROTATION_STATUS_FILE" ]]; then
+        log_error "ROTATION_STATUS_FILE must be unset or name a status file"
+        return 1
+    fi
+    local status_dir
+    status_dir=$(dirname -- "$ROTATION_STATUS_FILE") || return 1
+    if [[ ! -d "$status_dir" ]]; then
+        log_error "ROTATION_STATUS_FILE parent does not exist: $status_dir"
+        return 1
+    fi
+    if [[ -L "$ROTATION_STATUS_FILE" || ( -e "$ROTATION_STATUS_FILE" && ! -f "$ROTATION_STATUS_FILE" ) ]]; then
+        log_error "ROTATION_STATUS_FILE must name a regular file: $ROTATION_STATUS_FILE"
+        return 1
+    fi
+    return 0
+}
+
+# Write one complete state with an atomic rename.  The caller creates the
+# initial infra file before invoking a producer, so an unexpected death before
+# this function runs remains infra rather than becoming an invented verdict.
+_write_rotation_status() {
+    local state="$1"
+
+    if [[ -z "${ROTATION_STATUS_FILE+x}" ]]; then
+        return 0
+    fi
+    _rotation_status_file_is_valid || return 1
+
+    local status_dir status_base status_tmp
+    status_dir=$(dirname -- "$ROTATION_STATUS_FILE") || return 1
+    status_base=$(basename -- "$ROTATION_STATUS_FILE") || return 1
+    if [[ ! -d "$status_dir" ]]; then
+        log_error "ROTATION_STATUS_FILE parent does not exist: $status_dir"
+        return 1
+    fi
+    if [[ -L "$ROTATION_STATUS_FILE" || ( -e "$ROTATION_STATUS_FILE" && ! -f "$ROTATION_STATUS_FILE" ) ]]; then
+        log_error "ROTATION_STATUS_FILE must name a regular file: $ROTATION_STATUS_FILE"
+        return 1
+    fi
+    status_tmp=$(mktemp "$status_dir/.${status_base}.tmp.XXXXXX") || {
+        log_error "Could not create temporary rotation status file in $status_dir"
+        return 1
+    }
+    printf '%s\n' "$state" > "$status_tmp" || {
+        rm -f -- "$status_tmp" || true
+        return 1
+    }
+    mv -f -- "$status_tmp" "$ROTATION_STATUS_FILE" || {
+        rm -f -- "$status_tmp" || true
+        return 1
+    }
+    if [[ ! -f "$ROTATION_STATUS_FILE" ]]; then
+        log_error "ROTATION_STATUS_FILE was not written as a regular file: $ROTATION_STATUS_FILE"
+        return 1
+    fi
+}
+
+# This is intentionally a build-phase result, not a compiler diagnosis:
+# buildx can fail while pulling, fetching, cloning, or compiling.  The only
+# positive evidence available here is that this build phase exhausted retries.
+_ROTATION_BUILD_STATUS=infra
+_ROTATION_BUILD_HAS_INFRA=false
+_ROTATION_BUILD_PENDING=infra
+_record_rotation_build_status() {
+    local state="$1"
+    case "$state" in
+        build-failed)
+            # A later unclassified/infra failure removes attribution.  Positive
+            # evidence must survive only when nothing contradicts its scope.
+            if [[ "$_ROTATION_BUILD_HAS_INFRA" != true ]]; then
+                _ROTATION_BUILD_PENDING=build-failed
+            fi
+            ;;
+        infra)
+            _ROTATION_BUILD_STATUS=infra
+            _ROTATION_BUILD_PENDING=infra
+            _ROTATION_BUILD_HAS_INFRA=true
+            ;;
+        *)
+            log_error "Unknown rotation build status: $state"
+            _ROTATION_BUILD_STATUS=infra
+            _ROTATION_BUILD_PENDING=infra
+            return 1
+            ;;
+    esac
+}
 
 usage() {
     local exit_code="${1:-0}"
@@ -488,14 +582,15 @@ build_extension() {
 
     # Retry loop for transient failures (network blips on FROM pull, apk add, git clone).
     # EXT_BUILD_RETRIES defaults to 3; set to a lower value in tests.
-    # Persistent failures (real musl incompatibility, auth error) fail all attempts
-    # and propagate the original rc so the caller can distinguish compile (rc=1)
-    # from push (rc=2) failures. Retries reduce — but do not eliminate — the
-    # transient-vs-incompatibility ambiguity: a version excluded after N persistent
-    # failures is treated as a genuine build miss.
+    # Any non-rc=1 attempt makes the exhausted sequence infrastructure: the final
+    # rc alone cannot erase an earlier transport failure, and an unknown rc is not
+    # positive evidence of a candidate defect. Only all-rc=1 failures remain an
+    # ambiguous build-phase result. Retries reduce but do not eliminate that
+    # ambiguity, so rotation requires agreement from both architecture legs.
     local _max_attempts="${EXT_BUILD_RETRIES:-3}"
     local _attempt=0
     local _build_rc=0
+    local _saw_infra=false
     while [[ "$_attempt" -lt "$_max_attempts" ]]; do
         _attempt=$(( _attempt + 1 ))
         _build_rc=0
@@ -504,14 +599,25 @@ build_extension() {
         if [[ "$_build_rc" -eq 0 ]]; then
             return 0
         fi
+        if [[ "$_build_rc" -ne 1 ]]; then
+            _saw_infra=true
+        fi
         if [[ "$_attempt" -lt "$_max_attempts" ]]; then
             local _backoff=$(( _attempt * 3 ))
             log_warning "build_ext_image attempt $_attempt/$_max_attempts failed (rc=$_build_rc) for $ext_name $ext_version — retrying in ${_backoff}s"
             sleep "$_backoff"
         fi
     done
-    log_error "build_ext_image failed after $_max_attempts attempt(s) (rc=$_build_rc) for $ext_name $ext_version — persistent failure"
-    return "$_build_rc"
+    if [[ "$_attempt" -eq 0 ]]; then
+        log_error "build_ext_image made no attempts for $ext_name $ext_version — treating it as infrastructure"
+        return 2
+    fi
+    if [[ "$_saw_infra" == true ]]; then
+        log_error "build_ext_image failed after $_max_attempts attempt(s) for $ext_name $ext_version — at least one attempt was infrastructure or unclassified"
+        return 2
+    fi
+    log_error "build_ext_image failed after $_max_attempts attempt(s) (rc=$_build_rc) for $ext_name $ext_version — ambiguous build-phase failure"
+    return 1
 }
 
 # Tag extension with registry name (always needed for COPY --from= to work)
@@ -1002,6 +1108,7 @@ build_tag_push_extensions() {
                 version_set_json="[\"$ceiling\"]"
             else
                 log_error "$ext: version-set resolver failed — skipping build"
+                _record_rotation_build_status infra
                 failed+=("$ext")
                 continue
             fi
@@ -1037,6 +1144,7 @@ build_tag_push_extensions() {
                     set_size=1
                 else
                     log_error "$ext: semver/ceiling validation failed — skipping build (fail-closed)"
+                    _record_rotation_build_status infra
                     failed+=("$ext")
                     continue
                 fi
@@ -1099,26 +1207,29 @@ build_tag_push_extensions() {
 
             # Attempt build for this version.
             # build_extension returns:
-            #   0  — success (compile + push, or local build)
-            #   1  — compile failure (musl incompatibility or Dockerfile error)
+            #   0  — success (build + push, or local build)
+            #   1  — build phase failure after retries (cause is ambiguous)
             #   2  — push failure (infra/auth/network; only on BUILD_PLATFORM path)
             local _build_rc=0
             build_extension "$ext" "$config_file" "$major_ver" "$container_dir" "$version" || _build_rc=$?
 
             if [[ "$_build_rc" -eq 2 ]]; then
                 # Push failure (infra/auth/network) is FATAL for ALL versions —
-                # ceiling AND non-ceiling.  It is not a compile incompatibility and
-                # must never be silently excluded from the version set.
+                # ceiling AND non-ceiling. It must never be silently excluded
+                # from the version set.
                 log_error "$ext $version push failed (infra error) — fatal regardless of ceiling"
+                _record_rotation_build_status infra
                 failed+=("$ext@$version")
                 continue
             fi
 
             if [[ "$_build_rc" -ne 0 ]]; then
-                # Compile failure (rc=1 or any other non-zero, non-2 code):
-                # ceiling is fatal; non-ceiling is tolerated (musl compat).
+                # An all-rc=1 build-phase failure is fatal for the ceiling and
+                # tolerated for non-ceiling versions. It is not a compiler
+                # diagnosis: exhausted retries are the only attribution.
                 if [[ "$version" == "$ceiling" ]]; then
                     log_error "$ext $version (ceiling) build failed"
+                    _record_rotation_build_status build-failed
                     failed+=("$ext@$version")
                 else
                     log_warning "$ext $version build failed (non-ceiling, skipping)"
@@ -1134,6 +1245,7 @@ build_tag_push_extensions() {
                 # Tag failure is always fatal — it is a registry/infra error, not musl.
                 if ! tag_extension "$ext" "$config_file" "$major_ver" "$version"; then
                     log_error "$ext $version tag failed (infra error)"
+                    _record_rotation_build_status infra
                     failed+=("$ext@$version")
                     continue
                 fi
@@ -1142,6 +1254,7 @@ build_tag_push_extensions() {
                 if [[ "$do_push" == "true" ]]; then
                     if ! push_extension "$ext" "$config_file" "$major_ver" "$version"; then
                         log_error "$ext $version push failed"
+                        _record_rotation_build_status infra
                         failed+=("$ext@$version")
                         continue
                     fi
@@ -1220,6 +1333,7 @@ build_tag_push_extensions() {
                 local _ba_rc=0
                 _bundle_and_write_artifact "$ext" "$config_file" "$major_ver" "$version_set_json" "$ceiling" "$do_push" || _ba_rc=$?
                 if [[ "$_ba_rc" -ne 0 ]]; then
+                    _record_rotation_build_status infra
                     failed+=("$ext@artifact")
                     continue
                 fi
@@ -1231,7 +1345,13 @@ build_tag_push_extensions() {
     echo ""
     if [[ ${#failed[@]} -gt 0 ]]; then
         log_error "Failed extensions: ${failed[*]}"
-        exit 1
+        # Commit a build-failed verdict only after the complete build loop has
+        # ended in its known failure path.  A shell error before this point
+        # leaves the trap's default infra in place.
+        if [[ "$_ROTATION_BUILD_PENDING" == build-failed ]]; then
+            _ROTATION_BUILD_STATUS=build-failed
+        fi
+        return 1
     else
         if [[ "$do_push" == "true" ]]; then
             log_success "All extensions built and pushed successfully"
@@ -2425,6 +2545,7 @@ main() {
     # Validate the optional package axis before any prerequisite, registry, or
     # build action. A malformed suffix must never influence a reference.
     validate_extension_package_suffix || return 1
+    _rotation_status_file_is_valid || return 1
 
     validate_prerequisites
 
@@ -2439,7 +2560,8 @@ main() {
     # Handle list mode
     if [[ "$LIST_ONLY" == "true" ]]; then
         list_extension_status "$config_file" "$major_ver"
-        exit 0
+        _ROTATION_BUILD_STATUS=success
+        return 0
     fi
 
     # Handle finalize-multiarch mode (stage B: merge per-arch manifests, write artifact).
@@ -2447,11 +2569,15 @@ main() {
     if [[ "$FINALIZE_MULTIARCH" == "true" ]]; then
         if [[ "$DRY_RUN" == "true" ]]; then
             log_info "[DRY-RUN] Would merge per-arch manifests into multi-arch manifests for pg${major_ver}"
-            exit 0
+            _ROTATION_BUILD_STATUS=success
+            return 0
         fi
         local _fm_rc=0
         finalize_multiarch_manifests "$config_file" "$major_ver" "$container_dir" || _fm_rc=$?
-        exit "$_fm_rc"
+        if [[ "$_fm_rc" -eq 0 ]]; then
+            _ROTATION_BUILD_STATUS=success
+        fi
+        return "$_fm_rc"
     fi
 
     # Check registry auth (unless local-only or dry-run)
@@ -2477,7 +2603,10 @@ main() {
         handle_pull_only_mode "$config_file" "$major_ver" "$container_dir"
         local _fp_rc=0
         _emit_final_versionset_pass "$config_file" "$major_ver" "$container_dir" "${EXTENSION:-}" "$do_push" || _fp_rc=$?
-        exit "$_fp_rc"
+        if [[ "$_fp_rc" -eq 0 ]]; then
+            _ROTATION_BUILD_STATUS=success
+        fi
+        return "$_fp_rc"
     fi
 
     # Build mode — determine which extensions to build.
@@ -2488,14 +2617,14 @@ main() {
         local _explicit_dockerfile="$container_dir/extensions/build/${EXTENSION}.Dockerfile"
         if [[ ! -f "$_explicit_dockerfile" ]]; then
             log_error "Extension '$EXTENSION': no Dockerfile at $_explicit_dockerfile"
-            exit 1
+            return 1
         fi
         local _rc=0
         _should_build_extension "$EXTENSION" "$config_file" "$major_ver" "$container_dir" || _rc=$?
         case "$_rc" in
             0) extensions_to_build=("$EXTENSION") ;;
             1) : ;;
-            *) log_error "$EXTENSION: version-set resolver failed — aborting (fail-closed)"; exit 1 ;;
+            *) log_error "$EXTENSION: version-set resolver failed — aborting (fail-closed)"; _record_rotation_build_status infra; return 1 ;;
         esac
     else
         while IFS= read -r ext; do
@@ -2504,7 +2633,7 @@ main() {
             case "$_rc" in
                 0) extensions_to_build+=("$ext") ;;
                 1) : ;;
-                *) log_error "$ext: version-set resolver failed — aborting (fail-closed)"; exit 1 ;;
+                *) log_error "$ext: version-set resolver failed — aborting (fail-closed)"; _record_rotation_build_status infra; return 1 ;;
             esac
         done < <(list_extensions_by_priority "$config_file" "$major_ver")
     fi
@@ -2543,7 +2672,10 @@ main() {
         local _fp_rc=0
         _emit_final_versionset_pass "$config_file" "$major_ver" "$container_dir" "${EXTENSION:-}" "$do_push" || _fp_rc=$?
 
-        exit "$_fp_rc"
+        if [[ "$_fp_rc" -eq 0 ]]; then
+            _ROTATION_BUILD_STATUS=success
+        fi
+        return "$_fp_rc"
     fi
 
     log_info "Extensions to build: ${extensions_to_build[*]}"
@@ -2582,8 +2714,10 @@ main() {
     local _fp_rc=0
     _emit_final_versionset_pass "$config_file" "$major_ver" "$container_dir" "${EXTENSION:-}" "$do_push" || _fp_rc=$?
     if [[ "$_fp_rc" -ne 0 ]]; then
-        exit "$_fp_rc"
+        return "$_fp_rc"
     fi
+    _ROTATION_BUILD_STATUS=success
+    return 0
 }
 
 # Only run main when executed directly, not when sourced (e.g. by unit tests)
@@ -2591,7 +2725,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     # Install EXIT cleanup only when executing as a program. When sourced (e.g.
     # by unit tests) no trap is installed here so the caller's EXIT trap is
     # never clobbered. _RESOLVER_CACHE_DIR is already set at source time above.
-    # shellcheck disable=SC2064
-    trap "rm -rf \"${_RESOLVER_CACHE_DIR}\" \"${_BUILT_THIS_RUN_DIR}\"" EXIT
+    _rotation_status_file_is_valid || exit 1
+    # shellcheck disable=SC2064,SC2154
+    trap '_exit_status=$?; _cleanup_status=0; rm -rf "${_RESOLVER_CACHE_DIR}" "${_BUILT_THIS_RUN_DIR}" || _cleanup_status=$?; if [[ "$_exit_status" -eq 0 && "$_cleanup_status" -ne 0 ]]; then _exit_status=$_cleanup_status; _ROTATION_BUILD_STATUS=infra; fi; _write_rotation_status "$_ROTATION_BUILD_STATUS" || { _write_status=$?; [[ "$_exit_status" -eq 0 ]] && _exit_status=$_write_status; }; exit "$_exit_status"' EXIT
     main "$@"
 fi

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -317,8 +317,13 @@ _write_rotation_status() {
 _rotation_build_exit() {
     local _exit_status="$1"
     local _cleanup_status=0
+    local _cleanup_paths=()
 
-    rm -rf "${_RESOLVER_CACHE_DIR}" "${_BUILT_THIS_RUN_DIR}" || _cleanup_status=$?
+    [[ -n "${_RESOLVER_CACHE_DIR:-}" ]] && _cleanup_paths+=("$_RESOLVER_CACHE_DIR")
+    [[ -n "${_BUILT_THIS_RUN_DIR:-}" ]] && _cleanup_paths+=("$_BUILT_THIS_RUN_DIR")
+    if [[ ${#_cleanup_paths[@]} -gt 0 ]]; then
+        rm -rf "${_cleanup_paths[@]}" || _cleanup_status=$?
+    fi
     if [[ "$_cleanup_status" -ne 0 ]]; then
         # A failed cleanup invalidates the producer evidence, even after a
         # completed build. Preserve a pre-existing non-zero process status so
@@ -1384,10 +1389,18 @@ build_tag_push_extensions() {
 # In-memory variables cannot survive command-substitution subshells ($(...)), so
 # each resolved JSON is written to a per-run temp directory keyed by
 # "<ext>-<major>". The cache directory is created at source time so that every
-# $(...) subshell inherits the path via the exported variable. The EXIT trap
-# that removes this directory is installed ONLY inside the execution guard
-# below (when the script runs as a program), so sourcing this file never
-# clobbers the caller's own EXIT trap.
+# $(...) subshell inherits the path via the exported variable.
+#
+# For direct execution, validate the status target before allocating either
+# directory, then install the EXIT trap immediately before the first allocation.
+# We reject the alternative of validating after allocation: an invalid target
+# must be refused before the build spends any temporary resources. Sourcing
+# keeps the caller's EXIT trap untouched.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    _rotation_status_file_is_valid || exit 1
+    # shellcheck disable=SC2064,SC2154
+    trap '_rotation_build_exit "$?"' EXIT
+fi
 _RESOLVER_CACHE_DIR="$(mktemp -d)"
 export _RESOLVER_CACHE_DIR
 
@@ -2741,11 +2754,5 @@ main() {
 
 # Only run main when executed directly, not when sourced (e.g. by unit tests)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    # Install EXIT cleanup only when executing as a program. When sourced (e.g.
-    # by unit tests) no trap is installed here so the caller's EXIT trap is
-    # never clobbered. _RESOLVER_CACHE_DIR is already set at source time above.
-    _rotation_status_file_is_valid || exit 1
-    # shellcheck disable=SC2064,SC2154
-    trap '_rotation_build_exit "$?"' EXIT
     main "$@"
 fi

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -304,7 +304,7 @@ _write_rotation_status() {
         rm -f -- "$status_tmp" || true
         return 1
     }
-    mv -f -- "$status_tmp" "$ROTATION_STATUS_FILE" || {
+    mv -f -T -- "$status_tmp" "$ROTATION_STATUS_FILE" || {
         rm -f -- "$status_tmp" || true
         return 1
     }
@@ -312,6 +312,25 @@ _write_rotation_status() {
         log_error "ROTATION_STATUS_FILE was not written as a regular file: $ROTATION_STATUS_FILE"
         return 1
     fi
+}
+
+_rotation_build_exit() {
+    local _exit_status="$1"
+    local _cleanup_status=0
+
+    rm -rf "${_RESOLVER_CACHE_DIR}" "${_BUILT_THIS_RUN_DIR}" || _cleanup_status=$?
+    if [[ "$_cleanup_status" -ne 0 ]]; then
+        # A failed cleanup invalidates the producer evidence, even after a
+        # completed build. Preserve a pre-existing non-zero process status so
+        # a genuine build failure remains a failure at the caller.
+        [[ "$_exit_status" -eq 0 ]] && _exit_status=$_cleanup_status
+        _ROTATION_BUILD_STATUS=infra
+    fi
+    _write_rotation_status "$_ROTATION_BUILD_STATUS" || {
+        local _write_status=$?
+        [[ "$_exit_status" -eq 0 ]] && _exit_status=$_write_status
+    }
+    exit "$_exit_status"
 }
 
 # This is intentionally a build-phase result, not a compiler diagnosis:
@@ -2727,6 +2746,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     # never clobbered. _RESOLVER_CACHE_DIR is already set at source time above.
     _rotation_status_file_is_valid || exit 1
     # shellcheck disable=SC2064,SC2154
-    trap '_exit_status=$?; _cleanup_status=0; rm -rf "${_RESOLVER_CACHE_DIR}" "${_BUILT_THIS_RUN_DIR}" || _cleanup_status=$?; if [[ "$_exit_status" -eq 0 && "$_cleanup_status" -ne 0 ]]; then _exit_status=$_cleanup_status; _ROTATION_BUILD_STATUS=infra; fi; _write_rotation_status "$_ROTATION_BUILD_STATUS" || { _write_status=$?; [[ "$_exit_status" -eq 0 ]] && _exit_status=$_write_status; }; exit "$_exit_status"' EXIT
+    trap '_rotation_build_exit "$?"' EXIT
     main "$@"
 fi

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -26,6 +26,152 @@ _source_build_extensions() {
     popd > /dev/null 2>&1
 }
 
+_capture_rotation_build_status() {
+    local rc=0
+    if build_tag_push_extensions "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" true timescaledb; then
+        rc=0
+    else
+        rc=$?
+    fi
+    printf 'rotation-status=%s\n' "$_ROTATION_BUILD_STATUS"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Rotation producer state: a build phase exhausted after retries is distinct
+# from push and resolver failures, which remain infra.  These tests exercise
+# the same build_tag_push_extensions paths used by the rotation leg.
+# ---------------------------------------------------------------------------
+
+@test "rotation status: push failure is infra and keeps its existing failure exit" {
+    export EXT_BUILD_RETRIES=1
+    _ROTATION_BUILD_STATUS=infra
+    _ROTATION_BUILD_HAS_INFRA=false
+
+    build_ext_image() { return 2; }
+    export -f build_ext_image
+
+    unset ROTATION_STATUS_FILE
+    run _capture_rotation_build_status
+    local without_status_rc="$status"
+
+    export ROTATION_STATUS_FILE="$TEST_TEMP_DIR/build-status"
+    _ROTATION_BUILD_STATUS=infra
+    _ROTATION_BUILD_HAS_INFRA=false
+    run _capture_rotation_build_status
+    local with_status_rc="$status"
+
+    [ "$without_status_rc" -eq 1 ]
+    [ "$with_status_rc" -eq 1 ]
+    [[ "$output" == *"rotation-status=infra"* ]]
+}
+
+@test "rotation status: resolver failure is infra and keeps its existing failure exit" {
+    export ROTATION_STATUS_FILE="$TEST_TEMP_DIR/build-status"
+    _ROTATION_BUILD_STATUS=infra
+    _ROTATION_BUILD_HAS_INFRA=false
+
+    resolve_version_set() { return 1; }
+    export -f resolve_version_set
+
+    run _capture_rotation_build_status
+    local rc="$status"
+
+    [ "$rc" -eq 1 ]
+    [[ "$output" == *"rotation-status=infra"* ]]
+}
+
+@test "rotation status: exhausted ceiling build retries are build-failed and directory targets are refused" {
+    export EXT_BUILD_RETRIES=1
+    export ROTATION_STATUS_FILE="$TEST_TEMP_DIR/build-status"
+    _ROTATION_BUILD_STATUS=infra
+    _ROTATION_BUILD_HAS_INFRA=false
+
+    build_ext_image() { return 1; }
+    export -f build_ext_image
+
+    run _capture_rotation_build_status
+    local rc="$status"
+
+    [ "$rc" -eq 1 ]
+    [[ "$output" == *"rotation-status=build-failed"* ]]
+    mkdir "$ROTATION_STATUS_FILE"
+
+    run _write_rotation_status infra
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ROTATION_STATUS_FILE must name a regular file"* ]]
+
+    rmdir "$ROTATION_STATUS_FILE"
+    local status_target="$TEST_TEMP_DIR/build-status-target"
+    printf 'unchanged\n' > "$status_target"
+    ln -s "$status_target" "$ROTATION_STATUS_FILE"
+
+    run _write_rotation_status infra
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ROTATION_STATUS_FILE must name a regular file"* ]]
+    [ "$(<"$status_target")" = unchanged ]
+}
+
+@test "rotation status: an infra retry before a build-phase failure remains infra" {
+    export EXT_BUILD_RETRIES=3
+    export _rotation_attempt=0
+    _ROTATION_BUILD_STATUS=infra
+    _ROTATION_BUILD_HAS_INFRA=false
+
+    build_ext_image() {
+        _rotation_attempt=$((_rotation_attempt + 1))
+        case "$_rotation_attempt" in
+            1|2) return 2 ;;
+            3) return 1 ;;
+        esac
+        return 99
+    }
+    sleep() { :; }
+    export -f build_ext_image sleep
+
+    run _capture_rotation_build_status
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"rotation-status=infra"* ]]
+}
+
+@test "zero build attempts are infrastructure, not a build failure" {
+    local build_marker="$TEST_TEMP_DIR/build-ran"
+    export EXT_BUILD_RETRIES=0
+
+    build_ext_image() {
+        : > "$build_marker"
+        return 1
+    }
+    export -f build_ext_image
+
+    run build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -eq 2 ]
+    [ ! -e "$build_marker" ]
+    [[ "$output" == *"made no attempts"* ]]
+}
+
+@test "rotation status target is refused before build prerequisites run" {
+    local status_file="$TEST_TEMP_DIR/build-status"
+    local status_target="$TEST_TEMP_DIR/build-status-target"
+    local prerequisite_marker="$TEST_TEMP_DIR/prerequisite-ran"
+    printf 'unchanged\n' > "$status_target"
+    ln -s "$status_target" "$status_file"
+    export ROTATION_STATUS_FILE="$status_file"
+
+    validate_prerequisites() { : > "$prerequisite_marker"; }
+
+    run main postgres
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ROTATION_STATUS_FILE must name a regular file"* ]]
+    [ ! -e "$prerequisite_marker" ]
+    [ "$(<"$status_target")" = unchanged ]
+}
+
 # ---------------------------------------------------------------------------
 # Setup / Teardown
 # ---------------------------------------------------------------------------
@@ -69,7 +215,7 @@ EOF
 
 teardown() {
     teardown_temp_dir
-    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR NO_CACHE
+    unset FORCE FORCE_SCOPED_EXTENSION_REFS LOCAL_ONLY DRY_RUN CONTAINER ROOT_DIR NO_CACHE ROTATION_STATUS_FILE EXT_BUILD_RETRIES
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -32,6 +32,7 @@ _source_build_extensions() {
 
 setup() {
     setup_temp_dir
+    STATUS_TARGET_FIXTURES=()
 
     # Minimal extension filesystem under TEST_TEMP_DIR
     CONTAINER_DIR="$TEST_TEMP_DIR/postgres"
@@ -76,8 +77,21 @@ EOF
 }
 
 teardown() {
+    local fixture cleanup_failed=0
+    # Status-target refusal tests may return before their final assertion. Keep
+    # their deliberately-invalid fixtures outside the test body cleanup so
+    # Bats removes them on both passing and failing paths.
+    for fixture in "${STATUS_TARGET_FIXTURES[@]}"; do
+        chmod -R u+w -- "$fixture" 2>/dev/null || true
+        rm -rf -- "$fixture"
+        if [[ -e "$fixture" || -L "$fixture" ]]; then
+            echo "FAIL: status-target fixture remains after teardown: $fixture" >&2
+            cleanup_failed=1
+        fi
+    done
     teardown_temp_dir
     unset FORCE LOCAL_ONLY CONTAINER ROOT_DIR
+    return "$cleanup_failed"
 }
 
 # ---------------------------------------------------------------------------
@@ -108,6 +122,33 @@ teardown() {
         echo "FAIL: deliberate --help must exit zero"
         return 1
     }
+    local temp_root="$TEST_TEMP_DIR/status-refusal-tmp"
+    local directory_target="$TEST_TEMP_DIR/status-target-directory"
+    local symlink_target="$TEST_TEMP_DIR/status-target-symlink"
+    local symlink_destination="$TEST_TEMP_DIR/status-target-destination"
+    local unwritable_parent="$TEST_TEMP_DIR/status-target-unwritable"
+    local unwritable_target="$unwritable_parent/build-status"
+    mkdir -p "$temp_root" "$directory_target" "$unwritable_parent"
+    printf 'unchanged\n' > "$symlink_destination"
+    ln -s "$symlink_destination" "$symlink_target"
+    chmod u-w "$unwritable_parent"
+    STATUS_TARGET_FIXTURES=("$directory_target" "$symlink_target" "$symlink_destination" "$unwritable_parent")
+
+    run env TMPDIR="$temp_root" ROTATION_STATUS_FILE="$directory_target" \
+        "$SCRIPTS_DIR/build-extensions.sh" --help
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ROTATION_STATUS_FILE must name a regular file"* ]]
+    [[ -z "$(find "$temp_root" -mindepth 1 -print -quit)" ]]
+
+    run env TMPDIR="$temp_root" ROTATION_STATUS_FILE="$symlink_target" \
+        "$SCRIPTS_DIR/build-extensions.sh" --help
+    [ "$status" -ne 0 ]
+    [[ -z "$(find "$temp_root" -mindepth 1 -print -quit)" ]]
+
+    run env TMPDIR="$temp_root" ROTATION_STATUS_FILE="$unwritable_target" \
+        "$SCRIPTS_DIR/build-extensions.sh" --help
+    [ "$status" -ne 0 ]
+    [[ -z "$(find "$temp_root" -mindepth 1 -print -quit)" ]]
 }
 
 @test "EXIT cleanup failure records infra instead of a success verdict" {

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -110,6 +110,26 @@ teardown() {
     }
 }
 
+@test "EXIT cleanup failure records infra instead of a success verdict" {
+    local bin_dir="$TEST_TEMP_DIR/cleanup-failure-bin"
+    local status_file="$TEST_TEMP_DIR/cleanup-failure-status"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/rm" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -rf ]]; then
+    exit 1
+fi
+exec /bin/rm "$@"
+EOF
+    chmod +x "$bin_dir/rm"
+
+    run env PATH="$bin_dir:$PATH" ROTATION_STATUS_FILE="$status_file" \
+        "$SCRIPTS_DIR/build-extensions.sh" --help
+
+    [ "$status" -ne 0 ]
+    [ "$(<"$status_file")" = infra ]
+}
+
 @test "entry point refuses missing and option-shaped option values" {
     run bash -c '"$@" 2>&1' _ "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version --dry-run
     [ "$status" -eq 2 ] || {

--- a/tests/unit/rotation-workflow-guards.bats
+++ b/tests/unit/rotation-workflow-guards.bats
@@ -99,6 +99,84 @@ _rotation_read_status() {
     done
 }
 
+@test "rotation test jobs rethrow each tolerated candidate failure" {
+    local job build_condition build_run suite_condition suite_run
+
+    # These names intentionally couple the guard to the steps it rethrows. That
+    # is cheaper and clearer than adding workflow-only ids for test addressing.
+    for job in test-amd64 test-arm64; do
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail candidate image build result\") | .if" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+        [ "$status" -eq 0 ]
+        build_condition="$output"
+        [ "$build_condition" = "steps.build-e2e-image.outcome == 'failure'" ]
+
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail candidate image build result\") | .run" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+        [ "$status" -eq 0 ]
+        build_run="$output"
+        [ "$build_run" = "exit 1" ]
+
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail e2e suite result\") | .if" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+        [ "$status" -eq 0 ]
+        suite_condition="$output"
+        [ "$suite_condition" = "steps.e2e.outcome == 'failure'" ]
+
+        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail e2e suite result\") | .run" \
+            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+        [ "$status" -eq 0 ]
+        suite_run="$output"
+        [ "$suite_run" = "exit 1" ]
+    done
+}
+
+@test "rotation cleanup failure makes a build-failed producer infra without hiding its failure exit" {
+    local bin_dir="$BATS_TEST_TMPDIR/cleanup-failure-bin"
+    local status_file="$BATS_TEST_TMPDIR/cleanup-failure-status"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/rm" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -rf ]]; then
+    exit 75
+fi
+exec /bin/rm "$@"
+EOF
+    chmod +x "$bin_dir/rm"
+
+    run env PATH="$bin_dir:$PATH" TMPDIR="$BATS_TEST_TMPDIR" ROTATION_STATUS_FILE="$status_file" \
+        bash -c '
+            source "$1"
+            _ROTATION_BUILD_STATUS=build-failed
+            _RESOLVER_CACHE_DIR="$2/resolver-cache"
+            _BUILT_THIS_RUN_DIR="$2/built-this-run"
+            _rotation_build_exit 1
+        ' _ "$PROJECT_ROOT/scripts/build-extensions.sh" "$BATS_TEST_TMPDIR"
+
+    [ "$status" -ne 0 ]
+    [ "$(<"$status_file")" = infra ]
+}
+
+@test "rotation status rename cannot place a record inside a raced target directory" {
+    local status_file="$BATS_TEST_TMPDIR/build-status"
+
+    run env TMPDIR="$BATS_TEST_TMPDIR" ROTATION_STATUS_FILE="$status_file" \
+        bash -c '
+            source "$1"
+            mv() {
+                mkdir "$ROTATION_STATUS_FILE"
+                command mv "$@"
+            }
+            if _write_rotation_status infra; then
+                exit 1
+            fi
+            [[ -d "$ROTATION_STATUS_FILE" ]]
+            [[ -z "$(find "$ROTATION_STATUS_FILE" -mindepth 1 -print -quit)" ]]
+        ' _ "$PROJECT_ROOT/scripts/build-extensions.sh"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "rotation status artifacts keep build producer state files" {
     local names build_path attribution issue_body
 

--- a/tests/unit/rotation-workflow-guards.bats
+++ b/tests/unit/rotation-workflow-guards.bats
@@ -5,6 +5,68 @@
 
 load "../test_helper"
 
+bats_require_minimum_version 1.5.0
+
+_rotation_read_status() {
+    # The quarantine runner has downloaded artifacts but no repository checkout.
+    # Run the extracted function from an isolated directory so a repository file
+    # cannot accidentally make this test pass.
+    eval "$ROTATION_READER_SOURCE"
+    read_rotation_status "$1"
+}
+
+@test "rotation consumer needs no checkout and accepts only exact producer records" {
+    mkdir -p "$BATS_TEST_TMPDIR/rotation-artifacts/status"
+    pushd "$BATS_TEST_TMPDIR" >/dev/null || return 1
+
+    run yq -r '.jobs.quarantine.steps[] | select(.id == "attribution") | .run' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'source '* ]]
+    [[ "$output" != *'helpers/'* ]]
+    [[ "$output" != *'_escape_gha_command'* ]]
+
+    local function_source cleanup_source
+    cleanup_source=$(sed -n '/^remove_canonical_file() {/,/^}$/p' <<< "$output") || return 1
+    function_source="$cleanup_source"$'\n'"$(sed -n '/^read_rotation_status() {/,/^}$/p' <<< "$output")" || return 1
+
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c "$(declare -f _rotation_read_status); _rotation_read_status build-amd64"
+    [ "$status" -eq 0 ]
+    [ "$output" = infra ]
+
+    printf 'not-a-state detail\n' > rotation-artifacts/status/build-amd64
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c "$(declare -f _rotation_read_status); _rotation_read_status build-amd64"
+    [ "$status" -eq 0 ]
+    [ "$output" = infra ]
+
+    printf 'build-failed\n\n' > rotation-artifacts/status/build-amd64
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c "$(declare -f _rotation_read_status); _rotation_read_status build-amd64"
+    [ "$status" -eq 0 ]
+    [ "$output" = infra ]
+
+    printf 'build\0failed\n' > rotation-artifacts/status/build-amd64
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c "$(declare -f _rotation_read_status); _rotation_read_status build-amd64"
+    [ "$status" -eq 0 ]
+    [ "$output" = infra ]
+
+    printf 'build-failed\n' > rotation-artifacts/status/build-amd64
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c "$(declare -f _rotation_read_status); _rotation_read_status build-amd64"
+    [ "$status" -eq 0 ]
+    [ "$output" = build-failed ]
+
+    printf 'success\n' > rotation-artifacts/status/build-amd64
+    run --separate-stderr env ROTATION_READER_SOURCE="$function_source" bash -c '
+        set -e
+        rm() { return 1; }
+        eval "$ROTATION_READER_SOURCE"
+        read_rotation_status build-amd64 > state
+        [ "$(<state)" = success ]
+    '
+    [ "$status" -eq 0 ]
+
+    popd >/dev/null || return 1
+}
+
 @test "rotation uploads use visible paths and fail empty matches" {
     local path policy count=0
 
@@ -20,7 +82,8 @@ load "../test_helper"
         [ "$policy" = error ]
         count=$((count + 1))
     done <<< "$output"
-    [ "$count" -eq 4 ]
+    # Two upload steps, each run for every architecture: frozen digest and build attribution.
+    [ "$count" -eq 2 ]
 }
 
 @test "rotation e2e suites identify the exact full build cell" {
@@ -36,8 +99,8 @@ load "../test_helper"
     done
 }
 
-@test "rotation status artifacts keep producer-specific names" {
-    local names build_path
+@test "rotation status artifacts keep build producer state files" {
+    local names build_path attribution issue_body
 
     run yq -r '
       .jobs[] | .steps[]?
@@ -48,10 +111,8 @@ load "../test_helper"
 
     [ "$status" -eq 0 ]
     names="$output"
-    [ "$(printf '%s\n' "$names" | sort -u | wc -l)" -eq 3 ]
+    [ "$(printf '%s\n' "$names" | sort -u | wc -l)" -eq 1 ]
     [[ "$names" == *'rotation-status-build-${{ matrix.arch }}'* ]]
-    [[ "$names" == *'rotation-status-test-amd64'* ]]
-    [[ "$names" == *'rotation-status-test-arm64'* ]]
 
     run yq -r '.jobs.build.steps[] | select(.name == "Upload build attribution") | .with.path' \
         "$PROJECT_ROOT/.github/workflows/rotation.yaml"
@@ -61,8 +122,40 @@ load "../test_helper"
     run yq -r '.jobs.quarantine.steps[] | select(.id == "attribution") | .run' \
         "$PROJECT_ROOT/.github/workflows/rotation.yaml"
     [ "$status" -eq 0 ]
-    [[ "$output" == *'expected_statuses=(build-amd64 build-arm64)'* ]]
-    [[ "$output" == *'Missing failure attribution from completed producer'* ]]
+    attribution="$output"
+    [[ "$attribution" == *'status_names=(build-amd64 build-arm64)'* ]]
+    [[ "$attribution" == *'treating it as infra'* ]]
+    [[ "$attribution" == *'remove_canonical_file "$canonical_file"'* ]]
+    [[ "$attribution" == *'if ! rm -f -- "$canonical_file"; then'* ]]
+    [[ "$attribution" != *'_escape_gha_command'* ]]
+    [[ "$attribution" == *'"${states[build-amd64]}" == build-failed && "${states[build-arm64]}" == build-failed'* ]]
+    [[ "$attribution" == *"A test failure cannot quarantine"* ]]
+    [[ "$attribution" == *'state_lines+=("${status_name}=${states[$status_name]}")'* ]]
+
+    run yq -r '.jobs.quarantine.steps[] | select(.name == "Quarantine failing extension pair") | .run' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    issue_body="$output"
+    [[ "$issue_body" == *"Producer states:"* ]]
+    [[ "$issue_body" == *'for producer_state in "${producer_states[@]}"; do'* ]]
+}
+
+@test "one build-failed leg does not warrant quarantine" {
+    local attribution decision_source
+
+    run yq -r '.jobs.quarantine.steps[] | select(.id == "attribution") | .run' \
+        "$PROJECT_ROOT/.github/workflows/rotation.yaml"
+    [ "$status" -eq 0 ]
+    attribution="$output"
+    decision_source=$(sed -n '/^quarantine_evidence_warrants_action() {/,/^}$/p' <<< "$attribution") || return 1
+
+    run env ROTATION_DECISION_SOURCE="$decision_source" bash -c '
+        declare -A states=([build-amd64]=build-failed [build-arm64]=infra)
+        eval "$ROTATION_DECISION_SOURCE"
+        quarantine_evidence_warrants_action
+        [[ "$create" == false && ${#reasons[@]} -eq 0 ]]
+    '
+    [ "$status" -eq 0 ]
 }
 
 @test "build-container accepts only literal boolean push values" {
@@ -139,25 +232,6 @@ load "../test_helper"
     [ "$status" -eq 0 ]
     compile_index="$output"
     [ "$compile_index" -eq $((recheck_index + 1)) ]
-}
-
-@test "rotation attributes a failed candidate image build on both architectures" {
-    local build_condition suite_condition
-
-    for job in test-amd64 test-arm64; do
-        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail attributable candidate image build result\") | .if" \
-            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
-
-        [ "$status" -eq 0 ]
-        build_condition="$output"
-        [ "$build_condition" = "steps.build-e2e-image.outcome == 'failure'" ]
-
-        run yq -r ".jobs.\"$job\".steps[] | select(.name == \"Fail attributable e2e suite result\") | .if" \
-            "$PROJECT_ROOT/.github/workflows/rotation.yaml"
-        [ "$status" -eq 0 ]
-        suite_condition="$output"
-        [ "$suite_condition" = "steps.e2e.outcome == 'failure'" ]
-    done
 }
 
 @test "rotation test-job push comments do not claim a post-build push" {


### PR DESCRIPTION
A registry outage during the rotation's compile step, or a login failure inside
`build-container`, set the attributable flag and quarantined a healthy `(extension, pg major)`
pair for 30 days.

The flag was the job's exit status, and `scripts/build-extensions.sh` collapses four different
failures into `exit 1`: a compile failure, a push failure, a version-set resolver failure that
queries upstream over the network, and a semver validation failure. A non-zero `docker buildx
build` covers a `FROM` pull, an `apk` fetch and a `git clone` besides, and the retry loop's own
comment says retries "reduce — but do not eliminate" that ambiguity.

Each build leg now writes its own class — `success`, `build-failed` or `infra` — into a file the
caller pre-creates as `infra`, atomically, refusing a target that exists and is not a regular
file. A producer that dies without writing leaves no verdict. The consumer compares whole files
against three canonical byte sequences with `cmp`, so a corrupt suffix, an extra newline or an
embedded NUL reads as `infra`, and it needs no repository checkout of its own.

Infra dominates: a `2, 2, 1` retry sequence yields `infra`, zero attempts yields `infra` because a
build that never ran has not failed to build, and a cleanup failure after any verdict yields
`infra` while a genuine build failure still exits non-zero.

Quarantine requires **both** build legs at `build-failed`. One leg cannot tell a recipe that
stopped compiling from a transport failure; two legs agreeing on different runners without cache
is the cheapest discriminator short of parsing build logs. So the issue body says the
architectures exhausted their build retries, not that the extension no longer compiles.

**A test failure cannot quarantine at all**, deliberately. Both test legs run the shared `full`
postgres suite, which aggregates every extension's assertions into one count, so an assertion
failure names the suite and not the candidate — while rotating `timescaledb`, an unrelated
PostGIS regression would otherwise have suppressed the TimescaleDB pair. Restoring attributable
runtime quarantine means passing the candidate's identity into the harness, which is a separate
change.

This branch is a prune of `fix/1353-attribution-failure-class`, which reached its budget after
four rounds. Its test-side evidence channel had no reader — a quarantine needs both build legs to
fail, that failure skips `freeze-digests`, which gates both test jobs — so that half is deleted
here rather than carried. `postgres/test.sh`, `test-harness/test-harness.sh` and
`tests/e2e-test.sh` are byte-identical to `master`, and `assert-failed` appears nowhere.

## Verification

`bats -j 8 tests/unit/*.bats` — 2763 collected, 0 failed. `actionlint` and `shellcheck -S warning`
clean.

Each guard is pinned by a mutation that kills it: a push failure and a resolver failure each stay
`infra`, a missing or unrecognised record stays `infra`, one `build-failed` leg does not
quarantine, a `2, 2, 1` sequence and zero attempts both yield `infra`, a suffix or embedded NUL
stays `infra`, a directory or symlink target is refused, and a rename cannot land inside a
directory.

## Follow-ups

Landed on capped evidence at the declared three-round budget. Residue: #1384 (a failed
enumeration reads as nothing to do, pre-existing and cross-linked with #1346) and #1387 (the
status sink is validated for type but not writability, plus two smaller items).

Closes #1353.
