### PR TITLE
Resolve a version set once per run even when the cache fails

### DIFF
--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -22,6 +22,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$ROOT_DIR/helpers/extension-utils.sh"
 # shellcheck source=../helpers/version-set-resolver.sh
 source "$ROOT_DIR/helpers/version-set-resolver.sh"
+# shellcheck source=../helpers/hash-utils.sh
+source "$ROOT_DIR/helpers/hash-utils.sh"
 # shellcheck source=../helpers/retry.sh
 source "$ROOT_DIR/helpers/retry.sh"
 
@@ -628,9 +630,11 @@ list_extension_status() {
 
         # Resolve the full version set (cached). On resolver failure degrade
         # to the single ceiling so --list is never blocked by upstream outage.
-        if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+        if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
             log_warning "$ext: version-set resolver failed — showing ceiling only (LOCAL_ONLY)"
             version_set_json="[\"${ceiling}\"]"
+        else
+            version_set_json="$_RESOLVED_VERSION_SET_JSON"
         fi
 
         local ver
@@ -861,7 +865,7 @@ handle_pull_only_mode() {
         # (PULL_ONLY=true), where a transient resolver outage must not block a
         # local image fetch. Keep fail-closed for the true publish path (neither
         # flag set).
-        if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+        if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
             if [[ "$LOCAL_ONLY" == "true" || "$PULL_ONLY" == "true" ]]; then
                 log_warning "$ext: version-set resolver failed — degrading to ceiling $ceiling (recovery path)"
                 version_set_json="[\"${ceiling}\"]"
@@ -869,6 +873,8 @@ handle_pull_only_mode() {
                 log_error "$ext: version-set resolver failed — aborting pull-only (fail-closed)"
                 exit 1
             fi
+        else
+            version_set_json="$_RESOLVED_VERSION_SET_JSON"
         fi
 
         local ver
@@ -1222,7 +1228,7 @@ build_tag_push_extensions() {
         # transient upstream outage never blocks a manual rebuild.
         local ceiling version_set_json
         ceiling=$(ext_config "$ext" "version" "$config_file")
-        if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+        if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
             if [[ "$LOCAL_ONLY" == "true" ]]; then
                 log_warning "$ext: version-set resolver failed — degrading to ceiling $ceiling (LOCAL_ONLY)"
                 version_set_json="[\"$ceiling\"]"
@@ -1232,6 +1238,8 @@ build_tag_push_extensions() {
                 failed+=("$ext")
                 continue
             fi
+        else
+            version_set_json="$_RESOLVED_VERSION_SET_JSON"
         fi
 
         local set_size
@@ -1485,10 +1493,6 @@ build_tag_push_extensions() {
 }
 
 # File-backed memoisation for resolve_version_set.
-# In-memory variables cannot survive command-substitution subshells ($(...)), so
-# each resolved JSON is written to a per-run temp directory keyed by
-# "<ext>-<major>". The cache directory is created at source time so that every
-# $(...) subshell inherits the path via the exported variable.
 #
 # For direct execution, validate the status target before allocating either
 # directory, then install the EXIT trap immediately before the first allocation.
@@ -1503,6 +1507,8 @@ fi
 _RESOLVER_CACHE_DIR="$(mktemp -d)"
 export _RESOLVER_CACHE_DIR
 
+_RESOLVED_VERSION_SET_JSON=""
+
 # Per-run tracking of successfully built+pushed versions to guard against
 # GHCR/Docker Hub propagation lag: a version whose push succeeded this run
 # is counted available regardless of what the post-push registry probe sees.
@@ -1513,17 +1519,50 @@ _BUILT_THIS_RUN_DIR="$(mktemp -d)"
 export _BUILT_THIS_RUN_DIR
 
 _resolve_cached() {
-    local ext="$1" major="$2" config_file="${3:-}"
-    local cache_file="${_RESOLVER_CACHE_DIR}/${ext}-${major}.json"
+    # Resolve a version set for (config identity, extension, major).
+    # stdout is unspecified; on success the validated result is available only
+    # through _RESOLVED_VERSION_SET_JSON.
+    #
+    # A successful resolution is memoized for one main() invocation when its
+    # local _RESOLVED_VERSION_SETS map is dynamically visible. Failures are not
+    # memoized: later stages deliberately retry them as transient-outage recovery.
+    # Without that map (for example, a sourced direct caller), this degrades to
+    # the file cache rather than failing.
+    # The SHA-256 covers the complete config content, so every configuration
+    # input that can affect resolve_version_set is part of the identity.
+    _RESOLVED_VERSION_SET_JSON=""
+
+    local ext="$1" major="$2" effective_config_file="${3:-${_EXT_CONFIG}}"
+    local config_identity cache_key cache_file
     local result cache_hit=false
     local _resolver_path_cached="" _ceiling_cached=""
+    local memoization_available=false
+    local memoization_declaration=""
+
+    # The map is local to main(). declare -p avoids subscript expansion against
+    # an unset array under set -u when this script was sourced from a function.
+    if memoization_declaration=$(declare -p _RESOLVED_VERSION_SETS 2> /dev/null) \
+        && [[ "$memoization_declaration" == "declare -A "* ]]; then
+        memoization_available=true
+    fi
+
+    config_identity=$(sha256_file "$effective_config_file") || return 1
+    cache_key="${config_identity}:${ext}:${major}"
+    cache_file="${_RESOLVER_CACHE_DIR}/${ext}-${major}-${config_identity}.json"
+
+    if [[ "$memoization_available" == "true" ]]; then
+        if [[ -n "${_RESOLVED_VERSION_SETS["$cache_key"]+x}" ]]; then
+            _RESOLVED_VERSION_SET_JSON="${_RESOLVED_VERSION_SETS["$cache_key"]}"
+            return 0
+        fi
+    fi
 
     # Resolver-backed extensions require a strict semver/ceiling validation.
     # Read that configuration once so cache and resolver results use the same gate.
-    if [[ -n "${config_file:-}" ]]; then
-        _resolver_path_cached=$(yq -r ".extensions.${ext}.version_set.resolver // \"\"" "${config_file}" 2>/dev/null || true)
+    if [[ -n "${effective_config_file:-}" ]]; then
+        _resolver_path_cached=$(yq -r ".extensions.${ext}.version_set.resolver // \"\"" "${effective_config_file}" 2>/dev/null || true)
         if [[ -n "$_resolver_path_cached" ]]; then
-            _ceiling_cached=$(yq -r ".extensions.${ext}.version" "${config_file}" 2>/dev/null || true)
+            _ceiling_cached=$(yq -r ".extensions.${ext}.version" "${effective_config_file}" 2>/dev/null || true)
         fi
     fi
 
@@ -1542,7 +1581,7 @@ _resolve_cached() {
     # this function only after these shared validations pass.
     while true; do
         if [[ "$cache_hit" != "true" ]]; then
-            result=$(resolve_version_set "$ext" "$major" "${config_file}") || return 1
+            result=$(resolve_version_set "$ext" "$major" "${effective_config_file}") || return 1
         fi
 
         # Validate: must be a non-empty JSON array where every element is a string.
@@ -1578,9 +1617,17 @@ _resolve_cached() {
     done
 
     if [[ "$cache_hit" == "true" ]]; then
-        echo "$result"
+        if [[ "$memoization_available" == "true" ]]; then
+            _RESOLVED_VERSION_SETS["$cache_key"]="$result"
+        fi
+        _RESOLVED_VERSION_SET_JSON="$result"
         return 0
     fi
+
+    if [[ "$memoization_available" == "true" ]]; then
+        _RESOLVED_VERSION_SETS["$cache_key"]="$result"
+    fi
+    _RESOLVED_VERSION_SET_JSON="$result"
 
     # Write atomically so a concurrent subshell never reads a partial file.
     # The validated result remains usable even when cache persistence fails.
@@ -1599,7 +1646,7 @@ _resolve_cached() {
         fi
     fi
 
-    echo "$result"
+    return 0
 }
 
 # _image_needs_build <image>
@@ -1785,7 +1832,7 @@ _should_build_extension() {
     # local recovery path (LOCAL_ONLY=true), degrade to the single ceiling version
     # so a transient upstream outage never blocks a manual rebuild.
     local version_set_json
-    if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+    if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
         if [[ "$LOCAL_ONLY" == "true" ]]; then
             log_warning "$ext: version-set resolver failed — degrading to ceiling $version (LOCAL_ONLY)"
             version_set_json="[\"$version\"]"
@@ -1793,6 +1840,8 @@ _should_build_extension() {
             log_error "$ext: version-set resolver failed in pre-filter check"
             return 2
         fi
+    else
+        version_set_json="$_RESOLVED_VERSION_SET_JSON"
     fi
 
     # Single-version path: preserve exact existing log strings for the 8-case tests.
@@ -1969,7 +2018,7 @@ _emit_final_versionset_pass() {
 
         # Use the cache — resolver was already called during the build/filter phase.
         # If not in cache yet (e.g. pull-only path or scoped run), resolve now.
-        if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+        if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
             # Resolver failure in the final pass: distinguish publish vs recovery.
             # - Publish path (NOT LOCAL_ONLY and NOT PULL_ONLY): fail-closed —
             #   a required retention artifact cannot be produced; the run must
@@ -1992,6 +2041,7 @@ _emit_final_versionset_pass() {
             fi
             continue
         fi
+        version_set_json="$_RESOLVED_VERSION_SET_JSON"
 
         local set_size
         set_size=$(echo "$version_set_json" | jq 'length')
@@ -2422,11 +2472,12 @@ finalize_multiarch_manifests() {
 
         # Resolver-backed extension: resolve version set, validate, then merge.
         local version_set_json
-        if ! version_set_json=$(_resolve_cached "$ext" "$major_ver" "$config_file"); then
+        if ! _resolve_cached "$ext" "$major_ver" "$config_file"; then
             log_error "$ext: resolver failed in finalize-multiarch — cannot produce multi-arch manifests (fail-closed)"
             _failed=true
             continue
         fi
+        version_set_json="$_RESOLVED_VERSION_SET_JSON"
 
         # Validate: must be semver + ceiling present.
         if ! validate_semver_set_json "$version_set_json" "$ceiling"; then
@@ -2714,6 +2765,10 @@ finalize_multiarch_manifests() {
 }
 
 main() {
+    # Successful resolver results live for exactly this main() invocation.
+    # Bash dynamic scoping makes this map available to every helper main() calls.
+    local -A _RESOLVED_VERSION_SETS=()
+
     parse_args "$@"
     log_dry_run_cache_mode
 

--- a/tests/unit/build-extensions-versionset.bats
+++ b/tests/unit/build-extensions-versionset.bats
@@ -26,6 +26,12 @@ _source_build_extensions() {
     popd > /dev/null 2>&1
 }
 
+_resolver_cache_file() {
+    local ext="$1" major="$2" config_file="$3" config_identity
+    config_identity=$(sha256_file "$config_file")
+    printf '%s/%s-%s-%s.json' "$_RESOLVER_CACHE_DIR" "$ext" "$major" "$config_identity"
+}
+
 _capture_rotation_build_status() {
     local rc=0
     if build_tag_push_extensions "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" true timescaledb; then
@@ -209,6 +215,9 @@ EOF
 
     # Install mocks AFTER sourcing
     _setup_default_mocks
+
+    unset -v _RESOLVED_VERSION_SETS
+    _RESOLVED_VERSION_SET_JSON=""
 
     ROOT_DIR="$TEST_TEMP_DIR"
 }
@@ -1091,7 +1100,7 @@ _count_log_lines() {
     [ "$build_count" -eq 0 ]
 }
 
-@test "resolver-call-count: resolve_version_set called exactly once per (ext,major) across filter+build" {
+@test "resolver-call-count: source inside a function still resolves once across filter+build" {
     local counter_file="$TEST_TEMP_DIR/resolver_call_count"
     printf '0' > "$counter_file"
 
@@ -1120,7 +1129,8 @@ _count_log_lines() {
         export FORCE=false LOCAL_ONLY=false DRY_RUN=false CONTAINER=postgres
         export counter_file=\"$counter_file\"
         cd \"$SCRIPTS_DIR\"
-        source ./build-extensions.sh
+        source_build_extensions() { source ./build-extensions.sh; }
+        source_build_extensions
         # Re-set ROOT_DIR after source — build-extensions.sh resets it to the real repo
         export ROOT_DIR=\"$TEST_TEMP_DIR\"
 
@@ -1162,10 +1172,20 @@ _count_log_lines() {
         CONFIG=\"$CONFIG_FILE\"
         CDIR=\"$CONTAINER_DIR\"
 
-        # Simulate the main() pattern: filter step then build step
-        if _should_build_extension timescaledb \"\$CONFIG\" 18 \"\$CDIR\"; then
-            build_tag_push_extensions \"\$CONFIG\" 18 \"\$CDIR\" true timescaledb
-        fi
+        # Match main()'s memoization lifetime: filter step then build step
+        # share a local associative map. Prove the first write succeeded, then
+        # remove its file: the second stage must retain the in-memory result.
+        filter_and_build() {
+            local -A _RESOLVED_VERSION_SETS=()
+            if _should_build_extension timescaledb \"\$CONFIG\" 18 \"\$CDIR\"; then
+                config_identity=\$(sha256_file \"\$CONFIG\")
+                cache_file=\"\${_RESOLVER_CACHE_DIR}/timescaledb-18-\${config_identity}.json\"
+                [[ -f \"\$cache_file\" ]]
+                rm -f -- \"\$cache_file\"
+                build_tag_push_extensions \"\$CONFIG\" 18 \"\$CDIR\" true timescaledb
+            fi
+        }
+        filter_and_build
     "
 
     [ "$status" -eq 0 ]
@@ -1173,7 +1193,163 @@ _count_log_lines() {
     local call_count
     call_count=$(cat "$counter_file")
     # Must be exactly 1 — the at-most-once invariant
-    [ "$call_count" -eq 1 ]
+    [ "$call_count" -eq 1 ] || {
+        echo "resolver calls observed: $call_count" >&2
+        false
+    }
+}
+
+@test "resolver-call-count: cache write failure still resolves once across filter+build" {
+    local counter_file="$TEST_TEMP_DIR/resolver_call_count"
+    local filtered_set expected_set='["2.25.0","2.26.0","2.27.1"]'
+    printf '0' > "$counter_file"
+
+    resolve_version_set() {
+        local n
+        n=$(cat "$counter_file")
+        printf '%d' $(( n + 1 )) > "$counter_file"
+        printf '%s\n' "$expected_set"
+    }
+    mktemp() {
+        if [[ "${1:-}" == "${_RESOLVER_CACHE_DIR}/"* ]]; then
+            return 70
+        fi
+        command mktemp "$@"
+    }
+
+    filter_and_build() {
+        local -A _RESOLVED_VERSION_SETS=()
+        if ! _should_build_extension timescaledb "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR"; then
+            return 1
+        fi
+        filtered_set="$_RESOLVED_VERSION_SET_JSON"
+        build_tag_push_extensions "$CONFIG_FILE" "$MAJOR_VER" "$CONTAINER_DIR" true timescaledb
+    }
+    filter_and_build
+
+    [ "$(<"$counter_file")" -eq 1 ] || {
+        echo "resolver calls observed: $(<"$counter_file")" >&2
+        false
+    }
+    [ "$filtered_set" = "$expected_set" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = "$expected_set" ]
+}
+
+@test "resolver-call-count: distinct config identities resolve independently" {
+    local counter_file="$TEST_TEMP_DIR/resolver_call_count"
+    local second_config="$TEST_TEMP_DIR/postgres/extensions/config-second.yaml"
+    local first_set second_set
+    printf '0' > "$counter_file"
+    cp "$CONFIG_FILE" "$second_config"
+    printf '\n# distinct resolver identity\n' >> "$second_config"
+
+    resolve_version_set() {
+        local n
+        n=$(cat "$counter_file")
+        printf '%d' $(( n + 1 )) > "$counter_file"
+        if [[ "$3" == "$CONFIG_FILE" ]]; then
+            printf '%s\n' '["2.27.1"]'
+        else
+            printf '%s\n' '["2.26.0"]'
+        fi
+    }
+
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE"
+    first_set="$_RESOLVED_VERSION_SET_JSON"
+    _resolve_cached timescaledb "$MAJOR_VER" "$second_config"
+    second_set="$_RESOLVED_VERSION_SET_JSON"
+    _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE"
+    [ "$_RESOLVED_VERSION_SET_JSON" = "$first_set" ]
+    _resolve_cached timescaledb "$MAJOR_VER" "$second_config"
+    [ "$_RESOLVED_VERSION_SET_JSON" = "$second_set" ]
+
+    [ "$(<"$counter_file")" -eq 2 ] || {
+        echo "resolver calls observed: $(<"$counter_file")" >&2
+        false
+    }
+    [ "$first_set" = '["2.27.1"]' ]
+    [ "$second_set" = '["2.26.0"]' ]
+}
+
+@test "resolver-call-count: default config identities resolve independently" {
+    local counter_file="$TEST_TEMP_DIR/resolver_call_count"
+    local second_config="$TEST_TEMP_DIR/postgres/extensions/config-second.yaml"
+    local first_set second_set
+    printf '0' > "$counter_file"
+    cp "$CONFIG_FILE" "$second_config"
+    sed -i 's/2.27.1/2.26.0/' "$second_config"
+
+    resolve_version_set() {
+        local n
+        n=$(cat "$counter_file")
+        printf '%d' $(( n + 1 )) > "$counter_file"
+        if [[ "$3" == "$CONFIG_FILE" ]]; then
+            printf '%s\n' '["2.27.1"]'
+        else
+            printf '%s\n' '["2.26.0"]'
+        fi
+    }
+
+    _EXT_CONFIG="$CONFIG_FILE"
+    _resolve_cached timescaledb "$MAJOR_VER"
+    first_set="$_RESOLVED_VERSION_SET_JSON"
+    _EXT_CONFIG="$second_config"
+    _resolve_cached timescaledb "$MAJOR_VER"
+    second_set="$_RESOLVED_VERSION_SET_JSON"
+
+    [ "$(<"$counter_file")" -eq 2 ] || {
+        echo "resolver calls observed: $(<"$counter_file")" >&2
+        false
+    }
+    [ "$first_set" = '["2.27.1"]' ]
+    [ "$second_set" = '["2.26.0"]' ]
+}
+
+@test "resolver-call-count: re-source resets the file cache without a main lifetime" {
+    local counter_file="$TEST_TEMP_DIR/resolver_call_count"
+    printf '0' > "$counter_file"
+
+    run bash -c "
+        cd \"$SCRIPTS_DIR\"
+        source ./build-extensions.sh
+        resolve_version_set() {
+            local n; n=\$(cat \"$counter_file\")
+            printf '%d' \$(( n + 1 )) > \"$counter_file\"
+            printf '%s\\n' '[\"2.27.1\"]'
+        }
+        _resolve_cached timescaledb \"$MAJOR_VER\" \"$CONFIG_FILE\"
+        first_cache_dir=\"\$_RESOLVER_CACHE_DIR\"
+        source ./build-extensions.sh
+        resolve_version_set() {
+            local n; n=\$(cat \"$counter_file\")
+            printf '%d' \$(( n + 1 )) > \"$counter_file\"
+            printf '%s\\n' '[\"2.27.1\"]'
+        }
+        _resolve_cached timescaledb \"$MAJOR_VER\" \"$CONFIG_FILE\"
+        rm -rf -- \"\$first_cache_dir\" \"\$_RESOLVER_CACHE_DIR\"
+    "
+
+    [ "$status" -eq 0 ] || {
+        echo "resolver calls observed after re-source: $(<"$counter_file")" >&2
+        false
+    }
+    [ "$(<"$counter_file")" -eq 2 ] || {
+        echo "resolver calls observed: $(<"$counter_file")" >&2
+        false
+    }
+}
+
+@test "cached resolver direct call without main lifetime returns a validated result" {
+    run bash -c "
+        set -u
+        cd \"$SCRIPTS_DIR\"
+        source ./build-extensions.sh
+        resolve_version_set() { printf '%s\\n' '[\"2.27.1\"]'; }
+        _resolve_cached timescaledb \"$MAJOR_VER\" \"$CONFIG_FILE\"
+        [[ \"\$_RESOLVED_VERSION_SET_JSON\" == '[\"2.27.1\"]' ]]
+    "
+
+    [ "$status" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -4093,7 +4269,8 @@ EOF
 }
 
 @test "cached resolver returns the validated result when mktemp fails" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/cache-mktemp-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file cache-mktemp "$MAJOR_VER" "$CONFIG_FILE")
     local stdout_file="$TEST_TEMP_DIR/cache-mktemp.stdout"
     local stderr_file="$TEST_TEMP_DIR/cache-mktemp.stderr"
     local rc=0
@@ -4104,13 +4281,15 @@ EOF
     _resolve_cached cache-mktemp "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -eq 0 ]
-    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [ ! -s "$stdout_file" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["1.2.3"]' ]
     [[ "$(<"$stderr_file")" == *"cache-mktemp (PG $MAJOR_VER) at $cache_file: mktemp failed"* ]]
     [ ! -e "$cache_file" ]
 }
 
 @test "cached resolver returns the validated result and removes its temporary when printf fails" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/cache-printf-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file cache-printf "$MAJOR_VER" "$CONFIG_FILE")
     local temporary_file="${_RESOLVER_CACHE_DIR}/cache-printf-temporary"
     local stdout_file="$TEST_TEMP_DIR/cache-printf.stdout"
     local stderr_file="$TEST_TEMP_DIR/cache-printf.stderr"
@@ -4131,14 +4310,16 @@ EOF
     _resolve_cached cache-printf "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -eq 0 ]
-    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [ ! -s "$stdout_file" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["1.2.3"]' ]
     [[ "$(<"$stderr_file")" == *"cache-printf (PG $MAJOR_VER) at $cache_file: printf failed"* ]]
     [ ! -e "$cache_file" ]
     [ ! -e "$temporary_file" ]
 }
 
 @test "cached resolver returns the validated result and preserves an existing entry when mv fails" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/cache-mv-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file cache-mv "$MAJOR_VER" "$CONFIG_FILE")
     local temporary_file="${_RESOLVER_CACHE_DIR}/cache-mv-temporary"
     local original_file="$TEST_TEMP_DIR/cache-mv-original"
     local stdout_file="$TEST_TEMP_DIR/cache-mv.stdout"
@@ -4159,14 +4340,16 @@ EOF
     _resolve_cached cache-mv "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -eq 0 ]
-    [ "$(<"$stdout_file")" = '["1.2.3"]' ]
+    [ ! -s "$stdout_file" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["1.2.3"]' ]
     [[ "$(<"$stderr_file")" == *"cache-mv (PG $MAJOR_VER) at $cache_file: mv failed"* ]]
     cmp -s "$original_file" "$cache_file"
     [ ! -e "$temporary_file" ]
 }
 
 @test "cached resolver returns a valid cache entry without invoking the resolver" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file timescaledb "$MAJOR_VER" "$CONFIG_FILE")
     local stdout_file="$TEST_TEMP_DIR/cache-hit.stdout"
     local stderr_file="$TEST_TEMP_DIR/cache-hit.stderr"
     local resolver_log="$TEST_TEMP_DIR/cache-hit-resolver.log"
@@ -4181,13 +4364,15 @@ EOF
     _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -eq 0 ]
-    [ "$(<"$stdout_file")" = '["2.26.0"]' ]
+    [ ! -s "$stdout_file" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["2.26.0"]' ]
     [ ! -e "$resolver_log" ]
     [ ! -s "$stderr_file" ]
 }
 
 @test "cached resolver treats an unreadable cache entry as a miss" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file timescaledb "$MAJOR_VER" "$CONFIG_FILE")
     local stdout_file="$TEST_TEMP_DIR/cache-read.stdout"
     local stderr_file="$TEST_TEMP_DIR/cache-read.stderr"
     local resolver_log="$TEST_TEMP_DIR/cache-read-resolver.log"
@@ -4203,13 +4388,15 @@ EOF
     _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -eq 0 ]
-    [ "$(<"$stdout_file")" = '["2.27.1"]' ]
+    [ ! -s "$stdout_file" ]
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["2.27.1"]' ]
     [ "$(wc -l < "$resolver_log")" -eq 1 ]
     [[ "$(<"$stderr_file")" == *"timescaledb (PG $MAJOR_VER) at $cache_file: read failed"* ]]
 }
 
 @test "cached resolver treats invalid cache entries as misses" {
-    local cache_file="${_RESOLVER_CACHE_DIR}/timescaledb-${MAJOR_VER}.json"
+    local cache_file
+    cache_file=$(_resolver_cache_file timescaledb "$MAJOR_VER" "$CONFIG_FILE")
     local stdout_file="$TEST_TEMP_DIR/cache-invalid.stdout"
     local stderr_file="$TEST_TEMP_DIR/cache-invalid.stderr"
     local resolver_log="$TEST_TEMP_DIR/cache-invalid-resolver.log"
@@ -4224,11 +4411,13 @@ EOF
         command printf '%s' "$invalid_entry" > "$cache_file"
         rm -f "$resolver_log"
         rc=0
+        unset -v _RESOLVED_VERSION_SETS
 
         _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
         [ "$rc" -eq 0 ]
-        [ "$(<"$stdout_file")" = '["2.27.1"]' ]
+        [ ! -s "$stdout_file" ]
+        [ "$_RESOLVED_VERSION_SET_JSON" = '["2.27.1"]' ]
         [ "$(wc -l < "$resolver_log")" -eq 1 ]
         [[ "$(<"$stderr_file")" == *"timescaledb (PG $MAJOR_VER) at $cache_file"* ]]
     done
@@ -4239,12 +4428,22 @@ EOF
     local stderr_file="$TEST_TEMP_DIR/cache-resolver-failure.stderr"
     local rc=0
 
-    resolve_version_set() { return 75; }
+    resolve_version_set() {
+        if [[ "$1" == cache-seed ]]; then
+            command printf '%s\n' '["1.2.3"]'
+        else
+            return 75
+        fi
+    }
+
+    _resolve_cached cache-seed "$MAJOR_VER" "$CONFIG_FILE"
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["1.2.3"]' ]
 
     _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -ne 0 ]
     [ ! -s "$stdout_file" ]
+    [ -z "$_RESOLVED_VERSION_SET_JSON" ]
 }
 
 @test "cached resolver fails without output when the resolver fails the ceiling guard" {
@@ -4252,13 +4451,23 @@ EOF
     local stderr_file="$TEST_TEMP_DIR/cache-resolver-ceiling.stderr"
     local rc=0
 
-    resolve_version_set() { command printf '%s\n' '["2.28.0"]'; }
+    resolve_version_set() {
+        if [[ "$1" == cache-seed ]]; then
+            command printf '%s\n' '["1.2.3"]'
+        else
+            command printf '%s\n' '["2.28.0"]'
+        fi
+    }
+
+    _resolve_cached cache-seed "$MAJOR_VER" "$CONFIG_FILE"
+    [ "$_RESOLVED_VERSION_SET_JSON" = '["1.2.3"]' ]
 
     _resolve_cached timescaledb "$MAJOR_VER" "$CONFIG_FILE" > "$stdout_file" 2> "$stderr_file" || rc=$?
 
     [ "$rc" -ne 0 ]
     [ ! -s "$stdout_file" ]
     [[ "$(<"$stderr_file")" == *"injection guard"* ]]
+    [ -z "$_RESOLVED_VERSION_SET_JSON" ]
 }
 
 @test "lineage artifact new destination follows umask 0002 like a direct redirection" {

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -64,6 +64,9 @@ EOF
     # `ext_image_name`. Mocks declared before would be overwritten.
     _setup_default_mocks
 
+    unset -v _RESOLVED_VERSION_SETS
+    _RESOLVED_VERSION_SET_JSON=""
+
     # After sourcing, redirect ROOT_DIR to our temp tree
     ROOT_DIR="$TEST_TEMP_DIR"
 }
@@ -602,29 +605,29 @@ EOF
 @test "cached resolver treats an unreadable cache entry as a miss" {
     # The cache entry is a regular file this run wrote itself, so no filesystem
     # state makes `cat` fail for a root test runner. Mock the read instead.
-    printf '["9.9.9"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
+    local config_identity cache_file
+    config_identity=$(sha256_file "$CONFIG_FILE")
+    cache_file="${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}-${config_identity}.json"
+    printf '["9.9.9"]\n' > "$cache_file"
     cat() { return 1; }
     resolve_version_set() { printf '["1.2.3"]\n'; }
     local stderr_file="$TEST_TEMP_DIR/resolver-cache-read.stderr"
-    _resolve_cached_with_stderr() {
-        _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE" 2> "$stderr_file"
-    }
+    _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE" 2> "$stderr_file"
 
-    run _resolve_cached_with_stderr
-
-    [ "$status" -eq 0 ]
-    assert_equals '["1.2.3"]' "$output"
+    assert_equals '["1.2.3"]' "$_RESOLVED_VERSION_SET_JSON"
     output=$(< "$stderr_file")
-    assert_output_contains "resolver cache for pgvector (PG $MAJOR_VER) at ${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json: read failed; resolving normally"
+    assert_output_contains "resolver cache for pgvector (PG $MAJOR_VER) at $cache_file: read failed; resolving normally"
 }
 
 @test "cached resolver returns a readable cache entry" {
-    printf '["1.2.3"]\n' > "${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}.json"
+    local config_identity cache_file
+    config_identity=$(sha256_file "$CONFIG_FILE")
+    cache_file="${_RESOLVER_CACHE_DIR}/pgvector-${MAJOR_VER}-${config_identity}.json"
+    printf '["1.2.3"]\n' > "$cache_file"
 
-    run _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE"
+    _resolve_cached pgvector "$MAJOR_VER" "$CONFIG_FILE"
 
-    [ "$status" -eq 0 ]
-    assert_equals '["1.2.3"]' "$output"
+    assert_equals '["1.2.3"]' "$_RESOLVED_VERSION_SET_JSON"
 }
 
 @test "prerequisites require jq as well as yq" {


### PR DESCRIPTION
`_resolve_cached` was called through command substitution at six points in one run — status,
pull-only, build, prefilter, the final artifact pass, multi-arch finalization — so nothing it held in
memory survived a call and the file cache was the only channel between them. That cache alone carried
the at-most-once guarantee the suite asserts.

Once a cache-write failure stopped being fatal, a full disk meant each of the six resolved again, and
two resolutions of one run can see different registry state: a backfilled tag, a registry visibility
inconsistency, a tag deleted and republished. A green build could then publish an image retaining
fewer extension versions than a later stage computed. The fail-closed guard at
`helpers/extension-utils.sh:1694` does not catch that — it counts the ceiling in `available[]`, which
guards the pin rather than the completeness of the retention window, and the collector consumes
`available[]` and nothing else.

The result now reaches callers through `_RESOLVED_VERSION_SET_JSON`, the six calls run in the current
shell, and resolved sets are held in a map keyed by `sha256(config content):extension:major`. The
file cache uses the same key in its filename, so the two identities cannot drift.

## Where the map lives, and why it moved twice

The first version declared it at file scope. That is global only when the script is sourced at shell
top level: sourced from inside a function it is local to that function and gone on return, and
reading it afterwards under `set -u` kills the shell. Three of this repository's test files source it
from `setup()`, and the Bats wrapper the branch had added supplied the array — hiding the difference
from production rather than exposing it.

Measured on this host:

```
=== sourced from inside a function ===       seed: unbound variable
=== set -u, ${a[k]+x} on an unset array ===  key: unbound variable
```

The second line generalises: `${a[k]+x}` is not a safe existence test for an unset associative array.

The map now lives in `main`'s scope, where Bash's dynamic scoping reaches all six call sites;
`_resolve_cached` tests for it with `declare -p` and falls back to the file cache when it is absent;
the Bats wrapper is gone. Verified with a probe whose control — the same read against a deliberately
undeclared array — dies as it must, while the branch survives with `rc=0` after being sourced from a
function with no `main` on the stack.

Also here: the config digest now calls `helpers/hash-utils.sh::sha256_file`, which already existed and
was re-derived byte for byte; the comment no longer promises memoization of failures that are
deliberately retried; and it no longer claims a stdout result the function stopped producing.

## Verification

- `bats` over every tracked `*.bats` file: **2898 pass, 0 fail, 113 files**, each file's plan matching
  its own record count.
- `shellcheck -x -S warning` exits 0.
- Mutations, each red after a green control: forcing the memory lookup to miss turns both counting
  tests red including the cache-write-failure one; dropping the config identity from the key turns the
  two-config test red; removing the reset on sourcing turns the re-source test red; not clearing the
  out-parameter at entry turns both no-output failure tests red; losing the `_EXT_CONFIG` default
  turns the default-config test red; and forcing the guard to believe the map present turns two tests
  red **by assertion**, without killing bats.

## Not fixed here

#1436 — two of this branch's own tests stay green under the regression they name: the config-aware key
is asserted only on the filename because `setup()` unsets the map, and the cache-write-failure test
proves memoization rather than that the write failed. It also carries a stdout contract asserted one
way and documented another, and a lifetime comment narrower than the three lifetimes that exist.

Also open: #1429 (a `yq` read that swallows its own errors disables the injection guard; an eviction
can delete an entry another caller just published; the config can change between the hash and the
reads), #1431 (the ceiling itself is never validated, so a malformed bound means no bound), #1432,
#1434 (the README states Bash 4.0+ while production code uses `declare -g`, which needs 4.2), #1435
(`validate_prerequisites` does not probe for the hash command every resolution now needs).

Closes #1430
