### PR TITLE
Resolve interpreters through PATH, and make sha256_file return

### DIFF
--- a/helpers/base-cache-utils.sh
+++ b/helpers/base-cache-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Base image cache utilities
 # Reads base_image_cache from config.yaml and provides helpers for:
 # - Syncing Docker Hub base images to GHCR (CI sync job — sync_base_images_to_ghcr)

--- a/helpers/dependency-freshness.sh
+++ b/helpers/dependency-freshness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Dependency freshness resolvers for SBOM changelog enrichment.
 #
 # Public entry points:

--- a/helpers/extension-utils.sh
+++ b/helpers/extension-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Shared utilities for extension building and management
 # Used by scripts/build-extensions.sh
 # Works both locally and in GitHub Actions

--- a/helpers/generate-utils.sh
+++ b/helpers/generate-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Shared utilities for Dockerfile generators (template+generator pattern)
 # Used by: web-shell/generate-dockerfile.sh, github-runner/generate-dockerfile.sh
 #

--- a/helpers/hash-utils.sh
+++ b/helpers/hash-utils.sh
@@ -14,18 +14,23 @@
 # sha256_file <path>
 # Prints the lowercase SHA-256 digest of the file at <path>.
 # Returns 1 if the file cannot be read or sha256sum does not produce a first
