### PR TITLE
Let a failed './make list' say why, and stop stderr becoming container data

### DIFF
--- a/helpers/dependency-graph.sh
+++ b/helpers/dependency-graph.sh
@@ -60,19 +60,32 @@ _depgraph_valid_containers() {
         printf '%s' "$_DEPGRAPH_CONTAINERS_OVERRIDE"
     else
         local _make_out
-        if ! _make_out=$(cd "$PROJECT_ROOT" && ./make list 2>/dev/null); then
-            echo "::error::Failed to enumerate project containers via './make list'" >&2
+        # A successful `./make list` writes nothing to stderr today, so hiding
+        # stderr would only hide a failure's reason.
+        if ! _make_out=$(cd "$PROJECT_ROOT" && ./make list); then
+            printf '\n%s\n' "::error::Failed to enumerate project containers via './make list'" >&2 || :
             return 1
         fi
-        # Filter to strict container-name lines only (defense in depth: drops any
-        # banner/diagnostic output that may have leaked into stdout, same charset
-        # as the validator in cascade-resolver.yaml line 76).
-        _make_out=$(printf '%s' "$_make_out" | grep -E '^[a-z0-9_-]+$' || true)
-        if [[ -z "$_make_out" ]]; then
-            echo "::error::'./make list' returned empty container set" >&2
+        # Filter to strict ASCII container-name lines only (defense in depth:
+        # drops any banner/diagnostic output that may have leaked into stdout,
+        # same charset as the validator in cascade-resolver.yaml line 76).
+        # Spell out the bytes rather than using [a-z]: locale-collated ranges
+        # can accept non-ASCII letters.  Keeping this in Bash also means a
+        # missing or killed filter/join subprocess cannot become an empty or
+        # partial container set.
+        local _container
+        local -a _valid_container_names=()
+        while IFS= read -r _container || [[ -n "$_container" ]]; do
+            [[ -n "$_container" ]] || continue
+            [[ "$_container" == *[!abcdefghijklmnopqrstuvwxyz0123456789_-]* ]] && continue
+            _valid_container_names+=("$_container")
+        done <<< "$_make_out"
+        if ((${#_valid_container_names[@]} == 0)); then
+            printf '\n%s\n' "::error::'./make list' returned empty container set" >&2 || :
             return 1
         fi
-        printf '%s' "$(printf '%s' "$_make_out" | tr '\n' ' ')"
+        local IFS=' '
+        printf '%s' "${_valid_container_names[*]}"
     fi
 }
 
@@ -204,11 +217,7 @@ _depgraph_get_deps() {
     # substitutions used as conditional operands (bash §3.7.5), so a simple
     # `if ! var=$(cmd)` or `var=$(cmd) || ...` will not propagate failures from
     # nested helpers.  We must check the exit code explicitly.
-    valid_containers="$(_depgraph_valid_containers 2>&1)" || {
-        # Re-emit the error (already contains ::error:: from _depgraph_valid_containers)
-        printf '%s\n' "$valid_containers" >&2
-        return 1
-    }
+    valid_containers="$(_depgraph_valid_containers)" || return 1
     local lineage_dir="${_DEPGRAPH_LINEAGE_DIR:-${PROJECT_ROOT}/.build-lineage}"
 
     # Glob lineage files FIRST — the active-tag filter only makes sense when files

--- a/tests/unit/dependency-graph.bats
+++ b/tests/unit/dependency-graph.bats
@@ -2,8 +2,9 @@
 
 # Unit tests for helpers/dependency-graph.sh
 #
-# All tests use _DEPGRAPH_CONTAINERS_OVERRIDE and _DEPGRAPH_LINEAGE_DIR to
+# Most tests use _DEPGRAPH_CONTAINERS_OVERRIDE and _DEPGRAPH_LINEAGE_DIR to
 # avoid touching the real project containers or .build-lineage directory.
+# Production-path cases use an isolated PROJECT_ROOT with a root-local ./make shim.
 #
 # Mutation guards:
 #   Remove internal-ref check → external library/php matches as php
@@ -257,36 +258,71 @@ _write_lineage() {
 # Defect B.2 fix: _depgraph_valid_containers fail-closed on './make list' failure
 # ---------------------------------------------------------------------------
 @test "depgraph: valid_containers — './make list' failure → non-zero exit (fail-closed)" {
-    # Unset the override so the code takes the ./make list path.
-    # Place a failing make stub in PATH.
+    # Mutation guard: restoring `2>/dev/null` on ./make list hides this reason
+    # and makes this test fail.
     unset _DEPGRAPH_CONTAINERS_OVERRIDE
-    mkdir -p "$TEST_TEMP_DIR/bin"
-    printf '#!/usr/bin/env bash\nexit 1\n' > "$TEST_TEMP_DIR/bin/make"
-    chmod +x "$TEST_TEMP_DIR/bin/make"
-    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE PATH="$TEST_TEMP_DIR/bin:$PATH" \
+    local mock_root="$TEST_TEMP_DIR/failing_make_root"
+    mkdir -p "$mock_root"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' 'distinctive make-list failure reason' >&2" 'exit 1' > "$mock_root/make"
+    chmod +x "$mock_root/make"
+    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE \
         bash -c "
-            PROJECT_ROOT='$TEST_TEMP_DIR'
+            PROJECT_ROOT='$mock_root'
             source '${HELPERS_DIR}/dependency-graph.sh'
             _depgraph_valid_containers
         "
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"::error::"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"distinctive make-list failure reason"* ]]
+    [[ "$output" == *"::error::Failed to enumerate project containers via './make list'"* ]]
+    local expected=$'distinctive make-list failure reason\n\n::error::Failed to enumerate project containers via \'./make list\''
+    [ "$output" = "$expected" ]
 }
 
 @test "depgraph: valid_containers — './make list' returns empty → non-zero exit (fail-closed)" {
-    # Place a stub that exits 0 but prints nothing.
+    # Mutation guard: deleting the empty-result guard returns success and makes
+    # this test fail. The diagnostic has no trailing newline to prove the static
+    # annotation begins a line regardless of the child command's final byte.
     unset _DEPGRAPH_CONTAINERS_OVERRIDE
-    mkdir -p "$TEST_TEMP_DIR/bin"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$TEST_TEMP_DIR/bin/make"
-    chmod +x "$TEST_TEMP_DIR/bin/make"
-    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE PATH="$TEST_TEMP_DIR/bin:$PATH" \
+    local mock_root="$TEST_TEMP_DIR/empty_make_root"
+    mkdir -p "$mock_root"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s' 'no containers found' >&2" 'exit 0' > "$mock_root/make"
+    chmod +x "$mock_root/make"
+    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE \
         bash -c "
-            PROJECT_ROOT='$TEST_TEMP_DIR'
+            PROJECT_ROOT='$mock_root'
             source '${HELPERS_DIR}/dependency-graph.sh'
             _depgraph_valid_containers
         "
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"::error::"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no containers found"* ]]
+    [[ "$output" == *"::error::'./make list' returned empty container set"* ]]
+    local expected=$'no containers found\n::error::\'./make list\' returned empty container set'
+    [ "$output" = "$expected" ]
+}
+
+# ---------------------------------------------------------------------------
+# Stdout filtering must remain independent from the stderr-banner regression
+# test below. Removing the ASCII validator lets this invalid stdout line into
+# the set.
+# ---------------------------------------------------------------------------
+@test "depgraph: valid_containers — invalid stdout line excluded from container set" {
+    unset _DEPGRAPH_CONTAINERS_OVERRIDE
+    local mock_root="$TEST_TEMP_DIR/stdout_filter_root"
+    mkdir -p "$mock_root"
+    printf '%s\n' '#!/usr/bin/env bash' \
+        "printf '%s\\n' php not/a-container debian" > "$mock_root/make"
+    chmod +x "$mock_root/make"
+
+    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE \
+        bash -c "
+            PROJECT_ROOT='$mock_root'
+            source '${HELPERS_DIR}/dependency-graph.sh'
+            _depgraph_valid_containers
+        "
+    [ "$status" -eq 0 ]
+    [ "$output" = "php debian" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -299,19 +335,15 @@ _write_lineage() {
 # _depgraph_is_internal_ref would then wrongly classify an external ref like
 # "ghcr.io/oorabona/Found:latest" as internal, perturbing cascade gating.
 #
-# The fix (a) discards stderr (2>/dev/null) and (b) filters stdout to lines
-# matching ^[a-z0-9_-]+$ before joining.
+# The strict stdout filter keeps only lines matching ^[a-z0-9_-]+$ before
+# joining.
 #
 # This test creates a temp PROJECT_ROOT with a ./make shim that:
 #   - prints a banner on stderr ("✅ Found 'docker-compose', continuing.")
 #   - prints two container names on stdout ("php\ndebian\n")
-# It then asserts the result contains php and debian but NOT any banner token.
+# It then asserts the returned container list is exactly php and debian.
 #
-# Mutation guards:
-#   reverting 2>/dev/null → 2>&1: banner leaks into output; "Found"
-#            appears in the valid-container set and this test fails.
-#   removing the grep -E filter: banner tokens on stdout (if any)
-#            would not be stripped; test would catch future regressions.
+# The adjacent invalid-stdout test is the mutation guard for the grep -E filter.
 # ---------------------------------------------------------------------------
 
 @test "depgraph: valid_containers — stderr banner NOT captured into container set (FIX 2)" {
@@ -327,17 +359,44 @@ _write_lineage() {
         bash -c "
             PROJECT_ROOT='$mock_root'
             source '${HELPERS_DIR}/dependency-graph.sh'
-            _depgraph_valid_containers
+            _depgraph_valid_containers 2> /dev/null
         "
     [ "$status" -eq 0 ]
-    # Valid container names must be present
-    [[ "$output" == *"php"* ]]
-    [[ "$output" == *"debian"* ]]
-    # Banner tokens must NOT appear in the container set
-    [[ "$output" != *"Found"* ]]
-    [[ "$output" != *"docker-compose"* ]]
-    [[ "$output" != *"continuing"* ]]
-    [[ "$output" != *"✅"* ]]
+    [ "$output" = "php debian" ]
+}
+
+@test "depgraph: get_deps — make stderr banner stays out of caller container data" {
+    # The production caller must capture only stdout.  If it restores 2>&1,
+    # the banner's newline prefixes alpha and membership drops this dependency.
+    unset _DEPGRAPH_CONTAINERS_OVERRIDE
+    local mock_root="$TEST_TEMP_DIR/caller_banner_root's"
+    mkdir -p "$mock_root/web-shell"
+    printf 'base_image: "ghcr.io/oorabona/alpha:latest"\n' > "$mock_root/web-shell/config.yaml"
+    printf '#!/usr/bin/env bash\nprintf '"'"'warning from make list\\n'"'"' >&2\nprintf '"'"'alpha\\nbeta\\n'"'"'\n' \
+        > "$mock_root/make"
+    chmod +x "$mock_root/make"
+
+    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE \
+        PROJECT_ROOT="$mock_root" HELPERS_DIR="$HELPERS_DIR" _DEPGRAPH_OWNER_OVERRIDE=oorabona \
+        bash -c 'source "$HELPERS_DIR/dependency-graph.sh"; _depgraph_get_deps web-shell'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"warning from make list"* ]]
+    [[ "$output" == *"alpha"* ]]
+    [[ "$output" != *"beta"* ]]
+}
+
+@test "depgraph: valid_containers — non-ASCII names rejected under en_US.utf8" {
+    unset _DEPGRAPH_CONTAINERS_OVERRIDE
+    local mock_root="$TEST_TEMP_DIR/ascii_container_root's"
+    mkdir -p "$mock_root"
+    printf '#!/usr/bin/env bash\nprintf '"'"'alpha\\ncafé\\nstraße\\nniño\\nbeta\\n'"'"'\n' > "$mock_root/make"
+    chmod +x "$mock_root/make"
+
+    run env -u _DEPGRAPH_CONTAINERS_OVERRIDE LC_ALL=en_US.utf8 \
+        PROJECT_ROOT="$mock_root" HELPERS_DIR="$HELPERS_DIR" \
+        bash -c 'source "$HELPERS_DIR/dependency-graph.sh"; _depgraph_valid_containers'
+    [ "$status" -eq 0 ]
+    [ "$output" = "alpha beta" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`_depgraph_valid_containers` ran `./make list 2>/dev/null`, so a failure printed only that
enumeration failed. Every sighting of the intermittent unit-suite failure in #1148 came through this
caller and carried no reason.

The redirect was correct when written: a successful `./make list` printed
`✅ Found 'docker-compose', continuing.` to stderr as recently as `81c7566b^`. That banner is gone —
the same command now writes **0 bytes** there — so hiding stderr only hides failures.

Removing it exposed a coupling worth more than the diagnostic. `_depgraph_get_deps` captured the
helper with `2>&1`, so a *successful* `./make list` writing anything to stderr would merge it into
the container allowlist: the first container ends up preceded by a newline, its space-delimited
membership test fails, and its dependencies silently disappear — while stderr ending in a space
injects a name stdout never listed. That capture is gone, along with the re-emission block whose own
comment said the error was already on stderr.

Two defects in the filter beside it went with it. `grep -E '^[a-z0-9_-]+$'` ran under the inherited
locale, so `LC_ALL=en_US.utf8` accepted `café`, `straße` and `niño` as container names. And `|| true`
on that pipeline turned a missing or killed `grep` into an empty result reported as "returned no
containers". Validation is now a Bash loop spelling out its ASCII bytes, with no subprocess whose
failure can become data.

## Verification

- Full bats suite: 2914 pass, 0 fail, 113 files, each file's plan matching its own record count.
- `shellcheck -x -S warning` and `bash -n` clean.
- Mutation-proved with green controls: restoring `2>/dev/null` on the invocation, restoring `2>&1` at
  the caller, admitting `é` to the byte set, and disabling the name accumulator each turn a test red.
- Observed for a failing `make`: the reason, then the generic annotation, each starting a line —
  including when the child's stderr has no trailing newline.

## Evidence, stated plainly

The declared three-round budget was spent, one round was bought under `--budget-ok`, and that round
refused on the `2>&1` coupling above. The operator authorised fixing it rather than landing with it,
which moved HEAD past the judged tree and made the capped mint inapplicable by design. This push
therefore uses the emergency override. The alternative was landing a change that turns a chatty
helper from a log-noise regression into a dependency-graph corruption.

## Known and filed

- #1148 stays open. The flake reproduced during this work in
  `tests/unit/detect-verification-inputs.bats:166`, green alone, carrying no enumeration error — so
  `./make list` does not explain that sighting. The issue carries the analysis and the next lead.
- #1451 — four other `./make list` callers disagree on failure; one turns it into an empty list.

Refs #1148
