### PR TITLE
Refuse to prune a package whose manifest graph cannot be resolved

### DIFF
--- a/helpers/version-record-validation.sh
+++ b/helpers/version-record-validation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Shared jq validation contracts for GHCR package-version records used by the
-# destructive registry pruners.  Callers deliberately choose one of the two
+# destructive registry pruners.  Callers deliberately choose one of the three
 # named contracts below; they cannot supply their own field list.
 
 # `created_at` is only checked for RFC3339 string shape here.  #1301 owns
@@ -18,13 +18,16 @@ def valid_id:
   else false
   end;
 
+def valid_digest:
+  if type == "string" then test("^sha256:[0-9a-f]{64}\\z") else false end;
+
 def version_base($index):
   if type != "object" then "versions[\($index)]"
   elif has("id") | not then "versions[\($index)].id is missing"
   elif (.id | valid_id | not) then "versions[\($index)].id is invalid"
   elif has("name") | not then "versions[\($index)].name is missing"
   elif (.name | type) != "string" then "versions[\($index)].name is invalid"
-  elif (.name | test("^sha256:[0-9a-f]{64}\\z") | not) then "versions[\($index)].name is invalid"
+  elif (.name | valid_digest | not) then "versions[\($index)].name is invalid"
   elif has("metadata") | not then "versions[\($index)].metadata is missing"
   elif (.metadata | type) != "object" then "versions[\($index)].metadata is invalid"
   elif (.metadata | has("container") | not) then "versions[\($index)].metadata.container is missing"
@@ -48,6 +51,80 @@ def version_old_versions_contract($index):
    elif (.created_at | type) != "string" or (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})\\z") | not) then "versions[\($index)].created_at is invalid"
    else null
    end);
