### PR TITLE
State the Bash baseline the code needs, and refuse a broken hash tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,12 @@ That's it. The CI picks it up automatically on next push.
 ## Requirements
 
 - Docker Engine 20.10+ (or Podman)
-- Bash 4.0+
-- [yq](https://github.com/mikefarah/yq) (for variant containers)
+- Supported Bash baseline: 4.4+ — `mapfile -d` is used on the documented extension build path.
+- [yq](https://github.com/mikefarah/yq) (for variant containers and extension builds)
+- [jq](https://jqlang.org/) (for extension builds)
+- `sha256sum` (for extension-build resolver cache identities). GNU coreutils
+  provides it; on macOS, `brew install coreutils` and put its `libexec/gnubin`
+  on `PATH`.
 - A `timeout` accepting `-k`, for the e2e suite and registry helpers — it keeps
   container cleanup and registry operations from waiting forever on a child
   that ignores SIGTERM. GNU coreutils provides it and most Linux distributions

--- a/helpers/collect-lines.sh
+++ b/helpers/collect-lines.sh
@@ -18,10 +18,10 @@
 # Producers used here return explicitly; `helpers/generate-utils.sh::list_distros`
 # is the one that had to be changed to.
 #
-# Bash 4.0 compatibility is deliberate: do not use local/declare -n namerefs
-# (they require Bash 4.3).  This covers array collection through mapfile/readarray
-# from process substitution.  It does not cover while-read process-substitution
-# consumers: 61 non-test sites remain and are tracked separately in #1117.
+# The helper supports array collection through mapfile/readarray from process
+# substitution.
+# It does not cover while-read process-substitution consumers: 61 non-test sites
+# remain and are tracked separately in #1117.
 # GHCR tag enumeration before a deletion decision is handled explicitly by its
 # caller.  The helper is intentionally a library function: it returns status and
 # never exits its caller.

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -1247,9 +1247,9 @@ _generate_flavor_initdb_block() {
 #
 # Caller captures stdout and splits on the delimiter to obtain stages_block and copies_block.
 #
-# Portable bash-4.0 pattern (no local -n namerefs, which require bash 4.3+):
+# Serialized version-to-ref input:
 #   <ver_ref_list> is a newline-delimited list of "<version>\t<ref>" pairs.
-#   Caller serializes its version→ref map as "<ver>\t<ref>\n..." and passes it.
+#   Caller constructs a serialized version→ref list as "<ver>\t<ref>\n..." and passes it.
 #
 # Args:
 #   $1  ext          extension name (e.g. "timescaledb")
@@ -1743,14 +1743,9 @@ generate_dockerfile() {
                     raw_versions=$(echo "$_versionset_json" | jq -r '.available[]' 2>/dev/null || true)
 
                     if [[ -n "$raw_versions" ]]; then
-                        # Build version→ref map for the emitter.
-                        # Use the global _ECS_REF_MAP (bash-4.0 portable; no local -n namerefs
-                        # which require bash 4.3+).  Reset before population to avoid stale
-                        # entries from a previous extension in the same generate_dockerfile call.
-                        # Build a serialized version→ref list (tab-delimited "<ver>\t<ref>" lines).
-                        # Portable bash-4.0 pattern: no local -n namerefs (require bash 4.3+);
-                        # no global associative arrays (unreliable across forked subshells when
-                        # sourced inside a function scope). Serializing as a string passes cleanly.
+                        # Build one serialized version→ref list (tab-delimited "<ver>\t<ref>" lines)
+                        # for both branches: self-heal has a resolved-ref map, while the artifact
+                        # branch constructs refs directly.
                         local _ecs_ver_ref_list=""
                         if [[ "$_versionset_from_selfheal" == "true" ]]; then
                             # Self-heal path: refs already resolved by the source gateway above.

--- a/helpers/hash-utils.sh
+++ b/helpers/hash-utils.sh
@@ -12,10 +12,22 @@
 # Do NOT add set -e at file scope; this is a sourced helper.
 
 # sha256_file <path>
-# Prints the lowercase hex SHA-256 of the file at <path>.
-# Returns 1 if the file cannot be read.
+# Prints the lowercase SHA-256 digest of the file at <path>.
+# Returns 1 if the file cannot be read or sha256sum does not produce a first
+# whitespace-delimited 64-hex field without an interior newline.  Text after
+# that field is accepted; command substitution discards trailing newlines.
 sha256_file() {
     local file="${1:?sha256_file: file path required}"
+    local sha256_output digest
     [[ -r "$file" ]] || { echo "sha256_file: cannot read '$file'" >&2; return 1; }
-    sha256sum < "$file" | awk '{print $1}'
+    if ! sha256_output=$(sha256sum < "$file"); then
+        echo "sha256_file: sha256sum failed for '$file'" >&2
+        return 1
+    fi
+    digest="${sha256_output%%[[:space:]]*}"
+    if [[ "$sha256_output" == *$'\n'* || ${#digest} -ne 64 || "$digest" == *[!0-9A-Fa-f]* ]]; then
+        echo "sha256_file: sha256sum returned an invalid digest for '$file'" >&2
+        return 1
+    fi
+    printf '%s\n' "${digest,,}"
 }

--- a/scripts/build-extensions.sh
+++ b/scripts/build-extensions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build and push extension images for containers with compiled extensions
 # Images are pushed to registry (ghcr.io) for use with COPY --from=
 #
@@ -803,7 +803,7 @@ pull_extension() {
 
 # --- Helpers extracted from main() for readability ---
 
-# Validate container dir, config, yq, and jq are available. Exits on failure.
+# Validate prerequisites. Exits on failure.
 validate_prerequisites() {
     local container_dir="$ROOT_DIR/$CONTAINER"
     if [[ ! -d "$container_dir" ]]; then
@@ -815,11 +815,15 @@ validate_prerequisites() {
         exit 1
     fi
     if ! command -v yq &>/dev/null; then
-        log_error "yq is required for YAML parsing. Install with: brew install yq"
+        log_error "yq is required for YAML parsing; see README.md#requirements to install it and put yq on PATH."
         exit 1
     fi
     if ! command -v jq &>/dev/null; then
-        log_error "jq is required for JSON parsing. Install with: brew install jq"
+        log_error "jq is required for JSON parsing; see README.md#requirements to install it and put jq on PATH."
+        exit 1
+    fi
+    if ! command -v sha256sum &>/dev/null; then
+        log_error "sha256sum is required for resolver cache hashing; see README.md#requirements, including macOS PATH setup."
         exit 1
     fi
 }

--- a/tests/unit/build-extensions.bats
+++ b/tests/unit/build-extensions.bats
@@ -630,18 +630,33 @@ EOF
     assert_equals '["1.2.3"]' "$_RESOLVED_VERSION_SET_JSON"
 }
 
-@test "prerequisites require jq as well as yq" {
+@test "prerequisites require yq, jq, and sha256sum" {
     local test_path="$TEST_TEMP_DIR/bin"
     mkdir -p "$test_path"
+
+    ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
+    [ "$status" -ne 0 ]
+    assert_output_contains "yq is required for YAML parsing; see README.md#requirements"
+    assert_output_contains "put yq on PATH"
+
     printf '#!/bin/bash\nexit 0\n' > "$test_path/yq"
     chmod +x "$test_path/yq"
 
     ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
     [ "$status" -ne 0 ]
-    assert_output_contains "jq is required for JSON parsing"
+    assert_output_contains "jq is required for JSON parsing; see README.md#requirements"
+    assert_output_contains "put jq on PATH"
 
     printf '#!/bin/bash\nexit 0\n' > "$test_path/jq"
     chmod +x "$test_path/jq"
+
+    ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
+    [ "$status" -ne 0 ]
+    assert_output_contains "sha256sum is required for resolver cache hashing; see README.md#requirements"
+    assert_output_contains "macOS PATH setup"
+
+    printf '#!/bin/bash\nexit 0\n' > "$test_path/sha256sum"
+    chmod +x "$test_path/sha256sum"
 
     ROOT_DIR="$TEST_TEMP_DIR" CONTAINER="postgres" PATH="$test_path" run validate_prerequisites
     [ "$status" -eq 0 ]

--- a/tests/unit/hash-utils.bats
+++ b/tests/unit/hash-utils.bats
@@ -53,6 +53,78 @@ teardown() {
     [ "$output" = "$expected" ]
 }
 
+@test "sha256_file: accepts a binary-stdin marker after the digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local expected
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    expected=$(printf '%064d' 0)
+    printf '#!/usr/bin/env bash\nprintf "%%064d *-\\n" 0\n' > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    PATH="$bin_dir:$PATH" run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+}
+
+@test "sha256_file: lowercases an uppercase digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local uppercase_digest='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    [ "${#uppercase_digest}" -eq 64 ]
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$uppercase_digest *-" > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    PATH="$bin_dir:$PATH" run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "${uppercase_digest,,}" ]
+}
+
+@test "sha256_file: does not change a caller's BASH_REMATCH" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local captured="$TEST_TEMP_DIR/captured"
+    printf 'data\n' > "$file"
+
+    local caller_input='caller-123'
+    [[ "$caller_input" =~ ^([a-z]+)-([0-9]+)$ ]]
+    local caller_match="${BASH_REMATCH[1]}"
+    local caller_capture="${BASH_REMATCH[2]}"
+
+    if ! sha256_file "$file" > "$captured"; then
+        echo "sha256_file unexpectedly failed"
+        return 1
+    fi
+    [ "${BASH_REMATCH[1]}" = "$caller_match" ]
+    [ "${BASH_REMATCH[2]}" = "$caller_capture" ]
+}
+
+@test "sha256_file: accepts the GNU stdin form and trailing blank lines" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local digest='0000000000000000000000000000000000000000000000000000000000000000'
+    local payload="${digest}  -"$'\n\n'
+    local expected="$TEST_TEMP_DIR/expected"
+    local actual="$TEST_TEMP_DIR/actual"
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    printf '#!/bin/bash\nprintf "%%s" %q\nexit 0\n' "$payload" > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    printf '%s' "$payload" > "$expected"
+    if ! "$bin_dir/sha256sum" > "$actual"; then
+        echo "generated sha256sum stub failed"
+        return 1
+    fi
+    cmp -s "$expected" "$actual"
+
+    PATH="$bin_dir:$PATH" run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$digest" ]
+}
+
 # ---------------------------------------------------------------------------
 # Regression lock — backslash in filename
 # ---------------------------------------------------------------------------
@@ -92,6 +164,17 @@ teardown() {
     [ "$output" = "$expected" ]
 }
 
+@test "sha256_file: preserves stdin hashing for a filename containing a backslash and newline" {
+    local file="$TEST_TEMP_DIR/foo\\bar"$'\n'"line.bin"
+    local expected
+    printf 'newline-safe data\n' > "$file"
+
+    expected=$(sha256sum < "$file" | awk '{print $1}')
+    run sha256_file "$file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+}
+
 # ---------------------------------------------------------------------------
 # Fail-closed — missing or unreadable file
 # ---------------------------------------------------------------------------
@@ -116,4 +199,75 @@ teardown() {
 @test "sha256_file: returns non-zero when called without arguments" {
     run sha256_file
     [ "$status" -ne 0 ]
+}
+
+# A broken or incompatible sha256sum must not supply a cache identity.
+@test "sha256_file: refuses empty sha256sum output without emitting a digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local captured="$TEST_TEMP_DIR/captured"
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    printf '#!/bin/bash\nexit 0\n' > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    PATH="$bin_dir:$PATH"
+    if sha256_file "$file" > "$captured"; then
+        echo "sha256_file accepted empty sha256sum output"
+        return 1
+    fi
+    [ ! -s "$captured" ]
+}
+
+@test "sha256_file: refuses a failing sha256sum without emitting a digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local captured="$TEST_TEMP_DIR/captured"
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    # shellcheck disable=SC2183 # The generated stub, not this test, consumes %064d.
+    printf '#!/bin/bash\nprintf "%064d  -\\n" 0\nexit 9\n' > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    PATH="$bin_dir:$PATH"
+    if sha256_file "$file" > "$captured"; then
+        echo "sha256_file accepted a failing sha256sum"
+        return 1
+    fi
+    [ ! -s "$captured" ]
+}
+
+@test "sha256_file: refuses malformed sha256sum output without emitting a digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local captured="$TEST_TEMP_DIR/captured"
+    local malformed
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+
+    for malformed in \
+        'abc  -' \
+        '00000000000000000000000000000000000000000000000000000000000000000  -' \
+        'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg  -' \
+        $'0000000000000000000000000000000000000000000000000000000000000000  -\n0000000000000000000000000000000000000000000000000000000000000000  -'; do
+        local expected="$TEST_TEMP_DIR/expected"
+        local actual="$TEST_TEMP_DIR/actual"
+        printf '#!/bin/bash\nprintf "%%s" %q\nexit 0\n' "$malformed" > "$bin_dir/sha256sum"
+        chmod +x "$bin_dir/sha256sum"
+        printf '%s' "$malformed" > "$expected"
+        if ! "$bin_dir/sha256sum" > "$actual"; then
+            echo "generated sha256sum stub failed for malformed output: $malformed"
+            return 1
+        fi
+        if ! cmp -s "$expected" "$actual"; then
+            echo "generated sha256sum stub did not emit the malformed output exactly: $malformed"
+            return 1
+        fi
+        PATH="$bin_dir:$PATH"
+        if sha256_file "$file" > "$captured"; then
+            printf 'FAIL: sha256_file accepted malformed sha256sum output: %q\n' "$malformed"
+            return 1
+        fi
+        [ ! -s "$captured" ]
+    done
 }


### PR DESCRIPTION
The README asked for a Bash version derived from one construct. Sweeping every version-gated
construct instead gives 4.4: `mapfile -d` in `generate_dockerfile` is the only one above 4.2 that no
guard protects. Every `EPOCHREALTIME` use is guarded and prints an explicit degraded line, so it buys
duration output rather than correctness and does not raise the baseline.

At 4.4 namerefs are available, so three comments forbidding them on version grounds lose their
reason. The one that had a second reason now states it, and two comments describing a data flow the
file does not have are gone.

`sha256_file` now fails unless `sha256sum` succeeds and yields one 64-hex first field, returned
lowercased. Its pipeline previously masked a failing command because `awk` still exits 0, and an
empty digest collapsed every configuration for one extension and major onto a single cache identity.

Requirements now names `jq` and `sha256sum`, which the extension build exits without, and the three
prerequisite messages point there instead of prescribing one platform's package manager.
`scripts/build-extensions.sh` resolves its interpreter through `PATH` like the launcher that runs it.

## Verification

- Full bats suite: 2906 pass, 0 fail, 113 files, each file's plan matching its own record count.
- `shellcheck -x -S warning` and `bash -n` clean on every changed shell file.
- Four predicates mutation-proved with the control green and the mutant red each time: the
  lowercasing, the digest-length test, the non-hex test, and the interior-newline test.
- A test in this area was found green while proving nothing — its stub generator passed two `printf`
  conversions one argument, so two fixtures produced invalid shell and were rejected as a failing
  command rather than as malformed output. One of them listed the ordinary GNU `sha256sum` output as
  malformed. Each fixture now runs its own stub and compares its stdout before the function sees it,
  and the GNU form is asserted as accepted.

## Known and filed

- #1439 — twelve other files pin `#!/bin/bash`, so running them directly ignores a `PATH`-installed
  Bash. Only `scripts/build-extensions.sh` is changed here.
- #1441 — `sha256_file`'s hex test depends on locale and a shell option, command substitution erases
  NUL bytes, and its arity check terminates a sourced caller.
- #1442 — a config replaced mid-run is memoized under the previous revision's digest.

Closes #1434
Closes #1435
