### PR TITLE
Refuse to prune when the listing and the package total disagree

### DIFF
--- a/helpers/version-record-validation.sh
+++ b/helpers/version-record-validation.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Shared jq validation contracts for GHCR package-version records used by the
-# destructive registry pruners.  Callers deliberately choose one of the three
-# named contracts below; they cannot supply their own field list.
+# destructive registry pruners.  Callers deliberately choose one of the named
+# contracts below; they cannot supply their own field list.
 
 # `created_at` is only checked for RFC3339 string shape here.  #1301 owns
 # timestamp parsing and ordering semantics.
-# shellcheck disable=SC2089
+# shellcheck disable=SC2034,SC2089,SC2090
 VERSION_RECORD_VALIDATION_JQ='
 def valid_tag:
   # jq ^ is a true start anchor; use \z rather than $ so a final newline is
@@ -90,11 +90,13 @@ def first_manifest_child_error:
 # document from the metadata that document reports: its top-level mediaType,
 # the presence and type of its manifests field, and the declared mediaType of
 # each direct descriptor.  It does not fetch a child to confirm the media type
-# declared by its descriptor or follow subject; both cost one request per node,
-# the cost of a transitive walk.
-# oorabona/docker-containers#1338 owns that walk.
+# declared by its descriptor.  A top-level subject is refused: adding only its
+# digest to children would leave that subject document unfetched, so any child
+# references it contains could not be classified.  The transitive walk needed
+# to resolve subjects belongs to oorabona/docker-containers#1338.
 def manifest_protection_contract:
   if type != "object" then error("top-level manifest is not an object")
+  elif has("subject") then error("top-level manifest has an unresolved subject")
   elif has("mediaType") | not then error("top-level manifest has no mediaType")
   elif has("mediaType") and ((.mediaType | type) != "string") then error("top-level manifest has a non-string mediaType")
   elif has("mediaType") and (.mediaType | named_manifest_media_type | not) then error("top-level manifest has unsupported mediaType \(.mediaType | @json)")
@@ -141,6 +143,20 @@ def duplicate_id_error:
         end)
   | .error;
 
+# The package endpoint supplies a total to compare with a paginated versions
+# listing.  This detects cardinality drift, not every omission: with 200
+# records, deleting one from page 1 before page 2 shifts an offset so page 2
+# skips a live record; the 199 collected records can then agree with a later
+# package total of 199.  Duplicate IDs are checked separately.  This entry
+# point is intentionally separate from validate_old_versions.
+def validate_versions_listing_count($reported_count):
+  versions_collection_contract as $collection_error
+  | if $collection_error != null then error("validation failed: \($collection_error)")
+    elif (($reported_count | type) != "number" or ($reported_count | floor) != $reported_count or $reported_count < 0 or length != $reported_count) then
+      error("validation failed: package version_count is invalid or does not match the versions listing")
+    else true
+    end;
+
 def validate_outdated_tags_versions:
   versions_collection_contract as $collection_error
   | if $collection_error != null then error("validation failed: \($collection_error)")
@@ -161,5 +177,3 @@ def validate_old_versions:
       | if $error == null then true else error("validation failed: \($error)") end
     end;
 '
-# shellcheck disable=SC2090
-export VERSION_RECORD_VALIDATION_JQ