+
+# A kept version may report an index.  Only direct descriptors that declare a
+# plain image manifest are accepted without walking a further level of the graph.
+def named_manifest_media_type:
+  type == "string" and (
+    . == "application/vnd.oci.image.index.v1+json" or
+    . == "application/vnd.docker.distribution.manifest.list.v2+json" or
+    . == "application/vnd.oci.image.manifest.v1+json" or
+    . == "application/vnd.docker.distribution.manifest.v2+json"
+  );
+
+# This validates only the metadata each direct descriptor reports; its declared
+# media type is not confirmed against the document at its digest.
+def manifest_child_error($index):
+  if type != "object" then "child descriptor \($index) is not an object"
+  elif has("mediaType") | not then "child descriptor \($index) has no mediaType"
+  elif has("mediaType") and ((.mediaType | type) != "string") then "child descriptor \($index) has a non-string mediaType"
+  elif has("mediaType") and (.mediaType | named_manifest_media_type | not) then "child descriptor \($index) has unsupported mediaType \(.mediaType | @json)"
+  elif .mediaType == "application/vnd.oci.image.index.v1+json" then "child descriptor \($index) is a nested OCI index"
+  elif .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json" then "child descriptor \($index) is a nested Docker manifest list"
+  elif has("digest") | not then "child descriptor \($index) has no digest"
+  elif (.digest | valid_digest | not) then "child descriptor \($index) has a malformed digest"
+  else null
+  end;
+
+# `first` stops evaluating direct descriptors once the first refusal is found.
+# The caller reports only that refusal, so later descriptors are not inspected.
+def first_manifest_child_error:
+  first(
+    range(0; (.manifests | length)) as $index
+    | .manifests[$index]
+    | manifest_child_error($index)
+    | select(. != null)
+  ) // null;
+
+# This is deliberately a one-level protection contract.  It classifies a
+# document from the metadata that document reports: its top-level mediaType,
+# the presence and type of its manifests field, and the declared mediaType of
+# each direct descriptor.  It does not fetch a child to confirm the media type
+# declared by its descriptor or follow subject; both cost one request per node,
+# the cost of a transitive walk.
+# oorabona/docker-containers#1338 owns that walk.
+def manifest_protection_contract:
+  if type != "object" then error("top-level manifest is not an object")
+  elif has("mediaType") | not then error("top-level manifest has no mediaType")
+  elif has("mediaType") and ((.mediaType | type) != "string") then error("top-level manifest has a non-string mediaType")
+  elif has("mediaType") and (.mediaType | named_manifest_media_type | not) then error("top-level manifest has unsupported mediaType \(.mediaType | @json)")
+  elif .mediaType == "application/vnd.oci.image.index.v1+json" then
+    if has("manifests") | not then error("top-level OCI index has no manifests field")
+    elif (.manifests | type) != "array" then error("top-level OCI index has a non-array manifests field")
+    else first_manifest_child_error as $child_error
+    | if $child_error == null then
+        {children: [.manifests[].digest]}
+      else error($child_error)
+      end
+    end
+  elif .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json" then
+    if has("manifests") | not then error("top-level Docker manifest list has no manifests field")
+    elif (.manifests | type) != "array" then error("top-level Docker manifest list has a non-array manifests field")
+    else first_manifest_child_error as $child_error
+    | if $child_error == null then
+        {children: [.manifests[].digest]}
+      else error($child_error)
+      end
+    end
+  elif .mediaType == "application/vnd.oci.image.manifest.v1+json" then
+    if has("manifests") then error("top-level OCI image manifest has a manifests field")
+    else {children: []}
+    end
+  elif .mediaType == "application/vnd.docker.distribution.manifest.v2+json" then
+    if has("manifests") then error("top-level Docker image manifest has a manifests field")
+    else {children: []}
+    end
+  end;
 
 def versions_collection_contract:
   if type == "array" then null else "versions must be an array" end;

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -100,7 +100,7 @@ purge_ghcr() {
   local versions version_count versions_file="" obsolete_file="" protected_file=""
   local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0 validation_error validation_status
   local record_b64 record_json
-  local protected_digests="" ghcr_token manifest children
+  local protected_digests="" ghcr_token manifest children protection_result
   local -a kept_digests=()
 
   cleanup_files() { rm -f "$versions_file" "$obsolete_file" "$protected_file"; }
@@ -213,14 +213,15 @@ purge_ghcr() {
         echo "  ✗ Failed to fetch manifest for ${digest:0:19}; skipping $container" >&2
         return "$PROTECTION_FAILURE"
       fi
-      if ! jq -e 'type == "object"' >/dev/null <<< "$manifest"; then
+      if ! protection_result=$(jq -ce "$VERSION_RECORD_VALIDATION_JQ
+        manifest_protection_contract" <<< "$manifest" 2>&1); then
         cleanup_files
-        echo "  ✗ Failed to parse manifest for ${digest:0:19}; skipping $container" >&2
+        echo "  ✗ Refused manifest protection for ${digest:0:19}: $protection_result; skipping $container" >&2
         return "$PROTECTION_FAILURE"
       fi
-      if ! children=$(jq -r '.manifests[]?.digest // empty' <<< "$manifest"); then
+      if ! children=$(jq -r '.children[]' <<< "$protection_result"); then
         cleanup_files
-        echo "  ✗ Failed to read manifest for ${digest:0:19}; skipping $container" >&2
+        echo "  ✗ Failed to read protected manifest children for ${digest:0:19}; skipping $container" >&2
         return "$PROTECTION_FAILURE"
       fi
       if [[ -n "$children" ]] && ! printf '%s\n' "$children" >> "$protected_file"; then

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -124,6 +124,194 @@ assert_dockerhub_called_after_complete_ghcr_plan() {
     fi
 }
 
+run_manifest_protection_refusal() {
+    local manifest_json="$1"
+    local expected_reason="$2"
+    local gh_log="$_STUB_DIR/manifest-protection-gh.log"
+    local dockerhub_calls="$_STUB_DIR/manifest-protection-dockerhub.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        MANIFEST_JSON="$manifest_json" \
+        GH_LOG="$gh_log" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "0|0"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+            }
+            curl() {
+                if [[ "$*" == *"/token?"* ]]; then printf "%s\\n" "{\"token\":\"registry-token\"}"
+                elif [[ "$*" == *"/manifests/"* ]]; then printf "%s\\n" "$MANIFEST_JSON"
+                else echo "unexpected curl: $*" >&2; return 1
+                fi
+            }
+            main protected
+        '
+
+    if [[ "$status" -ne 1 ]]; then
+        echo "ASSERTION FAILED: manifest protection refusal was not returned" >&2
+        return 1
+    fi
+    if [[ "$output" != *"Refused manifest protection for sha256:aaaaaaaaaaaa"* || "$output" != *"$expected_reason"* ]]; then
+        echo "ASSERTION FAILED: refusal did not name the kept digest and reason" >&2
+        return 1
+    fi
+    if [[ -s "$gh_log" || -s "$dockerhub_calls" ]]; then
+        echo "ASSERTION FAILED: manifest protection refusal attempted a registry deletion" >&2
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# GHCR manifest-protection contract (#1338)
+# ---------------------------------------------------------------------------
+
+@test "purge_ghcr refuses a kept OCI index with a nested OCI index child before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.index.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}' \
+        "nested OCI index"
+}
+
+@test "purge_ghcr refuses a kept OCI index with a nested Docker manifest list child before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}' \
+        "nested Docker manifest list"
+}
+
+@test "purge_ghcr refuses an untyped sibling after a valid manifest child before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},{"digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}]}' \
+        "child descriptor 1 has no mediaType"
+}
+
+@test "purge_ghcr refuses a child with an unsupported mediaType before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.example.unknown.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}' \
+        "unsupported mediaType"
+}
+
+@test "purge_ghcr refuses children with missing or newline-tainted digests before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json"}]}' \
+        "child descriptor 0 has no digest"
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"}]}' \
+        "child descriptor 0 has a malformed digest"
+}
+
+@test "purge_ghcr refuses top-level manifests with missing or unsupported mediaType before DELETE" {
+    run_manifest_protection_refusal \
+        '{"manifests":[]}' \
+        "top-level manifest has no mediaType"
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.example.unknown.v1+json","manifests":[]}' \
+        "top-level manifest has unsupported mediaType"
+}
+
+@test "purge_ghcr refuses a kept OCI index without manifests before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json"}' \
+        "top-level OCI index has no manifests field"
+}
+
+@test "purge_ghcr refuses a kept Docker manifest list without manifests before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json"}' \
+        "top-level Docker manifest list has no manifests field"
+}
+
+@test "purge_ghcr refuses indexes whose manifests field is not an array before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":null}' \
+        "top-level OCI index has a non-array manifests field"
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":{}}' \
+        "top-level OCI index has a non-array manifests field"
+}
+
+@test "purge_ghcr refuses leaf manifests that carry manifests before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.manifest.v1+json","manifests":[]}' \
+        "top-level OCI image manifest has a manifests field"
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.docker.distribution.manifest.v2+json","manifests":[]}' \
+        "top-level Docker image manifest has a manifests field"
+}
+
+@test "purge_ghcr protects plain-manifest children and deletes only a genuinely unreferenced orphan" {
+    local gh_log="$_STUB_DIR/manifest-protection-gh.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$gh_log" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DOCKERHUB_USERNAME="" \
+        DOCKERHUB_TOKEN="" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}}},{\"id\":103,\"name\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"metadata\":{\"container\":{\"tags\":[]}}},{\"id\":104,\"name\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
+            }
+            curl() {
+                if [[ "$*" == *"/token?"* ]]; then printf "%s\\n" "{\"token\":\"registry-token\"}"
+                elif [[ "$*" == *"/manifests/"* ]]; then printf "%s\\n" "{\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"},{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\"digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}]}"
+                else echo "unexpected curl: $*" >&2; return 1
+                fi
+            }
+            main protected
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$gh_log")" == *"/versions/104"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/102"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/103"* ]]
+}
+
+@test "purge_ghcr accepts a leaf manifest without manifests and completes normally" {
+    local gh_log="$_STUB_DIR/manifest-protection-gh.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$gh_log" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DOCKERHUB_USERNAME="" \
+        DOCKERHUB_TOKEN="" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+            }
+            curl() {
+                if [[ "$*" == *"/token?"* ]]; then printf "%s\\n" "{\"token\":\"registry-token\"}"
+                elif [[ "$*" == *"/manifests/"* ]]; then printf "%s\\n" "{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"}"
+                else echo "unexpected curl: $*" >&2; return 1
+                fi
+            }
+            main protected
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$gh_log")" == *"/versions/102"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # Direct-match tests (regression: existing behaviour must be preserved)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The monthly registry prune protected a kept image's children one level deep. A child that is itself
an index had its own children protected by nothing, so the orphan sweep deleted them and left the
kept image pointing at manifests the registry no longer had.

