### PR TITLE
Make the pruners' inert negated assertions able to fail

### DIFF
--- a/tests/unit/cleanup-ext-images.bats
+++ b/tests/unit/cleanup-ext-images.bats
@@ -7,6 +7,8 @@
 #
 # They never hit the real network.
 
+bats_require_minimum_version 1.7.0
+
 load "../test_helper"
 
 setup() {
@@ -137,10 +139,10 @@ _run_cleanup_main_with_records() {
 }
 
 @test "_parse_ext_managed_tag rejects unparseable and foreign tags" {
-    ! _parse_ext_managed_tag "pg17-latest"
-    ! _parse_ext_managed_tag "pg17-2.27.1-windows"
-    ! _parse_ext_managed_tag "latest"
-    ! _parse_ext_managed_tag "other-image-tag"
+    run ! _parse_ext_managed_tag "pg17-latest"
+    run ! _parse_ext_managed_tag "pg17-2.27.1-windows"
+    run ! _parse_ext_managed_tag "latest"
+    run ! _parse_ext_managed_tag "other-image-tag"
 }
 
 @test "GHCR record contract keeps tags as an array and exposes whether they were observed" {

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -2,6 +2,8 @@
 
 # Unit tests for scripts/cleanup-old-versions.sh fail-closed registry handling.
 
+bats_require_minimum_version 1.7.0
+
 setup() {
     TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
@@ -481,7 +483,10 @@ EOF
         set +e
         source "$1"
         source_status=$?
-        ! declare -F purge_container >/dev/null
+        if declare -F purge_container >/dev/null; then
+            echo "ASSERTION FAILED: purge_container must not exist after failed validation-helper source" >&2
+            exit 1
+        fi
         [[ "$source_status" -ne 0 ]]
     ' _ "$missing_root/scripts/cleanup-old-versions.sh"
 

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -4,6 +4,8 @@
 # Focus: is_valid_tag — bake cache tag validity derived from underlying base tag;
 # GHCR manifest-protection contract and end-to-end deletion assertions
 
+bats_require_minimum_version 1.7.0
+
 # Source is_valid_tag from the script.  Sourcing is intentionally inert: it
 # defines functions only, so these tests do not need to arrange a fake main.
 
@@ -24,7 +26,18 @@ setup() {
 
     # Source the script without triggering validation, output, or main.
     # shellcheck source=/dev/null
-    source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" 2>/dev/null || true
+    if ! source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh" 2>/dev/null; then
+        echo "ASSERTION FAILED: required functions script_root, build_valid_tags, is_valid_tag, purge_ghcr, purge_dockerhub, and main are unavailable because cleanup-outdated-tags.sh could not be sourced" >&2
+        return 1
+    fi
+
+    local required_function
+    for required_function in script_root build_valid_tags is_valid_tag purge_ghcr purge_dockerhub main; do
+        if ! declare -F "$required_function" >/dev/null; then
+            echo "ASSERTION FAILED: $required_function must be defined after sourcing cleanup-outdated-tags.sh" >&2
+            return 1
+        fi
+    done
 
     export _STUB_DIR
 }
@@ -71,10 +84,10 @@ make_valid_tags() {
     is_valid_tag "latest-windows-ltsc2022" "$valid_tags"
     is_valid_tag "latest-windows-ltsc2022-dev" "$valid_tags"
     is_valid_tag "latest-debian-trixie-base" "$valid_tags"
-    ! is_valid_tag "latest-debian-trixie" "$valid_tags"
-    ! is_valid_tag "latest-windows-ltsc2025" "$valid_tags"
-    ! is_valid_tag "latest-nonexistent" "$valid_tags"
-    ! is_valid_tag "latest-windows-ltsc2019" "$valid_tags"
+    run ! is_valid_tag "latest-debian-trixie" "$valid_tags"
+    run ! is_valid_tag "latest-windows-ltsc2025" "$valid_tags"
+    run ! is_valid_tag "latest-nonexistent" "$valid_tags"
+    run ! is_valid_tag "latest-windows-ltsc2019" "$valid_tags"
 }
 
 assert_tag_decode_failure_stops_before_delete() {
@@ -109,7 +122,10 @@ assert_prepared_decode_preserves_delete_totals() {
         set +e
         source "$1"
         source_status=$?
-        ! declare -F purge_ghcr >/dev/null
+        if declare -F purge_ghcr >/dev/null; then
+            echo "ASSERTION FAILED: purge_ghcr must not exist after failed validation-helper source" >&2
+            exit 1
+        fi
         [[ "$source_status" -ne 0 ]]
     ' _ "$missing_root/scripts/cleanup-outdated-tags.sh"
 
@@ -632,7 +648,7 @@ run_orphan_phase_completion_case() {
 @test "is_valid_tag: unknown tag returns invalid" {
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "9.9.9" "$valid_tags"
+    run ! is_valid_tag "9.9.9" "$valid_tags"
 }
 
 @test "is_valid_tag: arch-specific of a valid base tag (amd64) returns valid" {
@@ -678,13 +694,13 @@ run_orphan_phase_completion_case() {
     # 1.0.0 is no longer in valid_tags (rotated out)
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-1.0.0-amd64" "$valid_tags"
+    run ! is_valid_tag "buildcache-1.0.0-amd64" "$valid_tags"
 }
 
 @test "is_valid_tag: buildcache-<rotated-out-tag>-arm64 is purged when base tag is invalid" {
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-1.0.0-arm64" "$valid_tags"
+    run ! is_valid_tag "buildcache-1.0.0-arm64" "$valid_tags"
 }
 
 @test "is_valid_tag: buildcache with variant suffix preserved when variant base is valid" {
@@ -698,7 +714,7 @@ run_orphan_phase_completion_case() {
     # 2.334.0-dev rotated out; only 2.334.0 remains
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-2.334.0-dev-amd64" "$valid_tags"
+    run ! is_valid_tag "buildcache-2.334.0-dev-amd64" "$valid_tags"
 }
 
 @test "is_valid_tag: buildcache with distro-qualified tag (trixie) preserved when base valid" {
@@ -711,7 +727,7 @@ run_orphan_phase_completion_case() {
 @test "is_valid_tag: buildcache with distro-qualified tag purged when base invalid" {
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-trixie-amd64" "$valid_tags"
+    run ! is_valid_tag "buildcache-trixie-amd64" "$valid_tags"
 }
 
 # ---------------------------------------------------------------------------
@@ -729,7 +745,7 @@ run_orphan_phase_completion_case() {
     local valid_tags
     valid_tags=$(make_valid_tags "foo-amd64" "latest" "buildcache")
     # buildcache-foo-amd64-bar-amd64 → base = foo-amd64-bar, NOT in valid_tags
-    ! is_valid_tag "buildcache-foo-amd64-bar-amd64" "$valid_tags"
+    run ! is_valid_tag "buildcache-foo-amd64-bar-amd64" "$valid_tags"
 }
 
 # ---------------------------------------------------------------------------
@@ -740,13 +756,13 @@ run_orphan_phase_completion_case() {
     # buildcache-2.334.0 (no -amd64/-arm64) → no recognised arch suffix → invalid
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-2.334.0" "$valid_tags"
+    run ! is_valid_tag "buildcache-2.334.0" "$valid_tags"
 }
 
 @test "is_valid_tag: double-prefix buildcache-buildcache- is invalid" {
     local valid_tags
     valid_tags=$(make_valid_tags "2.334.0" "latest" "buildcache")
-    ! is_valid_tag "buildcache-buildcache-2.334.0-amd64" "$valid_tags"
+    run ! is_valid_tag "buildcache-buildcache-2.334.0-amd64" "$valid_tags"
 }
 
 @test "is_valid_tag: buildcache-amd64 is valid as arch-specific variant of bare buildcache" {


### PR DESCRIPTION
Eight of the eighteen `! command` lines in the three cleanup test files could not fail a test. Bash
exempts a negated command from `errexit`, so a violated negation carries on and only the last in a
sequence decides the outcome. Two groups of four consecutive negations therefore had three decorative
each, and two more sat inside `bash -c` children; the other ten already ended their tests.

Three assertion families are involved, all guarding what the monthly pruner deletes:

- `is_valid_tag` rejecting a tag that must not be kept,
- `_parse_ext_managed_tag` rejecting a name it must not manage,
- two checks that the purge primitive must not exist after the validation helper fails to source.

Sixteen sites become `run ! …`, which fails the test itself when the command succeeds. The two inside
`bash -c` become explicit `declare -F` branches, because Bats' `run` is not defined in a child shell —
placing `run !` there yields `run: command not found`, and `set +e` lets the next check overwrite the
127. Setup in `cleanup-outdated-tags.bats` now refuses a failed source instead of silencing it, since
`run !` accepts 127 and an absent function otherwise satisfies every rejection.

## This fixes no observed defect

Making **all 146 sites across all 27 files** decisive in the real checkout produced **zero** newly
failing tests. #1303's claim that converting would turn some tests red is refuted, and the issue now
records the measurement. This strengthens detection; it repairs no current behaviour.

## Verification

- Plan and record counts unchanged: 75/75, 30/30, 27/27.
- Full suite: 2914 pass, 0 fail, 113 files, each file's plan matching its own record count.
- `shellcheck -x -S warning` clean on all three.
- Proved against production, not asserted: mutating `is_valid_tag` to accept everything turns its
  tests red with a green control; inserting `purge_ghcr() ( : )` after the failed source likewise —
  and that one stayed green both before this branch and after its first round.

## Evidence

Three gate rounds declared and spent; the last refused and its capped marker is minted against tree
`20124a25fed5` with #1453 and #1454 open. Two earlier rounds each found defects this branch had
introduced: the two `run !` sites landed in child shells, and a commit message that said all eighteen
negations were inert while also saying only the last in a sequence decides — ten were already
decisive.

## Filed from the terminal round

- #1453 — `is_valid_tag` treats every non-zero `grep` status as "tag not present", so a `grep` that
  errors (2) or is missing (127) authorises a deletion. Production, deletion path, pre-existing.
- #1454 — a focused `_parse_ext_managed_tag` rejection can still pass with the function undefined;
  the source diagnostic is still discarded; and `cleanup-old-versions.bats` declares a Bats 1.7 floor
  it no longer needs.

The remaining 24 files carrying this construct stay on #1303, in the order the measurement suggests.

Refs #1303
