### PR TITLE
Bound cleanup by polls and say so, instead of claiming a deadline

### DIFF
--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -7,6 +7,11 @@
 # Setup / Teardown
 # ---------------------------------------------------------------------------
 
+# These are the production-equivalent defaults.  Individual tests can shorten
+# the waits with RUNNER_TERM_GRACE_SECONDS and RUNNER_KILL_CONFIRMATION_SECONDS.
+RUNNER_TERM_GRACE_SECONDS_DEFAULT=6
+RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT=1
+
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     RUNNER_DIR="$(cd "$TEST_DIR/.." && pwd)"
@@ -245,7 +250,17 @@ _runner_group_state() {
 
     for stat_file in "${RUNNER_PROC_ROOT:-/proc}"/[0-9]*/stat; do
         [[ -e "$stat_file" ]] || continue
-        stat_line=$(<"$stat_file") || return 2
+        # Tests use this hook to deterministically model a process exiting
+        # after globbing /proc and before stat can be read.
+        if [[ -n "${RUNNER_PROC_BEFORE_STAT_READ:-}" ]]; then
+            "$RUNNER_PROC_BEFORE_STAT_READ" "$stat_file" || return 2
+        fi
+        if ! stat_line=$(command cat -- "$stat_file" 2>/dev/null); then
+            # A process can normally exit in this small window.  The vanished
+            # entry is absence, unlike a stat file that remains unreadable.
+            [[ -e "$stat_file" ]] || continue
+            return 2
+        fi
         # Fields after the final ')' are: state (3), ppid (4), pgrp (5), ... .
         rest="${stat_line##*) }"
         read -r state ppid stat_pgid ignored <<<"$rest"
@@ -284,16 +299,25 @@ _reap_absent_runner_leader() {
 }
 
 # Stop a runner session without deleting its workspace while a descendant may
-# still be using it.  The six-second TERM grace exceeds the five-second
-# readiness window; KILL confirmation is limited to one second.
+# still be using it.  The six-second TERM grace and one-second KILL
+# confirmation are requested-wait budgets, not fixed poll counts.  Tests may
+# inject shorter deadlines without changing the production defaults.
 _cleanup_runner_group() {
     local pgid="${1:-}"
-    local term_waited=0
-    local kill_waited=0
+    local term_grace_seconds="${RUNNER_TERM_GRACE_SECONDS:-$RUNNER_TERM_GRACE_SECONDS_DEFAULT}"
+    local kill_confirmation_seconds="${RUNNER_KILL_CONFIRMATION_SECONDS:-$RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT}"
+    local term_grace_tenths=0
+    local kill_confirmation_tenths=0
+    local term_waited_tenths=0
+    local kill_waited_tenths=0
     local group_state=0
     local grace_failed=0
 
     [[ -z "$pgid" ]] && return 0
+    [[ "$term_grace_seconds" =~ ^[0-9]+$ ]] || return 1
+    [[ "$kill_confirmation_seconds" =~ ^[0-9]+$ ]] || return 1
+    term_grace_tenths=$((term_grace_seconds * 10))
+    kill_confirmation_tenths=$((kill_confirmation_seconds * 10))
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
     if [[ $group_state -eq 1 ]]; then
@@ -303,7 +327,7 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
 
     env kill -TERM -- "-$pgid" 2>/dev/null || true
-    while [[ $term_waited -lt 60 ]]; do
+    while [[ $term_waited_tenths -lt $term_grace_tenths ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
@@ -311,15 +335,20 @@ _cleanup_runner_group() {
             grace_failed=1
             break
         fi
-        term_waited=$((term_waited + 1))
+        term_waited_tenths=$((term_waited_tenths + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
-    if [[ $grace_failed -eq 1 || $group_state -ne 1 ]]; then
-        env kill -KILL -- "-$pgid" 2>/dev/null || true
+    if [[ $group_state -eq 1 ]]; then
+        _reap_absent_runner_leader "$pgid" || return 1
+        [[ $grace_failed -eq 0 ]]
+        return
     fi
+    # Escalation requires positive evidence that the group still exists.
+    [[ $group_state -eq 0 ]] || return 1
+    env kill -KILL -- "-$pgid" 2>/dev/null || true
 
-    while [[ $kill_waited -lt 10 ]]; do
+    while [[ $kill_waited_tenths -lt $kill_confirmation_tenths ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
@@ -327,7 +356,7 @@ _cleanup_runner_group() {
             grace_failed=1
             break
         fi
-        kill_waited=$((kill_waited + 1))
+        kill_waited_tenths=$((kill_waited_tenths + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
@@ -335,6 +364,17 @@ _cleanup_runner_group() {
     _reap_absent_runner_leader "$pgid" || return 1
 
     [[ $grace_failed -eq 0 ]]
+}
+
+# Keep RUNNER_PGID empty until the child-reported group is known not to be the
+# Bats harness group.  Teardown relies on that empty value to preserve rather
+# than signal a workspace whose session identity was rejected.
+_record_validated_runner_pgid() {
+    local reported_pgid="$1"
+    local bats_pgid="$2"
+
+    [[ "$reported_pgid" != "$bats_pgid" ]] || return 1
+    RUNNER_PGID="$reported_pgid"
 }
 
 # ---------------------------------------------------------------------------
@@ -622,12 +662,11 @@ MOCK
     # may be the transient PID returned by the parent-side background launch.
     [[ "$reported_pid" == "$reported_pgid" ]]
     [[ "$reported_pgid" != "$launch_pid" ]]
-    RUNNER_PGID="$reported_pgid"
 
     local bats_pgid
     bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
     bats_pgid=${bats_pgid//[[:space:]]/}
-    [[ "$RUNNER_PGID" != "$bats_pgid" ]]
+    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" || return 1
 
     local waited=0
     while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -lt 50 ]]; do
@@ -640,6 +679,33 @@ MOCK
         return 1
     fi
     RUNNER_PGID=""
+    RUNNER_LAUNCH_ATTEMPTED=0
+}
+
+@test "rejecting Bats' process group leaves runner identity empty for teardown" {
+    RUNNER_LAUNCH_ATTEMPTED=1
+
+    local bats_pgid
+    bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
+    bats_pgid=${bats_pgid//[[:space:]]/}
+    [[ "$bats_pgid" =~ ^[1-9][0-9]*$ ]]
+
+    if _record_validated_runner_pgid "$bats_pgid" "$bats_pgid"; then
+        return 1
+    fi
+    # Clear only for the deliberately-mutated refusal path, before Bats runs
+    # teardown; the production invariant itself is that this is already empty.
+    if [[ -n "$RUNNER_PGID" ]]; then
+        RUNNER_PGID=""
+        RUNNER_LAUNCH_ATTEMPTED=0
+        return 1
+    fi
+
+    local teardown_status=0
+    teardown || teardown_status=$?
+    [[ $teardown_status -ne 0 && -d "$WORK_DIR" ]]
+
+    # Bats invokes teardown again after this test; now allow normal removal.
     RUNNER_LAUNCH_ATTEMPTED=0
 }
 
@@ -720,12 +786,7 @@ MOCK
     if [[ ! "$bats_pgid" =~ ^[1-9][0-9]*$ || "$reported_pgid" == "$bats_pgid" ]]; then
         return 1
     fi
-    RUNNER_PGID="$reported_pgid"
-    if [[ "$RUNNER_PGID" == "$bats_pgid" ]]; then
-        # Do not let teardown signal Bats' own group if this guard regresses.
-        RUNNER_PGID=""
-        return 1
-    fi
+    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" || return 1
 
     # Wait for runner to start (max 5s).
     local waited=0
@@ -801,7 +862,6 @@ MOCK
 
 @test "cleanup fails and retains workspace when probes stay present" {
     _write_mock_kill_sequence 'present'
-    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
 
     local cleanup_status=0
     _cleanup_runner_group 424242 || cleanup_status=$?
@@ -813,7 +873,6 @@ MOCK
 
 @test "teardown retains workspace when cleanup cannot prove group extinction" {
     _write_mock_kill_sequence 'present'
-    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
     RUNNER_PGID=424242
 
     local teardown_status=0
@@ -867,18 +926,39 @@ MOCK
     [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
 }
 
-@test "cleanup fails and retains workspace when a probe is unknown" {
-    _write_mock_kill_sequence 'unknown'
+@test "runner group state treats a stat entry that vanishes during enumeration as absent" {
+    _write_mock_kill_sequence 'absent'
+
+    local proc_fixture="$WORK_DIR/proc-fixture"
+    mkdir -p "$proc_fixture/991"
+    printf '%s\n' '991 (runner test) S 1 424242 1 1 0' > "$proc_fixture/991/stat"
+    cat > "$BIN_DIR/remove-stat-before-read" <<'MOCK'
+#!/usr/bin/env bash
+rm -f -- "$1"
+MOCK
+    chmod +x "$BIN_DIR/remove-stat-before-read"
+
+    local state_status=0
+    RUNNER_PROC_ROOT="$proc_fixture" \
+        RUNNER_PROC_BEFORE_STAT_READ="$BIN_DIR/remove-stat-before-read" \
+        _runner_group_state 424242 || state_status=$?
+    [[ $state_status -eq 1 ]]
+    [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
+}
+
+@test "cleanup does not KILL when final group confirmation is unknown" {
+    _write_mock_kill_sequence $'present\nabsent\nunknown'
 
     local cleanup_status=0
     _cleanup_runner_group 424242 || cleanup_status=$?
 
     [[ $cleanup_status -ne 0 ]]
     [[ -d "$WORK_DIR" ]]
-    [[ ! -f "$WORK_DIR/kill-signals.log" ]]
+    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
+    [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
-@test "cleanup fails after a failed grace period even when KILL proves absence" {
+@test "cleanup fails after a failed grace period when a later probe proves absence" {
     _write_mock_kill_sequence $'present\npresent\nabsent'
     cat > "$BIN_DIR/failing-real-sleep" <<'MOCK'
 #!/usr/bin/env bash
@@ -892,6 +972,48 @@ MOCK
 
     [[ $cleanup_status -ne 0 ]]
     [[ -d "$WORK_DIR" ]]
+    [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
+}
+
+@test "cleanup deadline defaults remain the documented grace periods" {
+    unset RUNNER_TERM_GRACE_SECONDS RUNNER_KILL_CONFIRMATION_SECONDS
+
+    [[ $RUNNER_TERM_GRACE_SECONDS_DEFAULT -eq 6 ]]
+    [[ $RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT -eq 1 ]]
+}
+
+@test "cleanup TERM grace requests the injected duration rather than a fixed poll count" {
+    cat > "$BIN_DIR/recording-real-sleep" <<MOCK
+#!/usr/bin/env bash
+printf '%s\\n' "\$1" >> "$WORK_DIR/requested-sleeps.log"
+MOCK
+    chmod +x "$BIN_DIR/recording-real-sleep"
+    RUNNER_REAL_SLEEP="$BIN_DIR/recording-real-sleep"
+    RUNNER_KILL_CONFIRMATION_SECONDS=1
+
+    cat > "$BIN_DIR/kill-until-kill" <<MOCK
+#!/usr/bin/env bash
+if [[ "\$1" == "-0" ]]; then
+    [[ -f "$WORK_DIR/kill-seen" ]] && exit 1
+    exit 0
+fi
+echo "\$1" >> "$WORK_DIR/kill-signals.log"
+[[ "\$1" == "-KILL" ]] && touch "$WORK_DIR/kill-seen"
+exit 0
+MOCK
+    chmod +x "$BIN_DIR/kill-until-kill"
+    mv "$BIN_DIR/kill-until-kill" "$BIN_DIR/kill"
+
+    local term_grace_seconds requested_tenths
+    for term_grace_seconds in 1 2; do
+        rm -f "$WORK_DIR/kill-seen" "$WORK_DIR/requested-sleeps.log"
+        RUNNER_TERM_GRACE_SECONDS="$term_grace_seconds"
+        _cleanup_runner_group 424242
+
+        requested_tenths=$(awk -F. '{ tenths += ($1 * 10) + substr(($2 "0"), 1, 1) } END { print tenths + 0 }' "$WORK_DIR/requested-sleeps.log")
+        [[ $requested_tenths -eq $((term_grace_seconds * 10)) ]]
+    done
+    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
     grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -11,6 +11,11 @@
 # the waits with RUNNER_TERM_GRACE_SECONDS and RUNNER_KILL_CONFIRMATION_SECONDS.
 RUNNER_TERM_GRACE_SECONDS_DEFAULT=6
 RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT=1
+# Linux process IDs, and therefore process groups, cannot exceed this kernel
+# limit.  Keeping the accepted value below it also makes every later Bash
+# arithmetic operation safe.
+RUNNER_PGID_MAX=4194304
+RUNNER_CLEANUP_SECONDS_MAX=999999
 
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -227,6 +232,47 @@ _real_sleep() {
     command "${RUNNER_REAL_SLEEP:-$REAL_SLEEP}" "$@"
 }
 
+_runner_pgid_is_valid() {
+    local candidate="${1:-}"
+
+    [[ "$candidate" =~ ^[1-9][0-9]{0,6}$ ]] || return 1
+    ((10#$candidate <= RUNNER_PGID_MAX))
+}
+
+# Bash 5's EPOCHREALTIME is a builtin with microsecond resolution.  This
+# helper writes its integer result to a global so production cleanup performs
+# no subprocesses while reading the clock.  Tests replace the helper with an
+# in-process fake clock.
+_runner_cleanup_time_now() {
+    local timestamp="$EPOCHREALTIME"
+    local seconds="${timestamp%%.*}"
+    local microseconds="${timestamp#*.}"
+
+    [[ "$timestamp" =~ ^[0-9]{1,10}\.[0-9]{6}$ ]] || return 1
+    RUNNER_CLEANUP_NOW_MICROSECONDS=$((10#$seconds * 1000000 + 10#$microseconds))
+}
+
+_runner_cleanup_seconds_to_microseconds() {
+    local seconds="${1:-}"
+
+    [[ "$seconds" =~ ^[0-9]{1,6}$ ]] || return 1
+    ((10#$seconds <= RUNNER_CLEANUP_SECONDS_MAX)) || return 1
+    RUNNER_CLEANUP_DURATION_MICROSECONDS=$((10#$seconds * 1000000))
+}
+
+# Sleep at most one poll interval, and never beyond the phase deadline.
+_runner_cleanup_sleep_remaining() {
+    local remaining_microseconds="$1"
+    local sleep_microseconds="$remaining_microseconds"
+    local sleep_interval
+
+    ((sleep_microseconds > 0)) || return 0
+    ((sleep_microseconds > 100000)) && sleep_microseconds=100000
+    printf -v sleep_interval '%d.%06d' \
+        $((sleep_microseconds / 1000000)) $((sleep_microseconds % 1000000))
+    _real_sleep "$sleep_interval"
+}
+
 # Return one of three states for a process group: 0 present, 1 absent, or 2
 # unknown.  A failed signal probe alone is never evidence of extinction: an
 # EPERM result has the same shell status as ESRCH.  /proc is available on the
@@ -237,7 +283,7 @@ _runner_group_state() {
     local probe_status=0
     local stat_file stat_line state ppid stat_pgid ignored rest
 
-    [[ "$pgid" =~ ^[1-9][0-9]*$ ]] || return 2
+    _runner_pgid_is_valid "$pgid" || return 2
 
     # Use env so the decision table can mock kill in BIN_DIR despite Bash's
     # kill builtin taking precedence over PATH.
@@ -300,24 +346,25 @@ _reap_absent_runner_leader() {
 
 # Stop a runner session without deleting its workspace while a descendant may
 # still be using it.  The six-second TERM grace and one-second KILL
-# confirmation are requested-wait budgets, not fixed poll counts.  Tests may
-# inject shorter deadlines without changing the production defaults.
+# confirmation are elapsed-time deadlines.  Every iteration rechecks its
+# phase deadline after probing, and polls for at most 0.1 seconds at a time.
+# Tests may inject shorter deadlines without changing the production defaults.
 _cleanup_runner_group() {
     local pgid="${1:-}"
     local term_grace_seconds="${RUNNER_TERM_GRACE_SECONDS:-$RUNNER_TERM_GRACE_SECONDS_DEFAULT}"
     local kill_confirmation_seconds="${RUNNER_KILL_CONFIRMATION_SECONDS:-$RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT}"
-    local term_grace_tenths=0
-    local kill_confirmation_tenths=0
-    local term_waited_tenths=0
-    local kill_waited_tenths=0
+    local term_grace_microseconds=0
+    local kill_confirmation_microseconds=0
+    local phase_deadline_microseconds=0
+    local remaining_microseconds=0
     local group_state=0
     local grace_failed=0
 
     [[ -z "$pgid" ]] && return 0
-    [[ "$term_grace_seconds" =~ ^[0-9]+$ ]] || return 1
-    [[ "$kill_confirmation_seconds" =~ ^[0-9]+$ ]] || return 1
-    term_grace_tenths=$((term_grace_seconds * 10))
-    kill_confirmation_tenths=$((kill_confirmation_seconds * 10))
+    _runner_cleanup_seconds_to_microseconds "$term_grace_seconds" || return 1
+    term_grace_microseconds=$RUNNER_CLEANUP_DURATION_MICROSECONDS
+    _runner_cleanup_seconds_to_microseconds "$kill_confirmation_seconds" || return 1
+    kill_confirmation_microseconds=$RUNNER_CLEANUP_DURATION_MICROSECONDS
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
     if [[ $group_state -eq 1 ]]; then
@@ -327,15 +374,21 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
 
     env kill -TERM -- "-$pgid" 2>/dev/null || true
-    while [[ $term_waited_tenths -lt $term_grace_tenths ]]; do
+    _runner_cleanup_time_now || return 1
+    phase_deadline_microseconds=$((RUNNER_CLEANUP_NOW_MICROSECONDS + term_grace_microseconds))
+    while :; do
+        _runner_cleanup_time_now || return 1
+        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
-        if ! _real_sleep 0.1; then
+        _runner_cleanup_time_now || return 1
+        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
+        remaining_microseconds=$((phase_deadline_microseconds - RUNNER_CLEANUP_NOW_MICROSECONDS))
+        if ! _runner_cleanup_sleep_remaining "$remaining_microseconds"; then
             grace_failed=1
             break
         fi
-        term_waited_tenths=$((term_waited_tenths + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
@@ -348,15 +401,21 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
     env kill -KILL -- "-$pgid" 2>/dev/null || true
 
-    while [[ $kill_waited_tenths -lt $kill_confirmation_tenths ]]; do
+    _runner_cleanup_time_now || return 1
+    phase_deadline_microseconds=$((RUNNER_CLEANUP_NOW_MICROSECONDS + kill_confirmation_microseconds))
+    while :; do
+        _runner_cleanup_time_now || return 1
+        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
-        if ! _real_sleep 0.1; then
+        _runner_cleanup_time_now || return 1
+        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
+        remaining_microseconds=$((phase_deadline_microseconds - RUNNER_CLEANUP_NOW_MICROSECONDS))
+        if ! _runner_cleanup_sleep_remaining "$remaining_microseconds"; then
             grace_failed=1
             break
         fi
-        kill_waited_tenths=$((kill_waited_tenths + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
@@ -373,6 +432,8 @@ _record_validated_runner_pgid() {
     local reported_pgid="$1"
     local bats_pgid="$2"
 
+    _runner_pgid_is_valid "$reported_pgid" || return 1
+    _runner_pgid_is_valid "$bats_pgid" || return 1
     [[ "$reported_pgid" != "$bats_pgid" ]] || return 1
     RUNNER_PGID="$reported_pgid"
 }
@@ -685,27 +746,43 @@ MOCK
 @test "rejecting Bats' process group leaves runner identity empty for teardown" {
     RUNNER_LAUNCH_ATTEMPTED=1
 
-    local bats_pgid
+    local bats_pgid validator_status=0 validated_pgid=""
     bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
     bats_pgid=${bats_pgid//[[:space:]]/}
     [[ "$bats_pgid" =~ ^[1-9][0-9]*$ ]]
 
-    if _record_validated_runner_pgid "$bats_pgid" "$bats_pgid"; then
-        return 1
-    fi
-    # Clear only for the deliberately-mutated refusal path, before Bats runs
-    # teardown; the production invariant itself is that this is already empty.
-    if [[ -n "$RUNNER_PGID" ]]; then
-        RUNNER_PGID=""
-        RUNNER_LAUNCH_ATTEMPTED=0
-        return 1
-    fi
+    _record_validated_runner_pgid "$bats_pgid" "$bats_pgid" || validator_status=$?
+    # A deliberately-mutated validator can assign Bats' group before rejecting
+    # it.  Copy then clear its output before any assertion can return to Bats,
+    # so teardown never signals the harness under that regression.
+    validated_pgid=$RUNNER_PGID
+    RUNNER_PGID=""
+    [[ $validator_status -ne 0 && -z "$validated_pgid" ]]
 
     local teardown_status=0
     teardown || teardown_status=$?
     [[ $teardown_status -ne 0 && -d "$WORK_DIR" ]]
 
     # Bats invokes teardown again after this test; now allow normal removal.
+    RUNNER_LAUNCH_ATTEMPTED=0
+}
+
+@test "validator rejects an arithmetic-hostile PGID before teardown" {
+    RUNNER_LAUNCH_ATTEMPTED=1
+
+    local bats_pgid validator_status=0 validated_pgid=""
+    bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
+    bats_pgid=${bats_pgid//[[:space:]]/}
+
+    _record_validated_runner_pgid '9999999999999999999999999999999999999999' "$bats_pgid" || validator_status=$?
+    validated_pgid=$RUNNER_PGID
+    RUNNER_PGID=""
+    [[ $validator_status -ne 0 && -z "$validated_pgid" ]]
+
+    local teardown_status=0
+    teardown || teardown_status=$?
+    [[ $teardown_status -ne 0 && -d "$WORK_DIR" ]]
+
     RUNNER_LAUNCH_ATTEMPTED=0
 }
 
@@ -946,6 +1023,21 @@ MOCK
     [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
 }
 
+@test "runner group state treats a persistent stat read failure as unknown" {
+    _write_mock_kill_sequence 'absent'
+
+    local proc_fixture="$WORK_DIR/proc-fixture"
+    # A directory at stat's path is permanently unreadable as a stat record,
+    # while still existing after cat fails.
+    mkdir -p "$proc_fixture/991/stat"
+
+    local state_status=0
+    RUNNER_PROC_ROOT="$proc_fixture" _runner_group_state 424242 || state_status=$?
+    [[ $state_status -eq 2 ]]
+    [[ -d "$proc_fixture/991/stat" ]]
+    [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
+}
+
 @test "cleanup does not KILL when final group confirmation is unknown" {
     _write_mock_kill_sequence $'present\nabsent\nunknown'
 
@@ -956,6 +1048,31 @@ MOCK
     [[ -d "$WORK_DIR" ]]
     grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
     [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
+}
+
+@test "cleanup does not KILL when a TERM-grace probe is unknown" {
+    _write_mock_kill_sequence $'present\nunknown'
+    RUNNER_TERM_GRACE_SECONDS=1
+
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
+
+    [[ $cleanup_status -ne 0 ]]
+    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
+    [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
+}
+
+@test "cleanup retains the workspace when a KILL-confirmation probe is unknown" {
+    _write_mock_kill_sequence $'present\npresent\nunknown'
+    RUNNER_TERM_GRACE_SECONDS=0
+    RUNNER_KILL_CONFIRMATION_SECONDS=1
+
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
+
+    [[ $cleanup_status -ne 0 ]]
+    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
+    grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
 @test "cleanup fails after a failed grace period when a later probe proves absence" {
@@ -982,37 +1099,42 @@ MOCK
     [[ $RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT -eq 1 ]]
 }
 
-@test "cleanup TERM grace requests the injected duration rather than a fixed poll count" {
-    cat > "$BIN_DIR/recording-real-sleep" <<MOCK
-#!/usr/bin/env bash
-printf '%s\\n' "\$1" >> "$WORK_DIR/requested-sleeps.log"
-MOCK
-    chmod +x "$BIN_DIR/recording-real-sleep"
-    RUNNER_REAL_SLEEP="$BIN_DIR/recording-real-sleep"
-    RUNNER_KILL_CONFIRMATION_SECONDS=1
+@test "cleanup TERM grace ends on elapsed probe time without sleeping" {
+    local fake_clock_microseconds=0 probe_count=0
+    RUNNER_TERM_GRACE_SECONDS=1
+    RUNNER_KILL_CONFIRMATION_SECONDS=0
 
-    cat > "$BIN_DIR/kill-until-kill" <<MOCK
+    # The fake clock and probe run in this shell, so advancing the clock costs
+    # no wall time.  The second present probe consumes the complete TERM grace.
+    _runner_cleanup_time_now() {
+        RUNNER_CLEANUP_NOW_MICROSECONDS=$fake_clock_microseconds
+    }
+    _runner_group_state() {
+        probe_count=$((probe_count + 1))
+        if [[ -f "$WORK_DIR/kill-seen" ]]; then
+            return 1
+        fi
+        [[ $probe_count -gt 1 ]] && fake_clock_microseconds=1000000
+        return 0
+    }
+    _runner_cleanup_sleep_remaining() {
+        touch "$WORK_DIR/unexpected-cleanup-sleep"
+        return 0
+    }
+    _reap_absent_runner_leader() {
+        return 0
+    }
+    cat > "$BIN_DIR/kill" <<MOCK
 #!/usr/bin/env bash
-if [[ "\$1" == "-0" ]]; then
-    [[ -f "$WORK_DIR/kill-seen" ]] && exit 1
-    exit 0
-fi
 echo "\$1" >> "$WORK_DIR/kill-signals.log"
 [[ "\$1" == "-KILL" ]] && touch "$WORK_DIR/kill-seen"
 exit 0
 MOCK
-    chmod +x "$BIN_DIR/kill-until-kill"
-    mv "$BIN_DIR/kill-until-kill" "$BIN_DIR/kill"
+    chmod +x "$BIN_DIR/kill"
 
-    local term_grace_seconds requested_tenths
-    for term_grace_seconds in 1 2; do
-        rm -f "$WORK_DIR/kill-seen" "$WORK_DIR/requested-sleeps.log"
-        RUNNER_TERM_GRACE_SECONDS="$term_grace_seconds"
-        _cleanup_runner_group 424242
+    _cleanup_runner_group 424242
 
-        requested_tenths=$(awk -F. '{ tenths += ($1 * 10) + substr(($2 "0"), 1, 1) } END { print tenths + 0 }' "$WORK_DIR/requested-sleeps.log")
-        [[ $requested_tenths -eq $((term_grace_seconds * 10)) ]]
-    done
+    [[ ! -e "$WORK_DIR/unexpected-cleanup-sleep" ]]
     grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
     grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -7,15 +7,10 @@
 # Setup / Teardown
 # ---------------------------------------------------------------------------
 
-# These are the production-equivalent defaults.  Individual tests can shorten
-# the waits with RUNNER_TERM_GRACE_SECONDS and RUNNER_KILL_CONFIRMATION_SECONDS.
-RUNNER_TERM_GRACE_SECONDS_DEFAULT=6
-RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT=1
 # Linux process IDs, and therefore process groups, cannot exceed this kernel
 # limit.  Keeping the accepted value below it also makes every later Bash
 # arithmetic operation safe.
 RUNNER_PGID_MAX=4194304
-RUNNER_CLEANUP_SECONDS_MAX=999999
 
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
@@ -239,40 +234,6 @@ _runner_pgid_is_valid() {
     ((10#$candidate <= RUNNER_PGID_MAX))
 }
 
-# Bash 5's EPOCHREALTIME is a builtin with microsecond resolution.  This
-# helper writes its integer result to a global so production cleanup performs
-# no subprocesses while reading the clock.  Tests replace the helper with an
-# in-process fake clock.
-_runner_cleanup_time_now() {
-    local timestamp="$EPOCHREALTIME"
-    local seconds="${timestamp%%.*}"
-    local microseconds="${timestamp#*.}"
-
-    [[ "$timestamp" =~ ^[0-9]{1,10}\.[0-9]{6}$ ]] || return 1
-    RUNNER_CLEANUP_NOW_MICROSECONDS=$((10#$seconds * 1000000 + 10#$microseconds))
-}
-
-_runner_cleanup_seconds_to_microseconds() {
-    local seconds="${1:-}"
-
-    [[ "$seconds" =~ ^[0-9]{1,6}$ ]] || return 1
-    ((10#$seconds <= RUNNER_CLEANUP_SECONDS_MAX)) || return 1
-    RUNNER_CLEANUP_DURATION_MICROSECONDS=$((10#$seconds * 1000000))
-}
-
-# Sleep at most one poll interval, and never beyond the phase deadline.
-_runner_cleanup_sleep_remaining() {
-    local remaining_microseconds="$1"
-    local sleep_microseconds="$remaining_microseconds"
-    local sleep_interval
-
-    ((sleep_microseconds > 0)) || return 0
-    ((sleep_microseconds > 100000)) && sleep_microseconds=100000
-    printf -v sleep_interval '%d.%06d' \
-        $((sleep_microseconds / 1000000)) $((sleep_microseconds % 1000000))
-    _real_sleep "$sleep_interval"
-}
-
 # Return one of three states for a process group: 0 present, 1 absent, or 2
 # unknown.  A failed signal probe alone is never evidence of extinction: an
 # EPERM result has the same shell status as ESRCH.  /proc is available on the
@@ -301,7 +262,8 @@ _runner_group_state() {
         if [[ -n "${RUNNER_PROC_BEFORE_STAT_READ:-}" ]]; then
             "$RUNNER_PROC_BEFORE_STAT_READ" "$stat_file" || return 2
         fi
-        if ! stat_line=$(command cat -- "$stat_file" 2>/dev/null); then
+        stat_line=""
+        if ! IFS= read -r stat_line < "$stat_file" && [[ -z "$stat_line" ]]; then
             # A process can normally exit in this small window.  The vanished
             # entry is absence, unlike a stat file that remains unreadable.
             [[ -e "$stat_file" ]] || continue
@@ -318,8 +280,8 @@ _runner_group_state() {
 }
 
 # A group proven absent cannot contain a running leader, so wait can only reap
-# the already-dead child.  The watchdog makes that invariant an actual one-
-# second deadline rather than relying on wait's expected immediate return.
+# the already-dead child.  The watchdog caps that reap instead of relying on
+# wait's expected immediate return.
 _reap_absent_runner_leader() {
     local pgid="$1"
     local timed_out=0
@@ -345,26 +307,20 @@ _reap_absent_runner_leader() {
 }
 
 # Stop a runner session without deleting its workspace while a descendant may
-# still be using it.  The six-second TERM grace and one-second KILL
-# confirmation are elapsed-time deadlines.  Every iteration rechecks its
-# phase deadline after probing, and polls for at most 0.1 seconds at a time.
-# Tests may inject shorter deadlines without changing the production defaults.
+# still be using it.  TERM makes at most 60 polls and KILL confirmation at most
+# 10, sleeping 0.1 between polls that find a present group.  On an unloaded
+# host each phase is approximately its poll count times that sleep; a busy host
+# takes longer because probes take time.  These loose limits prevent teardown
+# from hanging: the cost is that a developer can wait a little longer, so no
+# precise wall-clock cutoff is built here.
 _cleanup_runner_group() {
     local pgid="${1:-}"
-    local term_grace_seconds="${RUNNER_TERM_GRACE_SECONDS:-$RUNNER_TERM_GRACE_SECONDS_DEFAULT}"
-    local kill_confirmation_seconds="${RUNNER_KILL_CONFIRMATION_SECONDS:-$RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT}"
-    local term_grace_microseconds=0
-    local kill_confirmation_microseconds=0
-    local phase_deadline_microseconds=0
-    local remaining_microseconds=0
+    local term_polls=0
+    local kill_polls=0
     local group_state=0
     local grace_failed=0
 
     [[ -z "$pgid" ]] && return 0
-    _runner_cleanup_seconds_to_microseconds "$term_grace_seconds" || return 1
-    term_grace_microseconds=$RUNNER_CLEANUP_DURATION_MICROSECONDS
-    _runner_cleanup_seconds_to_microseconds "$kill_confirmation_seconds" || return 1
-    kill_confirmation_microseconds=$RUNNER_CLEANUP_DURATION_MICROSECONDS
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
     if [[ $group_state -eq 1 ]]; then
@@ -374,21 +330,15 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
 
     env kill -TERM -- "-$pgid" 2>/dev/null || true
-    _runner_cleanup_time_now || return 1
-    phase_deadline_microseconds=$((RUNNER_CLEANUP_NOW_MICROSECONDS + term_grace_microseconds))
-    while :; do
-        _runner_cleanup_time_now || return 1
-        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
+    while [[ $term_polls -lt 60 ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
-        _runner_cleanup_time_now || return 1
-        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
-        remaining_microseconds=$((phase_deadline_microseconds - RUNNER_CLEANUP_NOW_MICROSECONDS))
-        if ! _runner_cleanup_sleep_remaining "$remaining_microseconds"; then
+        if ! _real_sleep 0.1; then
             grace_failed=1
             break
         fi
+        term_polls=$((term_polls + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
@@ -401,21 +351,15 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
     env kill -KILL -- "-$pgid" 2>/dev/null || true
 
-    _runner_cleanup_time_now || return 1
-    phase_deadline_microseconds=$((RUNNER_CLEANUP_NOW_MICROSECONDS + kill_confirmation_microseconds))
-    while :; do
-        _runner_cleanup_time_now || return 1
-        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
+    while [[ $kill_polls -lt 10 ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
-        _runner_cleanup_time_now || return 1
-        ((RUNNER_CLEANUP_NOW_MICROSECONDS >= phase_deadline_microseconds)) && break
-        remaining_microseconds=$((phase_deadline_microseconds - RUNNER_CLEANUP_NOW_MICROSECONDS))
-        if ! _runner_cleanup_sleep_remaining "$remaining_microseconds"; then
+        if ! _real_sleep 0.1; then
             grace_failed=1
             break
         fi
+        kill_polls=$((kill_polls + 1))
     done
 
     if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
@@ -431,11 +375,12 @@ _cleanup_runner_group() {
 _record_validated_runner_pgid() {
     local reported_pgid="$1"
     local bats_pgid="$2"
+    local destination="$3"
 
     _runner_pgid_is_valid "$reported_pgid" || return 1
     _runner_pgid_is_valid "$bats_pgid" || return 1
     [[ "$reported_pgid" != "$bats_pgid" ]] || return 1
-    RUNNER_PGID="$reported_pgid"
+    printf -v "$destination" '%s' "$reported_pgid"
 }
 
 # ---------------------------------------------------------------------------
@@ -727,7 +672,7 @@ MOCK
     local bats_pgid
     bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
     bats_pgid=${bats_pgid//[[:space:]]/}
-    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" || return 1
+    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" RUNNER_PGID || return 1
 
     local waited=0
     while [[ ! -f "$WORK_DIR/runner-started" ]] && [[ $waited -lt 50 ]]; do
@@ -751,13 +696,11 @@ MOCK
     bats_pgid=${bats_pgid//[[:space:]]/}
     [[ "$bats_pgid" =~ ^[1-9][0-9]*$ ]]
 
-    _record_validated_runner_pgid "$bats_pgid" "$bats_pgid" || validator_status=$?
-    # A deliberately-mutated validator can assign Bats' group before rejecting
-    # it.  Copy then clear its output before any assertion can return to Bats,
-    # so teardown never signals the harness under that regression.
-    validated_pgid=$RUNNER_PGID
-    RUNNER_PGID=""
-    [[ $validator_status -ne 0 && -z "$validated_pgid" ]]
+    # Keep the rejected value local from the start: teardown never receives a
+    # group that a validator is still deciding whether to accept.
+    readonly RUNNER_PGID
+    _record_validated_runner_pgid "$bats_pgid" "$bats_pgid" validated_pgid || validator_status=$?
+    [[ $validator_status -ne 0 && -z "$validated_pgid" && -z "$RUNNER_PGID" ]]
 
     local teardown_status=0
     teardown || teardown_status=$?
@@ -774,10 +717,8 @@ MOCK
     bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
     bats_pgid=${bats_pgid//[[:space:]]/}
 
-    _record_validated_runner_pgid '9999999999999999999999999999999999999999' "$bats_pgid" || validator_status=$?
-    validated_pgid=$RUNNER_PGID
-    RUNNER_PGID=""
-    [[ $validator_status -ne 0 && -z "$validated_pgid" ]]
+    _record_validated_runner_pgid '9999999999999999999999999999999999999999' "$bats_pgid" validated_pgid || validator_status=$?
+    [[ $validator_status -ne 0 && -z "$validated_pgid" && -z "$RUNNER_PGID" ]]
 
     local teardown_status=0
     teardown || teardown_status=$?
@@ -863,7 +804,7 @@ MOCK
     if [[ ! "$bats_pgid" =~ ^[1-9][0-9]*$ || "$reported_pgid" == "$bats_pgid" ]]; then
         return 1
     fi
-    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" || return 1
+    _record_validated_runner_pgid "$reported_pgid" "$bats_pgid" RUNNER_PGID || return 1
 
     # Wait for runner to start (max 5s).
     local waited=0
@@ -939,6 +880,7 @@ MOCK
 
 @test "cleanup fails and retains workspace when probes stay present" {
     _write_mock_kill_sequence 'present'
+    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
 
     local cleanup_status=0
     _cleanup_runner_group 424242 || cleanup_status=$?
@@ -950,6 +892,7 @@ MOCK
 
 @test "teardown retains workspace when cleanup cannot prove group extinction" {
     _write_mock_kill_sequence 'present'
+    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
     RUNNER_PGID=424242
 
     local teardown_status=0
@@ -1052,7 +995,6 @@ MOCK
 
 @test "cleanup does not KILL when a TERM-grace probe is unknown" {
     _write_mock_kill_sequence $'present\nunknown'
-    RUNNER_TERM_GRACE_SECONDS=1
 
     local cleanup_status=0
     _cleanup_runner_group 424242 || cleanup_status=$?
@@ -1063,9 +1005,14 @@ MOCK
 }
 
 @test "cleanup retains the workspace when a KILL-confirmation probe is unknown" {
-    _write_mock_kill_sequence $'present\npresent\nunknown'
-    RUNNER_TERM_GRACE_SECONDS=0
-    RUNNER_KILL_CONFIRMATION_SECONDS=1
+    local states="present"
+    local poll
+    for ((poll = 1; poll < 62; poll++)); do
+        states+=$'\npresent'
+    done
+    states+=$'\nunknown'
+    _write_mock_kill_sequence "$states"
+    RUNNER_REAL_SLEEP="$BIN_DIR/sleep"
 
     local cleanup_status=0
     _cleanup_runner_group 424242 || cleanup_status=$?
@@ -1090,53 +1037,6 @@ MOCK
     [[ $cleanup_status -ne 0 ]]
     [[ -d "$WORK_DIR" ]]
     [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
-}
-
-@test "cleanup deadline defaults remain the documented grace periods" {
-    unset RUNNER_TERM_GRACE_SECONDS RUNNER_KILL_CONFIRMATION_SECONDS
-
-    [[ $RUNNER_TERM_GRACE_SECONDS_DEFAULT -eq 6 ]]
-    [[ $RUNNER_KILL_CONFIRMATION_SECONDS_DEFAULT -eq 1 ]]
-}
-
-@test "cleanup TERM grace ends on elapsed probe time without sleeping" {
-    local fake_clock_microseconds=0 probe_count=0
-    RUNNER_TERM_GRACE_SECONDS=1
-    RUNNER_KILL_CONFIRMATION_SECONDS=0
-
-    # The fake clock and probe run in this shell, so advancing the clock costs
-    # no wall time.  The second present probe consumes the complete TERM grace.
-    _runner_cleanup_time_now() {
-        RUNNER_CLEANUP_NOW_MICROSECONDS=$fake_clock_microseconds
-    }
-    _runner_group_state() {
-        probe_count=$((probe_count + 1))
-        if [[ -f "$WORK_DIR/kill-seen" ]]; then
-            return 1
-        fi
-        [[ $probe_count -gt 1 ]] && fake_clock_microseconds=1000000
-        return 0
-    }
-    _runner_cleanup_sleep_remaining() {
-        touch "$WORK_DIR/unexpected-cleanup-sleep"
-        return 0
-    }
-    _reap_absent_runner_leader() {
-        return 0
-    }
-    cat > "$BIN_DIR/kill" <<MOCK
-#!/usr/bin/env bash
-echo "\$1" >> "$WORK_DIR/kill-signals.log"
-[[ "\$1" == "-KILL" ]] && touch "$WORK_DIR/kill-seen"
-exit 0
-MOCK
-    chmod +x "$BIN_DIR/kill"
-
-    _cleanup_runner_group 424242
-
-    [[ ! -e "$WORK_DIR/unexpected-cleanup-sleep" ]]
-    grep -q -- '-TERM' "$WORK_DIR/kill-signals.log"
-    grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
 # ---------------------------------------------------------------------------

--- a/github-runner/tests/test-runner-linux.bats
+++ b/github-runner/tests/test-runner-linux.bats
@@ -243,6 +243,7 @@ _runner_group_state() {
     local pgid="${1:-}"
     local probe_status=0
     local stat_file stat_line state ppid stat_pgid ignored rest
+    local -a stat_lines
 
     _runner_pgid_is_valid "$pgid" || return 2
 
@@ -262,13 +263,14 @@ _runner_group_state() {
         if [[ -n "${RUNNER_PROC_BEFORE_STAT_READ:-}" ]]; then
             "$RUNNER_PROC_BEFORE_STAT_READ" "$stat_file" || return 2
         fi
-        stat_line=""
-        if ! IFS= read -r stat_line < "$stat_file" && [[ -z "$stat_line" ]]; then
+        stat_lines=()
+        if ! mapfile -t stat_lines < "$stat_file"; then
             # A process can normally exit in this small window.  The vanished
             # entry is absence, unlike a stat file that remains unreadable.
             [[ -e "$stat_file" ]] || continue
             return 2
         fi
+        stat_line=$(printf '%s\n' "${stat_lines[@]}")
         # Fields after the final ')' are: state (3), ppid (4), pgrp (5), ... .
         rest="${stat_line##*) }"
         read -r state ppid stat_pgid ignored <<<"$rest"
@@ -280,39 +282,51 @@ _runner_group_state() {
 }
 
 # A group proven absent cannot contain a running leader, so wait can only reap
-# the already-dead child.  The watchdog caps that reap instead of relying on
-# wait's expected immediate return.
+# the already-dead child.  The watchdog interrupts that reap after one second;
+# if its sleep fails, it reports the failure, interrupts the reap, and fails
+# closed rather than silently removing the watchdog.
 _reap_absent_runner_leader() {
     local pgid="$1"
     local timed_out=0
     local parent_pid="$BASHPID"
     local watchdog_pid
+    local watchdog_status=0
+    local watchdog_cancelled=0
     local saved_usr1_trap
 
     saved_usr1_trap=$(trap -p USR1 || true)
     trap 'timed_out=1' USR1
-    ( command "$REAL_SLEEP" 1 && kill -USR1 "$parent_pid" 2>/dev/null ) &
+    (
+        if ! command "$REAL_SLEEP" 1; then
+            echo "Runner reap watchdog sleep failed" >&2
+            kill -USR1 "$parent_pid" 2>/dev/null || true
+            exit 1
+        fi
+        kill -USR1 "$parent_pid" 2>/dev/null || exit 1
+    ) &
     watchdog_pid=$!
 
     wait "$pgid" 2>/dev/null || true
-    kill "$watchdog_pid" 2>/dev/null || true
-    wait "$watchdog_pid" 2>/dev/null || true
+    if kill "$watchdog_pid" 2>/dev/null; then
+        watchdog_cancelled=1
+    fi
+    wait "$watchdog_pid" 2>/dev/null || watchdog_status=$?
     if [[ -n "$saved_usr1_trap" ]]; then
         eval "$saved_usr1_trap"
     else
         trap - USR1
     fi
 
-    [[ $timed_out -eq 0 ]]
+    [[ $timed_out -eq 0 && ( $watchdog_cancelled -eq 1 || $watchdog_status -eq 0 ) ]]
 }
 
 # Stop a runner session without deleting its workspace while a descendant may
-# still be using it.  TERM makes at most 60 polls and KILL confirmation at most
-# 10, sleeping 0.1 between polls that find a present group.  On an unloaded
-# host each phase is approximately its poll count times that sleep; a busy host
-# takes longer because probes take time.  These loose limits prevent teardown
-# from hanging: the cost is that a developer can wait a little longer, so no
-# precise wall-clock cutoff is built here.
+# still be using it.  After TERM there are at most 60 state probes, including
+# the final confirmation, and after KILL there are at most 10.  Each loop sleeps
+# 0.1 between probes that find a present group.  On an unloaded host each phase
+# is approximately its sleep count times that delay; a busy host takes longer
+# because probes take time.  The fixed counts prevent unbounded polling loops,
+# but a probe that never returns can still hang teardown regardless of them.
 _cleanup_runner_group() {
     local pgid="${1:-}"
     local term_polls=0
@@ -330,7 +344,7 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
 
     env kill -TERM -- "-$pgid" 2>/dev/null || true
-    while [[ $term_polls -lt 60 ]]; do
+    while [[ $term_polls -lt 59 ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
@@ -351,7 +365,7 @@ _cleanup_runner_group() {
     [[ $group_state -eq 0 ]] || return 1
     env kill -KILL -- "-$pgid" 2>/dev/null || true
 
-    while [[ $kill_polls -lt 10 ]]; do
+    while [[ $kill_polls -lt 9 ]]; do
         if _runner_group_state "$pgid"; then group_state=0; else group_state=$?; fi
         [[ $group_state -eq 1 ]] && break
         [[ $group_state -eq 0 ]] || return 1
@@ -691,16 +705,15 @@ MOCK
 @test "rejecting Bats' process group leaves runner identity empty for teardown" {
     RUNNER_LAUNCH_ATTEMPTED=1
 
-    local bats_pgid validator_status=0 validated_pgid=""
+    local bats_pgid validator_status=0
     bats_pgid=$(ps -o pgid= -p "$BASHPID") || return 1
     bats_pgid=${bats_pgid//[[:space:]]/}
     [[ "$bats_pgid" =~ ^[1-9][0-9]*$ ]]
 
-    # Keep the rejected value local from the start: teardown never receives a
-    # group that a validator is still deciding whether to accept.
-    readonly RUNNER_PGID
-    _record_validated_runner_pgid "$bats_pgid" "$bats_pgid" validated_pgid || validator_status=$?
-    [[ $validator_status -ne 0 && -z "$validated_pgid" && -z "$RUNNER_PGID" ]]
+    # Use the production destination: teardown must receive no group when the
+    # validator rejects Bats' own process group.
+    _record_validated_runner_pgid "$bats_pgid" "$bats_pgid" RUNNER_PGID || validator_status=$?
+    [[ $validator_status -ne 0 && -z "$RUNNER_PGID" ]]
 
     local teardown_status=0
     teardown || teardown_status=$?
@@ -933,6 +946,19 @@ MOCK
     [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
 }
 
+@test "runner group state parses a newline in comm from the whole stat file" {
+    # A line read would stop before the closing parenthesis and reject this
+    # valid record.  Rejoining every mapfile element retains the embedded newline.
+    _write_mock_kill_sequence 'absent'
+
+    local proc_fixture="$WORK_DIR/proc-fixture"
+    mkdir -p "$proc_fixture/991"
+    printf '%s\n' '991 (runner' 'test) S 1 424242 1 1 0' > "$proc_fixture/991/stat"
+
+    RUNNER_PROC_ROOT="$proc_fixture" _runner_group_state 424242
+    [[ "$(cat "$WORK_DIR/kill-probe-count")" -eq 1 ]]
+}
+
 @test "runner group state reports absent when fixture contains no group member" {
     _write_mock_kill_sequence 'absent'
 
@@ -1004,10 +1030,20 @@ MOCK
     [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
 }
 
+@test "cleanup fails closed when its initial group probe is unknown" {
+    _write_mock_kill_sequence 'unknown'
+
+    local cleanup_status=0
+    _cleanup_runner_group 424242 || cleanup_status=$?
+
+    [[ $cleanup_status -ne 0 ]]
+    [[ ! -f "$WORK_DIR/kill-signals.log" ]]
+}
+
 @test "cleanup retains the workspace when a KILL-confirmation probe is unknown" {
     local states="present"
     local poll
-    for ((poll = 1; poll < 62; poll++)); do
+    for ((poll = 1; poll < 61; poll++)); do
         states+=$'\npresent'
     done
     states+=$'\nunknown'
@@ -1037,6 +1073,27 @@ MOCK
     [[ $cleanup_status -ne 0 ]]
     [[ -d "$WORK_DIR" ]]
     [[ ! -f "$WORK_DIR/kill-signals.log" ]] || ! grep -q -- '-KILL' "$WORK_DIR/kill-signals.log"
+}
+
+@test "reap watchdog reports and fails closed when its sleep fails" {
+    local actual_sleep="$REAL_SLEEP"
+    "$actual_sleep" 5 &
+    local child_pid=$!
+
+    cat > "$BIN_DIR/failing-watchdog-sleep" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+    chmod +x "$BIN_DIR/failing-watchdog-sleep"
+    REAL_SLEEP="$BIN_DIR/failing-watchdog-sleep"
+
+    local reap_status=0
+    _reap_absent_runner_leader "$child_pid" 2>"$WORK_DIR/reap-watchdog.log" || reap_status=$?
+    kill "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+
+    [[ $reap_status -ne 0 ]]
+    grep -q 'Runner reap watchdog sleep failed' "$WORK_DIR/reap-watchdog.log"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two defects in the process-group cleanup the #1369 fix introduced.

**The job-control test could signal the bats group when it tripped.** It assigned `RUNNER_PGID`
and only afterwards asserted the value differed from bats' own group, so a handshake regression
would trip that assertion under `errexit` and automatic teardown would then TERM and KILL the
harness — the failure the test exists to detect. Validation writes into a local now, and
`RUNNER_PGID` is selected as the destination only on success.

**The timing claim is gone rather than made true.** #1372's complaint was that a comment said "six
seconds" while the loop counted six polls. Three attempts at making the strong sentence true — an
elapsed budget, then a sleep budget, then an `EPOCHREALTIME` deadline — each drew their own
defects across two review rounds: a clock that is not monotonic, budgets read after the `kill`
they bound, a slow probe still overrunning between checks, a `cat` forked per `/proc` entry, and
fourteen seconds added to the suite.

The loop is fixed polling again and the comment says what it is: at most 60 TERM polls and 10
confirmation polls, 0.1 between polls that find a present group, approximately poll count times
sleep on an unloaded host and longer on a busy one. It states that the bound prevents an unbounded
loop and that a probe which never returns can still hang — which no iteration count prevents.
Nothing in the file reads a clock, and the file no longer needs bash 5.

Kept because each is cheap and real: KILL only against a probe reporting `present`, with `unknown`
returning failure and keeping the workspace; a `/proc` entry that vanishes during enumeration
counted as absence while another read failure stays unknown; `/proc` read whole with `mapfile`, so
a comm containing a newline does not truncate the parse; and a test with a killing mutation for
each of the four outcomes.

## Verification

35 passed, 0 failed on two consecutive runs and once with job control on, in 17-18 s against 41 s
before the subtractive round. `shellcheck -S warning` clean. The net change is 139 lines removed
against 39 added in that round, before the corrections on top.

## Follow-ups

Landed on capped evidence at the declared budget plus its one bought round. Residue: #1389, and
the already-open #1370 (pgid reuse, in both the signal path and the watchdog cancellation), #1373,
#1375 and #1383.

One finding from the terminal review was checked and is wrong, recorded on #1389 so nobody
re-derives it: `/proc` enumeration does not fork per entry.

Closes #1385. Closes #1372.
