### PR TITLE
fix(ci): a drift run that evaluated nothing no longer reports no drift

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1806,6 +1806,147 @@ jobs:
           REQUESTED_CONTAINER: ${{ inputs.container }}
           SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
+          # Keep the closing annotation truthful when the detector has error
+          # records.  Its values are counts calculated from JSON only: never
+          # interpolate lineage-derived strings into a workflow command.
+          emit_drift_notice() {
+            local notice_json="$1"
+            local mode="${2:-normal}"
+            local drift_count error_count evaluated_count variant_count
+
+            drift_count=$(printf '%s' "$notice_json" | jq \
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy"))] | length')
+            # Both coverage counts intentionally derive from notice_json.  The
+            # coverage decision must describe one population, even when the
+            # later PR matrix is scoped to a requested container.
+            error_count=$(printf '%s' "$notice_json" | jq \
+              '[.[] | .variants[] | select(.status == "error")] | length')
+            evaluated_count=$(printf '%s' "$notice_json" | jq \
+              '[.[] | .variants[] | select(.status != "error")] | length')
+            variant_count=$((error_count + evaluated_count))
+
+            if [[ "$error_count" -gt 0 ]]; then
+              echo "::notice::Base image digest drift coverage incomplete: ${evaluated_count} variant(s) evaluated; ${error_count} could not be evaluated"
+              # A successful detector process only means its JSON is valid.  An
+              # error record means that JSON does not cover every active variant,
+              # so fail this consumer step after preserving the coverage notice.
+              return 1
+            elif [[ "$variant_count" -eq 0 ]]; then
+              echo "::notice::No base image digest drift evaluation was performed — nothing to evaluate"
+            elif [[ "$mode" == "coverage" ]]; then
+              # The coverage gate runs before any scoped success path.  A
+              # populated, complete result has no closing notice until its
+              # scoped or unscoped consumer output has been assembled below.
+              return 0
+            elif [[ "$drift_count" -gt 0 ]]; then
+              echo "::notice::Digest drift detected for ${drift_count} container(s)"
+            else
+              echo "::notice::No base image digest drift detected"
+            fi
+          }
+
+          # Consume a validated detector result.  Keeping this whole decision
+          # sequence in one function lets its coverage-first behavior be tested
+          # directly without a live workflow dispatch.
+          consume_drift_result() {
+            local drift_json="$1"
+            local requested_container="$2"
+            local drift_containers_all drift_containers_csv error_containers_csv
+            local drift_containers drift_matrix drift_matrix_leaves drift_matrix_consumers
+            local population_variant_count
+
+            # Coverage is deliberately decided from the unfiltered result
+            # before a requested-container scope can take a successful exit.
+            emit_drift_notice "$drift_json" coverage || return 1
+            population_variant_count=$(printf '%s' "$drift_json" | jq \
+              '[.[] | .variants[]] | length')
+
+            # An empty unfiltered population was already announced by the
+            # coverage decision.  Publish every advertised empty output and
+            # stop before a requested-container branch can claim it is clean.
+            if [[ "$population_variant_count" -eq 0 ]]; then
+              {
+                echo "drift_containers=[]"
+                echo "drift_matrix=[]"
+                echo "drift_matrix_leaves=[]"
+                echo "drift_matrix_consumers=[]"
+                echo "drift_containers_csv="
+                echo "error_containers_csv="
+              } >> "$GITHUB_OUTPUT"
+              return 0
+            fi
+
+            # Compute repo-wide drift_containers_csv from the UNFILTERED drift_json.
+            # This must happen BEFORE the REQUESTED_CONTAINER filter below, so that
+            # _eval_parent_state always sees the full drift picture regardless of how
+            # workflow_dispatch was scoped.  Without this split a scoped dispatch
+            # (e.g. requested_container=wordpress) would produce drift_containers_csv
+            # containing only "wordpress", causing State B to mark a still-drifting
+            # "php" parent as stable and auto-merging the child against a stale image.
+            drift_containers_all=$(echo "$drift_json" | jq -c \
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
+              || echo "[]")
+            drift_containers_csv=$(echo "$drift_containers_all" | jq -r 'join(",")')
+            echo "drift_containers_csv=${drift_containers_csv}" >> "$GITHUB_OUTPUT"
+
+            # Compute repo-wide error_containers_csv from the UNFILTERED drift_json.
+            # Containers with ANY variant status == "error" are those whose probe FAILED
+            # this run — their actual drift state is UNKNOWN.  Plumbed as CURRENT_ERROR_SET
+            # into the cascade-labels step so _eval_parent_state can treat an errored parent
+            # as in_flux (conservative: wait rather than auto-merge against unknown state).
+            error_containers_csv=$(echo "$drift_json" | jq -r \
+              '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
+              || echo "")
+            echo "error_containers_csv=${error_containers_csv}" >> "$GITHUB_OUTPUT"
+
+            if [[ -n "$requested_container" ]]; then
+              drift_json=$(echo "$drift_json" | jq --arg c "$requested_container" '[.[] | select(.container == $c)]')
+              if [[ "$(echo "$drift_json" | jq 'length')" == "0" ]]; then
+                # Escape for GHA ::notice:: — %0A in value would inject a new command.
+                _escaped_container="${requested_container//%/%25}"
+                _escaped_container="${_escaped_container//$'\n'/%0A}"
+                _escaped_container="${_escaped_container//$'\r'/%0D}"
+                echo "::notice::No drift detected for requested container ${_escaped_container}"
+                echo "drift_containers=[]" >> "$GITHUB_OUTPUT"
+                return 0
+              fi
+            fi
+
+            # Extract container names with actionable drift (drift or legacy status)
+            # from the (possibly scoped) drift_json.  Used to build the PR-opening matrix;
+            # cascade gating uses drift_containers_csv computed above from the unfiltered set.
+            drift_containers=$(echo "$drift_json" | jq -c \
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
+              || echo "[]")
+            echo "drift_containers=${drift_containers}" >> "$GITHUB_OUTPUT"
+
+            # Build enriched matrix: include internal_deps_csv per container (used for leaf/consumer split)
+            drift_matrix=$(echo "$drift_json" | jq -c \
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) |
+                {container: .container,
+                 internal_deps_csv: ((.internal_deps // []) | join(","))}]' \
+              || echo "[]")
+            echo "drift_matrix=${drift_matrix}" >> "$GITHUB_OUTPUT"
+
+            # Two-job split (leaves vs consumers):
+            #   drift_matrix_leaves   — containers with no project-internal deps
+            #     consumed by open-drift-prs-leaves job
+            #   drift_matrix_consumers — containers with project-internal deps
+            #     consumed by open-drift-prs-consumers job, which has
+            #     `needs: [open-drift-prs-leaves]` so parent PRs are already
+            #     created before any consumer matrix item starts.
+            drift_matrix_leaves=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv == "")]')
+            drift_matrix_consumers=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv != "")]')
+            echo "drift_matrix_leaves=${drift_matrix_leaves}" >> "$GITHUB_OUTPUT"
+            echo "drift_matrix_consumers=${drift_matrix_consumers}" >> "$GITHUB_OUTPUT"
+
+            # The empty result was already announced by the coverage decision;
+            # do not turn it into a clean-drift notice here.
+            if [[ "$population_variant_count" -gt 0 ]]; then
+              emit_drift_notice "$drift_json"
+            fi
+          }
+
           chmod +x scripts/detect-base-digest-drift.sh
           detect_rc=0
           drift_json=$(./scripts/detect-base-digest-drift.sh 2>/tmp/drift-detect-stderr.log) || detect_rc=$?
