### PR TITLE
fix(cleanup): validate every record before it can authorise a deletion

### DIFF
--- a/helpers/version-record-validation.sh
+++ b/helpers/version-record-validation.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shared jq validation contracts for GHCR package-version records used by the
+# destructive registry pruners.  Callers deliberately choose one of the two
+# named contracts below; they cannot supply their own field list.
+
+# `created_at` is only checked for RFC3339 string shape here.  #1301 owns
+# timestamp parsing and ordering semantics.
+# shellcheck disable=SC2089
+VERSION_RECORD_VALIDATION_JQ='
+def valid_tag:
+  # jq ^ is a true start anchor; use \z rather than $ so a final newline is
+  # not silently accepted as part of a whole-string check.
+  if type == "string" then test("^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}\\z") else false end;
+
+def valid_id:
+  if type == "number" then (tostring | test("^[1-9][0-9]*\\z"))
+  elif type == "string" then test("^[1-9][0-9]*\\z")
+  else false
+  end;
+
+def version_base($index):
+  if type != "object" then "versions[\($index)]"
+  elif has("id") | not then "versions[\($index)].id is missing"
+  elif (.id | valid_id | not) then "versions[\($index)].id is invalid"
+  elif has("name") | not then "versions[\($index)].name is missing"
+  elif (.name | type) != "string" then "versions[\($index)].name is invalid"
+  elif (.name | test("^sha256:[0-9a-f]{64}\\z") | not) then "versions[\($index)].name is invalid"
+  elif has("metadata") | not then "versions[\($index)].metadata is missing"
+  elif (.metadata | type) != "object" then "versions[\($index)].metadata is invalid"
+  elif (.metadata | has("container") | not) then "versions[\($index)].metadata.container is missing"
+  elif (.metadata.container | type) != "object" then "versions[\($index)].metadata.container is invalid"
+  elif (.metadata.container | has("tags") | not) then "versions[\($index)].metadata.container.tags is missing"
+  elif (.metadata.container.tags | type) != "array" then "versions[\($index)].metadata.container.tags is invalid"
+  else
+    ([range(0; (.metadata.container.tags | length)) as $tag_index
+      | .metadata.container.tags[$tag_index]
+      | select(valid_tag | not)
+      | "versions[\($index)].metadata.container.tags[\($tag_index)] is invalid"]
+     | .[0])
+  end;
+
+def version_outdated_tags_contract($index):
+  version_base($index);
+
+def version_old_versions_contract($index):
+  version_base($index) //
+  (if has("created_at") | not then "versions[\($index)].created_at is missing"
+   elif (.created_at | type) != "string" or (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})\\z") | not) then "versions[\($index)].created_at is invalid"
+   else null
+   end);
+
+def versions_collection_contract:
+  if type == "array" then null else "versions must be an array" end;
+
+def duplicate_id_error:
+  . as $versions
+  | reduce range(0; length) as $index
+      ({seen: {}, error: null};
+        if .error != null then .
+        else ($versions[$index].id | tostring) as $id
+        | if .seen[$id] == null then .seen[$id] = $index
+          else .error = "versions[\($index)].id duplicates an earlier value at versions[\(.seen[$id])]"
+          end
+        end)
+  | .error;
+
+def validate_outdated_tags_versions:
+  versions_collection_contract as $collection_error
+  | if $collection_error != null then error("validation failed: \($collection_error)")
+    else
+      ([range(0; length) as $index | .[$index] | version_outdated_tags_contract($index)]
+       | map(select(. != null)) | .[0]) as $record_error
+      | ($record_error // duplicate_id_error) as $error
+      | if $error == null then true else error("validation failed: \($error)") end
+    end;
+
+def validate_old_versions:
+  versions_collection_contract as $collection_error
+  | if $collection_error != null then error("validation failed: \($collection_error)")
+    else
+      ([range(0; length) as $index | .[$index] | version_old_versions_contract($index)]
+       | map(select(. != null)) | .[0]) as $record_error
+      | ($record_error // duplicate_id_error) as $error
+      | if $error == null then true else error("validation failed: \($error)") end
+    end;
+'
+# shellcheck disable=SC2090
+export VERSION_RECORD_VALIDATION_JQ

--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -4,6 +4,15 @@
 # Required env vars: GH_TOKEN, OWNER
 # Optional env vars: DRY_RUN (default: false), KEEP_LATEST_COUNT (default: 10), KEEP_MONTHS (default: 6)
 
+_cleanup_old_versions_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../helpers/version-record-validation.sh
+if ! source "$_cleanup_old_versions_root/helpers/version-record-validation.sh"; then
+  echo "Failed to source version record validation helper: $_cleanup_old_versions_root/helpers/version-record-validation.sh" >&2
+  unset _cleanup_old_versions_root
+  return 1 2>/dev/null || exit 1
+fi
+unset _cleanup_old_versions_root
+
 script_root() {
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
@@ -24,13 +33,14 @@ print_banner() {
 # Write kept|deleted|delete_failures to stdout once a package was completely
 # assessed.  Its return status, rather than that record, communicates failure:
 # 10 listing failure, 11 processing failure, 12 one or more delete failures,
-# and 13 a failure after every record was assessed.  Deletion-plan replay is
-# execution, not assessment, so a replay failure also returns 13.
+# 13 a failure after every record was assessed, and 14 an uninterpretable
+# record. Deletion-plan replay is execution, not assessment, so a replay
+# failure also returns 13.
 purge_container() {
   local container="$1"
   local versions version_count versions_file="" deletions_file=""
   local position=0 kept=0 deleted=0 delete_failures=0
-  local version_id tags created_at keep_reason tag tag_list major version_ts cutoff_ts processing_error=0 deletion_read_error=0
+  local version_id tags created_at keep_reason tag tag_list major version_ts cutoff_ts processing_error=0 deletion_read_error=0 validation_error validation_status
   local record_b64 record_json
   declare -A major_seen=()
 
@@ -66,6 +76,20 @@ purge_container() {
     return 0
   fi
 
+  if validation_error=$(jq -er "$VERSION_RECORD_VALIDATION_JQ
+    validate_old_versions" <<< "$versions" 2>&1 >/dev/null); then
+    :
+  else
+    validation_status=$?
+    if [[ "$validation_status" -eq 5 ]]; then
+      validation_error="${validation_error##*validation failed: }"
+      echo "  ✗ Version validation failed: validation failed: $validation_error; skipping $container" >&2
+      return "$UNINTERPRETABLE_RECORD_FAILURE"
+    fi
+    echo "  ✗ Version validator could not run: $validation_error; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
+  fi
+
   if ! cutoff_ts=$(date -d "$CUTOFF_DATE" +%s); then
     echo "  ✗ Failed to parse cutoff date; skipping $container" >&2
     return "$PROCESSING_FAILURE"
@@ -87,8 +111,10 @@ purge_container() {
     return "$PROCESSING_FAILURE"
   fi
 
-  # Decide every record before deleting any of them.  A malformed date in a
-  # later record must leave earlier obsolete records untouched.
+  # Decide every record before deleting any of them.  The shared age contract
+  # has checked every field read below; #1301 owns timestamp parsing and
+  # ordering semantics.  A malformed date in a later record must leave earlier
+  # obsolete records untouched.
   while IFS= read -r record_b64; do
     [[ -z "$record_b64" ]] && continue
     if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
@@ -210,7 +236,7 @@ main() {
   : "${KEEP_LATEST_COUNT:=10}"
   : "${KEEP_MONTHS:=6}"
 
-  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 INCOMPLETE_DELETION_FAILURE=16
+  local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 INCOMPLETE_DELETION_FAILURE=16
   local root_dir containers container result status
   local kept deleted delete_failures
   root_dir=$(script_root) || return 1
@@ -252,7 +278,7 @@ main() {
         [[ "$status" -ne "$POST_DELETE_PROCESSING_FAILURE" ]] || total_processing_failures=$((total_processing_failures + 1))
         ;;
       "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
-      "$PROCESSING_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
+      "$PROCESSING_FAILURE"|"$UNINTERPRETABLE_RECORD_FAILURE") total_processing_failures=$((total_processing_failures + 1)) ;;
       # Reserved: planning is complete before deletion begins, so this script
       # does not produce 16.  Keep it fail-closed for an explicit future
       # partial-assessment producer rather than treating it as execution.

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -2,6 +2,15 @@
 # Purge container images whose tags are not in the current valid build set.
 # Required env vars: GH_TOKEN, OWNER
 
+_cleanup_outdated_tags_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../helpers/version-record-validation.sh
+if ! source "$_cleanup_outdated_tags_root/helpers/version-record-validation.sh"; then
+  echo "Failed to source version record validation helper: $_cleanup_outdated_tags_root/helpers/version-record-validation.sh" >&2
+  unset _cleanup_outdated_tags_root
+  return 1 2>/dev/null || exit 1
+fi
+unset _cleanup_outdated_tags_root
+
 script_root() {
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
@@ -13,7 +22,28 @@ build_valid_tags() {
   if ! builds_json=$("$ROOT_DIR/make" list-builds "$container" 2>/dev/null); then
     return 1
   fi
-  if ! jq -e 'type == "array" and length > 0' >/dev/null <<< "$builds_json"; then
+  if ! jq -e '
+    def valid_tag:
+      # jq ^ is a true start anchor; \z, rather than $, rejects a final newline.
+      if type == "string" then test("^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}\\z") else false end;
+    type == "array" and length > 0
+    and all(.[];
+      type == "object"
+      and (.tag | valid_tag)
+      and (.variant | type == "string" and (. == "" or valid_tag))
+      and (.flavor | type == "string" and (. == "" or valid_tag))
+      and (.os == "linux" or .os == "windows")
+      and (.is_default | type == "boolean")
+      and (.is_latest_version | type == "boolean")
+      and (if .variant != "" and .is_latest_version == true
+           then ("latest-" + .variant | valid_tag)
+           else true
+           end)
+      and (if .os == "windows" and .is_default != true and .flavor != "" and .is_latest_version == true
+           then ("latest-" + .flavor | valid_tag)
+           else true
+           end))
+  ' >/dev/null <<< "$builds_json"; then
     return 1
   fi
   if ! tags=$(jq -r '.[].tag' <<< "$builds_json"); then
@@ -63,11 +93,12 @@ is_valid_tag() {
 
 purge_ghcr() {
   # 10 listing failure, 11 processing failure, 12 delete failure, 13 failure
-  # after complete assessment, and 15 protection failure.  Replaying either
-  # completed deletion list is execution, so a replay failure returns 13.
+  # after complete assessment, 14 uninterpretable record, and 15 protection
+  # failure. Replaying either completed deletion list is execution, so a replay
+  # failure returns 13.
   local container="$1" valid_tags="$2"
   local versions version_count versions_file="" obsolete_file="" protected_file=""
-  local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0
+  local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0 validation_error validation_status
   local record_b64 record_json
   local protected_digests="" ghcr_token manifest children
   local -a kept_digests=()
@@ -99,6 +130,19 @@ purge_ghcr() {
       return "$PROCESSING_FAILURE"
     fi
     return 0
+  fi
+  if validation_error=$(jq -er "$VERSION_RECORD_VALIDATION_JQ
+    validate_outdated_tags_versions" <<< "$versions" 2>&1 >/dev/null); then
+    :
+  else
+    validation_status=$?
+    if [[ "$validation_status" -eq 5 ]]; then
+      validation_error="${validation_error##*validation failed: }"
+      echo "  ✗ GHCR version validation failed: validation failed: $validation_error; skipping $container" >&2
+      return "$UNINTERPRETABLE_RECORD_FAILURE"
+    fi
+    echo "  ✗ GHCR version validator could not run: $validation_error; skipping $container" >&2
+    return "$PROCESSING_FAILURE"
   fi
   if ! versions_file=$(mktemp) || ! obsolete_file=$(mktemp); then
     cleanup_files
@@ -324,10 +368,9 @@ main() {
   ROOT_DIR=$(script_root) || return 1
   export ROOT_DIR
 
-  # 14 is reserved for a distinct uninterpretable-record producer.  Current
-  # decoding failures are processing failures (11).  16 is reserved for a
-  # future partial-assessment producer; this plan-then-delete implementation
-  # deliberately has none, and replay failures are post-complete (13).
+  # 16 is reserved for a future partial-assessment producer; this plan-then-
+  # delete implementation deliberately has none, and replay failures are
+  # post-complete (13).
   local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15 INCOMPLETE_DELETION_FAILURE=16
   local containers container valid_tags valid_count result ghcr_status dh_result dh_status
   local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed skip_dockerhub

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -36,12 +36,12 @@ if [[ "${GH_MODE:-}" == "empty-listing" && "$*" == *"/container/broken/versions"
 fi
 
 if [[ "${GH_MODE:-}" == "malformed-record" && "$*" == *"/container/broken/versions"* ]]; then
-    printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":"not-an-array"}},"created_at":"2000-01-01T00:00:00Z"}]'
+    printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":"not-an-array"}},"created_at":"2000-01-01T00:00:00Z"}]'
     exit 0
 fi
 
 if [[ "${GH_MODE:-}" == "delete-failure" || "${GH_MODE:-}" == "cleanup-failure" ]]; then
-    printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+    printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
 else
     printf '%s\n' '[]'
 fi
@@ -65,8 +65,8 @@ assert_no_delete_attempts() {
     fi
 }
 
-assert_output_reports_invalid_date() {
-    if [[ "$output" != *"Failed to parse version date; skipping stale"* ]]; then
+assert_output_reports_invalid_created_at() {
+    if [[ "$output" != *"validation failed: versions[1].created_at is invalid"* ]]; then
         echo "ASSERTION FAILED: expected invalid later date to stop the package before DELETE" >&2
         return 1
     fi
@@ -137,8 +137,8 @@ assert_prepared_decode_preserves_delete_totals() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf '%s\n' '[{"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
-printf '%s\n' '[{"id":102,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+printf '%s\n' '[{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
 EOF
     chmod +x "$STUB_DIR/gh"
 
@@ -182,7 +182,7 @@ EOF
     [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
 }
 
-@test "a JSON record that jq cannot prepare is unassessed, cleans its temporary file, and does not abandon later packages" {
+@test "an invalid version record is unassessed, attempts no deletion, and does not abandon later packages" {
     cat > "$STUB_DIR/mktemp" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -204,10 +204,11 @@ EOF
         bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" broken healthy
 
     [[ "$status" -eq 1 ]]
-    [[ "$output" == *"Failed to read version record; skipping broken"* ]]
+    [[ "$output" == *"validation failed: versions[0].metadata.container.tags is invalid"* ]]
     [[ "$output" == *"Processing: healthy"* ]]
     [[ "$output" == *"Packages assessed: 1"* ]]
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ ! -s "$GH_LOG" ]]
     [[ ! -e "$temp_file" ]]
 }
 
@@ -224,6 +225,23 @@ EOF
 
     [[ "$status" -eq 0 ]]
     [[ -z "$output" ]]
+}
+
+@test "sourcing fails closed when the version validation helper is absent" {
+    local missing_root="$BATS_TEST_TMPDIR/missing-helper"
+    mkdir -p "$missing_root/scripts"
+    cp "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" "$missing_root/scripts/cleanup-old-versions.sh"
+
+    run env -u VERSION_RECORD_VALIDATION_JQ bash -c '
+        set +e
+        source "$1"
+        source_status=$?
+        ! declare -F purge_container >/dev/null
+        [[ "$source_status" -ne 0 ]]
+    ' _ "$missing_root/scripts/cleanup-old-versions.sh"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Failed to source version record validation helper: $missing_root/helpers/version-record-validation.sh"* ]]
 }
 
 teardown() {
@@ -272,7 +290,7 @@ teardown() {
     [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
 }
 
-@test "an invalid later date attempts no DELETE for the package" {
+@test "an invalid later created_at attempts no DELETE for the package" {
     cat > "$STUB_DIR/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -283,8 +301,8 @@ if [[ "$*" == *"--method DELETE"* ]]; then
 fi
 
 printf '%s\n' '[
-  {"id":101,"metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},
-  {"id":102,"metadata":{"container":{"tags":[]}},"created_at":"not-a-date"}
+  {"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},
+  {"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"not-a-date"}
 ]'
 EOF
     chmod +x "$STUB_DIR/gh"
@@ -301,7 +319,7 @@ EOF
 
     assert_no_delete_attempts "$GH_LOG"
     [[ "$status" -eq 1 ]]
-    assert_output_reports_invalid_date
+    assert_output_reports_invalid_created_at
     [[ "$output" == *"Packages assessed: 0"* ]]
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
 }
@@ -359,7 +377,7 @@ EOF
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"metadata\":{\"container\":{\"tags\":[\"v1.2.3\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"v1.2.3\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             jq() {
                 if [[ "${!#}" == ".tags[]" ]]; then echo "jq: tag decode exhausted" >&2; return 1; fi
@@ -388,7 +406,7 @@ EOF
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             base64() {
                 calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")
@@ -404,4 +422,185 @@ EOF
     [[ "$(<"$GH_LOG")" != *"/versions/102"* ]]
     assert_prepared_decode_preserves_delete_totals
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+}
+
+run_old_version_validation_case() {
+    local response_json="$1"
+    local expected_field="$2"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        RESPONSE_JSON="$response_json" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\n" "$RESPONSE_JSON"
+            }
+            main malformed
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"validation failed: $expected_field"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ ! -s "$GH_LOG" ]]
+}
+
+@test "age cleanup maps jq exit 5 to 14 and jq exit 137 to 11" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        CUTOFF_DATE="2000-01-01T00:00:00Z" \
+        bash -c '
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14
+            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
+            purge_container malformed
+        '
+
+    [[ "$status" -eq 14 ]]
+
+    local real_jq
+    real_jq="$(command -v jq)"
+    cat > "$STUB_DIR/jq" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+    [[ "$argument" == *"validate_old_versions"* ]] && exit 137
+done
+exec "$REAL_JQ" "$@"
+EOF
+    chmod +x "$STUB_DIR/jq"
+
+    run env \
+        PATH="$STUB_DIR:$PATH" \
+        REAL_JQ="$real_jq" \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        CUTOFF_DATE="2000-01-01T00:00:00Z" \
+        bash -c '
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14
+            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
+            purge_container validator-killed
+        '
+
+    [[ "$status" -eq 11 ]]
+    [[ "$output" == *"Version validator could not run"* ]]
+}
+
+@test "age cleanup validation entry point rejects non-arrays and accepts an empty array" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/helpers/version-record-validation.sh"
+        for versions in null "{}" "\"\""; do
+            if validation_error=$(jq -er "$VERSION_RECORD_VALIDATION_JQ validate_old_versions" <<< "$versions" 2>&1 >/dev/null); then
+                exit 1
+            else
+                validation_status=$?
+            fi
+            [[ "$validation_status" -eq 5 ]]
+            [[ "$validation_error" == *"validation failed: versions must be an array"* ]]
+        done
+        jq -er "$VERSION_RECORD_VALIDATION_JQ validate_old_versions" <<< "[]" | grep -qx true
+    '
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "age cleanup accepts canonical numeric and string IDs with empty tags" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                [[ "$*" == *"--method DELETE"* ]] && return 1
+                printf "%s\n" "[{\"id\":1,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":\"2\",\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            main valid
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Packages skipped (processing failed): 0"* ]]
+}
+
+@test "age cleanup rejects invalid digest and IDs before any deletion" {
+    run_old_version_validation_case \
+        '[{"id":101,"name":"sha256:not-a-digest","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].name is invalid'
+    run_old_version_validation_case \
+        '[{"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is missing'
+    run_old_version_validation_case \
+        '[{"id":0,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+    run_old_version_validation_case \
+        '[{"id":-1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+    run_old_version_validation_case \
+        '[{"id":"abc","name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+    run_old_version_validation_case \
+        '[{"id":"01","name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+    run_old_version_validation_case \
+        '[{"id":1.0,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+    run_old_version_validation_case \
+        '[{"id":1e3,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[0].id is invalid'
+}
+
+@test "age cleanup rejects duplicate normalized IDs before any deletion" {
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},{"id":"1","name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[1].id duplicates an earlier value at versions[0]'
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},{"id":"01","name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]' \
+        'versions[1].id is invalid'
+}
+
+@test "age cleanup rejects malformed and trailing-newline RFC3339 timestamps before any deletion" {
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"1 year ago"}]' \
+        'versions[0].created_at is invalid'
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"not-a-date"}]' \
+        'versions[0].created_at is invalid'
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":""}]' \
+        'versions[0].created_at is invalid'
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2026-08-22T08:01:12"}]' \
+        'versions[0].created_at is invalid'
+    run_old_version_validation_case \
+        '[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2026-08-22T08:01:12Z\n"}]' \
+        'versions[0].created_at is invalid'
+}
+
+@test "age cleanup accepts the measured RFC3339 created_at shape" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/helpers/version-record-validation.sh"
+        jq -e "$VERSION_RECORD_VALIDATION_JQ validate_old_versions" <<'\''JSON'\''
+[{"id":1,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2026-08-22T08:01:12Z"}]
+JSON
+    '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "true" ]]
 }

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -99,6 +99,23 @@ assert_prepared_decode_preserves_delete_totals() {
     fi
 }
 
+@test "sourcing fails closed when the version validation helper is absent" {
+    local missing_root="$BATS_TEST_TMPDIR/missing-helper"
+    mkdir -p "$missing_root/scripts"
+    cp "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" "$missing_root/scripts/cleanup-outdated-tags.sh"
+
+    run env -u VERSION_RECORD_VALIDATION_JQ bash -c '
+        set +e
+        source "$1"
+        source_status=$?
+        ! declare -F purge_ghcr >/dev/null
+        [[ "$source_status" -ne 0 ]]
+    ' _ "$missing_root/scripts/cleanup-outdated-tags.sh"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Failed to source version record validation helper: $missing_root/helpers/version-record-validation.sh"* ]]
+}
+
 assert_dockerhub_called_after_complete_ghcr_plan() {
     local call_file="$1"
     if [[ ! -s "$call_file" ]]; then
@@ -323,8 +340,8 @@ assert_dockerhub_called_after_complete_ghcr_plan() {
             build_valid_tags() { printf "%s\\n" "latest"; }
             purge_dockerhub() { printf "%s\\n" "0|0"; }
             gh() {
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:first\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}}]"
-                printf "%s\\n" "[{\"id\":102,\"name\":\"sha256:second\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}}]"
+                printf "%s\\n" "[{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
             }
             main stale
         '
@@ -460,7 +477,7 @@ assert_dockerhub_called_after_complete_ghcr_plan() {
                     echo "gh: delete denied" >&2
                     return 1
                 fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:stale\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
             }
             main stale
         '
@@ -507,7 +524,7 @@ EOF
                 if [[ "$*" == *"--method DELETE"* ]]; then
                     return 0
                 fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:stale\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
             }
             main stale
         '
@@ -538,7 +555,7 @@ EOF
             purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:protected\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}}]"
             }
             jq() {
                 if [[ "${!#}" == ".tags[]" ]]; then echo "jq: tag decode exhausted" >&2; return 1; fi
@@ -572,7 +589,7 @@ EOF
             purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:first\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}},{\"id\":102,\"name\":\"sha256:second\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
             }
             base64() {
                 calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")
@@ -589,4 +606,230 @@ EOF
     [[ "$(<"$gh_log")" != *"/versions/102"* ]]
     assert_prepared_decode_preserves_delete_totals
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+}
+
+run_outdated_validation_case() {
+    local response_json="$1"
+    local expected_field="$2"
+    local gh_log="$_STUB_DIR/validation-gh.log"
+    local dockerhub_calls="$_STUB_DIR/validation-dockerhub.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        RESPONSE_JSON="$response_json" \
+        GH_LOG="$gh_log" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\n" "latest"; }
+            purge_dockerhub() { printf "%s\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\n" "1|0"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\n" "$RESPONSE_JSON"
+            }
+            main malformed
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"validation failed: $expected_field"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
+    [[ ! -s "$gh_log" ]]
+    [[ ! -s "$dockerhub_calls" ]]
+}
+
+@test "outdated-tag cleanup maps jq exit 5 to 14 and jq exit 137 to 11" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        bash -c '
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15
+            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}}}]"; }
+            purge_ghcr malformed latest
+        '
+
+    [[ "$status" -eq 14 ]]
+
+    local real_jq
+    real_jq="$(command -v jq)"
+    cat > "$_STUB_DIR/jq" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+    [[ "$argument" == *"validate_outdated_tags_versions"* ]] && exit 137
+done
+exec "$REAL_JQ" "$@"
+EOF
+    chmod +x "$_STUB_DIR/jq"
+
+    run env \
+        PATH="$_STUB_DIR:$PATH" \
+        REAL_JQ="$real_jq" \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        bash -c '
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15
+            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}}}]"; }
+            purge_ghcr validator-killed latest
+        '
+
+    [[ "$status" -eq 11 ]]
+    [[ "$output" == *"GHCR version validator could not run"* ]]
+}
+
+@test "outdated-tag validation entry point rejects non-arrays and accepts an empty array" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+        set -euo pipefail
+        source "$PROJECT_ROOT/helpers/version-record-validation.sh"
+        for versions in null "{}" "\"\""; do
+            if validation_error=$(jq -er "$VERSION_RECORD_VALIDATION_JQ validate_outdated_tags_versions" <<< "$versions" 2>&1 >/dev/null); then
+                exit 1
+            else
+                validation_status=$?
+            fi
+            [[ "$validation_status" -eq 5 ]]
+            [[ "$validation_error" == *"validation failed: versions must be an array"* ]]
+        done
+        jq -er "$VERSION_RECORD_VALIDATION_JQ validate_outdated_tags_versions" <<< "[]" | grep -qx true
+    '
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "outdated-tag cleanup accepts an observed empty GHCR tags array" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="true" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\n" "latest"; }
+            gh() {
+                [[ "$*" == *"--method DELETE"* ]] && return 1
+                printf "%s\n" "[{\"id\":\"101\",\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
+            }
+            main untagged
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Packages skipped (processing failed): 0"* ]]
+}
+
+@test "outdated-tag cleanup rejects absent GHCR tags before any deletion" {
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{}}}]' \
+        'versions[0].metadata.container.tags is missing'
+}
+
+@test "outdated-tag cleanup rejects null GHCR tags before any deletion" {
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":null}}}]' \
+        'versions[0].metadata.container.tags is invalid'
+}
+
+@test "outdated-tag cleanup rejects a non-array GHCR tags field before any deletion" {
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":"latest"}}}]' \
+        'versions[0].metadata.container.tags is invalid'
+}
+
+@test "outdated-tag cleanup rejects pipe and comma GHCR tags before any deletion" {
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["bad|tag"]}}}]' \
+        'versions[0].metadata.container.tags[0] is invalid'
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["bad,tag"]}}}]' \
+        'versions[0].metadata.container.tags[0] is invalid'
+}
+
+@test "outdated-tag cleanup rejects trailing newlines in tags, digests, and IDs" {
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["latest\n"]}}}]' \
+        'versions[0].metadata.container.tags[0] is invalid'
+    run_outdated_validation_case \
+        '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n","metadata":{"container":{"tags":["latest"]}}}]' \
+        'versions[0].name is invalid'
+    run_outdated_validation_case \
+        '[{"id":"101\n","name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["latest"]}}}]' \
+        'versions[0].id is invalid'
+}
+
+@test "build_valid_tags accepts a Linux build with an empty flavor" {
+    local root_dir="$BATS_TEST_TMPDIR/build-empty-flavor-root"
+    mkdir -p "$root_dir"
+    export ROOT_DIR="$root_dir"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        'printf "%s\n" '\''[{"tag":"1.2.3","variant":"debian","flavor":"","os":"linux","is_default":true,"is_latest_version":true}]'\''' \
+        > "$root_dir/make"
+    chmod +x "$root_dir/make"
+
+    run build_valid_tags example
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"latest-debian"* ]]
+}
+
+run_invalid_build_case() {
+    local build_json="$1"
+    local root_dir="$BATS_TEST_TMPDIR/build-invalid-element-root"
+    mkdir -p "$root_dir"
+    export ROOT_DIR="$root_dir"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' '$build_json'" \
+        > "$root_dir/make"
+    chmod +x "$root_dir/make"
+
+    run build_valid_tags example
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" != *"latest-"* ]]
+}
+
+@test "build_valid_tags rejects os darwin without emitting latest-" {
+    run_invalid_build_case '[{"tag":"1.2.3","variant":"","flavor":"","os":"darwin","is_default":true,"is_latest_version":true}]'
+}
+
+@test "build_valid_tags rejects a string is_default without emitting latest-" {
+    run_invalid_build_case '[{"tag":"1.2.3","variant":"","flavor":"","os":"linux","is_default":"false","is_latest_version":true}]'
+}
+
+@test "build_valid_tags rejects an empty tag without emitting latest-" {
+    run_invalid_build_case '[{"tag":"","variant":"","flavor":"","os":"linux","is_default":true,"is_latest_version":true}]'
+}
+
+@test "build_valid_tags rejects a null variant without emitting latest-" {
+    run_invalid_build_case '[{"tag":"1.2.3","variant":null,"flavor":"","os":"linux","is_default":true,"is_latest_version":true}]'
+}
+
+@test "build_valid_tags rejects trailing newlines in emitted and component tags" {
+    run_invalid_build_case '[{"tag":"release\n","variant":"","flavor":"","os":"linux","is_default":true,"is_latest_version":true}]'
+    run_invalid_build_case '[{"tag":"release","variant":"release\n","flavor":"","os":"linux","is_default":true,"is_latest_version":true}]'
+    run_invalid_build_case '[{"tag":"release","variant":"","flavor":"release\n","os":"windows","is_default":false,"is_latest_version":true}]'
+}
+
+@test "build_valid_tags validates the full emitted latest alias length" {
+    local variant_121 variant_122 root_dir build_json
+    variant_121=$(printf '%*s' 121 '' | tr ' ' a)
+    variant_122=$(printf '%*s' 122 '' | tr ' ' a)
+    root_dir="$BATS_TEST_TMPDIR/build-alias-length-root"
+    mkdir -p "$root_dir"
+    export ROOT_DIR="$root_dir"
+    build_json="[{\"tag\":\"release\",\"variant\":\"$variant_121\",\"flavor\":\"\",\"os\":\"linux\",\"is_default\":true,\"is_latest_version\":true}]"
+    printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' '$build_json'" > "$root_dir/make"
+    chmod +x "$root_dir/make"
+
+    run build_valid_tags example
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"latest-$variant_121"* ]]
+
+    run_invalid_build_case "[{\"tag\":\"release\",\"variant\":\"$variant_122\",\"flavor\":\"\",\"os\":\"linux\",\"is_default\":true,\"is_latest_version\":true}]"
 }


