### PR TITLE
Stop the age pruner deleting manifests it cannot resolve

### DIFF
--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -145,7 +145,13 @@ purge_container() {
     position=$((position + 1))
     keep_reason=""
 
-    if grep -q ",latest," <<< ",$tags,"; then
+    # Age cannot establish whether an untagged manifest is a live platform
+    # child of a retained index. Retain it here: cleanup-outdated-tags.sh is
+    # the only deletion authority. Its workflow sweep coverage is stated once
+    # in the run summary below.
+    if [[ -z "$tags" ]]; then
+      keep_reason="untagged; deferred to cleanup-outdated-tags.sh"
+    elif grep -q ",latest," <<< ",$tags,"; then
       keep_reason="has 'latest' tag"
     elif [[ "$position" -le "$KEEP_LATEST_COUNT" ]]; then
       keep_reason="in top $KEEP_LATEST_COUNT recent"
@@ -179,7 +185,7 @@ purge_container() {
     fi
 
     if [[ -n "$keep_reason" ]]; then
-      echo "  ✓ Keep #$position (tags: ${tags:-untagged}) - $keep_reason" >&2
+      echo "  ✓ Keep #$position (version $version_id; tags: ${tags:-untagged}) - $keep_reason" >&2
       kept=$((kept + 1))
     elif ! printf '%s|%s\n' "$position" "$record_b64" >> "$deletions_file"; then
       echo "  ✗ Failed to prepare deletion list; skipping $container" >&2
@@ -263,6 +269,14 @@ main() {
   if [[ $# -gt 0 ]]; then
     containers="$*"
   else
+    # The workflow's reference-aware sweep coverage is stated once in the run
+    # summary below. Untagged versions are retained here, not deleted.
+    # That sweep is the sole authority for deleting untagged versions: it protects
+    # .manifests[].digest children of kept manifests, but does not follow OCI
+    # referrers (attestations, SBOMs, signatures) or external digest pins.
+    # Keep the discovery paths aligned; otherwise untagged versions can only
+    # accumulate. If its obsolete-tag deletion fails, it skips orphan cleanup
+    # fail-closed, which deliberately retains untagged versions for that run.
     containers=$(find "$root_dir" -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed "s|^$root_dir/||" | sort) || return 1
   fi
 
@@ -327,6 +341,8 @@ main() {
   echo "Versions kept: $total_kept"
   echo "Versions deleted: $total_deleted"
   echo "Delete failures: $total_delete_failures"
+  echo "Untagged versions: retained here; cleanup-outdated-tags.sh is their only deletion authority. Sweep coverage: scheduled runs and unfiltered purge dispatches sweep the whole discovered set; filtered purge dispatches sweep only the selected package; dispatches without purge_obsolete sweep nothing."
+  echo "If that sweep skips orphan cleanup after a deletion failure, retention is fail-closed for this run."
   echo "========================================"
 
   if [[ "$total_listing_failures" -gt 0 || "$total_processing_failures" -gt 0 || "$total_delete_failures" -gt 0 ]]; then

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -53,7 +53,7 @@ if [[ "${GH_MODE:-}" == "malformed-record" && "$*" == *"/container/broken/versio
 fi
 
 if [[ "${GH_MODE:-}" == "delete-failure" || "${GH_MODE:-}" == "cleanup-failure" ]]; then
-    printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":[]}},"created_at":"2000-01-01T00:00:00Z"}]'
+    printf '%s\n' '[{"id":101,"name":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","metadata":{"container":{"tags":["obsolete"]}},"created_at":"2000-01-01T00:00:00Z"}]'
 else
     printf '%s\n' '[]'
 fi
@@ -144,7 +144,7 @@ assert_prepared_decode_preserves_delete_totals() {
     [[ "$output" == *"Packages skipped (listing failed): 1"* ]]
 }
 
-@test "two paginated version arrays are flattened so a second-page version is classified" {
+@test "two paginated version arrays are flattened so a second-page untagged version is retained" {
     cat > "$STUB_DIR/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -169,8 +169,8 @@ EOF
         bash "$PROJECT_ROOT/scripts/cleanup-old-versions.sh" stale
 
     [[ "$status" -eq 0 ]]
-    if [[ "$output" != *"Would delete version 102"* ]]; then
-        echo "ASSERTION FAILED: expected second-page version 102 to be classified" >&2
+    if [[ "$output" == *"Would delete version 102"* || "$output" != *"Keep #2 (version 102; tags: untagged) - untagged; deferred to cleanup-outdated-tags.sh"* ]]; then
+        echo "ASSERTION FAILED: expected second-page untagged version 102 to be retained" >&2
         return 1
     fi
     [[ "$output" == *"Found 2 versions"* ]]
@@ -224,7 +224,7 @@ EOF
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
                 if [[ "$*" == *"/versions"* ]]; then
-                    printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+                    printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"obsolete\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
                 else
                     printf "%s\\n" "{\"version_count\":2}"
                 fi
@@ -235,6 +235,60 @@ EOF
     [[ "$status" -eq 0 ]]
     [[ "$(<"$GH_LOG")" == *"/versions/102"* ]]
     [[ "$output" == *"Summary: kept=1, deleted=1, delete_failures=0"* ]]
+}
+
+@test "stale untagged records beyond the latest-count window never reach DELETE" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\n" "{\"version_count\":3}"; return 0; fi
+                printf "%s\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":103,\"name\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            main stale-untagged
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ ! -s "$GH_LOG" ]]
+    [[ "$output" == *"Summary: kept=3, deleted=0, delete_failures=0"* ]]
+    [[ "$output" == *"Versions deleted: 0"* ]]
+}
+
+@test "age cleanup deletes a stale tagged record but not a stale untagged record" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="false" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\n" "{\"version_count\":2}"; return 0; fi
+                printf "%s\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"obsolete\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            main mixed-stale
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
+    [[ "$(<"$GH_LOG")" != *"/versions/102"* ]]
+    [[ "$(wc -l < "$GH_LOG")" -eq 1 ]]
+    [[ "$output" == *"Summary: kept=1, deleted=1, delete_failures=0"* ]]
+    [[ "$output" == *"Versions deleted: 1"* ]]
 }
 
 @test "an absent or non-numeric package version total refuses the listing" {
@@ -604,7 +658,7 @@ EOF
             gh() {
                 if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
                 if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":2}"; return 0; fi
-                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"obsolete-a\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"},{\"id\":102,\"name\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"metadata\":{\"container\":{\"tags\":[\"obsolete-b\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
             }
             base64() {
                 calls=0; [[ -f "$BASE64_CALLS" ]] && calls=$(<"$BASE64_CALLS")


### PR DESCRIPTION
An untagged GHCR version matches none of the age pruner's three tag-based keep rules, so age alone
decided its fate — and age cannot tell a dead layer from a live platform child of a retained
multi-arch index. It never asked what referenced it.

Untagged versions are now retained here. `scripts/cleanup-outdated-tags.sh` runs next in the same
job and already deletes them, protected by the manifest graph, over a superset of the same packages.

## Why subtraction rather than a protection stage

Adding one here could not resolve only the tagged versions: sampling 60 untagged versions per
package, 11 of 60 on postgres and up to 24 of 60 on web-shell are themselves indexes with children.
It would have to resolve every kept version — roughly 12 500 manifest fetches for postgres alone,
monthly. Removing the unprotected path costs nothing and closes it by construction.

## Verification

- Replaying the four keep rules against the live registry at a cutoff 120 days out: **46 untagged
  manifests across postgres, web-shell, sslh, jekyll and vector would be deleted while a version the
  pruner keeps references them.** Nothing is deleted today only because the registry is uniformly
  young — the oldest version beyond position 10 sits at 180 days, one day inside the cutoff.
- Full bats suite: 2908 pass, 0 fail, 113 files, each file's plan matching its own record count.
- `shellcheck -x -S warning` and `bash -n` clean.
- The untagged keep rule and the deferral log line are each mutation-proved, control green and
  mutant red.

## Known and filed

- #1446 — a **tagged** platform child still routes into the age rules. Measured: 0 instances at the
  120-day cutoff, 1 at 730 days. Closing that class needs a single mark-and-sweep owner.
- #1447 — `container_filter` reaches only one of the two pruners, so a targeted dispatch still
  age-prunes every package.

Deleting OCI referrers was considered and does not apply: 0 of 138 manifests sampled across eight
packages carries a `subject`. The script documents that limit rather than guarding it.

Closes #1415
