### PR TITLE
fix(extensions): fail closed when the extension enumeration fails

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -539,7 +539,15 @@ list_extension_status() {
     printf "%-15s %-10s %-12s %s\n" "Extension" "Version" "Status" "Image"
     printf "%-15s %-10s %-12s %s\n" "---------" "-------" "------" "-----"
 
-    for ext in $(list_extensions_by_priority "$config_file" "$major_ver"); do
+    local ext_list
+    if ! ext_list=$(list_extensions_by_priority "$config_file" "$major_ver"); then
+        log_error "extension enumeration for status listing failed — aborting (fail-closed)"
+        return 1
+    fi
+
+    local ext
+    while IFS= read -r ext; do
+        [[ -z "$ext" ]] && continue
         local ceiling version_set_json
         ceiling=$(ext_config "$ext" "version" "$config_file")
 
@@ -566,7 +574,7 @@ list_extension_status() {
             echo -e "$status"
             printf "%-39s %s\n" "" "$image"
         done < <(echo "$version_set_json" | jq -r '.[]')
-    done
+    done <<< "$ext_list"
 
     echo ""
 }
@@ -716,7 +724,7 @@ pull_extension() {
 
 # --- Helpers extracted from main() for readability ---
 
-# Validate container dir, config, and yq are available. Exits on failure.
+# Validate container dir, config, yq, and jq are available. Exits on failure.
 validate_prerequisites() {
     local container_dir="$ROOT_DIR/$CONTAINER"
     if [[ ! -d "$container_dir" ]]; then
@@ -731,6 +739,10 @@ validate_prerequisites() {
         log_error "yq is required for YAML parsing. Install with: brew install yq"
         exit 1
     fi
+    if ! command -v jq &>/dev/null; then
+        log_error "jq is required for JSON parsing. Install with: brew install jq"
+        exit 1
+    fi
 }
 
 # Pull-only mode: pull extensions from registry, build missing ones locally.
@@ -743,18 +755,26 @@ handle_pull_only_mode() {
 
     local extensions_to_pull=()
     local extensions_to_build=()
+    local ext ext_ver
 
     if [[ -n "$EXTENSION" ]]; then
         extensions_to_pull=("$EXTENSION")
     else
+        local ext_list
+        if ! ext_list=$(list_extensions_by_priority "$config_file" "$major_ver"); then
+            log_error "extension enumeration for pull-only mode failed — aborting (fail-closed)"
+            return 1
+        fi
+
         while IFS= read -r ext; do
+            [[ -z "$ext" ]] && continue
             local dockerfile="$container_dir/extensions/build/${ext}.Dockerfile"
             if [[ ! -f "$dockerfile" ]]; then
                 log_warning "$ext: no Dockerfile (skipped)"
                 continue
             fi
             extensions_to_pull+=("$ext")
-        done < <(list_extensions_by_priority "$config_file" "$major_ver")
+        done <<< "$ext_list"
     fi
 
     for ext in "${extensions_to_pull[@]}"; do
@@ -1418,7 +1438,7 @@ _resolve_cached() {
     local cache_file="${_RESOLVER_CACHE_DIR}/${ext}-${major}.json"
 
     if [[ -f "$cache_file" ]]; then
-        cat "$cache_file"
+        cat "$cache_file" || return 1
         return 0
     fi
 
@@ -1814,7 +1834,10 @@ _emit_final_versionset_pass() {
     if [[ -n "${EXTENSION:-}" ]]; then
         ext_list="$EXTENSION"
     else
-        ext_list=$(list_extensions_by_priority "$config_file" "$major_ver")
+        if ! ext_list=$(list_extensions_by_priority "$config_file" "$major_ver"); then
+            log_error "extension enumeration for final versionset pass failed — aborting (fail-closed)"
+            return 1
+        fi
     fi
 
     local ext
@@ -2176,7 +2199,10 @@ finalize_multiarch_manifests() {
     if [[ -n "${EXTENSION:-}" ]]; then
         ext_list="$EXTENSION"
     else
-        ext_list=$(list_extensions_by_priority "$config_file" "$major_ver")
+        if ! ext_list=$(list_extensions_by_priority "$config_file" "$major_ver"); then
+            log_error "extension enumeration for multi-arch manifest finalization failed — aborting (fail-closed)"
+            return 1
+        fi
     fi
 
     local _failed=false
@@ -2643,6 +2669,15 @@ main() {
 
     # Build mode — determine which extensions to build.
     local extensions_to_build=()
+    local ext _pre_clean_ext _btpe_ext _mixed_clean_ext
+    local ext_list=""
+
+    if [[ -z "$EXTENSION" ]]; then
+        if ! ext_list=$(list_extensions_by_priority "$config_file" "$major_ver"); then
+            log_error "extension enumeration for build mode failed — aborting (fail-closed)"
+            exit 1
+        fi
+    fi
 
     if [[ -n "$EXTENSION" ]]; then
         # Strict typo check: explicit --extension must have a real Dockerfile
@@ -2660,6 +2695,7 @@ main() {
         esac
     else
         while IFS= read -r ext; do
+            [[ -z "$ext" ]] && continue
             local _rc=0
             _should_build_extension "$ext" "$config_file" "$major_ver" "$container_dir" || _rc=$?
             case "$_rc" in
@@ -2667,7 +2703,7 @@ main() {
                 1) : ;;
                 *) log_error "$ext: version-set resolver failed — aborting (fail-closed)"; _record_rotation_build_status infra; return 1 ;;
             esac
-        done < <(list_extensions_by_priority "$config_file" "$major_ver")
+        done <<< "$ext_list"
     fi
 
     if [[ ${#extensions_to_build[@]} -eq 0 ]]; then
@@ -2690,11 +2726,10 @@ main() {
         if [[ -n "$EXTENSION" ]]; then
             _cleanup_stale_duration_files "$EXTENSION" "$major_ver"
         else
-            local _pre_clean_ext
             while IFS= read -r _pre_clean_ext; do
                 [[ -z "$_pre_clean_ext" ]] && continue
                 _cleanup_stale_duration_files "$_pre_clean_ext" "$major_ver"
-            done < <(list_extensions_by_priority "$config_file" "$major_ver")
+            done <<< "$ext_list"
         fi
 
         # Write versionset artifacts for all in-scope resolver-backed extensions.
@@ -2726,13 +2761,12 @@ main() {
         for _btpe_ext in "${extensions_to_build[@]}"; do
             _btpe_set["$_btpe_ext"]=1
         done
-        local _mixed_clean_ext
         while IFS= read -r _mixed_clean_ext; do
             [[ -z "$_mixed_clean_ext" ]] && continue
             # Skip extensions that will be cleaned inside build_tag_push_extensions.
             [[ -n "${_btpe_set[$_mixed_clean_ext]:-}" ]] && continue
             _cleanup_stale_duration_files "$_mixed_clean_ext" "$major_ver"
-        done < <(list_extensions_by_priority "$config_file" "$major_ver")
+        done <<< "$ext_list"
     fi
 
     build_tag_push_extensions "$config_file" "$major_ver" "$container_dir" "$do_push" "${extensions_to_build[@]}"

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -1,9 +1,7 @@
 #!/usr/bin/env bats
 
-# Unit tests for _should_build_extension() in scripts/build-extensions.sh
-#
-# 8-case truth table covering LOCAL_ONLY, FORCE, docker-inspect result,
-# registry presence, and missing Dockerfile.
+# Unit tests for _should_build_extension() truth table plus CLI entry-point,
+# enumeration, cache-read, and prerequisite coverage in scripts/build-extensions.sh
 #
 # Mocking strategy:
 #   - docker()           : bash function override (exits 0 = image found, 1 = not found)
@@ -15,15 +13,13 @@
 load "../test_helper"
 
 # ---------------------------------------------------------------------------
-# Source helper: push to scripts/ so SCRIPT_DIR/ROOT_DIR resolve correctly.
+# Source helper: build-extensions.sh resolves its own SCRIPT_DIR/ROOT_DIR.
 # build-extensions.sh has a BASH_SOURCE guard so main() is NOT called when
 # the script is sourced rather than executed directly.
 # ---------------------------------------------------------------------------
 _source_build_extensions() {
-    pushd "$SCRIPTS_DIR" > /dev/null 2>&1
     # shellcheck disable=SC1091
-    source "./build-extensions.sh"
-    popd > /dev/null 2>&1
+    source "$SCRIPTS_DIR/build-extensions.sh"
 }
 
 # ---------------------------------------------------------------------------
@@ -61,10 +57,6 @@ EOF
     export LOCAL_ONLY=false
     export CONTAINER="postgres"
 
-    # Override ROOT_DIR so that build-extensions.sh path resolution doesn't
-    # point at the real repo (we re-assign after sourcing below)
-    export ROOT_DIR="$TEST_TEMP_DIR"
-
     _source_build_extensions
 
     # Install mocks AFTER sourcing — build-extensions.sh sources
@@ -89,6 +81,10 @@ teardown() {
             cleanup_failed=1
         fi
     done
+    # Sourcing the script creates both per-run directories; it installs no EXIT
+    # trap when sourced, so each test would otherwise leave two behind.
+    [[ -z "${_RESOLVER_CACHE_DIR:-}" ]] || rm -rf -- "$_RESOLVER_CACHE_DIR"
+    [[ -z "${_BUILT_THIS_RUN_DIR:-}" ]] || rm -rf -- "$_BUILT_THIS_RUN_DIR"
     teardown_temp_dir
     unset FORCE LOCAL_ONLY CONTAINER ROOT_DIR
     return "$cleanup_failed"
@@ -307,7 +303,8 @@ EOF
         echo "FAIL: --extension -foo must remain option-shaped rather than grammar-valid"
         return 1
     }
-    ! [[ '-foo' =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]] || {
+    local option_shaped_extension='-foo'
+    ! [[ "$option_shaped_extension" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]] || {
         echo "FAIL: extension diagnostic grammar must not describe -foo as valid"
         return 1
     }
@@ -471,4 +468,170 @@ _setup_default_mocks() {
     run _should_build_extension "pgvector" "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
     [ "$status" -eq 0 ]
     [ ! -e "$TEST_TEMP_DIR/registry_probe_called" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fail-closed extension enumeration
+# ---------------------------------------------------------------------------
+
+_mock_failed_extension_enumeration() {
+    list_extensions_by_priority() {
+        return 1
+    }
+}
+
+_malformed_config_yq_path() {
+    local test_path="$TEST_TEMP_DIR/malformed-config-bin"
+    local malformed_config="$TEST_TEMP_DIR/malformed-config.yaml"
+    local real_yq
+    real_yq="$(command -v yq)"
+
+    mkdir -p "$test_path"
+    printf 'extensions: [\n' > "$malformed_config"
+    cat > "$test_path/yq" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *'.extensions | to_entries[]'* ]]; then
+    printf 'pgvector\\n'
+    exit 0
+fi
+set -- "\${@:1:\$#-1}" "$malformed_config"
+exec "$real_yq" "\$@"
+EOF
+    chmod +x "$test_path/yq"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$test_path/docker"
+    chmod +x "$test_path/docker"
+    printf '%s' "$test_path"
+}
+
+@test "pull-only mode fails closed when extension enumeration fails" {
+    EXTENSION=""
+    _mock_failed_extension_enumeration
+
+    run handle_pull_only_mode "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -ne 0 ]
+    assert_output_not_contains "All extensions pulled successfully"
+    assert_output_contains "extension enumeration for pull-only mode failed — aborting (fail-closed)"
+}
+
+@test "pull-only entry point fails closed when config access fails after enumeration" {
+    local malformed_yq_path
+    malformed_yq_path="$(_malformed_config_yq_path)"
+    unset -f docker
+
+    run env CI=true PATH="$malformed_yq_path:$PATH" "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version "$MAJOR_VER" --pull-only
+    [ "$status" -ne 0 ]
+    assert_output_not_contains "All extensions pulled successfully"
+}
+
+@test "status listing fails closed when extension enumeration fails" {
+    export EXTENSION=""
+    _mock_failed_extension_enumeration
+
+    run list_extension_status "$CONFIG_FILE" "$MAJOR_VER"
+    [ "$status" -ne 0 ]
+    assert_output_contains "extension enumeration for status listing failed — aborting (fail-closed)"
+}
+
+@test "list entry point fails closed when config access fails after enumeration" {
+    local malformed_yq_path
+    malformed_yq_path="$(_malformed_config_yq_path)"
+
+    run env PATH="$malformed_yq_path:$PATH" "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version "$MAJOR_VER" --list
+    [ "$status" -ne 0 ]
+    assert_output_not_contains "ghcr.io/"
+}
+
+@test "build entry point fails closed when extension enumeration cannot parse config" {
+    local test_path="$TEST_TEMP_DIR/malformed-enumeration-bin"
+    local malformed_config="$TEST_TEMP_DIR/malformed-enumeration.yaml"
+    local real_yq
+    real_yq="$(command -v yq)"
+    mkdir -p "$test_path"
+    printf 'extensions: [\n' > "$malformed_config"
+    cat > "$test_path/yq" <<EOF
+#!/usr/bin/env bash
+set -- "\${@:1:\$#-1}" "$malformed_config"
+exec "$real_yq" "\$@"
+EOF
+    chmod +x "$test_path/yq"
+
+    run env PATH="$test_path:$PATH" "$SCRIPTS_DIR/build-extensions.sh" postgres --major-version "$MAJOR_VER" --local-only
+
+    [ "$status" -ne 0 ]
+    assert_output_not_contains "All extensions are up to date"
+    assert_output_contains "extension enumeration for build mode failed — aborting (fail-closed)"
+}
+
+@test "final versionset and multi-arch passes fail closed when extension enumeration fails" {
+    export EXTENSION=""
+    export DRY_RUN=false
+    _mock_failed_extension_enumeration
+
+    run _emit_final_versionset_pass "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -ne 0 ]
+    assert_output_contains "extension enumeration for final versionset pass failed — aborting (fail-closed)"
+
+    run finalize_multiarch_manifests "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+    [ "$status" -ne 0 ]
+    assert_output_contains "extension enumeration for multi-arch manifest finalization failed — aborting (fail-closed)"
+}
+
+@test "an empty extension enumeration selects nothing rather than an empty name" {
+    export EXTENSION=""
+    export LIST_ONLY=false
+    export FINALIZE_MULTIARCH=false
+    export LOCAL_ONLY=true
+    export PULL_ONLY=false
+    export DRY_RUN=false
+    export MAJOR_VERSION="$MAJOR_VER"
+    # Succeeds, emits nothing: every extension disabled, or none reaching this major.
+    list_extensions_by_priority() { return 0; }
+    _should_build_extension() { printf 'CALLED[%s]\n' "$1"; return 1; }
+    validate_extension_package_suffix() { return 0; }
+    validate_prerequisites() { return 0; }
+    log_dry_run_cache_mode() { :; }
+    _emit_final_versionset_pass() { return 0; }
+
+    run main postgres
+
+    [ "$status" -eq 0 ]
+    assert_output_not_contains "CALLED["
+}
+
+@test "cached resolver fails when its cache entry cannot be read" {
+    # The cache entry is a regular file this run wrote itself, so no filesystem
+    # state makes `cat` fail for a root test runner. Mock the read instead.
+    printf '["1.2.3"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
+    cat() { return 1; }
+
+    run _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE"
+
+    [ "$status" -ne 0 ]
+}
+
+@test "cached resolver returns a readable cache entry" {
+    printf '["1.2.3"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
+
+    run _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE"
+
+    [ "$status" -eq 0 ]
+    assert_equals '["1.2.3"]' "$output"
+}
+
+@test "prerequisites require jq as well as yq" {
+    local test_path="$TEST_TEMP_DIR/bin"
+    mkdir -p "$test_path"
+    printf '#!/bin/bash\nexit 0\n' > "$test_path/yq"
+    chmod +x "$test_path/yq"
+
+    ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
+    [ "$status" -ne 0 ]
+    assert_output_contains "jq is required for JSON parsing"
+
+    printf '#!/bin/bash\nexit 0\n' > "$test_path/jq"
+    chmod +x "$test_path/jq"
+
+    ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
`list_extensions_by_priority` runs one `yq` over `postgres/extensions/config.yaml` and returns its
status. Seven consumers in `scripts/build-extensions.sh` discarded it, so a failed enumeration read
as an empty list and the caller reported success.

With one unclosed flow sequence appended to that config, on `master`:

| command | before | after |
|---|---|---|
| `build-extensions.sh postgres --major-version 18 --local-only` | `✅ All extensions are up to date`, exit 0, built nothing | exit 1, `❌ extension enumeration for build mode failed — aborting (fail-closed)` |
| `… --pull-only` | `✅ All extensions pulled successfully`, exit 0 | exit 1, names the pull-only enumeration |
| `… --list` | empty table, exit 0 | exit 1, names the status listing |

An intact config still builds and lists 26 rows.

The seven sites came in three shapes: five `done < <(…)` or `for x in $(…)`, which bash does not
propagate, and two `ext_list=$(…)` assignments inside `_emit_final_versionset_pass` and
`finalize_multiarch_manifests`, whose callers map an rc with `|| _rc=$?` — that suppresses `errexit`
in the function body, so the assignment's failure was invisible there too. Each now captures the
status in the form `check-version-drift.sh:574` already used. `main` reads the enumeration once and
reuses it at all three of its uses, removing two redundant `yq` runs; that is a single read within
`main`, not a snapshot for the whole run.

`list_extensions_by_priority` itself is unchanged. It already returned the right status, and over a
hundred cases in `build-extensions-versionset.bats` stub its stdout contract.

Two smaller holes in the same family are closed with it: `_resolve_cached` returned a cache entry
with an unconditional `return 0` after `cat`, so a read failure was an empty string at status 0; and
`validate_prerequisites` required `yq` but not `jq`, leaving the ceiling-fallback path to meet
`jq -r '.[]'` with no jq and iterate zero times in silence. Those are why the eight
`echo "$version_set_json" | jq -r '.[]'` loops are left alone — `echo` on a shell variable cannot
fail, the value is either a literal or a `_resolve_cached` result validated before caching, and jq
is now required at the boundary.

Also here, from review: `main` and `handle_pull_only_mode` declare their loop iterators `local`, so
neither overwrites a variable belonging to a caller that sources the script.

## Verification

All three modes exit 1 against a malformed config and still work against an intact one. 2811 bats
tests pass, 0 fail. `shellcheck -S warning` clean. Mutation proofs on the four guards this branch
adds — the two bare entry-point calls, the empty-name guard and the cache read — each with the
control green and the mutant red on a one-line substitution.

Under `bats -j 8` the two container-backed suites intermittently fail and pass alone; that is the
known parallel flake, recorded on #1148.

## Follow-ups

#1391 (a partial cache write is promoted and reported as a successful resolve), #1392 (artifact
writes unchecked and non-atomic, so a failed write is logged as success) and #1393 (loop iterators
not declared local across the rest of the file). All three are pre-existing on `master`, verified
with `git show origin/master:`.

Closes #1384.
