### PR TITLE
fix(cleanup): refuse a sweep that discovered no containers

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,7 +62,7 @@ jobs:
         if: ${{ always() && (github.event_name == 'schedule' || inputs.purge_obsolete == true) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run || 'false' }}
           OWNER: ${{ github.repository_owner }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/helpers/logging.sh
+++ b/helpers/logging.sh
@@ -151,5 +151,9 @@ has_dockerfile() {
 # Usage: list_containers [base_dir]
 list_containers() {
     local base="${1:-.}"
-    find "$base" -maxdepth 2 \( -name "Dockerfile" -o -name "Dockerfile.*" \) | sed 's|^\./||' | cut -d'/' -f1 | sort -u
+    (
+        set -o pipefail
+        CDPATH='' cd -- "$base" >/dev/null || return 1
+        find . -maxdepth 2 \( -name "Dockerfile" -o -name "Dockerfile.*" \) | sed 's|^\./||' | cut -d'/' -f1 | sort -u
+    )
 }

--- a/scripts/cleanup-outdated-tags.sh
+++ b/scripts/cleanup-outdated-tags.sh
@@ -406,11 +406,19 @@ main() {
   # 16 is fail-closed when the listing required an orphan assessment but a
   # prior deletion failure or replay abort prevented that phase from running.
   local LISTING_FAILURE=10 PROCESSING_FAILURE=11 DELETE_FAILURE=12 POST_DELETE_PROCESSING_FAILURE=13 UNINTERPRETABLE_RECORD_FAILURE=14 PROTECTION_FAILURE=15 INCOMPLETE_DELETION_FAILURE=16
-  local containers container valid_tags valid_count result ghcr_status dh_result dh_status
+  local containers container valid_tags valid_count result ghcr_status dh_result dh_status containers_discovered=true
   local kept obsolete orphans delete_failures dh_assessed dh_deleted package_assessed skip_dockerhub
   local total_assessed=0 total_build_failures=0 total_listing_failures=0 total_processing_failures=0 total_ghcr_delete_failures=0 total_dh_delete_failures=0
   local total_kept=0 total_obsolete=0 total_orphans=0 total_dh_deleted=0
-  if [[ $# -gt 0 ]]; then containers="$*"; else containers=$("$ROOT_DIR/make" list) || return 1; fi
+  if [[ $# -gt 0 ]]; then
+    containers="$*"
+  elif ! containers=$("$ROOT_DIR/make" list); then
+    containers_discovered=false
+  fi
+  if [[ "$containers_discovered" != true || -z "${containers//[[:space:]]/}" ]]; then
+    printf '%s\n' "Could not enumerate containers; refusing to make pruning decisions" >&2
+    return 1
+  fi
 
   for container in $containers; do
     echo ""; echo "========================================"; echo "Purging obsolete images: $container"; echo "========================================"

--- a/scripts/snapshot-stats.sh
+++ b/scripts/snapshot-stats.sh
@@ -22,7 +22,7 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 # shellcheck source=../helpers/logging.sh
 source "$ROOT_DIR/helpers/logging.sh"
 
-# list_containers uses relative paths; run from repo root.
+# Anchor relative snapshot paths and no-argument container enumeration at the repository root.
 cd "$ROOT_DIR"
 
 NAMESPACE="${1:-oorabona}"

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -49,6 +49,23 @@ teardown() {
     unset GH_TOKEN OWNER DRY_RUN _STUB_DIR ORIGINAL_PATH ROOT_DIR
 }
 
+@test "sourcing cleanup-outdated-tags leaves caller command and colour variables unset" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN="true" bash -c '
+        set -euo pipefail
+        unset DOCKER SKOPEO RED GREEN YELLOW BLUE NC
+        source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+        for variable in DOCKER SKOPEO RED GREEN YELLOW BLUE NC; do
+            if [[ -v "$variable" ]]; then
+                printf "%s was changed while sourcing\\n" "$variable" >&2
+                exit 1
+            fi
+        done
+    '
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
 # ---------------------------------------------------------------------------
 # Helper: build a newline-separated valid-tag list
 # ---------------------------------------------------------------------------
@@ -799,6 +816,66 @@ run_orphan_phase_completion_case() {
     [[ "$output" == *"GHCR — delete failures: 0"* ]]
 }
 
+@test "unfiltered main refuses an empty container discovery before making pruning decisions" {
+    local stub_root="$BATS_TEST_TMPDIR/empty-container-discovery"
+    local gh_calls="$BATS_TEST_TMPDIR/empty-container-discovery-gh-calls"
+    mkdir -p "$stub_root"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stub_root/make"
+    chmod +x "$stub_root/make"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        STUB_ROOT="$stub_root" \
+        GH_CALLS="$gh_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            script_root() { printf "%s\\n" "$STUB_ROOT"; }
+            gh() { printf "%s\\n" "$*" >> "$GH_CALLS"; }
+            main
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Could not enumerate containers; refusing to make pruning decisions"* ]]
+    [[ "$output" != *"Purge Summary"* ]]
+    [ ! -e "$gh_calls" ]
+}
+
+@test "explicitly empty container selection refuses before making API calls" {
+    local stub_root="$BATS_TEST_TMPDIR/empty-explicit-container"
+    local gh_calls="$BATS_TEST_TMPDIR/empty-explicit-container-gh-calls"
+    mkdir -p "$stub_root"
+
+    run env \
+        PROJECT_ROOT="$PROJECT_ROOT" \
+        STUB_ROOT="$stub_root" \
+        GH_CALLS="$gh_calls" \
+        GH_TOKEN="$GH_TOKEN" \
+        OWNER="$OWNER" \
+        DRY_RUN="false" \
+        bash -c '
+            set -euo pipefail
+            source "$PROJECT_ROOT/scripts/cleanup-outdated-tags.sh"
+            script_root() { printf "%s\\n" "$STUB_ROOT"; }
+            gh() { printf "%s\\n" "$*" >> "$GH_CALLS"; }
+            for selection in "" "   "; do
+                if main "$selection"; then
+                    printf "main accepted an empty or whitespace selection\\n" >&2
+                    exit 1
+                fi
+            done
+            [ ! -e "$GH_CALLS" ]
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Could not enumerate containers; refusing to make pruning decisions"* ]]
+    [[ "$output" != *"Purge Summary"* ]]
+    [ ! -e "$gh_calls" ]
+}
+
 @test "purge_ghcr treats a zero-status non-JSON body as a listing failure and leaves the package unassessed" {
     run env \
         PROJECT_ROOT="$PROJECT_ROOT" \
@@ -957,6 +1034,7 @@ run_orphan_phase_completion_case() {
     [[ "$purge_step" == *"continue-on-error: true"* ]]
     [[ "$purge_step" == *"always() && (github.event_name == 'schedule' || inputs.purge_obsolete == true)"* ]]
     [[ "$workflow" == *"steps.cleanup_old_versions.outcome }}\" == \"failure\" || \"\${{ steps.purge_obsolete_images.outcome"* ]]
+    [[ "$purge_step" == *"github.event_name == 'schedule' && 'true' || inputs.dry_run || 'false'"* ]]
 
     # This is the failure path that GitHub Actions evaluates: continue-on-error
     # preserves the age-pruner outcome while always() still starts the second

--- a/tests/unit/logging.bats
+++ b/tests/unit/logging.bats
@@ -10,6 +10,78 @@ setup() {
     source "$HELPERS_DIR/logging.sh"
 }
 
+@test "list_containers has identical output for relative, absolute, trailing-slash, and metacharacter bases" {
+    local base="$BATS_TEST_TMPDIR/containers+a.b"
+    mkdir -p "$base/nginx"
+    touch "$base/nginx/Dockerfile" "$base/nginx/Dockerfile.alpine"
+
+    run bash -c 'source "$1"; cd "$2"; list_containers .' _ "$HELPERS_DIR/logging.sh" "$base"
+    [ "$status" -eq 0 ]
+    local relative_output="$output"
+
+    run bash -c 'source "$1"; list_containers "$2"' _ "$HELPERS_DIR/logging.sh" "$base"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$relative_output" ]
+
+    run bash -c 'source "$1"; list_containers "$2/"' _ "$HELPERS_DIR/logging.sh" "$base"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$relative_output" ]
+
+    run bash -c 'source "$1"; cd "$(dirname "$2")"; list_containers "$(basename "$2")"' _ "$HELPERS_DIR/logging.sh" "$base"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$relative_output" ]
+    [ "$output" = "nginx" ]
+}
+
+@test "list_containers fails without names for a non-existent base" {
+    run bash -c 'source "$1"; list_containers "$2" 2>/dev/null' _ "$HELPERS_DIR/logging.sh" "$BATS_TEST_TMPDIR/does-not-exist"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "list_containers fails when find prints a name then fails" {
+    local stub_dir="$BATS_TEST_TMPDIR/find-failure-bin"
+    local find_calls="$BATS_TEST_TMPDIR/find-failure-calls"
+    mkdir -p "$stub_dir"
+    printf '#!/usr/bin/env bash\nprintf "%s\\n" "partial/Dockerfile"\nprintf "%s\\n" reached > "$FIND_CALLS"\nexit 42\n' > "$stub_dir/find"
+    chmod +x "$stub_dir/find"
+
+    run env PATH="$stub_dir:$PATH" FIND_CALLS="$find_calls" bash -c 'source "$1"; list_containers "$2"' _ "$HELPERS_DIR/logging.sh" "$BATS_TEST_TMPDIR"
+
+    [ "$status" -ne 0 ]
+    [ -s "$find_calls" ]
+}
+
+@test "list_containers ignores CDPATH for a relative base and preserves the caller value" {
+    local base_parent="$BATS_TEST_TMPDIR/base-parent"
+    local cdpath_parent="$BATS_TEST_TMPDIR/cdpath-parent"
+    local relative_base="containers"
+    local cdpath_after="$BATS_TEST_TMPDIR/cdpath-after"
+    mkdir -p "$base_parent/$relative_base/expected-container"
+    mkdir -p "$cdpath_parent/$relative_base/decoy-container"
+    touch "$base_parent/$relative_base/expected-container/Dockerfile"
+    touch "$cdpath_parent/$relative_base/decoy-container/Dockerfile"
+
+    run bash -c 'source "$1"; cd "$2" || exit; CDPATH="$3"; list_containers "$4"; list_status=$?; printf "%s\\n" "$CDPATH" > "$5"; exit "$list_status"' _ "$HELPERS_DIR/logging.sh" "$base_parent" "$cdpath_parent" "$relative_base" "$cdpath_after"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "expected-container" ]
+    [ "$(<"$cdpath_after")" = "$cdpath_parent" ]
+}
+
+@test "list_containers accepts an option-like base directory" {
+    local parent="$BATS_TEST_TMPDIR/option-like-parent"
+    local home="$BATS_TEST_TMPDIR/option-like-home"
+    mkdir -p "$parent/-P/expected-container" "$home/decoy-container"
+    touch "$parent/-P/expected-container/Dockerfile"
+    touch "$home/decoy-container/Dockerfile"
+
+    run bash -c 'source "$1"; cd "$2" || exit; HOME="$3"; list_containers -P' _ "$HELPERS_DIR/logging.sh" "$parent" "$home"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "expected-container" ]
+}
+
 teardown() {
     teardown_temp_dir
 }


### PR DESCRIPTION
`list_containers` returned nothing when its base was an absolute path. `find` printed
`/repo/ansible/Dockerfile`, the `sed 's|^\./||'` stripped nothing, and `cut -d'/' -f1` returned the
empty field before the leading slash — so every entry collapsed to empty and the function exited 0
with one blank line.

```
$ ./make list | grep -c .
14
$ /data/dev/docker-containers/make list | grep -c .
0
```

`scripts/cleanup-outdated-tags.sh` is the one caller that invokes `make` by absolute path, in the
branch a run with no container argument takes — every scheduled run. The monthly reference-aware
sweep therefore assessed zero packages and reported success. The 2026-08-01 scheduled run logged
`Dry run: false`, then `GHCR — kept: 0, obsolete: 0, orphans: 0`, and passed.

The function now enters its base in a subshell, so `find` always prints relative paths. That also
fixes a base whose name contains regular-expression metacharacters, where interpolating the base into
the `sed` expression would not. A failing `find` or an unreadable base now fails the function instead
of yielding an empty success.

**An unfiltered run that discovers no containers refuses**, makes no API call, and exits non-zero.
Zero packages assessed is what let this survive, and it is now a failure rather than a clean sweep.

**The scheduled sweep plans without deleting.** Repairing enumeration arms a deletion path that has
never executed unattended, against everything it would have removed over its lifetime — 25 501
orphans on `postgres` alone. Deletion stays an operator dispatch until the backfill is done package
by package; a dispatch still honours its `dry_run` input, and the age-based pruner is unchanged.

**The job timeout goes from 30 to 75 minutes**, because the work is real:

```
$ time DRY_RUN=true ./scripts/cleanup-outdated-tags.sh postgres
  Found 25743 GHCR versions
  GHCR summary: kept=190, obsolete=52, orphans=25501, delete_failures=0
elapsed=848s
```

The other thirteen packages add roughly ten minutes and the age pruner runs first in the same job, so
a complete run was about 28 minutes against a 30-minute cap set when this sweep assessed nothing. The
per-record cost behind that number is #1476.

Closes #1466

## Verified

- 2885 unit tests green, 24 in `tests/unit/logging.bats` including two new ones that assert exact
  output against a decoy directory a regression would select instead.
- Eight mutation proofs; two re-run independently — removing `CDPATH=''` or the `--` each turns the
  suite red.
- `shellcheck -x -S warning`, `bash -n`, `actionlint` clean.
- An unfiltered dry run against the live registry now discovers and assesses packages where it
  assessed zero.
