### PR TITLE
Check every lineage write before reporting it succeeded

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -314,6 +314,81 @@ _write_rotation_status() {
     fi
 }
 
+# Write a complete lineage artifact without replacing the destination inode.
+# The producer writes only to a temporary file, so a producer failure leaves an
+# existing destination byte-identical.  The temporary does not reserve space
+# for the final copy: a successful producer does not prove there is room to
+# publish it.  The final copy writes through the destination (and a destination
+# symlink), which preserves its inode and metadata.  Its redirection can
+# truncate the destination before a copy failure, leaving it empty or partial,
+# just as the direct redirections this helper replaced could.  This helper does
+# not protect that final-write case; #1427 owns any change to that publication
+# strategy.
+# This helper is deliberately explicit about every command status: its callers
+# commonly run on the left of `||`, where errexit is disabled for the function
+# body.
+#
+# Usage: _write_lineage_artifact <destination> <producer-command> [args...]
+# The producer command writes the artifact body to stdout.
+_write_lineage_artifact() {
+    if [[ "$#" -lt 2 ]]; then
+        log_error "Usage: _write_lineage_artifact <destination> <producer-command> [args...]"
+        return 1
+    fi
+
+    local destination="$1"
+    shift
+    local destination_dir
+    local destination_base="${destination##*/}"
+    local tmp_file write_status cleanup_status
+
+    destination_dir=$(dirname -- "$destination")
+
+    if ! mkdir -p "$destination_dir"; then
+        log_error "Could not create lineage artifact directory: $destination_dir"
+        return 1
+    fi
+
+    if ! tmp_file=$(mktemp "${destination_dir}/.${destination_base}.tmp.XXXXXX"); then
+        log_error "Could not create temporary lineage artifact: $destination"
+        return 1
+    fi
+
+    if "$@" > "$tmp_file"; then
+        :
+    else
+        write_status=$?
+        if rm -f "$tmp_file"; then
+            log_error "Lineage artifact write failed: $destination (rc=$write_status)"
+        else
+            cleanup_status=$?
+            log_error "Lineage artifact write failed: $destination (rc=$write_status); temporary file retained: $tmp_file (cleanup rc=$cleanup_status)"
+        fi
+        return "$write_status"
+    fi
+
+    if cat "$tmp_file" > "$destination"; then
+        if rm -f "$tmp_file"; then
+            :
+        else
+            cleanup_status=$?
+            log_error "Lineage artifact temporary cleanup failed: $destination; temporary file retained: $tmp_file (cleanup rc=$cleanup_status)"
+            return "$cleanup_status"
+        fi
+        return 0
+    else
+        write_status=$?
+    fi
+
+    if rm -f "$tmp_file"; then
+        log_error "Lineage artifact copy failed: $destination (rc=$write_status)"
+    else
+        cleanup_status=$?
+        log_error "Lineage artifact copy failed: $destination (rc=$write_status); temporary file retained: $tmp_file (cleanup rc=$cleanup_status)"
+    fi
+    return "$write_status"
+}
+
 _rotation_build_exit() {
     local _exit_status="$1"
     local _cleanup_status=0
@@ -1043,7 +1118,6 @@ _bundle_and_write_artifact() {
     fi
 
     local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
-    mkdir -p "${ROOT_DIR}/.build-lineage"
 
     local _available_json _excluded_json _resolved_json
     _available_json=$(printf '%s\n' "${_confirmed_available[@]+"${_confirmed_available[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
@@ -1051,21 +1125,22 @@ _bundle_and_write_artifact() {
     _resolved_json=$(echo "$version_set_json" | jq '.')
     if [[ "$_version_digests_json" == "null" ]]; then
         # No-push path: omit version_digests (local/no-push artifact).
-        jq -nc \
+        if ! _write_lineage_artifact "$_vs_lineage_file" jq -nc \
             --arg ext "$ext" \
             --arg pg_major "$major_ver" \
             --arg ceiling "$ceiling" \
             --argjson resolved "$_resolved_json" \
             --argjson available "$_available_json" \
             --argjson excluded "$_excluded_json" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
-            > "$_vs_lineage_file"
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}'; then
+            return 1
+        fi
         log_info "Version-set lineage (build path, no-push — no version_digests): $_vs_lineage_file"
     else
         # Pushed path: include version_digests so consumer emits digest-pinned refs.
         local _version_digests_repository
         _version_digests_repository=$(ext_image_repository "$ext") || return 1
-        jq -nc \
+        if ! _write_lineage_artifact "$_vs_lineage_file" jq -nc \
             --arg ext "$ext" \
             --arg pg_major "$major_ver" \
             --arg ceiling "$ceiling" \
@@ -1074,8 +1149,9 @@ _bundle_and_write_artifact() {
             --argjson excluded "$_excluded_json" \
             --argjson version_digests "$_version_digests_json" \
             --arg version_digests_repository "$_version_digests_repository" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}' \
-            > "$_vs_lineage_file"
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}'; then
+            return 1
+        fi
         log_info "Version-set lineage (build path, pushed — with version_digests): $_vs_lineage_file"
     fi
     return 0
@@ -1332,16 +1408,19 @@ build_tag_push_extensions() {
                 local _ver_lineage_suffix=""
                 [[ -n "${ARCH_SUFFIX:-}" ]] && _ver_lineage_suffix="-${ARCH_SUFFIX}"
                 local _ver_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-${_ver_safe}${_ver_lineage_suffix}.json"
-                mkdir -p "${ROOT_DIR}/.build-lineage"
-                jq -nc \
+                if ! _write_lineage_artifact "$_ver_lineage_file" jq -nc \
                     --arg ext "$ext" \
                     --arg version "$version" \
                     --arg pg_major "$major_ver" \
                     --arg image "$_ver_image" \
                     --argjson duration "$_ver_duration" \
                     --arg built_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-                    '{ext:$ext, version:$version, pg_major:$pg_major, image:$image, duration_seconds:$duration, built_at:$built_at}' \
-                    > "$_ver_lineage_file"
+                    '{ext:$ext, version:$version, pg_major:$pg_major, image:$image, duration_seconds:$duration, built_at:$built_at}'; then
+                    log_error "$ext $version: extension lineage artifact could not be written"
+                    _record_rotation_build_status infra
+                    failed+=("$ext@${version}:lineage")
+                    continue
+                fi
                 log_info "Extension lineage: $_ver_lineage_file (${_ver_duration}s)"
             fi
         done < <(echo "$version_set_json" | jq -r '.[]')
@@ -1479,9 +1558,21 @@ _resolve_cached() {
 
     # Write atomically so a concurrent subshell never reads a partial file.
     local tmp_file
-    tmp_file="$(mktemp "${_RESOLVER_CACHE_DIR}/${ext}-${major}.XXXXXX")"
-    printf '%s' "$result" > "$tmp_file"
-    mv "$tmp_file" "$cache_file"
+    if ! tmp_file="$(mktemp "${_RESOLVER_CACHE_DIR}/${ext}-${major}.XXXXXX")"; then
+        return 1
+    fi
+    if ! printf '%s' "$result" > "$tmp_file"; then
+        if ! rm -f "$tmp_file"; then
+            return 1
+        fi
+        return 1
+    fi
+    if ! mv -fT "$tmp_file" "$cache_file"; then
+        if ! rm -f "$tmp_file"; then
+            return 1
+        fi
+        return 1
+    fi
 
     echo "$result"
 }
@@ -2029,22 +2120,22 @@ _emit_versionset_artifact() {
     fi
 
     local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
-    mkdir -p "${ROOT_DIR}/.build-lineage"
 
     local available_json excluded_json resolved_json
     available_json=$(printf '%s\n' "${available_versions[@]+"${available_versions[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
     excluded_json="[$(IFS=,; echo "${excluded_entries[*]+"${excluded_entries[*]}"}")]"
     resolved_json=$(echo "$version_set_json" | jq '.')
 
-    jq -nc \
+    if ! _write_lineage_artifact "$_vs_lineage_file" jq -nc \
         --arg ext "$ext" \
         --arg pg_major "$major_ver" \
         --arg ceiling "$ceiling" \
         --argjson resolved "$resolved_json" \
         --argjson available "$available_json" \
         --argjson excluded "$excluded_json" \
-        '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}' \
-        > "$_vs_lineage_file"
+        '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded}'; then
+        return 1
+    fi
     log_info "Version-set lineage (presence-based): $_vs_lineage_file"
 }
 
@@ -2550,7 +2641,6 @@ finalize_multiarch_manifests() {
         # The consumer (generate_dockerfile) uses these digests to emit
         # digest-pinned COPY --from= lines in the collector stage.
         local _vs_lineage_file="${ROOT_DIR}/.build-lineage/ext-${ext}-pg${major_ver}-versionset.json"
-        mkdir -p "${ROOT_DIR}/.build-lineage"
 
         local _available_json _excluded_json _resolved_json _version_digests_json _version_digests_repository
         _available_json=$(printf '%s\n' "${_confirmed_available[@]+"${_confirmed_available[@]}"}" | jq -Rsc 'split("\n") | map(select(. != ""))')
@@ -2575,7 +2665,7 @@ finalize_multiarch_manifests() {
         _vd_obj+='}'
         _version_digests_json="$_vd_obj"
 
-        jq -nc \
+        if ! _write_lineage_artifact "$_vs_lineage_file" jq -nc \
             --arg ext "$ext" \
             --arg pg_major "$major_ver" \
             --arg ceiling "$ceiling" \
@@ -2584,8 +2674,10 @@ finalize_multiarch_manifests() {
             --argjson excluded "$_excluded_json" \
             --argjson version_digests "$_version_digests_json" \
             --arg version_digests_repository "$_version_digests_repository" \
-            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}' \
-            > "$_vs_lineage_file"
+            '{ext:$ext, pg_major:$pg_major, ceiling:$ceiling, resolved:$resolved, available:$available, excluded:$excluded, version_digests:$version_digests, version_digests_repository:$version_digests_repository}'; then
+            _failed=true
+            continue
+        fi
         log_success "Versionset artifact written: $_vs_lineage_file"
 
     done <<< "$ext_list"

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -322,6 +322,29 @@ _setup_default_mocks() {
     # log_* pass-through (already sourced from extension-utils.sh chain)
 }
 
+_prepare_finalize_versionset_artifact() {
+    resolve_version_set() {
+        printf '%s\n' '["2.25.0","2.26.0","2.27.1"]'
+    }
+
+    list_extensions_by_priority() {
+        printf '%s\n' 'timescaledb'
+    }
+
+    # Every version already has a valid multi-arch manifest, so the finalizer
+    # takes its reuse path and reaches only the artifact write under test.
+    ext_ref_resolve() {
+        printf 'ghcr.io/test/ext-%s:pg%s-%s' "$1" "$3" "$2"
+    }
+
+    docker() {
+        if [[ "${1:-}" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+            printf 'linux/amd64\nlinux/arm64\n'
+        fi
+        return 0
+    }
+}
+
 # ---------------------------------------------------------------------------
 # ext_ref_resolve — run-scoped forced extension refs
 #
@@ -4067,6 +4090,390 @@ EOF
     # GREEN after fix: file absent.
     [ "$status" -eq 0 ]
     [ ! -f "$artifact" ]
+}
+
+@test "cached resolver refuses mktemp failure without emitting or creating a cache entry" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/cache-mktemp-${MAJOR_VER}.json"
+
+    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    mktemp() { return 70; }
+
+    run _resolve_cached cache-mktemp "$MAJOR_VER" "$CONFIG_FILE"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$cache_file" ]
+    [ -z "$output" ]
+}
+
+@test "cached resolver removes its temporary file when printf fails" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/cache-printf-${MAJOR_VER}.json"
+    local temporary_file="${_RESOLVER_CACHE_DIR}/cache-printf-temporary"
+
+    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    mktemp() {
+        command touch "$temporary_file"
+        command printf '%s\n' "$temporary_file"
+    }
+    printf() {
+        if [[ "${1:-}" == '%s' && "${2:-}" == '["1.2.3"]' ]]; then
+            return 71
+        fi
+        command printf "$@"
+    }
+
+    run _resolve_cached cache-printf "$MAJOR_VER" "$CONFIG_FILE"
+
+    [ "$status" -ne 0 ]
+    [ ! -e "$cache_file" ]
+    [ ! -e "$temporary_file" ]
+    [ -z "$output" ]
+}
+
+@test "cached resolver preserves an existing cache entry when mv fails" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/cache-mv-${MAJOR_VER}.json"
+    local temporary_file="${_RESOLVER_CACHE_DIR}/cache-mv-temporary"
+    local original_file="$TEST_TEMP_DIR/cache-mv-original"
+
+    printf '%s\n' 'previous complete entry' > "$original_file"
+    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    # Recreate the pre-existing cache just before promotion. This makes the
+    # write path observable while proving a failed mv cannot replace it.
+    mktemp() {
+        command cp "$original_file" "$cache_file"
+        command touch "$temporary_file"
+        command printf '%s\n' "$temporary_file"
+    }
+    mv() { return 72; }
+
+    run _resolve_cached cache-mv "$MAJOR_VER" "$CONFIG_FILE"
+
+    [ "$status" -ne 0 ]
+    cmp -s "$original_file" "$cache_file"
+    [ ! -e "$temporary_file" ]
+    [ -z "$output" ]
+}
+
+@test "lineage artifact new destination follows umask 0002 like a direct redirection" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/new-versionset.json"
+    local redirected_file="$lineage_dir/direct-redirection.json"
+
+    mkdir -p "$lineage_dir"
+    (
+        umask 0002
+        printf '%s\n' 'reference' > "$redirected_file"
+        run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+        [ "$status" -eq 0 ]
+        [ "$(<"$artifact")" = '{"complete":true}' ]
+        [ "$(stat -c '%a' "$artifact")" = "$(stat -c '%a' "$redirected_file")" ]
+        [ "$(stat -c '%a' "$artifact")" = '664' ]
+    )
+}
+
+@test "lineage artifact new destination follows umask 0077 like a direct redirection" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/new-private-versionset.json"
+    local redirected_file="$lineage_dir/direct-private-redirection.json"
+
+    mkdir -p "$lineage_dir"
+    (
+        umask 0077
+        printf '%s\n' 'reference' > "$redirected_file"
+        run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+        [ "$status" -eq 0 ]
+        [ "$(<"$artifact")" = '{"complete":true}' ]
+        [ "$(stat -c '%a' "$artifact")" = "$(stat -c '%a' "$redirected_file")" ]
+        [ "$(stat -c '%a' "$artifact")" = '600' ]
+    )
+}
+
+@test "lineage artifact preserves an existing destination's mode and inode" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/existing-versionset.json"
+    local inode_before
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    chmod 0640 "$artifact"
+    inode_before=$(stat -c '%i' "$artifact")
+
+    run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+
+    [ "$status" -eq 0 ]
+    [ "$(<"$artifact")" = '{"complete":true}' ]
+    [ "$(stat -c '%i' "$artifact")" = "$inode_before" ]
+    [ "$(stat -c '%a' "$artifact")" = '640' ]
+}
+
+@test "lineage artifact writes through a destination symlink" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/versionset-link.json"
+    local target="$lineage_dir/versionset-target.json"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$target"
+    ln -s "$(basename "$target")" "$artifact"
+
+    run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+
+    [ "$status" -eq 0 ]
+    [ -L "$artifact" ]
+    [ "$(readlink "$artifact")" = "$(basename "$target")" ]
+    [ "$(<"$target")" = '{"complete":true}' ]
+}
+
+@test "lineage artifact preserves hard-link siblings" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/versionset.json"
+    local sibling="$lineage_dir/versionset-sibling.json"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    ln "$artifact" "$sibling"
+
+    run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+
+    [ "$status" -eq 0 ]
+    [ "$(<"$artifact")" = '{"complete":true}' ]
+    [ "$(<"$sibling")" = '{"complete":true}' ]
+    [ "$(stat -c '%h' "$artifact")" = '2' ]
+    [ "$(stat -c '%h' "$sibling")" = '2' ]
+}
+
+@test "lineage artifact basename destination uses the current directory" {
+    local work_dir="$TEST_TEMP_DIR/relative-lineage"
+
+    mkdir -p "$work_dir"
+    run bash -c 'cd "$1" && source "$2" && _write_lineage_artifact artifact.json printf "%s\\n" "{\"complete\":true}"' \
+        bash "$work_dir" "$SCRIPTS_DIR/build-extensions.sh"
+
+    [ "$status" -eq 0 ]
+    [ -f "$work_dir/artifact.json" ]
+    [ ! -d "$work_dir/artifact.json" ]
+    [ "$(<"$work_dir/artifact.json")" = '{"complete":true}' ]
+}
+
+@test "lineage artifact producer failure preserves the previous destination and cleans its temporary" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/failed-versionset.json"
+    local original_file="$TEST_TEMP_DIR/failed-versionset-original"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    cp "$artifact" "$original_file"
+    failing_producer() { return 73; }
+
+    run _write_lineage_artifact "$artifact" failing_producer
+
+    [ "$status" -eq 73 ]
+    [[ "$output" == *"Lineage artifact write failed: $artifact (rc=73)"* ]]
+    cmp -s "$original_file" "$artifact"
+    [ -z "$(compgen -G "$lineage_dir/.failed-versionset.json.tmp.*" || true)" ]
+}
+
+@test "lineage artifact copy failure truncates the destination and cleans its temporary" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/copy-failed-versionset.json"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    cat() { return 74; }
+
+    run _write_lineage_artifact "$artifact" printf '%s\n' '{"complete":true}'
+
+    [ "$status" -eq 74 ] || { echo "copy status=$status output=$output"; false; }
+    [[ "$output" == *"Lineage artifact copy failed: $artifact (rc=74)"* ]]
+    # Bash opens this redirection before invoking the failing cat function.
+    [ "$(wc -c < "$artifact")" -eq 0 ]
+    [ -z "$(compgen -G "$lineage_dir/.copy-failed-versionset.json.tmp.*" || true)" ]
+}
+
+_assert_lineage_writer_failure_at_caller() {
+    local caller="$1"
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact original_file success_log
+
+    mkdir -p "$lineage_dir"
+    # These caller-policy tests stub the writer to verify that each caller
+    # propagates its failure and suppresses success reporting.  They do not
+    # cover the writer or its publication behavior.
+    _write_lineage_artifact() { return 76; }
+
+    case "$caller" in
+        bundle-no-push)
+            artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+            success_log="Version-set lineage (build path, no-push"
+            LOCAL_ONLY=true
+            PULL_ONLY=false
+            image_exists_in_registry() { return 0; }
+            _image_present_3state() { return 0; }
+            ;;
+        bundle-pushed)
+            artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+            success_log="Version-set lineage (build path, pushed"
+            LOCAL_ONLY=false
+            PULL_ONLY=false
+            image_exists_in_registry() { return 0; }
+            _image_present_3state() { return 0; }
+            ;;
+        per-version)
+            artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-2.27.1.json"
+            success_log="Extension lineage: $artifact"
+            resolve_version_set() { printf '%s\n' '["2.27.1"]'; }
+            image_exists_in_registry() { return 1; }
+            _cleanup_stale_duration_files() { :; }
+            ;;
+        presence-based)
+            artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+            success_log="Version-set lineage (presence-based):"
+            image_exists_in_registry() { return 0; }
+            _image_present_3state() { return 0; }
+            ;;
+        *)
+            echo "unknown caller fixture: $caller" >&2
+            return 1
+            ;;
+    esac
+
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    cp "$artifact" "$TEST_TEMP_DIR/${caller}-original"
+    original_file="$TEST_TEMP_DIR/${caller}-original"
+
+    # Rerun after seeding the old destination so the caller is the observed
+    # failure boundary rather than an artifact-setup path.
+    case "$caller" in
+        bundle-no-push)
+            run _bundle_and_write_artifact timescaledb "$CONFIG_FILE" "$MAJOR_VER" \
+                '["2.25.0","2.26.0","2.27.1"]' 2.27.1 false
+            ;;
+        bundle-pushed)
+            run _bundle_and_write_artifact timescaledb "$CONFIG_FILE" "$MAJOR_VER" \
+                '["2.25.0","2.26.0","2.27.1"]' 2.27.1 true
+            ;;
+        per-version)
+            run build_tag_push_extensions "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" true timescaledb
+            ;;
+        presence-based)
+            run _emit_versionset_artifact timescaledb "$CONFIG_FILE" "$MAJOR_VER" \
+                '["2.25.0","2.26.0","2.27.1"]' 2.27.1
+            ;;
+    esac
+
+    [ "$status" -ne 0 ] || { echo "caller=$caller status=$status output=$output"; false; }
+    [[ "$output" != *"$success_log"* ]] || { echo "caller=$caller reported success: $output"; false; }
+    cmp -s "$original_file" "$artifact" || { echo "caller=$caller changed the prior artifact: $output"; false; }
+}
+
+@test "bundle no-push propagates a lineage writer failure without a success log" {
+    _assert_lineage_writer_failure_at_caller bundle-no-push
+}
+
+@test "bundle pushed propagates a lineage writer failure without a success log" {
+    _assert_lineage_writer_failure_at_caller bundle-pushed
+}
+
+@test "per-version lineage caller propagates a writer failure without a success log" {
+    _assert_lineage_writer_failure_at_caller per-version
+}
+
+@test "presence-based versionset lineage caller propagates a writer failure without a success log" {
+    _assert_lineage_writer_failure_at_caller presence-based
+}
+
+@test "lineage artifact refuses zero arguments before creating anything" {
+    local lineage_dir="$TEST_TEMP_DIR/no-arguments-lineage"
+    local artifact="$lineage_dir/versionset.json"
+
+    run bash -u -c 'source "$1"; _write_lineage_artifact' \
+        bash "$SCRIPTS_DIR/build-extensions.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: _write_lineage_artifact <destination> <producer-command> [args...]"* ]]
+    [ ! -e "$artifact" ]
+    [ ! -d "$lineage_dir" ]
+}
+
+@test "lineage artifact refuses one argument before creating anything" {
+    local lineage_dir="$TEST_TEMP_DIR/no-producer-lineage"
+    local artifact="$lineage_dir/versionset.json"
+
+    run bash -u -c 'source "$1"; _write_lineage_artifact "$2"' \
+        bash "$SCRIPTS_DIR/build-extensions.sh" "$artifact"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: _write_lineage_artifact <destination> <producer-command> [args...]"* ]]
+    [ ! -e "$artifact" ]
+    [ ! -d "$lineage_dir" ]
+}
+
+@test "finalize refuses a jq artifact write without logging success or replacing the artifact" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+    local original_file="$TEST_TEMP_DIR/finalize-artifact-original"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    cp "$artifact" "$original_file"
+    _prepare_finalize_versionset_artifact
+    jq() {
+        if [[ "${1:-}" == '-nc' ]]; then
+            printf '%s\n' 'forced jq artifact failure' >&2
+            return 73
+        fi
+        command jq "$@"
+    }
+
+    run finalize_multiarch_manifests "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"Versionset artifact written:"* ]]
+    cmp -s "$original_file" "$artifact"
+}
+
+@test "finalize refuses an uncreatable artifact directory before jq writes" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    local artifact="$lineage_dir/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+    local original_file="$TEST_TEMP_DIR/finalize-mkdir-artifact-original"
+    local write_marker="$TEST_TEMP_DIR/finalize-jq-was-called"
+
+    mkdir -p "$lineage_dir"
+    printf '%s\n' 'previous complete artifact' > "$artifact"
+    cp "$artifact" "$original_file"
+    _prepare_finalize_versionset_artifact
+    mkdir() {
+        if [[ "${1:-}" == '-p' && "${2:-}" == "$lineage_dir" ]]; then
+            printf '%s\n' 'forced artifact directory failure' >&2
+            return 74
+        fi
+        command mkdir "$@"
+    }
+    jq() {
+        if [[ "${1:-}" == '-nc' ]]; then
+            command touch "$write_marker"
+        fi
+        command jq "$@"
+    }
+
+    run finalize_multiarch_manifests "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"Versionset artifact written:"* ]]
+    [ ! -e "$write_marker" ]
+    cmp -s "$original_file" "$artifact"
+}
+
+@test "finalize still writes the same versionset artifact and logs success" {
+    local artifact="$TEST_TEMP_DIR/.build-lineage/ext-timescaledb-pg${MAJOR_VER}-versionset.json"
+
+    _prepare_finalize_versionset_artifact
+
+    run finalize_multiarch_manifests "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Versionset artifact written: $artifact"* ]]
+    [ -f "$artifact" ]
+    [ "$(jq -r '.ceiling' "$artifact")" = '2.27.1' ]
+    [ "$(jq '.available | length' "$artifact")" -eq 3 ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`scripts/build-extensions.sh` reported success after two kinds of write it never checked. Both are
reached by an ordinary disk-full or permission failure, with no second actor, and both fail silently:
the run is green and the artifact it names is truncated, empty or absent.

**The resolver cache.** `_resolve_cached` promoted its entry with `mktemp`, `printf` and `mv`
unchecked, and every caller invokes it from a conditional assignment where errexit is off. On a short
write, `printf` returned non-zero having written a prefix, `mv` promoted that file, the trailing
`echo` returned 0, and later cache hits read the truncated entry and also returned 0. All three
commands are checked now, the temporary is removed on failure, and nothing is emitted.

**The lineage artifacts.** Five writes shared one shape: an unchecked `mkdir -p`, a direct
redirection to the destination, then `log_success`, inside functions also called on the left of `||`.
A failure truncated a valid artifact and the run stayed green. All five now go through one writer:
the producer writes to a temporary beside the destination, and its output reaches the destination
only after the producer succeeded. Four unchecked `mkdir -p` call sites became one checked call.

## Why the writer copies instead of renaming

The first version published by renaming the temporary over the destination. That replaces the inode,
and each review round found another thing the new inode does not carry: the mode became `0600`
(measured, against `664` for a redirection and a `644` destination coming out at `600`), then
ownership and ACLs, a setuid bit restored onto fresh content that a redirection clears, a symlink
replaced instead of its target written, hard links split from their siblings. Reproducing metadata
piece by piece was the proposed remedy and each round found the next missing piece.

Publication is now `cat "$tmp_file" > "$destination"`. The inode is never replaced, so mode,
ownership, ACLs, security labels, hard links and symlink targets survive because nothing touches
them, and a new destination is created under the process umask exactly as the five redirections were.

What that does not protect, stated in the writer's comment: a failure during the final copy can leave
the destination partially written, as the redirections it replaced also could. The temporary does not
reserve space for the copy, so a successful producer proves nothing about room to publish.
#1427 carries that property.

## Verification

- `bats` over every tracked `*.bats` file: **2888 pass, 0 fail, 113 files**, each file's TAP plan
  matching its own record count.
- `shellcheck -x -S warning`, the flags CI uses, exits 0 on this file before and after.
- Each guard was disabled in turn and the test named for it observed failing, then the file restored
  and its `sha256` confirmed. The mutation worth naming replaces the copy with a rename: five tests go
  red, including a `stat -c %i` comparison, a symlink case and a hard-link case, so the tests hold the
  shape rather than only the mode.
- Four call sites that no test drove through a failing writer now have one each.

## Not fixed here

#1424 (a cache write failure returns the resolver-failure status, so `--list` can degrade and exit 0),
#1425 (a sixth `mktemp`+`mv` site leaves its artifact at 0600), #1426 (this bats file leaks two
temporary directories per test), #1427 (the truncation window above, orphaned temporaries on an
interrupted run, unsynchronised concurrent writers, an emitter with no production caller, a stale
"atomic" in a caller comment, and a producer that succeeds without writing).

Closes #1391 #1392