### PR DESCRIPTION
Both registry pruners classified records without checking their shape, on a path that deletes for
real: `cleanup-registry.yaml` runs `cron: '0 3 1 * *'` with `DRY_RUN=false`.

In jq, `null != ""` is true and `"latest-" + null` is `"latest-"`. So a build record with a null
`variant` or `flavor` put the literal tag `latest-` in the protected set and a null `tag` put `null`
there; and a version record whose `metadata.container.tags` was absent or null normalised to `[]`,
which the orphan pass selects and deletes.

Every consumed field is now checked once per package before any classification, and a package that
fails is skipped with nothing deleted, returning the status already reserved for an uninterpretable
record.

**An empty `tags` array stays valid.** Six live GHCR packages, 30 889 records: none with an absent,
null or non-array `tags`, and 2225 of github-runner's 2314 carrying `tags: []`. An untagged layer is
the ordinary case; treating it as malformed would stop all pruning. All six still validate on this
branch.

**Tags must match Docker's grammar.** The record line the loops read is pipe-separated with the tags
comma-joined inside the third field, so a tag containing `|` shifts every field after it.

**Ids must be canonical and unique.** `gh api --paginate` can repeat a record when a page boundary
shifts, and `1`, `"01"` and `"1\n"` would otherwise be three accepted keys that become one DELETE
target.