-# whitespace-delimited 64-hex field without an interior newline.  Text after
-# that field is accepted; command substitution discards trailing newlines.
+# whitespace-delimited ASCII 64-hex field without an interior newline. Text
+# after that field is accepted. Validation sees the text that survives command
+# substitution: raw NUL bytes and trailing newlines were already removed.
 sha256_file() {
-    local file="${1:?sha256_file: file path required}"
-    local sha256_output digest
+    local file sha256_output digest
+    if (($# != 1)) || [[ -z "$1" ]]; then
+        echo "sha256_file: exactly one non-empty file path required" >&2
+        return 1
+    fi
+    file="$1"
     [[ -r "$file" ]] || { echo "sha256_file: cannot read '$file'" >&2; return 1; }
     if ! sha256_output=$(sha256sum < "$file"); then
         echo "sha256_file: sha256sum failed for '$file'" >&2
         return 1
     fi
     digest="${sha256_output%%[[:space:]]*}"
-    if [[ "$sha256_output" == *$'\n'* || ${#digest} -ne 64 || "$digest" == *[!0-9A-Fa-f]* ]]; then
+    if [[ "$sha256_output" == *$'\n'* || ${#digest} -ne 64 || "$digest" == *[!0123456789abcdefABCDEF]* ]]; then
         echo "sha256_file: sha256sum returned an invalid digest for '$file'" >&2
         return 1
     fi

--- a/helpers/python-tags
+++ b/helpers/python-tags
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Get Python package latest version
 
 function get_pypi_latest_version() {
 	local package=$1
-	local version=$(curl -s --fail --max-time 30 "https://pypi.org/pypi/${package}/json" | jq -r '.info.version' 2>/dev/null)
+	local version
+	version=$(curl -s --fail --max-time 30 "https://pypi.org/pypi/${package}/json" | jq -r '.info.version' 2>/dev/null) || true
 	if [[ -n "$version" && "$version" != "null" ]]; then
 		echo "$version"
 	else

--- a/helpers/sbom-utils.sh
+++ b/helpers/sbom-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SBOM (Software Bill of Materials) utilities
 # Provides functions for SBOM generation, comparison, and build history tracking.
 #

--- a/helpers/skopeo-squash
+++ b/helpers/skopeo-squash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Containerized skopeo helper for squashing images in registries
 
 set -euo pipefail

--- a/helpers/template-utils.sh
+++ b/helpers/template-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generic Dockerfile template expansion utilities
 # Replaces @@MARKER@@ comment lines in a Dockerfile template with generated content.
 #

--- a/helpers/validate-base-cache-schema.sh
+++ b/helpers/validate-base-cache-schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-base-cache-schema.sh
 # Static schema-validation guard for base_image_cache entries in config.yaml files.
 #

--- a/helpers/validate-extensions-schema.sh
+++ b/helpers/validate-extensions-schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-extensions-schema.sh
 # Static schema-validation guard for postgres/extensions/config.yaml.
 #

--- a/helpers/variant-utils.sh
+++ b/helpers/variant-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Variant utilities for multi-image containers
 # Used by build-container.sh and generate-dashboard.sh
 #

--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Age-based cleanup of GHCR container versions.
 #
 # Required env vars: GH_TOKEN, OWNER

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Purge container images whose tags are not in the current valid build set.
 # Required env vars: GH_TOKEN, OWNER
 

--- a/scripts/rotate-versions.sh
+++ b/scripts/rotate-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rotate versions in variants.yaml for automated version updates
 #
 # Usage: rotate-versions.sh <container_dir> <new_version> [major_line]

--- a/tests/unit/hash-utils.bats
+++ b/tests/unit/hash-utils.bats
@@ -201,6 +201,108 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
+@test "sha256_file: rejects non-ASCII digests regardless of locale glob ranges" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local stdout="$TEST_TEMP_DIR/stdout"
+    local error_file="$TEST_TEMP_DIR/stderr"
+    local non_ascii_digest payload
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    non_ascii_digest=$(printf 'ª%.0s' {1..64})
+    payload="$non_ascii_digest  -"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$payload" > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    run locale -a
+    [ "$status" -eq 0 ] || {
+        echo "FAIL: locale -a must succeed before testing en_US.utf8"
+        return 1
+    }
+    printf '%s\n' "$output" | grep -Fxq 'en_US.utf8' || {
+        echo "FAIL: en_US.utf8 locale is required to test locale-independent digest validation"
+        return 1
+    }
+
+    run env LC_ALL=en_US.utf8 bash -c '
+        shopt -u globasciiranges
+        [[ "$1" == *[!0-9A-Fa-f]* ]]
+    ' _ "$non_ascii_digest"
+    [ "$status" -ne 0 ] || {
+        echo "FAIL: en_US.utf8 control must accept ª in the old non-ASCII range predicate"
+        return 1
+    }
+
+    run env PATH="$bin_dir:$PATH" LC_ALL=en_US.utf8 bash -c '
+        shopt -u globasciiranges
+        source "$1"
+        sha256_file "$2" > "$3" 2> "$4"
+    ' bash "$HELPERS_DIR/hash-utils.sh" "$file" "$stdout" "$error_file"
+
+    [ "$status" -ne 0 ]
+    [ ! -s "$stdout" ]
+    [[ "$(<"$error_file")" == *"invalid digest"* ]]
+}
+
+@test "sha256_file: no or empty path returns to the sourced caller" {
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local stdout error_file
+    mkdir -p "$bin_dir"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$(printf '%064d' 0)  -" > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    for invocation in no-argument empty-argument; do
+        stdout="$TEST_TEMP_DIR/$invocation.stdout"
+        error_file="$TEST_TEMP_DIR/$invocation.stderr"
+        if [[ "$invocation" == no-argument ]]; then
+            run env PATH="$bin_dir:$PATH" bash -c '
+                source "$1"
+                if sha256_file > "$2" 2> "$3"; then
+                    exit 1
+                fi
+                printf "caller-reached\\n"
+            ' bash "$HELPERS_DIR/hash-utils.sh" "$stdout" "$error_file"
+        else
+            run env PATH="$bin_dir:$PATH" bash -c '
+                source "$1"
+                if sha256_file "" > "$2" 2> "$3"; then
+                    exit 1
+                fi
+                printf "caller-reached\\n"
+            ' bash "$HELPERS_DIR/hash-utils.sh" "$stdout" "$error_file"
+        fi
+
+        [ "$status" -eq 0 ]
+        [ "$output" = "caller-reached" ]
+        [ ! -s "$stdout" ]
+        [[ "$(<"$error_file")" == *"file path required"* ]]
+    done
+}
+
+@test "sha256_file: rejects extra path arguments without emitting a digest" {
+    local file="$TEST_TEMP_DIR/data.bin"
+    local bin_dir="$TEST_TEMP_DIR/bin"
+    local stdout="$TEST_TEMP_DIR/stdout"
+    local error_file="$TEST_TEMP_DIR/stderr"
+    printf 'data\n' > "$file"
+    mkdir -p "$bin_dir"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$(printf '%064d' 0)  -" > "$bin_dir/sha256sum"
+    chmod +x "$bin_dir/sha256sum"
+
+    run env PATH="$bin_dir:$PATH" bash -c '
+        source "$1"
+        if sha256_file "$2" ignored > "$3" 2> "$4"; then
+            exit 1
+        fi
+        printf "caller-reached\\n"
+    ' bash "$HELPERS_DIR/hash-utils.sh" "$file" "$stdout" "$error_file"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "caller-reached" ]
+    [ ! -s "$stdout" ]
+    [[ "$(<"$error_file")" == *"one non-empty file path"* ]]
+}
+
 # A broken or incompatible sha256sum must not supply a cache identity.
 @test "sha256_file: refuses empty sha256sum output without emitting a digest" {
     local file="$TEST_TEMP_DIR/data.bin"
@@ -223,10 +325,12 @@ teardown() {
     local file="$TEST_TEMP_DIR/data.bin"
     local bin_dir="$TEST_TEMP_DIR/bin"
     local captured="$TEST_TEMP_DIR/captured"
+    local failing_payload
     printf 'data\n' > "$file"
     mkdir -p "$bin_dir"
-    # shellcheck disable=SC2183 # The generated stub, not this test, consumes %064d.
-    printf '#!/bin/bash\nprintf "%064d  -\\n" 0\nexit 9\n' > "$bin_dir/sha256sum"
+    # The outer printf consumes %064d here; %q quotes that payload for the generated stub.
+    failing_payload=$(printf '%064d  -\n' 0)
+    printf '#!/usr/bin/env bash\nprintf "%%s" %q\nexit 9\n' "$failing_payload" > "$bin_dir/sha256sum"
     chmod +x "$bin_dir/sha256sum"
 
     PATH="$bin_dir:$PATH"


### PR DESCRIPTION
Fourteen files under `scripts/` and `helpers/` pinned `#!/bin/bash`, so a host whose `/bin/bash`
predates the documented baseline ignored the Bash the README asks it to install. Four of them are
executed by path, one through a relative `../helpers/` invocation; the other eleven are sourced,
where the line was inert, and now match the 51 files that already resolved through `PATH`.

`sha256_file` had two defects, both measured:

- Its hex test used `[!0-9A-Fa-f]`, a glob range that follows collation. Under `LC_ALL=en_US.utf8`
  with `globasciiranges` unset, 64 `ª` characters passed and were returned as a digest — which
  `scripts/build-extensions.sh` then uses as a cache key and a filename. It now enumerates the ASCII
  set.
- `${1:?…}` terminated the caller instead of returning. With no argument or an empty one, the `||`
  branch never ran and a marker placed after the call never printed; only inside `$( )` did the
  caller survive, which is why the one production caller was insulated. It now takes exactly one
  non-empty path and returns. Extra arguments are rejected rather than ignored.

## Verification

- Full bats suite: 2911 pass, 0 fail, 113 files, each file's plan matching its own record count.
- `shellcheck -x -S warning` and `bash -n` clean on every changed file, including the two
  extensionless helpers.
- Three predicates mutation-proved with green controls: the arity check returning rather than
  exiting, the enumerated ASCII set, and the locale test against the reverted predicate.
- The locale test follows `tests/unit/build-extensions.bats:241-252` — it requires `en_US.utf8` to
  exist and exercises a hostile control, so it cannot pass on a host whose collation never had the
  problem.

## Known and filed

- #1439 stays open for sixteen host-side files elsewhere: four repository-root scripts, `tests/`,
  `.github/scripts/`, and `examples/`. No path rule separates host-side from image-side —
  `postgres/generate-dockerfile.sh` and `tor/version.sh` live under image directories and correctly
  use `env`, while `ansible/docker-entrypoint.sh` uses `env` inside the image.
- #1449 — `helpers/skopeo-squash` never runs (`SQUASH_IMAGE` is set nowhere), does not flatten, and
  would replace a multi-arch index with an amd64-only image if it did.

A test guarding the shebangs was written and then removed: across two review rounds it produced seven
findings, five of them defects in its own earlier fixes, while defending against a contributor who
could edit it in the same commit.

Closes #1441
