### PR TITLE
fix(cleanup): say how many versions a run decided to delete, and which

### DIFF
--- a/scripts/cleanup-old-versions.sh
+++ b/scripts/cleanup-old-versions.sh
@@ -30,8 +30,10 @@ print_banner() {
   echo "========================================"
 }
 
-# Write kept|deleted|delete_failures to stdout once a package was completely
-# assessed.  Its return status, rather than that record, communicates failure:
+# Write kept|decided|deleted|delete_failures to stdout once a package was
+# completely assessed. `decided` counts the completed deletion plan, while
+# `deleted` counts successful removal outcomes. Its return status, rather than
+# that record, communicates failure:
 # 10 listing failure, 11 processing failure, 12 one or more delete failures,
 # 13 a failure after every record was assessed, and 14 an uninterpretable
 # record. Deletion-plan replay is execution, not assessment, so a replay
@@ -39,7 +41,7 @@ print_banner() {
 purge_container() {
   local container="$1"
   local versions package version_count reported_version_count versions_file="" deletions_file=""
-  local position=0 kept=0 deleted=0 delete_failures=0
+  local position=0 kept=0 decided=0 deleted=0 delete_failures=0
   local version_id tags created_at keep_reason tag tag_list major version_ts cutoff_ts processing_error=0 deletion_read_error=0 validation_error validation_status
   local record_b64 record_json
   declare -A major_seen=()
@@ -87,7 +89,7 @@ purge_container() {
   echo "  Found $version_count versions" >&2
   if [[ "$version_count" -eq 0 ]]; then
     echo "  No versions found (might be new or private)" >&2
-    if ! printf '%s\n' "0|0|0"; then
+    if ! printf '%s\n' "0|0|0|0"; then
       return "$PROCESSING_FAILURE"
     fi
     return 0
@@ -191,6 +193,8 @@ purge_container() {
       echo "  ✗ Failed to prepare deletion list; skipping $container" >&2
       processing_error=1
       break
+    else
+      decided=$((decided + 1))
     fi
   done < "$versions_file"
 
@@ -221,16 +225,16 @@ purge_container() {
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       "/users/${OWNER}/packages/container/${container}/versions/${version_id}"; then
-      echo "    ✓ Deleted" >&2
+      echo "    ✓ Deleted version $version_id" >&2
       deleted=$((deleted + 1))
     else
-      echo "    ✗ Failed to delete" >&2
+      echo "    ✗ Failed to delete version $version_id" >&2
       delete_failures=$((delete_failures + 1))
     fi
   done < "$deletions_file"
 
   if [[ "$deletion_read_error" -ne 0 ]]; then
-    if ! printf '%s\n' "$kept|$deleted|$delete_failures"; then
+    if ! printf '%s\n' "$kept|$decided|$deleted|$delete_failures"; then
       rm -f "$deletions_file"
       return "$PROCESSING_FAILURE"
     fi
@@ -238,7 +242,7 @@ purge_container() {
     return "$POST_DELETE_PROCESSING_FAILURE"
   fi
 
-  if ! printf '%s\n' "$kept|$deleted|$delete_failures"; then
+  if ! printf '%s\n' "$kept|$decided|$deleted|$delete_failures"; then
     return "$PROCESSING_FAILURE"
   fi
   if ! rm -f "$deletions_file"; then
@@ -261,7 +265,7 @@ main() {
 
   local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 INCOMPLETE_DELETION_FAILURE=16
   local root_dir containers container result status
-  local kept deleted delete_failures
+  local kept decided deleted delete_failures
   root_dir=$(script_root) || return 1
   CUTOFF_DATE=$(date -d "-${KEEP_MONTHS} months" +%Y-%m-%dT%H:%M:%SZ) || return 1
   print_banner
@@ -280,7 +284,7 @@ main() {
     containers=$(find "$root_dir" -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed "s|^$root_dir/||" | sort) || return 1
   fi
 
-  local total_deleted=0 total_kept=0 total_assessed=0
+  local total_decided=0 total_deleted=0 total_kept=0 total_assessed=0
   local total_listing_failures=0 total_processing_failures=0 total_delete_failures=0
   for container in $containers; do
     echo ""
@@ -296,16 +300,17 @@ main() {
 
     case "$status" in
       0|"$DELETE_FAILURE"|"$POST_DELETE_PROCESSING_FAILURE")
-        if ! IFS='|' read -r kept deleted delete_failures <<< "$result"; then
+        if ! IFS='|' read -r kept decided deleted delete_failures <<< "$result"; then
           echo "  ✗ Failed to read cleanup result; skipping $container"
           total_processing_failures=$((total_processing_failures + 1))
           continue
         fi
         total_assessed=$((total_assessed + 1))
         total_kept=$((total_kept + kept))
+        total_decided=$((total_decided + decided))
         total_deleted=$((total_deleted + deleted))
         total_delete_failures=$((total_delete_failures + delete_failures))
-        echo "  Summary: kept=$kept, deleted=$deleted, delete_failures=$delete_failures"
+        echo "  Summary: kept=$kept, decided=$decided, deleted=$deleted, delete_failures=$delete_failures"
         [[ "$status" -ne "$POST_DELETE_PROCESSING_FAILURE" ]] || total_processing_failures=$((total_processing_failures + 1))
         ;;
       "$LISTING_FAILURE") total_listing_failures=$((total_listing_failures + 1)) ;;
@@ -314,13 +319,14 @@ main() {
       # does not produce 16.  Keep it fail-closed for an explicit future
       # partial-assessment producer rather than treating it as execution.
       "$INCOMPLETE_DELETION_FAILURE")
-        if ! IFS='|' read -r kept deleted delete_failures <<< "$result"; then
+        if ! IFS='|' read -r kept decided deleted delete_failures <<< "$result"; then
           echo "  ✗ Failed to read incomplete cleanup result; skipping $container"
         else
           total_kept=$((total_kept + kept))
+          total_decided=$((total_decided + decided))
           total_deleted=$((total_deleted + deleted))
           total_delete_failures=$((total_delete_failures + delete_failures))
-          echo "  Summary: kept=$kept, deleted=$deleted, delete_failures=$delete_failures"
+          echo "  Summary: kept=$kept, decided=$decided, deleted=$deleted, delete_failures=$delete_failures"
         fi
         total_processing_failures=$((total_processing_failures + 1))
         ;;
@@ -339,6 +345,7 @@ main() {
   echo "Packages skipped (listing failed): $total_listing_failures"
   echo "Packages skipped (processing failed): $total_processing_failures"
   echo "Versions kept: $total_kept"
+  echo "Versions decided for deletion: $total_decided"
   echo "Versions deleted: $total_deleted"
   echo "Delete failures: $total_delete_failures"
   echo "Untagged versions: retained here; cleanup-outdated-tags.sh is their only deletion authority. Sweep coverage: scheduled runs and unfiltered purge dispatches sweep the whole discovered set; filtered purge dispatches sweep only the selected package; dispatches without purge_obsolete sweep nothing."

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -87,7 +87,7 @@ assert_output_reports_invalid_created_at() {
 }
 
 assert_summary_reports_successful_deletion() {
-    if [[ "$output" != *"Summary: kept=0, deleted=1, delete_failures=0"* ]]; then
+    if [[ "$output" != *"Summary: kept=0, decided=1, deleted=1, delete_failures=0"* ]]; then
         echo "ASSERTION FAILED: expected summary to report the successful deletion after cleanup failure" >&2
         return 1
     fi
@@ -102,7 +102,7 @@ assert_tag_decode_failure_stops_before_delete() {
 }
 
 assert_prepared_decode_preserves_delete_totals() {
-    if [[ "$output" != *"Summary: kept=0, deleted=1, delete_failures=0"* || "$output" != *"Packages assessed: 1"* ]]; then
+    if [[ "$output" != *"Summary: kept=0, decided=2, deleted=1, delete_failures=0"* || "$output" != *"Packages assessed: 1"* ]]; then
         echo "ASSERTION FAILED: a completed deletion plan must keep successful deletes in the totals and assess the package" >&2
         return 1
     fi
@@ -236,7 +236,7 @@ EOF
 
     [[ "$status" -eq 0 ]]
     [[ "$(<"$GH_LOG")" == *"/versions/102"* ]]
-    [[ "$output" == *"Summary: kept=1, deleted=1, delete_failures=0"* ]]
+    [[ "$output" == *"Summary: kept=1, decided=1, deleted=1, delete_failures=0"* ]]
 }
 
 @test "stale untagged records beyond the latest-count window never reach DELETE" {
@@ -261,7 +261,8 @@ EOF
 
     [[ "$status" -eq 0 ]]
     [[ ! -s "$GH_LOG" ]]
-    [[ "$output" == *"Summary: kept=3, deleted=0, delete_failures=0"* ]]
+    [[ "$output" == *"Summary: kept=3, decided=0, deleted=0, delete_failures=0"* ]]
+    [[ "$output" == *"Versions decided for deletion: 0"* ]]
     [[ "$output" == *"Versions deleted: 0"* ]]
 }
 
@@ -289,8 +290,37 @@ EOF
     [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
     [[ "$(<"$GH_LOG")" != *"/versions/102"* ]]
     [[ "$(wc -l < "$GH_LOG")" -eq 1 ]]
-    [[ "$output" == *"Summary: kept=1, deleted=1, delete_failures=0"* ]]
+    [[ "$output" == *"Summary: kept=1, decided=1, deleted=1, delete_failures=0"* ]]
+    [[ "$output" == *"Versions decided for deletion: 1"* ]]
     [[ "$output" == *"Versions deleted: 1"* ]]
+}
+
+@test "dry run reports a decided deletion without reporting a removal" {
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        GH_LOG="$GH_LOG" \
+        GH_TOKEN="test-token" \
+        OWNER="test-owner" \
+        DRY_RUN="true" \
+        KEEP_LATEST_COUNT="0" \
+        KEEP_MONTHS="0" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-old-versions.sh"
+            gh() {
+                if [[ "$*" == *"--method DELETE"* ]]; then printf "DELETE:%s\\n" "$*" >> "$GH_LOG"; return 0; fi
+                if [[ "$*" != *"/versions"* ]]; then printf "%s\\n" "{\"version_count\":1}"; return 0; fi
+                printf "%s\\n" "[{\"id\":101,\"name\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"metadata\":{\"container\":{\"tags\":[\"obsolete\"]}},\"created_at\":\"2000-01-01T00:00:00Z\"}]"
+            }
+            main stale
+        '
+
+    [[ "$status" -eq 0 ]]
+    [[ ! -s "$GH_LOG" ]]
+    [[ "$output" == *"Summary: kept=0, decided=1, deleted=0, delete_failures=0"* ]]
+    [[ "$output" == *"Versions decided for deletion: 1"* ]]
+    [[ "$output" == *"Versions deleted: 0"* ]]
+    [[ "$output" == *"Delete failures: 0"* ]]
 }
 
 @test "an absent or non-numeric package version total refuses the listing" {
@@ -532,10 +562,11 @@ teardown() {
 
     [[ "$status" -eq 1 ]]
     [[ "$output" == *"gh: delete denied"* ]]
-    [[ "$output" == *"Failed to delete"* ]]
-    [[ "$output" == *"Summary: kept=0, deleted=0, delete_failures=1"* ]]
+    [[ "$output" == *"Failed to delete version 101"* ]]
+    [[ "$output" == *"Summary: kept=0, decided=1, deleted=0, delete_failures=1"* ]]
     [[ "$output" == *"Packages assessed: 1"* ]]
     [[ "$output" == *"Packages skipped (listing failed): 0"* ]]
+    [[ "$output" == *"Versions decided for deletion: 1"* ]]
     [[ "$output" == *"Delete failures: 1"* ]]
     [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
 }


### PR DESCRIPTION
`scripts/cleanup-old-versions.sh` printed a `Would delete` line per version and no total. Over the
thirteen packages it assesses that meant reading ten decisions out of 32 025 assessed versions by
hand, under a summary that said `Versions deleted: 0` — correct for a dry run, and useless as a
preview of the unattended monthly job that runs with deletion enabled.

The run now reports three independent numbers at both the per-package and the run level: how many
versions it decided to delete, how many it removed, and how many failed. `deleted` stays inside the
successful-DELETE branch, so a failed deletion still counts as a failure and not as a removal.

Both live outcomes also name the version they acted on. Only the dry-run line did before, so a
failure could be counted but not attributed without re-listing the package — the position it printed
is an index into an API listing and is not stable between runs.

Same class of defect as #1302 on the Docker Hub side, which is not touched here.

## Verified

- `bats tests/unit/cleanup-old-versions.bats` — 28 tests, plan matching. Six existing summary
  assertions updated to the new format, each keeping the counts it already asserted; one dry-run test
  added.
- Full suite: 2915 pass, 0 fail across 113 files.
- `shellcheck -x -S warning` and `bash -n` clean.
- Against the live registry: the command that reported `Versions deleted: 0` now reports
  `Versions decided for deletion: 10`, matching its ten printed decision lines, with
  `Versions deleted: 0` unchanged.
