### PR TITLE
fix(monitor): the registry helper refuses instead of widening or going quiet

### DIFF
--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -63,6 +63,28 @@ runs:
         
         # Extract entries authorized for monitor PRs (make script already handles all logic)
         containers_with_updates=()
+
+        # A process substitution does not propagate jq's exit status to the
+        # loop. Validate the complete producer payload first so malformed JSON
+        # cannot be published as a successful zero-update observation.
+        if ! jq -e '
+          type == "array" and
+          all(.[];
+            type == "object" and
+            (.container | type == "string" and length > 0) and
+            (.update_available | type == "boolean") and
+            (.actionable | type == "boolean") and
+            (if .actionable then
+              .update_available and
+              (.registry_lookup | type == "string" and (. == "matched" or . == "no-match"))
+            else
+              true
+            end)
+          )
+        ' <<< "$version_info" > /dev/null; then
+          echo "::error::check-updates returned invalid or unauthorized version_info entry" >&2
+          exit 1
+        fi
         
         while IFS= read -r container_data; do
           container=$(echo "$container_data" | jq -r '.container')

--- a/helpers/docker-tag
+++ b/helpers/docker-tag
@@ -40,6 +40,13 @@ function docker-tag-matching-tags() {
   local timeout_seconds=${3:-120}
   local registry_url raw all_tags matching_tags filtered_tags rc
 
+  # An absent filter cannot answer which published tags are relevant.  Keep it
+  # in the same failed-enumeration state rather than letting grep match all
+  # tags with an empty expression.
+  if [[ -z "$pattern" ]]; then
+    return 3
+  fi
+
   registry_url=$(docker-tag-registry-url "$image")
   raw=$(docker-tag-list-raw "$registry_url" "$timeout_seconds")
   rc=$?
@@ -59,7 +66,7 @@ function docker-tag-matching-tags() {
     return 3
   fi
 
-  matching_tags=$(printf '%s\n' "$all_tags" | grep -E "$pattern" 2>/dev/null)
+  matching_tags=$(printf '%s\n' "$all_tags" | grep -E -- "$pattern" 2>/dev/null)
   rc=$?
   if [ "$rc" -eq 1 ]; then
     return 0
@@ -100,21 +107,34 @@ function docker-tag-digest() {
   raw=$(timeout "$timeout_seconds" docker run --rm "$SKOPEO_IMAGE" inspect "$ref" 2>/dev/null)
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    return 1
+    return 3
   fi
 
-  digest=$(printf '%s' "$raw" | jq -r '.Digest // empty' 2>/dev/null)
+  digest=$(printf '%s' "$raw" | jq -er '
+    if (.Digest | type) == "string" and (.Digest | length) > 0 then
+      .Digest
+    else
+      error("inspect output lacks a digest")
+    end
+  ' 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 3
+  fi
+
   if [[ -n "$digest" && "$digest" != "null" ]]; then
     printf '%s\n' "$digest"
     return 0
   fi
 
-  return 1
+  return 3
 }
 
 function latest-docker-tag() {
   local image=$1
   local pattern=$2
+
+  [[ -n "$pattern" ]] || return 3
   
   # Get all tags using skopeo and filter with pattern.
   # timeout 120: cold image pull + list-tags can take 30-60s; 120s is generous
@@ -143,6 +163,12 @@ function check-docker-tag() {
   local image=$1
   local tag_pattern=$2
   local registry_url
+
+  # An absent filter identifies no tag.  Refuse it before the registry query,
+  # consistent with docker-tag-matching-tags.
+  if [[ -z "$tag_pattern" ]]; then
+    return 3
+  fi
   
   registry_url=$(docker-tag-registry-url "$image")
   
@@ -154,7 +180,7 @@ function check-docker-tag() {
   while [ $retry_count -lt $max_retries ]; do
     result=$(docker run --rm "$SKOPEO_IMAGE" list-tags "$registry_url" 2>/dev/null | \
       jq -r '.Tags[]? // empty' 2>/dev/null | \
-      grep -E "$tag_pattern" 2>/dev/null | \
+      grep -E -- "$tag_pattern" 2>/dev/null | \
       head -n1)
     
     if [[ -n "$result" && "$result" != "null" ]]; then
@@ -178,15 +204,27 @@ function resolve-numeric-alias() {
   local image=$1
   local tag=$2
   local numeric_pattern=$3
-  local target_digest candidates candidate candidate_digest
+  local target_digest candidates candidate candidate_digest rc
 
-  target_digest=$(docker-tag-digest "$image" "$tag" 30) || return 1
-  candidates=$(docker-tag-matching-tags "$image" "$numeric_pattern" 120) || return 1
+  [[ -n "$numeric_pattern" ]] || return 3
+
+  target_digest=$(docker-tag-digest "$image" "$tag" 30) || return 3
+  if candidates=$(docker-tag-matching-tags "$image" "$numeric_pattern" 120); then
+    :
+  else
+    rc=$?
+    # Preserve the distinction between a completed empty enumeration (1) and
+    # an enumeration that did not conclude (3) for the downgrade guard.
+    case "$rc" in
+      1) return 1 ;;
+      *) return 3 ;;
+    esac
+  fi
 
   while IFS= read -r candidate; do
     [[ -n "$candidate" ]] || continue
 
-    candidate_digest=$(docker-tag-digest "$image" "$candidate" 30) || continue
+    candidate_digest=$(docker-tag-digest "$image" "$candidate" 30) || return 3
     if [[ "$candidate_digest" == "$target_digest" ]]; then
       printf '%s\n' "$candidate"
       return 0

--- a/make
+++ b/make
@@ -97,9 +97,10 @@ check_updates_current_blocks_latest() {
   local latest_version=$2
   local normalized_current=$current_version
   local normalized_latest=$latest_version
+  local rc
 
   if ! command -v dpkg >/dev/null 2>&1; then
-    return 1
+    return 3
   fi
 
   case "$normalized_current" in
@@ -112,8 +113,15 @@ check_updates_current_blocks_latest() {
   esac
 
   if [[ "$normalized_current" =~ ^[0-9] && "$normalized_latest" =~ ^[0-9] ]]; then
-    dpkg --compare-versions "$normalized_current" gt "$normalized_latest" 2>/dev/null
-    return $?
+    if dpkg --compare-versions "$normalized_current" gt "$normalized_latest" 2>/dev/null; then
+      return 0
+    else
+      rc=$?
+    fi
+    if [ "$rc" -eq 1 ]; then
+      return 1
+    fi
+    return 3
   fi
 
   local numeric_alias_image numeric_alias_pattern
@@ -124,19 +132,43 @@ check_updates_current_blocks_latest() {
   # latest-version lookup. Require an explicit image-like source to opt in.
   if [[ -n "$numeric_alias_image" && -n "$numeric_alias_pattern" && "$numeric_alias_image" == */* ]]; then
     local current_numeric_alias latest_numeric_alias
-    current_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$current_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n' || true)
-    latest_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$latest_version" "$numeric_alias_pattern" 2>/dev/null | head -1 | tr -d '\n' || true)
-
-    if [[ -z "$current_numeric_alias" || -z "$latest_numeric_alias" ]]; then
-      return 1
+    if current_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$current_version" "$numeric_alias_pattern" 2>/dev/null); then
+      :
+    else
+      rc=$?
+      # Only a completed comparison with no alias (1) concludes.  Execution
+      # failures and statuses not yet classified keep the guard indeterminate.
+      case "$rc" in
+        1) return 1 ;;
+        *) return 3 ;;
+      esac
+    fi
+    if latest_numeric_alias=$(../helpers/docker-tag resolve-numeric-alias "$numeric_alias_image" "$latest_version" "$numeric_alias_pattern" 2>/dev/null); then
+      :
+    else
+      rc=$?
+      # Keep this classification identical to the current-alias lookup above.
+      case "$rc" in
+        1) return 1 ;;
+        *) return 3 ;;
+      esac
     fi
 
-    if [[ ! "$current_numeric_alias" =~ ^[0-9] || ! "$latest_numeric_alias" =~ ^[0-9] ]]; then
-      return 1
+    # A resolver success is usable only when it is exactly one non-empty
+    # numeric line.  Do not normalize malformed output into a comparison.
+    if [[ ! "$current_numeric_alias" =~ ^[0-9]+$ || ! "$latest_numeric_alias" =~ ^[0-9]+$ ]]; then
+      return 3
     fi
 
-    dpkg --compare-versions "$current_numeric_alias" gt "$latest_numeric_alias" 2>/dev/null
-    return $?
+    if dpkg --compare-versions "$current_numeric_alias" gt "$latest_numeric_alias" 2>/dev/null; then
+      return 0
+    else
+      rc=$?
+    fi
+    if [ "$rc" -eq 1 ]; then
+      return 1
+    fi
+    return 3
   fi
 
   return 1
@@ -636,8 +668,13 @@ check_updates() {
           if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
             :
           else
-            update_available="true"
-            status="update-available"
+            local downgrade_guard_rc=$?
+            if [ "$downgrade_guard_rc" -eq 1 ]; then
+              update_available="true"
+              status="update-available"
+            else
+              status="downgrade-guard-failed"
+            fi
           fi
         fi
 
@@ -680,11 +717,12 @@ check_updates() {
     # Get current and latest versions using container-specific patterns
     # Query GHCR (primary registry) to avoid stale Docker Hub data causing duplicate PRs
     local pattern current_version registry_lookup lookup_info
+    lookup_info=$'failed\t'
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$pattern")
-    else
-      # Fallback: try common version pattern
-      lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "^[0-9]+\.[0-9]+(\.[0-9]+)?$")
+      pattern=$(printf '%s' "$pattern" | head -1 | tr -d '\n')
+      if [[ -n "$pattern" ]]; then
+        lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$pattern")
+      fi
     fi
     IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
     latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
@@ -705,8 +743,13 @@ check_updates() {
       if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
         :
       else
-        update_available="true"
-        status="update-available"
+        local downgrade_guard_rc=$?
+        if [ "$downgrade_guard_rc" -eq 1 ]; then
+          update_available="true"
+          status="update-available"
+        else
+          status="downgrade-guard-failed"
+        fi
       fi
     fi
 

--- a/tests/unit/check-upstream-versions-action.bats
+++ b/tests/unit/check-upstream-versions-action.bats
@@ -42,7 +42,9 @@ run_action() {
     local output_file="$TEST_DIR/github-output"
     : > "$output_file"
     GITHUB_OUTPUT="$output_file" bash ./run-check-versions.sh
+    local action_status=$?
     cat "$output_file"
+    return "$action_status"
 }
 
 @test "composite action excludes declared non-actionable updates" {
@@ -54,22 +56,22 @@ run_action() {
     [[ "$output" == *"update_count=0"* ]]
 }
 
-@test "composite action fails closed when actionable is absent" {
+@test "composite action rejects an entry when actionable is absent" {
     write_make_result '[{"container":"future-container","current_version":"1.0.0","latest_version":"1.1.0","update_available":true,"status":"update-available"}]'
 
     run run_action
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"containers_with_updates=[]"* ]]
-    [[ "$output" == *"update_count=0"* ]]
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
 }
 
-@test "composite action fails closed when actionable is the string true" {
+@test "composite action rejects an entry when actionable is the string true" {
     write_make_result '[{"container":"string-actionable","current_version":"1.0.0","latest_version":"1.1.0","update_available":true,"actionable":"true","registry_lookup":"matched","status":"update-available"}]'
 
     run run_action
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"containers_with_updates=[]"* ]]
-    [[ "$output" == *"update_count=0"* ]]
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
 }
 
 # Positive control for the two exclusion tests above. Without it a mutation that
@@ -90,4 +92,58 @@ run_action() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"containers_with_updates=[]"* ]]
     [[ "$output" == *"Registry lookup did not conclude"* ]]
+}
+
+@test "composite action rejects an entry without a container" {
+    write_make_result '[{"actionable":true,"update_available":true,"registry_lookup":"matched"}]'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
+}
+
+@test "composite action rejects actionable entries without an available update" {
+    write_make_result '[{"container":"contradiction","update_available":false,"actionable":true,"registry_lookup":"matched"}]'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
+}
+
+@test "composite action rejects actionable entries whose lookup did not conclude" {
+    write_make_result '[{"container":"failed-lookup","update_available":true,"actionable":true,"registry_lookup":"failed"}]'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
+}
+
+@test "composite action rejects actionable entries without a concluded lookup" {
+    write_make_result '[{"container":"missing-lookup","update_available":true,"actionable":true}]'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
+}
+
+@test "composite action reports zero updates for a well-formed empty array" {
+    write_make_result '[]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"containers_with_updates=[]"* ]]
+    [[ "$output" == *"update_count=0"* ]]
+}
+
+@test "composite action fails when check-updates emits truncated JSON" {
+    write_make_result '[{"container":"truncated"'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count=0"* ]]
 }

--- a/tests/unit/latest-docker-tag.bats
+++ b/tests/unit/latest-docker-tag.bats
@@ -94,7 +94,7 @@ case "$command" in
         if [[ "$ref" != "docker://library/debian" ]]; then
             exit 41
         fi
-        printf '{"Repository":"library/debian","Tags":["11","12","13","12.14","bookworm","trixie","bullseye"]}\n'
+        printf '{"Repository":"library/debian","Tags":["11","12","trixie"]}\n'
         ;;
     inspect)
         if [[ "${1:-}" == "--format" ]]; then
@@ -102,18 +102,15 @@ case "$command" in
         fi
         ref="${1:-}"
         case "$ref" in
-            docker://library/debian:trixie|docker://library/debian:13)
+            docker://library/debian:trixie)
                 echo "sha256:thirteen"
                 ;;
             docker://library/debian:11)
                 # Transient failure on an unrelated earlier candidate.
                 exit 1
                 ;;
-            docker://library/debian:bookworm|docker://library/debian:12)
+            docker://library/debian:12)
                 echo "sha256:twelve"
-                ;;
-            docker://library/debian:bullseye)
-                echo "sha256:eleven"
                 ;;
             *)
                 exit 42
@@ -128,11 +125,45 @@ EOF
     chmod +x "${TEST_TEMP_DIR}/bin/docker"
 }
 
+write_fake_tag_listing_docker() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${REGISTRY_CALL_LOG:?}"
+printf '%s\n' "$*" >> "$REGISTRY_CALL_LOG"
+printf '{"Repository":"library/debian","Tags":["bookworm","trixie"]}\n'
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+}
+
+write_fake_malformed_inspect_docker() {
+    mkdir -p "${TEST_TEMP_DIR}/bin"
+    cat > "${TEST_TEMP_DIR}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "run" ]]; then
+    exit 99
+fi
+shift
+[[ "${1:-}" == "--rm" ]] && shift
+shift # skopeo image
+[[ "${1:-}" == "inspect" ]] || exit 98
+shift
+
+if [[ "${1:-}" == "--format" ]]; then
+    exit 1
+fi
+
+printf 'not valid JSON\n'
+EOF
+    chmod +x "${TEST_TEMP_DIR}/bin/docker"
+}
+
 run_resolve_numeric_alias() {
-    env PATH="${TEST_TEMP_DIR}/bin:$PATH" bash -c '
-        source "$1"
-        resolve-numeric-alias "$2" "$3" "$4"
-    ' _ "$HELPER" "$@"
+    env PATH="${TEST_TEMP_DIR}/bin:$PATH" "$HELPER" resolve-numeric-alias "$@"
 }
 
 @test "resolve-numeric-alias returns the numeric tag with a matching digest" {
@@ -153,20 +184,102 @@ run_resolve_numeric_alias() {
     [ -z "$output" ]
 }
 
-@test "resolve-numeric-alias returns 1 and no output when a lookup fails" {
+@test "resolve-numeric-alias returns 3 and no output when the target digest lookup fails" {
     write_fake_digest_docker
 
     run run_resolve_numeric_alias "library/debian" "missing" '^[0-9]+$'
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 3 ]
     [ -z "$output" ]
 }
 
-@test "resolve-numeric-alias skips a candidate whose digest lookup transiently fails" {
+@test "resolve-numeric-alias returns 3 when a candidate digest lookup fails" {
     write_fake_digest_docker_with_transient_failure
 
     run run_resolve_numeric_alias "library/debian" "trixie" '^[0-9]+$'
 
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+}
+
+@test "resolve-numeric-alias treats an unclassified enumeration status as indeterminate" {
+    run bash -c '
+        source "$1"
+        docker-tag-digest() { printf "sha256:target\\n"; }
+        docker-tag-matching-tags() { return 127; }
+        resolve-numeric-alias "library/debian" "trixie" "^[0-9]+$"
+    ' _ "$HELPER"
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+}
+
+@test "resolve-numeric-alias rejects an empty pattern before contacting the registry" {
+    write_fake_tag_listing_docker
+    local call_log="${TEST_TEMP_DIR}/registry-calls"
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" REGISTRY_CALL_LOG="$call_log" \
+        "$HELPER" resolve-numeric-alias "library/debian" "trixie" ""
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+    [ ! -e "$call_log" ]
+}
+
+@test "docker-tag-matching-tags rejects an empty pattern before contacting the registry" {
+    write_fake_tag_listing_docker
+    local call_log="${TEST_TEMP_DIR}/registry-calls"
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" REGISTRY_CALL_LOG="$call_log" \
+        "$HELPER" docker-tag-matching-tags "library/debian" ""
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+    [ ! -e "$call_log" ]
+}
+
+@test "latest-docker-tag rejects an empty pattern before contacting the registry" {
+    write_fake_tag_listing_docker
+    local call_log="${TEST_TEMP_DIR}/registry-calls"
+    ln -s "$HELPER" "${TEST_TEMP_DIR}/bin/latest-docker-tag"
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" REGISTRY_CALL_LOG="$call_log" \
+        latest-docker-tag "library/debian" ""
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
+    [ ! -e "$call_log" ]
+}
+
+@test "check-docker-tag rejects an empty pattern before contacting the registry" {
+    write_fake_tag_listing_docker
+    local call_log="${TEST_TEMP_DIR}/registry-calls"
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" REGISTRY_CALL_LOG="$call_log" \
+        "$HELPER" check-docker-tag "library/debian" ""
+
+    [ "$status" -eq 3 ]
+    [ ! -e "$call_log" ]
+}
+
+@test "check-docker-tag accepts a non-empty pattern and queries the registry" {
+    write_fake_tag_listing_docker
+    local call_log="${TEST_TEMP_DIR}/registry-calls"
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" REGISTRY_CALL_LOG="$call_log" \
+        "$HELPER" check-docker-tag "library/debian" '^trixie$'
+
     [ "$status" -eq 0 ]
-    [ "$output" = "13" ]
+    [ "$output" = "trixie" ]
+    [ -s "$call_log" ]
+}
+
+@test "docker-tag-digest returns 3 when fallback inspect output is malformed" {
+    write_fake_malformed_inspect_docker
+
+    run env PATH="${TEST_TEMP_DIR}/bin:$PATH" \
+        "$HELPER" docker-tag-digest "library/debian" "trixie"
+
+    [ "$status" -eq 3 ]
+    [ -z "$output" ]
 }

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -717,6 +717,62 @@ EOF
     chmod +x ./make
 }
 
+# Replaces the numeric-alias resolver while leaving check-updates and its
+# current-version lookup as their real entry points.  The case-specific
+# outcomes exercise both resolver invocations in the downgrade guard.
+write_resolver_fixture_helper() {
+    cat > helpers/docker-tag <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(basename "$0")" in
+    latest-docker-tag)
+        printf '%s\n' "${MOCK_CURRENT:-trixie}"
+        ;;
+    docker-tag)
+        [[ "${1:-}" == "resolve-numeric-alias" ]] || exit 99
+        case "${RESOLVER_CASE:?}" in
+            current-127)
+                if [[ "${3:-}" == "trixie" ]]; then exit 127; fi
+                ;;
+            latest-137)
+                if [[ "${3:-}" == "bookworm" ]]; then exit 137; fi
+                ;;
+            current-multiline)
+                if [[ "${3:-}" == "trixie" ]]; then
+                    printf '13\n12\n'
+                    exit 0
+                fi
+                ;;
+            latest-nonnumeric)
+                if [[ "${3:-}" == "bookworm" ]]; then
+                    printf 'bookworm\n'
+                    exit 0
+                fi
+                ;;
+            current-no-alias)
+                if [[ "${3:-}" == "trixie" ]]; then exit 1; fi
+                ;;
+            normal)
+                ;;
+            *)
+                exit 98
+                ;;
+        esac
+        case "${3:-}" in
+            trixie) printf '13\n' ;;
+            bookworm) printf '12\n' ;;
+            *) exit 97 ;;
+        esac
+        ;;
+    *)
+        exit 96
+        ;;
+esac
+EOF
+    chmod +x helpers/docker-tag
+}
+
 @test "check_updates multi-entry: emits one entry per retained major for latest_per_major container" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
@@ -857,6 +913,67 @@ EOF
     status_value=$(echo "$output" | jq -r '.[0].status')
     [[ "$update_available" == "true" ]]
     [[ "$status_value" == "update-available" ]]
+}
+
+# Positive control for registry-pattern refusal cases below: a version.sh that
+# supplies a usable pattern still reaches the registry helper and can report an
+# actionable update.
+@test "check_updates default path: a non-empty registry pattern remains actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "matched" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "true" ]]
+}
+
+@test "check_updates default path: a failing registry-pattern probe refuses instead of widening" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "--registry-pattern" ]]; then
+    exit 17
+fi
+echo "1.1.0-ubuntu"
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "registry-lookup-failed" ]]
+}
+
+@test "check_updates default path: an empty registry-pattern probe refuses instead of matching every tag" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "--registry-pattern" ]]; then
+    printf '\n'
+    exit 0
+fi
+echo "1.1.0-ubuntu"
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "registry-lookup-failed" ]]
 }
 
 @test "check_updates default path: digit-leading versions skip numeric alias probes" {
@@ -1039,6 +1156,26 @@ WEOF
     [ "$status" -eq 3 ]
 }
 
+@test "latest-docker-tag treats a dash-prefixed pattern as a grep operand" {
+    local shim_dir real_jq real_grep
+    shim_dir="$TEST_DIR/dash-pattern-shim"
+    mkdir -p "$shim_dir"
+    real_jq=$(command -v jq)
+    real_grep=$(command -v grep)
+    ln -s "$real_jq" "$shim_dir/jq"
+    ln -s "$real_grep" "$shim_dir/grep"
+    ln -s "$ORIG_DIR/helpers/docker-tag" "$shim_dir/latest-docker-tag"
+    cat > "$shim_dir/timeout" <<'SHEOF'
+#!/bin/bash
+printf '{"Repository":"docker://library/alpine","Tags":["1.2.3","--help"]}\n'
+SHEOF
+    chmod +x "$shim_dir/timeout"
+
+    run env PATH="$shim_dir:/usr/bin:/bin" "$shim_dir/latest-docker-tag" alpine --help
+    [ "$status" -eq 0 ]
+    [ "$output" = "--help" ]
+}
+
 @test "check_updates latest_per_major path reads its declaration once per container" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
@@ -1161,6 +1298,140 @@ EOF
     [[ "$latest_version" == "trixie" ]]
     [[ "$update_available" == "true" ]]
     [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: resolver exit 127 leaves the current alias comparison indeterminate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=current-127 ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: resolver exit 137 leaves the latest alias comparison indeterminate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=latest-137 ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: multiline resolver success is indeterminate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=current-multiline ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: non-numeric resolver success is indeterminate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=latest-nonnumeric ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: a valid numeric resolver comparison still blocks a downgrade" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=normal ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "up_to_date" ]]
+}
+
+@test "check_updates default path: a completed unmappable current alias keeps its existing no-match policy" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    write_resolver_fixture_helper
+
+    run env RESOLVER_CASE=current-no-alias ./make check-updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "update-available" ]]
+}
+
+@test "check_updates default path: an alias enumeration failure makes a non-numeric comparison non-actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    # The direct GHCR lookup still concludes, but the numeric-alias candidate
+    # enumeration fails. This must not turn a possible downgrade into an update.
+    sed -i '/docker:\/\/library\/debian)/a\\                exit 1' bin/docker
+
+    run run_check_updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].current_version')" == "trixie" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "bookworm" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: a target digest inspection failure makes a non-numeric comparison non-actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    # Both formatted and fallback inspection of the current alias fail.
+    sed -i '/docker:\/\/library\/debian:trixie|docker:\/\/library\/debian:13)/a\                exit 1' bin/docker
+
+    run run_check_updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: a candidate digest inspection failure makes a non-numeric comparison non-actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_debian_check_updates_fixture "trixie" "bookworm"
+    # Candidate 11 is not the target digest, but its unavailable digest still
+    # makes the alias comparison indeterminate rather than safe to update.
+    sed -i 's/\["11","12","13","12.14","bookworm","trixie","bullseye"\]/["11","12","bookworm","trixie","bullseye"]/' bin/docker
+    sed -i '/docker:\/\/library\/debian:bullseye|docker:\/\/library\/debian:11)/a\                exit 1' bin/docker
+
+    run run_check_updates debian
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
 }
 
 @test "check_updates default path: testing and stable labels without numeric alias remain permissive" {


### PR DESCRIPTION
Four places on the path that decides whether a container needs an update turned an inability to
answer into an answer.

A pattern beginning with a dash configured `grep` rather than filtering with it. An unavailable
or empty registry pattern fell back to a generic expression, so a container whose published tags
carry a required suffix matched whatever the registry happened to hold. A registry outage during
alias resolution reached the downgrade guard as "no match found", letting a downgrade be
proposed. And output the producer could not serialise ran the consuming loop zero times and
reported that nothing needed updating.

Each now reports that it could not conclude, and an entry in that state opens no pull request.
The rule is stated as a closed world rather than as a list of failures to handle: exactly one
status from the alias resolver means the comparison concluded, and every other status — including
ones nobody has classified — is indeterminate.

Refs #1516.

## Verified

- Full bats suite: 2989 tests, 0 failures, up from 2965 on master. The added tests cover a
  dash-prefixed pattern, an empty pattern at each entry point, a resolver returning 127 and 137,
  a resolver returning success with non-numeric output, a payload with no container, and a
  payload whose authorization contradicts its own state.
- `shellcheck -x -S warning` on `make` and `helpers/docker-tag`: zero findings.
- Every pattern-accepting entry point was enumerated with the line of its guard and the line of
  its first registry call, to show the guard precedes the call.
- Mutation proofs seen red for restoring a catch-all that maps failures to the concluded status,
  for concluding on malformed output, for removing the pattern guard, and for making an
  unclassified enumeration conclude.

Not run locally: the container e2e suite, which builds images and reads nothing this diff
changes.

## Known and filed, not fixed here

#1533 carries ten further places where the registry-reading path treats an operational failure or
a malformed answer as evidence. #1531 covers a git-valid release tag no registry accepts. The
workflow-input interpolation belongs to #1513.