--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -38,7 +38,7 @@ print_banner() {
 # failure also returns 13.
 purge_container() {
   local container="$1"
-  local versions version_count versions_file="" deletions_file=""
+  local versions package version_count reported_version_count versions_file="" deletions_file=""
   local position=0 kept=0 deleted=0 delete_failures=0
   local version_id tags created_at keep_reason tag tag_list major version_ts cutoff_ts processing_error=0 deletion_read_error=0 validation_error validation_status
   local record_b64 record_json
@@ -64,8 +64,25 @@ purge_container() {
   fi
 
   if ! version_count=$(jq -er 'length' <<< "$versions"); then
-    echo "  ✗ Failed to count versions; skipping $container" >&2
-    return "$PROCESSING_FAILURE"
+    echo "  ✗ Failed to count version listing; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+
+  if ! package=$(gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/users/${OWNER}/packages/container/${container}"); then
+    echo "  ✗ Failed to get package version total; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! reported_version_count=$(jq -c '.version_count' <<< "$package"); then
+    echo "  ✗ Failed to read package version_count; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! validation_error=$(jq -er --argjson reported_version_count "$reported_version_count" "$VERSION_RECORD_VALIDATION_JQ
+    validate_versions_listing_count(\$reported_version_count)" <<< "$versions" 2>&1 >/dev/null); then
+    echo "  ✗ Version listing count does not agree with package version_count or version_count was invalid: ${validation_error##*validation failed: }; skipping $container" >&2
+    return "$LISTING_FAILURE"
   fi
   echo "  Found $version_count versions" >&2
   if [[ "$version_count" -eq 0 ]]; then

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -94,11 +94,12 @@ is_valid_tag() {
 purge_ghcr() {
   # 10 listing failure, 11 processing failure, 12 delete failure, 13 failure
   # after complete assessment, 14 uninterpretable record, and 15 protection
-  # failure. Replaying either completed deletion list is execution, so a replay
-  # failure returns 13.
+  # failure. 16 means an untagged record required the orphan assessment but it
+  # did not run. Replaying a completed deletion list is execution, so a replay
+  # failure otherwise returns 13.
   local container="$1" valid_tags="$2"
-  local versions version_count versions_file="" obsolete_file="" protected_file=""
-  local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0 validation_error validation_status
+  local versions package_metadata version_count reported_version_count versions_file="" obsolete_file="" protected_file=""
+  local version_id digest tags tag tag_list has_valid kept=0 obsolete=0 orphans=0 delete_failures=0 deletion_read_error=0 orphan_assessment_required=false incomplete_orphan_assessment=false validation_error validation_status
   local record_b64 record_json
   local protected_digests="" ghcr_token manifest children protection_result
   local -a kept_digests=()
@@ -121,7 +122,21 @@ purge_ghcr() {
   fi
   if ! version_count=$(jq -er 'length' <<< "$versions"); then
     echo "  ✗ Failed to count GHCR versions; skipping $container" >&2
-    return "$PROCESSING_FAILURE"
+    return "$LISTING_FAILURE"
+  fi
+  if ! package_metadata=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/users/${OWNER}/packages/container/${container}"); then
+    echo "  ✗ Failed to get GHCR version count; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! reported_version_count=$(jq -c '.version_count' <<< "$package_metadata"); then
+    echo "  ✗ Failed to read GHCR package version_count; skipping $container" >&2
+    return "$LISTING_FAILURE"
+  fi
+  if ! validation_error=$(jq -er --argjson reported_version_count "$reported_version_count" "$VERSION_RECORD_VALIDATION_JQ
+    validate_versions_listing_count(\$reported_version_count)" <<< "$versions" 2>&1 >/dev/null); then
+    echo "  ✗ GHCR version listing count does not agree with package version_count or version_count was invalid: ${validation_error##*validation failed: }; skipping $container" >&2
+    return "$LISTING_FAILURE"
   fi
   echo "  Found $version_count GHCR versions" >&2
   if [[ "$version_count" -eq 0 ]]; then
@@ -170,7 +185,10 @@ purge_ghcr() {
       echo "  ✗ Failed to read GHCR version record; skipping $container" >&2
       return "$PROCESSING_FAILURE"
     fi
-    [[ -z "$tags" ]] && continue
+    if [[ -z "$tags" ]]; then
+      orphan_assessment_required=true
+      continue
+    fi
     has_valid=false
     if ! tag_list=$(jq -r '.tags[]' <<< "$record_json"); then
       cleanup_files
@@ -213,8 +231,10 @@ purge_ghcr() {
         echo "  ✗ Failed to fetch manifest for ${digest:0:19}; skipping $container" >&2
         return "$PROTECTION_FAILURE"
       fi
-      if ! protection_result=$(jq -ce "$VERSION_RECORD_VALIDATION_JQ
-        manifest_protection_contract" <<< "$manifest" 2>&1); then
+      if ! protection_result=$(jq -ce -s "$VERSION_RECORD_VALIDATION_JQ
+        if length == 1 then .[0] | manifest_protection_contract
+        else error(\"GHCR manifest response must contain exactly one JSON value\")
+        end" <<< "$manifest" 2>&1); then
         cleanup_files
         echo "  ✗ Refused manifest protection for ${digest:0:19}: $protection_result; skipping $container" >&2
         return "$PROTECTION_FAILURE"
@@ -269,9 +289,20 @@ purge_ghcr() {
       return "$PROCESSING_FAILURE"
     fi
     cleanup_files
+    if [[ "$orphan_assessment_required" == true ]]; then
+      echo "  ✗ Orphan assessment skipped: a required orphan phase did not run; skipping $container" >&2
+      return "$INCOMPLETE_DELETION_FAILURE"
+    fi
     return "$POST_DELETE_PROCESSING_FAILURE"
   fi
 
+  if [[ "$delete_failures" -gt 0 ]]; then
+    : # A surviving obsolete parent may still reference its untagged children.
+    if [[ "$orphan_assessment_required" == true ]]; then
+      incomplete_orphan_assessment=true
+      echo "  ✗ Orphan assessment skipped: a required orphan phase did not run; skipping $container" >&2
+    fi
+  else
   while IFS= read -r record_b64; do
     [[ -z "$record_b64" ]] && continue
     if ! record_json=$(printf '%s' "$record_b64" | base64 -d) \
@@ -298,6 +329,7 @@ purge_ghcr() {
       orphans=$((orphans + 1))
     fi
   done < "$versions_file"
+  fi
   if [[ "$deletion_read_error" -ne 0 ]]; then
     if ! printf '%s\n' "$kept|$obsolete|$orphans|$delete_failures"; then
       cleanup_files
@@ -311,8 +343,10 @@ purge_ghcr() {
   fi
   if ! cleanup_files; then
     echo "  ✗ Failed to remove GHCR work files after cleanup" >&2
+    [[ "$incomplete_orphan_assessment" == true ]] && return "$INCOMPLETE_DELETION_FAILURE"
     return "$POST_DELETE_PROCESSING_FAILURE"
   fi
+  [[ "$incomplete_orphan_assessment" == true ]] && return "$INCOMPLETE_DELETION_FAILURE"
   [[ "$delete_failures" -eq 0 ]] || return "$DELETE_FAILURE"
 }
 
@@ -369,9 +403,8 @@ main() {
   ROOT_DIR=$(script_root) || return 1
   export ROOT_DIR
 
-  # 16 is reserved for a future partial-assessment producer; this plan-then-
-  # delete implementation deliberately has none, and replay failures are
-  # post-complete (13).
+  # 16 is fail-closed when the listing required an orphan assessment but a
+  # prior deletion failure or replay abort prevented that phase from running.
   local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15 INCOMPLETE_DELETION_FAILURE=16
   local containers container valid_tags valid_count result ghcr_status dh_result dh_status
   local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed skip_dockerhub
@@ -401,14 +434,14 @@ main() {
         fi ;;
       "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)); skip_dockerhub=true ;;
       "$PROCESSING_FAILURE"|"$UNINTERPRETABLE_RECORD_FAILURE"|"$PROTECTION_FAILURE") total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true ;;
-      # Reserved fail-closed status; see the declaration above.  A status 16
-      # caller has not supplied a completed assessment, so Docker Hub stays off.
+      # A status 16 caller has not supplied a completed assessment, so Docker
+      # Hub stays off.
       "$INCOMPLETE_DELETION_FAILURE")
         if ! IFS='|' read -r kept obsolete orphans delete_failures <<< "$result"; then
           echo "  ✗ Failed to read incomplete GHCR cleanup result; skipping $container"
         else
-          total_kept=$((total_kept + kept)); total_obsolete=$((total_obsolete + obsolete)); total_orphans=$((total_orphans + orphans)); total_ghcr_delete_failures=$((total_ghcr_delete_failures + delete_failures))
-          echo "  GHCR summary: kept=$kept, obsolete=$obsolete, orphans=$orphans, delete_failures=$delete_failures"
+          total_kept=$((total_kept + kept)); total_obsolete=$((total_obsolete + obsolete)); total_ghcr_delete_failures=$((total_ghcr_delete_failures + delete_failures))
+          echo "  GHCR summary: kept=$kept, obsolete=$obsolete, orphan phase not assessed, delete_failures=$delete_failures"
         fi
         total_processing_failures=$((total_processing_failures + 1)); skip_dockerhub=true
         ;;

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -21,6 +21,18 @@ if [[ "$*" == *"--method DELETE"* ]]; then
     exit 0
 fi
 
+if [[ "$*" != *"/versions"* ]]; then
+    case "${GH_MODE:-}" in
+        delete-failure|cleanup-failure) package_version_count=1 ;;
+        malformed-record)
+            [[ "$*" == *"/container/broken"* ]] && package_version_count=1 || package_version_count=0
+            ;;
+        *) package_version_count=0 ;;
+    esac
+    printf '{"version_count":%s}\n' "$package_version_count"
+    exit 0
+fi
+
 if [[ "${GH_MODE:-}" == "listing-failure" && "$*" == *"/container/broken/versions"* ]]; then
     echo "gh: API rate limit exceeded" >&2
     exit 1
@@ -137,6 +149,11 @@ assert_prepared_decode_preserves_delete_totals() {
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$*" != *"/versions"* ]]; then
+    printf '%s\n' '{"version_count":2}'
+    exit 0
+fi
+
 printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
 printf '%s\n' '[{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
 EOF
@@ -159,10 +176,114 @@ EOF
     [[ "$output" == *"Found 2 versions"* ]]
 }
 
+@test "a short version listing is unassessed, attempts no deletion, and does not abandon later packages" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" == *"/versions"* ]]; then
+                    [[ "$*" == *"/container/short/versions"* ]] && printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]" || printf "%s\\n" "[]"
+                elif [[ "$*" == *"/container/short"* ]]; then
+                    printf "%s\\n" "{\"version_count\":2}"
+                else
+                    printf "%s\\n" "{\"version_count\":0}"
+                fi
+            }
+            main short healthy
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Version listing count does not agree with package version_count or version_count was invalid: package version_count is invalid or does not match the versions listing; skipping short"* ]]
+    [[ "$output" == *"Processing: healthy"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+    [[ ! -s "$GH_LOG" ]]
+}
+
+@test "a listing matching its package total keeps the normal retention and deletion behavior" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="1" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" == *"/versions"* ]]; then
+                    printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+                else
+                    printf "%s\\n" "{\"version_count\":2}"
+                fi
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$GH_LOG")" == *"/versions/102"* ]]
+    [[ "$output" == *"Summary: kept=1, deleted=1, delete_failures=0"* ]]
+}
+
+@test "an absent or non-numeric package version total refuses the listing" {
+    local package_response
+    for package_response in '{}' '{"version_count":"two"}'; do
+        : > "$GH_LOG"
+        run env \
+            PROJECT_ROOT="$PROJECT_ROOT" \
+            GH_LOG="$GH_LOG" \
+            PACKAGE_RESPONSE="$package_response" \
+            GH_TOKEN="test-token" \
+            OWNER="test-owner" \
+            DRY_RUN="false" \
+            KEEP_LATEST_COUNT="0" \
+            KEEP_MONTHS="0" \
+            bash -c '
+                set -euo pipefail
+                source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+                gh() {
+                    if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                    if [[ "$*" == *"/versions"* ]]; then
+                        [[ "$*" == *"/container/broken/versions"* ]] && printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]" || printf "%s\\n" "[]"
+                    elif [[ "$*" == *"/container/broken"* ]]; then
+                        printf "%s\\n" "$PACKAGE_RESPONSE"
+                    else
+                        printf "%s\\n" "{\"version_count\":0}"
+                    fi
+                }
+                main broken healthy
+            '
+
+        [[ "$status" -eq 1 ]]
+        [[ "$output" == *"Version listing count does not agree with package version_count or version_count was invalid: package version_count is invalid or does not match the versions listing; skipping broken"* ]]
+        [[ "$output" == *"Processing: healthy"* ]]
+        [[ "$output" == *"Packages assessed: 1"* ]]
+        [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
+        [[ ! -s "$GH_LOG" ]]
+    done
+}
+
 @test "a non-array first paginated page is rejected even when a later page is valid" {
     cat > "$STUB_DIR/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [[ "$*" != *"/versions"* ]]; then
+    printf '%s\n' '{"version_count":1}'
+    exit 0
+fi
 
 printf '%s\n' '{}'
 printf '%s\n' '[]'
@@ -210,6 +331,76 @@ EOF
     [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
     [[ ! -s "$GH_LOG" ]]
     [[ ! -e "$temp_file" ]]
+}
+
+@test "a preparation failure removes both work files and does not abandon later packages" {
+    local versions_file="$STUB_DIR/versions-file"
+    local deletions_file="$STUB_DIR/deletions-file"
+    local observed_file="$STUB_DIR/work-files-observed"
+    local mktemp_calls="$STUB_DIR/mktemp-calls"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        PRUNER_VERSIONS_FILE="$versions_file" \
+        PRUNER_DELETIONS_FILE="$deletions_file" \
+        PRUNER_WORK_FILES_OBSERVED="$observed_file" \
+        PRUNER_MKTEMP_CALLS="$mktemp_calls" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" == *"/versions"* ]]; then
+                    [[ "$*" == *"/container/broken/versions"* ]] && printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]" || printf "%s\\n" "[]"
+                elif [[ "$*" == *"/container/broken"* ]]; then
+                    printf "%s\\n" "{\"version_count\":1}"
+                else
+                    printf "%s\\n" "{\"version_count\":0}"
+                fi
+            }
+            mktemp() {
+                calls=0; [[ -f "$PRUNER_MKTEMP_CALLS" ]] && calls=$(<"$PRUNER_MKTEMP_CALLS")
+                calls=$((calls + 1)); printf "%s\\n" "$calls" > "$PRUNER_MKTEMP_CALLS"
+                case "$calls" in
+                    1) temp_path="$PRUNER_VERSIONS_FILE" ;;
+                    2) temp_path="$PRUNER_DELETIONS_FILE" ;;
+                    *) return 1 ;;
+                esac
+                : > "$temp_path"
+                printf "%s\\n" "$temp_path"
+            }
+            jq() {
+                local argument
+                for argument in "$@"; do
+                    case "$argument" in
+                        ".[] | {id: "*)
+                            [[ -e "$PRUNER_VERSIONS_FILE" && -e "$PRUNER_DELETIONS_FILE" ]] || return 97
+                            printf "both work files existed\\n" > "$PRUNER_WORK_FILES_OBSERVED"
+                            echo "jq: preparation failed" >&2
+                            return 1
+                            ;;
+                    esac
+                done
+                command jq "$@"
+            }
+            main broken healthy
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$observed_file")" == "both work files existed" ]]
+    [[ ! -e "$versions_file" ]]
+    [[ ! -e "$deletions_file" ]]
+    [[ ! -s "$GH_LOG" ]]
+    [[ "$output" == *"Failed to prepare version list; skipping broken"* ]]
+    [[ "$output" == *"Processing: healthy"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+    [[ "$output" == *"Packages skipped (processing failed): 1"* ]]
 }
 
 @test "sourcing is inert and script_root uses BASH_SOURCE rather than the caller directory" {
@@ -300,6 +491,11 @@ if [[ "$*" == *"--method DELETE"* ]]; then
     exit 0
 fi
 
+if [[ "$*" != *"/versions"* ]]; then
+    printf '%s\n' '{"version_count":2}'
+    exit 0
+fi
+
 printf '%s\n' '[
   {"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"},
   {"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}},"created_at":"not-a-date"}
@@ -377,6 +573,7 @@ EOF
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":1}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"v1.2.3\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             jq() {
@@ -406,6 +603,7 @@ EOF
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             base64() {
@@ -442,6 +640,7 @@ run_old_version_validation_case() {
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then command jq -c "{version_count: length}" <<< "$RESPONSE_JSON"; return 0; fi
                 printf "%s\n" "$RESPONSE_JSON"
             }
             main malformed
@@ -462,7 +661,7 @@ run_old_version_validation_case() {
         bash -c '
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14
-            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
+            gh() { [[ "$*" != *"/versions"* ]] && { printf "%s\\n" "{\"version_count\":1}"; return; }; printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
             purge_container malformed
         '
 
@@ -473,7 +672,7 @@ run_old_version_validation_case() {
     cat > "$STUB_DIR/jq" <<'EOF'
 #!/usr/bin/env bash
 for argument in "$@"; do
-    [[ "$argument" == *"validate_old_versions"* ]] && exit 137
+    [[ "$argument" == *$'\n    validate_old_versions' ]] && exit 137
 done
 exec "$REAL_JQ" "$@"
 EOF
@@ -489,7 +688,7 @@ EOF
         bash -c '
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14
-            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
+            gh() { [[ "$*" != *"/versions"* ]] && { printf "%s\\n" "{\"version_count\":1}"; return; }; printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"; }
             purge_container validator-killed
         '
 
@@ -529,6 +728,7 @@ EOF
             source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
             gh() {
                 [[ "$*" == *"--method DELETE"* ]] && return 1
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\n" "{\"version_count\":2}"; return 0; fi
                 printf "%s\n" "[{\"id\":1,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":\"2\",\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             main valid

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 # Unit tests for scripts/cleanup-outdated-tags.sh
-# Focus: is_valid_tag — bake cache tag validity derived from underlying base tag
+# Focus: is_valid_tag — bake cache tag validity derived from underlying base tag;
+# GHCR manifest-protection contract and end-to-end deletion assertions
 
 # Source is_valid_tag from the script.  Sourcing is intentionally inert: it
 # defines functions only, so these tests do not need to arrange a fake main.
@@ -145,6 +146,7 @@ run_manifest_protection_refusal() {
             purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "0|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
             }
             curl() {
@@ -168,6 +170,287 @@ run_manifest_protection_refusal() {
         echo "ASSERTION FAILED: manifest protection refusal attempted a registry deletion" >&2
         return 1
     fi
+}
+
+run_outdated_tags_safety_case() {
+    local listing_json="$1"
+    local package_json="$2"
+    local manifest_body="$3"
+    local delete_failure_id="$4"
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        LISTING_JSON="$listing_json" \
+        PACKAGE_JSON="$package_json" \
+        MANIFEST_BODY="$manifest_body" \
+        DELETE_FAILURE_ID="$delete_failure_id" \
+        GH_LOG="$gh_log" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DOCKERHUB_USERNAME="" \
+        DOCKERHUB_TOKEN="" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    printf "DELETE:%s\\n" "$*" >> "$GH_LOG"
+                    [[ -z "$DELETE_FAILURE_ID" || "$*" != *"/versions/$DELETE_FAILURE_ID"* ]] || return 1
+                    return 0
+                elif [[ "$*" == *"/versions"* ]]; then
+                    printf "%s\\n" "$LISTING_JSON"
+                else
+                    printf "%s\\n" "$PACKAGE_JSON"
+                fi
+            }
+            curl() {
+                if [[ "$*" == *"/token?"* ]]; then printf "%s\\n" "{\"token\":\"registry-token\"}"
+                elif [[ "$*" == *"/manifests/"* ]]; then printf "%s" "$MANIFEST_BODY"
+                else echo "unexpected curl: $*" >&2; return 1
+                fi
+            }
+            main stale
+        '
+}
+
+run_orphan_phase_completion_case() {
+    local listing_json="$1"
+    local delete_failure_id="$2"
+    local base64_abort_at="$3"
+    local gh_log="$_STUB_DIR/orphan-phase-gh.log"
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        LISTING_JSON="$listing_json" \
+        DELETE_FAILURE_ID="$delete_failure_id" \
+        BASE64_ABORT_AT="$base64_abort_at" \
+        GH_LOG="$gh_log" \
+        DOCKERHUB_CALLS="$dockerhub_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    printf "DELETE:%s\\n" "$*" >> "$GH_LOG"
+                    [[ -z "$DELETE_FAILURE_ID" || "$*" != *"/versions/$DELETE_FAILURE_ID"* ]] || return 1
+                    return 0
+                fi
+                if [[ "$*" != *"/versions"* ]]; then
+                    printf "%s\\n" "{\"version_count\":$(command jq length <<< "$LISTING_JSON")}"
+                    return 0
+                fi
+                printf "%s\\n" "$LISTING_JSON"
+            }
+            base64() {
+                calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")
+                calls=$((calls + 1)); printf "%s\\n" "$calls" > "$BASE64_CALLS"
+                [[ -z "$BASE64_ABORT_AT" || "$calls" -ne "$BASE64_ABORT_AT" ]] || { echo "base64: prepared record lost" >&2; return 1; }
+                command base64 "$@"
+            }
+            export BASE64_CALLS="$GH_LOG.base64-calls"
+            main stale
+        '
+}
+
+# ---------------------------------------------------------------------------
+# GHCR deletion safety: count-agreeing listing, completed parent deletion, one manifest
+# ---------------------------------------------------------------------------
+
+@test "an untagged record skipped after an obsolete DELETE failure is unassessed and skips Docker Hub" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}}}]'
+    local gh_log="$_STUB_DIR/orphan-phase-gh.log"
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run_orphan_phase_completion_case "$listing" 101 ''
+
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/102"* ]]
+    [[ ! -s "$dockerhub_calls" ]]
+    [[ "$output" == *"Orphan assessment skipped: a required orphan phase did not run"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphan phase not assessed, delete_failures=1"* ]]
+    [[ "$output" != *"GHCR summary: kept=0, obsolete=1, orphans="* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+    [[ "$output" == *"Docker Hub cleanup skipped: GHCR safety assessment was incomplete"* ]]
+}
+
+@test "an obsolete DELETE failure without an untagged record remains assessed and runs Docker Hub" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}}]'
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run_orphan_phase_completion_case "$listing" 101 ''
+
+    [[ "$status" -eq 1 ]]
+    [[ -s "$dockerhub_calls" ]]
+    [[ "$output" != *"Orphan assessment skipped"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphans=0, delete_failures=1"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+}
+
+@test "an untagged record skipped after an obsolete replay abort is unassessed and skips Docker Hub" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale-first"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":["stale-second"]}}},{"id":103,"name":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","metadata":{"container":{"tags":[]}}}]'
+    local gh_log="$_STUB_DIR/orphan-phase-gh.log"
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run_orphan_phase_completion_case "$listing" '' 5
+
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/102"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/103"* ]]
+    [[ ! -s "$dockerhub_calls" ]]
+    [[ "$output" == *"Orphan assessment skipped: a required orphan phase did not run"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphan phase not assessed, delete_failures=0"* ]]
+    [[ "$output" != *"GHCR summary: kept=0, obsolete=1, orphans="* ]]
+    [[ "$output" == *"Packages assessed: 0"* ]]
+}
+
+@test "an incomplete package does not add an unassessed orphan count to the run total" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DOCKERHUB_USERNAME="" \
+        DOCKERHUB_TOKEN="" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            build_valid_tags() { printf "%s\\n" "latest"; }
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then
+                    [[ "$*" != *"/stale/versions/101"* ]]
+                    return
+                elif [[ "$*" == *"/stale/versions"* ]]; then
+                    printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
+                elif [[ "$*" == *"/complete/versions"* ]]; then
+                    printf "%s\\n" "[{\"id\":201,\"name\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}},{\"id\":202,\"name\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
+                else
+                    printf "%s\\n" "{\"version_count\":2}"
+                fi
+            }
+            main stale complete
+        '
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphan phase not assessed, delete_failures=1"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphans=1, delete_failures=0"* ]]
+    [[ "$output" == *"GHCR — kept: 0, obsolete: 2, orphans: 1"* ]]
+}
+
+@test "an obsolete replay abort without an untagged record remains assessed and runs Docker Hub" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale-first"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":["stale-second"]}}}]'
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run_orphan_phase_completion_case "$listing" '' 4
+
+    [[ "$status" -eq 1 ]]
+    [[ -s "$dockerhub_calls" ]]
+    [[ "$output" != *"Orphan assessment skipped"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphans=0, delete_failures=0"* ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+}
+
+@test "a completed GHCR assessment is assessed and runs Docker Hub" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}}]'
+    local dockerhub_calls="$_STUB_DIR/orphan-phase-dockerhub.log"
+
+    run_orphan_phase_completion_case "$listing" '' ''
+
+    [[ "$status" -eq 0 ]]
+    [[ -s "$dockerhub_calls" ]]
+    [[ "$output" == *"Packages assessed: 1"* ]]
+}
+
+@test "purge_ghcr skips orphan deletion when an obsolete parent DELETE fails" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '' 101
+
+    [[ "$status" -eq 1 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" != *"/versions/102"* ]]
+    [[ "$output" == *"GHCR summary: kept=0, obsolete=1, orphan phase not assessed, delete_failures=1"* ]]
+    [[ "$output" != *"GHCR summary: kept=0, obsolete=1, orphans="* ]]
+}
+
+@test "purge_ghcr deletes an orphan after all obsolete parent DELETEs succeed" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '' ''
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" == *"/versions/102"* ]]
+}
+
+@test "purge_ghcr refuses a short listing before any deletion" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '' ''
+
+    [[ "$status" -eq 1 ]]
+    [[ ! -s "$gh_log" ]]
+    [[ "$output" == *"GHCR version listing count does not agree with package version_count or version_count was invalid"* ]]
+}
+
+@test "purge_ghcr accepts a listing that matches the reported version_count" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":[]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '' ''
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$gh_log")" == *"/versions/101"* ]]
+    [[ "$(<"$gh_log")" == *"/versions/102"* ]]
+}
+
+@test "purge_ghcr refuses absent, null, and non-numeric package version_count values" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["stale"]}}}]'
+    local package_json gh_log
+
+    for package_json in '{}' '{"version_count":null}' '{"version_count":"1"}'; do
+        gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+        run_outdated_tags_safety_case "$listing" "$package_json" '' ''
+        [[ "$status" -eq 1 ]]
+        [[ ! -s "$gh_log" ]]
+        [[ "$output" == *"GHCR version listing count does not agree with package version_count or version_count was invalid"* ]]
+    done
+}
+
+@test "purge_ghcr refuses a manifest response containing two JSON documents before DELETE" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["latest"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":["stale"]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '{"mediaType":"application/vnd.oci.image.manifest.v1+json"}
+{"mediaType":"application/vnd.oci.image.manifest.v1+json"}' ''
+
+    [[ "$status" -eq 1 ]]
+    [[ ! -s "$gh_log" ]]
+    [[ "$output" == *"must contain exactly one JSON value"* ]]
+}
+
+@test "purge_ghcr refuses an empty manifest response before DELETE" {
+    local listing='[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["latest"]}}},{"id":102,"name":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","metadata":{"container":{"tags":["stale"]}}}]'
+    local gh_log="$_STUB_DIR/outdated-tags-safety-gh.log"
+
+    run_outdated_tags_safety_case "$listing" '{"version_count":2}' '' ''
+
+    [[ "$status" -eq 1 ]]
+    [[ ! -s "$gh_log" ]]
+    [[ "$output" == *"must contain exactly one JSON value"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -246,6 +529,27 @@ run_manifest_protection_refusal() {
         "top-level Docker image manifest has a manifests field"
 }
 
+@test "purge_ghcr refuses a kept leaf manifest carrying a top-level subject object before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.manifest.v1+json","subject":{"digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}' \
+        "top-level manifest has an unresolved subject"
+}
+
+@test "purge_ghcr refuses a kept index carrying a top-level subject before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.index.v1+json","subject":{},"manifests":[]}' \
+        "top-level manifest has an unresolved subject"
+}
+
+@test "purge_ghcr refuses top-level subject strings and nulls before DELETE" {
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.manifest.v1+json","subject":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}' \
+        "top-level manifest has an unresolved subject"
+    run_manifest_protection_refusal \
+        '{"mediaType":"application/vnd.oci.image.manifest.v1+json","subject":null}' \
+        "top-level manifest has an unresolved subject"
+}
+
 @test "purge_ghcr protects plain-manifest children and deletes only a genuinely unreferenced orphan" {
     local gh_log="$_STUB_DIR/manifest-protection-gh.log"
 
@@ -263,6 +567,7 @@ run_manifest_protection_refusal() {
             build_valid_tags() { printf "%s\\n" "latest"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":4}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}}},{\"id\":103,\"name\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"metadata\":{\"container\":{\"tags\":[]}}},{\"id\":104,\"name\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
             }
             curl() {
@@ -280,7 +585,7 @@ run_manifest_protection_refusal() {
     [[ "$(<"$gh_log")" != *"/versions/103"* ]]
 }
 
-@test "purge_ghcr accepts a leaf manifest without manifests and completes normally" {
+@test "purge_ghcr accepts a leaf manifest without subject and deletes a genuinely unreferenced orphan" {
     local gh_log="$_STUB_DIR/manifest-protection-gh.log"
 
     run env \
@@ -297,7 +602,8 @@ run_manifest_protection_refusal() {
             build_valid_tags() { printf "%s\\n" "latest"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
             }
             curl() {
                 if [[ "$*" == *"/token?"* ]]; then printf "%s\\n" "{\"token\":\"registry-token\"}"
@@ -310,6 +616,7 @@ run_manifest_protection_refusal() {
 
     [[ "$status" -eq 0 ]]
     [[ "$(<"$gh_log")" == *"/versions/102"* ]]
+    [[ "$output" == *"GHCR summary: kept=1, obsolete=0, orphans=1, delete_failures=0"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -528,6 +835,7 @@ run_manifest_protection_refusal() {
             build_valid_tags() { printf "%s\\n" "latest"; }
             purge_dockerhub() { printf "%s\\n" "0|0"; }
             gh() {
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}}]"
                 printf "%s\\n" "[{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
             }
@@ -665,6 +973,7 @@ run_manifest_protection_refusal() {
                     echo "gh: delete denied" >&2
                     return 1
                 fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":1}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
             }
             main stale
@@ -712,6 +1021,7 @@ EOF
                 if [[ "$*" == *"--method DELETE"* ]]; then
                     return 0
                 fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":1}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale\"]}}}]"
             }
             main stale
@@ -743,6 +1053,7 @@ EOF
             purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":1}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"latest\"]}}}]"
             }
             jq() {
@@ -777,6 +1088,7 @@ EOF
             purge_dockerhub() { printf "%s\\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\\n" "1|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
                 printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"stale-first\"]}}},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"stale-second\"]}}}]"
             }
             base64() {
@@ -817,6 +1129,7 @@ run_outdated_validation_case() {
             purge_dockerhub() { printf "%s\n" "$1" >> "$DOCKERHUB_CALLS"; printf "%s\n" "1|0"; }
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\n" "{\"version_count\":$(jq length <<< "$RESPONSE_JSON")}"; return 0; fi
                 printf "%s\n" "$RESPONSE_JSON"
             }
             main malformed
@@ -837,7 +1150,7 @@ run_outdated_validation_case() {
         bash -c '
             source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
             LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15
-            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}}}]"; }
+            gh() { if [[ "$*" == *"/versions"* ]]; then printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{}}}]"; else printf "%s\\n" "{\"version_count\":1}"; fi; }
             purge_ghcr malformed latest
         '
 
@@ -848,7 +1161,7 @@ run_outdated_validation_case() {
     cat > "$_STUB_DIR/jq" <<'EOF'
 #!/usr/bin/env bash
 for argument in "$@"; do
-    [[ "$argument" == *"validate_outdated_tags_versions"* ]] && exit 137
+    [[ "$argument" == *$'\n    validate_outdated_tags_versions' ]] && exit 137
 done
 exec "$REAL_JQ" "$@"
 EOF
@@ -863,7 +1176,7 @@ EOF
         bash -c '
             source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
             LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15
-            gh() { printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}}}]"; }
+            gh() { if [[ "$*" == *"/versions"* ]]; then printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}}}]"; else printf "%s\\n" "{\"version_count\":1}"; fi; }
             purge_ghcr validator-killed latest
         '
 
