### PR TITLE
fix(cleanup): protect the rolling alias the Windows publisher creates

### DIFF
--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -9,7 +9,7 @@ script_root() {
 }
 
 build_valid_tags() {
-  local container="$1" builds_json tags variant_tags
+  local container="$1" builds_json tags variant_tags flavor_tags
   if ! builds_json=$("$ROOT_DIR/make" list-builds "$container" 2>/dev/null); then
     return 1
   fi
@@ -20,11 +20,19 @@ build_valid_tags() {
     return 1
   fi
   tags+=$'\nlatest\nbuildcache'
-  if ! variant_tags=$(jq -r '.[] | select(.variant != "" and .is_latest_version == true) | "latest-" + .variant' <<< "$builds_json" | sort -u); then
+  if ! variant_tags=$(set -o pipefail; jq -r '.[] | select(.variant != "" and .is_latest_version == true) | "latest-" + .variant' <<< "$builds_json" | sort -u); then
     return 1
   fi
   if [[ -n "$variant_tags" ]]; then
     tags+=$'\n'"$variant_tags"
+  fi
+  # Publisher creates latest-<flavor> on any version for non-default Windows builds with a non-empty flavor.
+  # This script's is_latest_version filter is narrower; #1395 tracks the difference.
+  if ! flavor_tags=$(set -o pipefail; jq -r '.[] | select(.os == "windows" and .is_default != true and .flavor != "" and .is_latest_version == true) | "latest-" + .flavor' <<< "$builds_json" | sort -u); then
+    return 1
+  fi
+  if [[ -n "$flavor_tags" ]]; then
+    tags+=$'\n'"$flavor_tags"
   fi
   printf '%s\n' "$tags" | sort -u
 }

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -32,7 +32,7 @@ teardown() {
     PATH="$ORIGINAL_PATH"
     export PATH
     rm -rf "${_STUB_DIR:-}"
-    unset GH_TOKEN OWNER DRY_RUN _STUB_DIR ORIGINAL_PATH
+    unset GH_TOKEN OWNER DRY_RUN _STUB_DIR ORIGINAL_PATH ROOT_DIR
 }
 
 # ---------------------------------------------------------------------------
@@ -40,6 +40,40 @@ teardown() {
 # ---------------------------------------------------------------------------
 make_valid_tags() {
     printf '%s\n' "$@"
+}
+
+@test "build_valid_tags mirrors rolling aliases from Linux variants and Windows flavors" {
+    local root_dir="$BATS_TEST_TMPDIR/build-valid-tags-root"
+    mkdir -p "$root_dir"
+    export ROOT_DIR="$root_dir"
+    printf '%s\n' \
+        '#!/bin/bash' \
+        'if [[ "$1" == "list-builds" && "$2" == "github-runner" ]]; then' \
+        '  printf "%s\\n" '\''[{"version":"2.334.0","os":"windows","variant":"windows-ltsc2022-dev","tag":"2.334.0-windows-ltsc2022-dev","flavor":"windows-ltsc2022","is_default":false,"is_latest_version":true},{"version":"2.334.0","os":"linux","variant":"debian-trixie-base","tag":"2.334.0-debian-trixie-base","flavor":"debian-trixie","is_default":false,"is_latest_version":true},{"version":"2.334.0","os":"windows","variant":"","tag":"2.334.0","flavor":"windows-ltsc2025","is_default":true,"is_latest_version":true},{"version":"2.333.0","os":"windows","variant":"windows-ltsc2019-dev","tag":"2.333.0-windows-ltsc2019-dev","flavor":"windows-ltsc2019","is_default":false,"is_latest_version":false}]'\'' ' \
+        'fi' > "$root_dir/make"
+    chmod +x "$root_dir/make"
+
+    local valid_tags expected_tags
+    valid_tags=$(build_valid_tags "github-runner")
+    expected_tags=$(make_valid_tags \
+        "2.333.0-windows-ltsc2019-dev" \
+        "2.334.0" \
+        "2.334.0-debian-trixie-base" \
+        "2.334.0-windows-ltsc2022-dev" \
+        "buildcache" \
+        "latest" \
+        "latest-debian-trixie-base" \
+        "latest-windows-ltsc2022" \
+        "latest-windows-ltsc2022-dev")
+
+    [[ "$valid_tags" == "$expected_tags" ]]
+    is_valid_tag "latest-windows-ltsc2022" "$valid_tags"
+    is_valid_tag "latest-windows-ltsc2022-dev" "$valid_tags"
+    is_valid_tag "latest-debian-trixie-base" "$valid_tags"
+    ! is_valid_tag "latest-debian-trixie" "$valid_tags"
+    ! is_valid_tag "latest-windows-ltsc2025" "$valid_tags"
+    ! is_valid_tag "latest-nonexistent" "$valid_tags"
+    ! is_valid_tag "latest-windows-ltsc2019" "$valid_tags"
 }
 
 assert_tag_decode_failure_stops_before_delete() {


### PR DESCRIPTION
`build_valid_tags` derived the set of tags cleanup will not delete as `latest-<variant>` only. The
Windows branch of `build-container/action.yaml` publishes `latest-<flavor>`, so
`latest-windows-ltsc2022` — which GHCR holds today — was in no part of that set.

`cleanup-registry.yaml` runs `cron: '0 3 1 * *'` with `DRY_RUN=false` on the scheduled path, so the
next run on 2026-09-01 would have deleted it.

The set now also carries `latest-<flavor>` under the publisher's own three conditions —
`os == "windows"`, `is_default != true`, `flavor != ""` — alongside `is_latest_version == true`.
No published tag changes; retiring the legacy alias in favour of the variant form is a deprecation
decision about a public tag and is not this change.

## Verification

Measured against the live registry, before and after. `github-runner` holds seven `latest*` tags:

```
latest                      latest-windows-ltsc2022
latest-debian-trixie-base   latest-windows-ltsc2022-base
latest-debian-trixie-dev    latest-windows-ltsc2022-dev
latest-ubuntu-2404-dev
```

On `master`, `build_valid_tags github-runner` protects six and leaves `latest-windows-ltsc2022`
deletable. On this branch it protects all seven, and emits none of `latest-ubuntu-2404`,
`latest-debian-trixie`, `latest-base` or `latest-full` — aliases no publisher creates, which an
earlier revision of this branch protected and which would have become unprunable had they ever
appeared.

2812 bats tests pass, 0 fail. `shellcheck -S warning` clean. Mutation proofs on each condition of
the new predicate and on the block as a whole, each control-green and mutant-red, plus a
hand-written proof that a `jq` failure is detected when the caller has `pipefail` unset.

Two further corrections came out of review and are here: the new test's `teardown` ran
`rm -rf "${_ROOT_DIR:-}"` against a variable `setup()` never assigned, so it could delete a path the
invoking environment exported — the fixture root now lives under `BATS_TEST_TMPDIR` and the tracker
is gone. Both `jq | sort` derivations, the new one and its pre-existing twin, now run in a
substitution that sets `pipefail` itself.

## Follow-ups

Landed on capped evidence at the declared three-round budget. Residue: **#1395** (cleanup protects
the flavor alias only for the newest version while the publisher creates it for every version — not
reachable with the current `variants.yaml`, and the durable answer is one shared alias-policy helper
both sides consume), **#1396** (two variants publish the same Windows flavor alias, so its content
is whichever build finished last), **#1397** (`build_valid_tags` manufactures a protected tag from a
null or absent build-record field, since `null != ""` is true in jq).

Three pre-existing findings on the same two scripts were reported and left: #1294, #1338, #1285.
The next two branches in this series take them.

Closes #1339.
