### PR TITLE
fix(e2e): accept a component that reports fewer version segments than its tag

### DIFF
--- a/test-harness/image-identity.sh
+++ b/test-harness/image-identity.sh
@@ -189,17 +189,66 @@ _image_identity_record_field() {
     ' <<<"${E2E_IMAGE_IDENTITY:-}" 2>/dev/null
 }
 
+_image_identity_numeric_versions_equivalent() (
+    local actual="$1" expected="$2"
+    local numeric_dotted_pattern='^[0-9]+([.][0-9]+)*$'
+    local harness_dir helper actual_greater_status expected_greater_status
+
+    [[ "$actual" =~ $numeric_dotted_pattern && "$expected" =~ $numeric_dotted_pattern ]] || return 1
+
+    harness_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 2
+    helper="$harness_dir/../helpers/version-utils.sh"
+    [[ -r "$helper" ]] || return 2
+    # shellcheck source=../helpers/version-utils.sh
+    if ! source "$helper" >/dev/null 2>&1; then
+        return 2
+    fi
+    # This detects a helper that loaded but supplied no comparator only when no
+    # same-name function was already present; it does not establish provenance.
+    declare -F version_is_greater >/dev/null || return 2
+
+    if version_is_greater "$actual" "$expected"; then
+        actual_greater_status=0
+    else
+        actual_greater_status=$?
+    fi
+    if version_is_greater "$expected" "$actual"; then
+        expected_greater_status=0
+    else
+        expected_greater_status=$?
+    fi
+    (( actual_greater_status == 1 && expected_greater_status == 1 ))
+)
+
 # Harness assertions for container suites. Suites pass their observed value;
 # they never parse an image reference or the identity record themselves.
 e2e_assert_reported_component_version() {
-    local actual="$1" expected
+    local actual="$1" expected numeric_comparison_status
     if ! expected=$(_image_identity_record_field component_version); then
         th_fail "the reported component version has resolved image identity" \
             "the harness did not provide a valid resolved image identity"
         return 0
     fi
-    th_assert_eq "the reported component version matches the resolved image ($expected)" \
-        "$actual" "$expected"
+
+    if [[ "$actual" == "$expected" ]]; then
+        th_pass "the reported component version matches the resolved image release ($expected)"
+        return 0
+    fi
+
+    if _image_identity_numeric_versions_equivalent "$actual" "$expected"; then
+        th_pass "the reported component version matches the resolved image release ($expected)"
+        return 0
+    else
+        numeric_comparison_status=$?
+    fi
+    if (( numeric_comparison_status == 2 )); then
+        th_fail "the reported component version matches the resolved image release ($expected)" \
+            "required helper version-utils.sh is unavailable"
+        return 0
+    fi
+
+    th_fail "the reported component version matches the resolved image release ($expected)" \
+        "expected: '$expected', got: '$actual'"
 }
 
 e2e_assert_declared_variant() {

--- a/tests/unit/e2e-test.bats
+++ b/tests/unit/e2e-test.bats
@@ -16,15 +16,10 @@ setup() {
     # tests, and a different owner invalidates the ambiguous-image fixture.
     export GITHUB_REPOSITORY_OWNER=oorabona
     FIXTURE_REPO="$TEST_TEMP_DIR/repo"
-    mkdir -p "$FIXTURE_REPO/tests" "$FIXTURE_REPO/helpers"
+    mkdir -p "$FIXTURE_REPO/tests"
     cp "$PROJECT_ROOT/tests/e2e-test.sh" "$FIXTURE_REPO/tests/e2e-test.sh"
-    cp "$PROJECT_ROOT/helpers/logging.sh" "$FIXTURE_REPO/helpers/logging.sh"
-    cp "$PROJECT_ROOT/helpers/variant-utils.sh" "$FIXTURE_REPO/helpers/variant-utils.sh"
-    # variant-utils.sh sources it, so an isolated root without it fails at the
-    # source line rather than in the test's subject.
-    cp "$PROJECT_ROOT/helpers/collect-lines.sh" "$FIXTURE_REPO/helpers/collect-lines.sh"
-    mkdir -p "$FIXTURE_REPO/test-harness"
-    cp "$PROJECT_ROOT/test-harness/image-identity.sh" "$FIXTURE_REPO/test-harness/image-identity.sh"
+    cp -r "$PROJECT_ROOT/helpers" "$FIXTURE_REPO/"
+    cp -r "$PROJECT_ROOT/test-harness" "$FIXTURE_REPO/"
     chmod +x "$FIXTURE_REPO/tests/e2e-test.sh"
 }
 

--- a/tests/unit/image-identity.bats
+++ b/tests/unit/image-identity.bats
@@ -26,6 +26,190 @@ make_container() {
     printf '%s\n' "$dir"
 }
 
+assert_reported_component_version() {
+    local actual="$1" expected="$2"
+    local record
+    record=$(jq -cn --arg version "$expected" \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        source "$1/test-harness/test-harness.sh"
+        source "$1/test-harness/image-identity.sh"
+        E2E_IMAGE_IDENTITY="$3"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version "$2"
+        th_summary
+    ' _ "$PROJECT_ROOT" "$actual" "$record"
+}
+
+@test "accepts numeric-dotted component releases with omitted zero segments" {
+    local actual expected
+    for actual in 7.1 7.1.0; do
+        if [[ "$actual" == "7.1" ]]; then
+            expected=7.1.0
+        else
+            expected=7.1
+        fi
+        assert_reported_component_version "$actual" "$expected"
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"ok 1 - the reported component version matches the resolved image release"* ]]
+    done
+}
+
+@test "refuses different numeric-dotted component releases" {
+    local expected
+    for expected in 7.2.0 7.11.0; do
+        assert_reported_component_version 7.1 "$expected"
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"not ok 1 - the reported component version matches the resolved image release"* ]]
+    done
+}
+
+@test "keeps suffix-bearing component versions byte-for-byte exact" {
+    assert_reported_component_version 7.1.0-beta 7.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not ok 1 - the reported component version matches the resolved image release"* ]]
+}
+
+@test "fails closed for an unparseable component release" {
+    assert_reported_component_version release-candidate 7.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not ok 1 - the reported component version matches the resolved image release"* ]]
+}
+
+@test "uses its private numeric comparator despite a caller stub" {
+    local record
+    record=$(jq -cn --arg version 7.2.0 \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        source "$1/test-harness/test-harness.sh"
+        version_is_greater() { return 1; }
+        declare -F version_is_greater >/dev/null || exit 97
+        source "$1/test-harness/image-identity.sh"
+        declare -F version_is_greater >/dev/null || exit 98
+        E2E_IMAGE_IDENTITY="$2"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version 7.1
+        th_summary
+        summary_status=$?
+        printf "caller-stub-defined\n"
+        exit "$summary_status"
+    ' _ "$PROJECT_ROOT" "$record"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"caller-stub-defined"* ]]
+    [[ "$output" == *"not ok 1 - the reported component version matches the resolved image release"* ]]
+}
+
+@test "does not export version utility names when sourced" {
+    run bash -c '
+        for name in version_is_greater DEFAULT_VERSION_PATTERN _version_numeric_tuple _version_normalize_numeric_component get_registry_pattern get_current_published_version; do
+            unset "$name"
+            unset -f "$name"
+        done
+        source "$1"
+        for name in version_is_greater DEFAULT_VERSION_PATTERN _version_numeric_tuple _version_normalize_numeric_component get_registry_pattern get_current_published_version; do
+            if declare -F "$name" >/dev/null || declare -p "$name" >/dev/null 2>&1; then
+                printf "%s is present\n" "$name"
+                exit 1
+            fi
+        done
+        printf "version utility names absent\n"
+    ' _ "$RESOLVER"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "version utility names absent" ]
+}
+
+@test "preserves a caller's BASH_REMATCH through numeric comparison" {
+    local record
+    record=$(jq -cn --arg version 7.1.0 \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        source "$1/test-harness/test-harness.sh"
+        source "$1/test-harness/image-identity.sh"
+        [[ alpha42 =~ ^([a-z]+)([0-9]+)$ ]]
+        E2E_IMAGE_IDENTITY="$2"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version 7.1
+        th_summary
+        printf "captures=%s,%s\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    ' _ "$PROJECT_ROOT" "$record"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"captures=alpha,42"* ]]
+}
+
+@test "leaves BASH_REMATCH unset when the caller had none" {
+    local record
+    record=$(jq -cn --arg version 7.1.0 \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        source "$1/test-harness/test-harness.sh"
+        source "$1/test-harness/image-identity.sh"
+        unset BASH_REMATCH
+        E2E_IMAGE_IDENTITY="$2"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version 7.1
+        declare -p BASH_REMATCH >/dev/null 2>&1 && exit 1
+        th_summary
+    ' _ "$PROJECT_ROOT" "$record"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "reports a missing version helper without aborting while sourced" {
+    local fixture_root fixture_resolver record
+    fixture_root="$TEST_TEMP_DIR/missing-helper"
+    fixture_resolver="$fixture_root/test-harness/image-identity.sh"
+    mkdir -p "$fixture_root/test-harness"
+    cp "$RESOLVER" "$fixture_resolver"
+    record=$(jq -cn --arg version 7.1.0 \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        set -e
+        source "$1/test-harness/test-harness.sh"
+        source "$2"
+        E2E_IMAGE_IDENTITY="$3"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version 7.1
+        th_summary
+    ' _ "$PROJECT_ROOT" "$fixture_resolver" "$record"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"required helper version-utils.sh is unavailable"* ]]
+    [[ "$output" != *"expected: '7.1.0', got: '7.1'"* ]]
+}
+
+@test "reports a version helper that supplies no comparator without aborting while sourced" {
+    local fixture_root fixture_resolver record
+    fixture_root="$TEST_TEMP_DIR/no-comparator-helper"
+    fixture_resolver="$fixture_root/test-harness/image-identity.sh"
+    mkdir -p "$fixture_root/test-harness" "$fixture_root/helpers"
+    cp "$RESOLVER" "$fixture_resolver"
+    : > "$fixture_root/helpers/version-utils.sh"
+    record=$(jq -cn --arg version 7.1.0 \
+        '{reference: "image:tag", tag: "tag", component_version: $version, kind: "single", variant: null, flavor: null}')
+
+    run bash -c '
+        set -e
+        source "$1/test-harness/test-harness.sh"
+        source "$2"
+        E2E_IMAGE_IDENTITY="$3"
+        th_init --name "identity assertion" --report tap --no-color
+        e2e_assert_reported_component_version 7.1
+        th_summary
+    ' _ "$PROJECT_ROOT" "$fixture_resolver" "$record"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"required helper version-utils.sh is unavailable"* ]]
+    [[ "$output" != *"expected: '7.1.0', got: '7.1'"* ]]
+}
+
 @test "resolves a port-bearing reference" {
     local dir
     dir=$(make_container web-shell '


### PR DESCRIPTION
The wordpress end-to-end run failed on a dependency bump with 18 assertions passing and one failing:

```
FAIL the reported component version matches the resolved image (7.1.0)
    expected: '7.1.0', got: '7.1'
```

Both values are right at their source. `wordpress/version.sh` derives the tag from Docker Hub's
three-segment `library/wordpress` tags; WordPress reports `7.1`, which is what WordPress calls that
release. Upstream publishes both spellings:

```
$ ./helpers/latest-docker-tag library/wordpress '^[0-9]+\.[0-9]+\.[0-9]+$'   → 7.1.0
$ ./helpers/latest-docker-tag library/wordpress '^[0-9]+\.[0-9]+$'           → 7.1
```

`wordpress/test.sh:31` already accepted either shape and line 35 then demanded three segments — one
file asserting both that two segments are valid and that they are not. It would fail on every `x.y.0`
release, and the end-to-end suite runs on `pull_request` only, so `master` never re-raises it.

`e2e_assert_reported_component_version` now compares byte-for-byte first and falls back to
`version_is_greater`, which already treats a missing segment as zero — equality is "neither is
greater". The fallback is reached only when both sides are purely numeric-dotted, so `7.1.0-beta`
against `7.1.0` still fails, which `sslh/test.sh:46` depends on: its comment requires an exact token
because a substring rule would accept `2.2.4` inside `12.2.40`.

The comparison runs in a function whose body is a subshell and which sources the helper inside
itself, so sourcing the harness defines only the image-identity API and leaves the caller's
`BASH_REMATCH` alone.

Sourcing that helper broke one record of `tests/unit/e2e-test.bats`, whose fixture repository was
built from a hand-written list of six `cp` lines. The list is gone — the fixture copies `helpers/`
and `test-harness/` whole, so a dependency added to a copied script cannot break it again.

Closes #1459

## Verified

- 2895 unit tests, 0 failures. `tests/unit/image-identity.bats` 28/28 and `tests/unit/e2e-test.bats`
  45/45, both run directly.
- Four mutation proofs re-run independently: relaxing the equality condition, replacing the
  numeric-dotted guard with `true`, converting the subshell function to a braces function, and
  deleting the comparator-availability check — each turns the suite red.
- Four isolation properties checked with their own controls: no version-helper name leaks into the
  caller, `BASH_REMATCH` survives, a caller-defined `version_is_greater` does not decide the verdict,
  and a missing helper produces its own message.
- `shellcheck -x -S warning`, `bash -n` clean.

Landed on capped evidence. Residue: #1484 — the module derives its own directory at call time in two
places; unreachable through any current caller, all of which source through an absolute path.