@@ -902,6 +1215,7 @@ EOF
             build_valid_tags() { printf "%s\n" "latest"; }
             gh() {
                 [[ "$*" == *"--method DELETE"* ]] && return 1
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\n" "{\"version_count\":1}"; return 0; fi
                 printf "%s\n" "[{\"id\":\"101\",\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}}}]"
             }
             main untagged


### PR DESCRIPTION
Both registry pruners delete from an unattended monthly job
(`.github/workflows/cleanup-registry.yaml`, `cron: '0 3 1 * *'`, `DRY_RUN=false`), and
`cleanup-old-versions.sh` runs first. Five ways they acted on information they had not established.

**A listing that may be missing records.** `gh api --paginate` can omit one when a page boundary
shifts mid-listing, and the omitted record can be a tagged parent whose untagged child is then swept
as an orphan. Both pruners now compare the collected count against `version_count` from the package
endpoint, through one shared contract, and skip the package before classifying anything when they
disagree or when the total is absent, null or not a non-negative integer.

Agreement is not proof of completeness, and nothing here claims it is: a record deleted from page 1
before page 2 is fetched shifts the offset so page 2 skips one, leaving the counts equal on an
incomplete listing. The contract's comment carries that counter-example. What the check detects is a
cardinality drift, which with the existing duplicate-id check covers the omission and duplication
cases that change the count.

**A failed obsolete deletion.** The surviving index still referenced its untagged children, and the
orphan sweep took them. The sweep is now skipped whenever an obsolete deletion failed.

**A package reported as assessed when it was not.** Skipping that sweep left `purge_ghcr` returning
a status `main` counts as complete, so the run printed `Packages assessed: 1`, an orphan count of
zero, and ran the Docker Hub cleanup. Both abort paths now return `INCOMPLETE_DELETION_FAILURE` when
the listing held an untagged record, the summary says the orphan phase was not assessed instead of
printing a number, and nothing is added to the run total. That status was declared with a `main` arm
that keeps Docker Hub off and had no caller, so the arm had never executed.

**A manifest response with more than one JSON value.** `jq` reads a stream, so two documents were
classified independently and both accepted. The call requires exactly one.

**A top-level `subject`.** It returned an empty child set, so an untagged version at that digest was
swept while the retained manifest still referred to it. It now refuses. Adding the digest to the
protected set was the alternative and was rejected: that document is never fetched, so if it is
itself an index its children stay unprotected while the result reads as complete.

Also here: the shared jq program is no longer exported into every child process's environment, and a
work-file cleanup guarantee that the validator pass had made unreachable is tested again.

## Measured

`version_count` is exact against the fully paginated record count on five packages spanning 13 to
2314 records, 0 disagreements (`registry` 13, `buildkit` 57, `tor` 60, `web-shell` 1071,
`github-runner` 2314). The listing response is a bare array with no envelope, so the total has to
come from the package endpoint. For the subject refusal: 0 of 109 tagged documents carry `subject`;
6 of 202 children do, all in `buildkit`, and each points at a digest its parent index already lists
— so the refusal fires on nothing in the registry today.

## Verification

- `bats` over every tracked `*.bats` file: **2868 pass, 0 fail, 113 files**, each file's TAP plan
  matching its own record count.
- `shellcheck` on the three changed shell files reports exactly what it reports on `master`.
- Each guard was disabled in turn and the test named for it observed failing, then the file restored
  and its `sha256` confirmed: the completeness comparison (one test red in *each* pruner's suite,
  which is how the shared contract is shown to be shared), the orphan gate, the one-document check,
  the subject refusal, the orphan-required flag, the status-16 return, and the not-assessed wording.

## Not fixed here

#1422 (a decoding failure inside the orphan loop still reports a complete assessment, plus a stale
test-section heading), #1421 (the four refusal reasons for a listing print the same sentence without
either number). Pre-existing and out of scope: #1415, #1400, #1405, #1414, #1285.

Refs #1402 #1416 #1417 #1418
Closes #1403