@@ -1828,13 +1969,13 @@ jobs:
 
           echo "$drift_json" > /tmp/drift.json
 
-          # Surface probe error count; per-variant ::error:: lines are already
+          # Surface unavailable-variant count; per-variant diagnostics are already
           # emitted by the script itself (escaped) and passed through via stderr above.
           # Do NOT re-compose warning lines from drift_json fields here — those fields
           # are untrusted lineage data and would reintroduce GHA command injection.
           error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' || echo 0)
           if [[ "$error_count" -gt 0 ]]; then
-            echo "::warning::${error_count} digest probe(s) failed — drift may be undetected for those variants (see ::error:: lines above)"
+            echo "::warning::${error_count} variant(s) could not be evaluated — drift may be undetected for those variants (see diagnostics above)"
           fi
 
           # Validate drift_json shape before downstream use.  An invalid JSON
@@ -1845,88 +1986,9 @@ jobs:
             exit 1
           fi
 
-          # Scope to requested container when workflow_dispatch.inputs.container is set.
-          # Older jobs in this workflow already honor this input; apply the same
-          # filter here so a manual run for one container does not fan out drift
-          # PRs across all drifting containers.
-          #
-          # SECURITY: inputs.container is a workflow_dispatch user-supplied string.
-          # Interpolating ${{ inputs.container }} directly inside the shell body of
-          # a `run:` block allows injection — a value like `foo" ]]; then cmd; #`
-          # is substituted BEFORE bash parses the script.  Canonical GHA mitigation:
-          # expose via `env:` (set above as REQUESTED_CONTAINER) so the value is
-          # treated as data, never as code.  See OWASP / GitHub security hardening
-          # docs on "Untrusted input in workflow expressions".
-          # Compute repo-wide drift_containers_csv from the UNFILTERED drift_json.
-          # This must happen BEFORE the REQUESTED_CONTAINER filter below, so that
-          # _eval_parent_state always sees the full drift picture regardless of how
-          # workflow_dispatch was scoped.  Without this split a scoped dispatch
-          # (e.g. requested_container=wordpress) would produce drift_containers_csv
-          # containing only "wordpress", causing State B to mark a still-drifting
-          # "php" parent as stable and auto-merging the child against a stale image.
-          drift_containers_all=$(echo "$drift_json" | jq -c \
-            '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
-            || echo "[]")
-          drift_containers_csv=$(echo "$drift_containers_all" | jq -r 'join(",")')
-          echo "drift_containers_csv=${drift_containers_csv}" >> "$GITHUB_OUTPUT"
-
-          # Compute repo-wide error_containers_csv from the UNFILTERED drift_json.
-          # Containers with ANY variant status == "error" are those whose probe FAILED
-          # this run — their actual drift state is UNKNOWN.  Plumbed as CURRENT_ERROR_SET
-          # into the cascade-labels step so _eval_parent_state can treat an errored parent
-          # as in_flux (conservative: wait rather than auto-merge against unknown state).
-          error_containers_csv=$(echo "$drift_json" | jq -r \
-            '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
-            || echo "")
-          echo "error_containers_csv=${error_containers_csv}" >> "$GITHUB_OUTPUT"
-
-          if [[ -n "$REQUESTED_CONTAINER" ]]; then
-            drift_json=$(echo "$drift_json" | jq --arg c "$REQUESTED_CONTAINER" '[.[] | select(.container == $c)]')
-            if [[ "$(echo "$drift_json" | jq 'length')" == "0" ]]; then
-              # Escape for GHA ::notice:: — %0A in value would inject a new command.
-              _escaped_container="${REQUESTED_CONTAINER//%/%25}"
-              _escaped_container="${_escaped_container//$'\n'/%0A}"
-              _escaped_container="${_escaped_container//$'\r'/%0D}"
-              echo "::notice::No drift detected for requested container ${_escaped_container}"
-              echo "drift_containers=[]" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          # Extract container names with actionable drift (drift or legacy status)
-          # from the (possibly scoped) drift_json.  Used to build the PR-opening matrix;
-          # cascade gating uses drift_containers_csv computed above from the unfiltered set.
-          drift_containers=$(echo "$drift_json" | jq -c \
-            '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
-            || echo "[]")
-          echo "drift_containers=${drift_containers}" >> "$GITHUB_OUTPUT"
-
-          # Build enriched matrix: include internal_deps_csv per container (used for leaf/consumer split)
-          drift_matrix=$(echo "$drift_json" | jq -c \
-            '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) |
-              {container: .container,
-               internal_deps_csv: ((.internal_deps // []) | join(","))}]' \
-            || echo "[]")
-          echo "drift_matrix=${drift_matrix}" >> "$GITHUB_OUTPUT"
-
-          # Two-job split (leaves vs consumers):
-          #   drift_matrix_leaves   — containers with no project-internal deps
-          #     consumed by open-drift-prs-leaves job
-          #   drift_matrix_consumers — containers with project-internal deps
-          #     consumed by open-drift-prs-consumers job, which has
-          #     `needs: [open-drift-prs-leaves]` so parent PRs are already
-          #     created before any consumer matrix item starts.
-          drift_matrix_leaves=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv == "")]')
-          drift_matrix_consumers=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv != "")]')
-          echo "drift_matrix_leaves=${drift_matrix_leaves}" >> "$GITHUB_OUTPUT"
-          echo "drift_matrix_consumers=${drift_matrix_consumers}" >> "$GITHUB_OUTPUT"
-
-          count=$(echo "$drift_containers" | jq 'length')
-          if [[ "$count" -gt 0 ]]; then
-            echo "::notice::Digest drift detected for ${count} container(s): ${drift_containers}"
-          else
-            echo "::notice::No base image digest drift detected"
-          fi
+          # The consumer owns the coverage decision as well as the scoped PR
+          # outputs.  It must see the original JSON before any scope is applied.
+          consume_drift_result "$drift_json" "$REQUESTED_CONTAINER"
 
   open-drift-prs-leaves:
     name: Open drift PR (leaf) for ${{ matrix.container }}

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -706,6 +706,20 @@ for lineage_file in "${lineage_files[@]}"; do
     if [[ "$base_image_ref" =~ \$ ]]; then
         gha_warning 'Skipping %s: base_image_ref contains unresolved placeholder: %s' \
             "$basename_file" "$base_image_ref" >&2