The GHCR contract is shared between the two scripts with one named entry point each and no
caller-supplied field list, so the common fields cannot drift the way #1339's two alias derivations
did. The digest grammar is `is_valid_oci_digest`'s, not a second one.

## Verification

68 bats cases across the two suites, `shellcheck -S warning` clean on all three shell files, 2836
tests in the full suite, and eleven mutation proofs.

Checked directly rather than only through the suite: a trailing newline on a tag, a digest, or an id
is rejected; `"01"` is rejected and `1` accepted; `1` and `"01"` together are a duplicate;
`created_at: "1 year ago"` is rejected and `2026-08-22T08:01:12Z` accepted; `null`, `{}` and `""`
are rejected as collections while `[]` is accepted; and with the helper deleted, sourcing
`cleanup-old-versions.sh` returns 1 with `purge_container` undefined.

Three review findings were in the validators themselves. `$` in jq matches before a final newline
(`jq -rn '"latest\n" | test("^[a-z]+$")'` → `true`), so every end anchor is `\z`. A killed `jq` was
reported as an uninterpretable record; exit 5 is the contract rejecting and maps to 14, every other
non-zero is a process failure and maps to 11, with tests in both directions.

## Follow-ups

Landed on capped evidence at the declared three-round budget. The terminal round returned 15
findings, 13 of them pre-existing on `master`.

New: **#1400** (short reads read as EOF in five loops, leaked work files, unbounded network calls),
**#1401** (credentials in `curl` process arguments), **#1402** (a pagination boundary that omits a
record can orphan a tagged image — this branch closes the duplicate half only), **#1403** (this
branch's own two: a test guarantee lost to a rename, and the helper exporting its jq program).
**#1399** covers the same `$`-anchor defect at three sites this branch never touched, one of them
`cleanup-ext-images.sh`'s retention window.

Re-confirmed and commented rather than re-filed: #1302, #1305, #1338, #1285, #1301, #1395.

Closes #1294. Closes #1397.
