### PR TITLE
fix(ci): bake lineage records the base identity the build consumed

### DIFF
--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -2327,7 +2327,7 @@ jobs:
             lineage_file=".build-lineage/${container}-${tag}.json"
             built_at="$(date -Iseconds)"
             ghcr_image="${REMOTE_CR}/${container}:${tag}"
-            jq -cn \
+            lineage_record=$(jq -cn \
               --arg container "$container" \
               --arg version "$tag" \
               --arg tag "$tag" \
@@ -2347,7 +2347,8 @@ jobs:
                 built_at:$built_at,
                 is_default:($is_default == "true"),
                 is_latest_version:($is_latest == "true")} + $base_fields' \
-              > "$lineage_file" || true
+              )
+            write_lineage_record_atomically "$lineage_file" "$lineage_record"
           done
 
       # Upload all bake SBOMs as a single combined artifact so the bake-attest

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -2006,10 +2006,9 @@ jobs:
           DRY_RUN: ${{ env.DRY_RUN }}
           DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
           BAKE_FINAL_BUILDS: ${{ needs.detect-containers.outputs.bake_final_builds }}
-          # Full per-target BuildKit provenance contains the resolved external
-          # materials. The lineage emitter reads this build-produced evidence;
-          # a later registry/tag inspection would not identify this build's base.
-          BUILDX_METADATA_PROVENANCE: max
+          # mode=min keeps the resolved external materials consumed by lineage,
+          # without retaining build-argument values and source maps.
+          BUILDX_METADATA_PROVENANCE: min
           PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |
@@ -2165,7 +2164,7 @@ jobs:
           overwrite: true
 
       # Trivy scanning is handled by the dedicated bake-trivy job (FIX 5).
-      # amd64-only: SBOM generation + attestation + lineage emission.
+      # amd64-only: SBOM generation and attestation collection are advisory.
       # v1 behaviour: on pull_request the bake job is BUILD-ONLY (compile validation);
       # nothing is pushed to the registry so SBOM generation and attestation are
       # skipped — scanning stale or absent refs would produce misleading results.
@@ -2179,7 +2178,7 @@ jobs:
         with:
           syft-version: v1.51.0
 
-      - name: Generate SBOM and emit lineage (bake amd64)
+      - name: Generate SBOM and collect attestation subjects (bake amd64)
         id: bake-sbom
         if: steps.install-syft-bake.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
         env:
@@ -2192,7 +2191,6 @@ jobs:
           set -euo pipefail
           source ./helpers/logging.sh
           source ./helpers/retry.sh
-          source ./helpers/base-image-utils.sh
           source ./helpers/sbom-utils.sh
           chmod +x scripts/generate-bake-hcl.sh
 
@@ -2232,11 +2230,6 @@ jobs:
             cell=$(jq -c ".[$i]" <<< "$cells_json")
             container=$(jq -r '.container'       <<< "$cell")
             tag=$(jq -r '.tag'                   <<< "$cell")
-            flavor=$(jq -r '.flavor // ""'       <<< "$cell")
-            target_id=$(jq -r '.target_id'         <<< "$cell")
-            runtime_base=$(jq -c '.runtime_base'   <<< "$cell")
-            is_default=$(jq -r 'if .is_default then "true" else "false" end' <<< "$cell")
-            is_latest=$(jq -r 'if has("is_latest_version") then (if .is_latest_version then "true" else "false" end) else "true" end' <<< "$cell")
             iref=$(jq -r '.intermediate_ref'     <<< "$cell")
             image_ref="${iref//\$\{REMOTE_CR\}/${REMOTE_CR}}-amd64"
 
@@ -2265,7 +2258,66 @@ jobs:
                 "$attest_manifest" > "${attest_manifest}.tmp" && mv "${attest_manifest}.tmp" "$attest_manifest" || true
             fi
 
-            # Emit schema-v2 lineage JSON
+            echo "::endgroup::"
+          done
+          echo "attest_manifest=${attest_manifest}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      # Provenance is produced by the successful bake itself, not by Syft.
+      # This is intentionally mandatory: production bakes must either publish
+      # every lineage record or fail visibly before the job can report success.
+      - name: Emit lineage (bake amd64)
+        id: bake-lineage
+        if: steps.bake-build.outcome == 'success' && github.event_name != 'pull_request' && env.DRY_RUN != 'true'
+        env:
+          BAKE_CONTAINERS: ${{ steps.bake-containers.outputs.containers }}
+          BAKE_RETAINED_CONTAINERS: ${{ steps.bake-containers.outputs.retained_containers }}
+          BAKE_FINAL_BUILDS: ${{ needs.detect-containers.outputs.bake_final_builds }}
+          REMOTE_CR: ghcr.io/${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          source ./helpers/base-image-utils.sh
+          source ./helpers/retry.sh
+          chmod +x scripts/generate-bake-hcl.sh
+
+          scope_args=()
+          [[ -n "${SCOPE_VERSIONS:-}" ]] && scope_args+=(--scope-versions "${SCOPE_VERSIONS}")
+          [[ -n "${SCOPE_FLAVORS:-}" ]] && scope_args+=(--scope-flavors "${SCOPE_FLAVORS}")
+          [[ -n "${BUILD_SCOPE:-}" ]] && scope_args+=(--scope "${BUILD_SCOPE}")
+          [[ -n "${CONTAINER_SCOPES:-}" ]] && scope_args+=(--container-scopes "${CONTAINER_SCOPES}")
+          final_args=()
+          if [[ -n "${BAKE_FINAL_BUILDS:-}" && "${BAKE_FINAL_BUILDS}" != "[]" ]]; then
+            final_args=(--include-final-build)
+          fi
+
+          # shellcheck disable=SC2086
+          cells_json=$(./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" "${final_args[@]}" ${BAKE_CONTAINERS})
+          if [[ "${BUILD_ALL_RETAINED:-false}" == "true" && -n "${BAKE_RETAINED_CONTAINERS:-}" ]]; then
+            # shellcheck disable=SC2086
+            retained_cells=$(_BAKE_INCLUDE_ALL_RETAINED=true ./scripts/generate-bake-hcl.sh --cells "${scope_args[@]}" "${final_args[@]}" --all-retained ${BAKE_RETAINED_CONTAINERS})
+            cells_json=$(jq -s '(.[0] + .[1]) | unique_by([.container, (.tag // ""), (.flavor // "")])' <<< "$cells_json"$'\n'"$retained_cells")
+          fi
+          ncells=$(jq 'length' <<< "$cells_json")
+          mkdir -p .build-lineage
+
+          for (( i=0; i<ncells; i++ )); do
+            cell=$(jq -c ".[$i]" <<< "$cells_json")
+            container=$(jq -r '.container' <<< "$cell")
+            tag=$(jq -r '.tag' <<< "$cell")
+            flavor=$(jq -r '.flavor // ""' <<< "$cell")
+            target_id=$(jq -r '.target_id' <<< "$cell")
+            runtime_base=$(jq -c '.runtime_base' <<< "$cell")
+            is_default=$(jq -r 'if .is_default then "true" else "false" end' <<< "$cell")
+            is_latest=$(jq -r 'if has("is_latest_version") then (if .is_latest_version then "true" else "false" end) else "true" end' <<< "$cell")
+            iref=$(jq -r '.intermediate_ref' <<< "$cell")
+            image_ref="${iref//\$\{REMOTE_CR\}/${REMOTE_CR}}-amd64"
+
+            digest=""
+            raw_manifest=$(retry_with_backoff 3 10 docker buildx imagetools inspect "$image_ref" --raw 2>/dev/null || true)
+            if [[ -n "$raw_manifest" ]]; then
+              digest="sha256:$(printf '%s' "$raw_manifest" | sha256sum | awk '{print $1}')"
+            fi
+
             target_metadata=$(jq -c --arg tid "$target_id" '.[$tid] // {}' \
               "${RUNNER_TEMP}/bake-metadata-amd64.json")
             if ! base_fields=$(lineage_base_fields_from_provenance "$runtime_base" "$target_metadata"); then
@@ -2277,17 +2329,17 @@ jobs:
             ghcr_image="${REMOTE_CR}/${container}:${tag}"
             jq -cn \
               --arg container "$container" \
-              --arg version   "$tag" \
-              --arg tag       "$tag" \
-              --arg flavor    "$flavor" \
-              --arg platform  "linux/amd64" \
+              --arg version "$tag" \
+              --arg tag "$tag" \
+              --arg flavor "$flavor" \
+              --arg platform "linux/amd64" \
               --arg build_digest "$digest" \
               --argjson base_fields "$base_fields" \
-              --arg ghcr      "$ghcr_image" \
+              --arg ghcr "$ghcr_image" \
               --arg dockerhub "docker.io/oorabona/${container}:${tag}" \
-              --arg built_at  "$built_at" \
+              --arg built_at "$built_at" \
               --arg is_default "$is_default" \
-              --arg is_latest  "$is_latest" \
+              --arg is_latest "$is_latest" \
               '{lineage_schema_version:2,
                 container:$container, version:$version, tag:$tag, flavor:$flavor,
                 platform:$platform, build_digest:$build_digest,
@@ -2296,11 +2348,7 @@ jobs:
                 is_default:($is_default == "true"),
                 is_latest_version:($is_latest == "true")} + $base_fields' \
               > "$lineage_file" || true
-
-            echo "::endgroup::"
           done
-          echo "attest_manifest=${attest_manifest}" >> "$GITHUB_OUTPUT"
-        continue-on-error: true
 
       # Upload all bake SBOMs as a single combined artifact so the bake-attest
       # matrix job can download them in one step.  The glob .build-lineage/*.sbom.json
@@ -2331,7 +2379,7 @@ jobs:
 
       - name: Upload build lineage (bake amd64)
         id: upload_build_lineage_bake_amd64
-        if: steps.bake-sbom.outcome == 'success' && github.event_name != 'pull_request'
+        if: steps.bake-lineage.outcome == 'success' && github.event_name != 'pull_request'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
@@ -2512,9 +2560,8 @@ jobs:
           DRY_RUN: ${{ env.DRY_RUN }}
           DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
           BAKE_FINAL_BUILDS: ${{ needs.detect-containers.outputs.bake_final_builds }}
-          # Keep the per-target resolved materials in bake-metadata-arm64 too;
-          # amd64 lineage consumes its sibling metadata in the same format.
-          BUILDX_METADATA_PROVENANCE: max
+          # mode=min retains the resolved materials and omits source maps.
+          BUILDX_METADATA_PROVENANCE: min
           PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |

--- a/.github/workflows/auto-build.yaml
+++ b/.github/workflows/auto-build.yaml
@@ -2006,6 +2006,10 @@ jobs:
           DRY_RUN: ${{ env.DRY_RUN }}
           DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
           BAKE_FINAL_BUILDS: ${{ needs.detect-containers.outputs.bake_final_builds }}
+          # Full per-target BuildKit provenance contains the resolved external
+          # materials. The lineage emitter reads this build-produced evidence;
+          # a later registry/tag inspection would not identify this build's base.
+          BUILDX_METADATA_PROVENANCE: max
           PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |
@@ -2188,6 +2192,7 @@ jobs:
           set -euo pipefail
           source ./helpers/logging.sh
           source ./helpers/retry.sh
+          source ./helpers/base-image-utils.sh
           source ./helpers/sbom-utils.sh
           chmod +x scripts/generate-bake-hcl.sh
 
@@ -2228,6 +2233,8 @@ jobs:
             container=$(jq -r '.container'       <<< "$cell")
             tag=$(jq -r '.tag'                   <<< "$cell")
             flavor=$(jq -r '.flavor // ""'       <<< "$cell")
+            target_id=$(jq -r '.target_id'         <<< "$cell")
+            runtime_base=$(jq -c '.runtime_base'   <<< "$cell")
             is_default=$(jq -r 'if .is_default then "true" else "false" end' <<< "$cell")
             is_latest=$(jq -r 'if has("is_latest_version") then (if .is_latest_version then "true" else "false" end) else "true" end' <<< "$cell")
             iref=$(jq -r '.intermediate_ref'     <<< "$cell")
@@ -2259,6 +2266,12 @@ jobs:
             fi
 
             # Emit schema-v2 lineage JSON
+            target_metadata=$(jq -c --arg tid "$target_id" '.[$tid] // {}' \
+              "${RUNNER_TEMP}/bake-metadata-amd64.json")
+            if ! base_fields=$(lineage_base_fields_from_provenance "$runtime_base" "$target_metadata"); then
+              echo "::error::Bake provenance did not provide the final runnable base digest for ${container}:${tag} (target ${target_id})"
+              exit 1
+            fi
             lineage_file=".build-lineage/${container}-${tag}.json"
             built_at="$(date -Iseconds)"
             ghcr_image="${REMOTE_CR}/${container}:${tag}"
@@ -2269,19 +2282,19 @@ jobs:
               --arg flavor    "$flavor" \
               --arg platform  "linux/amd64" \
               --arg build_digest "$digest" \
-              --arg base_image_ref "" \
+              --argjson base_fields "$base_fields" \
               --arg ghcr      "$ghcr_image" \
               --arg dockerhub "docker.io/oorabona/${container}:${tag}" \
               --arg built_at  "$built_at" \
               --arg is_default "$is_default" \
               --arg is_latest  "$is_latest" \
-              '{container:$container, version:$version, tag:$tag, flavor:$flavor,
+              '{lineage_schema_version:2,
+                container:$container, version:$version, tag:$tag, flavor:$flavor,
                 platform:$platform, build_digest:$build_digest,
-                base_image_ref:$base_image_ref,
                 images:{ghcr:$ghcr, dockerhub:$dockerhub},
                 built_at:$built_at,
                 is_default:($is_default == "true"),
-                is_latest_version:($is_latest == "true")}' \
+                is_latest_version:($is_latest == "true")} + $base_fields' \
               > "$lineage_file" || true
 
             echo "::endgroup::"
@@ -2499,6 +2512,9 @@ jobs:
           DRY_RUN: ${{ env.DRY_RUN }}
           DOCKER_NO_CACHE: ${{ env.DOCKER_NO_CACHE }}
           BAKE_FINAL_BUILDS: ${{ needs.detect-containers.outputs.bake_final_builds }}
