### PR TITLE
fix: four independent defects in the registry cleanup surface

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -34,6 +34,15 @@ env:
   KEEP_LATEST_COUNT: 10
   KEEP_MONTHS: 6
 
+# Never cancel a started cleanup: a half-replayed deletion plan leaves no summary. The key is
+# fixed rather than partitioned by container_filter, because cleanup-old-versions sweeps every
+# discovered container and cleanup-ext-images is workflow-global.
+# A newer dispatch supersedes a PENDING run, which shows up as cancelled. The obsolete-tag prune
+# it carried is not recovered by the schedule, which runs that pruner with DRY_RUN=true.
+concurrency:
+  group: cleanup-registry
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -88,7 +97,7 @@ jobs:
     # record. Nothing prevents a writer outside this workflow from changing it
     # between that re-read and DELETE.
     # Independent lifecycle job — not in any build/consume path.
-    # Runs weekly on schedule and on any operator dispatch. Default: dry-run.  Operator must set execute_ext_cleanup=true to delete.
+    # Runs weekly on schedule and on every workflow_dispatch, including the automatic dispatch from upstream-monitor. Default: dry-run. Operator must set execute_ext_cleanup=true to delete.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout

--- a/docs/WORKFLOW_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ARCHITECTURE.md
@@ -4,8 +4,6 @@
 
 This document describes the complete CI/CD architecture: version detection, multi-platform builds, registry push, dashboard generation, and maintenance automation.
 