Every fetched manifest is now classified before anything is deleted. An OCI index or Docker
manifest list must carry an array-valued `manifests`; a plain image manifest must carry none and
contributes no children; a descriptor contributes its digest only when it declares one of the two
image-manifest media types and a well-formed `sha256` digest. Anything else returns the existing
protection failure — the arm a failed manifest fetch already takes — before either deletion loop, so
that package is skipped, nothing is deleted for it, and the run ends non-zero. The digest pattern
moves into a shared `valid_digest` used by both the version-record contract and the new one.

## Why refuse instead of resolving the graph transitively

#1338 asks for a transitive walk. That needs a bound, a visited set and a cycle rule, and it would
answer a shape that does not occur: measured against live GHCR on 2026-08-24, across all 18
packages, 295 tagged manifests and 372 child descriptors, **no child is itself an index** and every
descriptor carries a `mediaType`. The refusal removes the deletion for a tenth of the code, and its
message is the signal that the walk has become worth building. #1338 stays open for it.

The contract's comment now states its bound: it classifies from the metadata a document reports, it
does not fetch a child to confirm the declared media type, and it does not follow `subject`.

## Verification

- `bats` over every tracked `*.bats` file: **2848 pass, 0 fail, 113 files**, each file's TAP plan
  matching its own record count. (Running them with `-j 8` into one stream interleaves records from
  different files onto one line and loses them from the count, so each file gets its own log.)
- `shellcheck` on both changed shell files reports exactly what it reports on `master` — two
  `SC1091`, two `SC2016`, two `SC2317`, all informational and pre-existing.
- Each new guard was removed in turn and the test named for it observed failing, then the file
  restored and its `sha256` confirmed unchanged: the nested-index arms (two tests red), the child
  `mediaType` presence (one), the top-level `mediaType` presence (one), the index-must-have-
  `manifests` arm (two), the leaf-must-not-have-`manifests` arm (one), and `\z` weakened to `$` in
  `valid_digest` (two, one of them a pre-existing test — the shared predicate is load-bearing).

## Not fixed here

Review residue, filed rather than folded in: #1416 (a concatenated JSON response is classified
twice), #1417 (a failed index deletion does not stop its children being swept), #1418 (two
statements that no longer match the code). Pre-existing and out of scope: #1415 (the age-based
pruner deletes untagged records with no manifest protection at all, and runs first in the same
job), #1400, #1401, #1285.

Refs #1338