+          # Keep the per-target resolved materials in bake-metadata-arm64 too;
+          # amd64 lineage consumes its sibling metadata in the same format.
+          BUILDX_METADATA_PROVENANCE: max
           PR_TAG_SUFFIX: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && format('-pr{0}', github.event.pull_request.number) || '' }}
           REBUILD: ${{ (inputs.rebuild != '' && inputs.rebuild != 'none' && inputs.rebuild) || (inputs.force_rebuild == true && 'all') || 'none' }}
         run: |

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1863,7 +1863,7 @@ jobs:
                   (.variant_tag | type == "string" and length > 0) and
                   (.status as $status |
                     ($status | type == "string") and
-                    (["drift", "unchanged", "legacy", "error", "no_external_base"] | index($status) != null)) and
+                    (["drift", "unchanged", "legacy", "error", "no_external_base", "sibling_target"] | index($status) != null)) and
                   (if .status == "error" then
                      (has("error_reason") and (.error_reason | type == "string" and length > 0))
                    else
@@ -1903,6 +1903,8 @@ jobs:
               return 1
             elif [[ "$record_count" -eq 0 ]]; then
               echo "::notice::No base image digest drift evaluation was performed — nothing to evaluate"
+            elif [[ "$compared_count" -eq 0 ]]; then
+              echo "::notice::No direct base image digest comparison was applicable"
             elif [[ "$mode" == "coverage" ]]; then
               # The coverage gate runs before any scoped success path.  A
               # populated, complete result has no closing notice until its

--- a/.github/workflows/upstream-monitor.yaml
+++ b/.github/workflows/upstream-monitor.yaml
@@ -1866,6 +1866,14 @@ jobs:
                     (["drift", "unchanged", "legacy", "error", "no_external_base", "sibling_target"] | index($status) != null)) and
                   (if .status == "error" then
                      (has("error_reason") and (.error_reason | type == "string" and length > 0))
+                   elif .status == "sibling_target" then
+                     (has("base_image_sibling") and
+                      (.base_image_sibling | type == "object") and
+                      (.base_image_sibling as $supplier |
+                        ([$supplier.container, $supplier.version, $supplier.platform,
+                          $supplier.textual_ref, $supplier.bake_target_id]
+                         | all(type == "string" and length > 0)) and
+                        ($supplier.flavor | type == "string")))
                    else
                      true
                    end)))

--- a/helpers/base-image-utils.sh
+++ b/helpers/base-image-utils.sh
@@ -14,6 +14,7 @@
 #   {"kind":"external","ref":"registry/image:tag"}
 #   {"kind":"no_external_base"}       # final stage is scratch
 #   {"kind":"unresolved","ref":"${ARG}/image"}
+#   {"kind":"sibling_target","supplier":{...}}
 #
 # The function is intentionally pure: no cwd, globals, labels, registry I/O,
 # or Docker invocation.  Effective build args take precedence over Dockerfile
@@ -129,6 +130,21 @@ lineage_base_fields_from_identity() {
             jq -cn '{base_image_kind:"unresolved_external_base"}'
             return 0
             ;;
+        sibling_target)
+            # A Bake context can replace the textual final FROM reference with
+            # another target in this same invocation. This is neither an
+            # external material nor scratch, so retain its exact supplier cell.
+            jq -e '
+              .supplier as $supplier
+              | ($supplier | type == "object") and
+                ([$supplier.container, $supplier.version, $supplier.platform,
+                  $supplier.textual_ref, $supplier.bake_target_id] | all(type == "string" and length > 0)) and
+                ($supplier.flavor | type == "string")
+            ' >/dev/null <<< "$base_identity" || return 1
+            jq -cn --argjson supplier "$(jq -c '.supplier' <<< "$base_identity")" \
+                '{base_image_kind:"sibling_target", base_image_sibling:$supplier}'
+            return 0
+            ;;
         external)
             ;;
         *)
