### PR TITLE
fix(ci): base image drift no longer reports clean from a scan that did not happen

### DIFF
--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1752,7 +1752,6 @@ jobs:
       drift_matrix_leaves: ${{ steps.detect.outputs.drift_matrix_leaves }}
       drift_matrix_consumers: ${{ steps.detect.outputs.drift_matrix_consumers }}
       drift_containers_csv: ${{ steps.detect.outputs.drift_containers_csv }}
-      error_containers_csv: ${{ steps.detect.outputs.error_containers_csv }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1806,32 +1805,83 @@ jobs:
           REQUESTED_CONTAINER: ${{ inputs.container }}
           SYNC_MANIFEST_FILE: base-sync-manifest/base-sync-manifest.jsonl
         run: |
+          # Use the repository's complete workflow-command escaper for the
+          # requested-container notice below (including the legacy ##[ marker).
+          source helpers/gha.sh
+
+          # One vocabulary defines every status that completed evaluation. Both
+          # the coverage tally and requested-container gate consume it below.
+          evaluated_drift_statuses() {
+            printf '%s\n' '["drift", "unchanged", "legacy", "no_external_base"]'
+          }
+
+          # The detector protocol is deliberately narrow.  Do not accept JSON merely
+          # because it parses: the matrix builders need unique, shell-safe container
+          # keys and string dependency entries, while coverage needs explicit reasons
+          # for both variant- and container-level failures.
+          validate_drift_result() {
+            local candidate="$1"
+            jq -e '
+              type == "array" and
+              (. as $records |
+                [$records[] | .container] | unique | length == ($records | length)) and
+              all(.[];
+                type == "object" and
+                (.container | type == "string" and test("^[a-z0-9_-]+$")) and
+                (.variants | type == "array" and length > 0) and
+                (if has("error_reason") then
+                   (.error_reason | type == "string" and length > 0) and
+                   (has("internal_deps") | not)
+                 else
+                   (has("internal_deps") and
+                    (.internal_deps | type == "array") and
+                    all(.internal_deps[];
+                      type == "string" and test("^[a-z0-9_-]+$")))
+                 end) and
+                all(.variants[];
+                  type == "object" and
+                  (.variant_tag | type == "string" and length > 0) and
+                  (.status as $status |
+                    ($status | type == "string") and
+                    (["drift", "unchanged", "legacy", "error", "no_external_base"] | index($status) != null)) and
+                  (if .status == "error" then
+                     (has("error_reason") and (.error_reason | type == "string" and length > 0))
+                   else
+                     true
+                   end)))
+            ' <<<"$candidate" >/dev/null
+          }
+
           # Keep the closing annotation truthful when the detector has error
           # records.  Its values are counts calculated from JSON only: never
           # interpolate lineage-derived strings into a workflow command.
           emit_drift_notice() {
             local notice_json="$1"
             local mode="${2:-normal}"
-            local drift_count error_count evaluated_count variant_count
+            local drift_count unavailable_count compared_count record_count evaluated_statuses
+
+            evaluated_statuses=$(evaluated_drift_statuses)
 
             drift_count=$(printf '%s' "$notice_json" | jq \
               '[.[] | select(.variants | any(.status == "drift" or .status == "legacy"))] | length')
             # Both coverage counts intentionally derive from notice_json.  The
             # coverage decision must describe one population, even when the
             # later PR matrix is scoped to a requested container.
-            error_count=$(printf '%s' "$notice_json" | jq \
-              '[.[] | .variants[] | select(.status == "error")] | length')
-            evaluated_count=$(printf '%s' "$notice_json" | jq \
-              '[.[] | .variants[] | select(.status != "error")] | length')
-            variant_count=$((error_count + evaluated_count))
+            unavailable_count=$(printf '%s' "$notice_json" | jq \
+              '([.[] | select(has("error_reason"))] +
+                [.[] | .variants[] | select(.status == "error")]) | length')
+            compared_count=$(printf '%s' "$notice_json" | jq --argjson evaluated_statuses "$evaluated_statuses" \
+              '[.[] | .variants[] |
+                select(.status as $status | $evaluated_statuses | index($status) != null)] | length')
+            record_count=$(printf '%s' "$notice_json" | jq '[.[] | .variants[]] | length')
 
-            if [[ "$error_count" -gt 0 ]]; then
-              echo "::notice::Base image digest drift coverage incomplete: ${evaluated_count} variant(s) evaluated; ${error_count} could not be evaluated"
+            if [[ "$unavailable_count" -gt 0 ]]; then
+              echo "::notice::Base image digest drift coverage incomplete: ${compared_count} comparison record(s) evaluated; ${unavailable_count} coverage record(s) could not be evaluated"
               # A successful detector process only means its JSON is valid.  An
               # error record means that JSON does not cover every active variant,
               # so fail this consumer step after preserving the coverage notice.
               return 1
-            elif [[ "$variant_count" -eq 0 ]]; then
+            elif [[ "$record_count" -eq 0 ]]; then
               echo "::notice::No base image digest drift evaluation was performed — nothing to evaluate"
             elif [[ "$mode" == "coverage" ]]; then
               # The coverage gate runs before any scoped success path.  A
@@ -1851,28 +1901,29 @@ jobs:
           consume_drift_result() {
             local drift_json="$1"
             local requested_container="$2"
-            local drift_containers_all drift_containers_csv error_containers_csv
+            local drift_containers_all drift_containers_csv
             local drift_containers drift_matrix drift_matrix_leaves drift_matrix_consumers
-            local population_variant_count
+            local population_record_count evaluated_statuses
 
             # Coverage is deliberately decided from the unfiltered result
             # before a requested-container scope can take a successful exit.
             emit_drift_notice "$drift_json" coverage || return 1
-            population_variant_count=$(printf '%s' "$drift_json" | jq \
+            population_record_count=$(printf '%s' "$drift_json" | jq \
               '[.[] | .variants[]] | length')
 
             # An empty unfiltered population was already announced by the
             # coverage decision.  Publish every advertised empty output and
             # stop before a requested-container branch can claim it is clean.
-            if [[ "$population_variant_count" -eq 0 ]]; then
-              {
-                echo "drift_containers=[]"
-                echo "drift_matrix=[]"
-                echo "drift_matrix_leaves=[]"
-                echo "drift_matrix_consumers=[]"
-                echo "drift_containers_csv="
-                echo "error_containers_csv="
-              } >> "$GITHUB_OUTPUT"
+            if [[ "$population_record_count" -eq 0 ]]; then
+              if [[ -n "$requested_container" ]]; then
+                echo "::error::Requested container $(_escape_gha_command "$requested_container") has no evaluated drift variants" >&2
+                return 1
+              fi
+              gha_output drift_containers '[]'
+              gha_output drift_matrix '[]'
+              gha_output drift_matrix_leaves '[]'
+              gha_output drift_matrix_consumers '[]'
+              gha_output drift_containers_csv ''
               return 0
             fi
 
@@ -1884,31 +1935,19 @@ jobs:
             # containing only "wordpress", causing State B to mark a still-drifting
             # "php" parent as stable and auto-merging the child against a stale image.
             drift_containers_all=$(echo "$drift_json" | jq -c \
-              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
-              || echo "[]")
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]')
             drift_containers_csv=$(echo "$drift_containers_all" | jq -r 'join(",")')
-            echo "drift_containers_csv=${drift_containers_csv}" >> "$GITHUB_OUTPUT"
-
-            # Compute repo-wide error_containers_csv from the UNFILTERED drift_json.
-            # Containers with ANY variant status == "error" are those whose probe FAILED
-            # this run — their actual drift state is UNKNOWN.  Plumbed as CURRENT_ERROR_SET
-            # into the cascade-labels step so _eval_parent_state can treat an errored parent
-            # as in_flux (conservative: wait rather than auto-merge against unknown state).
-            error_containers_csv=$(echo "$drift_json" | jq -r \
-              '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
-              || echo "")
-            echo "error_containers_csv=${error_containers_csv}" >> "$GITHUB_OUTPUT"
+            gha_output drift_containers_csv "$drift_containers_csv"
 
             if [[ -n "$requested_container" ]]; then
               drift_json=$(echo "$drift_json" | jq --arg c "$requested_container" '[.[] | select(.container == $c)]')
-              if [[ "$(echo "$drift_json" | jq 'length')" == "0" ]]; then
-                # Escape for GHA ::notice:: — %0A in value would inject a new command.
-                _escaped_container="${requested_container//%/%25}"
-                _escaped_container="${_escaped_container//$'\n'/%0A}"
-                _escaped_container="${_escaped_container//$'\r'/%0D}"
-                echo "::notice::No drift detected for requested container ${_escaped_container}"
-                echo "drift_containers=[]" >> "$GITHUB_OUTPUT"
-                return 0
+              evaluated_statuses=$(evaluated_drift_statuses)
+              scoped_record_count=$(printf '%s' "$drift_json" | jq --argjson evaluated_statuses "$evaluated_statuses" \
+                '[.[] | .variants[] |
+                  select(.status as $status | $evaluated_statuses | index($status) != null)] | length')
+              if [[ "$scoped_record_count" -eq 0 ]]; then
+                echo "::error::Requested container $(_escape_gha_command "$requested_container") has no evaluated drift variants" >&2
+                return 1
               fi
             fi
 
@@ -1916,17 +1955,15 @@ jobs:
             # from the (possibly scoped) drift_json.  Used to build the PR-opening matrix;
             # cascade gating uses drift_containers_csv computed above from the unfiltered set.
             drift_containers=$(echo "$drift_json" | jq -c \
-              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]' \
-              || echo "[]")
-            echo "drift_containers=${drift_containers}" >> "$GITHUB_OUTPUT"
+              '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) | .container]')
+            gha_output drift_containers "$drift_containers"
 
             # Build enriched matrix: include internal_deps_csv per container (used for leaf/consumer split)
             drift_matrix=$(echo "$drift_json" | jq -c \
               '[.[] | select(.variants | any(.status == "drift" or .status == "legacy")) |
                 {container: .container,
-                 internal_deps_csv: ((.internal_deps // []) | join(","))}]' \
-              || echo "[]")
-            echo "drift_matrix=${drift_matrix}" >> "$GITHUB_OUTPUT"
+                 internal_deps_csv: ((.internal_deps // []) | join(","))}]')
+            gha_output drift_matrix "$drift_matrix"
 
             # Two-job split (leaves vs consumers):
             #   drift_matrix_leaves   — containers with no project-internal deps
@@ -1937,12 +1974,12 @@ jobs:
             #     created before any consumer matrix item starts.
             drift_matrix_leaves=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv == "")]')
             drift_matrix_consumers=$(echo "$drift_matrix" | jq -c '[.[] | select(.internal_deps_csv != "")]')
-            echo "drift_matrix_leaves=${drift_matrix_leaves}" >> "$GITHUB_OUTPUT"
-            echo "drift_matrix_consumers=${drift_matrix_consumers}" >> "$GITHUB_OUTPUT"
+            gha_output drift_matrix_leaves "$drift_matrix_leaves"
+            gha_output drift_matrix_consumers "$drift_matrix_consumers"
 
             # The empty result was already announced by the coverage decision;
             # do not turn it into a clean-drift notice here.
-            if [[ "$population_variant_count" -gt 0 ]]; then
+            if [[ "$population_record_count" -gt 0 ]]; then
               emit_drift_notice "$drift_json"
             fi
           }
@@ -1951,16 +1988,21 @@ jobs:
           detect_rc=0
           drift_json=$(./scripts/detect-base-digest-drift.sh 2>/tmp/drift-detect-stderr.log) || detect_rc=$?
 
+          replay_drift_stderr() {
+            local stderr_file="$1"
+            [[ -s "$stderr_file" ]] || return 0
+
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              printf '%s\n' "$line"
+            done < "$stderr_file" >&2
+          }
+
           # Always replay buffered stderr — per-variant ::error:: diagnostics must
           # be visible regardless of whether the detector succeeded or failed.
           # Under bash -e, the bare command substitution above would abort the step
           # immediately on non-zero exit, leaving the replay block unreachable.
           # Capturing the exit code first ensures the replay always runs.
-          if [[ -s /tmp/drift-detect-stderr.log ]]; then
-            while IFS= read -r line; do
-              printf '%s\n' "$line"
-            done < /tmp/drift-detect-stderr.log >&2
-          fi
+          replay_drift_stderr /tmp/drift-detect-stderr.log
 
           if [[ $detect_rc -ne 0 ]]; then
             echo "::error::Drift detector failed with exit code $detect_rc" >&2
@@ -1969,21 +2011,22 @@ jobs:
 
           echo "$drift_json" > /tmp/drift.json
 
-          # Surface unavailable-variant count; per-variant diagnostics are already
+          # Validate the protocol before even counting records.  A syntactically
+          # valid object or an unknown status is not a completed drift scan.
+          if ! validate_drift_result "$drift_json"; then
+            echo "::error::Drift JSON violates the detector result schema" >&2
+            exit 1
+          fi
+
+          # Surface unavailable-record count; per-variant diagnostics are already
           # emitted by the script itself (escaped) and passed through via stderr above.
           # Do NOT re-compose warning lines from drift_json fields here — those fields
           # are untrusted lineage data and would reintroduce GHA command injection.
-          error_count=$(echo "$drift_json" | jq '[.[] | .variants[] | select(.status == "error")] | length' || echo 0)
-          if [[ "$error_count" -gt 0 ]]; then
-            echo "::warning::${error_count} variant(s) could not be evaluated — drift may be undetected for those variants (see diagnostics above)"
-          fi
-
-          # Validate drift_json shape before downstream use.  An invalid JSON
-          # payload (e.g. from a poisoned lineage entry) must fail loudly rather
-          # than silently masking drift as "no containers need rebuild".
-          if ! jq_err=$(jq -e . <<<"$drift_json" 2>&1 >/dev/null); then
-            echo "::error::Drift JSON is invalid; lineage may be corrupted: ${jq_err}" >&2
-            exit 1
+          unavailable_record_count=$(echo "$drift_json" | jq \
+            '([.[] | select(has("error_reason"))] +
+              [.[] | .variants[] | select(.status == "error")]) | length')
+          if [[ "$unavailable_record_count" -gt 0 ]]; then
+            echo "::warning::${unavailable_record_count} coverage record(s) could not be evaluated — drift may be undetected (see diagnostics above)"
           fi
 
           # The consumer owns the coverage decision as well as the scoped PR
@@ -2571,10 +2614,9 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           INTERNAL_DEPS: ${{ matrix.internal_deps_csv }}
           CURRENT_DRIFT_SET: ${{ needs.detect-digest-drift.outputs.drift_containers_csv }}
-          CURRENT_ERROR_SET: ${{ needs.detect-digest-drift.outputs.error_containers_csv }}
         run: |
-          # Four-state parent evaluation: in_flux | ready
-          # Ordering: A → B0 → B → C
+          # Three-state parent evaluation: in_flux | ready
+          # Ordering: A → B → C
           #
           # STATE A: open drift PR → in_flux (parent is still being integrated)
           #   Ground truth for "is there pending parent work?" — queried FIRST because it
@@ -2583,15 +2625,9 @@ jobs:
           #   is now derived from the UNFILTERED drift_json (repo-wide truth), but State A
           #   runs first anyway for safety.
           #
-          # STATE B0: parent probe errored this run → in_flux (conservative)
-          #   A probe error means the parent's actual drift state is UNKNOWN — we cannot
-          #   distinguish "stable" from "drifting but unreachable".  Treating an unknown
-          #   parent as ready risks auto-merging a child against a stale parent image.
-          #   Conservative answer: wait (same as in_flux) until the next successful probe.
-          #
           # STATE B: parent not in CURRENT_DRIFT_SET → stable (ready); OR parent IS in
           #   CURRENT_DRIFT_SET but no open PR → conservative in_flux.
-          #   Only safe AFTER the open-PR check (A) and error check (B0): no open PR and
+          #   Only safe AFTER the open-PR check (A): no open PR and
           #   no probe error means the parent was cleanly stable this run.
           #   CURRENT_DRIFT_SET is now repo-wide (Defect E fix), so the scoped-dispatch
           #   false-negative that previously appeared here is eliminated.
@@ -2631,26 +2667,8 @@ jobs:
               echo "in_flux"
               return 0
             fi
-            # STATE B0: Did the parent probe ERROR this run?
-            # Only reached when there is no open drift PR (State A cleared above).
-            # An error means we genuinely don't know whether the parent's image matches
-            # what the child consumes; safer to wait than auto-merge against unknown state.
-            if [[ -n "${CURRENT_ERROR_SET:-}" ]]; then
-              local _parent_errored=0
-              for _c in ${CURRENT_ERROR_SET//,/ }; do
-                if [[ "$_c" == "$parent" ]]; then
-                  _parent_errored=1
-                  break
-                fi
-              done
-              if [[ $_parent_errored -eq 1 ]]; then
-                echo "::notice::Parent ${parent} probe errored this run — waiting conservatively"
-                echo "in_flux"
-                return 0
-              fi
-            fi
             # STATE B: Is the parent in the current drift set?
-            # Only reached when there is no open drift PR (A) and no probe error (B0).
+            # Only reached when there is no open drift PR (State A).
             # If the parent is absent from CURRENT_DRIFT_SET, it was rebuilt in a prior run —
             # GHCR already has the stable image. Short-circuit to ready.
             if [[ -n "${CURRENT_DRIFT_SET:-}" ]]; then

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -5,11 +5,12 @@
 # Outputs a JSON array on stdout, grouped per container:
 #   [{"container":"foo","variants":[{"variant_tag":"1.0-alpine","status":"drift",...},...]}]
 #
-# Tri-state status per variant:
+# Status per variant (closed vocabulary):
 #   drift     — recorded_digest != current_digest (real drift)
 #   unchanged — recorded_digest == current_digest (no action needed)
-#   error     — registry probe failed (timeout, 401, 404); NOT collapsed to drift
+#   error     — the variant could not be evaluated; error_reason identifies why
 #   legacy    — lineage lacks base_image_digest field (pre-v2); rebuild baselines it
+#   no_external_base — the stage has no external base to compare (no action needed)
 #
 # Usage:
 #   detect-base-digest-drift.sh [--baseline-only] [LINEAGE_DIR]
@@ -490,11 +491,18 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
+    # A malformed active lineage payload has no trustworthy identity to attach
+    # to an error record.  Failing the detector is the only honest result.
+    if ! jq -e 'type == "object"' "$lineage_file" >/dev/null 2>&1; then
+        gha_error "Could not evaluate %s: lineage payload is not a JSON object" "$basename_file" >&2
+        exit 1
+    fi
+
     # Parse required fields
     container=$(jq -re '.container // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$container" ]]; then
-        gha_warning "Skipping %s: missing 'container' field" "$basename_file" >&2
-        continue
+        gha_error "Could not evaluate %s: missing 'container' field" "$basename_file" >&2
+        exit 1
     fi
 
     # Control-character rejection — MUST be BEFORE any validation or caching.
@@ -502,9 +510,9 @@ for lineage_file in "${lineage_files[@]}"; do
     # as TWO patterns, so "ansible" matches and "malicious" passes validation silently.
     # Explicit cntrl-char rejection at entry point closes that bypass entirely.
     if [[ "$container" =~ [[:cntrl:]] ]]; then
-        gha_warning 'Rejecting lineage entry %s: container name contains control chars: %s' \
+        gha_error 'Could not evaluate lineage entry %s: container name contains control chars: %s' \
             "$basename_file" "$container" >&2
-        continue
+        exit 1
     fi
 
     # Positive charset gate: container names must consist only of lowercase
@@ -513,9 +521,9 @@ for lineage_file in "${lineage_files[@]}"; do
     # pass grep -xF while containing shell metacharacters.  Rejecting here ensures
     # NO container reaching the emitted drift matrices can contain metacharacters.
     if ! [[ "$container" =~ ^[a-z0-9_-]+$ ]]; then
-        gha_warning 'Rejecting lineage entry %s: container name contains invalid characters: %s' \
+        gha_error 'Could not evaluate lineage entry %s: container name contains invalid characters: %s' \
             "$basename_file" "$container" >&2
-        continue
+        exit 1
     fi
 
     # Per-container scope: skip lineage entries for other containers (filter on the
@@ -544,24 +552,24 @@ for lineage_file in "${lineage_files[@]}"; do
         fi
     fi
     if ! grep -qxF -- "$container" <<<"$_valid_containers"; then
-        gha_warning "Skipping %s: invalid container name '%s' (not in ./make list)" \
+        gha_error "Could not evaluate %s: invalid container name '%s' (not in ./make list)" \
             "$basename_file" "$container" >&2
-        continue
+        exit 1
     fi
 
     variant_tag=$(jq -re '.tag // empty' "$lineage_file" 2>/dev/null || true)
     if [[ -z "$variant_tag" ]]; then
-        gha_warning "Skipping %s: missing 'tag' field" "$basename_file" >&2
-        continue
+        gha_error "Could not evaluate %s: missing 'tag' field" "$basename_file" >&2
+        exit 1
     fi
 
     # Reject tags with control characters before any grep/markdown operations.
     # A tag like "active\npayload" would pass grep -xF (multiple patterns) and
     # reach markdown with incomplete escaping. Validate early to close bypass.
     if [[ "$variant_tag" =~ [[:cntrl:]] ]]; then
-        gha_warning 'Rejecting lineage entry %s: tag contains control chars: %s' \
+        gha_error 'Could not evaluate lineage entry %s: tag contains control chars: %s' \
             "$basename_file" "$variant_tag" >&2
-        continue
+        exit 1
     fi
 
     # Filter to active build-matrix tags only (NORMAL MODE ONLY).
@@ -658,6 +666,7 @@ for lineage_file in "${lineage_files[@]}"; do
 
     base_image_ref=$(jq -re '.base_image_ref // empty' "$lineage_file" 2>/dev/null || true)
     recorded_digest=$(jq -re '.base_image_digest // empty' "$lineage_file" 2>/dev/null || true)
+    base_image_kind=$(jq -re '.base_image_kind // empty' "$lineage_file" 2>/dev/null || true)
     error_reason=""
 
     # Track container ordering
@@ -670,16 +679,10 @@ for lineage_file in "${lineage_files[@]}"; do
     # Determine status
     # ---------------------------------------------------------------------------
 
-    # Fix 4 (baseline-only precedence):
-    # In --baseline-only mode the goal is to baseline ALL pre-v2 entries, including
-    # ones where base_image_ref still contains a placeholder.  So legacy-emit takes
-    # precedence over the placeholder-skip in baseline mode.
-    #
-    # In normal (cron) mode the placeholder-skip MUST run first: a file with ${...}
-    # in base_image_ref and no recorded digest must not be mis-classified as legacy
-    # and trigger a bogus drift PR.
+    # Baseline mode emits only legacy records. It has to take precedence over
+    # producer markers too: otherwise a marker-bearing legacy entry leaks a
+    # non-legacy record despite --baseline-only's documented contract.
     if [[ "$BASELINE_ONLY" == "true" ]]; then
-        # Baseline mode: emit legacy first (even for placeholder refs)
         if [[ -z "$recorded_digest" || "$recorded_digest" == "unresolved" ]]; then
             safe_ref=$(_sanitize_for_json "${base_image_ref:-unknown}")
             variant_json=$(jq -cn \
@@ -688,23 +691,41 @@ for lineage_file in "${lineage_files[@]}"; do
                 --arg status       "legacy" \
                 '{variant_tag: $variant_tag, base_image_ref: $base_ref, status: $status, legacy: true}')
             _container_variants["$container"]+="${variant_json}"$'\n'
-            continue
         fi
+        continue
+    fi
 
-        # Skip if base_image_ref is a placeholder (non-legacy entry with unresolved ref)
-        if [[ "$base_image_ref" =~ \$ ]]; then
-            gha_warning 'Skipping %s: base_image_ref contains unresolved placeholder: %s' \
-                "$basename_file" "$base_image_ref" >&2
-            continue
-        fi
-
-        # In baseline-only mode, suppress real drift records for fully-resolved entries
+    # A scratch final stage is a successful build with no external image to
+    # compare.  Keep it distinct from unchanged: no digest comparison happened.
+    # An unresolved external reference, on the other hand, leaves coverage
+    # unknown and must fail closed.  Both markers take precedence over legacy
+    # handling so producer-intended meaning is never reclassified from fields
+    # that are necessarily absent for these stages.
+    if [[ "$base_image_kind" == "no_external_base" ]]; then
+        variant_json=$(jq -cn \
+            --arg variant_tag "$variant_tag" \
+            --arg status "no_external_base" \
+            '{variant_tag: $variant_tag, status: $status}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
+        continue
+    fi
+    if [[ "$base_image_kind" == "unresolved_external_base" ]]; then
+        safe_ref=$(_sanitize_for_json "$base_image_ref")
+        safe_recorded=$(_sanitize_for_json "$recorded_digest")
+        variant_json=$(jq -cn \
+            --arg variant_tag "$variant_tag" \
+            --arg base_ref "$safe_ref" \
+            --arg recorded_digest "$safe_recorded" \
+            --arg status "error" \
+            --arg error_reason "unresolved_external_base" \
+            '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi
 
     # Normal mode: placeholder-skip runs before legacy check to prevent mis-classification
     if [[ "$base_image_ref" =~ \$ ]]; then
-        gha_warning 'Skipping %s: base_image_ref contains unresolved placeholder: %s' \
+        gha_warning 'Could not evaluate %s: base_image_ref contains unresolved placeholder: %s' \
             "$basename_file" "$base_image_ref" >&2
         # Keep an explicit machine-readable record: without one, an active
         # variant with an unresolved ref vanishes from the result and the
@@ -723,10 +744,16 @@ for lineage_file in "${lineage_files[@]}"; do
         continue
     fi
 
-    # Skip if base_image_ref is unknown or missing (must run BEFORE legacy check
+    # An unknown sentinel and an absent field are separate producer failures.
+    # Both must run before legacy check so neither is rebuilt as a legacy entry.
     # which would otherwise emit a legacy record for a corrupt/unknown entry).
     if [[ -z "$base_image_ref" || "$base_image_ref" == "unknown" ]]; then
-        gha_warning 'Skipping %s: base_image_ref is unknown or missing' "$basename_file" >&2
+        if [[ -z "$base_image_ref" ]]; then
+            error_reason="missing_base_image_ref"
+        else
+            error_reason="unknown_base_image_ref"
+        fi
+        gha_warning 'Could not evaluate %s: base_image_ref is %s' "$basename_file" "$error_reason" >&2
         # Keep an explicit machine-readable record: without one, an active
         # variant with no usable ref vanishes from the result and the workflow
         # can falsely report a clean drift run.  This can be the first record
@@ -743,7 +770,7 @@ for lineage_file in "${lineage_files[@]}"; do
             --arg base_ref        "$safe_ref" \
             --arg recorded_digest "$safe_recorded" \
             --arg status          "error" \
-            --arg error_reason    "missing_base_image_ref" \
+            --arg error_reason    "$error_reason" \
             '{variant_tag: $variant_tag, base_image_ref: $base_ref, recorded_digest: $recorded_digest, status: $status, error_reason: $error_reason}')
         _container_variants["$container"]+="${variant_json}"$'\n'
         continue
@@ -820,26 +847,35 @@ for lineage_file in "${lineage_files[@]}"; do
         manifest_resolution_handled=true
         _manifest_source_ref=""
         if _manifest_source_ref=$(base_cache_canonical_docker_io_ref "$base_image_ref"); then
-            if _sync_manifest_lookup "$_manifest_source_ref" \
-                && [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" == "synced" ]] \
-                && [[ -n "$_SYNC_MANIFEST_LOOKUP_DIGEST" ]]; then
-                current_digest="$_SYNC_MANIFEST_LOOKUP_DIGEST"
+            if _sync_manifest_lookup "$_manifest_source_ref"; then
+                if [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" == "synced" && -n "$_SYNC_MANIFEST_LOOKUP_DIGEST" ]]; then
+                    current_digest="$_SYNC_MANIFEST_LOOKUP_DIGEST"
+                elif [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" != "synced" ]]; then
+                    probe_failed=true
+                    error_reason="base_sync_failed"
+                else
+                    probe_failed=true
+                    error_reason="base_sync_digest_missing"
+                fi
             else
                 probe_failed=true
-                error_reason="base not synced this cycle (sync failed/absent); drift unknown, re-checked next sync"
+                error_reason="base_sync_record_absent"
             fi
         else
             probe_failed=true
-            error_reason="base not synced this cycle (manifest key unavailable); drift unknown, re-checked next sync"
+            error_reason="base_sync_manifest_key_unavailable"
         fi
     elif [[ -n "${SYNC_MANIFEST_FILE:-}" && "$base_image_ref" == ghcr.io/* ]]; then
         if _sync_manifest_lookup_by_sync_image "$base_image_ref"; then
             manifest_resolution_handled=true
             if [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" == "synced" && -n "$_SYNC_MANIFEST_LOOKUP_DIGEST" ]]; then
                 current_digest="$_SYNC_MANIFEST_LOOKUP_DIGEST"
+            elif [[ "$_SYNC_MANIFEST_LOOKUP_STATUS" != "synced" ]]; then
+                probe_failed=true
+                error_reason="ghcr_mirror_sync_failed"
             else
                 probe_failed=true
-                error_reason="GHCR mirror not synced this cycle (sync failed/digestless); drift unknown, re-checked next sync"
+                error_reason="ghcr_mirror_sync_digest_missing"
             fi
         fi
     fi
@@ -854,15 +890,17 @@ for lineage_file in "${lineage_files[@]}"; do
             current_digest="$_probe_digest_cached_out"
         else
             probe_failed=true
-            if [[ -n "${_PROBE_DIGEST_ERROR:-}" ]]; then
-                error_reason="$_PROBE_DIGEST_ERROR"
+            if [[ "${_PROBE_DIGEST_ERROR:-}" == registry\ did\ not\ answer* ]]; then
+                error_reason="registry_probe_timeout"
+            else
+                error_reason="registry_probe_failed"
             fi
         fi
     fi
 
     if [[ "$probe_failed" == "true" || -z "$current_digest" ]]; then
         if [[ -z "$error_reason" ]]; then
-            error_reason="registry probe failed for ${base_image_ref} (container=${container} tag=${variant_tag})"
+            error_reason="registry_probe_failed"
         fi
         gha_error 'probe-error: %s' "$error_reason" >&2
         safe_ref=$(_sanitize_for_json "$base_image_ref")
@@ -940,10 +978,10 @@ for container in "${_container_order[@]}"; do
     variants_array+="]"
 
     # Validate the variants array is valid JSON
-    if ! printf '%s' "$variants_array" | jq '.' >/dev/null 2>&1; then
-        gha_warning "Skipping container '%s': could not build valid variants JSON" \
+    if ! printf '%s' "$variants_array" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        gha_error "Could not assemble container '%s': variants are not valid JSON" \
             "$container" >&2
-        continue
+        exit 1
     fi
 
     # Compute project-internal deps for this container.
@@ -982,25 +1020,17 @@ for container in "${_container_order[@]}"; do
             gha_error 'Failed to compute internal_deps for %s; cannot make cascade decision' \
                 "$container" >&2
         fi
-        # Emit the container as an error-only record, discarding any already-assembled
-        # variant fragments for this run.  Rationale: internal_deps is unavailable, so
-        # we cannot classify this container as a leaf (empty deps) or consumer (non-empty
-        # deps).  Emitting internal_deps:[] would be an unsafe leaf — it could trigger
-        # auto-merge against a stale parent.  Mirroring __CONTAINER_SKIP__ semantics
-        # (single status:error variant, no internal_deps, excluded from leaf/consumer
-        # matrices) is the only safe option.  Downstream _eval_parent_state State B0
-        # treats the container as in_flux when it appears in CURRENT_ERROR_SET.
+        # Preserve every variant result already assembled for this container and
+        # record the dependency failure at container scope.  It is not a variant:
+        # no base-image probe produced it.  Omitting internal_deps prevents this
+        # failed container from entering either matrix if a future consumer
+        # ignores the coverage failure.
         _dg_err_container_safe=$(_sanitize_for_json "$container")
-        _dg_err_reason_safe=$(_sanitize_for_json "dep_graph_unavailable")
-        _dg_err_variant_json=$(jq -cn \
-            --arg variant_tag     "" \
-            --arg status          "error" \
-            --arg error_reason    "$_dg_err_reason_safe" \
-            '{variant_tag: $variant_tag, status: $status, error_reason: $error_reason}')
         _dg_err_container_json=$(jq -cn \
             --arg container    "$_dg_err_container_safe" \
-            --argjson variants "[${_dg_err_variant_json}]" \
-            '{container: $container, variants: $variants}')
+            --argjson variants "$variants_array" \
+            --arg error_reason "dep_graph_unavailable" \
+            '{container: $container, variants: $variants, error_reason: $error_reason}')
         if [[ "$first_container" == "true" ]]; then
             first_container=false
         else
@@ -1013,7 +1043,10 @@ for container in "${_container_order[@]}"; do
     _internal_deps_json="[]"
     if [[ -n "$_container_internal_deps" ]]; then
         _internal_deps_json=$(printf '%s' "$_container_internal_deps" | \
-            jq -Rc 'split(" ") | map(select(length > 0))' 2>/dev/null || echo "[]")
+            jq -Rc 'split(" ") | map(select(length > 0))' 2>/dev/null) || {
+            gha_error "Could not assemble internal dependencies for '%s'" "$container" >&2
+            exit 1
+        }
     fi
 
     container_json=$(jq -cn \

--- a/tests/unit/cascade-resolver.bats
+++ b/tests/unit/cascade-resolver.bats
@@ -594,16 +594,15 @@ _run_identify_parent() {
 }
 
 # ---------------------------------------------------------------------------
-# Four-state parent evaluation (_eval_parent_state) — open PR first, error-safe
+# Three-state parent evaluation (_eval_parent_state) — open PR first
 #
 # The _eval_parent_state function (defined in "Apply cascade labels (strict)"
 # in upstream-monitor.yaml) emits 'in_flux' or 'ready' on stdout, with
 # notices/warnings on GHA annotation lines.
 #
-# Ordering (A → B0 → B → C):
+# Ordering (A → B → C):
 #   State A:  open drift PR → in_flux  (ground truth — runs FIRST, independent of drift-set scope)
-#   State B0: parent probe errored this run → in_flux  (conservative: unknown state must not merge)
-#   State B:  parent not in CURRENT_DRIFT_SET → ready  (only safe after A+B0 confirm clean)
+#   State B:  parent not in CURRENT_DRIFT_SET → ready  (only safe after A confirms clean)
 #   State C:  parent drifting, no PR yet → in_flux  (conservative wait)
 #
 # Mock strategy:
@@ -611,86 +610,17 @@ _run_identify_parent() {
 #   - RUN_STARTED_AT: set per-test to control the timestamp comparison
 # ---------------------------------------------------------------------------
 
-# Body of _eval_parent_state extracted verbatim from the workflow step.
-# Variables on the calling side: parent=$1; gh is mocked.
-EVAL_PARENT_STATE_BODY='
-_eval_parent_state() {
-  local parent="$1"
-  # STATE A: open drift PR → in_flux
-  # Runs FIRST — ground truth independent of how CURRENT_DRIFT_SET was scoped.
-  local open_pr _open_pr_raw _open_pr_rc
-  # Capture gh output separately so head cannot mask a gh API/auth failure —
-  # this step has no pipefail, so a pipeline'"'"'s exit status is the last
-  # command'"'"'s (head), not gh'"'"'s.  Splitting capture and head-1 makes gh rc
-  # the authoritative failure signal.
-  _open_pr_raw=$(gh pr list \
-    --head "update/base-digest-${parent}" \
-    --label "base-digest-drift" \
-    --base master \
-    --state open \
-    --json number,isCrossRepository \
-    --jq '"'"'.[] | select(.isCrossRepository == false) | .number'"'"' 2>&1)
-  _open_pr_rc=$?
-  if [[ $_open_pr_rc -ne 0 ]]; then
-    echo "::error::gh pr list failed while checking parent ${parent} open-PR state (rc=${_open_pr_rc}): ${_open_pr_raw}"
-    return 2
-  fi
-  open_pr=$(printf '"'"'%s\n'"'"' "$_open_pr_raw" | head -1)
-  if [[ -n "$open_pr" ]]; then
-    echo "::notice::Parent ${parent} has open drift PR #${open_pr}"
-    echo "in_flux"
-    return 0
-  fi
-  # STATE B0: Did the parent probe ERROR this run?
-  # Only reached when there is no open drift PR (State A cleared above).
-  # An error means we genuinely do not know whether the parent image matches
-  # what the child consumes; safer to wait than auto-merge against unknown state.
-  if [[ -n "${CURRENT_ERROR_SET:-}" ]]; then
-    local _parent_errored=0
-    for _c in ${CURRENT_ERROR_SET//,/ }; do
-      if [[ "$_c" == "$parent" ]]; then
-        _parent_errored=1
-        break
-      fi
-    done
-    if [[ $_parent_errored -eq 1 ]]; then
-      echo "::notice::Parent ${parent} probe errored this run — waiting conservatively"
-      echo "in_flux"
-      return 0
-    fi
-  fi
-  # STATE B: parent not in CURRENT_DRIFT_SET → stable, ready
-  # Only safe after State A (no open PR) and State B0 (no probe error).
-  if [[ -n "${CURRENT_DRIFT_SET:-}" ]]; then
-    local _parent_drifting=0
-    for _c in ${CURRENT_DRIFT_SET//,/ }; do
-      if [[ "$_c" == "$parent" ]]; then
-        _parent_drifting=1
-        break
-      fi
-    done
-    if [[ $_parent_drifting -eq 0 ]]; then
-      echo "::notice::Parent ${parent} has no open drift PR and is not in the current drift set — GHCR image is stable, ready"
-      echo "ready"
-      return 0
-    fi
-    # Parent IS in the drift snapshot, no open PR → conservative in_flux.
-    # A tag-specific GHCR freshness check is not safe here: the package-wide
-    # /versions API returns the most-recently-CREATED version regardless of tag,
-    # so a concurrent push of a different tag would yield a false-ready.
-    # See ADR-011 §Known Limitations.
-    echo "::notice::Parent ${parent} is drifting this run, no open PR yet — waiting conservatively"
-    echo "in_flux"
-    return 0
-  fi
-  # STATE C (conservative in_flux): CURRENT_DRIFT_SET unset -- no snapshot available.
-  # Cannot determine parent state; wait for the next successful cron run.
-  echo "::notice::Parent ${parent} is drifting this run but has no open PR yet — waiting"
-  echo "in_flux"
-  return 0
+# Extract the production function from the workflow step on every test run.
+# This is intentionally not a maintained copy: assertions exercise exactly the
+# function the workflow executes, with only gh and environment inputs mocked.
+_extract_eval_parent_state() {
+    local workflow_run function_body
+    workflow_run=$(yq -r '.jobs."open-drift-prs-consumers".steps[] | select(.name == "Apply cascade labels (strict)") | .run' \
+        "$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml") || return 1
+    function_body=$(sed -n '/^_eval_parent_state() {/,/^}/p' <<<"$workflow_run")
+    [ -n "$function_body" ] || return 1
+    printf '%s' "$function_body"
 }
-_eval_parent_state "$PARENT_ARG"
-'
 
 # Writes a mock gh for three-state tests.
 # $1 = mode:
@@ -703,6 +633,14 @@ _eval_parent_state "$PARENT_ARG"
 # the package-wide GHCR check was reverted (not tag-specific; see ADR-011 §Known Limitations).
 _setup_three_state_mock() {
     local mode="$1"
+    case "$mode" in
+        open-pr|open-pr-fork|open-pr-no-label|no-open-pr|pr-list-error)
+            ;;
+        *)
+            echo "unknown three-state mock mode: $mode" >&2
+            return 1
+            ;;
+    esac
     mkdir -p "$TEST_TEMP_DIR/bin"
     local calls_log="$TEST_TEMP_DIR/gh_calls.log"
     touch "$calls_log"
@@ -736,10 +674,18 @@ _setup_three_state_mock() {
     export PATH="$TEST_TEMP_DIR/bin:$PATH"
 }
 
+@test "three-state mock rejects an unknown mode" {
+    run _setup_three_state_mock "ghcr-stale"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unknown three-state mock mode"* ]]
+}
+
 _run_eval_parent_state() {
     local parent="$1"
     local script="$TEST_TEMP_DIR/eval_parent_state.sh"
-    printf '#!/usr/bin/env bash\nset -uo pipefail\n%s\n' "$EVAL_PARENT_STATE_BODY" > "$script"
+    local function_body
+    function_body=$(_extract_eval_parent_state) || return 1
+    printf '#!/usr/bin/env bash\nset -uo pipefail\n%s\n_eval_parent_state "$PARENT_ARG"\n' "$function_body" > "$script"
     chmod +x "$script"
     PARENT_ARG="$parent" run "$script"
 }
@@ -876,7 +822,8 @@ _run_eval_parent_state() {
     # Structural invariant: the body must capture gh output into a variable
     # (explicit rc check) BEFORE applying head -1.  The pipe-inside-if-guard
     # anti-pattern is structurally absent.
-    local body="$EVAL_PARENT_STATE_BODY"
+    local body
+    body=$(_extract_eval_parent_state)
     # New pattern: explicit rc variable present
     [[ "$body" == *"_open_pr_rc"* ]]
     # Old anti-pattern must be absent: gh pr list ... | head -1 inside the if guard
@@ -1218,104 +1165,6 @@ MOCK_BODY
 }
 
 # ---------------------------------------------------------------------------
-# State B0: probe error → in_flux (Defect L regression lock)
-#
-# When a parent's digest probe errored this run (status=error), the parent's
-# actual drift state is UNKNOWN.  The prior logic excluded error containers from
-# drift_containers_csv, so State B would see the parent absent from the drift set
-# and return ready — auto-merging the child against a parent whose image may be
-# stale.  State B0 closes this gap: a parent in CURRENT_ERROR_SET is treated as
-# in_flux regardless of the drift set.
-#
-# Mutation guards:
-#   removing State B0 → errored parent gets ready (the original defect)
-#            (test "errored parent in CURRENT_ERROR_SET → in_flux, not ready")
-#   inverting _parent_errored check → errored parent gets ready
-#            (test "errored parent → in_flux even when absent from CURRENT_DRIFT_SET")
-#   State A must still short-circuit before B0
-#            (test "errored parent with open PR → in_flux via State A, not B0")
-# ---------------------------------------------------------------------------
-
-@test "parent in CURRENT_ERROR_SET → in_flux (probe error treated as unknown)" {
-    # Parent probe failed this run; no open PR (State A cleared).
-    # State B0 must return in_flux — we do not know if the parent is stable.
-    _setup_three_state_mock "ghcr-stale"
-    CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="" _run_eval_parent_state "debian"
-    [ "$status" -eq 0 ]
-    state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
-    [ "$state_token" = "in_flux" ]
-}
-
-@test "errored parent → emits ::notice:: with probe-error message" {
-    _setup_three_state_mock "ghcr-stale"
-    CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="" _run_eval_parent_state "debian"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"::notice::"* ]]
-    [[ "$output" == *"probe errored"* ]]
-}
-
-@test "errored parent not in CURRENT_DRIFT_SET → in_flux (not short-circuited to ready by State B)" {
-    # This is the exact defect: error excluded from drift set → State B saw absent → ready.
-    # With State B0, error set is checked BEFORE the drift set, so ready is never reached.
-    _setup_three_state_mock "ghcr-stale"
-    CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="wordpress,ansible" _run_eval_parent_state "debian"
-    [ "$status" -eq 0 ]
-    state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
-    [ "$state_token" = "in_flux" ]
-    # State B must not have emitted "stable, ready" for the errored parent
-    ! [[ "$output" == *"GHCR image is stable, ready"* ]]
-}
-
-@test "parent with open PR → in_flux via State A (not B0)" {
-    # State A runs before B0: an open PR is caught by State A, B0 is never reached.
-    _setup_three_state_mock "open-pr"
-    CURRENT_ERROR_SET="debian" CURRENT_DRIFT_SET="" _run_eval_parent_state "debian"
-    [ "$status" -eq 0 ]
-    state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
-    [ "$state_token" = "in_flux" ]
-    # Must have used State A, not State B0
-    [[ "$output" == *"has open drift PR"* ]]
-    ! [[ "$output" == *"probe errored"* ]]
-}
-
-@test "empty CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
-    # When CURRENT_ERROR_SET is empty/unset, B0 is a no-op.
-    # Parent absent from drift set → State B returns ready.
-    _setup_three_state_mock "ghcr-stale"
-    CURRENT_ERROR_SET="" CURRENT_DRIFT_SET="wordpress" _run_eval_parent_state "php"
-    [ "$status" -eq 0 ]
-    state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
-    [ "$state_token" = "ready" ]
-}
-
-@test "unset CURRENT_ERROR_SET → State B0 skipped, falls through to State B" {
-    # Same as above but CURRENT_ERROR_SET is unset (not just empty).
-    _setup_three_state_mock "ghcr-stale"
-    CURRENT_DRIFT_SET="wordpress" _run_eval_parent_state "php"
-    [ "$status" -eq 0 ]
-    state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
-    [ "$state_token" = "ready" ]
-}
-
-@test "body contains CURRENT_ERROR_SET loop (State B0 is present)" {
-    # Structural invariant: State B0 must be present in the function body.
-    local body="$EVAL_PARENT_STATE_BODY"
-    [[ "$body" == *"CURRENT_ERROR_SET"* ]]
-    [[ "$body" == *"_parent_errored"* ]]
-}
-
-@test "B0 appears before State B loop in function body (ordering invariant)" {
-    # Structural invariant: CURRENT_ERROR_SET check must precede CURRENT_DRIFT_SET check.
-    local body="$EVAL_PARENT_STATE_BODY"
-    local b0_pos b_pos
-    b0_pos=$(echo "$body" | grep -n "_parent_errored=0" | head -1 | cut -d: -f1)
-    b_pos=$(echo "$body" | grep -n "_parent_drifting=0" | head -1 | cut -d: -f1)
-    [[ -n "$b0_pos" ]]
-    [[ -n "$b_pos" ]]
-    [ "$b0_pos" -lt "$b_pos" ]
-}
-
-# ---------------------------------------------------------------------------
 # State B: stable-parent deadlock fix (formerly State 0)
 #
 # When CURRENT_DRIFT_SET is set and the parent is NOT in it AND there is no
@@ -1336,7 +1185,7 @@ MOCK_BODY
     # CURRENT_DRIFT_SET contains wordpress, NOT php.
     # State A (open-PR) returns empty → State B must return ready for php without
     # calling the GHCR API.
-    _setup_three_state_mock "ghcr-stale"
+    _setup_three_state_mock "no-open-pr"
     CURRENT_DRIFT_SET="wordpress,ansible" _run_eval_parent_state "php"
     [ "$status" -eq 0 ]
     state_token=$(echo "$output" | grep -E '^(in_flux|ready)$' | tail -1)
@@ -1347,7 +1196,7 @@ MOCK_BODY
 }
 
 @test "StateB: parent not in drift set → emits ::notice:: with stable-parent message" {
-    _setup_three_state_mock "ghcr-stale"
+    _setup_three_state_mock "no-open-pr"
     CURRENT_DRIFT_SET="wordpress" _run_eval_parent_state "php"
     [ "$status" -eq 0 ]
     [[ "$output" == *"::notice::"* ]]
@@ -1391,7 +1240,8 @@ MOCK_BODY
 
 @test "StateB: body contains CURRENT_DRIFT_SET loop (State B is present)" {
     # State B MUST be present in the function body.
-    local body="$EVAL_PARENT_STATE_BODY"
+    local body
+    body=$(_extract_eval_parent_state)
     [[ "$body" == *"CURRENT_DRIFT_SET"* ]]
     [[ "$body" == *"_parent_drifting"* ]]
 }
@@ -1432,7 +1282,8 @@ MOCK_BODY
 @test "State A runs before State B (open-PR check precedes drift-set loop in body)" {
     # Structural invariant: the gh pr list call must appear before the CURRENT_DRIFT_SET
     # iteration loop (_parent_drifting loop).
-    local body="$EVAL_PARENT_STATE_BODY"
+    local body
+    body=$(_extract_eval_parent_state)
     local pr_list_pos drift_loop_pos
     pr_list_pos=$(echo "$body" | grep -n "gh pr list" | head -1 | cut -d: -f1)
     # Use the iteration variable assignment, not the if-condition (avoids matching comments)
@@ -1499,7 +1350,8 @@ MOCK_BODY
     # Architectural regression lock: the GHCR /versions API must NOT be present in
     # the function body.  If someone re-introduces it without per-tag label support,
     # this test catches the regression immediately.
-    local body="$EVAL_PARENT_STATE_BODY"
+    local body
+    body=$(_extract_eval_parent_state)
     ! echo "$body" | grep -q "packages/container"
 }
 

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -385,7 +385,7 @@ EOF
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
     [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "error" ]
-    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry did not answer within 1s" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry_probe_timeout" ]
 }
 
 @test "probe-retry: final 401 replaces an earlier timeout reason" {
@@ -425,7 +425,7 @@ STUB_EOF
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
 
     [ "$(<"$counter_file")" -eq 3 ]
-    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "stub: 401 unauthorized" ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')" = "registry_probe_failed" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -590,6 +590,27 @@ EOF
 
     status_val=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
     [ "$status_val" = "legacy" ]
+}
+
+@test "baseline-only: marker-bearing entries emit only legacy records" {
+    local lineage_dir="$TEST_TEMP_DIR/baseline-markers/.build-lineage"
+    mkdir -p "$lineage_dir"
+
+    cat > "$lineage_dir/foo-scratch.json" <<'EOF'
+{"container":"foo","tag":"scratch","base_image_kind":"no_external_base"}
+EOF
+    cat > "$lineage_dir/bar-unresolved.json" <<'EOF'
+{"container":"bar","tag":"unresolved","base_image_kind":"unresolved_external_base","base_image_ref":"${REMOTE_CR}/library/debian:trixie-slim"}
+EOF
+    cat > "$lineage_dir/foo-current.json" <<'EOF'
+{"container":"foo","tag":"current","base_image_kind":"no_external_base","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+EOF
+
+    local result
+    result=$(bash "${DETECTOR_SCRIPT}" --baseline-only "$lineage_dir" 2>/dev/null)
+
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 2 ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status != "legacy")] | length')" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -841,12 +862,12 @@ EOF
 
 # ---------------------------------------------------------------------------
 # Fix r4-1: Container name validation — poisoning prevention
-# Lineage entries whose .container field is NOT in `./make list` output must
-# be skipped with a ::warning::, never processed.
+# Lineage entries whose .container field is NOT in `./make list` output cannot
+# be attached safely to an output record, so the detector must fail closed.
 # Regression: a corrupted entry with container: "docs" (or ".github", or a
 # path with "/") would otherwise cause the bot to act on non-container dirs.
 # ---------------------------------------------------------------------------
-@test "container-validation: entry with invalid container name 'docs' is skipped" {
+@test "container-validation: invalid container name fails closed" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -862,14 +883,15 @@ EOF
 EOF
 
     # Unset override: "docs" is not in the real ./make list
+    local rc=0
     result=$(unset _VALID_CONTAINERS_OVERRIDE && PROBE_CMD="/bin/false" \
-        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
 
-    # Invalid container must be filtered out — output must be empty
-    [ "$result" = "[]" ]
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
 }
 
-@test "container-validation: entry with invalid container name 'docs' emits ::warning:: to stderr" {
+@test "container-validation: invalid container name emits ::error:: to stderr" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -888,11 +910,10 @@ EOF
     unset _VALID_CONTAINERS_OVERRIDE
     PROBE_CMD="/bin/false" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log" >/dev/null || true
 
-    # stderr must contain ::warning:: about invalid container
-    grep -q '::warning::' "$stderr_log"
+    grep -q '::error::' "$stderr_log"
 }
 
-@test "container-validation: entry with container name containing slash is skipped" {
+@test "container-validation: container name containing slash fails closed" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage"
     mkdir -p "$lineage_dir"
 
@@ -908,11 +929,12 @@ EOF
 EOF
 
     # Unset override: "../docs" is certainly not in ./make list
+    local rc=0
     result=$(unset _VALID_CONTAINERS_OVERRIDE && PROBE_CMD="/bin/false" \
-        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
 
-    # Path-traversal container name must be filtered out
-    [ "$result" = "[]" ]
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -1608,77 +1630,6 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Defect L regression lock: error_containers_csv derivation
-#
-# The detect-digest-drift step must emit error_containers_csv alongside
-# drift_containers_csv.  The jq expression is:
-#   '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")'
-# This test verifies that a drift_json with mixed status:error / status:drift
-# entries correctly populates only the errored containers in the CSV output,
-# and that the drifting containers are NOT included in error_containers_csv.
-# ---------------------------------------------------------------------------
-@test "error_containers_csv jq — error containers appear, drift containers do not" {
-    # Simulate the drift_json that the workflow step has in memory.
-    # foo = all variants errored; bar = drifting; baz = stable.
-    local drift_json
-    drift_json=$(cat <<'EOF'
-[
-  {"container": "foo", "variants": [{"status": "error"}, {"status": "error"}]},
-  {"container": "bar", "variants": [{"status": "drift"}, {"status": "stable"}]},
-  {"container": "baz", "variants": [{"status": "stable"}]}
-]
-EOF
-)
-
-    # This is the exact jq expression used in the workflow step.
-    error_csv=$(printf '%s' "$drift_json" | jq -r \
-        '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
-        || echo "JQFAIL")
-
-    # foo must appear (has error variant)
-    [[ "$error_csv" == *"foo"* ]]
-    # bar must NOT appear (only drift, no error)
-    [[ "$error_csv" != *"bar"* ]]
-    # baz must NOT appear (stable only)
-    [[ "$error_csv" != *"baz"* ]]
-}
-
-@test "error_containers_csv jq — mixed error+drift container appears in error CSV" {
-    # A container with both error and drift variants must appear in error_containers_csv.
-    local drift_json
-    drift_json=$(cat <<'EOF'
-[
-  {"container": "php", "variants": [{"status": "error"}, {"status": "drift"}]}
-]
-EOF
-)
-
-    error_csv=$(printf '%s' "$drift_json" | jq -r \
-        '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
-        || echo "JQFAIL")
-
-    [[ "$error_csv" == *"php"* ]]
-}
-
-@test "error_containers_csv jq — empty when no errors" {
-    # When all containers are stable or drifting (no errors), error_containers_csv is empty.
-    local drift_json
-    drift_json=$(cat <<'EOF'
-[
-  {"container": "bar", "variants": [{"status": "drift"}]},
-  {"container": "baz", "variants": [{"status": "stable"}]}
-]
-EOF
-)
-
-    error_csv=$(printf '%s' "$drift_json" | jq -r \
-        '[.[] | select(.variants | any(.status == "error")) | .container] | join(",")' \
-        || echo "JQFAIL")
-
-    [ -z "$error_csv" ]
-}
-
-# ---------------------------------------------------------------------------
 # Fix r7-4a: ./make list hard-fail in detect-base-digest-drift.sh
 # Regression guard: when _VALID_CONTAINERS_OVERRIDE is explicitly empty (not set
 # at all, so the script falls through to ./make list), and ./make list fails,
@@ -2051,13 +2002,9 @@ bar" \
         PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
 
-    # Script exits 0 (a single rejected entry is not fatal)
-    [ "$rc" -eq 0 ]
-
-    # Output must be empty array (the entry was rejected, not passed through)
-    local result_len
-    result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    # An unsafe identity cannot become an empty, successful scan.
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -2483,7 +2430,7 @@ EOF
     [ ! -f "$marker" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
-    [[ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" == *"base not synced this cycle"* ]]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" = "base_sync_failed" ]
 }
 
 @test "sync-manifest: absent docker.io record emits error without probe" {
@@ -2520,7 +2467,7 @@ EOF
     [ ! -f "$marker" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
-    [[ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" == *"base not synced this cycle"* ]]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" = "base_sync_record_absent" ]
 }
 
 @test "sync-manifest: failed ghcr mirror record emits error without probe" {
@@ -2559,7 +2506,7 @@ EOF
     [ ! -f "$marker" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].status')" = "error" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].current_digest // "absent"')" = "absent" ]
-    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" = "GHCR mirror not synced this cycle (sync failed/digestless); drift unknown, re-checked next sync" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | .variants[].error_reason')" = "ghcr_mirror_sync_failed" ]
 }
 
 @test "sync-manifest: synced ghcr mirror record uses recorded digest without probe" {
@@ -2865,17 +2812,14 @@ STUB
         PROBE_CMD="$probe_stub" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$TEST_TEMP_DIR/r21a2-stderr.txt") || rc=$?
 
-    # Must exit 0 (invalid container is a warning, not fatal)
-    [ "$rc" -eq 0 ]
+    # An unsafe identity cannot become a successful empty scan.
+    [ "$rc" -eq 1 ]
 
     # Probe must NOT have been called
     run grep -c "PROBE CALLED on --help container" "$TEST_TEMP_DIR/r21a2-stderr.txt"
     [ "$output" = "0" ]
 
-    # Result is empty
-    local result_len
-    result_len=$(printf '%s' "$result" | jq 'length')
-    [ "$result_len" -eq 0 ]
+    [ -z "$result" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -3257,13 +3201,13 @@ EOF
 
 # ---------------------------------------------------------------------------
 # GHA workflow-command escape — rejected container / tag values
-# Regression guard for Defect A (gate r25): the rejection-path ::warning::
+# Regression guard for Defect A (gate r25): the rejection-path ::error::
 # must route poisoned values through _escape_gha_command, NOT printf '%q'.
-# A value containing a literal %0A must appear as %250A in the warning
+# A value containing a literal %0A must appear as %250A in the error annotation
 # (% → %25 then 0A suffix), not as a raw newline or %0A command separator.
 # A value embedding ::add-mask:: must not reintroduce that command.
 # ---------------------------------------------------------------------------
-@test "container name with literal %0A is not passed raw in ::warning::" {
+@test "container name with literal %0A fails with an escaped ::error:: annotation" {
     # Build a lineage file where container field contains the literal string %0A
     # (percent-zero-A — a GHA encoded newline that would inject a new command).
     local lineage_dir="$TEST_TEMP_DIR/r25a1/.build-lineage"
@@ -3284,7 +3228,7 @@ EOF
 }
 EOF
 
-    # Container name contains control char (%0A is not a cntrl byte here, but
+    # Container name contains an invalid percent-encoded newline (%0A is not a cntrl byte here, but
     # the rejection path for invalid-container (not in ./make list) is the
     # relevant site).  Use an empty override so the validation fast-path fires.
     local stderr_output rc=0
@@ -3292,25 +3236,38 @@ EOF
         _VALID_CONTAINERS_OVERRIDE="foo" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
 
-    # The ::warning:: line must NOT contain a literal %0A sequence that would
-    # inject a workflow command.  After _escape_gha_command it becomes %250A.
-    # grep -F matches fixed strings — if %0A appears verbatim the test fails.
-    if printf '%s' "$stderr_output" | grep -qF '::warning::' 2>/dev/null; then
-        # Extract only the warning line(s) and verify %0A is escaped.
-        local warning_lines
-        warning_lines=$(printf '%s' "$stderr_output" | grep -F '::warning::' || true)
-        # Must NOT contain bare %0A in the value portion
-        ! printf '%s' "$warning_lines" | grep -qF '%0Abar'
-        # Must contain the escaped form %250A (% was encoded first)
-        printf '%s' "$warning_lines" | grep -qF '%250Abar'
-    fi
+    [ "$rc" -eq 1 ]
+    local error_lines
+    error_lines=$(printf '%s' "$stderr_output" | grep -F '::error::')
+    # Must NOT contain bare %0A in the value portion.
+    ! printf '%s' "$error_lines" | grep -qF '%0Abar'
+    # Must contain the escaped form %250A (% was encoded first).
+    printf '%s' "$error_lines" | grep -qF '%250Abar'
 }
 
-@test "tag with newline cntrl char — ::warning:: must not contain raw newline after rejection" {
+@test "Detect drift stderr replay preserves an unterminated diagnostic" {
+    local workflow_run replay_helper buffered_stderr replayed_stderr
+    workflow_run=$(yq -r '.jobs."detect-digest-drift".steps[] | select(.id == "detect") | .run' \
+        "$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml")
+    replay_helper=$(sed -n '/^replay_drift_stderr() {/,/^}/p' <<<"$workflow_run")
+    [ -n "$replay_helper" ]
+
+    buffered_stderr="$TEST_TEMP_DIR/drift-detector-stderr"
+    replayed_stderr="$TEST_TEMP_DIR/replayed-stderr"
+    bash -c 'printf "detector stopped mid-diagnostic" >&2; kill -TERM "$$"' \
+        2>"$buffered_stderr" >/dev/null || true
+
+    eval "$replay_helper"
+    replay_drift_stderr "$buffered_stderr" 2>"$replayed_stderr"
+
+    [ "$(cat "$replayed_stderr")" = "detector stopped mid-diagnostic" ]
+}
+
+@test "tag with newline cntrl char fails with an escaped ::error:: annotation" {
     # Build a lineage file with a tag containing an embedded newline (cntrl char).
-    # The rejection path at the cntrl-char check must emit the value through
+    # The fatal rejection path at the cntrl-char check must emit the value through
     # _escape_gha_command so the newline becomes %0A (literal percent-zero-A),
-    # NOT a real newline that would terminate the ::warning:: command and inject
+    # NOT a real newline that would terminate the ::error:: command and inject
     # the next line as a workflow command.
     local lineage_dir="$TEST_TEMP_DIR/r25a2/.build-lineage"
     mkdir -p "$lineage_dir"
@@ -3333,11 +3290,13 @@ pathlib.Path('${lineage_dir}/foo-1.0.json').write_text(json.dumps(d))
         _VALID_CONTAINERS_OVERRIDE="foo" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>&1 >/dev/null) || rc=$?
 
-    # The emitted warning must NOT contain the injection payload as a separate
+    [ "$rc" -eq 1 ]
+    # The emitted error must NOT contain the injection payload as a separate
     # workflow command.  If the newline was not escaped, ::add-mask:: would
     # appear on its own line as a parseable GHA command.
     # We assert: no line in the output starts with ::add-mask::
     ! printf '%s' "$stderr_output" | grep -qE '^::add-mask::'
+    printf '%s' "$stderr_output" | grep -qF '::error::'
 }
 
 # ---------------------------------------------------------------------------
@@ -3622,7 +3581,8 @@ EOF
 
     [ "$rc" -eq 0 ]
     [ "$(printf '%s' "$result" | jq '[.[] | .variants[]] | length')" -eq 3 ]
-    [ "$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error" and .error_reason == "missing_base_image_ref")] | length')" -eq 2 ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error" and .error_reason == "missing_base_image_ref")] | length')" -eq 1 ]
+    [ "$(printf '%s' "$result" | jq '[.[] | .variants[] | select(.status == "error" and .error_reason == "unknown_base_image_ref")] | length')" -eq 1 ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "empty") | .base_image_ref')" = "" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "unknown") | .base_image_ref')" = "unknown" ]
     [ "$(printf '%s' "$result" | jq -r '.[] | .variants[] | select(.variant_tag == "valid") | .status')" = "unchanged" ]
@@ -3632,15 +3592,196 @@ EOF
 # workflow. This covers the coverage gate, scoping, notices, and its success
 # exits without requiring a live workflow dispatch.
 _load_drift_consumer() {
-    local workflow_run notice_helper consumer_helper
+    local workflow_run statuses_helper validator_helper notice_helper consumer_helper
     workflow_run=$(yq -r '.jobs."detect-digest-drift".steps[] | select(.id == "detect") | .run' \
         "$PROJECT_ROOT/.github/workflows/upstream-monitor.yaml")
+    statuses_helper=$(sed -n '/^evaluated_drift_statuses() {/,/^}/p' <<<"$workflow_run")
+    validator_helper=$(sed -n '/^validate_drift_result() {/,/^}/p' <<<"$workflow_run")
     notice_helper=$(sed -n '/^emit_drift_notice() {/,/^}/p' <<<"$workflow_run")
     consumer_helper=$(sed -n '/^consume_drift_result() {/,/^}/p' <<<"$workflow_run")
+    [ -n "$statuses_helper" ] || return 1
+    [ -n "$validator_helper" ] || return 1
     [ -n "$notice_helper" ] || return 1
     [ -n "$consumer_helper" ] || return 1
+    source "$PROJECT_ROOT/helpers/gha.sh"
+    eval "$statuses_helper"
+    eval "$validator_helper"
     eval "$notice_helper"
     eval "$consumer_helper"
+}
+
+@test "active lineage with no tag fails instead of emitting an invalid empty variant_tag" {
+    local lineage_dir="$TEST_TEMP_DIR/missing-tag/.build-lineage"
+    mkdir -p "$lineage_dir"
+    cat > "$lineage_dir/myimage-missing-tag.json" <<'EOF'
+{"container":"myimage","base_image_ref":"alpine:3.21","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+EOF
+
+    local rc=0 result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
+}
+
+@test "active lineage with a control-only tag fails instead of emitting an invalid empty variant_tag" {
+    local lineage_dir="$TEST_TEMP_DIR/control-tag/.build-lineage"
+    mkdir -p "$lineage_dir"
+    printf '%s\n' '{"container":"myimage","tag":"\u0001\u0002","base_image_ref":"alpine:3.21","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+        > "$lineage_dir/myimage-control-tag.json"
+
+    local rc=0 result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
+}
+
+@test "well-formed lineage still exits 0" {
+    local lineage_dir="$TEST_TEMP_DIR/well-formed-tag/.build-lineage"
+    mkdir -p "$lineage_dir"
+    printf '%s\n' '{"container":"myimage","tag":"stable","base_image_ref":"alpine:3.21","base_image_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+        > "$lineage_dir/myimage-stable.json"
+
+    local probe_stub rc=0 result
+    probe_stub=$(_make_digest_probe_stub "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" PROBE_CMD="$probe_stub" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 0 ]
+    [ "$(printf '%s' "$result" | jq -r '.[0].variants[0].status')" = "unchanged" ]
+}
+
+@test "malformed active lineage payload fails instead of producing an empty scan" {
+    local lineage_dir="$TEST_TEMP_DIR/malformed-lineage/.build-lineage"
+    mkdir -p "$lineage_dir"
+    printf '{not-json\n' > "$lineage_dir/myimage-bad.json"
+
+    local rc=0 result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
+}
+
+@test "active lineage with no container fails instead of producing an empty scan" {
+    local lineage_dir="$TEST_TEMP_DIR/missing-container/.build-lineage"
+    mkdir -p "$lineage_dir"
+    printf '{"tag":"latest"}\n' > "$lineage_dir/missing-container.json"
+
+    local rc=0 result
+    result=$(_VALID_CONTAINERS_OVERRIDE="myimage" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
+}
+
+@test "base_image_kind no_external_base is non-actionable and does not fail coverage" {
+    local lineage_dir="$TEST_TEMP_DIR/base-image-kind-no-external"
+    local same_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    mkdir -p "$lineage_dir"
+    jq -cn --arg digest "$same_digest" \
+        '{container: "control", tag: "latest", base_image_ref: "alpine:3.21", base_image_digest: $digest}' \
+        > "$lineage_dir/control.json"
+    jq -cn '{container: "sslh", tag: "latest", base_image_kind: "no_external_base"}' \
+        > "$lineage_dir/sslh.json"
+    local probe_stub="$TEST_TEMP_DIR/probe-base-image-kind-no-external"
+    printf '#!/usr/bin/env bash\nprintf '"'"'{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'"'"'\n' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    result=$(_VALID_CONTAINERS_OVERRIDE=$'sslh\ncontrol' \
+        _DEPGRAPH_CONTAINERS_OVERRIDE='sslh control' \
+        PROBE_CMD="$probe_stub" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+    [ "$(printf '%s' "$result" | jq -r '.[] | select(.container == "sslh") | .variants[0].status')" = "no_external_base" ]
+    # Control without base_image_kind still reaches the normal digest comparison.
+    [ "$(printf '%s' "$result" | jq -r '.[] | select(.container == "control") | .variants[0].status')" = "unchanged" ]
+
+    _load_drift_consumer
+    validate_drift_result "$result"
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+    run consume_drift_result "$result" ''
+    [ "$status" -eq 0 ]
+    [ "$output" = "::notice::No base image digest drift detected" ]
+    [ "$(get_output drift_containers)" = "[]" ]
+    [ "$(get_output drift_matrix)" = "[]" ]
+}
+
+@test "a no_external_base-only result is evaluated unscoped and when scoped" {
+    _load_drift_consumer
+
+    local drift_json output rc=0
+    drift_json='[{"container":"sslh","internal_deps":[],"variants":[{"variant_tag":"latest","status":"no_external_base"}]}]'
+    validate_drift_result "$drift_json"
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
+
+    output=$(consume_drift_result "$drift_json" '') || rc=$?
+    [ "$rc" -eq 0 ]
+    [ "$output" = "::notice::No base image digest drift detected" ]
+    [[ "$output" != *"nothing to evaluate"* ]]
+
+    rc=0
+    : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result "$drift_json" 'sslh') || rc=$?
+    [ "$rc" -eq 0 ]
+    [ "$output" = "::notice::No base image digest drift detected" ]
+    [ "$(get_output drift_containers)" = "[]" ]
+}
+
+@test "base_image_kind unresolved_external_base fails coverage with its own reason" {
+    local lineage_dir="$TEST_TEMP_DIR/base-image-kind-unresolved"
+    local same_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    mkdir -p "$lineage_dir"
+    jq -cn '{container: "unresolved", tag: "latest", base_image_kind: "unresolved_external_base"}' \
+        > "$lineage_dir/unresolved.json"
+    jq -cn --arg digest "$same_digest" \
+        '{container: "control", tag: "latest", base_image_ref: "alpine:3.21", base_image_digest: $digest}' \
+        > "$lineage_dir/control.json"
+    local probe_stub="$TEST_TEMP_DIR/probe-base-image-kind-unresolved"
+    printf '#!/usr/bin/env bash\nprintf '"'"'{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'"'"'\n' > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    result=$(_VALID_CONTAINERS_OVERRIDE=$'unresolved\ncontrol' \
+        _DEPGRAPH_CONTAINERS_OVERRIDE='unresolved control' \
+        PROBE_CMD="$probe_stub" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+    [ "$(printf '%s' "$result" | jq -r '.[] | select(.container == "unresolved") | .variants[0].status')" = "error" ]
+    [ "$(printf '%s' "$result" | jq -r '.[] | select(.container == "unresolved") | .variants[0].error_reason')" = "unresolved_external_base" ]
+    # Control without the marker still reaches comparison instead of this branch.
+    [ "$(printf '%s' "$result" | jq -r '.[] | select(.container == "control") | .variants[0].status')" = "unchanged" ]
+
+    _load_drift_consumer
+    validate_drift_result "$result"
+    local rc=0 notice
+    notice=$(emit_drift_notice "$result") || rc=$?
+    [ "$rc" -eq 1 ]
+    [[ "$notice" == *"coverage incomplete"* ]]
+}
+
+@test "consumer schema rejects every relied-on malformed record shape" {
+    _load_drift_consumer
+
+    local malformed rc=0
+    for malformed in \
+        '{}' \
+        '[{"container":"myimage","internal_deps":[],"variants":[{"variant_tag":"latest","status":"skipped"}]}]' \
+        '[{"container":"myimage","internal_deps":[],"variants":[{"variant_tag":"latest","status":"error"}]}]' \
+        '[{"container":"myimage","variants":[{"variant_tag":"latest","status":"unchanged"}]}]' \
+        '[{"container":"myimage","internal_deps":"base","variants":[{"variant_tag":"latest","status":"unchanged"}]}]' \
+        '[{"container":"myimage","internal_deps":[],"variants":[{"variant_tag":"latest","status":"unchanged"}]},{"container":"myimage","internal_deps":[],"variants":[{"variant_tag":"next","status":"unchanged"}]}]' \
+        '[{"container":"bad;key","internal_deps":[],"variants":[{"variant_tag":"latest","status":"unchanged"}]}]'; do
+        rc=0
+        validate_drift_result "$malformed" || rc=$?
+        [ "$rc" -eq 1 ]
+    done
+
+    validate_drift_result '[{"container":"myimage","internal_deps":["base"],"variants":[{"variant_tag":"latest","status":"unchanged"}]}]'
+}
+
+@test "container-level dependency failure is a coverage record, not a variant" {
+    _load_drift_consumer
+
+    local result notice rc=0
+    result='[{"container":"myimage","variants":[{"variant_tag":"latest","status":"unchanged"}],"error_reason":"dep_graph_unavailable"}]'
+    validate_drift_result "$result"
+    notice=$(emit_drift_notice "$result") || rc=$?
+    [ "$rc" -eq 1 ]
+    [ "$notice" = "::notice::Base image digest drift coverage incomplete: 1 comparison record(s) evaluated; 1 coverage record(s) could not be evaluated" ]
+    [ "$(printf '%s' "$result" | jq '.[] | .variants | length')" -eq 1 ]
 }
 
 @test "coverage-incomplete closing notice reports counts and fails the workflow step" {
@@ -3651,7 +3792,7 @@ _load_drift_consumer() {
     notice=$(emit_drift_notice "$incomplete_json") || rc=$?
 
     [ "$rc" -eq 1 ]
-    [ "$notice" = "::notice::Base image digest drift coverage incomplete: 1 variant(s) evaluated; 1 could not be evaluated" ]
+    [ "$notice" = "::notice::Base image digest drift coverage incomplete: 1 comparison record(s) evaluated; 1 coverage record(s) could not be evaluated" ]
     [[ "$notice" != *"No base image digest drift detected"* ]]
 
     clean_json='[{"container":"myimage","variants":[{"variant_tag":"valid","status":"unchanged"}]}]'
@@ -3670,26 +3811,49 @@ _load_drift_consumer() {
     ]'
     GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
     : > "$GITHUB_OUTPUT"
-    output=$(consume_drift_result "$drift_json" "clean") || rc=$?
+    output=$(consume_drift_result "$drift_json" "clean" 2>&1) || rc=$?
 
     [ "$rc" -eq 1 ]
-    [[ "$output" == *"Base image digest drift coverage incomplete: 1 variant(s) evaluated; 1 could not be evaluated"* ]]
+    [[ "$output" == *"Base image digest drift coverage incomplete: 1 comparison record(s) evaluated; 1 coverage record(s) could not be evaluated"* ]]
     [[ "$output" != *"No drift detected for requested container clean"* ]]
 }
 
-@test "scoped clean container still succeeds with its existing no-drift notice" {
+@test "scoped request absent from a populated result fails rather than reporting clean" {
     _load_drift_consumer
 
     local drift_json output rc=0
     drift_json='[{"container":"other","variants":[{"variant_tag":"latest","status":"unchanged"}]}]'
     GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
     : > "$GITHUB_OUTPUT"
+    output=$(consume_drift_result "$drift_json" "clean" 2>&1) || rc=$?
+
+    [ "$rc" -eq 1 ]
+    [[ "$output" == *"Requested container clean has no evaluated drift variants"* ]]
+    [[ "$output" != *"No drift detected for requested container clean"* ]]
+    [ "$(get_output drift_containers_csv)" = "" ]
+}
+
+@test "scoped clean container still succeeds" {
+    _load_drift_consumer
+
+    local drift_json output rc=0
+    drift_json='[
+      {"container":"clean","internal_deps":[],"variants":[{"variant_tag":"latest","status":"unchanged"}]},
+      {"container":"drifting","internal_deps":[],"variants":[{"variant_tag":"latest","status":"drift"}]}
+    ]'
+    validate_drift_result "$drift_json"
+    GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
+    : > "$GITHUB_OUTPUT"
     output=$(consume_drift_result "$drift_json" "clean") || rc=$?
 
     [ "$rc" -eq 0 ]
-    [[ "$output" == *"No drift detected for requested container clean"* ]]
-    [[ "$output" != *"Base image digest drift coverage incomplete"* ]]
-    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers_csv=\nerror_containers_csv=\ndrift_containers=[]' ]
+    [ "$output" = "::notice::No base image digest drift detected" ]
+    [ "$(get_output drift_containers)" = "[]" ]
+    [ "$(get_output drift_matrix)" = "[]" ]
+    [ "$(get_output drift_matrix_leaves)" = "[]" ]
+    [ "$(get_output drift_matrix_consumers)" = "[]" ]
+    # This remains unfiltered so cascade evaluation sees the full fleet.
+    [ "$(get_output drift_containers_csv)" = "drifting" ]
 }
 
 @test "empty unscoped drift result announces nothing to evaluate once and writes every output" {
@@ -3704,22 +3868,24 @@ _load_drift_consumer() {
     notice_count=$(printf '%s\n' "$output" | awk '/^::notice::/ { count++ } END { print count + 0 }')
     [ "$notice_count" -eq 1 ]
     [ "$output" = "::notice::No base image digest drift evaluation was performed — nothing to evaluate" ]
-    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers=[]\ndrift_matrix=[]\ndrift_matrix_leaves=[]\ndrift_matrix_consumers=[]\ndrift_containers_csv=\nerror_containers_csv=' ]
+    [ "$(get_output drift_containers)" = "[]" ]
+    [ "$(get_output drift_matrix)" = "[]" ]
+    [ "$(get_output drift_matrix_leaves)" = "[]" ]
+    [ "$(get_output drift_matrix_consumers)" = "[]" ]
+    [ "$(get_output drift_containers_csv)" = "" ]
 }
 
-@test "empty scoped drift result announces nothing to evaluate once and writes every output" {
+@test "empty scoped drift result fails rather than reporting a clean request" {
     _load_drift_consumer
 
     local output rc=0 notice_count
     GITHUB_OUTPUT="$TEST_TEMP_DIR/drift-consumer-output"
     : > "$GITHUB_OUTPUT"
-    output=$(consume_drift_result '[]' 'foo') || rc=$?
+    output=$(consume_drift_result '[]' 'foo' 2>&1) || rc=$?
 
-    [ "$rc" -eq 0 ]
-    notice_count=$(printf '%s\n' "$output" | awk '/^::notice::/ { count++ } END { print count + 0 }')
-    [ "$notice_count" -eq 1 ]
-    [ "$output" = "::notice::No base image digest drift evaluation was performed — nothing to evaluate" ]
-    [ "$(<"$GITHUB_OUTPUT")" = $'drift_containers=[]\ndrift_matrix=[]\ndrift_matrix_leaves=[]\ndrift_matrix_consumers=[]\ndrift_containers_csv=\nerror_containers_csv=' ]
+    [ "$rc" -eq 1 ]
+    [[ "$output" == *"Requested container foo has no evaluated drift variants"* ]]
+    [ ! -s "$GITHUB_OUTPUT" ]
 }
 
 @test "populated all-clean drift result keeps the clean notice" {
@@ -3902,7 +4068,7 @@ STUBEOF
 }
 
 # ---------------------------------------------------------------------------
-# Defect B.1 fix: _depgraph_get_deps failure → detect script emits an error record
+# Defect B.1 fix: _depgraph_get_deps failure → detect script emits a container error record
 #
 # When a ghcr.io/<owner>/... ref requires owner resolution but no owner source is
 # available, the dep-graph helper returns non-zero. The detect script must surface
@@ -3911,9 +4077,8 @@ STUBEOF
 # ---------------------------------------------------------------------------
 @test "internal_deps: owner unresolvable in dep-graph → detect exits 0, container emitted as error record (F2 regression-lock)" {
     # FIX 2: dep-graph failure must NOT abort the whole run (old behaviour: exit 1).
-    # The failing container must be surfaced as status:error with error_reason:dep_graph_unavailable
-    # and no internal_deps field — so it is excluded from the leaf/consumer matrices and
-    # downstream _eval_parent_state State B0 treats it as in_flux (conservative).
+    # The failing container must carry error_reason:dep_graph_unavailable at
+    # container scope and omit internal_deps, so it cannot enter either matrix.
     local fake_root="$TEST_TEMP_DIR/depgraph-fail"
     mkdir -p "$fake_root/scripts" "$fake_root/helpers" "$fake_root/.build-lineage"
     cp "${DETECTOR_SCRIPT}" "$fake_root/scripts/detect-base-digest-drift.sh"
@@ -3954,20 +4119,23 @@ EOF
     # Output must be valid JSON
     printf '%s' "$result" | jq '.' >/dev/null
 
-    # myapp must appear in output (as an error record, not dropped)
+    # myapp must appear in output (as a container error record, not dropped)
     container=$(printf '%s' "$result" | jq -r '.[0].container')
     [ "$container" = "myapp" ]
 
-    # Status must be "error"
-    status_val=$(printf '%s' "$result" | jq -r '.[0].variants[0].status')
-    [ "$status_val" = "error" ]
+    # A dependency-graph error must be at container scope, never in variants.
+    dep_graph_error_count=$(printf '%s' "$result" | jq \
+        '[.[] | select(.container == "myapp" and .error_reason == "dep_graph_unavailable")] | length')
+    [ "$dep_graph_error_count" -eq 1 ]
 
-    # error_reason must be dep_graph_unavailable
-    err_reason=$(printf '%s' "$result" | jq -r '.[0].variants[0].error_reason')
-    [ "$err_reason" = "dep_graph_unavailable" ]
+    # The variant evaluated before the dependency failure must survive it.
+    original_variant_count=$(printf '%s' "$result" | jq \
+        '[.[] | select(.container == "myapp") | .variants[] | select(.variant_tag == "1.0" and .error_reason == "registry_probe_failed")] | length')
+    [ "$original_variant_count" -eq 1 ]
 
     # internal_deps must NOT be present (no empty-deps leaf)
-    has_internal_deps=$(printf '%s' "$result" | jq '.[0] | has("internal_deps")')
+    has_internal_deps=$(printf '%s' "$result" | \
+        jq '.[] | select(.container == "myapp") | has("internal_deps")')
     [ "$has_internal_deps" = "false" ]
 }
 
@@ -3977,7 +4145,7 @@ EOF
 #
 # Invariants:
 #   overall exit code is 0 (not aborted)
-#   failing container is surfaced as status:error, error_reason:dep_graph_unavailable
+#   failing container has container-level error_reason:dep_graph_unavailable
 #   failing container does NOT have internal_deps field (no unsafe leaf)
 #   succeeding container still appears with its normal drift/unchanged record
 #   succeeding container IS NOT emitted as normal record with internal_deps:[]
@@ -4075,14 +4243,19 @@ STUB
     total=$(printf '%s' "$result" | jq 'length')
     [ "$total" -eq 2 ]
 
-    # failcontainer surfaced as status:error with dep_graph_unavailable reason
+    # The evaluated drift record survives; the dependency failure is not appended
+    # as a made-up variant.
     fail_status=$(printf '%s' "$result" | \
         jq -r '.[] | select(.container == "failcontainer") | .variants[0].status')
-    [ "$fail_status" = "error" ]
+    [ "$fail_status" = "drift" ]
 
     fail_reason=$(printf '%s' "$result" | \
-        jq -r '.[] | select(.container == "failcontainer") | .variants[0].error_reason')
+        jq -r '.[] | select(.container == "failcontainer") | .error_reason')
     [ "$fail_reason" = "dep_graph_unavailable" ]
+
+    fail_variant_count=$(printf '%s' "$result" | \
+        jq '.[] | select(.container == "failcontainer") | .variants | length')
+    [ "$fail_variant_count" -eq 1 ]
 
     # failcontainer does NOT have internal_deps (no unsafe empty-deps leaf)
     fail_has_deps=$(printf '%s' "$result" | \
@@ -4191,7 +4364,7 @@ EOF
 # Mutation guard: removing the charset gate causes the metachar container to
 # appear in the output (the test catches the regression).
 # ---------------------------------------------------------------------------
-@test "container name with semicolon (web;rm) is rejected, excluded from output" {
+@test "container name with semicolon (web;rm) fails closed" {
     local lineage_dir="$TEST_TEMP_DIR/.build-lineage-f1a"
     mkdir -p "$lineage_dir"
 
@@ -4209,17 +4382,17 @@ EOF
     # Override valid containers to include the dangerous name so grep -xF would
     # pass if the charset gate did not exist — the gate is what we are testing.
     local stderr_log="$TEST_TEMP_DIR/f1a-stderr.log"
+    local rc=0
     result=$(
         _VALID_CONTAINERS_OVERRIDE="web;rm" \
         PROBE_CMD="/bin/false" \
         bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>"$stderr_log"
-    )
+    ) || rc=$?
 
-    # Output must be empty: the container was rejected before processing
-    [ "$result" = "[]" ]
+    [ "$rc" -eq 1 ]
+    [ -z "$result" ]
 
-    # A ::warning:: must have been emitted to stderr naming the invalid chars
-    grep -q '::warning::' "$stderr_log"
+    grep -q '::error::' "$stderr_log"
 }
 
 @test "container name with only valid chars (web-shell) passes the charset gate" {


### PR DESCRIPTION
The base image digest drift detector answered "no drift" from scans that had not happened.

An absent lineage file, an empty one, and a record whose base reference was blank all skipped
silently and left the fleet reading clean. A malformed identity was tolerated rather than
refused. A probe failure was recorded and then not counted, so the workflow printed a clean result
over an incomplete scan.

The result is now a closed protocol. Every variant carries a status from a fixed vocabulary, a
stage built from `scratch` says so instead of being unreadable, and a coverage failure aborts the
job before any pull request is opened rather than letting a child be treated as ready behind a
parent nobody could probe. The workflow consumes the same vocabulary the detector produces, from
one declaration rather than two lists that could drift apart.

Refs #1526, #1527, #1528.

## Verified

- Full bats suite: 2966 tests, 0 failures, up from 2965 on master. The added tests cover an absent
  lineage file, an empty one, a blank base reference, a malformed identity, a probe timeout, a
  probe failure, and a container whose dependency graph could not be read.
- `shellcheck -x -S warning` on `scripts/detect-base-digest-drift.sh`: zero findings.
  `actionlint` on the workflow reports the same pre-existing diagnostics as master.
- Mutation proofs seen red for restoring the silent skip on absent lineage, for accepting a
  malformed identity, and for letting a coverage failure reach the pull-request jobs.
- The detector's helper functions are extracted and driven directly by the tests, so the
  assertions run the production code rather than a copy of it.

Not run locally: the container e2e suite, which builds images and reads nothing this diff changes.

## Known and filed, not fixed here

#1535 — a drift record can pair a non-error status with an error reason and still validate, the
coverage notice counts records no comparison was made for, and every non-timeout probe failure now
reports one reason. #1536 — ADR-010 and ADR-011 still describe the vocabulary and the parent state
this branch replaced. #1537 — the errored-parent safety rule now rests on the job dependency graph,
which no test asserts.