-**Last Updated:** February 2026
-
 ## Complete Automation Flow
 
 ```
@@ -164,7 +162,7 @@ gh workflow run recreate-manifests.yaml -f container=postgres
 | `shellcheck.yaml` | push, PR | Lint the build-system, version and test shell scripts with shellcheck, and the YAML config files with yamllint. Container runtime scripts are deliberately excluded |
 | `validate-version-scripts.yaml` | PR (version.sh changes) | Validate version.sh scripts can run |
 | `sync-dockerhub-readme.yaml` | push (README changes) | Sync README.md to Docker Hub descriptions |
-| `cleanup-registry.yaml` | schedule (weekly) | Delete old GHCR images per retention policy |
+| `cleanup-registry.yaml` | schedule (weekly), workflow_dispatch | Delete old GHCR images per retention policy |
 
 ## Composite Actions
 

--- a/openresty/tests/test-runner-linux.bats
+++ b/openresty/tests/test-runner-linux.bats
@@ -66,8 +66,7 @@ _find_image() {
 
 setup() {
     IMAGE=$(_find_image) || return 1
-    CONTAINER_NAME="openresty-bats-smoke-$$"
-    PORT=18080
+    CONTAINER_ID=""
 
     # Nginx config with a regex location that proves PCRE2 regex matching is functional.
     # location ~ ^/re/(\d+)$  uses a PCRE2 pattern; if PCRE2 is absent nginx
@@ -96,11 +95,18 @@ http {
 NGINX
 
     # Start the container with the custom nginx config
-    docker run -d \
-        --name "$CONTAINER_NAME" \
-        -p "${PORT}:8080" \
+    CONTAINER_ID=$(docker run -d \
+        -p 127.0.0.1::8080 \
         -v "${NGINX_CONF}:/usr/local/openresty/nginx/conf/nginx.conf:ro" \
-        "$IMAGE"
+        "$IMAGE")
+
+    local port_mapping
+    port_mapping=$(docker port "$CONTAINER_ID" 8080/tcp)
+    if [[ ! "$port_mapping" =~ ^127\.0\.0\.1:[0-9]+$ ]]; then
+        printf 'ERROR: expected one 127.0.0.1:<port> mapping; docker port returned: %q\n' "$port_mapping" >&2
+        return 1
+    fi
+    PORT=${port_mapping#127.0.0.1:}
 
     # Wait up to 15 s for nginx to become ready
     local waited=0
@@ -109,14 +115,16 @@ NGINX
         waited=$((waited + 1))
         if [[ $waited -ge 15 ]]; then
             echo "ERROR: openresty container did not become ready within 15s" >&2
-            docker logs "$CONTAINER_NAME" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
             return 1
         fi
     done
 }
 
 teardown() {
-    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    if [[ -n "${CONTAINER_ID:-}" ]]; then
+        docker rm -f "$CONTAINER_ID" 2>/dev/null || true
+    fi
     rm -f "$NGINX_CONF" 2>/dev/null || true
 }
 
@@ -143,14 +151,14 @@ teardown() {
 @test "nginx binary resolves libpcre2-8.so from /usr/local/openresty/pcre2/lib" {
     # Find the nginx binary path inside the container
     local nginx_bin
-    nginx_bin=$(docker exec "$CONTAINER_NAME" sh -c \
+    nginx_bin=$(docker exec "$CONTAINER_ID" sh -c \
         'command -v nginx || echo /usr/local/openresty/nginx/sbin/nginx')
 
     # ldd is the discriminating oracle here.
     # readelf/binutils is stripped from the runtime image (apk del .build-deps),
     # so readelf is never present at runtime — ldd (from musl libc) is always available.
     local ldd_output
-    ldd_output=$(docker exec "$CONTAINER_NAME" sh -c \
+    ldd_output=$(docker exec "$CONTAINER_ID" sh -c \
         "ldd \"$nginx_bin\" 2>/dev/null || true")
 
     echo "ldd output: $ldd_output"
@@ -173,7 +181,7 @@ teardown() {
 @test "nginx -V configure arguments reference /usr/local/openresty/pcre2/ (PCRE2 linked, not PCRE1)" {
     local version_output
     # nginx -V writes to stderr
-    version_output=$(docker exec "$CONTAINER_NAME" sh -c \
+    version_output=$(docker exec "$CONTAINER_ID" sh -c \
         'nginx -V 2>&1 || /usr/local/openresty/nginx/sbin/nginx -V 2>&1')
 
     echo "nginx -V output: $version_output"

--- a/tests/unit/cleanup-old-versions.bats
+++ b/tests/unit/cleanup-old-versions.bats
@@ -86,6 +86,20 @@ assert_output_reports_invalid_created_at() {
     fi
 }
 
+assert_output_has_line() {
+    local expected_line="$1"
+    local output_line
+
+    while IFS= read -r output_line; do
+        if [[ "$output_line" == "$expected_line" ]]; then
+            return 0
+        fi
+    done <<< "$output"
+
+    printf 'ASSERTION FAILED: expected output line: %s\n' "$expected_line" >&2
+    return 1
+}
+
 assert_summary_reports_successful_deletion() {
     if [[ "$output" != *"Summary: kept=0, decided=1, deleted=1, delete_failures=0"* ]]; then
         echo "ASSERTION FAILED: expected summary to report the successful deletion after cleanup failure" >&2
@@ -290,6 +304,7 @@ EOF
     [[ "$(<"$GH_LOG")" == *"/versions/101"* ]]
     [[ "$(<"$GH_LOG")" != *"/versions/102"* ]]
     [[ "$(wc -l < "$GH_LOG")" -eq 1 ]]
+    assert_output_has_line "    ✓ Deleted version 101"
     [[ "$output" == *"Summary: kept=1, decided=1, deleted=1, delete_failures=0"* ]]
     [[ "$output" == *"Versions decided for deletion: 1"* ]]
     [[ "$output" == *"Versions deleted: 1"* ]]
@@ -317,6 +332,7 @@ EOF
 
     [[ "$status" -eq 0 ]]
     [[ ! -s "$GH_LOG" ]]
+    assert_output_has_line "    [DRY RUN] Would delete version 101"
     [[ "$output" == *"Summary: kept=0, decided=1, deleted=0, delete_failures=0"* ]]
     [[ "$output" == *"Versions decided for deletion: 1"* ]]
     [[ "$output" == *"Versions deleted: 0"* ]]
@@ -562,7 +578,7 @@ teardown() {
 
     [[ "$status" -eq 1 ]]
     [[ "$output" == *"gh: delete denied"* ]]
-    [[ "$output" == *"Failed to delete version 101"* ]]
+    assert_output_has_line "    ✗ Failed to delete version 101"
     [[ "$output" == *"Summary: kept=0, decided=1, deleted=0, delete_failures=1"* ]]
     [[ "$output" == *"Packages assessed: 1"* ]]
     [[ "$output" == *"Packages skipped (listing failed): 0"* ]]

--- a/tests/unit/cleanup-outdated-tags.bats
+++ b/tests/unit/cleanup-outdated-tags.bats
@@ -1044,6 +1044,26 @@ run_orphan_phase_completion_case() {
 
 }
 
+@test "cleanup workflow serializes registry cleanup runs" {
+    local workflow_path
+    workflow_path="$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml"
+
+    run yq -r '.concurrency.group' "$workflow_path"
+    [ "$status" -eq 0 ]
+    if [ "$output" != 'cleanup-registry' ]; then
+        printf 'FAIL: expected cleanup concurrency group cleanup-registry, got %s\n' "$output" >&2
+        return 1
+    fi
+
+    run yq -r '.concurrency.cancel-in-progress' "$workflow_path"
+    [ "$status" -eq 0 ]
+    if [ "$output" != 'false' ]; then
+        printf 'FAIL: expected cleanup cancel-in-progress false, got %s\n' "$output" >&2
+        return 1
+    fi
+
+}
+
 @test "workflow attempts both registry pruners and fails after either failure" {
     local workflow purge_step
     workflow=$(<"$PROJECT_ROOT/.github/workflows/cleanup-registry.yaml")


### PR DESCRIPTION
Four independent defects in the registry cleanup surface.

**Parallel openresty smoke tests raced on a fixed host port.** Two tests bound 18080 in `setup`, so
under `bats --jobs` the loser reported `bind: address already in use` and it read as a broken image.
The container now publishes an ephemeral port, read back from `docker port`, and is addressed by the
id `docker run -d` returns. Verified 3/3 under `bats --jobs 4` on the case that used to fail.

**Two cleanup runs could overlap and the second counted the first's deletions as failures.**
`cleanup-registry.yaml` now declares `group: cleanup-registry` with `cancel-in-progress: false`, so
a started run always finishes. The key is fixed rather than partitioned by `container_filter`,
because `cleanup-old-versions.sh` sweeps every discovered container and `cleanup-ext-images.sh` is
workflow-global.

**Two of three deletion outcomes could lose the version id with the suite green.** All three now
assert whole lines through one helper. Emitting `Deleted version 1010` where `101` is expected turns
the suite red.

**A stale date and two wrong trigger descriptions are corrected.**

Verified: 2897 unit tests green, `actionlint -config-file /dev/null` clean on every workflow, and
three mutation proofs on the concurrency test — flipping `cancel-in-progress`, deleting the
`concurrency` block, and renaming the group each turn it red.

Closes #1473
Closes #1483
Closes #1469
Closes #1489

Known and filed separately, not addressed here: #1491, #1492, #1493, #1494.
