### PR TITLE
Fail the resolver lookup only when there is no validated result

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -1515,63 +1515,88 @@ export _BUILT_THIS_RUN_DIR
 _resolve_cached() {
     local ext="$1" major="$2" config_file="${3:-}"
     local cache_file="${_RESOLVER_CACHE_DIR}/${ext}-${major}.json"
+    local result cache_hit=false
+    local _resolver_path_cached="" _ceiling_cached=""
 
-    if [[ -f "$cache_file" ]]; then
-        cat "$cache_file" || return 1
-        return 0
-    fi
-
-    local result
-    result=$(resolve_version_set "$ext" "$major" "${config_file}") || return 1
-
-    # Validate: must be a non-empty JSON array where every element is a string.
-    # If the resolver exits 0 but emits malformed output or an empty array,
-    # treat it as a resolver failure (fail-closed) and do NOT cache the bad value.
-    if ! echo "$result" | jq -e 'type == "array" and length > 0 and (all(.[]; type == "string"))' > /dev/null 2>&1; then
-        log_error "resolver for $ext returned invalid version set (not a non-empty string array): $(_sanitize_for_log "$result")"
-        return 1
-    fi
-
-    # For RESOLVER-BACKED extensions only: apply strict whole-string semver +
-    # ceiling validation at the chokepoint BEFORE caching.
-    # This prevents the embedded-newline bypass where jq -r '.[]' would split a
-    # single element "2.27.1\n9.9.9" into two apparent versions, each passing a
-    # per-line semver check in every downstream consumer.
-    #
-    # Non-resolver single-version extensions (e.g. pg_ivm "1.14") return a
-    # single-element array from a config-controlled value — they are NOT resolver-
-    # backed and must NOT be subjected to this check (their format may not be 3-part
-    # semver). Detection: check for a non-empty version_set.resolver in config_file.
+    # Resolver-backed extensions require a strict semver/ceiling validation.
+    # Read that configuration once so cache and resolver results use the same gate.
     if [[ -n "${config_file:-}" ]]; then
-        local _resolver_path_cached
         _resolver_path_cached=$(yq -r ".extensions.${ext}.version_set.resolver // \"\"" "${config_file}" 2>/dev/null || true)
         if [[ -n "$_resolver_path_cached" ]]; then
-            # Read the ceiling for the clamp check.
-            local _ceiling_cached
             _ceiling_cached=$(yq -r ".extensions.${ext}.version" "${config_file}" 2>/dev/null || true)
-            if ! validate_semver_set_json "$result" "$_ceiling_cached"; then
-                log_error "resolver for $ext returned set that fails whole-string semver/ceiling validation (injection guard): $(_sanitize_for_log "$result")"
-                return 1
+        fi
+    fi
+
+    if [[ -f "$cache_file" ]]; then
+        if result=$(cat "$cache_file"); then
+            cache_hit=true
+        else
+            log_warning "resolver cache for $ext (PG $major) at $cache_file: read failed; resolving normally"
+            if ! rm -f "$cache_file"; then
+                log_warning "resolver cache for $ext (PG $major) at $cache_file: removal after read failure failed"
             fi
         fi
     fi
 
+    # A value, regardless of whether it came from the cache or resolver, leaves
+    # this function only after these shared validations pass.
+    while true; do
+        if [[ "$cache_hit" != "true" ]]; then
+            result=$(resolve_version_set "$ext" "$major" "${config_file}") || return 1
+        fi
+
+        # Validate: must be a non-empty JSON array where every element is a string.
+        if ! echo "$result" | jq -e 'type == "array" and length > 0 and (all(.[]; type == "string"))' > /dev/null 2>&1; then
+            if [[ "$cache_hit" == "true" ]]; then
+                log_warning "resolver cache for $ext (PG $major) at $cache_file: invalid version-set shape; resolving normally"
+                if ! rm -f "$cache_file"; then
+                    log_warning "resolver cache for $ext (PG $major) at $cache_file: removal after validation failure failed"
+                fi
+                cache_hit=false
+                continue
+            fi
+            log_error "resolver for $ext returned invalid version set (not a non-empty string array): $(_sanitize_for_log "$result")"
+            return 1
+        fi
+
+        # For resolver-backed extensions, reject whole-string semver and ceiling
+        # bypasses before either returning or caching the set.
+        if [[ -n "$_resolver_path_cached" ]] && ! validate_semver_set_json "$result" "$_ceiling_cached"; then
+            if [[ "$cache_hit" == "true" ]]; then
+                log_warning "resolver cache for $ext (PG $major) at $cache_file: semver/ceiling validation failed; resolving normally"
+                if ! rm -f "$cache_file"; then
+                    log_warning "resolver cache for $ext (PG $major) at $cache_file: removal after validation failure failed"
+                fi
+                cache_hit=false
+                continue
+            fi
+            log_error "resolver for $ext returned set that fails whole-string semver/ceiling validation (injection guard): $(_sanitize_for_log "$result")"
+            return 1
+        fi
+
+        break
+    done
+
+    if [[ "$cache_hit" == "true" ]]; then
+        echo "$result"
+        return 0
+    fi
+
     # Write atomically so a concurrent subshell never reads a partial file.
+    # The validated result remains usable even when cache persistence fails.
     local tmp_file
     if ! tmp_file="$(mktemp "${_RESOLVER_CACHE_DIR}/${ext}-${major}.XXXXXX")"; then
-        return 1
-    fi
-    if ! printf '%s' "$result" > "$tmp_file"; then
+        log_warning "resolver cache for $ext (PG $major) at $cache_file: mktemp failed; using validated result without caching"
+    elif ! printf '%s' "$result" > "$tmp_file"; then
+        log_warning "resolver cache for $ext (PG $major) at $cache_file: printf failed; using validated result without caching"
         if ! rm -f "$tmp_file"; then
-            return 1
+            log_warning "resolver cache for $ext (PG $major) at $cache_file: temporary removal after printf failure failed"
         fi
-        return 1
-    fi
-    if ! mv -fT "$tmp_file" "$cache_file"; then
+    elif ! mv -fT "$tmp_file" "$cache_file"; then
+        log_warning "resolver cache for $ext (PG $major) at $cache_file: mv failed; using validated result without caching"
         if ! rm -f "$tmp_file"; then
-            return 1
+            log_warning "resolver cache for $ext (PG $major) at $cache_file: temporary removal after mv failure failed"
         fi
-        return 1
     fi
 
     echo "$result"

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -4092,24 +4092,31 @@ EOF
     [ ! -f "$artifact" ]
 }
 
