### PR TITLE
fix(monitor): a failed registry lookup no longer proposes an update

### DIFF
--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -17,13 +17,13 @@ inputs:
 
 outputs:
   containers_with_updates:
-    description: 'JSON array of containers with upstream updates available'
+    description: 'JSON array of entries authorized to open a monitor PR'
     value: ${{ steps.check-versions.outputs.containers_with_updates }}
   update_count:
-    description: 'Number of containers with upstream updates'
+    description: 'Number of entries authorized to open a monitor PR'
     value: ${{ steps.check-versions.outputs.update_count }}
   version_info:
-    description: 'JSON object with version information for all checked containers'
+    description: 'JSON array of every version observation, including entries not authorized for monitor PRs'
     value: ${{ steps.check-versions.outputs.version_info }}
 
 runs:
@@ -61,7 +61,7 @@ runs:
           version_info=$(./make check-updates)
         fi
         
-        # Extract containers that need updates (make script already handles all logic)
+        # Extract entries authorized for monitor PRs (make script already handles all logic)
         containers_with_updates=()
         
         while IFS= read -r container_data; do
@@ -69,18 +69,23 @@ runs:
           current_version=$(echo "$container_data" | jq -r '.current_version')
           latest_version=$(echo "$container_data" | jq -r '.latest_version')
           update_available=$(echo "$container_data" | jq -r '.update_available')
+          actionable=$(echo "$container_data" | jq -r '.actionable == true')
           status=$(echo "$container_data" | jq -r '.status')
           
           echo "📋 $container: $current_version → $latest_version (update: $update_available)"
           
-          # Add to update list if make script determined update is available
-          if [ "$update_available" = "true" ]; then
+          # PR authorization is carried by make; absent fields fail closed.
+          if [ "$actionable" = "true" ]; then
             if [ "$status" = "new-container" ]; then
               echo "   🆕 New container ready for initial release"
             else
               echo "   🚀 Update needed: $latest_version"
             fi
             containers_with_updates+=("$container")
+          elif [ "$status" = "registry-lookup-failed" ]; then
+            echo "   ⚠️ Registry lookup did not conclude — no PR from this entry"
+          elif [ "$update_available" = "true" ]; then
+            echo "   ⏸️ Update available but this container declines monitor PRs"
           else
             echo "   ✅ Up to date"
           fi