+        # Keep an explicit machine-readable record: without one, an active
+        # variant with an unresolved ref vanishes from the result and the
+        # workflow can falsely report a clean drift run.  The placeholder check
+        # stays before the legacy check so it cannot produce a bogus rebuild PR.
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        variant_json=$(jq -cn \
+            --arg variant_tag     "$variant_tag" \
+            --arg base_ref        "$safe_ref" \
+            --arg recorded_digest "$safe_recorded" \
+            --arg status          "error" \
+            --arg error_reason    "unresolved_placeholder_base_image_ref" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi
 
@@ -713,6 +727,25 @@ for lineage_file in "${lineage_files[@]}"; do
     # which would otherwise emit a legacy record for a corrupt/unknown entry).
     if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
         gha_warning 'Skipping %s: base_image_ref is unknown or missing' "$basename_file" >&2
+        # Keep an explicit machine-readable record: without one, an active
+        # variant with no usable ref vanishes from the result and the workflow
+        # can falsely report a clean drift run.  This can be the first record
+        # seen for the container, so retain the registration guard used by the
+        # active-tags-unavailable error path.
+        if [[ -z "${_container_variants[$container]+x}" ]]; then
+            _container_order+=("$container")
+            _container_variants["$container"]=""
+        fi
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        variant_json=$(jq -cn \
+            --arg variant_tag     "$variant_tag" \
+            --arg base_ref        "$safe_ref" \
+            --arg recorded_digest "$safe_recorded" \
+            --arg status          "error" \
+            --arg error_reason    "missing_base_image_ref" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi
 

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -789,9 +789,9 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Unresolved placeholder in base_image_ref — skip with warning
+# Unresolved placeholder in base_image_ref — error record with warning
 # ---------------------------------------------------------------------------
-@test "unresolved-ref: entry with \${...} placeholder in base_image_ref is skipped" {
+@test "unresolved-ref: entry with \${...} placeholder in base_image_ref emits error" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
     cat > "$lineage_dir/foo-1.0.json" <<'EOF'
@@ -807,15 +807,17 @@ EOF
     result=$(PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
-    [ "$result" = "[]" ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 1 ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "unresolved_placeholder_base_image_ref" ]
 }
 
 # ---------------------------------------------------------------------------
-# Precedence guard: placeholder ref + missing digest must be skipped (not
-# classified as legacy).  Before Fix 3 the legacy check ran first and would
-# emit a bogus drift PR for pre-#530 lineage files.
+# Precedence guard: placeholder ref + missing digest must emit error (not
+# classified as legacy). Before Fix 3 the legacy check ran first and would
+# emit a bogus drift PR for pre-#530 lineage files; silent skipping later hid it.
 # ---------------------------------------------------------------------------
-@test "unresolved-ref: placeholder ref with missing digest is skipped, not emitted as legacy" {
+@test "unresolved-ref: placeholder ref with missing digest emits error, not legacy" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
     # Simulates a pre-#530 lineage entry: placeholder ref AND no recorded digest
@@ -831,8 +833,10 @@ EOF
     result=$(PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
-    # Must be empty — placeholder takes precedence over legacy classification
-    [ "$result" = "[]" ]
+    # Placeholder takes precedence over legacy classification and remains visible.
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 1 ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "unresolved_placeholder_base_image_ref" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1104,8 +1108,8 @@ EOF
 # Fix r5-4: --baseline-only precedence (legacy wins over placeholder-skip)
 # Regression guard: a pre-#530 lineage entry with a placeholder base_image_ref
 # AND no recorded digest must emit status=legacy in --baseline-only mode (so the
-# baseline migration picks it up), while the same entry must be SKIPPED (result=[])
-# in normal mode (to prevent bogus drift PRs).
+# baseline migration picks it up).  In normal mode it must instead emit an error
+# record: it cannot be evaluated and must not be mis-classified as legacy.
 # ---------------------------------------------------------------------------
 @test "baseline-only mode emits legacy for placeholder-ref + missing-digest entry" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
@@ -1132,22 +1136,59 @@ EOF
     [ "$status_val" = "legacy" ]
 }
 
-@test "normal mode still skips placeholder-ref + missing-digest entry (no regression)" {
+@test "normal mode emits placeholder error while concrete ref is evaluated" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
-    # Same pre-#530 entry
-    cat > "$lineage_dir/foo-1.0.json" <<'EOF'
+    # The unresolved placeholder must remain visible, rather than silently
+    # disappearing from normal-mode output.
+    cat > "$lineage_dir/foo-placeholder.json" <<'EOF'
 {
-  "lineage_schema_version": 1,
+  "lineage_schema_version": 2,
   "container": "foo",
-  "tag": "1.0",
-  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim"
+  "tag": "placeholder",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/foo-concrete.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "concrete",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }
 EOF
 
-    # Normal mode (no --baseline-only): must skip — empty output
-    result=$(PROBE_CMD="/bin/false" \
+    local probe_stub
+    probe_stub=$(_make_digest_probe_stub "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    result=$(_ACTIVE_TAGS_OVERRIDE_foo=$'placeholder\nconcrete' \
+        PROBE_CMD="$probe_stub" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 2 ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "placeholder") | .status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "placeholder") | .error_reason')" = "unresolved_placeholder_base_image_ref" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "concrete") | .status')" = "unchanged" ]
+}
+
+@test "baseline-only keeps nonlegacy placeholder suppression unchanged" {
+    local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/foo-placeholder.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "foo",
+  "tag": "placeholder",
+  "base_image_ref": "${REMOTE_CR}/library/debian:trixie-slim",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    # The baseline-only placeholder branch deliberately remains a skip for a
+    # non-legacy entry; it is a one-off migration mode, not normal detection.
+    result=$(PROBE_CMD="/bin/false" \
+        bash "${DETECTOR_SCRIPT}" --baseline-only "$lineage_dir" 2>/dev/null)
 
     [ "$result" = "[]" ]
 }
@@ -3532,6 +3573,168 @@ EOF
     err_reason=$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')
     [ "$err_status" = "error" ]
     [ "$err_reason" = "untrusted_ref" ]
+}
+
+# ---------------------------------------------------------------------------
+# Missing or unknown base_image_ref must remain visible in the public result.
+# Active variants used to warn and then disappear, allowing the workflow to
+# mistake zero drift records for a fully evaluated clean run.
+# ---------------------------------------------------------------------------
+
+@test "empty and unknown base_image_ref emit error records while valid ref is evaluated" {
+    local lineage_dir="$TEST_TEMP_DIR/missing-base-ref/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/myimage-empty.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "empty",
+  "base_image_ref": "",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/myimage-unknown.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "unknown",
+  "base_image_ref": "unknown",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+    cat > "$lineage_dir/myimage-valid.json" <<'EOF'
+{
+  "lineage_schema_version": 2,
+  "container": "myimage",
+  "tag": "valid",
+  "base_image_ref": "alpine:3.21",
+  "base_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+EOF
+
+    local probe_stub result rc=0
+    probe_stub=$(_make_digest_probe_stub "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" \
+        _ACTIVE_TAGS_OVERRIDE_myimage=$'empty\nunknown\nvalid' \
+        PROBE_CMD="$probe_stub" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+
+    [ "$rc" -eq 0 ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 3 ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error" and .error_reason == "missing_base_image_ref")] | length')" -eq 2 ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "empty") | .base_image_ref')" = "" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "unknown") | .base_image_ref')" = "unknown" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "valid") | .status')" = "unchanged" ]
+}
+
+# Execute the exact consumer decision sequence embedded in the production
+# workflow. This covers the coverage gate, scoping, notices, and its success
+# exits without requiring a live workflow dispatch.
+_load_drift_consumer() {
+    local workflow_run notice_helper consumer_helper
+    workflow_run=$(yq -r '.jobs."detect-digest-drift".steps[] | select(.id == "detect") | .run' \
+        "$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml")
+    notice_helper=$(sed -n '/^emit_drift_notice() {/,/^}/p' <<<"$workflow_run")
+    consumer_helper=$(sed -n '/^consume_drift_result() {/,/^}/p' <<<"$workflow_run")
+    [ -n "$notice_helper" ] || return 1
+    [ -n "$consumer_helper" ] || return 1
+    eval "$notice_helper"
+    eval "$consumer_helper"
+}
+
+@test "coverage-incomplete closing notice reports counts and fails the workflow step" {
+    _load_drift_consumer
+
+    local incomplete_json notice rc=0 clean_json clean_notice clean_rc=0
+    incomplete_json='[{"container":"myimage","variants":[{"variant_tag":"empty","status":"error","error_reason":"missing_base_image_ref"},{"variant_tag":"valid","status":"unchanged"}]}]'
+    notice=$(emit_drift_notice "$incomplete_json") || rc=$?
+
+    [ "$rc" -eq 1 ]
+    [ "$notice" = "::notice::Base image digest drift coverage incomplete: 1 variant(s) evaluated; 1 could not be evaluated" ]
+    [[ "$notice" != *"No base image digest drift detected"* ]]
+
+    clean_json='[{"container":"myimage","variants":[{"variant_tag":"valid","status":"unchanged"}]}]'
+    clean_notice=$(emit_drift_notice "$clean_json" 0) || clean_rc=$?
+    [ "$clean_rc" -eq 0 ]
+    [ "$clean_notice" = "::notice::No base image digest drift detected" ]
+}
+
+@test "scoped clean container fails when another container has incomplete coverage" {
+    _load_drift_consumer
+
+    local drift_json output rc=0
+    drift_json='[
+      {"container":"clean","variants":[{"variant_tag":"latest","status":"unchanged"}]},
+      {"container":"unavailable","variants":[{"variant_tag":"latest","status":"error"}]}
+    ]'
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result "$drift_json" "clean") || rc=$?
+
+    [ "$rc" -eq 1 ]
+    [[ "$output" == *"Base image digest drift coverage incomplete: 1 variant(s) evaluated; 1 could not be evaluated"* ]]
+    [[ "$output" != *"No drift detected for requested container clean"* ]]
+}
+
+@test "scoped clean container still succeeds with its existing no-drift notice" {
+    _load_drift_consumer
+
+    local drift_json output rc=0
+    drift_json='[{"container":"other","variants":[{"variant_tag":"latest","status":"unchanged"}]}]'
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result "$drift_json" "clean") || rc=$?
+
+    [ "$rc" -eq 0 ]
+    [[ "$output" == *"No drift detected for requested container clean"* ]]
+    [[ "$output" != *"Base image digest drift coverage incomplete"* ]]
+    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers_csv=\nerror_containers_csv=\ndrift_containers=[]' ]
+}
+
+@test "empty unscoped drift result announces nothing to evaluate once and writes every output" {
+    _load_drift_consumer
+
+    local output rc=0 notice_count
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result '[]' '') || rc=$?
+
+    [ "$rc" -eq 0 ]
+    notice_count=$(printf '%s\n' "$output" | awk '/^::notice::/ { count++ } END { print count + 0 }')
+    [ "$notice_count" -eq 1 ]
+    [ "$output" = "::notice::No base image digest drift evaluation was performed — nothing to evaluate" ]
+    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers=[]\ndrift_matrix=[]\ndrift_matrix_leaves=[]\ndrift_matrix_consumers=[]\ndrift_containers_csv=\nerror_containers_csv=' ]
+}
+
+@test "empty scoped drift result announces nothing to evaluate once and writes every output" {
+    _load_drift_consumer
+
+    local output rc=0 notice_count
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result '[]' 'foo') || rc=$?
+
+    [ "$rc" -eq 0 ]
+    notice_count=$(printf '%s\n' "$output" | awk '/^::notice::/ { count++ } END { print count + 0 }')
+    [ "$notice_count" -eq 1 ]
+    [ "$output" = "::notice::No base image digest drift evaluation was performed — nothing to evaluate" ]
+    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers=[]\ndrift_matrix=[]\ndrift_matrix_leaves=[]\ndrift_matrix_consumers=[]\ndrift_containers_csv=\nerror_containers_csv=' ]
+}
+
+@test "populated all-clean drift result keeps the clean notice" {
+    _load_drift_consumer
+
+    local drift_json output rc=0 notice_count
+    drift_json='[{"container":"clean","variants":[{"variant_tag":"latest","status":"unchanged"}]}]'
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result "$drift_json" '') || rc=$?
+
+    [ "$rc" -eq 0 ]
+    notice_count=$(printf '%s\n' "$output" | awk '/^::notice::/ { count++ } END { print count + 0 }')
+    [ "$notice_count" -eq 1 ]
+    [ "$output" = "::notice::No base image digest drift detected" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The base-image drift detector dropped any variant whose recorded base reference was missing,
`unknown`, or still an unresolved placeholder, so those variants left no trace and the run
closed by announcing that no drift existed. Every Linux cell of every container is currently in
that state, which made the announcement false on every scheduled run.

Each skipped variant now appears in the result with the reason it could not be evaluated. The
closing message reports how many variants were evaluated and how many were not, and the job
fails instead of passing when the count is incomplete, so the drift rebuild PRs are withheld
rather than decided on partial evidence. A run with nothing to evaluate says exactly that, once.

Refs #1521. The coverage it makes visible is restored in #1523, which is the next piece.

## Verified

- Full bats suite: 2963 tests, 0 failures.
- `shellcheck -x -S warning` on the detector: zero findings, identical to master.
- `actionlint` on the workflow: 20 findings here and 20 on master, none new, none in the changed
  step.
- The consumer sequence was extracted and driven directly for each case — empty population
  scoped and unscoped, a scoped container that is clean while another errors, and a populated
  all-clean control that still prints its single notice.
- Mutation proofs seen red for restoring the bare `continue`, the scoped return ahead of the
  coverage decision, the clean notice on an empty population, and the fall-through into the
  scoped-empty branch.

Not run locally: the container e2e suite, which builds images and reads nothing this diff
changes, and a live monitor dispatch. CI covers the first.

## Known and filed, not fixed here

#1523 #1526 #1527 #1528 carry the findings that are identical on master, or that need a decision
this branch could not take on its own.
