### PR TITLE
ci(cleanup): prune the registry weekly, not monthly

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -2,8 +2,8 @@ name: Cleanup Container Registry
 
 on:
   schedule:
-    # Run monthly on the 1st at 3:00 AM UTC
-    - cron: '0 3 1 * *'
+    # Run weekly every Monday at 3:17 AM UTC
+    - cron: '17 3 * * 1'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -88,7 +88,7 @@ jobs:
     # record. Nothing prevents a writer outside this workflow from changing it
     # between that re-read and DELETE.
     # Independent lifecycle job — not in any build/consume path.
-    # Runs monthly on schedule, or on operator dispatch with explicit opt-in.
+    # Runs weekly on schedule and on any operator dispatch. Default: dry-run.  Operator must set execute_ext_cleanup=true to delete.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -330,7 +330,7 @@ yq '.extensions.<name>.version' postgres/extensions/config.yaml
 | `auto-build.yaml` | Push, PR, manual | Build & push containers |
 | `upstream-monitor.yaml` | Schedule | Check for upstream updates |
 | `update-dashboard.yaml` | Schedule, manual | Regenerate status dashboard |
-| `cleanup-registry.yaml` | Manual | Clean old images |
+| `cleanup-registry.yaml` | Schedule, manual | Clean old images |
 
 ### Manual Workflow Trigger
 

--- a/docs/WORKFLOW_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ARCHITECTURE.md
@@ -81,7 +81,7 @@ This document describes the complete CI/CD architecture: version detection, mult
 │  shellcheck.yaml          ─ Lint all .sh on push/PR           │
 │  validate-version-scripts ─ Test version.sh on PR             │
 │  sync-dockerhub-readme    ─ Sync README to Docker Hub         │
-│  cleanup-registry         ─ Monthly GHCR image cleanup        │
+│  cleanup-registry         ─ Weekly GHCR image cleanup         │
 │  update-dashboard         ─ Jekyll site → GitHub Pages        │
 └───────────────────────────────────────────────────────────────┘
 ```
@@ -164,7 +164,7 @@ gh workflow run recreate-manifests.yaml -f container=postgres
 | `shellcheck.yaml` | push, PR | Lint the build-system, version and test shell scripts with shellcheck, and the YAML config files with yamllint. Container runtime scripts are deliberately excluded |
 | `validate-version-scripts.yaml` | PR (version.sh changes) | Validate version.sh scripts can run |
 | `sync-dockerhub-readme.yaml` | push (README changes) | Sync README.md to Docker Hub descriptions |
-| `cleanup-registry.yaml` | schedule (monthly) | Delete old GHCR images per retention policy |
+| `cleanup-registry.yaml` | schedule (weekly) | Delete old GHCR images per retention policy |
 
 ## Composite Actions
 

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -1024,6 +1024,26 @@ run_orphan_phase_completion_case() {
     [[ -z "$output" ]]
 }
 
+@test "cleanup workflow schedules weekly registry pruning" {
+    local workflow_path
+    workflow_path="$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml"
+
+    run yq -r '.on.schedule | length' "$workflow_path"
+    [ "$status" -eq 0 ]
+    if [ "$output" != '1' ]; then
+        printf "FAIL: expected exactly one cleanup schedule, got %s\n" "$output" >&2
+        return 1
+    fi
+
+    run yq -r '.on.schedule[0].cron' "$workflow_path"
+    [ "$status" -eq 0 ]
+    if [ "$output" != '17 3 * * 1' ]; then
+        printf "FAIL: expected weekly registry prune cron '17 3 * * 1', got %s\n" "$output" >&2
+        return 1
+    fi
+
+}
+
 @test "workflow attempts both registry pruners and fails after either failure" {
     local workflow purge_step
     workflow=$(<"$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml")


### PR DESCRIPTION
The registry prune ran on the 1st of each month and could not keep up with a month of publishing.

`postgres` publishes about 500 versions a day, measured by page offset over its versions
newest-first: `#1000` at 2026-08-24T18:13 and `#7000` at 2026-08-07T19:01. Per day over six days:
453, 709, 608, 476, 172, 582. So roughly **15 000 a month**, against the 190 the sweep keeps.

One run deletes about 8 700. From a live sweep of `postgres`:

```
  Found 25850 GHCR versions          ← 12 minutes of planning
  ...146 deletions a minute, steady over three consecutive 60s samples
  killed by the 75-minute job timeout, `cancelled`, no summary printed
  25 850 → 17 104
```

The binding constraint is the workflow token's hourly quota, not the timeout alone. A run dispatched
four minutes later failed at its first listing on every package with
`API rate limit exceeded for installation` and reported `Packages assessed: 0`. Raising the timeout
would not help: the script counts a refused DELETE as a delete failure and cannot wait for the window
to reset.

So the monthly cadence carried a deficit of about 6 300 versions a month and the registry grew
without bound. Weekly inverts it: about 3 750 accumulate against the same capacity, so each run
spends under half its budget, finishes inside the timeout, and **prints its summary** — a run killed
mid-replay reports nothing at all.

The cron also moves off the top of the hour, where GitHub delays or drops scheduled events under
load, and a comment claiming a manual dispatch needs opt-in to run is corrected: the `if:` beneath it
tests the event name only, and the comment five lines further down already said so.

## Verified

- 2896 unit tests, 0 failures. `tests/unit/cleanup-outdated-tags.bats` 79/79. `actionlint` clean.
- The cadence test parses `.on.schedule` with `yq` — already used by four sibling suites — and
  asserts exactly one entry with the expected cron. Its first version searched raw text and accepted
  a decoy with an active monthly cron and the weekly one commented out; that decoy is now rejected,
  with the real file still accepted as a control.
- Nothing else keys on the cadence: `KEEP_MONTHS` is an age threshold on the versions, and the
  extension prune's window is a resolver-version window.

Landed on capped evidence. Residue: #1487 — three lines in `docs/` still describe this workflow as
monthly or manual, filed at the review cap and fixed separately.

Related and deliberately untouched: #1486 (a run killed by the timeout or the quota leaves no
completion record, and exhaustion is counted as thousands of separate failures), #1483 (no
concurrency group), #1468 (both older pruners delete from an earlier listing without re-reading),
#1302 (the Docker Hub path reads one page and counts attempts as deletions).


---

The documentation fix for #1487 is folded in rather than deferred: `WORKFLOW_ARCHITECTURE.md` says
weekly in both the diagram and the trigger table, and `DEVELOPMENT.md`'s trigger column says
`Schedule, manual` — that last line was already false under the monthly schedule, since the scheduled
path deletes unattended. The diagram's box alignment is preserved: `Monthly` is seven characters and
`Weekly` six, so a space was added and all eight lines remain 65 characters wide.

That fold moved the tree, so the branch was reviewed once more. Residue now: #1489 — a stale
`Last Updated: February 2026` in a document edited in August, a comment saying "operator dispatch"
where `upstream-monitor.yaml:921` dispatches this workflow automatically, and a trigger table that
omits `workflow_dispatch`. #1487 is closed.