@@ -91,12 +96,12 @@ runs:
         if [ ${#containers_with_updates[@]} -eq 0 ]; then
           echo "containers_with_updates=[]" >> $GITHUB_OUTPUT
           echo "update_count=0" >> $GITHUB_OUTPUT
-          echo "📋 No containers need builds"
+          echo "📋 No entries are authorized for monitor PRs"
         else
           container_json=$(printf '%s\n' "${containers_with_updates[@]}" | jq -R . | jq -s -c .)
           echo "containers_with_updates=$container_json" >> $GITHUB_OUTPUT
           echo "update_count=${#containers_with_updates[@]}" >> $GITHUB_OUTPUT
-          echo "📋 Containers needing builds: ${containers_with_updates[*]}"
+          echo "📋 Entries authorized for monitor PRs: ${containers_with_updates[*]}"
         fi
         
         # Output complete version info

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Summary
         run: |
           update_count="${{ steps.check.outputs.update_count }}"
-          echo "Found $update_count containers with updates"
+          echo "Found $update_count entries authorized to open monitor PRs"
           if [ "$update_count" -gt 0 ]; then
             echo "Containers to update: ${{ steps.check.outputs.containers_with_updates }}"
           fi

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -296,9 +296,9 @@ Checks for upstream version updates across containers using individual `version.
 - `container` (optional): Specific container to check
 
 **Outputs:**
-- `containers_with_updates`: JSON array of containers needing updates
-- `update_count`: Number of containers with updates
-- `version_info`: Detailed version information
+- `containers_with_updates`: JSON array of entries authorized to open a monitor PR
+- `update_count`: Number of entries authorized to open a monitor PR
+- `version_info`: JSON array of every version observation, including entries not authorized for monitor PRs
 
 **Key Features:**
 - Supports both single container and bulk checking
@@ -416,9 +416,9 @@ Checks for upstream version updates across containers.
 - `container` (optional): Specific container to check
 
 **Outputs:**
-- `containers_with_updates`: JSON array of containers needing updates
-- `update_count`: Number of containers with updates
-- `version_info`: Detailed version information
+- `containers_with_updates`: JSON array of entries authorized to open a monitor PR
+- `update_count`: Number of entries authorized to open a monitor PR
+- `version_info`: JSON array of every version observation, including entries not authorized for monitor PRs
 
 ### Check Dependency Versions (`.github/actions/check-dependency-versions`)
 

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -127,7 +127,7 @@
     {% endif %}
 
     <!-- Pull command -->
-    {% if include.ghcr_image and include.dockerhub_image %}
+    {% if include.current_version_confirmed == true and include.ghcr_image and include.dockerhub_image %}
     <section>
       <h4>Pull command</h4>
       <div class="pull-section"
@@ -147,6 +147,12 @@
           </button>
         </div>
       </div>
+    </section>
+    {% elsif include.current_version_confirmed != true %}
+    <section>
+      <h4>Pull command</h4>
+      <p>Publication information is unavailable; no pull reference is shown.</p>
+      <p>Upstream version: {{ include.latest_version | default: "unknown" | escape }}</p>
     </section>
     {% endif %}
 

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -64,7 +64,7 @@
           <div class="detail-header">
             <div class="detail-title">
               <h1>{{ page.name }}</h1>
-              <span class="detail-badge">{{ page.current_version }}</span>
+              <span class="detail-badge">{{ page.current_version | default: "unknown" }}</span>
             </div>
             <div class="detail-actions">
               {%- assign _repo_url = site.github.repository_url | default: '' -%}
@@ -99,7 +99,14 @@
           {%- endif -%}
 
           {%- comment -%} Variant action bar — replaces static pull command + meta-cards {%- endcomment -%}
-          {% include variant-action-bar.html %}
+          {% if page.current_version_confirmed == true %}
+            {% include variant-action-bar.html %}
+          {% else %}
+            <section id="variants-pull" class="vab-section" aria-label="Publication information">
+              <p>Publication information is unavailable; no pull reference is shown.</p>
+              <p>Upstream version: {{ page.latest_version | default: "unknown" | escape }}</p>
+            </section>
+          {% endif %}
 
         </header>{%- comment -%} /Zone 1 — Identity {%- endcomment -%}
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -21,6 +21,7 @@ description: Real-time status monitoring for Docker containers with automated up
   {% include container-card.html
      name=container.name
      current_version=container.current_version
+     current_version_confirmed=container.current_version_confirmed
      latest_version=container.latest_version
      status_color=container.status_color
      status_text=container.status_text

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -312,21 +312,22 @@ get_container_versions() {
         return 1
     }
 
-    local current_version latest_version status_color status_text
+    local current_version latest_version status_color status_text current_version_confirmed="false"
 
     local _t0_skopeo=${EPOCHREALTIME:-}
     current_version=$(get_current_published_version "oorabona/$container")
     log_latency "skopeo-list-tags oorabona/$container" "$_t0_skopeo" 60
-    # Handle empty result
-    [[ -z "$current_version" ]] && current_version="no-published-version"
+    if [[ -n "$current_version" ]]; then
+        current_version_confirmed="true"
+    fi
 
     latest_version=$(timeout 30 ./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
 
     popd >/dev/null 2>&1
 
-    if [[ "$current_version" == "no-published-version" ]]; then
+    if [[ "$current_version_confirmed" != "true" ]]; then
         status_color="warning"
-        status_text="Not Published Yet"
+        status_text="Publication information unavailable"
     elif [[ "$current_version" == "unknown" || "$latest_version" == "unknown" ]]; then
         status_color="secondary"
         status_text="Unknown Status"
@@ -338,7 +339,7 @@ get_container_versions() {
         status_text="Update Available"
     fi
 
-    echo "${current_version}|${latest_version}|${status_color}|${status_text}"
+    echo "${current_version}|${latest_version}|${status_color}|${status_text}|${current_version_confirmed}"
 }
 
 # Get container description from README
@@ -616,7 +617,7 @@ variant_deps_for_flavor() {
 collect_variant_json() {
     local container="$1" container_dir="$2" variant_name="$3"
     local version="$4" current_version="$5" fallback_base_image="$6"
-    local is_versioned="${7:-false}"
+    local is_versioned="${7:-false}" current_version_confirmed="${8:-false}"
 
     local variant_tag variant_desc is_default
     variant_tag=$(variant_image_tag "$version" "$variant_name" "$container_dir")
@@ -646,7 +647,7 @@ collect_variant_json() {
 
     # Sizes — prefer lineage (post-#515 enriched fields), fall back to network
     local size_amd64="" size_arm64=""
-    if [[ "$current_version" != "no-published-version" ]]; then
+    if [[ "$current_version_confirmed" == "true" ]]; then
         local lineage_size_amd64 lineage_size_arm64
         lineage_size_amd64=$(echo "$lineage_json" | jq -r '.size_amd64_bytes // empty' 2>/dev/null) || lineage_size_amd64=""
         lineage_size_arm64=$(echo "$lineage_json" | jq -r '.size_arm64_bytes // empty' 2>/dev/null) || lineage_size_arm64=""
@@ -734,7 +735,7 @@ collect_variant_json() {
     local multi_arch_digests_json
     multi_arch_digests_json='{"index_digest":null,"manifest_digest_amd64":null,"manifest_digest_arm64":null}'
 
-    if [[ "$current_version" != "no-published-version" ]]; then
+    if [[ "$current_version_confirmed" == "true" ]]; then
         local lineage_platforms lineage_index_digest lineage_amd64 lineage_arm64
         lineage_platforms=$(echo "$lineage_json" | jq -c '.multi_arch_platforms // empty' 2>/dev/null) || lineage_platforms=""
         lineage_index_digest=$(echo "$lineage_json" | jq -r '.multi_arch_index_digest // empty' 2>/dev/null) || lineage_index_digest=""
@@ -907,6 +908,7 @@ collect_variant_json() {
 # Handles both multi-version (postgres) and single-version (terraform) layouts
 collect_variants_json() {
     local container="$1" container_dir="$2" current_version="$3" base_image="$4"
+    local current_version_confirmed="${5:-false}"
 
     local ver_count
     ver_count=$(version_count "$container_dir")
@@ -924,7 +926,7 @@ collect_variants_json() {
                 [[ -z "$variant_name" ]] && continue
                 local var_json
                 var_json=$(collect_variant_json "$container" "$container_dir" "$variant_name" \
-                    "$ver_tag" "$current_version" "$base_image" "true")
+                    "$ver_tag" "$current_version" "$base_image" "true" "$current_version_confirmed")
                 variants_arr=$(printf '%s\n%s' "$variants_arr" "$var_json" | jq -s '.[0] + [.[1]]')
             done < <(list_variants "$container_dir" "$ver_tag")
 
@@ -948,7 +950,7 @@ collect_variants_json() {
                 && [[ -f "$SCRIPT_DIR/.build-lineage/${container}-${ver_tag}.json" ]]; then
                 local var_json
                 var_json=$(collect_variant_json "$container" "$container_dir" "" \
-                    "$ver_tag" "$current_version" "$base_image" "true")
+                    "$ver_tag" "$current_version" "$base_image" "true" "$current_version_confirmed")
                 variants_arr=$(printf '%s\n%s' "[]" "$var_json" | jq -s '.[0] + [.[1]]')
             fi
 
@@ -968,7 +970,7 @@ collect_variants_json() {
             [[ -z "$variant_name" ]] && continue
             local var_json
             var_json=$(collect_variant_json "$container" "$container_dir" "$variant_name" \
-                "$current_version" "$current_version" "$base_image" "false")
+                "$current_version" "$current_version" "$base_image" "false" "$current_version_confirmed")
             variants_arr=$(printf '%s\n%s' "$variants_arr" "$var_json" | jq -s '.[0] + [.[1]]')
         done < <(list_variants "$container_dir")
 
@@ -1589,7 +1591,9 @@ generate_data() {
         local version_info
         version_info=$(get_container_versions "$container")
 
-        IFS='|' read -r current_version latest_version status_color status_text <<< "$version_info"
+        local current_version_confirmed
+        IFS='|' read -r current_version latest_version status_color status_text current_version_confirmed <<< "$version_info"
+        [[ "$current_version_confirmed" == "true" ]] || current_version_confirmed="false"
 
         local description
         description=$(get_container_description "$container")
@@ -1600,7 +1604,7 @@ generate_data() {
 
         # Fallback logic if CI status is unknown
         if [[ "$build_status" == "unknown" ]]; then
-            if [[ "$current_version" == "no-published-version" ]]; then
+            if [[ "$current_version_confirmed" != "true" ]]; then
                 build_status="pending"
             else
                 build_status="success"  # Assume success if published but no recent CI data
@@ -1623,7 +1627,7 @@ generate_data() {
 
         # Get image sizes (only if published)
         local sizes_amd64="" sizes_arm64=""
-        if [[ "$current_version" != "no-published-version" ]]; then
+        if [[ "$current_version_confirmed" == "true" ]]; then
             local sizes_raw
             sizes_raw=$(get_ghcr_sizes "oorabona/$container" 2>/dev/null) || true
             if [[ -n "$sizes_raw" ]]; then
@@ -1641,16 +1645,18 @@ generate_data() {
         container_json=$(
             NAME="$container" \
             CV="$current_version" LV="$latest_version" \
+            CVC="$current_version_confirmed" \
             SC="$status_color" ST="$status_text" BS="$build_status" \
             DESC="$description" \
-            GHCR="ghcr.io/oorabona/$container:$current_version" \
-            DH="docker.io/oorabona/$container:$current_version" \
+            GHCR="$([[ "$current_version_confirmed" == "true" ]] && printf 'ghcr.io/oorabona/%s:%s' "$container" "$current_version")" \
+            DH="$([[ "$current_version_confirmed" == "true" ]] && printf 'docker.io/oorabona/%s:%s' "$container" "$current_version")" \
             BD="$build_digest" BI="$base_image" \
             PC="$pull_count" PCF="$pull_count_formatted" SC2="$star_count" \
             SA="$sizes_amd64" SR="$sizes_arm64" \
             yq -n -o json '
                 .name = strenv(NAME) |
                 .current_version = strenv(CV) | .latest_version = strenv(LV) |
+                .current_version_confirmed = (strenv(CVC) == "true") |
                 .status_color = strenv(SC) | .status_text = strenv(ST) | .build_status = strenv(BS) |
                 .description = strenv(DESC) |
                 .ghcr_image = strenv(GHCR) | .dockerhub_image = strenv(DH) |
@@ -1768,7 +1774,7 @@ generate_data() {
         local container_dir="./$container"
         if has_variants "$container_dir"; then
             local variants_data
-            variants_data=$(collect_variants_json "$container" "$container_dir" "$current_version" "$base_image")
+            variants_data=$(collect_variants_json "$container" "$container_dir" "$current_version" "$base_image" "$current_version_confirmed")
             # Multi-variant: per-variant digests are in variants_data, clear container-level digest
             container_json=$(printf '%s\n%s' "$container_json" "$variants_data" | jq -s '.[0] + .[1] | .build_digest = "per-variant"')
 
@@ -1846,7 +1852,7 @@ generate_data() {
         # Container-level multi_arch_platforms: derived from GHCR manifest for the
         # container's current published tag. Used by non-variant containers and
         # versions-only containers where per-variant platforms are not emitted.
-        if [[ "$current_version" != "no-published-version" ]]; then
+        if [[ "$current_version_confirmed" == "true" ]]; then
             local container_arch_list=""
             local container_raw_sizes _t0_ghcr_cv=${EPOCHREALTIME:-}
             container_raw_sizes=$(ghcr_get_manifest_sizes "oorabona/$container" "$current_version" 2>/dev/null) || true

--- a/helpers/docker-tag
+++ b/helpers/docker-tag
@@ -38,18 +38,47 @@ function docker-tag-matching-tags() {
   local image=$1
   local pattern=$2
   local timeout_seconds=${3:-120}
-  local registry_url raw
+  local registry_url raw all_tags matching_tags filtered_tags rc
 
   registry_url=$(docker-tag-registry-url "$image")
-  raw=$(docker-tag-list-raw "$registry_url" "$timeout_seconds") || return 1
+  raw=$(docker-tag-list-raw "$registry_url" "$timeout_seconds")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # 3 means the registry enumeration did not conclude.  Keep 1 reserved for
+    # a successful enumeration with no matching tag, which existing callers
+    # already treat as "not published".
+    return 3
+  fi
 
-  printf '%s' "$raw" | \
-    jq -r '.Tags[]? // empty' 2>/dev/null | \
-    grep -E "$pattern" 2>/dev/null | \
-    # Exclude prerelease tags (rc, alpha, beta, dev, pre, snapshot, nightly).
-    # Anchored at end of string to avoid false positives (e.g. "go-alpine" != alpha).
-    grep -viE '\-?(rc|alpha|beta|dev|pre|snapshot|nightly)[0-9.]*$' 2>/dev/null | \
-    sort -V
+  # Parse before filtering so invalid/partial registry output cannot be
+  # mistaken for a successful empty match set.
+  all_tags=$(printf '%s' "$raw" | \
+    jq -r 'if ((.Tags | type) == "array" and all(.Tags[]; type == "string")) then .Tags[] else error("Tags must be an array of strings") end' 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 3
+  fi
+
+  matching_tags=$(printf '%s\n' "$all_tags" | grep -E "$pattern" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 1 ]; then
+    return 0
+  elif [ "$rc" -ne 0 ]; then
+    return 3
+  fi
+
+  # Exclude prerelease tags (rc, alpha, beta, dev, pre, snapshot, nightly).
+  # Anchored at end of string to avoid false positives (e.g. "go-alpine" != alpha).
+  filtered_tags=$(printf '%s\n' "$matching_tags" | \
+    grep -viE '\-?(rc|alpha|beta|dev|pre|snapshot|nightly)[0-9.]*$' 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 1 ]; then
+    return 0
+  elif [ "$rc" -ne 0 ]; then
+    return 3
+  fi
+
+  printf '%s\n' "$filtered_tags" | sort -V || return 3
 }
 
 function docker-tag-digest() {
@@ -93,8 +122,14 @@ function latest-docker-tag() {
   # Capture raw output and exit code FIRST so a 124 (timeout with partial stdout)
   # deterministically routes to the failure path rather than silently returning
   # whatever partial JSON the pipeline happened to parse before exit.
-  local result
-  result=$(docker-tag-matching-tags "$image" "$pattern" 120 | tail -n1)
+  local matching_tags result rc
+  matching_tags=$(docker-tag-matching-tags "$image" "$pattern" 120)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
+
+  result=$(printf '%s\n' "$matching_tags" | tail -n1)
 
   if [[ -n "$result" && "$result" != "null" ]]; then
     echo "$result"

--- a/make
+++ b/make
@@ -502,6 +502,64 @@ make() {
   return $_op_rc
 }
 
+# Emit a tab-separated registry lookup outcome and confirmed current version.
+# Exit 1 remains "enumeration succeeded but matched nothing" in
+# latest-docker-tag; exit 3 means the enumeration or its response failed.
+check_updates_current_version() {
+  local image=$1
+  local pattern=$2
+  local current_version rc
+
+  if current_version=$(../helpers/latest-docker-tag "$image" "$pattern" 2>/dev/null); then
+    rc=0
+  else
+    rc=$?
+  fi
+  current_version=$(printf '%s' "$current_version" | head -1 | tr -d '\n')
+
+  case "$rc" in
+    0)
+      # no-published-version is a legacy caller sentinel, never a confirmed tag.
+      if [[ -n "$current_version" && "$current_version" != "no-published-version" ]]; then
+        printf 'matched\t%s\n' "$current_version"
+      else
+        printf 'no-match\t\n'
+      fi
+      ;;
+    1) printf 'no-match\t\n' ;;
+    *) printf 'failed\t\n' ;;
+  esac
+}
+
+# An absent declaration preserves the historical behaviour (actionable when
+# there is a confirmed update). Do not use yq's `// true` here: false is a
+# valid declaration and must not be coalesced with an absent value.
+check_updates_declared_actionable() {
+  local container=$1
+  local declaration field_present action_tag declared_actionable
+
+  if [[ ! -e variants.yaml && ! -L variants.yaml ]]; then
+    printf 'true\n'
+    return
+  fi
+
+  if ! declaration=$(yq -r '[ (.build | has("upstream_monitor_actionable")), (.build.upstream_monitor_actionable | tag), .build.upstream_monitor_actionable] | @tsv' variants.yaml 2>/dev/null); then
+    printf 'check-updates: %s: unable to read variants.yaml; refusing monitor PR\n' "$container" >&2
+    printf 'false\n'
+    return
+  fi
+
+  IFS=$'\t' read -r field_present action_tag declared_actionable <<< "$declaration"
+  if [[ "$field_present" == "false" ]]; then
+    printf 'true\n'
+  elif [[ "$action_tag" == "!!bool" && ( "$declared_actionable" == "true" || "$declared_actionable" == "false" ) ]]; then
+    printf '%s\n' "$declared_actionable"
+  else
+    printf 'check-updates: %s: upstream_monitor_actionable must be a JSON boolean; refusing monitor PR\n' "$container" >&2
+    printf 'false\n'
+  fi
+}
+
 check_updates() {
   local target=${1:-""}
   local output_json="[]"
@@ -526,6 +584,11 @@ check_updates() {
 
     pushd "$container" > /dev/null
 
+    # Read the declaration once after entering the container directory so both
+    # retained-major and default paths use the same result.
+    local declared_actionable
+    declared_actionable=$(check_updates_declared_actionable "$container")
+
     # Detect retention strategy for multi-entry (latest_per_major) containers
     local strategy
     strategy=$(yq -r '.build.retention_strategy // ""' variants.yaml 2>/dev/null) || strategy=""
@@ -549,12 +612,9 @@ check_updates() {
         # Current published version on GHCR matching ^N\. pattern for this major
         local major_pattern
         major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
-        local current_version
-        # No matching published tag is a normal lookup outcome. Keep the
-        # current-version field empty in that case, independently of pipefail.
-        if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$major_pattern" 2>/dev/null | head -1 | tr -d '\n'); then
-          current_version=""
-        fi
+        local current_version registry_lookup lookup_info
+        lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$major_pattern")
+        IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
 
         # Latest upstream version for this major line
         local latest_version
@@ -562,9 +622,12 @@ check_updates() {
 
         # Determine update status
         local update_available="false"
+        local actionable="false"
         local status="up_to_date"
 
-        if [ -z "$current_version" ] || [ "$current_version" = "no-published-version" ]; then
+        if [[ "$registry_lookup" == "failed" ]]; then
+          status="registry-lookup-failed"
+        elif [[ "$registry_lookup" == "no-match" ]]; then
           if [ -n "$latest_version" ]; then
             update_available="true"
             status="new-container"
@@ -578,6 +641,10 @@ check_updates() {
           fi
         fi
 
+        if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+          actionable="true"
+        fi
+
         # Build per-major JSON entry.
         # container field = composite key (for action routing)
         # major_line field = the plain major number (for human-readable outputs)
@@ -588,6 +655,8 @@ check_updates() {
           --arg current "$current_version" \
           --arg latest "$latest_version" \
           --argjson update_available "$update_available" \
+          --argjson actionable "$actionable" \
+          --arg registry_lookup "$registry_lookup" \
           --arg status "$status" \
           '{
             container: $container,
@@ -595,6 +664,8 @@ check_updates() {
             current_version: $current,
             latest_version: $latest,
             update_available: $update_available,
+            actionable: $actionable,
+            registry_lookup: $registry_lookup,
             status: $status
           }')
 
@@ -608,24 +679,24 @@ check_updates() {
     # Default single-entry path (no latest_per_major strategy)
     # Get current and latest versions using container-specific patterns
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
-    local pattern
+    local pattern current_version registry_lookup lookup_info
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "$pattern" 2>/dev/null | head -1 | tr -d '\n'); then
-        current_version=""
-      fi
+      lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$pattern")
     else
       # Fallback: try common version pattern
-      if ! current_version=$(../helpers/latest-docker-tag "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$" 2>/dev/null | head -1 | tr -d '\n'); then
-        current_version=""
-      fi
+      lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$")
     fi
+    IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
 
     # Determine update status
     local update_available="false"
+    local actionable="false"
     local status="up_to_date"
 
-    if [ -z "$current_version" ] || [ "$current_version" = "no-published-version" ]; then
+    if [[ "$registry_lookup" == "failed" ]]; then
+      status="registry-lookup-failed"
+    elif [[ "$registry_lookup" == "no-match" ]]; then
       if [ -n "$latest_version" ]; then
         update_available="true"
         status="new-container"
@@ -639,18 +710,26 @@ check_updates() {
       fi
     fi
 
+    if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+      actionable="true"
+    fi
+
     # Build JSON object for this container
     container_json=$(jq -n \
       --arg container "$container" \
       --arg current "$current_version" \
       --arg latest "$latest_version" \
       --argjson update_available "$update_available" \
+      --argjson actionable "$actionable" \
+      --arg registry_lookup "$registry_lookup" \
       --arg status "$status" \
       '{
         container: $container,
         current_version: $current,
         latest_version: $latest,
         update_available: $update_available,
+        actionable: $actionable,
+        registry_lookup: $registry_lookup,
         status: $status
       }')
 

--- a/postgres/variants.yaml
+++ b/postgres/variants.yaml
@@ -15,6 +15,9 @@ build:
   # Postgres builds all supported PG majors on every push (not just the latest line).
   # Rationale: each major is a long-lived supported release stream, not a rolling history.
   always_all_versions: true
+  # #1512 will migrate the registry matcher; until then this lookup must not
+  # authorize a monitor-created PR even when an upstream version is available.
+  upstream_monitor_actionable: false
   # Explicit bake opt-in for the FINAL image only. Extension compilation remains
   # owned by build-extensions; bake only consumes pre-built extension images.
   bake_final_build: true

--- a/tests/unit/check-upstream-versions-action.bats
+++ b/tests/unit/check-upstream-versions-action.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+# Exercises the composite action's real check-versions script with a fixture
+# make entry point. The registry result is the only external dependency; the
+# action's selection logic itself is not mocked.
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    ORIG_DIR="$PWD"
+    cd "$TEST_DIR" || exit 1
+
+    mkdir -p .github/actions/check-upstream-versions
+    cp "$ORIG_DIR/.github/actions/check-upstream-versions/action.yaml" \
+        .github/actions/check-upstream-versions/action.yaml
+
+    # GitHub evaluates inputs before Bash sees the run block. In this hermetic
+    # invocation, replace the optional container expression with an empty value
+    # and execute the composite action's otherwise-unmodified script.
+    yq -r '.runs.steps[] | select(.id == "check-versions") | .run' \
+        .github/actions/check-upstream-versions/action.yaml |
+        sed 's#${{ inputs.container }}##g' > run-check-versions.sh
+    chmod +x run-check-versions.sh
+}
+
+teardown() {
+    cd "$ORIG_DIR" || true
+    rm -rf "$TEST_DIR"
+}
+
+write_make_result() {
+    local result="$1"
+    cat > make <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "check-updates" ]]; then
+  printf '%s\\n' '$result'
+fi
+EOF
+    chmod +x make
+}
+
+run_action() {
+    local output_file="$TEST_DIR/github-output"
+    : > "$output_file"
+    GITHUB_OUTPUT="$output_file" bash ./run-check-versions.sh
+    cat "$output_file"
+}
+
+@test "composite action excludes declared non-actionable updates" {
+    write_make_result '[{"container":"postgres","current_version":"","latest_version":"18.6-alpine","update_available":true,"actionable":false,"registry_lookup":"no-match","status":"new-container"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"containers_with_updates=[]"* ]]
+    [[ "$output" == *"update_count=0"* ]]
+}
+
+@test "composite action fails closed when actionable is absent" {
+    write_make_result '[{"container":"future-container","current_version":"1.0.0","latest_version":"1.1.0","update_available":true,"status":"update-available"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"containers_with_updates=[]"* ]]
+    [[ "$output" == *"update_count=0"* ]]
+}
+
+@test "composite action fails closed when actionable is the string true" {
+    write_make_result '[{"container":"string-actionable","current_version":"1.0.0","latest_version":"1.1.0","update_available":true,"actionable":"true","registry_lookup":"matched","status":"update-available"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"containers_with_updates=[]"* ]]
+    [[ "$output" == *"update_count=0"* ]]
+}
+
+# Positive control for the two exclusion tests above. Without it a mutation that
+# emptied containers_with_updates unconditionally would satisfy both of them.
+@test "composite action selects an actionable update" {
+    write_make_result '[{"container":"terraform","current_version":"1.15.9-alpine","latest_version":"1.16.0-alpine","update_available":true,"actionable":true,"registry_lookup":"matched","status":"update-available"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'containers_with_updates=["terraform"]'* ]]
+    [[ "$output" == *"update_count=1"* ]]
+}
+
+@test "composite action excludes an entry whose registry lookup failed" {
+    write_make_result '[{"container":"sslh","current_version":"","latest_version":"v2.3.1-alpine","update_available":false,"actionable":false,"registry_lookup":"failed","status":"registry-lookup-failed"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"containers_with_updates=[]"* ]]
+    [[ "$output" == *"Registry lookup did not conclude"* ]]
+}

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -10,6 +10,7 @@ setup() {
     source "$ORIG_DIR/helpers/logging.sh" 2>/dev/null || true
     source "$ORIG_DIR/helpers/variant-utils.sh" 2>/dev/null || true
     source "$ORIG_DIR/generate-dashboard.sh" 2>/dev/null || true
+    eval "$(declare -f get_container_versions | sed '1s/get_container_versions/_real_get_container_versions/')"
     _SOURCED_TRIVY_CACHE="${TRIVY_CACHE_FILE:-}"
     if [[ -n "$_saved_exit_trap" ]]; then
         eval "$_saved_exit_trap" 2>/dev/null || true
@@ -27,7 +28,7 @@ setup() {
     TRIVY_CACHE_FILE=$(mktemp)
     export DATA_FILE CONTAINERS_DIR STATS_FILE TRIVY_CACHE_FILE
 
-    get_container_versions()             { echo "1.0.0|1.0.0|green|Up to date"; }
+    get_container_versions()             { echo "1.0.0|1.0.0|green|Up to date|true"; }
     get_container_description()          { echo "Alpha test container"; }
     get_container_build_status()         { echo "success"; }
     populate_container_build_status_cache() { :; }
@@ -122,6 +123,43 @@ capture_container_page() {
         local container="$1" container_json="$2"
         echo "$container_json" > "$TEST_DIR/captured-${container}.json"
     }
+}
+
+@test "dashboard: unconfirmed current version carries explicit absence and no image references" {
+    make_fixture_container "unconfirmed"
+
+    get_current_published_version() { echo ""; }
+    run _real_get_container_versions "unconfirmed"
+    [ "$status" -eq 0 ]
+    [[ "$(tail -n1 <<< "$output")" == "|1.0.0|warning|Publication information unavailable|false" ]]
+
+    capture_container_page
+    get_container_versions() { echo "|9.9.9|warning|Publication information unavailable|false"; }
+
+    run generate_data
+    [ "$status" -eq 0 ]
+
+    local record
+    record=$(cat "$TEST_DIR/captured-unconfirmed.json")
+    echo "$record" | jq -e '
+        .current_version == "" and
+        .current_version_confirmed == false and
+        .latest_version == "9.9.9" and
+        .status_text == "Publication information unavailable" and
+        .ghcr_image == "" and
+        .dockerhub_image == ""
+    ' >/dev/null
+
+    # Lexical, and deliberately so: no Ruby or Jekyll runs in this environment,
+    # so nothing here renders Liquid. These two greps assert only that the
+    # templates branch on the explicit field rather than on a string sentinel.
+    # They cannot show what the built page emits — that check is fetching the
+    # deployed site, which is where a Liquid quirk that survives a source grep
+    # has bitten this repository before.
+    grep -q 'include.current_version_confirmed == true' \
+        "$ORIG_DIR/docs/site/_includes/container-card.html"
+    grep -q 'page.current_version_confirmed == true' \
+        "$ORIG_DIR/docs/site/_layouts/container-detail.html"
 }
 
 # Creates a minimal container directory that satisfies generate_data()'s

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 # Unit tests for the latest_per_major_versions helper in helpers/variant-utils.sh
 # and the --major flag in wordpress/version.sh
 
@@ -112,6 +114,15 @@ fi
 echo "1.0.0"
 VEOF
     chmod +x "$dir/version.sh"
+}
+
+@test "postgres declares its upstream monitor non-actionable pending #1512" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+
+    run yq -r '.build.upstream_monitor_actionable' "$ORIG_DIR/postgres/variants.yaml"
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+    grep -q '#1512' "$ORIG_DIR/postgres/variants.yaml"
 }
 
 # ----------------------------------------------------------------
@@ -418,14 +429,18 @@ EOF
     printf '# Args: <image> <pattern>\n' >> helpers/latest-docker-tag
     printf 'pattern="$2"\n' >> helpers/latest-docker-tag
     printf 'if echo "$pattern" | grep -qE "^\\^7"; then\n' >> helpers/latest-docker-tag
-    if [[ "$mock_ghcr_7" == "__EMPTY_FAILURE__" ]]; then
+    if [[ "$mock_ghcr_7" == "__ENUMERATION_FAILURE__" ]]; then
+        printf '  exit 3\n' >> helpers/latest-docker-tag
+    elif [[ "$mock_ghcr_7" == "__NO_MATCH__" ]]; then
         printf '  exit 1\n' >> helpers/latest-docker-tag
     else
         printf '  echo "%s"; exit 0\n' "${mock_ghcr_7}" >> helpers/latest-docker-tag
     fi
     printf 'fi\n' >> helpers/latest-docker-tag
     printf 'if echo "$pattern" | grep -qE "^\\^6"; then\n' >> helpers/latest-docker-tag
-    if [[ "$mock_ghcr_6" == "__EMPTY_FAILURE__" ]]; then
+    if [[ "$mock_ghcr_6" == "__ENUMERATION_FAILURE__" ]]; then
+        printf '  exit 3\n' >> helpers/latest-docker-tag
+    elif [[ "$mock_ghcr_6" == "__NO_MATCH__" ]]; then
         printf '  exit 1\n' >> helpers/latest-docker-tag
     else
         printf '  echo "%s"; exit 0\n' "${mock_ghcr_6}" >> helpers/latest-docker-tag
@@ -500,12 +515,14 @@ create_default_check_updates_fixture() {
     local mock_current="${1:-1.0.0-ubuntu}"
     local mock_latest="${2:-2.0.0-ubuntu}"
     local registry_pattern="${3:-^[0-9]+\.[0-9]+(\.[0-9]+)?-ubuntu$}"
+    local monitor_actionable="${4:-true}"
 
     mkdir -p ansible helpers scripts
 
-    cat > ansible/variants.yaml <<'EOF'
+    cat > ansible/variants.yaml <<EOF
 build:
   requires_extensions: false
+  upstream_monitor_actionable: ${monitor_actionable}
 versions:
   - tag: 1.0.0-ubuntu
 EOF
@@ -520,7 +537,9 @@ EOF
     if [[ "$mock_current" == "__NO_PUBLISHED__" ]]; then
         printf 'echo "no-published-version"\n' >> helpers/latest-docker-tag
         printf 'exit 0\n' >> helpers/latest-docker-tag
-    elif [[ "$mock_current" == "__EMPTY_FAILURE__" ]]; then
+    elif [[ "$mock_current" == "__ENUMERATION_FAILURE__" ]]; then
+        printf 'exit 3\n' >> helpers/latest-docker-tag
+    elif [[ "$mock_current" == "__NO_MATCH__" ]]; then
         printf 'exit 1\n' >> helpers/latest-docker-tag
     else
         printf 'echo "%s"\n' "$mock_current" >> helpers/latest-docker-tag
@@ -773,21 +792,55 @@ EOF
     [[ "$status_6" == "up_to_date" ]]
 }
 
-@test "check_updates multi-entry: accepted empty current_version ambiguity reports new-container" {
+@test "check_updates multi-entry: enumeration failure is reported and fails closed" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
-    # Accepted pre-existing ambiguity: Docker/GHCR/skopeo/rate-limit helper failures and genuinely unpublished containers both yield empty current_version; status is cosmetic, not a fully reasoned contract.
-    create_check_updates_fixture "7.0.0-alpine" "__EMPTY_FAILURE__" "7.0.0-alpine" "6.9.4-alpine"
+    create_check_updates_fixture "7.0.0-alpine" "__ENUMERATION_FAILURE__" "7.0.0-alpine" "6.9.4-alpine"
 
     run run_check_updates wordpress
     [ "$status" -eq 0 ]
 
     current_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .current_version')
     update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    actionable_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .actionable')
+    lookup_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .registry_lookup')
     status_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')
     [[ -z "$current_6" ]]
+    [[ "$update_6" == "false" ]]
+    [[ "$actionable_6" == "false" ]]
+    [[ "$lookup_6" == "failed" ]]
+    [[ "$status_6" == "registry-lookup-failed" ]]
+}
+
+@test "check_updates multi-entry: classifies a failed lookup with inherit_errexit enabled" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "__ENUMERATION_FAILURE__" "7.0.0-alpine" "6.9.4-alpine"
+
+    run --separate-stderr bash -O inherit_errexit ./make check-updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .registry_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "registry-lookup-failed" ]]
+}
+
+@test "check_updates multi-entry: successful no-match is distinct from enumeration failure" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "__NO_MATCH__" "7.0.0-alpine" "6.9.4-alpine"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+
+    lookup_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .registry_lookup')
+    update_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')
+    actionable_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .actionable')
+    status_6=$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')
+    [[ "$lookup_6" == "no-match" ]]
     [[ "$update_6" == "true" ]]
+    [[ "$actionable_6" == "true" ]]
     [[ "$status_6" == "new-container" ]]
 }
 
@@ -869,22 +922,161 @@ EOF
     [[ "$status_value" == "up_to_date" ]]
 }
 