@@ -140,6 +156,29 @@ lineage_base_fields_from_identity() {
     [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
     jq -cn --arg ref "$ref" --arg digest "$digest" \
         '{base_image_ref:$ref, base_image_digest:$digest}'
+}
+
+# write_lineage_record_atomically <destination> <json-record>
+#
+# A required lineage step succeeds only after a complete, parseable record has
+# been installed at its final path. The temporary file is beside the target so
+# the final rename is atomic.
+write_lineage_record_atomically() {
+    local destination="$1" record="$2"
+    local directory basename tmp_file
+    directory=$(dirname "$destination") || return 1
+    basename=$(basename "$destination") || return 1
+    mkdir -p "$directory" || return 1
+    tmp_file=$(mktemp "${directory}/.${basename}.tmp.XXXXXX") || return 1
+
+    if ! printf '%s\n' "$record" > "$tmp_file" || ! jq -e . "$tmp_file" >/dev/null; then
+        rm -f "$tmp_file"
+        return 1
+    fi
+    if ! mv -f "$tmp_file" "$destination"; then
+        rm -f "$tmp_file"
+        return 1
+    fi
 }
 
 # lineage_base_fields_from_provenance <base-identity-json> <target-metadata-json>

--- a/helpers/base-image-utils.sh
+++ b/helpers/base-image-utils.sh
@@ -19,38 +19,54 @@
 # or Docker invocation.  Effective build args take precedence over Dockerfile
 # ARG defaults; expansion is bounded so a cyclic value remains unresolved
 # rather than guessed.  The caller supplies the already-materialized content
-# for inline Dockerfiles (before Bake's $${...} HCL escaping).
+# for inline Dockerfiles (before Bake's $${...} HCL escaping).  It implements
+# only the final-FROM grammar used by this fleet: a reference (optionally
+# argument-derived), an optional AS name, or scratch.  New syntax must fail
+# here until the resolver deliberately learns how to interpret it.
 resolve_final_runnable_base() {
     local dockerfile_content="$1"
     local effective_args_json="${2-}"
-    [[ -n "$effective_args_json" ]] || effective_args_json='{}'
     local from_line="" line
+
+    if [[ -z "$effective_args_json" ]]; then
+        effective_args_json='{}'
+    elif ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$effective_args_json"; then
+        printf 'effective build arguments must be a valid JSON object\n' >&2
+        return 1
+    fi
 
     while IFS= read -r line; do
         [[ "$line" =~ ^[[:space:]]*FROM[[:space:]]+ ]] && from_line="$line"
     done <<< "$dockerfile_content"
 
     [[ -n "$from_line" ]] || {
-        jq -cn '{kind:"unresolved", ref:""}'
-        return 0
+        printf 'Dockerfile has no final FROM instruction\n' >&2
+        return 1
     }
 
-    # Docker permits flags before the image (`FROM --platform=$BUILDPLATFORM …`).
-    local rest raw_ref token
-    rest="${from_line#${from_line%%[![:space:]]*}}"
-    rest="${rest#FROM}"
-    rest="${rest#${rest%%[![:space:]]*}}"
-    raw_ref=""
-    for token in $rest; do
-        [[ "$token" == --* ]] && continue
-        raw_ref="$token"
-        break
+    # Deliberately accept only `<reference> [AS <stage>]`. In particular,
+    # `--platform`, continuations, and other Dockerfile forms are not safe to
+    # reduce to a base-image identity without extending this resolver.
+    local raw_ref
+    if [[ "$from_line" =~ ^[[:space:]]*FROM[[:space:]]+([^[:space:]]+)([[:space:]]+[Aa][Ss][[:space:]]+[A-Za-z0-9][A-Za-z0-9_.-]*)?[[:space:]]*$ ]]; then
+        raw_ref="${BASH_REMATCH[1]}"
+    else
+        printf 'unsupported final FROM syntax: %s\n' "$from_line" >&2
+        return 1
+    fi
+
+    # An argument-derived reference may contain only complete `$NAME` or
+    # `${NAME}` tokens. Removing those first makes parameter operators such as
+    # `${NAME:-fallback}` a visible unsupported construct rather than a
+    # partially resolved identity.
+    local syntax_check="$raw_ref"
+    while [[ "$syntax_check" =~ (\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*) ]]; do
+        syntax_check="${syntax_check/"${BASH_REMATCH[1]}"/}"
     done
-
-    [[ -n "$raw_ref" ]] || {
-        jq -cn '{kind:"unresolved", ref:""}'
-        return 0
-    }
+    if [[ "$syntax_check" == *'$'* || "$syntax_check" == *'{'* || "$syntax_check" == *'}'* ]]; then
+        printf 'unsupported final FROM syntax: %s\n' "$from_line" >&2
+        return 1
+    fi
     [[ "$raw_ref" == "scratch" ]] && {
         jq -cn '{kind:"no_external_base"}'
         return 0
@@ -58,12 +74,7 @@ resolve_final_runnable_base() {
 
     # Effective args win.  Dockerfile defaults fill only values the build did
     # not supply.  Use JSON as the map boundary so the helper has no globals.
-    local args_json
-    if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$effective_args_json"; then
-        args_json='{}'
-    else
-        args_json="$effective_args_json"
-    fi
+    local args_json="$effective_args_json"
 
     local defaults='{}' arg_name arg_value
     while IFS= read -r line; do
@@ -77,15 +88,19 @@ resolve_final_runnable_base() {
     done <<< "$dockerfile_content"
     args_json=$(jq -cn --argjson defaults "$defaults" --argjson effective "$args_json" '$defaults + $effective')
 
-    local resolved="$raw_ref" previous pass=0 key value
-    while [[ "$resolved" == *'$'* && $pass -lt 10 ]]; do
-        previous="$resolved"
-        while IFS=$'\t' read -r key value; do
-            [[ -n "$key" ]] || continue
-            resolved="${resolved//\$\{$key\}/$value}"
-            resolved="${resolved//\$$key/$value}"
-        done < <(jq -r 'to_entries[] | [.key, (.value | tostring)] | @tsv' <<< "$args_json")
-        [[ "$resolved" == "$previous" ]] && break
+    local resolved="$raw_ref" pass=0 token arg_name value
+    while [[ "$resolved" =~ (\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*) && $pass -lt 10 ]]; do
+        token="${BASH_REMATCH[1]}"
+        if [[ "${token:0:2}" == '${' ]]; then
+            arg_name="${token:2:${#token}-3}"
+        else
+            arg_name="${token:1}"
+        fi
+        if ! jq -e --arg key "$arg_name" 'has($key)' >/dev/null <<< "$args_json"; then
+            break
+        fi
+        value=$(jq -r --arg key "$arg_name" '.[$key] | tostring' <<< "$args_json")
+        resolved="${resolved/"$token"/$value}"
         ((pass++)) || true
     done
 
@@ -96,24 +111,55 @@ resolve_final_runnable_base() {
     fi
 }
 
+# The resolver's non-external outcomes have no coupled ref/digest fields. Keep
+# their lineage spelling here so every writer records them identically.
+#
+# lineage_base_fields_from_identity <base-identity-json> [<digest>]
+lineage_base_fields_from_identity() {
+    local base_identity="$1"
+    local digest="${2:-}"
+    local kind ref
+    kind=$(jq -r '.kind // "unresolved"' <<< "$base_identity") || return 1
+    case "$kind" in
+        no_external_base)
+            jq -cn '{base_image_kind:"no_external_base"}'
+            return 0
+            ;;
+        unresolved)
+            jq -cn '{base_image_kind:"unresolved_external_base"}'
+            return 0
+            ;;
+        external)
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    ref=$(jq -r '.ref // empty' <<< "$base_identity")
+    [[ -n "$ref" ]] || return 1
+    [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+    jq -cn --arg ref "$ref" --arg digest "$digest" \
+        '{base_image_ref:$ref, base_image_digest:$digest}'
+}
+
 # lineage_base_fields_from_provenance <base-identity-json> <target-metadata-json>
 #
 # Extract the digest of the selected final-stage base from Buildx's *per target*
-# `buildx.build.provenance` material list.  This is build-resolved evidence; it
-# never inspects a mutable tag after the build.  The source accepts the current
-# SLSA v0.2 (`predicate.materials`) and v1 (`resolvedDependencies`) layouts.
-# A no-external-base result omits both coupled fields and carries an explicit
-# marker for the drift consumer.
+# `buildx.build.provenance` material list. This is build-resolved evidence; it
+# never inspects a mutable tag after the build. Buildx decodes the exporter
+# response and writes the provenance predicate object itself, so the current
+# metadata-file shape has `buildx.build.provenance.materials` (no `predicate`
+# wrapper). This is the BuildKit SLSA v0.2 predicate which Buildx emits by
+# default; do not add speculative layouts without a producing Buildx version.
 lineage_base_fields_from_provenance() {
     local base_identity="$1"
     local target_metadata="$2"
     local kind ref digest
-    kind=$(jq -r '.kind // "unresolved"' <<< "$base_identity")
-    if [[ "$kind" == "no_external_base" ]]; then
-        jq -cn '{base_image_kind:"no_external_base"}'
-        return 0
+    kind=$(jq -r '.kind // "unresolved"' <<< "$base_identity") || return 1
+    if [[ "$kind" != "external" ]]; then
+        lineage_base_fields_from_identity "$base_identity"
+        return
     fi
-    [[ "$kind" == "external" ]] || return 1
     ref=$(jq -r '.ref // empty' <<< "$base_identity")
     [[ -n "$ref" ]] || return 1
 
@@ -124,7 +170,7 @@ lineage_base_fields_from_provenance() {
     digest=$(jq -r --arg ref "$ref" '
       def materials:
         (."buildx.build.provenance" // {}) as $p
-        | ($p.predicate.materials // $p.predicate.buildDefinition.resolvedDependencies // $p.predicate.runDetails.builderDependencies // []);
+        | ($p.materials // []);
       def purl_ref:
         sub("^pkg:docker/"; "") | split("?")[0] | sub("@"; ":");
       [ materials[]?
@@ -133,7 +179,5 @@ lineage_base_fields_from_provenance() {
            | if startswith("sha256:") then . else "sha256:" + . end)
       ][0] // empty
     ' <<< "$target_metadata")
-    [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
-    jq -cn --arg ref "$ref" --arg digest "$digest" \
-        '{base_image_ref:$ref, base_image_digest:$digest}'
+    lineage_base_fields_from_identity "$base_identity" "$digest"
 }

--- a/helpers/base-image-utils.sh
+++ b/helpers/base-image-utils.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# Base-image lineage helpers.
+#
+# v1 deliberately records only the external material that defines the final
+# runnable Dockerfile stage.  It does not try to report build-stage materials:
+# those are not part of this contract.  This is a fleet rule, not a general
+# Dockerfile rule.  A final `FROM <internal-stage>` would require ancestry
+# tracing; no tracked Dockerfile currently has one.
+
+# resolve_final_runnable_base <dockerfile-content> <effective-args-json>
+#
+# Print one JSON object:
+#   {"kind":"external","ref":"registry/image:tag"}
+#   {"kind":"no_external_base"}       # final stage is scratch
+#   {"kind":"unresolved","ref":"${ARG}/image"}
+#
+# The function is intentionally pure: no cwd, globals, labels, registry I/O,
+# or Docker invocation.  Effective build args take precedence over Dockerfile
+# ARG defaults; expansion is bounded so a cyclic value remains unresolved
+# rather than guessed.  The caller supplies the already-materialized content
+# for inline Dockerfiles (before Bake's $${...} HCL escaping).
+resolve_final_runnable_base() {
+    local dockerfile_content="$1"
+    local effective_args_json="${2-}"
+    [[ -n "$effective_args_json" ]] || effective_args_json='{}'
+    local from_line="" line
+
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*FROM[[:space:]]+ ]] && from_line="$line"
+    done <<< "$dockerfile_content"
+
+    [[ -n "$from_line" ]] || {
+        jq -cn '{kind:"unresolved", ref:""}'
+        return 0
+    }
+
+    # Docker permits flags before the image (`FROM --platform=$BUILDPLATFORM …`).
+    local rest raw_ref token
+    rest="${from_line#${from_line%%[![:space:]]*}}"
+    rest="${rest#FROM}"
+    rest="${rest#${rest%%[![:space:]]*}}"
+    raw_ref=""
+    for token in $rest; do
+        [[ "$token" == --* ]] && continue
+        raw_ref="$token"
+        break
+    done
+
+    [[ -n "$raw_ref" ]] || {
+        jq -cn '{kind:"unresolved", ref:""}'
+        return 0
+    }
+    [[ "$raw_ref" == "scratch" ]] && {
+        jq -cn '{kind:"no_external_base"}'
+        return 0
+    }
+
+    # Effective args win.  Dockerfile defaults fill only values the build did
+    # not supply.  Use JSON as the map boundary so the helper has no globals.
+    local args_json
+    if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$effective_args_json"; then
+        args_json='{}'
+    else
+        args_json="$effective_args_json"
+    fi
+
+    local defaults='{}' arg_name arg_value
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[[:space:]]*ARG[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+            arg_name="${BASH_REMATCH[1]}"
+            arg_value="${BASH_REMATCH[2]}"
+            arg_value="${arg_value%\"}"; arg_value="${arg_value#\"}"
+            arg_value="${arg_value%\'}"; arg_value="${arg_value#\'}"
+            defaults=$(jq -cn --argjson base "$defaults" --arg k "$arg_name" --arg v "$arg_value" '$base + {($k): $v}')
+        fi
+    done <<< "$dockerfile_content"
+    args_json=$(jq -cn --argjson defaults "$defaults" --argjson effective "$args_json" '$defaults + $effective')
+
+    local resolved="$raw_ref" previous pass=0 key value
+    while [[ "$resolved" == *'$'* && $pass -lt 10 ]]; do
+        previous="$resolved"
+        while IFS=$'\t' read -r key value; do
+            [[ -n "$key" ]] || continue
+            resolved="${resolved//\$\{$key\}/$value}"
+            resolved="${resolved//\$$key/$value}"
+        done < <(jq -r 'to_entries[] | [.key, (.value | tostring)] | @tsv' <<< "$args_json")
+        [[ "$resolved" == "$previous" ]] && break
+        ((pass++)) || true
+    done
+
+    if [[ "$resolved" == *'$'* ]]; then
+        jq -cn --arg ref "$resolved" '{kind:"unresolved", ref:$ref}'
+    else
+        jq -cn --arg ref "$resolved" '{kind:"external", ref:$ref}'
+    fi
+}
+
+# lineage_base_fields_from_provenance <base-identity-json> <target-metadata-json>
+#
+# Extract the digest of the selected final-stage base from Buildx's *per target*
+# `buildx.build.provenance` material list.  This is build-resolved evidence; it
+# never inspects a mutable tag after the build.  The source accepts the current
+# SLSA v0.2 (`predicate.materials`) and v1 (`resolvedDependencies`) layouts.
+# A no-external-base result omits both coupled fields and carries an explicit
+# marker for the drift consumer.
+lineage_base_fields_from_provenance() {
+    local base_identity="$1"
+    local target_metadata="$2"
+    local kind ref digest
+    kind=$(jq -r '.kind // "unresolved"' <<< "$base_identity")
+    if [[ "$kind" == "no_external_base" ]]; then
+        jq -cn '{base_image_kind:"no_external_base"}'
+        return 0
+    fi
+    [[ "$kind" == "external" ]] || return 1
+    ref=$(jq -r '.ref // empty' <<< "$base_identity")
+    [[ -n "$ref" ]] || return 1
+
+    # BuildKit represents Docker bases as package URLs, for example
+    # pkg:docker/docker.io/library/alpine@3.21?platform=linux%2Famd64.
+    # Match both the literal image reference and the purl's name@version form;
+    # the latter accommodates BuildKit's Docker Hub canonicalization.
+    digest=$(jq -r --arg ref "$ref" '
+      def materials:
+        (."buildx.build.provenance" // {}) as $p
+        | ($p.predicate.materials // $p.predicate.buildDefinition.resolvedDependencies // $p.predicate.runDetails.builderDependencies // []);
+      def purl_ref:
+        sub("^pkg:docker/"; "") | split("?")[0] | sub("@"; ":");
+      [ materials[]?
+        | select((.uri // "") as $uri | ($uri == $ref or ($uri | purl_ref) == $ref))
+        | (.digest.sha256? // empty
+           | if startswith("sha256:") then . else "sha256:" + . end)
+      ][0] // empty
+    ' <<< "$target_metadata")
+    [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+    jq -cn --arg ref "$ref" --arg digest "$digest" \
+        '{base_image_ref:$ref, base_image_digest:$digest}'
+}

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -260,7 +260,9 @@ _emit_build_lineage() {
 
     # Fix C: use jq -n --arg so values with '"' or backslash are safely escaped.
     # Fix E: include lineage_schema_version=2 for downstream schema detection.
-    jq -n \
+    # Construct the complete record before its single atomic publication.
+    local lineage_record
+    lineage_record=$(jq -n \
         --arg     container        "$container" \
         --arg     version          "$version" \
         --arg     tag              "$tag" \
@@ -278,6 +280,7 @@ _emit_build_lineage() {
         --arg     dockerhub_image  "$dockerhub_image:$tag" \
         --arg     ghcr_image       "$ghcr_image:$tag" \
         --argjson build_args       "$build_args_data" \
+        --argjson extensions_build_seconds "$extensions_build_seconds" \
         '{
           lineage_schema_version: 2,
           container:              $container,
@@ -298,25 +301,9 @@ _emit_build_lineage() {
             ghcr:      $ghcr_image
           },
           build_args: $build_args
-        } + $base_fields' > "$lineage_file"
-
-    # Conditionally merge extensions_build_seconds when the caller actually
-    # measured it. The field's PRESENCE (not its value) is the signal that
-    # downstream consumers (sbom-utils.sh::append_build_history, the dashboard
-    # frontend) use to detect "container has extensions concept". Containers
-    # without extensions/config.yaml pass the literal string "null" as the
-    # 10th arg — for those we omit the field entirely so the signal stays
-    # honest.
-    if [[ "$extensions_build_seconds" != "null" ]]; then
-        local _lineage_tmp="${lineage_file}.tmp"
-        if jq --argjson ext "$extensions_build_seconds" \
-            '. + {extensions_build_seconds: $ext}' "$lineage_file" > "$_lineage_tmp" 2>/dev/null; then
-            mv "$_lineage_tmp" "$lineage_file"
-        else
-            rm -f "$_lineage_tmp"
-            log_warning "Failed to merge extensions_build_seconds=$extensions_build_seconds into $lineage_file"
-        fi
-    fi
+        } + $base_fields
+          | if $extensions_build_seconds == null then . else . + {extensions_build_seconds: $extensions_build_seconds} end') || return 1
+    write_lineage_record_atomically "$lineage_file" "$lineage_record" || return 1
     log_info "Build lineage: $lineage_file"
 }
 
@@ -462,7 +449,11 @@ build_container() {
     # is still read — no behavior change for monolithic path.
     local _rbi_generated=0
     [[ -n "$_generated_dockerfile" ]] && _rbi_generated=1
-    _resolve_base_image "$dockerfile" "$version" "label_args" "$_rbi_generated"
+    if ! _resolve_base_image "$dockerfile" "$version" "label_args" "$_rbi_generated"; then
+        log_error "Failed to resolve final runnable base for $container:$tag"
+        [[ -n "$_generated_dockerfile" ]] && rm -f "$_generated_dockerfile"
+        return 1
+    fi
 
     # Pre-build context hook: download external artifacts needed by the Dockerfile
     # (e.g., github-runner downloads the runner agent tarball via gh CLI)
@@ -575,8 +566,12 @@ build_container() {
     fi
 
     if [[ "${DRY_RUN:-false}" != "true" ]]; then
-        _emit_build_lineage "$container" "$version" "$tag" "$flavor" "$dockerfile" \
-            "$_PLATFORMS" "$_RUNTIME_INFO" "$dockerhub_image" "$ghcr_image" "$_ext_seconds"
+        if ! _emit_build_lineage "$container" "$version" "$tag" "$flavor" "$dockerfile" \
+                "$_PLATFORMS" "$_RUNTIME_INFO" "$dockerhub_image" "$ghcr_image" "$_ext_seconds"; then
+            log_error "Failed to publish build lineage for $container:$tag"
+            [[ -n "$_generated_dockerfile" ]] && rm -f "$_generated_dockerfile"
+            return 1
+        fi
     else
         log_info "[DRY-RUN] Would write lineage: .build-lineage/${container}-${tag}.json"
     fi

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -16,6 +16,8 @@ source "$PROJECT_ROOT/helpers/build-cache-utils.sh"
 source "$PROJECT_ROOT/helpers/build-args-utils.sh"
 source "$PROJECT_ROOT/helpers/template-utils.sh"
 source "$PROJECT_ROOT/helpers/extension-utils.sh"
+# shellcheck source=../helpers/base-image-utils.sh
+source "$PROJECT_ROOT/helpers/base-image-utils.sh"
 # shellcheck source=../helpers/extension-duration-utils.sh
 [[ -f "$PROJECT_ROOT/helpers/extension-duration-utils.sh" ]] && source "$PROJECT_ROOT/helpers/extension-duration-utils.sh"
 
@@ -130,24 +132,20 @@ _prepare_build_args() {
     done < <(echo "${_BUILD_ARGS:-}" | grep -oE -- '--build-arg [^ ]+' | sed 's/--build-arg //' || true)
 }
 
-# Resolve base image reference from config.yaml or Dockerfile, substitute variables
-# Sets: _BASE_IMAGE_REF, _BASE_DIGEST, adds to label_args
+# Resolve the final runnable stage's external base reference.  The pure
+# substitution and final-FROM selection live in base-image-utils.sh so Bake and
+# the flat matrix cannot diverge as containers are added.
+# Sets: _BASE_IMAGE_REF, _BASE_DIGEST, _BASE_IMAGE_KIND; adds digest label.
 # Args: <dockerfile> <version> <label_args_var> [<from_generated>]
-#   from_generated: 1 = use the concrete FROM line in the generated Dockerfile as the
-#     authoritative base-image source (Fix A2); 0 = use config.yaml::base_image (default).
-#     Pass this explicitly from every call site — callers that forget default to monolithic
-#     semantics (0), which is safe but may miss the per-flavor fix for template containers.
+#   from_generated remains a compatibility argument; callers now pass concrete
+#   Dockerfile content to the shared final-stage resolver in either case.
 _resolve_base_image() {
     local dockerfile="$1"
     local version="$2"
     local label_args_var="$3"  # name of the label_args variable to append to
-    local from_generated="${4:-0}"  # Fix A2 positional param (replaces _RESOLVE_FROM_GENERATED env)
-
-    # Fix A2: when called with a generated Dockerfile (post-template-generation),
-    # the concrete FROM line is the authoritative source.  In that case, skip
-    # config.yaml::base_image — it contains the default-distro template value and
-    # would override the per-flavor FROM already baked into the generated file.
-    local _use_from_only="$from_generated"
+    # Kept as a positional compatibility slot for existing callers. The shared
+    # resolver always receives the concrete Dockerfile content, generated or not.
+    : "${4:-0}"
 
     # Fix A1: _BUILD_ARGS_RESOLVED is populated by _prepare_build_args (wrapper).
     # When _resolve_base_image is called directly in tests (without the wrapper),
@@ -157,126 +155,42 @@ _resolve_base_image() {
         declare -gA _BUILD_ARGS_RESOLVED=()
     fi
 
-    _BASE_IMAGE_REF=""
-    if [[ "$_use_from_only" != "1" && -f "./config.yaml" ]]; then
-        _BASE_IMAGE_REF=$(yq -r '.base_image // ""' ./config.yaml 2>/dev/null || true)
+    local effective_args='{}' key
+    for key in "${!_BUILD_ARGS_RESOLVED[@]}"; do
+        effective_args=$(jq -cn --argjson base "$effective_args" --arg k "$key" \
+            --arg v "${_BUILD_ARGS_RESOLVED[$key]}" '$base + {($k): $v}')
+    done
+    # Normal builds populate the map above. Keep the function's direct-call
+    # compatibility by providing the same standard values as fallback inputs;
+    # explicit effective args still win.
+    local standard_args
+    standard_args=$(jq -cn \
+        --arg version "$version" \
+        --arg major "${_MAJOR_VERSION:-}" \
+        --arg upstream "${_UPSTREAM_VERSION:-}" \
+        '{VERSION:$version}
+         + (if $major == "" then {} else {MAJOR_VERSION:$major} end)
+         + (if $upstream == "" then {} else {UPSTREAM_VERSION:$upstream} end)')
+    effective_args=$(jq -cn --argjson standard "$standard_args" --argjson effective "$effective_args" '$standard + $effective')
+    # _prepare_build_args normally already includes these final overrides. Keep
+    # direct callers (including the public helper tests) on Docker's last-value
+    # semantics too.
+    if [[ -n "${CUSTOM_BUILD_ARGS:-}" ]]; then
+        local custom_arg
+        while IFS= read -r custom_arg; do
+            local custom_key="${custom_arg%%=*}" custom_value="${custom_arg#*=}"
+            [[ "$custom_key" == "$custom_arg" || -z "$custom_key" ]] && continue
+            effective_args=$(jq -cn --argjson base "$effective_args" --arg k "$custom_key" \
+                --arg v "$custom_value" '$base + {($k): $v}')
+        done < <(printf '%s\n' "$CUSTOM_BUILD_ARGS" | grep -oE '\-\-build-arg [^ ]+' | sed 's/--build-arg //' || true)
     fi
-    # Always pre-compute the FROM line; used as fallback and as the authoritative
-    # source when _use_from_only=1.
-    local _dockerfile_from=""
-    _dockerfile_from=$(grep -E '^FROM ' "$dockerfile" | grep -v ' AS ' | tail -1 | awk '{print $2}' 2>/dev/null || true)
-    [[ -z "$_dockerfile_from" ]] && _dockerfile_from=$(grep -E '^FROM ' "$dockerfile" | tail -1 | awk '{print $2}' 2>/dev/null || true)
-    if [[ -z "$_BASE_IMAGE_REF" ]]; then
-        _BASE_IMAGE_REF="$_dockerfile_from"
-    fi
-
-    # Substitute known variables into the base image template.
-    #
-    # Ordering rationale: CUSTOM_BUILD_ARGS overrides must be parsed and applied
-    # BEFORE the standard VERSION/UPSTREAM_VERSION substitutions so that a build
-    # script's explicit --build-arg UPSTREAM_VERSION=<retained> wins over the
-    # helper-resolved _UPSTREAM_VERSION (which always reflects the latest upstream).
-    # Without this order, retained-version builds (e.g. terraform) would record the
-    # wrong base_image_ref in the lineage file because _UPSTREAM_VERSION (latest)
-    # would be substituted first, and the CUSTOM_BUILD_ARGS override would arrive
-    # too late to correct an already-expanded placeholder.
-    # Order: (1) parse CUSTOM_BUILD_ARGS, (2) apply overrides, (2.5) build_args
-    # resolved set from _prepare_build_args [Fix A1], (3) standard substitutions
-    # (no-ops for placeholders already consumed in steps 1-2.5), (4) Dockerfile
-    # ARG defaults.
-    if [[ "$_BASE_IMAGE_REF" =~ \$ ]]; then
-        # Step 1 + 2: Parse CUSTOM_BUILD_ARGS and apply overrides first so they win
-        # over all subsequent substitutions. Docker semantics: last --build-arg wins.
-        declare -A _custom_arg_overrides=()
-        if [[ -n "${CUSTOM_BUILD_ARGS:-}" ]]; then
-            while read -r arg_val; do
-                local _ov_name="${arg_val%%=*}"
-                local _ov_value="${arg_val#*=}"
-                [[ -n "$_ov_name" ]] && _custom_arg_overrides["$_ov_name"]="$_ov_value"
-            done < <(echo "$CUSTOM_BUILD_ARGS" | grep -oE '\-\-build-arg [^ ]+' | sed 's/--build-arg //' || true)
-        fi
-
-        # Apply CUSTOM_BUILD_ARGS overrides before standard substitutions.
-        for _ov_name in "${!_custom_arg_overrides[@]}"; do
-            local _ov_value="${_custom_arg_overrides[$_ov_name]}"
-            _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$_ov_name\}/$_ov_value}"
-            _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$_ov_name/$_ov_value}"
-        done
-
-        # Step 2.5 [Fix A1]: Apply build_args resolved set from _prepare_build_args.
-        # This covers ARGs whose values come from config.yaml build_args or version
-        # params — invisible to both CUSTOM_BUILD_ARGS and Dockerfile ARG defaults.
-        # Iterates up to 10 times to resolve cross-arg chains (A→B→C).  On cap-hit,
-        # remaining placeholders survive to sanitize-at-read in the dashboard.
-        if [[ ${#_BUILD_ARGS_RESOLVED[@]} -gt 0 ]]; then
-            local _pass=0
-            while [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -lt 10 ]]; do
-                local _prev="$_BASE_IMAGE_REF"
-                for _ba_name in "${!_BUILD_ARGS_RESOLVED[@]}"; do
-                    # Skip args already handled by CUSTOM_BUILD_ARGS
-                    [[ -v _custom_arg_overrides["$_ba_name"] ]] && continue
-                    local _ba_val="${_BUILD_ARGS_RESOLVED[$_ba_name]}"
-                    _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$_ba_name\}/$_ba_val}"
-                    _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$_ba_name/$_ba_val}"
-                done
-                # Converged: no more substitutions possible
-                [[ "$_BASE_IMAGE_REF" == "$_prev" ]] && break
-                (( _pass++ )) || true
-            done
-            if [[ "$_BASE_IMAGE_REF" =~ \$ && $_pass -ge 10 ]]; then
-                log_warning "base_image_ref cross-arg expansion capped at 10 passes: $_BASE_IMAGE_REF"
-                # On cap-hit, _BASE_IMAGE_REF is cleared to empty string.
-                # Sanitize-at-read in the dashboard displays "unknown" downstream.
-                _BASE_IMAGE_REF=""
-            fi
-        fi
-
-        # Step 3: Standard substitutions. These are no-ops for any placeholder
-        # already consumed by a CUSTOM_BUILD_ARGS override above.
-        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{VERSION\}/$version}"
-        _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$VERSION/$version}"
-        [[ -n "${_MAJOR_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{MAJOR_VERSION\}/$_MAJOR_VERSION}"
-        [[ -n "${_UPSTREAM_VERSION:-}" ]] && _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{UPSTREAM_VERSION\}/$_UPSTREAM_VERSION}"
-
-        # Step 4: Resolve Dockerfile ARG defaults (e.g. ARG REMOTE_CR=docker.io) for any
-        # variables not already substituted by a CUSTOM_BUILD_ARGS override above.
-        while IFS= read -r arg_line; do
-            local arg_name="${arg_line%%=*}"
-            local arg_default="${arg_line#*=}"
-            arg_default="${arg_default%\"}"
-            arg_default="${arg_default#\"}"
-            arg_default="${arg_default%\'}"
-            arg_default="${arg_default#\'}"
-            [[ -z "$arg_name" || "$arg_name" == "$arg_line" ]] && continue
-            # Skip if this arg was already applied via CUSTOM_BUILD_ARGS override
-            [[ -v _custom_arg_overrides["$arg_name"] ]] && continue
-            if [[ "$_BASE_IMAGE_REF" == *"\${$arg_name}"* || "$_BASE_IMAGE_REF" == *"\$$arg_name"* ]]; then
-                _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$\{$arg_name\}/$arg_default}"
-                _BASE_IMAGE_REF="${_BASE_IMAGE_REF//\$$arg_name/$arg_default}"
-            fi
-        done < <(grep -E '^ARG [A-Za-z_][A-Za-z0-9_]*=' "$dockerfile" | sed 's/^ARG //' || true)
-
-        unset _custom_arg_overrides
-
-        # Post-substitution fallback: if config.yaml base_image had a template
-        # expression that still contains ${ after all passes, fall back to the concrete
-        # FROM line in the Dockerfile — but ONLY when the 4th positional parameter
-        # from_generated=1 (the caller has already expanded the template, so the
-        # generated Dockerfile's FROM is the authoritative per-flavor base image).
-        #
-        # For monolithic containers (no template generation), config.yaml::base_image is
-        # the source of truth. If its placeholders remain unresolved, that is a build-time
-        # configuration error — substituting an unrelated concrete FROM line (e.g. a
-        # multi-stage final-stage "FROM scratch") would write false lineage silently.
-        # Instead, leave the unresolved literal so sanitize-at-read displays "unknown".
-        if [[ "$_BASE_IMAGE_REF" =~ \$\{ && "$_use_from_only" == "1" && -n "$_dockerfile_from" && ! "$_dockerfile_from" =~ \$\{ ]]; then
-            _BASE_IMAGE_REF="$_dockerfile_from"
-        fi
-
-        # Emit warning when a placeholder survives all substitution passes
-        if [[ "$_BASE_IMAGE_REF" =~ \$\{ ]]; then
-            log_warning "base_image_ref left un-resolved: $_BASE_IMAGE_REF"
-        fi
+    local base_identity
+    base_identity=$(resolve_final_runnable_base "$(< "$dockerfile")" "$effective_args")
+    _BASE_IMAGE_KIND=$(jq -r '.kind' <<< "$base_identity")
+    _BASE_IMAGE_REF=$(jq -r '.ref // empty' <<< "$base_identity")
+    if [[ "$_BASE_IMAGE_KIND" == "unresolved" ]]; then
+        log_warning "final runnable base_image_ref left unresolved after bounded expansion: ${_BASE_IMAGE_REF:-unknown}"
+        _BASE_IMAGE_REF=""
     fi
 
     # Resolve digest if we have a concrete image reference
@@ -287,7 +201,7 @@ _resolve_base_image() {
     # pattern was order-dependent and could return a per-arch child digest instead
     # of the index digest — causing a perpetual drift-PR loop.
     _BASE_DIGEST=""
-    if [[ -n "$_BASE_IMAGE_REF" && ! "$_BASE_IMAGE_REF" =~ \$ ]]; then
+    if [[ "$_BASE_IMAGE_KIND" == "external" && -n "$_BASE_IMAGE_REF" ]]; then
         _BASE_DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$_BASE_IMAGE_REF" 2>/dev/null | jq -r '.digest // empty' 2>/dev/null || true)
         if [[ -n "$_BASE_DIGEST" ]]; then
             # Fix r7-1: validate digest shape before embedding in label_args.
@@ -328,6 +242,22 @@ _emit_build_lineage() {
     local build_args_data
     build_args_data=$(build_args_json ".")
 
+    # A runnable scratch stage has no external material.  Keep the marker
+    # explicit and omit the coupled ref/digest pair; external records carry both.
+    local base_fields
+    if [[ "${_BASE_IMAGE_KIND:-external}" == "no_external_base" ]]; then
+        base_fields='{"base_image_kind":"no_external_base"}'
+    elif [[ -n "${_BASE_IMAGE_REF:-}" && "${_BASE_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+        base_fields=$(jq -cn \
+            --arg ref "$_BASE_IMAGE_REF" \
+            --arg digest "$_BASE_DIGEST" \
+            '{base_image_ref:$ref, base_image_digest:$digest}')
+    else
+        # Do not create the detector's ref-without-digest legacy shape. A
+        # failed matrix probe is explicit but has no comparison material.
+        base_fields='{"base_image_kind":"unresolved_external_base"}'
+    fi
+
     # Fix C: use jq -n --arg so values with '"' or backslash are safely escaped.
     # Fix E: include lineage_schema_version=2 for downstream schema detection.
     jq -n \
@@ -341,8 +271,7 @@ _emit_build_lineage() {
         --arg     image_id         "${image_id:-unknown}" \
         --arg     build_digest     "${BUILD_DIGEST:-unknown}" \
         --arg     oci_subject_digest "${OCI_SUBJECT_DIGEST:-}" \
-        --arg     base_image_ref   "${_BASE_IMAGE_REF:-unknown}" \
-        --arg     base_image_digest "${_BASE_DIGEST:-unresolved}" \
+        --argjson base_fields      "$base_fields" \
         --arg     built_at         "$build_ts" \
         --argjson duration_seconds "${_BUILD_DURATION_SECONDS:-null}" \
         --argjson github_actions   "${GITHUB_ACTIONS:-false}" \
@@ -361,8 +290,6 @@ _emit_build_lineage() {
           image_id:               $image_id,
           build_digest:           $build_digest,
           oci_subject_digest:     $oci_subject_digest,
-          base_image_ref:         $base_image_ref,
-          base_image_digest:      $base_image_digest,
           built_at:               $built_at,
           duration_seconds:       $duration_seconds,
           github_actions:         $github_actions,
@@ -371,7 +298,7 @@ _emit_build_lineage() {
             ghcr:      $ghcr_image
           },
           build_args: $build_args
-        }' > "$lineage_file"
+        } + $base_fields' > "$lineage_file"
 
     # Conditionally merge extensions_build_seconds when the caller actually
     # measured it. The field's PRESENCE (not its value) is the signal that

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -190,7 +190,6 @@ _resolve_base_image() {
     _BASE_IMAGE_REF=$(jq -r '.ref // empty' <<< "$base_identity")
     if [[ "$_BASE_IMAGE_KIND" == "unresolved" ]]; then
         log_warning "final runnable base_image_ref left unresolved after bounded expansion: ${_BASE_IMAGE_REF:-unknown}"
-        _BASE_IMAGE_REF=""
     fi
 
     # Resolve digest if we have a concrete image reference
@@ -242,21 +241,22 @@ _emit_build_lineage() {
     local build_args_data
     build_args_data=$(build_args_json ".")
 
-    # A runnable scratch stage has no external material.  Keep the marker
-    # explicit and omit the coupled ref/digest pair; external records carry both.
-    local base_fields
-    if [[ "${_BASE_IMAGE_KIND:-external}" == "no_external_base" ]]; then
-        base_fields='{"base_image_kind":"no_external_base"}'
-    elif [[ -n "${_BASE_IMAGE_REF:-}" && "${_BASE_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-        base_fields=$(jq -cn \
-            --arg ref "$_BASE_IMAGE_REF" \
-            --arg digest "$_BASE_DIGEST" \
-            '{base_image_ref:$ref, base_image_digest:$digest}')
-    else
+    # The shared helper translates resolver identities into the detector's
+    # marker vocabulary. Do not encode an unresolved reference as an empty
+    # base_image_ref: the marker is the assertion this writer can make.
+    local base_fields base_identity
+    base_identity=$(jq -cn \
+        --arg kind "${_BASE_IMAGE_KIND:-unresolved}" \
+        --arg ref "${_BASE_IMAGE_REF:-}" \
+        'if $kind == "external" then {kind:$kind, ref:$ref} else {kind:$kind} end')
+    if [[ "${_BASE_IMAGE_KIND:-unresolved}" == "external" && \
+            ( -z "${_BASE_IMAGE_REF:-}" || ! "${_BASE_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ) ]]; then
         # Do not create the detector's ref-without-digest legacy shape. A
-        # failed matrix probe is explicit but has no comparison material.
-        base_fields='{"base_image_kind":"unresolved_external_base"}'
+        # failed matrix probe has no comparison material, so represent it with
+        # the same explicit unresolved identity as the resolver does.
+        base_identity='{"kind":"unresolved"}'
     fi
+    base_fields=$(lineage_base_fields_from_identity "$base_identity" "${_BASE_DIGEST:-}") || return 1
 
     # Fix C: use jq -n --arg so values with '"' or backslash are safely escaped.
     # Fix E: include lineage_schema_version=2 for downstream schema detection.

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -714,7 +714,23 @@ for lineage_file in "${lineage_files[@]}"; do
     # internal build relationship, not an external image comparison; preserve
     # the producer's full supplier identity for the consumer.
     if [[ "$base_image_kind" == "sibling_target" ]]; then
-        base_image_sibling=$(jq -c '.base_image_sibling' "$lineage_file" 2>/dev/null || true)
+        if ! base_image_sibling=$(jq -ce '
+            .base_image_sibling as $supplier
+            | ($supplier | type == "object") and
+              ([$supplier.container, $supplier.version, $supplier.platform,
+                $supplier.textual_ref, $supplier.bake_target_id]
+               | all(type == "string" and length > 0)) and
+              ($supplier.flavor | type == "string")
+            | $supplier
+        ' "$lineage_file" 2>/dev/null); then
+            variant_json=$(jq -cn \
+                --arg variant_tag "$variant_tag" \
+                --arg status "error" \
+                --arg error_reason "malformed_sibling_target" \
+                '{variant_tag: $variant_tag, status: $status, error_reason: $error_reason}')
+            _container_variants["$container"]+="${variant_json}"$'\n'
+            continue
+        fi
         variant_json=$(jq -cn \
             --arg variant_tag "$variant_tag" \
             --argjson base_image_sibling "$base_image_sibling" \

--- a/scripts/detect-base-digest-drift.sh
+++ b/scripts/detect-base-digest-drift.sh
@@ -11,6 +11,7 @@
 #   error     — the variant could not be evaluated; error_reason identifies why
 #   legacy    — lineage lacks base_image_digest field (pre-v2); rebuild baselines it
 #   no_external_base — the stage has no external base to compare (no action needed)
+#   sibling_target — final base is another Bake target; no direct check applies
 #
 # Usage:
 #   detect-base-digest-drift.sh [--baseline-only] [LINEAGE_DIR]
@@ -706,6 +707,19 @@ for lineage_file in "${lineage_files[@]}"; do
             --arg variant_tag "$variant_tag" \
             --arg status "no_external_base" \
             '{variant_tag: $variant_tag, status: $status}')
+        _container_variants["$container"]+="${variant_json}"$'\n'
+        continue
+    fi
+    # A Bake target can use a sibling target as its final base.  This is an
+    # internal build relationship, not an external image comparison; preserve
+    # the producer's full supplier identity for the consumer.
+    if [[ "$base_image_kind" == "sibling_target" ]]; then
+        base_image_sibling=$(jq -c '.base_image_sibling' "$lineage_file" 2>/dev/null || true)
+        variant_json=$(jq -cn \
+            --arg variant_tag "$variant_tag" \
+            --argjson base_image_sibling "$base_image_sibling" \
+            --arg status "sibling_target" \
+            '{variant_tag: $variant_tag, base_image_sibling: $base_image_sibling, status: $status}')
         _container_variants["$container"]+="${variant_json}"$'\n'
         continue
     fi

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -1057,7 +1057,8 @@ _sibling_target_identity_for_cell() {
         [[ "$ref" == *"/${dep}:"* || "$ref" == *"/${dep}" ]] || continue
         dep_target_id=$(jq -r --arg dep "$dep" '.[$dep] // empty' <<< "$dep_target_ids_json") || return 1
         [[ -n "$dep_target_id" ]] || continue
-        supplier_cell=$(jq -ce '.[0]' <<< "${_EC_all_matrix_json[$dep]}") || return 1
+        supplier_cell="${_EC_first_cell_per_container[$dep]:-}"
+        [[ -n "$supplier_cell" ]] || return 1
         supplier_version=$(jq -r '.version' <<< "$supplier_cell") || return 1
         supplier_flavor=$(jq -r '.flavor // ""' <<< "$supplier_cell") || return 1
         # --cells is consumed by the amd64 lineage job; the target is built for
@@ -1176,7 +1177,9 @@ _enumerate_cells_init() {
         fi
     done <<< "$closure_newline"
 
-    # Matrix enumeration + first-target-per-container for dep-context lookup
+    # Matrix enumeration + selected cell/target per container for dep-context
+    # lookup. Retain both views of this one choice: sibling lineage records
+    # must not combine a selected target ID with another matrix cell's fields.
     # F4: use the caller-supplied include_all_retained flag (default false = latest-only).
     local _ec_all_retained="${_BAKE_INCLUDE_ALL_RETAINED:-false}"
     for c in "${_EC_closure_containers[@]}"; do
@@ -1243,6 +1246,7 @@ _enumerate_cells_init() {
             else
                 ftid="$(_target_id "${c}_${_EC_cell_version}_${_EC_cell_variant}")"
             fi
+            _EC_first_cell_per_container[$c]="$first_entry"
             _EC_first_target_per_container[$c]="$ftid"
         fi
     done
@@ -1448,6 +1452,7 @@ _build_bake_json() {
     # Shared init: validate, expand closure, fetch matrices
     declare -a _EC_closure_containers=()
     declare -A _EC_all_matrix_json=()
+    declare -A _EC_first_cell_per_container=()
     declare -A _EC_first_target_per_container=()
     if ! _enumerate_cells_init "${requested_containers[@]}"; then
         return 1
@@ -1633,6 +1638,7 @@ _emit_cells_json() {
     # Shared init: validate, expand closure, fetch matrices
     declare -a _EC_closure_containers=()
     declare -A _EC_all_matrix_json=()
+    declare -A _EC_first_cell_per_container=()
     declare -A _EC_first_target_per_container=()
     if ! _enumerate_cells_init "${requested_containers[@]}"; then
         return 1

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -1039,6 +1039,42 @@ _contexts_for_cell() {
     printf '%s' "$ctx"
 }
 
+# Replace an external-looking final FROM identity with a same-build supplier
+# identity whenever Bake injects a target: context for it. The context target
+# is the selected dependency cell, so retain its durable coordinates instead
+# of merely naming the dependency container.
+_sibling_target_identity_for_cell() {
+    local container="$1" base_identity="$2" dep_target_ids_json="$3"
+    local kind ref deps dep dep_target_id supplier_cell supplier_version supplier_flavor
+
+    kind=$(jq -r '.kind // empty' <<< "$base_identity") || return 1
+    [[ "$kind" == "external" ]] || { printf '%s' "$base_identity"; return 0; }
+    ref=$(jq -r '.ref // empty' <<< "$base_identity") || return 1
+    [[ -n "$ref" ]] || return 1
+    deps=$(_depgraph_get_deps "$container") || return 1
+
+    for dep in $deps; do
+        [[ "$ref" == *"/${dep}:"* || "$ref" == *"/${dep}" ]] || continue
+        dep_target_id=$(jq -r --arg dep "$dep" '.[$dep] // empty' <<< "$dep_target_ids_json") || return 1
+        [[ -n "$dep_target_id" ]] || continue
+        supplier_cell=$(jq -ce '.[0]' <<< "${_EC_all_matrix_json[$dep]}") || return 1
+        supplier_version=$(jq -r '.version' <<< "$supplier_cell") || return 1
+        supplier_flavor=$(jq -r '.flavor // ""' <<< "$supplier_cell") || return 1
+        # --cells is consumed by the amd64 lineage job; the target is built for
+        # this same platform in that Bake invocation.
+        jq -cn \
+            --arg container "$dep" \
+            --arg version "$supplier_version" \
+            --arg flavor "$supplier_flavor" \
+            --arg platform "linux/amd64" \
+            --arg textual_ref "$ref" \
+            --arg bake_target_id "$dep_target_id" \
+            '{kind:"sibling_target", supplier:{container:$container, version:$version, flavor:$flavor, platform:$platform, textual_ref:$textual_ref, bake_target_id:$bake_target_id}}'
+        return 0
+    done
+    printf '%s' "$base_identity"
+}
+
 # ---------------------------------------------------------------------------
 # _validate_internal_dependency_base_refs <targets_json> <dep_target_ids_json>
 #
@@ -1606,6 +1642,16 @@ _emit_cells_json() {
         return 1
     fi
 
+    # Match the bake document's dependency contexts: each dependency resolves
+    # to its selected first target cell.
+    local dep_target_ids_json='{}'
+    local _dep_name
+    for _dep_name in "${!_EC_first_target_per_container[@]}"; do
+        dep_target_ids_json=$(jq -cn --argjson base "$dep_target_ids_json" \
+            --arg key "$_dep_name" --arg value "${_EC_first_target_per_container[$_dep_name]}" \
+            '$base + {($key): $value}')
+    done
+
     # Accumulate cell objects into a JSON array
     local cells_json='[]'
 
@@ -1623,6 +1669,11 @@ _emit_cells_json() {
         if ! _base_identity=$(_runtime_base_identity_for_cell "$_c" "$_version" "$_flavor" \
                 "$_build_flavor" "$_cell_dockerfile" "$_config_args"); then
             printf 'ERROR: runtime base resolution failed for %q version=%q\n' "$_c" "$_version" >&2
+            return 1
+        fi
+        if ! _base_identity=$(_sibling_target_identity_for_cell \
+                "$_c" "$_base_identity" "$dep_target_ids_json"); then
+            printf 'ERROR: sibling target identity resolution failed for %q\n' "$_c" >&2
             return 1
         fi
         _obj=$(jq -cn \

--- a/scripts/generate-bake-hcl.sh
+++ b/scripts/generate-bake-hcl.sh
@@ -69,6 +69,8 @@ source "${PROJECT_ROOT}/helpers/logging.sh"
 source "${PROJECT_ROOT}/helpers/gha.sh"
 # shellcheck source=../helpers/build-args-utils.sh
 source "${PROJECT_ROOT}/helpers/build-args-utils.sh"
+# shellcheck source=../helpers/base-image-utils.sh
+source "${PROJECT_ROOT}/helpers/base-image-utils.sh"
 # validate-base-cache-schema provides _vbc_validate_build_args_config — the
 # canonical fail-closed validator for config.yaml build_args entries.
 # shellcheck source=../helpers/validate-base-cache-schema.sh
@@ -778,6 +780,44 @@ _compute_cell_build_args() {
     fi
 
     printf '%s' "$args"
+}
+
+# Resolve the final runnable stage and effective args that Bake receives.
+# Template generation is needed only when it changes the final FROM itself;
+# this keeps --cells as an offline enumeration of the same build matrix. Build
+# stages are deliberately excluded; see helpers/base-image-utils.sh for the
+# fleet-specific v1 boundary.
+_runtime_base_identity_for_cell() {
+    local container="$1" version="$2" flavor="$3" build_flavor="$4"
+    local cell_dockerfile="$5" config_args="$6"
+    local dockerfile abs_dockerfile template_for_gen source_dockerfile df_content final_from
+    dockerfile=$(_resolve_dockerfile "$container" "$cell_dockerfile" "$flavor" "$build_flavor")
+    abs_dockerfile="${PROJECT_ROOT}/${container}/${dockerfile}"
+    template_for_gen="$dockerfile"
+    if [[ -f "$abs_dockerfile" ]]; then
+        source_dockerfile="$abs_dockerfile"
+    elif [[ -f "${PROJECT_ROOT}/${container}/Dockerfile" ]]; then
+        source_dockerfile="${PROJECT_ROOT}/${container}/Dockerfile"
+        template_for_gen="Dockerfile"
+    else
+        return 1
+    fi
+    df_content=$(< "$source_dockerfile")
+
+    # A marker in an earlier build stage cannot affect the v1 final-runnable
+    # identity. Avoid running its generator here: cells mode is an offline
+    # matrix enumerator, and source availability must not remove build cells.
+    final_from=$(awk '/^[[:space:]]*FROM[[:space:]]+/{line=$0} END{print line}' <<< "$df_content")
+    if { [[ -z "$final_from" ]] && grep -qE '@@[A-Z_]+@@' <<< "$df_content"; } || \
+            [[ "$final_from" == *@@* ]]; then
+        df_content=$(_materialize_dockerfile "$container" "$template_for_gen" \
+            "$flavor" "$version" "$build_flavor") || return 1
+    fi
+
+    local args_json
+    args_json=$(_compute_cell_build_args "$container" "$version" "$flavor" \
+        "$build_flavor" "$config_args" "$df_content" 1) || return 1
+    resolve_final_runnable_base "$df_content" "$args_json"
 }
 
 # ---------------------------------------------------------------------------
@@ -1523,7 +1563,9 @@ _build_bake_json() {
 # ---------------------------------------------------------------------------
 # --cells mode: emit a compact JSON array — one object per linux build cell.
 # Same cell set as the bake mode (same closure + matrix + os==windows skip).
-# No Dockerfile work; no build_args computation.
+# Each cell carries its final runnable-stage identity, computed from the exact
+# materialized Dockerfile and args used by Bake.  The workflow pairs it with
+# Buildx's per-target provenance material after the build.
 #
 # Output per element:
 #   {
@@ -1575,7 +1617,14 @@ _emit_cells_json() {
     #        bake-buildresult.sh can correlate --metadata-file keys to cells.
     _on_cell_plain() {
         local _c="$1" _tag="$2" _flavor="$3" _is_default="$4" _iref="$5" _is_latest="${6:-false}" _variant="${7:-}" _tid="${8:-}"
-        local _obj
+        local _version="${9:-}" _build_flavor="${10:-}" _cell_dockerfile="${11:-Dockerfile}" _config_args="${12-}"
+        [[ -n "$_config_args" ]] || _config_args='{}'
+        local _obj _base_identity
+        if ! _base_identity=$(_runtime_base_identity_for_cell "$_c" "$_version" "$_flavor" \
+                "$_build_flavor" "$_cell_dockerfile" "$_config_args"); then
+            printf 'ERROR: runtime base resolution failed for %q version=%q\n' "$_c" "$_version" >&2
+            return 1
+        fi
         _obj=$(jq -cn \
             --arg container    "$_c" \
             --arg tag          "$_tag" \
@@ -1585,7 +1634,8 @@ _emit_cells_json() {
             --argjson is_latest_version "$( [ "$_is_latest"  = "true" ] && echo 'true' || echo 'false')" \
             --arg intermediate_ref "$_iref" \
             --arg target_id    "$_tid" \
-            '{container: $container, tag: $tag, flavor: $flavor, variant: $variant, is_default: $is_default, is_latest_version: $is_latest_version, intermediate_ref: $intermediate_ref, target_id: $target_id}')
+            --argjson runtime_base "$_base_identity" \
+            '{container: $container, tag: $tag, flavor: $flavor, variant: $variant, is_default: $is_default, is_latest_version: $is_latest_version, intermediate_ref: $intermediate_ref, target_id: $target_id, runtime_base: $runtime_base}')
         cells_json=$(jq -cn --argjson arr "$cells_json" --argjson obj "$_obj" '$arr + [$obj]')
     }
 
@@ -1595,6 +1645,12 @@ _emit_cells_json() {
         # requested set — their intermediates are never pushed.
         if [[ -z "${_requested_set[$c]+set}" ]]; then
             continue
+        fi
+
+        local config_args
+        if ! config_args=$(_config_build_args "$c"); then
+            printf 'ERROR: _config_build_args failed for %q\n' "$c" >&2
+            return 1
         fi
 
         local matrix="${_EC_all_matrix_json[$c]}"
@@ -1630,7 +1686,8 @@ _emit_cells_json() {
             local intermediate_ref="${_BAKE_REMOTE_CR}/${c}:${_EC_cell_tag}"
             _on_cell_plain "$c" "$_EC_cell_tag" "$_EC_cell_flavor" \
                 "$_EC_cell_is_default" "$intermediate_ref" "$_EC_cell_is_latest_version" \
-                "$_EC_cell_variant" "$cell_tid"
+                "$_EC_cell_variant" "$cell_tid" "$_EC_cell_version" \
+                "$_EC_cell_build_flavor" "$_EC_cell_dockerfile" "$config_args" || return 1
         done
     done
 

--- a/tests/unit/base-image-utils.bats
+++ b/tests/unit/base-image-utils.bats
@@ -57,11 +57,88 @@ setup() {
     local digest="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     local identity metadata result
     identity='{"kind":"external","ref":"ghcr.io/oorabona/library/alpine:latest"}'
-    metadata=$(jq -cn --arg d "$digest" '{"buildx.build.provenance": {predicate: {materials: [{uri: "pkg:docker/ghcr.io/oorabona/library/alpine@latest?platform=linux%2Famd64", digest: {sha256: $d}}]}}}')
+    # Buildx's metadata decoder base64-decodes the exporter response and
+    # unmarshals the provenance predicate directly. The wrapper is absent.
+    metadata=$(jq -cn --arg d "$digest" '{"buildx.build.provenance": {materials: [{uri: "pkg:docker/ghcr.io/oorabona/library/alpine@latest?platform=linux%2Famd64", digest: {sha256: $d}}]}}')
     result=$(lineage_base_fields_from_provenance "$identity" "$metadata")
     [ "$(jq -r '.base_image_ref' <<< "$result")" = "ghcr.io/oorabona/library/alpine:latest" ]
     [ "$(jq -r '.base_image_digest' <<< "$result")" = "sha256:${digest}" ]
     [ "$(jq 'has("base_image_ref") and has("base_image_digest")' <<< "$result")" = "true" ]
+}
+
+@test "provenance emitter refuses the statement wrapper Buildx does not write" {
+    local digest metadata
+    digest="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    metadata=$(jq -cn --arg d "$digest" '{"buildx.build.provenance": {predicate: {materials: [{uri: "pkg:docker/ghcr.io/oorabona/library/alpine@latest?platform=linux%2Famd64", digest: {sha256: $d}}]}}}')
+    run lineage_base_fields_from_provenance \
+        '{"kind":"external","ref":"ghcr.io/oorabona/library/alpine:latest"}' "$metadata"
+    [ "$status" -ne 0 ]
+}
+
+@test "argument expansion resolves the complete identifier, never a prefix" {
+    local result
+    result=$(resolve_final_runnable_base \
+        $'ARG RESTY_CONFIG_OPTIONS=wrong\nARG RESTY_CONFIG_OPTIONS_MORE=right\nFROM $RESTY_CONFIG_OPTIONS/library/alpine:latest\n' \
+        '{}')
+    [ "$(jq -r '.ref' <<< "$result")" = "wrong/library/alpine:latest" ]
+}
+
+@test "malformed effective build arguments are refused" {
+    run resolve_final_runnable_base 'FROM alpine:latest' '{not-json'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"effective build arguments must be a valid JSON object"* ]]
+}
+
+@test "non-object effective build arguments are refused" {
+    run resolve_final_runnable_base 'FROM alpine:latest' '[]'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"effective build arguments must be a valid JSON object"* ]]
+}
+
+@test "unsupported final FROM syntax is refused" {
+    run resolve_final_runnable_base 'FROM --platform=$TARGETPLATFORM alpine:latest' '{}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported final FROM syntax"* ]]
+}
+
+@test "every tracked production Dockerfile stays within the final FROM grammar" {
+    local dockerfile result
+    while IFS= read -r dockerfile; do
+        case "$dockerfile" in
+            examples/*|tests/*) continue ;;
+        esac
+        # These are generator inputs rather than Dockerfiles BuildKit receives.
+        rg -q '@@[A-Za-z_]+@@' "$PROJECT_ROOT/$dockerfile" && continue
+        if ! result=$(resolve_final_runnable_base "$(< "$PROJECT_ROOT/$dockerfile")" '{}'); then
+            printf 'final FROM is outside the lineage resolver grammar: %s\n' "$dockerfile" >&2
+            return 1
+        fi
+    done < <(git -C "$PROJECT_ROOT" ls-files | rg '(^|/)Dockerfile([._-]|$)')
+}
+
+@test "bake lineage is mandatory even when the Syft install is advisory" {
+    local workflow steps lineage syft
+    workflow="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    steps=$(yq -o=json '.jobs."bake-build-amd64".steps' "$workflow")
+    lineage=$(jq -c '.[] | select(.name == "Emit lineage (bake amd64)")' <<< "$steps")
+    syft=$(jq -c '.[] | select(.id == "install-syft-bake")' <<< "$steps")
+
+    [ -n "$lineage" ] || { printf 'mandatory bake lineage step is missing\n' >&2; return 1; }
+    [ "$(jq -r '."continue-on-error" // false' <<< "$lineage")" = "false" ] \
+        || { printf 'mandatory bake lineage step must not continue on error\n' >&2; return 1; }
+    [[ "$(jq -r '.if // ""' <<< "$lineage")" != *"install-syft-bake"* ]] \
+        || { printf 'mandatory bake lineage step must not depend on Syft\n' >&2; return 1; }
+    [ "$(jq -r '."continue-on-error" // false' <<< "$syft")" = "true" ] \
+        || { printf 'Syft install must remain advisory\n' >&2; return 1; }
+}
+
+@test "both bake architectures request minimum metadata provenance" {
+    local workflow amd64 arm64
+    workflow="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
+    amd64=$(yq -r '.jobs."bake-build-amd64".steps[] | select(.id == "bake-build") | .env.BUILDX_METADATA_PROVENANCE' "$workflow")
+    arm64=$(yq -r '.jobs."bake-build-arm64".steps[] | select(.id == "bake-build") | .env.BUILDX_METADATA_PROVENANCE' "$workflow")
+    [ "$amd64" = "min" ] || { printf 'amd64 bake metadata provenance must be min\n' >&2; return 1; }
+    [ "$arm64" = "min" ] || { printf 'arm64 bake metadata provenance must be min\n' >&2; return 1; }
 }
 
 @test "provenance emitter refuses a reference with no resolved material digest" {
@@ -83,4 +160,54 @@ setup() {
     result=$(lineage_base_fields_from_provenance '{"kind":"no_external_base"}' '{}')
     [ "$(jq -r '.base_image_kind' <<< "$result")" = "no_external_base" ]
     [ "$(jq 'has("base_image_ref") or has("base_image_digest")' <<< "$result")" = "false" ]
+}
+
+@test "bake lineage records an unresolved resolver result with the detector marker" {
+    local result
+    if ! result=$(lineage_base_fields_from_provenance \
+        '{"kind":"unresolved","ref":"${MISSING_BASE}/library/alpine:latest"}' '{}'); then
+        echo "Bake lineage must emit unresolved_external_base for an unresolved resolver identity"
+        return 1
+    fi
+    [ "$(jq -r '.base_image_kind' <<< "$result")" = "unresolved_external_base" ] || {
+        echo "Bake lineage must emit unresolved_external_base for an unresolved resolver identity"
+        return 1
+    }
+    [ "$(jq 'has("base_image_ref")' <<< "$result")" = "false" ] || {
+        echo "Bake lineage must not emit an empty base_image_ref for unresolved identity"
+        return 1
+    }
+}
+
+@test "flat lineage records an unresolved resolver result with the shared detector marker" {
+    local label_args="" record work="$BATS_TEST_TMPDIR"
+    printf 'FROM ${MISSING_BASE}/library/alpine:latest\n' > "$work/Dockerfile"
+
+    # Source before redirecting PROJECT_ROOT so the production helpers load
+    # from this checkout while the lineage artifact stays test-local.
+    source "$PROJECT_ROOT/scripts/build-container.sh"
+    PROJECT_ROOT="$work"
+    declare -gA _BUILD_ARGS_RESOLVED=()
+    docker() { return 0; }
+
+    _resolve_base_image "$work/Dockerfile" "1.0" "label_args"
+    [[ "$_BASE_IMAGE_KIND" == "unresolved" ]] || {
+        echo "Flat lineage must preserve the resolver unresolved identity"
+        return 1
+    }
+    [[ -n "$_BASE_IMAGE_REF" ]] || {
+        echo "Flat lineage must retain the unresolved reference until shared emission"
+        return 1
+    }
+    _emit_build_lineage "flat-test" "1.0" "1.0" "" "Dockerfile" \
+        "linux/amd64" "test" "docker.io/test" "ghcr.io/test"
+    record=$(< "$work/.build-lineage/flat-test-1.0.json")
+    [ "$(jq -r '.base_image_kind' <<< "$record")" = "unresolved_external_base" ] || {
+        echo "Flat lineage must emit unresolved_external_base for an unresolved resolver identity"
+        return 1
+    }
+    [ "$(jq 'has("base_image_ref")' <<< "$record")" = "false" ] || {
+        echo "Flat lineage must not emit an empty base_image_ref for unresolved identity"
+        return 1
+    }
 }

--- a/tests/unit/base-image-utils.bats
+++ b/tests/unit/base-image-utils.bats
@@ -44,7 +44,7 @@ setup() {
     [ "$status" -eq 0 ]
     # github-runner's template defaults REMOTE_CR, while the target passes it
     # explicitly. The returned ref proves the target-effective value won.
-    [ "$(jq -r '[.[] | .runtime_base.ref] | all(startswith("ghcr.io/oorabona/"))' <<< "$output")" = "true" ]
+    [ "$(jq -r '[.[] | select(.runtime_base.kind == "external") | .runtime_base.ref] | all(startswith("ghcr.io/oorabona/"))' <<< "$output")" = "true" ]
 
     run bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" github-runner
     [ "$status" -eq 0 ]
@@ -116,7 +116,7 @@ setup() {
     done < <(git -C "$PROJECT_ROOT" ls-files | rg '(^|/)Dockerfile([._-]|$)')
 }
 
-@test "bake lineage is mandatory even when the Syft install is advisory" {
+@test "bake lineage is mandatory and publishes records through the atomic writer" {
     local workflow steps lineage syft
     workflow="$PROJECT_ROOT/.github/workflows/auto-build.yaml"
     steps=$(yq -o=json '.jobs."bake-build-amd64".steps' "$workflow")
@@ -128,8 +128,64 @@ setup() {
         || { printf 'mandatory bake lineage step must not continue on error\n' >&2; return 1; }
     [[ "$(jq -r '.if // ""' <<< "$lineage")" != *"install-syft-bake"* ]] \
         || { printf 'mandatory bake lineage step must not depend on Syft\n' >&2; return 1; }
+    [[ "$(jq -r '.run' <<< "$lineage")" == *"write_lineage_record_atomically"* ]] \
+        || { printf 'mandatory bake lineage step must use the atomic verified writer\n' >&2; return 1; }
     [ "$(jq -r '."continue-on-error" // false' <<< "$syft")" = "true" ] \
         || { printf 'Syft install must remain advisory\n' >&2; return 1; }
+}
+
+@test "sibling Bake target lineage names the exact supplying cell rather than an external material" {
+    local cell result
+    cell=$(bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells wordpress | jq -c '.[]')
+    result=$(lineage_base_fields_from_provenance "$(jq -c '.runtime_base' <<< "$cell")" '{}')
+
+    [ "$(jq -r '.base_image_kind' <<< "$result")" = "sibling_target" ] || {
+        echo "Sibling target must emit its explicit lineage marker"
+        return 1
+    }
+    [ "$(jq 'has("base_image_ref") or has("base_image_digest")' <<< "$result")" = "false" ] || {
+        echo "Sibling target must not be recorded as a direct external base"
+        return 1
+    }
+    [ "$(jq -r '.base_image_sibling.container' <<< "$result")" = "php" ]
+    [ "$(jq -r '.base_image_sibling.version' <<< "$result")" = "8.5.9-fpm-alpine" ]
+    [ "$(jq -r '.base_image_sibling.flavor' <<< "$result")" = "" ]
+    [ "$(jq -r '.base_image_sibling.platform' <<< "$result")" = "linux/amd64" ]
+    [ "$(jq -r '.base_image_sibling.textual_ref' <<< "$result")" = "ghcr.io/oorabona/php:latest" ]
+    [ "$(jq -r '.base_image_sibling.bake_target_id' <<< "$result")" = "php_8_5_9_fpm_alpine" ] || {
+        echo "Sibling target must identify the precise supplying Bake cell"
+        return 1
+    }
+}
+
+@test "atomic lineage writer fails without publishing when its destination cannot be written" {
+    local blocked_parent destination
+    blocked_parent="$BATS_TEST_TMPDIR/not-a-directory"
+    printf 'block' > "$blocked_parent"
+    destination="$blocked_parent/lineage.json"
+
+    run write_lineage_record_atomically "$destination" '{"container":"foo"}'
+    [ "$status" -ne 0 ] || {
+        echo "Lineage write failure must surface to the required caller"
+        return 1
+    }
+    [ ! -e "$destination" ] || {
+        echo "Failed lineage write must leave no final file behind"
+        return 1
+    }
+}
+
+@test "atomic lineage writer rejects an unparseable record without publishing it" {
+    local destination="$BATS_TEST_TMPDIR/lineage.json"
+    run write_lineage_record_atomically "$destination" '{truncated'
+    [ "$status" -ne 0 ] || {
+        echo "Unparseable lineage record must fail the required caller"
+        return 1
+    }
+    [ ! -e "$destination" ] || {
+        echo "Unparseable lineage record must never reach the final path"
+        return 1
+    }
 }
 
 @test "both bake architectures request minimum metadata provenance" {

--- a/tests/unit/base-image-utils.bats
+++ b/tests/unit/base-image-utils.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# Contract tests for final-runnable-stage base lineage (#1523).
+
+load "../test_helper"
+
+setup() {
+    source "${PROJECT_ROOT}/helpers/base-image-utils.sh"
+}
+
+@test "single-stage external FROM resolves through effective args" {
+    local result
+    result=$(resolve_final_runnable_base $'ARG REGISTRY=docker.io\nFROM ${REGISTRY}/library/debian:trixie\n' \
+        '{"REGISTRY":"ghcr.io/oorabona"}')
+    [ "$(jq -r '.kind' <<< "$result")" = "external" ]
+    [ "$(jq -r '.ref' <<< "$result")" = "ghcr.io/oorabona/library/debian:trixie" ]
+}
+
+@test "five-stage Dockerfile resolves its final external FROM, not the first build stage" {
+    local result
+    result=$(resolve_final_runnable_base $'FROM hashicorp/terraform:1 AS terraform\nFROM alpine:3 AS tools\nFROM python:3 AS cloud\nFROM alpine:3 AS more-tools\nFROM ${REMOTE_CR}/library/alpine:latest\n' \
+        '{"REMOTE_CR":"ghcr.io/oorabona"}')
+    [ "$(jq -r '.ref' <<< "$result")" = "ghcr.io/oorabona/library/alpine:latest" ]
+}
+
+@test "final scratch has an explicit no-external-base identity" {
+    local result
+    result=$(resolve_final_runnable_base $'FROM alpine:3 AS build\nFROM scratch\n' '{}')
+    [ "$(jq -r '.kind' <<< "$result")" = "no_external_base" ]
+    [ "$(jq 'has("ref")' <<< "$result")" = "false" ]
+}
+
+@test "HCL-escaped inline content is resolved after unescaping and effective args override defaults" {
+    local result
+    # This reproduces Bake's emitted $${...}; its HCL reader restores ${...}
+    # before Dockerfile parsing, so the resolver must be called with that content.
+    result=$(resolve_final_runnable_base $'ARG REMOTE_CR=docker.io\nFROM ${REMOTE_CR}/library/ubuntu:24.04\n' \
+        '{"REMOTE_CR":"ghcr.io/oorabona"}')
+    [ "$(jq -r '.ref' <<< "$result")" = "ghcr.io/oorabona/library/ubuntu:24.04" ]
+}
+
+@test "Bake cells resolve the unescaped inline template with target-effective args" {
+    run bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" --cells github-runner
+    [ "$status" -eq 0 ]
+    # github-runner's template defaults REMOTE_CR, while the target passes it
+    # explicitly. The returned ref proves the target-effective value won.
+    [ "$(jq -r '[.[] | .runtime_base.ref] | all(startswith("ghcr.io/oorabona/"))' <<< "$output")" = "true" ]
+
+    run bash "${PROJECT_ROOT}/scripts/generate-bake-hcl.sh" github-runner
+    [ "$status" -eq 0 ]
+    # Bake's JSON contains the HCL-escaped spelling; resolution above occurred
+    # before this transformation, on the Dockerfile text BuildKit receives.
+    [ "$(jq -r '[.target[] | .["dockerfile-inline"]? | select(. != null) | contains("$${REMOTE_CR}")] | any' <<< "$output")" = "true" ]
+}
+
+@test "provenance emitter fields couple reference and build-resolved digest" {
+    local digest="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local identity metadata result
+    identity='{"kind":"external","ref":"ghcr.io/oorabona/library/alpine:latest"}'
+    metadata=$(jq -cn --arg d "$digest" '{"buildx.build.provenance": {predicate: {materials: [{uri: "pkg:docker/ghcr.io/oorabona/library/alpine@latest?platform=linux%2Famd64", digest: {sha256: $d}}]}}}')
+    result=$(lineage_base_fields_from_provenance "$identity" "$metadata")
+    [ "$(jq -r '.base_image_ref' <<< "$result")" = "ghcr.io/oorabona/library/alpine:latest" ]
+    [ "$(jq -r '.base_image_digest' <<< "$result")" = "sha256:${digest}" ]
+    [ "$(jq 'has("base_image_ref") and has("base_image_digest")' <<< "$result")" = "true" ]
+}
+
+@test "provenance emitter refuses a reference with no resolved material digest" {
+    run lineage_base_fields_from_provenance \
+        '{"kind":"external","ref":"ghcr.io/oorabona/library/alpine:latest"}' '{}'
+    [ "$status" -ne 0 ]
+}
+
+@test "provenance emitter has no post-build registry lookup path" {
+    local implementation
+    implementation=$(declare -f lineage_base_fields_from_provenance)
+    [[ "$implementation" != *"imagetools inspect"* ]]
+    [[ "$implementation" != *"docker manifest"* ]]
+    [[ "$implementation" != *"skopeo inspect"* ]]
+}
+
+@test "scratch lineage emits the explicit no-base marker and neither coupled field" {
+    local result
+    result=$(lineage_base_fields_from_provenance '{"kind":"no_external_base"}' '{}')
+    [ "$(jq -r '.base_image_kind' <<< "$result")" = "no_external_base" ]
+    [ "$(jq 'has("base_image_ref") or has("base_image_digest")' <<< "$result")" = "false" ]
+}

--- a/tests/unit/dashboard-integration-smoke.bats
+++ b/tests/unit/dashboard-integration-smoke.bats
@@ -1,14 +1,15 @@
 #!/usr/bin/env bats
 
 # Integration smoke tests for the base_image truth pipeline (issue #530).
-# Tests the full chain: _prepare_build_args → _resolve_base_image → _emit_build_lineage
-# → resolve_lineage_file (dashboard read).
+# Tests the resolver boundary and dashboard read path. Bake lineage now couples
+# the reference to a digest extracted from build provenance, so resolver tests
+# must not use a mocked registry probe as an emission substitute.
 #
 # Covers:
 #   - Monolithic fixture (sslh-style): build_args substitution via _BUILD_ARGS_RESOLVED
 #   - Template fixture (web-shell-style): post-template-generation FROM is authoritative
 #   - Dashboard read fast-path: network helpers are NOT called
-#   - Mutation guard: disabling A1 substitution pass causes base_image_ref to leak ${...}
+#   - Mutation guard: removing required effective args leaves the resolver identity unresolved
 
 load "../test_helper"
 
@@ -64,11 +65,9 @@ source_dashboard_fns() {
 }
 
 # ---------------------------------------------------------------------------
-# Smoke 1 — Monolithic fixture (Fix A1 end-to-end)
-# Pipeline: _prepare_build_args → _resolve_base_image → _emit_build_lineage
-# Assert: base_image_ref concrete, lineage_schema_version=2
+# Smoke 1 — Monolithic fixture: effective build args resolve the final base.
 # ---------------------------------------------------------------------------
-@test "Monolithic fixture produces concrete base_image_ref (Fix A1)" {
+@test "Monolithic fixture resolves concrete final base from effective build args" {
     local work="$TEST_TEMP_DIR/mono"
     mkdir -p "$work"
     cp "$FIXTURE_MONO/config.yaml"   "$work/"
@@ -81,27 +80,11 @@ source_dashboard_fns() {
     source_build_container
     export PROJECT_ROOT="$work"
 
-    # Mock docker (no real Docker needed)
-    docker() { echo ""; }
-    export -f docker
-
     # Run the substitution pipeline (version first, then flavor — matches production signature)
     _prepare_build_args "v2.3.1" ""
     _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
-
-    # Emit lineage
-    _emit_build_lineage \
-        "mono-fixture" "v2.3.1" "v2.3.1-alpine" "" \
-        "$work/Dockerfile" "linux/amd64" "" \
-        "example/mono-fixture" "ghcr.io/test/mono-fixture"
-
-    local lineage_file="$work/.build-lineage/mono-fixture-v2.3.1-alpine.json"
-    [ -f "$lineage_file" ]
-
-    local base_image_ref
-    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
-    # Must be concrete (no ${...} placeholder)
-    [[ "$base_image_ref" == "alpine:3.21" ]]
+    [ "$_BASE_IMAGE_KIND" = "external" ]
+    [ "$_BASE_IMAGE_REF" = "alpine:3.21" ]
 }
 
 @test "Monolithic fixture lineage_schema_version equals 2" {
@@ -137,7 +120,7 @@ source_dashboard_fns() {
 # Pipeline: template generation → _resolve_base_image with from_generated=1
 # Assert: base_image_ref = "alpine:3.21" (from generated Dockerfile, not config)
 # ---------------------------------------------------------------------------
-@test "Template fixture (alpine) produces alpine:3.21 (Fix A2)" {
+@test "Template fixture alpine resolves its generated final base" {
     local work="$TEST_TEMP_DIR/tpl"
     mkdir -p "$work"
     cp "$FIXTURE_TPL/config.yaml"          "$work/"
@@ -150,9 +133,6 @@ source_dashboard_fns() {
     cd "$work" || return 1
     source_build_container
     export PROJECT_ROOT="$work"
-
-    docker() { echo ""; }
-    export -f docker
 
     # Simulate what build_container does: generate the per-flavor Dockerfile
     local generated_df="$work/Dockerfile.alpine"
@@ -168,22 +148,12 @@ source_dashboard_fns() {
     # Resolve base image POST-template-generation (Fix A2): use generated Dockerfile
     _resolve_base_image "$generated_df" "1.0" "label_args" "1"
 
-    # Emit lineage
-    _emit_build_lineage \
-        "tpl-fixture" "1.0" "1.0-alpine" "alpine" \
-        "$generated_df" "linux/amd64" "" \
-        "example/tpl-fixture" "ghcr.io/test/tpl-fixture"
-
-    local lineage_file="$work/.build-lineage/tpl-fixture-1.0-alpine.json"
-    [ -f "$lineage_file" ]
-
-    local base_image_ref
-    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
-    # Must be alpine:3.21 (from generated Dockerfile), NOT the debian template default
-    [[ "$base_image_ref" == "alpine:3.21" ]]
+    # Must use the generated Dockerfile, not its debian template default.
+    [ "$_BASE_IMAGE_KIND" = "external" ]
+    [ "$_BASE_IMAGE_REF" = "alpine:3.21" ]
 }
 
-@test "Template fixture (debian) produces concrete debian base_image_ref" {
+@test "Template fixture debian resolves its generated final base" {
     local work="$TEST_TEMP_DIR/tpl-deb"
     mkdir -p "$work"
     cp "$FIXTURE_TPL/config.yaml"          "$work/"
@@ -197,9 +167,6 @@ source_dashboard_fns() {
     source_build_container
     export PROJECT_ROOT="$work"
 
-    docker() { echo ""; }
-    export -f docker
-
     # Generate debian-flavor Dockerfile
     local generated_df="$work/Dockerfile.debian"
     bash "$work/generate-dockerfile.sh" "$work/Dockerfile.template" "debian" > "$generated_df"
@@ -207,19 +174,10 @@ source_dashboard_fns() {
     _prepare_build_args "1.0" ""
     _resolve_base_image "$generated_df" "1.0" "label_args" "1"
 
-    _emit_build_lineage \
-        "tpl-fixture" "1.0" "1.0" "debian" \
-        "$generated_df" "linux/amd64" "" \
-        "example/tpl-fixture" "ghcr.io/test/tpl-fixture"
-
-    local lineage_file="$work/.build-lineage/tpl-fixture-1.0.json"
-    [ -f "$lineage_file" ]
-
-    local base_image_ref
-    base_image_ref=$(jq -r '.base_image_ref' "$lineage_file")
     # Must be concrete (no ${...} leak) and must mention debian
-    [[ "$base_image_ref" != *'${'* ]]
-    [[ "$base_image_ref" == *"debian"* ]]
+    [ "$_BASE_IMAGE_KIND" = "external" ]
+    [[ "$_BASE_IMAGE_REF" != *'${'* ]]
+    [[ "$_BASE_IMAGE_REF" == *"debian"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -287,9 +245,9 @@ source_dashboard_fns() {
 }
 
 # ---------------------------------------------------------------------------
-# Mutation guard: disabling A1 substitution pass causes ${...} to survive
+# Mutation guard: removing final-base substitution leaves its placeholder exposed.
 # ---------------------------------------------------------------------------
-@test "Mutation guard — disabling A1 substitution pass leaks placeholder" {
+@test "Final base requires effective build args for a concrete identity" {
     local work="$TEST_TEMP_DIR/mut"
     mkdir -p "$work"
     cp "$FIXTURE_MONO/config.yaml"   "$work/"
@@ -301,21 +259,27 @@ source_dashboard_fns() {
     source_build_container
     export PROJECT_ROOT="$work"
 
-    docker() { echo ""; }
-    export -f docker
-
     _prepare_build_args "v2.3.1" ""
 
-    # Simulate pre-fix behavior: clear _BUILD_ARGS_RESOLVED before resolving
-    # (this mimics the state before Fix A1 was applied)
-    declare -gA _BUILD_ARGS_RESOLVED=()
+    # Control: the prepared map makes the final base concrete.
+    local resolved_identity
+    resolved_identity=$(resolve_final_runnable_base "$(< "$work/Dockerfile")" \
+        "$(jq -cn --arg base "${_BUILD_ARGS_RESOLVED[OS_IMAGE_BASE]}" \
+            --arg tag "${_BUILD_ARGS_RESOLVED[OS_IMAGE_TAG]}" \
+            '{OS_IMAGE_BASE:$base, OS_IMAGE_TAG:$tag}')")
+    if [[ "$(jq -r '.kind' <<< "$resolved_identity")" != "external" || \
+          "$(jq -r '.ref' <<< "$resolved_identity")" != "alpine:3.21" ]]; then
+        echo "FAIL: effective-arg substitution did not produce alpine:3.21"
+        echo "resolved identity: $resolved_identity"
+        return 1
+    fi
 
-    _resolve_base_image "$work/Dockerfile" "v2.3.1" "label_args"
-
-    # Without _BUILD_ARGS_RESOLVED, _BASE_IMAGE_REF still has ${...} placeholders
-    # because the Dockerfile ARG lines have no defaults (ARG OS_IMAGE_BASE, not ARG OS_IMAGE_BASE=alpine)
-    # The mutation guard: _BASE_IMAGE_REF must still contain ${ when A1 is disabled
-    [[ "$_BASE_IMAGE_REF" == *'${'* ]]
+    # Model the missing-substitution result explicitly. The shared resolver
+    # must expose it as unresolved, never invent a concrete external base.
+    local mutated_identity
+    mutated_identity=$(resolve_final_runnable_base "$(< "$work/Dockerfile")" '{}')
+    [ "$(jq -r '.kind' <<< "$mutated_identity")" = "unresolved" ]
+    [[ "$(jq -r '.ref' <<< "$mutated_identity")" == *'${'* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -3701,6 +3701,48 @@ EOF
     [ "$(get_output drift_matrix)" = "[]" ]
 }
 
+@test "sibling target marker is not applicable, preserves its exact supplier, and is not a comparison" {
+    local lineage_dir="$TEST_TEMP_DIR/base-image-kind-sibling-target"
+    local sentinel="$TEST_TEMP_DIR/sibling-probe-called"
+    mkdir -p "$lineage_dir"
+    jq -cn '
+      {container:"wordpress", tag:"7.1.0-alpine", base_image_kind:"sibling_target",
+       base_image_sibling:{container:"php", version:"8.5.9-fpm-alpine", flavor:"",
+                           platform:"linux/amd64", textual_ref:"ghcr.io/oorabona/php:latest",
+                           bake_target_id:"php_8_5_9_fpm_alpine"}}
+    ' > "$lineage_dir/wordpress.json"
+    local probe_stub="$TEST_TEMP_DIR/probe-sibling-target"
+    printf '#!/usr/bin/env bash\ntouch "%s"\nexit 99\n' "$sentinel" > "$probe_stub"
+    chmod +x "$probe_stub"
+
+    local result
+    result=$(_VALID_CONTAINERS_OVERRIDE="wordpress" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="wordpress" \
+        PROBE_CMD="$probe_stub" bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+    [ ! -e "$sentinel" ] || {
+        echo "Sibling target must not trigger an external digest probe"
+        return 1
+    }
+    [ "$(jq -r '.[0].variants[0].status' <<< "$result")" = "sibling_target" ] || {
+        echo "Sibling target must have its own not-applicable outcome"
+        return 1
+    }
+    [ "$(jq -r '.[0].variants[0].base_image_sibling.bake_target_id' <<< "$result")" = "php_8_5_9_fpm_alpine" ] || {
+        echo "Sibling target outcome must retain the exact supplying cell"
+        return 1
+    }
+
+    _load_drift_consumer
+    validate_drift_result "$result"
+    local notice rc=0
+    notice=$(emit_drift_notice "$result") || rc=$?
+    [ "$rc" -eq 0 ]
+    [ "$notice" = "::notice::No direct base image digest comparison was applicable" ] || {
+        echo "Sibling target must not be counted as a comparison record"
+        return 1
+    }
+}
+
 @test "a no_external_base-only result is evaluated unscoped and when scoped" {
     _load_drift_consumer
 

--- a/tests/unit/detect-base-digest-drift.bats
+++ b/tests/unit/detect-base-digest-drift.bats
@@ -3743,6 +3743,39 @@ EOF
     }
 }
 
+@test "sibling target marker without a supplier is an error outcome and fails coverage" {
+    local lineage_dir="$TEST_TEMP_DIR/malformed-sibling-target"
+    mkdir -p "$lineage_dir"
+    jq -cn '{container:"wordpress", tag:"7.1.0-alpine", base_image_kind:"sibling_target"}' \
+        > "$lineage_dir/wordpress.json"
+
+    local result rc=0 notice
+    result=$(_VALID_CONTAINERS_OVERRIDE="wordpress" \
+        _DEPGRAPH_CONTAINERS_OVERRIDE="wordpress" \
+        bash "${DETECTOR_SCRIPT}" "$lineage_dir" 2>/dev/null)
+    [ "$(jq -r '.[0].variants[0].status' <<< "$result")" = "error" ] || {
+        echo "Sibling target without a supplier must be an error outcome"
+        return 1
+    }
+    [ "$(jq -r '.[0].variants[0].error_reason' <<< "$result")" = "malformed_sibling_target" ]
+
+    _load_drift_consumer
+    validate_drift_result "$result"
+    notice=$(emit_drift_notice "$result") || rc=$?
+    [ "$rc" -eq 1 ]
+    [[ "$notice" == *"coverage incomplete"* ]]
+}
+
+@test "workflow validator rejects a sibling target outcome without a supplier" {
+    _load_drift_consumer
+
+    local malformed='[{"container":"wordpress","internal_deps":[],"variants":[{"variant_tag":"7.1.0-alpine","status":"sibling_target"}]}]'
+    if validate_drift_result "$malformed"; then
+        echo "Workflow validator must reject a sibling target without a supplier"
+        return 1
+    fi
+}
+
 @test "a no_external_base-only result is evaluated unscoped and when scoped" {
     _load_drift_consumer
 

--- a/tests/unit/generate-bake-hcl.bats
+++ b/tests/unit/generate-bake-hcl.bats
@@ -2070,6 +2070,29 @@ YAML
     [ "$dangling_count" -eq 0 ]
 }
 
+@test "scoped sibling lineage coordinates come from the selected supplier cell" {
+    _run_generator --cells --all-retained \
+        --container-scopes '{"php":{"versions":"8.5.8-fpm-alpine"}}' wordpress php
+    [ "$status" -eq 0 ]
+
+    local sibling_records inconsistent_records
+    sibling_records=$(printf '%s' "$output" | jq '[.[] | select(.container == "wordpress") | .runtime_base.supplier] | length')
+    inconsistent_records=$(printf '%s' "$output" | jq '[.[]
+        | select(.container == "wordpress")
+        | .runtime_base.supplier
+        | select(.bake_target_id != "php_8_5_8_fpm_alpine" or .version != "8.5.8-fpm-alpine" or .flavor != "")
+      ] | length')
+
+    [ "$sibling_records" -gt 0 ] || {
+        echo "Scoped wordpress cells must record their sibling PHP supplier"
+        return 1
+    }
+    [ "$inconsistent_records" -eq 0 ] || {
+        echo "Sibling target ID and coordinates must name the same selected PHP cell"
+        return 1
+    }
+}
+
 @test "container scopes — empty map is byte-identical to no container scope flag" {
     _run_generator terraform debian
     [ "$status" -eq 0 ]

--- a/tests/unit/resolve-base-image-substitution.bats
+++ b/tests/unit/resolve-base-image-substitution.bats
@@ -558,16 +558,15 @@ DOCKER
 }
 
 # =============================================================================
-# Finding #1 (gate r5 copilot MEDIUM): ARG expansion cap must clear _BASE_IMAGE_REF
-# Pre-fix: cap fires, emits warning, but execution continues with unresolved literal.
-# Post-fix: cap fires → _BASE_IMAGE_REF is set to "" (or "unknown") AND a warning is
-# emitted.  Caller can detect failure via empty string.
+# An ARG expansion cap must not let a
+# partially-expanded literal reach a lineage record. The resolver may retain
+# that identity internally; emission records it as an unresolved external base.
 # =============================================================================
 
-@test "Expanding build_args chain hits iteration cap and clears _BASE_IMAGE_REF" {
+@test "Expansion cap prevents a partially-expanded literal in the lineage record" {
     # A self-referential chain where each substitution introduces a new placeholder
     # without converging: A=x${A}y — the value grows each iteration, never stabilising.
-    # The 10-iteration cap must fire AND _BASE_IMAGE_REF must be cleared to empty.
+    # The 10-iteration cap must fire without putting the growing literal in lineage.
     #
     # A symmetric bidirectional chain (A=${B}, B=${A}) converges instantly because
     # the value after each iteration equals the value before it — the cap is not reached.
@@ -586,10 +585,16 @@ DOCKER
     stderr_out=$(cat "$stderr_file")
     rm -f "$stderr_file"
 
-    # Post-fix: _BASE_IMAGE_REF must be empty (not the leaked growing literal)
-    [[ -z "$_BASE_IMAGE_REF" ]] || {
-        echo "FAIL: expected empty _BASE_IMAGE_REF after cap hit, got: '$_BASE_IMAGE_REF'"
-        echo "  (pre-fix: unresolved literal propagates to lineage file)"
+    _emit_build_lineage "cap-test" "1.0" "1.0" "" "./Dockerfile" \
+        "linux/amd64" "test-runtime" "docker.io/test/cap-test" "ghcr.io/test/cap-test"
+    local lineage_file="$TEST_DIR/.build-lineage/cap-test-1.0.json"
+
+    [[ "$(jq -r '.base_image_kind' "$lineage_file")" == "unresolved_external_base" ]] || {
+        echo "FAIL: cap-hit lineage must record unresolved_external_base"
+        return 1
+    }
+    [[ "$(jq 'has("base_image_ref")' "$lineage_file")" == "false" ]] || {
+        echo "FAIL: partially-expanded literal propagated to lineage file"
         return 1
     }
 


### PR DESCRIPTION
**Draft: do not merge.** Blocked on the design decision in #1553.

Container images built through bake recorded no base reference and no base digest, so no Linux cell
of any container could be evaluated for base image drift and the detector reported clean for the
whole fleet. This branch makes each cell record what its final runnable stage is built from and the
digest the build resolved for it.

Refs #1523.

## Why it is not mergeable as written

The detector probes a base with `docker buildx imagetools inspect --format '{{json .Manifest}}'`,
which yields the **image-index** digest. `scripts/build-container.sh:196-200` records that the flat
writer uses that same call specifically so writer and probe agree, and warns that a per-arch child
digest instead "could return a per-arch child digest instead of the index digest — causing a
perpetual drift-PR loop".

This branch takes its digest from a BuildKit provenance material, and those are platform-qualified.
So a normal bake would record the amd64 child digest, the monitor would read the index digest, and
every container would report drift on every run. That is worse than the gap it closes.

#1553 states the two ways out — record the index digest as the flat path does, or make lineage
per-platform and have the monitor select the matching child descriptor — and why the choice is real
rather than a detail.

## What is here and verified

- 3022 tests, 0 failures, rebased onto `30f4d7a6`.
- The provenance parser reads the level Buildx actually writes; the previous fixture invented a
  wrapper and so agreed with a parser that could never find anything.
- Lineage emission is its own required step rather than riding inside the advisory
  bill-of-materials step, and records are written aside, parsed and renamed into place.
- A cell whose final base is a sibling target in the same build — `wordpress` on `php` — records
  that, naming the exact supplying cell, and the detector reports it as having no direct check
  applicable.
- Mutation proofs observed red for the provenance JSON level, the unresolved marker, the flat
  writer's identity, the sibling marker's detector outcome, the scoped supplier coordinates, and a
  sibling record carrying no supplier.

## Filed, not fixed here

#1553 blocks. #1554 collects nine defects in the resolver and the status vocabulary. #1539 covers
four resolver inputs measured absent from this fleet. #1540 covers pre-existing lineage-path defects.
#1545 records that `_depgraph_get_consumers` has no production caller, so a `php` rebuild never
rebuilds `wordpress`.