-@test "cached resolver refuses mktemp failure without emitting or creating a cache entry" {
+@test "cached resolver returns the validated result when mktemp fails" {
     local cache_file="${_RESOLVER_CACHE_DIR}/cache-mktemp-${MAJOR_VER}.json"
+    local stdout_file="$TEST_TEMP_DIR/cache-mktemp.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-mktemp.stderr"
+    local rc=0
 
-    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    resolve_version_set() { command printf '%s\n' '["1.2.3"]'; }
     mktemp() { return 70; }
 
-    run _resolve_cached cache-mktemp "$MAJOR_VER" "$CONFIG_FILE"
+    _resolve_cached cache-mktemp "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
-    [ "$status" -ne 0 ]
+    [ "$rc" -eq 0 ]
+    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [[ "$(<"$stderr_file")" == *"cache-mktemp (PG $MAJOR_VER) at $cache_file: mktemp failed"* ]]
     [ ! -e "$cache_file" ]
-    [ -z "$output" ]
 }
 
-@test "cached resolver removes its temporary file when printf fails" {
+@test "cached resolver returns the validated result and removes its temporary when printf fails" {
     local cache_file="${_RESOLVER_CACHE_DIR}/cache-printf-${MAJOR_VER}.json"
     local temporary_file="${_RESOLVER_CACHE_DIR}/cache-printf-temporary"
+    local stdout_file="$TEST_TEMP_DIR/cache-printf.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-printf.stderr"
+    local rc=0
 
-    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    resolve_version_set() { command printf '%s\n' '["1.2.3"]'; }
     mktemp() {
         command touch "$temporary_file"
         command printf '%s\n' "$temporary_file"
@@ -4121,21 +4128,25 @@ EOF
         command printf "$@"
     }
 
-    run _resolve_cached cache-printf "$MAJOR_VER" "$CONFIG_FILE"
+    _resolve_cached cache-printf "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
-    [ "$status" -ne 0 ]
+    [ "$rc" -eq 0 ]
+    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [[ "$(<"$stderr_file")" == *"cache-printf (PG $MAJOR_VER) at $cache_file: printf failed"* ]]
     [ ! -e "$cache_file" ]
     [ ! -e "$temporary_file" ]
-    [ -z "$output" ]
 }
 
-@test "cached resolver preserves an existing cache entry when mv fails" {
+@test "cached resolver returns the validated result and preserves an existing entry when mv fails" {
     local cache_file="${_RESOLVER_CACHE_DIR}/cache-mv-${MAJOR_VER}.json"
     local temporary_file="${_RESOLVER_CACHE_DIR}/cache-mv-temporary"
     local original_file="$TEST_TEMP_DIR/cache-mv-original"
+    local stdout_file="$TEST_TEMP_DIR/cache-mv.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-mv.stderr"
+    local rc=0
 
-    printf '%s\n' 'previous complete entry' > "$original_file"
-    resolve_version_set() { printf '%s\n' '["1.2.3"]'; }
+    command printf '%s\n' '["1.2.2"]' > "$original_file"
+    resolve_version_set() { command printf '%s\n' '["1.2.3"]'; }
     # Recreate the pre-existing cache just before promotion. This makes the
     # write path observable while proving a failed mv cannot replace it.
     mktemp() {
@@ -4145,12 +4156,109 @@ EOF
     }
     mv() { return 72; }
 
-    run _resolve_cached cache-mv "$MAJOR_VER" "$CONFIG_FILE"
+    _resolve_cached cache-mv "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
-    [ "$status" -ne 0 ]
+    [ "$rc" -eq 0 ]
+    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [[ "$(<"$stderr_file")" == *"cache-mv (PG $MAJOR_VER) at $cache_file: mv failed"* ]]
     cmp -s "$original_file" "$cache_file"
     [ ! -e "$temporary_file" ]
-    [ -z "$output" ]
+}
+
+@test "cached resolver returns a valid cache entry without invoking the resolver" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local stdout_file="$TEST_TEMP_DIR/cache-hit.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-hit.stderr"
+    local resolver_log="$TEST_TEMP_DIR/cache-hit-resolver.log"
+    local rc=0
+
+    command printf '%s' '["2.26.0"]' > "$cache_file"
+    resolve_version_set() {
+        command printf 'called\n' >> "$resolver_log"
+        command printf '%s\n' '["2.27.1"]'
+    }
+
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
+
+    [ "$rc" -eq 0 ]
+    [ "$(<"$stdout_file")" = '["2.26.0"]' ]
+    [ ! -e "$resolver_log" ]
+    [ ! -s "$stderr_file" ]
+}
+
+@test "cached resolver treats an unreadable cache entry as a miss" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local stdout_file="$TEST_TEMP_DIR/cache-read.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-read.stderr"
+    local resolver_log="$TEST_TEMP_DIR/cache-read-resolver.log"
+    local rc=0
+
+    command printf '%s' '["2.26.0"]' > "$cache_file"
+    resolve_version_set() {
+        command printf 'called\n' >> "$resolver_log"
+        command printf '%s\n' '["2.27.1"]'
+    }
+    cat() { return 74; }
+
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
+
+    [ "$rc" -eq 0 ]
+    [ "$(<"$stdout_file")" = '["2.27.1"]' ]
+    [ "$(wc -l < "$resolver_log")" -eq 1 ]
+    [[ "$(<"$stderr_file")" == *"timescaledb (PG $MAJOR_VER) at $cache_file: read failed"* ]]
+}
+
+@test "cached resolver treats invalid cache entries as misses" {
+    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local stdout_file="$TEST_TEMP_DIR/cache-invalid.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-invalid.stderr"
+    local resolver_log="$TEST_TEMP_DIR/cache-invalid-resolver.log"
+    local invalid_entry rc
+
+    resolve_version_set() {
+        command printf 'called\n' >> "$resolver_log"
+        command printf '%s\n' '["2.27.1"]'
+    }
+
+    for invalid_entry in '{}' '[]' '["1.0",2]' '["2.28.0"]'; do
+        command printf '%s' "$invalid_entry" > "$cache_file"
+        rm -f "$resolver_log"
+        rc=0
+
+        _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
+
+        [ "$rc" -eq 0 ]
+        [ "$(<"$stdout_file")" = '["2.27.1"]' ]
+        [ "$(wc -l < "$resolver_log")" -eq 1 ]
+        [[ "$(<"$stderr_file")" == *"timescaledb (PG $MAJOR_VER) at $cache_file"* ]]
+    done
+}
+
+@test "cached resolver fails without output when the resolver fails" {
+    local stdout_file="$TEST_TEMP_DIR/cache-resolver-failure.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-resolver-failure.stderr"
+    local rc=0
+
+    resolve_version_set() { return 75; }
+
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
+
+    [ "$rc" -ne 0 ]
+    [ ! -s "$stdout_file" ]
+}
+
+@test "cached resolver fails without output when the resolver fails the ceiling guard" {
+    local stdout_file="$TEST_TEMP_DIR/cache-resolver-ceiling.stdout"
+    local stderr_file="$TEST_TEMP_DIR/cache-resolver-ceiling.stderr"
+    local rc=0
+
+    resolve_version_set() { command printf '%s\n' '["2.28.0"]'; }
+
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
+
+    [ "$rc" -ne 0 ]
+    [ ! -s "$stdout_file" ]
+    [[ "$(<"$stderr_file")" == *"injection guard"* ]]
 }
 
 @test "lineage artifact new destination follows umask 0002 like a direct redirection" {

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -599,15 +599,23 @@ EOF
     assert_output_not_contains "CALLED["
 }
 
-@test "cached resolver fails when its cache entry cannot be read" {
+@test "cached resolver treats an unreadable cache entry as a miss" {
     # The cache entry is a regular file this run wrote itself, so no filesystem
     # state makes `cat` fail for a root test runner. Mock the read instead.
-    printf '["1.2.3"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
+    printf '["9.9.9"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
     cat() { return 1; }
+    resolve_version_set() { printf '["1.2.3"]\n'; }
+    local stderr_file="$TEST_TEMP_DIR/resolver-cache-read.stderr"
+    _resolve_cached_with_stderr() {
+        _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE" 2> "$stderr_file"
+    }
 
-    run _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE"
+    run _resolve_cached_with_stderr
 
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 0 ]
+    assert_equals '["1.2.3"]' "$output"
+    output=$(< "$stderr_file")
+    assert_output_contains "resolver cache for pgvector (PG $MAJOR_VER) at ${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json: read failed; resolving normally"
 }
 
 @test "cached resolver returns a readable cache entry" {


### PR DESCRIPTION
`_resolve_cached` returned the same status for six situations, and its six callers read any non-zero
as "the resolver failed" and fell back to building the ceiling version alone. On `--list`,
`--local-only` and `--pull-only` that fallback exits 0, so a run reported a narrower version set than
the resolver had actually returned, logged as an upstream failure.

Three of those returns were cache writes. At that point the answer had already come back from the
resolver, passed the JSON shape check and passed the semver/ceiling injection guard, and sat in a
shell variable no cache operation touches. A write failure now warns — naming the extension, the
major, the cache path and the failed operation — and returns that validated result.

Nothing can be promoted partially, whatever the function returns: the temporary and the entry share a
private per-run directory, so `mv -fT` is a same-filesystem rename, a `printf` failure removes the
temporary before any rename, and a surviving temporary is named `${ext}-${major}.XXXXXX` while the
hit path opens `${ext}-${major}.json`.

**The cache-hit path had the same family of problems.** `cat "$cache_file" || return 1` reported a
read failure as a resolver failure, and it returned the entry's content **unvalidated** — both gates
ran only on the resolution path, so a corrupt entry left the function having bypassed the injection
guard. `_RESOLVER_CACHE_DIR` is exported, so this function being the sole writer is a convention
rather than something the code enforces. Both paths now run through one loop with one copy of each
gate; an entry that cannot be read, or whose content fails a gate, is warned about, removed if
possible, and treated as a miss.

One test changed its claim deliberately. `tests/unit/build-extensions.bats` asserted that an
unreadable entry makes the function fail — the contract this replaces. It was retargeted, and the
replacement asserts more than the original: status 0, the resolver's exact JSON, and the warning on
stderr.

## Verification

- `bats` over every tracked `*.bats` file: **2893 pass, 0 fail, 113 files**, each file's plan matching
  its own record count.
- `shellcheck -x -S warning`, the flags CI uses, exits 0.
- Three mutations observed red with a green control first: an invalid entry failing instead of being a
  miss, the `mv` failure failing the resolution again, and a hit re-resolving anyway.
- One mutation stayed **green** and is reported rather than hidden: forcing the "came from the cache,
  so do not rewrite" branch always taken. Rewriting an identical entry is idempotent, so no test sees
  it; the cost is one needless write per hit. #1432.

## Not fixed here

**#1430 is the one to read.** A cache-write failure retains the answer nowhere, so each of the six
call sites resolves again, and two resolutions in one run can see different registry state — a green
build can then publish an image retaining fewer versions than a later stage computed. The
`available[]` ceiling guard does not catch it: it guards the pin, not the completeness of the
retention window. Closing it means returning through a caller-supplied variable and holding resolved
sets in a parent-shell array; the six call sites were traced and none is inside a pipeline,
background job or command substitution.

This is still strictly better than the base, where the same failure degrades to the ceiling alone.

Also open: #1429 (the injection guard is gated on a `yq` read that swallows its own errors; the cache
key omits the config; an eviction can delete an entry another caller just published), #1431 (the
ceiling itself is never validated, so a malformed bound means no bound), #1432 (two tests observe
less than their surroundings imply).

Closes #1424