-@test "check_updates default path: accepted empty current_version ambiguity reports new-container" {
+@test "check_updates default path: enumeration failure is reported and fails closed" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
-    # Accepted pre-existing ambiguity: Docker/GHCR/skopeo/rate-limit helper failures and genuinely unpublished containers both yield empty current_version; status is cosmetic, not a fully reasoned contract.
-    create_default_check_updates_fixture "__EMPTY_FAILURE__" "14.1.0-ubuntu"
+    create_default_check_updates_fixture "__ENUMERATION_FAILURE__" "14.1.0-ubuntu"
 
     run run_check_updates ansible
     [ "$status" -eq 0 ]
 
     current_version=$(echo "$output" | jq -r '.[0].current_version')
     update_available=$(echo "$output" | jq -r '.[0].update_available')
+    actionable=$(echo "$output" | jq -r '.[0].actionable')
+    lookup=$(echo "$output" | jq -r '.[0].registry_lookup')
     status_value=$(echo "$output" | jq -r '.[0].status')
     [[ -z "$current_version" ]]
-    [[ "$update_available" == "true" ]]
-    [[ "$status_value" == "new-container" ]]
+    [[ "$update_available" == "false" ]]
+    [[ "$actionable" == "false" ]]
+    [[ "$lookup" == "failed" ]]
+    [[ "$status_value" == "registry-lookup-failed" ]]
+}
+
+@test "check_updates default path: classifies a failed lookup with inherit_errexit enabled" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "__ENUMERATION_FAILURE__" "14.1.0-ubuntu"
+
+    run --separate-stderr bash -O inherit_errexit ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "registry-lookup-failed" ]]
+}
+
+@test "check_updates default path: malformed variants declaration refuses monitor PRs" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    printf 'build:\n  upstream_monitor_actionable: [\n' > ansible/variants.yaml
+
+    run --separate-stderr ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$stderr" == *"ansible: unable to read variants.yaml"* ]]
+}
+
+@test "check_updates default path: an absent declaration remains actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/variants.yaml <<'EOF'
+build:
+  requires_extensions: false
+EOF
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "true" ]]
+}
+
+@test "check_updates default path: an absent variants file remains actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    rm ansible/variants.yaml
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "true" ]]
+}
+
+@test "check_updates default path: a dangling variants symlink refuses monitor PRs" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    rm ansible/variants.yaml
+    ln -s /nonexistent-variants-target ansible/variants.yaml
+
+    run --separate-stderr ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$stderr" == *"ansible: unable to read variants.yaml"* ]]
+}
+
+@test "docker-tag-matching-tags: unavailable sort returns rc=3" {
+    local shim_dir wrapper real_jq real_grep
+    shim_dir="$TEST_DIR/sort-unavailable-shim"
+    mkdir -p "$shim_dir"
+    real_jq=$(command -v jq)
+    real_grep=$(command -v grep)
+    ln -s "$real_jq" "$shim_dir/jq"
+    ln -s "$real_grep" "$shim_dir/grep"
+    cat > "$shim_dir/timeout" <<'SHEOF'
+#!/bin/bash
+printf '{"Repository":"docker://library/alpine","Tags":["3.20"]}\n'
+exit 0
+SHEOF
+    chmod +x "$shim_dir/timeout"
+
+    wrapper="$shim_dir/run-docker-tag-matching-tags.sh"
+    cat > "$wrapper" <<WEOF
+#!/bin/bash
+source "$ORIG_DIR/helpers/docker-tag"
+export PATH="$shim_dir"
+docker-tag-matching-tags "alpine" "^3\\."
+WEOF
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+    [ "$status" -eq 3 ]
+}
+
+@test "check_updates latest_per_major path reads its declaration once per container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.1-alpine" "6.9.5-alpine"
+    mkdir -p bin
+    local real_yq declaration_log
+    real_yq=$(command -v yq)
+    declaration_log="$TEST_DIR/actionable-yq.log"
+    cat > bin/yq <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"upstream_monitor_actionable"* ]]; then
+    printf '%s\n' "$*" >> "$YQ_ACTIONABLE_LOG"
+fi
+exec "$REAL_YQ" "$@"
+EOF
+    chmod +x bin/yq
+
+    export REAL_YQ="$real_yq"
+    export YQ_ACTIONABLE_LOG="$declaration_log"
+    export PATH="$TEST_DIR/bin:$PATH"
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$declaration_log" | tr -d ' ')" -eq 1 ]
+}
+
+@test "check_updates default path: declared non-actionable update remains reportable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$" "false"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "matched" ]]
 }
 
 @test "check_updates default path: same numeric tuple with different suffix is an update" {
@@ -1013,7 +1205,7 @@ EOF
     current_version=$(echo "$output" | jq -r '.[0].current_version')
     update_available=$(echo "$output" | jq -r '.[0].update_available')
     status_value=$(echo "$output" | jq -r '.[0].status')
-    [[ "$current_version" == "no-published-version" ]]
+    [[ -z "$current_version" ]]
     [[ "$update_available" == "true" ]]
     [[ "$status_value" == "new-container" ]]
 }

--- a/tests/unit/sbom-size-guard.bats
+++ b/tests/unit/sbom-size-guard.bats
@@ -333,9 +333,9 @@ SHEOF
 # latest-docker-tag (helpers/docker-tag) — capture-first rc check
 # =============================================================================
 
-@test "latest-docker-tag: timeout exit-124 with partial valid JSON returns rc=1 and empty stdout" {
+@test "latest-docker-tag: timeout exit-124 with partial valid JSON returns rc=3 and empty stdout" {
     # Mutation caught: removing the capture-first `rc` check in latest-docker-tag
-    # (i.e. dropping `rc=$?; if [ "$rc" -ne 0 ]; then return 1; fi`) would cause
+    # (i.e. dropping `rc=$?; if [ "$rc" -ne 0 ]; then return 3; fi`) would cause
     # `raw` to hold the partial valid tags JSON emitted before the kill, which then
     # passes through jq/.Tags[]/grep/sort/tail and produces a false-success tag on
     # stdout instead of an empty result.
@@ -343,7 +343,7 @@ SHEOF
     # This shim replaces `timeout` so that `timeout 120 docker run ...` prints a
     # syntactically-valid tags list to stdout (what a real skopeo would emit) then
     # exits 124 — exactly what happens when skopeo is killed mid-output by a wall-
-    # clock timeout.  The function must detect rc=124, return 1, and emit nothing.
+    # clock timeout. The function must detect rc=124, return 3, and emit nothing.
 
     # Source the helper (functions only; execution guard prevents side-effects).
     source "$ORIG_DIR/helpers/docker-tag" 2>/dev/null || true
@@ -379,9 +379,94 @@ WEOF
 
     run "$wrapper"
 
-    # rc must be 1 (failure path) — not 0 (false success).
-    [ "$status" -eq 1 ]
+    # rc 3 means registry enumeration failed — not 0 (false success), and
+    # not 1 (the established successful-enumeration/no-match outcome).
+    [ "$status" -eq 3 ]
     # stdout must be empty — the partial valid JSON must NOT have leaked through
     # the jq/.Tags[]/grep/sort/tail pipeline to produce a tag string.
+    [ -z "$output" ]
+}
+
+@test "latest-docker-tag: successful enumeration with no matches keeps exit 1" {
+    source "$ORIG_DIR/helpers/docker-tag" 2>/dev/null || true
+
+    local shim_dir wrapper
+    shim_dir="$TEST_DIR/no-matches-shim"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/timeout" <<'SHEOF'
+#!/bin/bash
+printf '{"Repository":"docker://library/alpine","Tags":["3.20","latest"]}\n'
+exit 0
+SHEOF
+    chmod +x "$shim_dir/timeout"
+
+    wrapper="$shim_dir/run-latest-docker-tag.sh"
+    cat > "$wrapper" <<WEOF
+#!/bin/bash
+source "$ORIG_DIR/helpers/docker-tag"
+export PATH="$shim_dir:\$PATH"
+latest-docker-tag "alpine" "^9\\." 2>/dev/null
+WEOF
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "latest-docker-tag: unparseable enumeration response returns rc=3" {
+    source "$ORIG_DIR/helpers/docker-tag" 2>/dev/null || true
+
+    local shim_dir wrapper
+    shim_dir="$TEST_DIR/unparseable-response-shim"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/timeout" <<'SHEOF'
+#!/bin/bash
+printf '{"Repository":"docker://library/alpine","Tags":\n'
+exit 0
+SHEOF
+    chmod +x "$shim_dir/timeout"
+
+    wrapper="$shim_dir/run-latest-docker-tag.sh"
+    cat > "$wrapper" <<WEOF
+#!/bin/bash
+source "$ORIG_DIR/helpers/docker-tag"
+export PATH="$shim_dir:\$PATH"
+latest-docker-tag "alpine" "^3\\." 2>/dev/null
+WEOF
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+}
+
+@test "latest-docker-tag: a non-string Tags member returns rc=3" {
+    source "$ORIG_DIR/helpers/docker-tag" 2>/dev/null || true
+
+    local shim_dir wrapper
+    shim_dir="$TEST_DIR/non-string-tags-shim"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/timeout" <<'SHEOF'
+#!/bin/bash
+printf '{"Repository":"docker://library/alpine","Tags":[{"tag":"3.20"}]}'
+exit 0
+SHEOF
+    chmod +x "$shim_dir/timeout"
+
+    wrapper="$shim_dir/run-latest-docker-tag.sh"
+    cat > "$wrapper" <<WEOF
+#!/bin/bash
+source "$ORIG_DIR/helpers/docker-tag"
+export PATH="$shim_dir:\$PATH"
+latest-docker-tag "alpine" "^3\\." 2>/dev/null
+WEOF
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+
+    [ "$status" -eq 3 ]
     [ -z "$output" ]
 }


### PR DESCRIPTION
The upstream monitor read "the registry enumeration failed" and "the enumeration succeeded and
matched nothing" as the same empty string, and opened a pull request from both. The dashboard
turned that same empty string into `docker pull ghcr.io/oorabona/postgres:no-published-version`
on the public site.

Each monitor entry now reports which of the three outcomes happened and carries an explicit
flag saying whether automation may open a PR from it; an absent flag is treated as no. A
container can decline monitor PRs, and postgres does until its published tags carry the version
the check compares against. The dashboard shows the container, its status and its upstream
version instead of a pull reference it could not confirm.

Refs #1512 — the tag-scheme migration stays open there; this is the part that stops the daily
false PR and the broken pull command today.

## Verified

- Full bats suite: 2955 tests, 0 failures.
- `shellcheck -x -S warning` on `make`, `helpers/docker-tag` and `generate-dashboard.sh`: zero
  findings, identical to master.
- The unconfirmed dashboard path was exercised through the real `get_container_versions` with
  the registry helper stubbed to each exit code, and against a stub that succeeds, so a
  confirmed record and an unconfirmed one are distinguishable.
- Mutation proofs seen red for the absent-file condition, the dangling-symlink condition, the
  boolean authorization check, the string-tag validation and the exit-code taxonomy.

Not run locally: the container e2e suite, which builds images and observes nothing this diff
changes, and a rendered Jekyll build — no Ruby in the dev environment. CI covers both.

## Known and filed, not fixed here

#1513 #1514 #1515 #1516 #1517 carry the findings that are identical on master or have no
runtime path.
