### PR TITLE
fix(monitor): a lookup that did not conclude is no longer published as a fact

### DIFF
--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -127,13 +127,13 @@
     {% endif %}
 
     <!-- Pull command -->
-    {% if include.current_version_confirmed == true and include.ghcr_image and include.dockerhub_image %}
+    {% if include.current_version_confirmed == true and include.ghcr_image %}
     <section>
       <h4>Pull command</h4>
       <div class="pull-section"
            data-ghcr-base="ghcr.io/{{ include.github_username }}/{{ include.name }}"
-           data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"
-           data-default-tag="{% if include.versions[0].variants[0] %}{{ include.versions[0].variants[0].tag }}{% elsif include.variants[0] %}{{ include.variants[0].tag }}{% else %}{{ include.current_version }}{% endif %}">
+           {%- if include.dockerhub_image %} data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"{% endif %}
+           data-default-tag="{{ include.current_version }}">
         <div class="pull-input-group">
           <input type="text"
                  class="pull-input"
@@ -171,6 +171,7 @@
             <div class="version-label">{{ version.base_tag | default: version.tag }}</div>
             <div class="variant-tags">
               {% for variant in version.variants %}
+                {% if variant.reference_confirmed == true %}
                 {%- comment -%}
                   Versions-only containers synthesize a single variant with empty
                   `name` (the version itself IS the canonical build). Render the
@@ -204,6 +205,7 @@
                   :{{ variant_label }}
                   {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
                 </span>
+                {% endif %}
               {% endfor %}
             </div>
           </div>
@@ -212,6 +214,7 @@
           <!-- Single-version structure -->
           <div class="variant-tags">
             {% for variant in include.variants %}
+              {% if variant.reference_confirmed == true %}
               {%- assign variant_label = variant.tag | default: variant.name -%}
               <span class="variant-tag{% if forloop.first %} selected{% endif %}"
                     title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
@@ -229,6 +232,7 @@
                 :{{ variant_label }}
                 {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
               </span>
+              {% endif %}
             {% endfor %}
           </div>
         {% endif %}

--- a/docs/site/_includes/container-card.html
+++ b/docs/site/_includes/container-card.html
@@ -1,6 +1,10 @@
 <!-- Container row card — details/summary expand pattern (D1 refactor) -->
 {%- assign default_variant = include.versions[0].variants[0] | default: include.variants[0] | default: include -%}
 {%- assign default_variant_tag = default_variant.tag | default: include.current_version | default: "latest" -%}
+{%- assign default_reference_confirmed = include.current_version_confirmed -%}
+{%- if include.versions or include.variants -%}
+  {%- assign default_reference_confirmed = default_variant.reference_confirmed -%}
+{%- endif -%}
 {%- assign size_amd64_label = include.size_amd64 | default: "—" -%}
 {%- assign size_amd64_raw = include.size_amd64 | default: "" | strip -%}
 {%- assign size_amd64_compact = size_amd64_raw | remove: " " | downcase -%}
@@ -15,6 +19,7 @@
 {%- capture default_image_ref -%}{{ include.name }}:{{ default_variant_tag }}{%- endcapture -%}
 <details class="container-card glass status-{{ include.status_color | default: 'secondary' }}"
          data-container="{{ include.name }}"
+         data-update-available="{{ include.update_available | default: false }}"
          data-github-username="{{ include.github_username }}"
          data-dockerhub-username="{{ include.dockerhub_username }}"
          aria-label="{{ include.name }} container - {{ include.status_text | default: 'Unknown status' }}">
@@ -127,14 +132,14 @@
     {% endif %}
 
     <!-- Pull command -->
-    {% if include.current_version_confirmed == true and include.ghcr_image %}
+    {% if default_reference_confirmed == true and include.ghcr_image %}
     <section>
       <h4>Pull command</h4>
       <div class="pull-section"
            data-ghcr-base="ghcr.io/{{ include.github_username }}/{{ include.name }}"
            {%- if include.dockerhub_image %} data-dockerhub-base="docker.io/{{ include.dockerhub_username }}/{{ include.name }}"{% endif %}
            data-default-tag="{{ include.current_version }}">
-        <div class="pull-input-group">
+        <div class="pull-input-group" data-pull-command>
           <input type="text"
                  class="pull-input"
                  id="pull-{{ include.name }}"
@@ -146,13 +151,13 @@
             <i class="ti ti-copy" aria-hidden="true"></i>
           </button>
         </div>
+        <p class="evidence-empty" data-pull-unavailable hidden>No published image was observed for this reference.</p>
       </div>
     </section>
-    {% elsif include.current_version_confirmed != true %}
+    {% elsif default_reference_confirmed != true %}
     <section>
       <h4>Pull command</h4>
-      <p>Publication information is unavailable; no pull reference is shown.</p>
-      <p>Upstream version: {{ include.latest_version | default: "unknown" | escape }}</p>
+      <p>No published image was observed for this reference.</p>
     </section>
     {% endif %}
 
@@ -171,7 +176,6 @@
             <div class="version-label">{{ version.base_tag | default: version.tag }}</div>
             <div class="variant-tags">
               {% for variant in version.variants %}
-                {% if variant.reference_confirmed == true %}
                 {%- comment -%}
                   Versions-only containers synthesize a single variant with empty
                   `name` (the version itself IS the canonical build). Render the
@@ -192,6 +196,7 @@
                       {%- if synthetic %} style="display: none" aria-hidden="true"{% endif %}
                       title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
                       data-tag="{{ variant.tag }}"
+                      data-reference-confirmed="{{ variant.reference_confirmed | default: false }}"
                       data-size-amd64="{{ variant.size_amd64 | default: '' }}"
                       data-size-arm64="{{ variant.size_arm64 | default: '' }}"
                       {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
@@ -205,7 +210,6 @@
                   :{{ variant_label }}
                   {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
                 </span>
-                {% endif %}
               {% endfor %}
             </div>
           </div>
@@ -214,11 +218,11 @@
           <!-- Single-version structure -->
           <div class="variant-tags">
             {% for variant in include.variants %}
-              {% if variant.reference_confirmed == true %}
               {%- assign variant_label = variant.tag | default: variant.name -%}
               <span class="variant-tag{% if forloop.first %} selected{% endif %}"
                     title="{{ variant.when_to_use | default: variant.description | escape }} — Click to select"
                     data-tag="{{ variant.tag }}"
+                    data-reference-confirmed="{{ variant.reference_confirmed | default: false }}"
                     data-size-amd64="{{ variant.size_amd64 | default: '' }}"
                     data-size-arm64="{{ variant.size_arm64 | default: '' }}"
                     {%- if variant.attestation_url %} data-attestation-url="{{ variant.attestation_url }}"{% endif %}
@@ -232,7 +236,6 @@
                 :{{ variant_label }}
                 {% if variant.is_default %}<span class="badge badge-primary" aria-hidden="true">default</span>{% endif %}
               </span>
-              {% endif %}
             {% endfor %}
           </div>
         {% endif %}

--- a/docs/site/_includes/dashboard-stats.html
+++ b/docs/site/_includes/dashboard-stats.html
@@ -25,6 +25,14 @@
   </div>
 
   <div class="stat-card glass">
+    <div class="stat-icon blue">
+      <i class="ti ti-package-export" aria-hidden="true"></i>
+    </div>
+    <div class="stat-value">{{ include.unpublished_releases | default: 0 }}</div>
+    <div class="stat-label">Unpublished Releases</div>
+  </div>
+
+  <div class="stat-card glass">
     <div class="stat-icon purple">
       <i class="ti ti-chart-bar" aria-hidden="true"></i>
     </div>

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -26,7 +26,9 @@
 {%- if page.versions -%}
   {%- for _vab_ver in page.versions -%}
     {%- for _vab_v in _vab_ver.variants -%}
-      {%- assign _vab_variants = _vab_variants | append: _vab_v.tag | append: "||" -%}
+      {%- if _vab_v.reference_confirmed == true -%}
+        {%- assign _vab_variants = _vab_variants | append: _vab_v.tag | append: "||" -%}
+      {%- endif -%}
     {%- endfor -%}
   {%- endfor -%}
 {%- endif -%}
@@ -76,15 +78,21 @@
   {%- assign _vab_first_row = true -%}
   {%- for _vab_ver in page.versions -%}
     {%- for _vab_v in _vab_ver.variants -%}
-      {%- unless _vab_first_row -%},{%- endunless -%}
-      {%- assign _vab_first_row = false -%}
-      {"tag":{{ _vab_v.tag | jsonify }},"version":{{ _vab_ver.base_tag | default: _vab_ver.tag | jsonify }},"flavor":{{ _vab_v.name | default: "" | jsonify }},"name":{{ _vab_v.name | default: "" | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+      {%- if _vab_v.reference_confirmed == true -%}
+        {%- unless _vab_first_row -%},{%- endunless -%}
+        {%- assign _vab_first_row = false -%}
+        {"tag":{{ _vab_v.tag | jsonify }},"version":{{ _vab_ver.base_tag | default: _vab_ver.tag | jsonify }},"flavor":{{ _vab_v.name | default: "" | jsonify }},"name":{{ _vab_v.name | default: "" | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+      {%- endif -%}
     {%- endfor -%}
   {%- endfor -%}
 {%- elsif page.variants -%}
+  {%- assign _vab_first_row = true -%}
   {%- for _vab_v in page.variants -%}
-    {%- unless forloop.first -%},{%- endunless -%}
-    {"tag":{{ _vab_v.tag | jsonify }},"version":"","flavor":{{ _vab_v.tag | jsonify }},"name":{{ _vab_v.tag | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+    {%- if _vab_v.reference_confirmed == true -%}
+      {%- unless _vab_first_row -%},{%- endunless -%}
+      {%- assign _vab_first_row = false -%}
+      {"tag":{{ _vab_v.tag | jsonify }},"version":"","flavor":{{ _vab_v.tag | jsonify }},"name":{{ _vab_v.tag | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
+    {%- endif -%}
   {%- endfor -%}
 {%- else -%}
   {"tag":{{ page.current_version | jsonify }},"version":"","flavor":"","name":"","size_amd64":{{ page.size_amd64 | default: "" | jsonify }},"size_arm64":{{ page.size_arm64 | default: "" | jsonify }},"build_digest":{{ page.build_digest | default: "" | jsonify }},"attestation_url":"","attestation_id":"","trivy_summary":null,"multi_arch_platforms":[]}
@@ -101,8 +109,6 @@
   {%- endif -%}
 {%- endif -%}
 
-{%- capture _vab_registries -%}[{"id":"ghcr","label":"GHCR"},{"id":"dockerhub","label":"Docker Hub"}]{%- endcapture -%}
-
 <section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
   <variant-action-bar
     data-container="{{ page.name | escape }}"
@@ -113,8 +119,8 @@
     data-flavors="{{ _vab_fla_arr | strip | escape }}"
     data-variants="{{ _vab_variants_json | strip | escape }}"
     data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
-    data-image-base-dockerhub="{{ page.dockerhub_username | default: page.github_username | escape }}/{{ page.name | escape }}"
-    data-registries='{{ _vab_registries | escape }}'
+    {%- if page.dockerhub_image %}data-image-base-dockerhub="{{ page.dockerhub_username | default: page.github_username | escape }}/{{ page.name | escape }}"{%- endif %}
+    data-registries='[{"id":"ghcr","label":"GHCR"}]'
   ></variant-action-bar>
 
   <noscript>
@@ -133,12 +139,16 @@
             {%- if page.versions -%}
               {%- for _ns_ver in page.versions -%}
                 {%- for _ns_v in _ns_ver.variants -%}
+                  {%- if _ns_v.reference_confirmed == true -%}
                   <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
+                  {%- endif -%}
                 {%- endfor -%}
               {%- endfor -%}
             {%- elsif page.variants -%}
               {%- for _ns_v in page.variants -%}
+                {%- if _ns_v.reference_confirmed == true -%}
                 <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
+                {%- endif -%}
               {%- endfor -%}
             {%- endif -%}
           </tbody>

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -23,14 +23,37 @@
 {%- endcomment -%}
 
 {%- assign _vab_variants = "" -%}
+{%- assign _vab_confirmed_count = 0 -%}
+{%- assign _vab_default_tag = "" -%}
+{%- assign _vab_default_version = "" -%}
+{%- assign _vab_default_flavor = "" -%}
 {%- if page.versions -%}
   {%- for _vab_ver in page.versions -%}
     {%- for _vab_v in _vab_ver.variants -%}
       {%- if _vab_v.reference_confirmed == true -%}
         {%- assign _vab_variants = _vab_variants | append: _vab_v.tag | append: "||" -%}
+        {%- assign _vab_confirmed_count = _vab_confirmed_count | plus: 1 -%}
+        {%- if _vab_default_tag == "" -%}
+          {%- assign _vab_default_tag = _vab_v.tag -%}
+          {%- assign _vab_default_version = _vab_ver.base_tag | default: _vab_ver.tag -%}
+          {%- assign _vab_default_flavor = _vab_v.name | default: "" -%}
+        {%- endif -%}
       {%- endif -%}
     {%- endfor -%}
   {%- endfor -%}
+{%- elsif page.variants -%}
+  {%- for _vab_single in page.variants -%}
+    {%- if _vab_single.reference_confirmed == true -%}
+      {%- assign _vab_confirmed_count = _vab_confirmed_count | plus: 1 -%}
+      {%- if _vab_default_tag == "" -%}
+        {%- assign _vab_default_tag = _vab_single.tag -%}
+        {%- assign _vab_default_flavor = _vab_single.tag -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- else -%}
+  {%- assign _vab_confirmed_count = 1 -%}
+  {%- assign _vab_default_tag = page.current_version -%}
 {%- endif -%}
 
 {%- comment -%} Determine unique versions for version pills {%- endcomment -%}
@@ -41,20 +64,38 @@
   output that fails JSON.parse.
 {%- endcomment -%}
 {%- capture _vab_ver_arr -%}
-{%- if page.versions and page.versions.size > 1 -%}[
+{%- if page.versions -%}[
+  {%- assign _vab_ver_first = true -%}
   {%- for _vv in page.versions -%}
-    {%- unless forloop.first -%},{%- endunless -%}
-    {"tag":{{ _vv.base_tag | default: _vv.tag | jsonify }},"label":{{ _vv.base_tag | default: _vv.tag | jsonify }}}
+    {%- assign _vab_version_confirmed = false -%}
+    {%- for _vv_variant in _vv.variants -%}
+      {%- if _vv_variant.reference_confirmed == true -%}{%- assign _vab_version_confirmed = true -%}{%- endif -%}
+    {%- endfor -%}
+    {%- if _vab_version_confirmed -%}
+      {%- unless _vab_ver_first -%},{%- endunless -%}
+      {%- assign _vab_ver_first = false -%}
+      {"tag":{{ _vv.base_tag | default: _vv.tag | jsonify }},"label":{{ _vv.base_tag | default: _vv.tag | jsonify }}}
+    {%- endif -%}
   {%- endfor -%}
 ]{%- else -%}[]{%- endif -%}
 {%- endcapture -%}
 
 {%- comment -%} Determine unique flavors for flavor pills {%- endcomment -%}
 {%- assign _has_flavors = false -%}
-{%- if page.versions and page.versions.size > 0 -%}
-  {%- assign _first_ver = page.versions[0] -%}
-  {%- for _fv in _first_ver.variants -%}
-    {%- if _fv.name and _fv.name != "" -%}
+{%- if page.versions and _vab_default_version != "" -%}
+  {%- for _fv_ver in page.versions -%}
+    {%- assign _fv_ver_tag = _fv_ver.base_tag | default: _fv_ver.tag -%}
+    {%- if _fv_ver_tag == _vab_default_version -%}
+      {%- for _fv in _fv_ver.variants -%}
+        {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
+          {%- assign _has_flavors = true -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- elsif page.variants -%}
+  {%- for _fv in page.variants -%}
+    {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
       {%- assign _has_flavors = true -%}
     {%- endif -%}
   {%- endfor -%}
@@ -62,13 +103,28 @@
 {%- capture _vab_fla_arr -%}
 {%- if _has_flavors -%}[
   {%- assign _fla_first = true -%}
-  {%- for _fv in _first_ver.variants -%}
-    {%- if _fv.name and _fv.name != "" -%}
-      {%- unless _fla_first -%},{%- endunless -%}
-      {%- assign _fla_first = false -%}
-      {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
-    {%- endif -%}
-  {%- endfor -%}
+  {%- if page.versions -%}
+    {%- for _fv_ver in page.versions -%}
+      {%- assign _fv_ver_tag = _fv_ver.base_tag | default: _fv_ver.tag -%}
+      {%- if _fv_ver_tag == _vab_default_version -%}
+        {%- for _fv in _fv_ver.variants -%}
+          {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
+            {%- unless _fla_first -%},{%- endunless -%}
+            {%- assign _fla_first = false -%}
+            {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- for _fv in page.variants -%}
+      {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
+        {%- unless _fla_first -%},{%- endunless -%}
+        {%- assign _fla_first = false -%}
+        {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
 ]{%- else -%}[]{%- endif -%}
 {%- endcapture -%}
 
@@ -100,34 +156,24 @@
 ]
 {%- endcapture -%}
 
-{%- assign _vab_default_version = "" -%}
-{%- assign _vab_default_flavor = "" -%}
-{%- if page.versions and page.versions.size > 0 -%}
-  {%- assign _vab_default_version = page.versions[0].base_tag | default: page.versions[0].tag -%}
-  {%- if page.versions[0].variants[0].name -%}
-    {%- assign _vab_default_flavor = page.versions[0].variants[0].name -%}
-  {%- endif -%}
-{%- endif -%}
-
 <section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
+  {%- if _vab_confirmed_count > 0 -%}
   <variant-action-bar
     data-container="{{ page.name | escape }}"
-    data-default-tag="{{ page.current_version | escape }}"
+    data-default-tag="{{ _vab_default_tag | escape }}"
     data-default-version="{{ _vab_default_version | escape }}"
     data-default-flavor="{{ _vab_default_flavor | escape }}"
     data-versions="{{ _vab_ver_arr | strip | escape }}"
     data-flavors="{{ _vab_fla_arr | strip | escape }}"
     data-variants="{{ _vab_variants_json | strip | escape }}"
     data-image-base="ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}"
-    {%- if page.dockerhub_image %}data-image-base-dockerhub="{{ page.dockerhub_username | default: page.github_username | escape }}/{{ page.name | escape }}"{%- endif %}
-    data-registries='[{"id":"ghcr","label":"GHCR"}]'
   ></variant-action-bar>
 
   <noscript>
     <div class="vab-noscript">
       <p class="vab-noscript-label">JavaScript is disabled — showing default variant.</p>
-      <pre><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }}</code></pre>
-      <pre><code>cosign verify ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }} \
+      <pre><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _vab_default_tag | escape }}</code></pre>
+      <pre><code>cosign verify ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _vab_default_tag | escape }} \
   --certificate-identity-regexp=https://github.com/{{ page.github_username | escape }} \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com</code></pre>
       {%- if page.versions or page.variants -%}
@@ -157,4 +203,7 @@
       {%- endif -%}
     </div>
   </noscript>
+  {%- else -%}
+  <p>Publication information is unavailable for every variant; no pull reference is shown.</p>
+  {%- endif -%}
 </section>

--- a/docs/site/_includes/variant-action-bar.html
+++ b/docs/site/_includes/variant-action-bar.html
@@ -22,40 +22,6 @@
                 attestation_url, attestation_id, trivy_summary, multi_arch_platforms }
 {%- endcomment -%}
 
-{%- assign _vab_variants = "" -%}
-{%- assign _vab_confirmed_count = 0 -%}
-{%- assign _vab_default_tag = "" -%}
-{%- assign _vab_default_version = "" -%}
-{%- assign _vab_default_flavor = "" -%}
-{%- if page.versions -%}
-  {%- for _vab_ver in page.versions -%}
-    {%- for _vab_v in _vab_ver.variants -%}
-      {%- if _vab_v.reference_confirmed == true -%}
-        {%- assign _vab_variants = _vab_variants | append: _vab_v.tag | append: "||" -%}
-        {%- assign _vab_confirmed_count = _vab_confirmed_count | plus: 1 -%}
-        {%- if _vab_default_tag == "" -%}
-          {%- assign _vab_default_tag = _vab_v.tag -%}
-          {%- assign _vab_default_version = _vab_ver.base_tag | default: _vab_ver.tag -%}
-          {%- assign _vab_default_flavor = _vab_v.name | default: "" -%}
-        {%- endif -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endfor -%}
-{%- elsif page.variants -%}
-  {%- for _vab_single in page.variants -%}
-    {%- if _vab_single.reference_confirmed == true -%}
-      {%- assign _vab_confirmed_count = _vab_confirmed_count | plus: 1 -%}
-      {%- if _vab_default_tag == "" -%}
-        {%- assign _vab_default_tag = _vab_single.tag -%}
-        {%- assign _vab_default_flavor = _vab_single.tag -%}
-      {%- endif -%}
-    {%- endif -%}
-  {%- endfor -%}
-{%- else -%}
-  {%- assign _vab_confirmed_count = 1 -%}
-  {%- assign _vab_default_tag = page.current_version -%}
-{%- endif -%}
-
 {%- comment -%} Determine unique versions for version pills {%- endcomment -%}
 {%- comment -%}
   Build a literal JSON array via capture, with per-field jsonify on each
@@ -64,38 +30,20 @@
   output that fails JSON.parse.
 {%- endcomment -%}
 {%- capture _vab_ver_arr -%}
-{%- if page.versions -%}[
-  {%- assign _vab_ver_first = true -%}
+{%- if page.versions and page.versions.size > 1 -%}[
   {%- for _vv in page.versions -%}
-    {%- assign _vab_version_confirmed = false -%}
-    {%- for _vv_variant in _vv.variants -%}
-      {%- if _vv_variant.reference_confirmed == true -%}{%- assign _vab_version_confirmed = true -%}{%- endif -%}
-    {%- endfor -%}
-    {%- if _vab_version_confirmed -%}
-      {%- unless _vab_ver_first -%},{%- endunless -%}
-      {%- assign _vab_ver_first = false -%}
-      {"tag":{{ _vv.base_tag | default: _vv.tag | jsonify }},"label":{{ _vv.base_tag | default: _vv.tag | jsonify }}}
-    {%- endif -%}
+    {%- unless forloop.first -%},{%- endunless -%}
+    {"tag":{{ _vv.base_tag | default: _vv.tag | jsonify }},"label":{{ _vv.base_tag | default: _vv.tag | jsonify }}}
   {%- endfor -%}
 ]{%- else -%}[]{%- endif -%}
 {%- endcapture -%}
 
 {%- comment -%} Determine unique flavors for flavor pills {%- endcomment -%}
 {%- assign _has_flavors = false -%}
-{%- if page.versions and _vab_default_version != "" -%}
-  {%- for _fv_ver in page.versions -%}
-    {%- assign _fv_ver_tag = _fv_ver.base_tag | default: _fv_ver.tag -%}
-    {%- if _fv_ver_tag == _vab_default_version -%}
-      {%- for _fv in _fv_ver.variants -%}
-        {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
-          {%- assign _has_flavors = true -%}
-        {%- endif -%}
-      {%- endfor -%}
-    {%- endif -%}
-  {%- endfor -%}
-{%- elsif page.variants -%}
-  {%- for _fv in page.variants -%}
-    {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
+{%- if page.versions and page.versions.size > 0 -%}
+  {%- assign _first_ver = page.versions[0] -%}
+  {%- for _fv in _first_ver.variants -%}
+    {%- if _fv.name and _fv.name != "" -%}
       {%- assign _has_flavors = true -%}
     {%- endif -%}
   {%- endfor -%}
@@ -103,28 +51,13 @@
 {%- capture _vab_fla_arr -%}
 {%- if _has_flavors -%}[
   {%- assign _fla_first = true -%}
-  {%- if page.versions -%}
-    {%- for _fv_ver in page.versions -%}
-      {%- assign _fv_ver_tag = _fv_ver.base_tag | default: _fv_ver.tag -%}
-      {%- if _fv_ver_tag == _vab_default_version -%}
-        {%- for _fv in _fv_ver.variants -%}
-          {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
-            {%- unless _fla_first -%},{%- endunless -%}
-            {%- assign _fla_first = false -%}
-            {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- else -%}
-    {%- for _fv in page.variants -%}
-      {%- if _fv.reference_confirmed == true and _fv.name and _fv.name != "" -%}
-        {%- unless _fla_first -%},{%- endunless -%}
-        {%- assign _fla_first = false -%}
-        {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endif -%}
+  {%- for _fv in _first_ver.variants -%}
+    {%- if _fv.name and _fv.name != "" -%}
+      {%- unless _fla_first -%},{%- endunless -%}
+      {%- assign _fla_first = false -%}
+      {"name":{{ _fv.name | jsonify }},"label":{{ _fv.name | jsonify }}}
+    {%- endif -%}
+  {%- endfor -%}
 ]{%- else -%}[]{%- endif -%}
 {%- endcapture -%}
 
@@ -134,33 +67,35 @@
   {%- assign _vab_first_row = true -%}
   {%- for _vab_ver in page.versions -%}
     {%- for _vab_v in _vab_ver.variants -%}
-      {%- if _vab_v.reference_confirmed == true -%}
-        {%- unless _vab_first_row -%},{%- endunless -%}
-        {%- assign _vab_first_row = false -%}
-        {"tag":{{ _vab_v.tag | jsonify }},"version":{{ _vab_ver.base_tag | default: _vab_ver.tag | jsonify }},"flavor":{{ _vab_v.name | default: "" | jsonify }},"name":{{ _vab_v.name | default: "" | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
-      {%- endif -%}
+      {%- unless _vab_first_row -%},{%- endunless -%}
+      {%- assign _vab_first_row = false -%}
+      {"tag":{{ _vab_v.tag | jsonify }},"version":{{ _vab_ver.base_tag | default: _vab_ver.tag | jsonify }},"flavor":{{ _vab_v.name | default: "" | jsonify }},"name":{{ _vab_v.name | default: "" | jsonify }},"reference_confirmed":{{ _vab_v.reference_confirmed | default: false | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
     {%- endfor -%}
   {%- endfor -%}
 {%- elsif page.variants -%}
-  {%- assign _vab_first_row = true -%}
   {%- for _vab_v in page.variants -%}
-    {%- if _vab_v.reference_confirmed == true -%}
-      {%- unless _vab_first_row -%},{%- endunless -%}
-      {%- assign _vab_first_row = false -%}
-      {"tag":{{ _vab_v.tag | jsonify }},"version":"","flavor":{{ _vab_v.tag | jsonify }},"name":{{ _vab_v.tag | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
-    {%- endif -%}
+    {%- unless forloop.first -%},{%- endunless -%}
+    {"tag":{{ _vab_v.tag | jsonify }},"version":"","flavor":{{ _vab_v.tag | jsonify }},"name":{{ _vab_v.tag | jsonify }},"reference_confirmed":{{ _vab_v.reference_confirmed | default: false | jsonify }},"size_amd64":{{ _vab_v.size_amd64 | default: "" | jsonify }},"size_arm64":{{ _vab_v.size_arm64 | default: "" | jsonify }},"build_digest":{{ _vab_v.build_digest | default: "" | jsonify }},"attestation_url":{{ _vab_v.attestation_url | default: "" | jsonify }},"attestation_id":{{ _vab_v.attestation_id | default: "" | jsonify }}{%- if _vab_v.trivy_summary -%},"trivy_summary":{{ _vab_v.trivy_summary | jsonify }}{%- else -%},"trivy_summary":null{%- endif -%}{%- if _vab_v.multi_arch_platforms -%},"multi_arch_platforms":{{ _vab_v.multi_arch_platforms | jsonify }}{%- else -%},"multi_arch_platforms":[]{%- endif -%}}
   {%- endfor -%}
 {%- else -%}
-  {"tag":{{ page.current_version | jsonify }},"version":"","flavor":"","name":"","size_amd64":{{ page.size_amd64 | default: "" | jsonify }},"size_arm64":{{ page.size_arm64 | default: "" | jsonify }},"build_digest":{{ page.build_digest | default: "" | jsonify }},"attestation_url":"","attestation_id":"","trivy_summary":null,"multi_arch_platforms":[]}
+  {"tag":{{ page.current_version | jsonify }},"version":"","flavor":"","name":"","reference_confirmed":{{ page.current_version_confirmed | default: false | jsonify }},"size_amd64":{{ page.size_amd64 | default: "" | jsonify }},"size_arm64":{{ page.size_arm64 | default: "" | jsonify }},"build_digest":{{ page.build_digest | default: "" | jsonify }},"attestation_url":"","attestation_id":"","trivy_summary":null,"multi_arch_platforms":[]}
 {%- endif -%}
 ]
 {%- endcapture -%}
 
+{%- assign _vab_default_version = "" -%}
+{%- assign _vab_default_flavor = "" -%}
+{%- if page.versions and page.versions.size > 0 -%}
+  {%- assign _vab_default_version = page.versions[0].base_tag | default: page.versions[0].tag -%}
+  {%- if page.versions[0].variants[0].name -%}
+    {%- assign _vab_default_flavor = page.versions[0].variants[0].name -%}
+  {%- endif -%}
+{%- endif -%}
+
 <section id="variants-pull" class="vab-section" aria-label="Variant selector and pull commands">
-  {%- if _vab_confirmed_count > 0 -%}
   <variant-action-bar
     data-container="{{ page.name | escape }}"
-    data-default-tag="{{ _vab_default_tag | escape }}"
+    data-default-tag="{{ page.current_version | escape }}"
     data-default-version="{{ _vab_default_version | escape }}"
     data-default-flavor="{{ _vab_default_flavor | escape }}"
     data-versions="{{ _vab_ver_arr | strip | escape }}"
@@ -171,11 +106,15 @@
 
   <noscript>
     <div class="vab-noscript">
+      {%- if page.current_version_confirmed == true -%}
       <p class="vab-noscript-label">JavaScript is disabled — showing default variant.</p>
-      <pre><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _vab_default_tag | escape }}</code></pre>
-      <pre><code>cosign verify ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _vab_default_tag | escape }} \
+      <pre><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }}</code></pre>
+      <pre><code>cosign verify ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ page.current_version | escape }} \
   --certificate-identity-regexp=https://github.com/{{ page.github_username | escape }} \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com</code></pre>
+      {%- else -%}
+      <p>No published image was observed for the default reference.</p>
+      {%- endif -%}
       {%- if page.versions or page.variants -%}
       <details>
         <summary>All variants</summary>
@@ -185,16 +124,12 @@
             {%- if page.versions -%}
               {%- for _ns_ver in page.versions -%}
                 {%- for _ns_v in _ns_ver.variants -%}
-                  {%- if _ns_v.reference_confirmed == true -%}
-                  <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
-                  {%- endif -%}
+                  <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td>{%- if _ns_v.reference_confirmed == true -%}<code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code>{%- else -%}No published image was observed for this reference.{%- endif -%}</td></tr>
                 {%- endfor -%}
               {%- endfor -%}
             {%- elsif page.variants -%}
               {%- for _ns_v in page.variants -%}
-                {%- if _ns_v.reference_confirmed == true -%}
-                <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td><code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code></td></tr>
-                {%- endif -%}
+                <tr><td><code>{{ _ns_v.tag | escape }}</code></td><td>{%- if _ns_v.reference_confirmed == true -%}<code>docker pull ghcr.io/{{ page.github_username | escape }}/{{ page.name | escape }}:{{ _ns_v.tag | escape }}</code>{%- else -%}No published image was observed for this reference.{%- endif -%}</td></tr>
               {%- endfor -%}
             {%- endif -%}
           </tbody>
@@ -203,7 +138,4 @@
       {%- endif -%}
     </div>
   </noscript>
-  {%- else -%}
-  <p>Publication information is unavailable for every variant; no pull reference is shown.</p>
-  {%- endif -%}
 </section>

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -82,10 +82,6 @@
                  class="btn" target="_blank" rel="noopener noreferrer" aria-label="View package on GitHub Container Registry">
                 <i class="ti ti-package" aria-hidden="true"></i> GHCR
               </a>
-              <a href="https://hub.docker.com/r/{{ page.dockerhub_username }}/{{ page.name }}"
-                 class="btn" target="_blank" rel="noopener noreferrer" aria-label="View image on Docker Hub">
-                <i class="ti ti-brand-docker" aria-hidden="true"></i> Docker Hub
-              </a>
             </div>
           </div>
 
@@ -386,6 +382,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
+              {%- if _prov_var.reference_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">
@@ -396,6 +393,7 @@
                      title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
                 </dd>
               </div>
+              {%- endif -%}
             </dl>
             <footer class="provenance-footer">
               <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"
@@ -513,6 +511,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
+              {%- if _prov_var.reference_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">
@@ -523,6 +522,7 @@
                      title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
                 </dd>
               </div>
+              {%- endif -%}
             </dl>
             <footer class="provenance-footer">
               <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"
@@ -638,6 +638,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
+              {%- if prov_variant.reference_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">
@@ -649,6 +650,7 @@
                      title="Verification guide — step-by-step commands to reproduce SBOM, Trivy, and cosign checks">guide →</a>
                 </dd>
               </div>
+              {%- endif -%}
             </dl>
             <footer class="provenance-footer">
               <a href="{{ '/verify-images/' | relative_url }}" class="trust-badge trust-badge--verify"

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -638,7 +638,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
-              {%- if prov_variant.reference_confirmed == true -%}
+              {%- if prov_variant.current_version_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -638,7 +638,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
-              {%- if page.current_version_confirmed == true -%}
+              {%- if prov_variant.reference_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">

--- a/docs/site/_layouts/container-detail.html
+++ b/docs/site/_layouts/container-detail.html
@@ -638,7 +638,7 @@
               </div>
                 {%- endif -%}
               {%- endif -%}
-              {%- if prov_variant.reference_confirmed == true -%}
+              {%- if page.current_version_confirmed == true -%}
               <div class="evidence-row">
                 <dt>Verify</dt>
                 <dd class="provenance-verify-cmd">

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -91,16 +91,6 @@
 
     <!-- Controls Bar -->
     <div class="controls-bar glass">
-      <div class="controls-group" role="group" aria-labelledby="registry-label">
-        <span class="controls-label" id="registry-label">Registry</span>
-        <div class="registry-toggle" role="radiogroup" aria-label="Select container registry">
-          <button class="registry-btn active" data-registry="ghcr"
-                  role="radio" aria-checked="true" aria-label="GitHub Container Registry">
-            <i class="ti ti-package" aria-hidden="true"></i> GHCR
-          </button>
-        </div>
-      </div>
-
       <div class="search-container">
         <i class="ti ti-search search-icon" aria-hidden="true"></i>
         <input type="search" class="search-input" id="search-input"

--- a/docs/site/_layouts/dashboard.html
+++ b/docs/site/_layouts/dashboard.html
@@ -98,10 +98,6 @@
                   role="radio" aria-checked="true" aria-label="GitHub Container Registry">
             <i class="ti ti-package" aria-hidden="true"></i> GHCR
           </button>
-          <button class="registry-btn" data-registry="dockerhub"
-                  role="radio" aria-checked="false" aria-label="Docker Hub">
-            <i class="ti ti-brand-docker" aria-hidden="true"></i> Docker Hub
-          </button>
         </div>
       </div>
 

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -1,7 +1,7 @@
 // docs/site/assets/js/components/variant-action-bar.js
 //
 // Vanilla custom element (light DOM). CSP-clean (no eval, no innerHTML).
-// Renders: registry pills + version pills + flavor pills + pull/verify commands + per-variant signals strip.
+// Renders: version pills + flavor pills + pull/verify commands + per-variant signals strip.
 // Sticky-on-scroll (auto-collapses to signals strip; scroll up re-expands). Dispatches variant-action-bar:variant-changed.
 // Two-way sync with legacy phase-b-variant-changed / version-tabs-changed events.
 
@@ -56,63 +56,39 @@
 
       this._container = this.dataset.container || '';
       this._imageBase = this.dataset.imageBase || '';
-      this._imageBaseDockerHub = this.dataset.imageBaseDockerhub || this.dataset.imageBase || '';
       this._defaultTag = this.dataset.defaultTag || '';
 
-      // Registry options. We only synthesize the GHCR + Docker Hub default pair
-      // when the page actually provides a Docker Hub image base — otherwise
-      // selecting "Docker Hub" would silently fall back to the GHCR base. Pages
-      // without `data-image-base-dockerhub` get GHCR-only (no pill group rendered).
-      var hasDockerHubBase = !!this.dataset.imageBaseDockerhub;
-      var defaultRegistries = hasDockerHubBase
-        ? [
-            { id: 'ghcr', label: 'GHCR' },
-            { id: 'dockerhub', label: 'Docker Hub' }
-          ]
-        : [{ id: 'ghcr', label: 'GHCR' }];
-      this._registries = parse(this.dataset.registries, defaultRegistries);
-      if (!this._registries || !this._registries.length) {
-        this._registries = defaultRegistries;
-      }
-      // Cross-validate: keep only registries whose pull-base is actually
-      // implemented in _updateCommands (today: 'ghcr' + 'dockerhub'). Drop any
-      // unknown ids — rendering a "quay" pill that silently falls back to a
-      // GHCR pull command is worse than not showing it at all. Also drop
-      // 'dockerhub' when data-image-base-dockerhub is missing (same reason).
-      var SUPPORTED_REGISTRY_IDS = { ghcr: true, dockerhub: true };
-      this._registries = this._registries.filter(function (r) {
-        if (!SUPPORTED_REGISTRY_IDS[r.id]) return false;
-        if (r.id === 'dockerhub') return hasDockerHubBase;
-        return true;
-      });
-      // Guarantee GHCR is always available — every container ships there and
-      // the pull-base path is always wired. Without this, a misconfigured
-      // data-registries (e.g. only "dockerhub" with no DH base) could leave
-      // the registry list empty and orphan _selectedRegistry below.
-      if (!this._registries.some(function (r) { return r.id === 'ghcr'; })) {
-        this._registries.unshift({ id: 'ghcr', label: 'GHCR' });
-      }
-      // Default registry: explicit attribute → first registry → 'ghcr'.
-      // Validate that the requested default exists in _registries; otherwise
-      // fall back to the first available so the radiogroup always has an active
-      // pill (avoids all-tabIndex=-1 keyboard-trap state).
-      var defaultFromAttr = (this.dataset.defaultRegistry || '').trim();
-      var firstId = this._registries.length > 0 ? this._registries[0].id : 'ghcr';
-      var validDefault = defaultFromAttr && this._registries.some(function (r) { return r.id === defaultFromAttr; });
-      this._selectedRegistry = validDefault ? defaultFromAttr : firstId;
-
-      // versions: array of version-group objects with .tag + .variants[]
-      this._versions = parse(this.dataset.versions, []);
-      // flavors: flat array of flavor objects ({ name, label })
-      this._flavors = parse(this.dataset.flavors, []);
       // variants: flat lookup array of all variant objects
-      this._variants = parse(this.dataset.variants, []);
+      this._variants = parse(this.dataset.variants, []).filter(function (variant) {
+        return variant.reference_confirmed !== false;
+      });
+      // Keep a defensive runtime boundary as well as the Liquid filter: a
+      // selectable version must have at least one record the component can
+      // show. Older generated pages may still carry reference_confirmed.
+      this._versions = parse(this.dataset.versions, []).filter(function (version) {
+        return this._variants.some(function (variant) {
+          return variant.version === version.tag;
+        });
+      }, this);
+      // The component rebuilds this when a version changes; start with the
+      // confirmed records for the selected version below.
+      this._flavors = parse(this.dataset.flavors, []);
 
       // Select the first version/flavor as default
-      this._selectedVersion = this.dataset.defaultVersion
-        || (this._versions[0] && this._versions[0].tag) || '';
+      var requestedVersion = this.dataset.defaultVersion || '';
+      var hasRequestedVersion = this._versions.some(function (version) {
+        return version.tag === requestedVersion;
+      });
+      this._selectedVersion = hasRequestedVersion
+        ? requestedVersion
+        : (this._versions[0] && this._versions[0].tag) || '';
       this._selectedFlavor = this.dataset.defaultFlavor
         || (this._flavors[0] && this._flavors[0].name) || '';
+
+      if (this._selectedVersion) {
+        this._flavors = this._flavorsForVersion(this._selectedVersion);
+        this._selectedFlavor = this._flavors[0] ? this._flavors[0].name : '';
+      }
 
       // Find initial selected variant
       this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
@@ -149,6 +125,19 @@
       return variants[0] || null;
     }
 
+    _flavorsForVersion(version) {
+      var flavors = [];
+      var seen = {};
+      for (var i = 0; i < this._variants.length; i++) {
+        var variant = this._variants[i];
+        var flavor = variant.flavor || variant.name || '';
+        if (variant.version !== version || !flavor || seen[flavor]) { continue; }
+        seen[flavor] = true;
+        flavors.push({ name: flavor, label: flavor });
+      }
+      return flavors;
+    }
+
     // -------------------------------------------------------
     // Render (DOM construction — no innerHTML, XSS-safe)
     // -------------------------------------------------------
@@ -166,21 +155,13 @@
       card.className = 'vab-card';
       this.appendChild(card);
 
-      // Row 1 — selectors: [REGISTRY pills] · [VERSION pills] · [FLAVOR pills]
+      // Row 1 — selectors: [VERSION pills] · [FLAVOR pills]
       var hasMultipleVersions = this._versions && this._versions.length > 1;
       var hasFlavors = this._flavors && this._flavors.length > 0;
-      var hasRegistries = this._registries && this._registries.length > 1;
 
-      if (hasRegistries || hasMultipleVersions || hasFlavors) {
+      if (hasMultipleVersions || hasFlavors) {
         var row1 = document.createElement('div');
         row1.className = 'vab-row vab-row--selectors';
-
-        if (hasRegistries) {
-          row1.appendChild(
-            this._makePillGroup('Registry', this._registries, 'id', this._selectedRegistry,
-              'vab-registry-pill', 'vab-registry-pills vab-pill-group--registry')
-          );
-        }
 
         if (hasMultipleVersions) {
           row1.appendChild(
@@ -334,36 +315,18 @@
     }
 
 
-    // Build the collapsed-state actions group (registry mini-toggle + mini copy button).
+    // Build the collapsed-state actions group (mini copy button).
     // Hidden via CSS in expanded mode; shown only when [data-collapsed] is set on the host.
     _makeCollapsedActions() {
       var wrap = document.createElement('div');
       wrap.className = 'vab-collapsed-actions';
-
-      // Only render registry toggle when there are multiple registries
-      if (this._registries && this._registries.length > 1) {
-        for (var i = 0; i < this._registries.length; i++) {
-          var reg = this._registries[i];
-          var btn = document.createElement('button');
-          btn.type = 'button';
-          btn.className = 'vab-registry-mini';
-          btn.setAttribute('data-vab-mini-registry', reg.id);
-          btn.setAttribute('aria-pressed', reg.id === this._selectedRegistry ? 'true' : 'false');
-          // Visible text is shortened to fit the sticky bar; aria-label keeps
-          // the full registry name accessible to screen readers.
-          btn.setAttribute('aria-label', 'Pull from ' + reg.label);
-          btn.textContent = reg.id === 'dockerhub' ? 'DH' : reg.label;
-          wrap.appendChild(btn);
-        }
-      }
 
       // Compact pull-command copy button
       var copyBtn = document.createElement('button');
       copyBtn.type = 'button';
       copyBtn.className = 'vab-copy-mini';
       copyBtn.setAttribute('data-vab-mini-copy', 'pull');
-      // Dynamic label set here; _updateCollapsedActionsState keeps it in sync
-      copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+      copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel());
       // Explicit classes so _onMiniCopyClick can use stable selectors
       var icon = document.createElement('span');
       icon.className = 'vab-copy-mini__icon';
@@ -389,12 +352,12 @@
       btn.type = 'button';
       btn.className = 'vab-sticky-cmd';
       btn.setAttribute('data-vab-sticky-cmd', '');
-      // aria-label keeps a stable identity ("Copy <registry> pull command"),
+      // aria-label keeps a stable identity ("Copy GHCR pull command"),
       // dynamic via _updateStickyCommand. Status feedback ("Copied" /
       // "Copy failed") is announced through a dedicated live region built
       // by _makeStickyStatus — putting status text on the button's own
       // aria-label is unreliable across screen readers.
-      btn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+      btn.setAttribute('aria-label', this._buildCopyAriaLabel());
       // Text is set by _updateStickyCommand() after _updateCommands() runs
       btn.textContent = '';
       return btn;
@@ -419,7 +382,7 @@
       if (!stickyEl) { return; }
       var pullEl = this.querySelector('[data-vab-cmd="pull"]');
       if (pullEl) { stickyEl.textContent = pullEl.textContent; }
-      stickyEl.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry));
+      stickyEl.setAttribute('aria-label', this._buildCopyAriaLabel());
     }
 
     // Copy handler for the collapsed sticky command button.
@@ -466,17 +429,11 @@
 
 
 
-    // Sync collapsed-actions buttons (aria-pressed) to current _selectedRegistry.
-    // Called after any registry change and on initial render (via _updateCommands).
+    // Keep the collapsed copy control's accessible label in sync with the
+    // command. GHCR is the sole published command source.
     _updateCollapsedActionsState() {
-      var miniBtns = this.querySelectorAll('[data-vab-mini-registry]');
-      for (var i = 0; i < miniBtns.length; i++) {
-        var active = miniBtns[i].getAttribute('data-vab-mini-registry') === this._selectedRegistry;
-        miniBtns[i].setAttribute('aria-pressed', active ? 'true' : 'false');
-      }
-      // Update the mini copy button's aria-label to reflect the current registry
       var copyBtn = this.querySelector('[data-vab-mini-copy]');
-      if (copyBtn) { copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel(this._selectedRegistry)); }
+      if (copyBtn) { copyBtn.setAttribute('aria-label', this._buildCopyAriaLabel()); }
     }
 
 
@@ -491,11 +448,7 @@
       var ghcrBase = this._imageBase;
       var owner = this._extractOwner(ghcrBase);
 
-      // Pull command uses selected registry; verify always uses GHCR (Sigstore lives there)
-      var pullBase = (this._selectedRegistry === 'dockerhub')
-        ? this._imageBaseDockerHub
-        : ghcrBase;
-      var pullCmd = 'docker pull ' + pullBase + ':' + tag;
+      var pullCmd = 'docker pull ' + ghcrBase + ':' + tag;
       var verifyCmd = 'cosign verify ' + ghcrBase + ':' + tag
         + ' --certificate-identity-regexp=https://github.com/' + owner
         + ' --certificate-oidc-issuer=https://token.actions.githubusercontent.com';
@@ -505,25 +458,6 @@
       if (pullEl) { pullEl.textContent = pullCmd; }
       if (verifyEl) { verifyEl.textContent = verifyCmd; }
 
-      // Show verify note when registry is not GHCR
-      var verifyBlock = verifyEl && verifyEl.closest('.vab-command-block');
-      if (verifyBlock) {
-        var existingNote = verifyBlock.querySelector('.vab-verify-note');
-        if (this._selectedRegistry !== 'ghcr') {
-          if (!existingNote) {
-            var note = document.createElement('small');
-            note.className = 'vab-verify-note';
-            note.setAttribute('role', 'status');
-            note.setAttribute('aria-live', 'polite');
-            note.textContent = 'Verified via GHCR · attestation source';
-            verifyBlock.appendChild(note);
-          }
-        } else {
-          if (existingNote) { verifyBlock.removeChild(existingNote); }
-        }
-      }
-
-      // Keep collapsed-actions mini toggle in sync
       this._updateCollapsedActionsState();
       // Sync sticky pull command text in collapsed bandeau
       this._updateStickyCommand();
@@ -560,10 +494,10 @@
 
     _onVersionPillClick(value) {
       this._selectedVersion = value;
-      this._updatePillActive('vab-version-pill', value);
+      this._flavors = this._flavorsForVersion(value);
+      this._selectedFlavor = (this._flavors[0] && this._flavors[0].name) || '';
       this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
-      this._updateCommands();
-      this._updateSignals();
+      this._render();
       this._dispatchVariantChanged();
     }
 
@@ -575,14 +509,6 @@
       this._updateSignals();
       this._dispatchVariantChanged();
     }
-
-
-    _onRegistryPillClick(value) {
-      this._selectedRegistry = value;
-      this._updatePillActive('vab-registry-pill', value);
-      this._updateCommands();
-    }
-
 
     // F4: also update roving tabindex when active pill changes
     _updatePillActive(pillClass, value) {
@@ -601,9 +527,8 @@
     // -------------------------------------------------------
 
     // Builds the dynamic aria-label for the mini copy button.
-    _buildCopyAriaLabel(reg) {
-      var name = reg === 'dockerhub' ? 'Docker Hub' : 'GHCR';
-      return 'Copy ' + name + ' pull command';
+    _buildCopyAriaLabel() {
+      return 'Copy GHCR pull command';
     }
 
     // M-A: single clipboard helper — resolves only on success, rejects on failure.
@@ -811,9 +736,6 @@
 
     // M-B: delegated click handler — stored as bound ref so it can be removed on disconnect
     _onClick(e) {
-      var rPill = e.target.closest('.vab-registry-pill');
-      if (rPill) { this._onRegistryPillClick(rPill.dataset.value); return; }
-
       var vPill = e.target.closest('.vab-version-pill');
       if (vPill) { this._onVersionPillClick(vPill.dataset.value); return; }
 
@@ -822,10 +744,6 @@
 
       var copyBtn = e.target.closest('.vab-copy-btn');
       if (copyBtn) { this._onCopyClick(copyBtn.getAttribute('data-vab-copy')); return; }
-
-      // Collapsed-mode mini registry toggle
-      var miniReg = e.target.closest('[data-vab-mini-registry]');
-      if (miniReg) { this._onRegistryPillClick(miniReg.getAttribute('data-vab-mini-registry')); return; }
 
       // Collapsed-mode mini copy button
       var miniCopy = e.target.closest('[data-vab-mini-copy]');
@@ -840,7 +758,7 @@
     // F4: keyboard navigation for radiogroup pills (WAI-ARIA APG roving tabindex).
     // ArrowLeft/Right move focus+selection; Home/End jump to first/last.
     _onKeydown(e) {
-      var pill = e.target.closest('.vab-registry-pill, .vab-version-pill, .vab-flavor-pill');
+      var pill = e.target.closest('.vab-version-pill, .vab-flavor-pill');
       if (!pill) { return; }
       var keys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
       if (keys.indexOf(e.key) === -1) { return; }

--- a/docs/site/assets/js/components/variant-action-bar.js
+++ b/docs/site/assets/js/components/variant-action-bar.js
@@ -58,37 +58,15 @@
       this._imageBase = this.dataset.imageBase || '';
       this._defaultTag = this.dataset.defaultTag || '';
 
-      // variants: flat lookup array of all variant objects
-      this._variants = parse(this.dataset.variants, []).filter(function (variant) {
-        return variant.reference_confirmed !== false;
-      });
-      // Keep a defensive runtime boundary as well as the Liquid filter: a
-      // selectable version must have at least one record the component can
-      // show. Older generated pages may still carry reference_confirmed.
-      this._versions = parse(this.dataset.versions, []).filter(function (version) {
-        return this._variants.some(function (variant) {
-          return variant.version === version.tag;
-        });
-      }, this);
-      // The component rebuilds this when a version changes; start with the
-      // confirmed records for the selected version below.
+      this._versions = parse(this.dataset.versions, []);
       this._flavors = parse(this.dataset.flavors, []);
+      this._variants = parse(this.dataset.variants, []);
 
       // Select the first version/flavor as default
-      var requestedVersion = this.dataset.defaultVersion || '';
-      var hasRequestedVersion = this._versions.some(function (version) {
-        return version.tag === requestedVersion;
-      });
-      this._selectedVersion = hasRequestedVersion
-        ? requestedVersion
-        : (this._versions[0] && this._versions[0].tag) || '';
+      this._selectedVersion = this.dataset.defaultVersion
+        || (this._versions[0] && this._versions[0].tag) || '';
       this._selectedFlavor = this.dataset.defaultFlavor
         || (this._flavors[0] && this._flavors[0].name) || '';
-
-      if (this._selectedVersion) {
-        this._flavors = this._flavorsForVersion(this._selectedVersion);
-        this._selectedFlavor = this._flavors[0] ? this._flavors[0].name : '';
-      }
 
       // Find initial selected variant
       this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
@@ -123,19 +101,6 @@
       }
 
       return variants[0] || null;
-    }
-
-    _flavorsForVersion(version) {
-      var flavors = [];
-      var seen = {};
-      for (var i = 0; i < this._variants.length; i++) {
-        var variant = this._variants[i];
-        var flavor = variant.flavor || variant.name || '';
-        if (variant.version !== version || !flavor || seen[flavor]) { continue; }
-        seen[flavor] = true;
-        flavors.push({ name: flavor, label: flavor });
-      }
-      return flavors;
     }
 
     // -------------------------------------------------------
@@ -381,7 +346,9 @@
       var stickyEl = this.querySelector('[data-vab-sticky-cmd]');
       if (!stickyEl) { return; }
       var pullEl = this.querySelector('[data-vab-cmd="pull"]');
-      if (pullEl) { stickyEl.textContent = pullEl.textContent; }
+      stickyEl.textContent = this._hasCommand && pullEl ? pullEl.textContent : '';
+      stickyEl.disabled = !this._hasCommand;
+      stickyEl.setAttribute('aria-disabled', this._hasCommand ? 'false' : 'true');
       stickyEl.setAttribute('aria-label', this._buildCopyAriaLabel());
     }
 
@@ -444,6 +411,7 @@
 
     _updateCommands() {
       var v = this._currentVariant;
+      var confirmed = !!(v && v.reference_confirmed === true);
       var tag = (v && v.tag) ? v.tag : this._defaultTag;
       var ghcrBase = this._imageBase;
       var owner = this._extractOwner(ghcrBase);
@@ -452,11 +420,18 @@
       var verifyCmd = 'cosign verify ' + ghcrBase + ':' + tag
         + ' --certificate-identity-regexp=https://github.com/' + owner
         + ' --certificate-oidc-issuer=https://token.actions.githubusercontent.com';
+      var unavailable = 'No published image was observed for this reference.';
 
       var pullEl = this.querySelector('[data-vab-cmd="pull"]');
       var verifyEl = this.querySelector('[data-vab-cmd="verify"]');
-      if (pullEl) { pullEl.textContent = pullCmd; }
-      if (verifyEl) { verifyEl.textContent = verifyCmd; }
+      if (pullEl) { pullEl.textContent = confirmed ? pullCmd : unavailable; }
+      if (verifyEl) { verifyEl.textContent = confirmed ? verifyCmd : unavailable; }
+      this._hasCommand = confirmed;
+      var copyButtons = this.querySelectorAll('[data-vab-copy], [data-vab-mini-copy]');
+      for (var i = 0; i < copyButtons.length; i++) {
+        copyButtons[i].disabled = !confirmed;
+        copyButtons[i].setAttribute('aria-disabled', confirmed ? 'false' : 'true');
+      }
 
       this._updateCollapsedActionsState();
       // Sync sticky pull command text in collapsed bandeau
@@ -494,10 +469,10 @@
 
     _onVersionPillClick(value) {
       this._selectedVersion = value;
-      this._flavors = this._flavorsForVersion(value);
-      this._selectedFlavor = (this._flavors[0] && this._flavors[0].name) || '';
+      this._updatePillActive('vab-version-pill', value);
       this._currentVariant = this._findVariant(this._selectedVersion, this._selectedFlavor);
-      this._render();
+      this._updateCommands();
+      this._updateSignals();
       this._dispatchVariantChanged();
     }
 

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -39,8 +39,8 @@
 
       cards.forEach(function(card) {
         var name = card.dataset.container.toLowerCase();
-        var statusColor = card.classList.contains('status-green') ? 'up-to-date' :
-                         card.classList.contains('status-warning') ? 'update-available' :
+        var statusColor = card.dataset.updateAvailable === 'true' ? 'update-available' :
+                         card.classList.contains('status-green') ? 'up-to-date' :
                          'not-published';
         // F1: also match description text and variant tag names
         var descEl = card.querySelector('.card-description');
@@ -87,10 +87,10 @@
       var counts = { 'all': cards.length, 'up-to-date': 0, 'update-available': 0, 'not-published': 0 };
 
       cards.forEach(function(card) {
-        if (card.classList.contains('status-green')) {
-          counts['up-to-date']++;
-        } else if (card.classList.contains('status-warning')) {
+        if (card.dataset.updateAvailable === 'true') {
           counts['update-available']++;
+        } else if (card.classList.contains('status-green')) {
+          counts['up-to-date']++;
         } else {
           counts['not-published']++;
         }
@@ -173,10 +173,15 @@
       var pullSection = card.querySelector('.pull-section');
       var ghcrBase = pullSection ? pullSection.dataset.ghcrBase : '';
       var imageUrl = ghcrBase + ':' + tag;
+      var referenceConfirmed = element.dataset.referenceConfirmed === 'true';
 
       var containerName = card.dataset.container;
       var input = document.getElementById('pull-' + containerName);
-      if (input) input.value = 'docker pull ' + imageUrl;
+      var pullCommand = card.querySelector('[data-pull-command]');
+      var pullUnavailable = card.querySelector('[data-pull-unavailable]');
+      if (pullCommand) pullCommand.hidden = !referenceConfirmed;
+      if (pullUnavailable) pullUnavailable.hidden = referenceConfirmed;
+      if (input && referenceConfirmed) input.value = 'docker pull ' + imageUrl;
 
       var sizeAmd64El = card.querySelector('[data-meta="size-amd64"]');
       var sizeArm64El = card.querySelector('[data-meta="size-arm64"]');

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -2,7 +2,9 @@
     'use strict';
 
     // State (theme managed by shared theme.js)
-    var currentRegistry = localStorage.getItem('preferredRegistry') || 'ghcr';
+    // This dashboard run has per-reference evidence only for GHCR. A saved
+    // mirror preference must not recreate a Docker Hub command by convention.
+    var currentRegistry = 'ghcr';
     var currentSearch = '';
     var currentStatus = 'all';
 
@@ -17,6 +19,7 @@
     // Set global registry for all containers
     function setGlobalRegistry(registry, save) {
       if (save === undefined) save = true;
+      if (registry !== 'ghcr') registry = 'ghcr';
       currentRegistry = registry;
       if (save) {
         localStorage.setItem('preferredRegistry', registry);
@@ -38,7 +41,9 @@
           var defaultTag = pullSection.dataset.defaultTag;
           var selectedVariant = card.querySelector('.variant-tag.selected');
           var tag = selectedVariant ? selectedVariant.dataset.tag : defaultTag;
-          var baseUrl = registry === 'ghcr' ? ghcrBase : dockerhubBase;
+          // Docker Hub is selectable only where the generator emitted an
+          // observed mirror reference. Never synthesize one from the name.
+          var baseUrl = registry === 'dockerhub' && dockerhubBase ? dockerhubBase : ghcrBase;
           var imageUrl = baseUrl + ':' + tag;
           var containerName = card.dataset.container;
           var input = document.getElementById('pull-' + containerName);
@@ -213,7 +218,7 @@
       var pullSection = card.querySelector('.pull-section');
       var ghcrBase = pullSection ? pullSection.dataset.ghcrBase : '';
       var dockerhubBase = pullSection ? pullSection.dataset.dockerhubBase : '';
-      var baseUrl = currentRegistry === 'ghcr' ? ghcrBase : dockerhubBase;
+      var baseUrl = currentRegistry === 'dockerhub' && dockerhubBase ? dockerhubBase : ghcrBase;
       var imageUrl = baseUrl + ':' + tag;
 
       var containerName = card.dataset.container;

--- a/docs/site/assets/js/dashboard.js
+++ b/docs/site/assets/js/dashboard.js
@@ -2,9 +2,6 @@
     'use strict';
 
     // State (theme managed by shared theme.js)
-    // This dashboard run has per-reference evidence only for GHCR. A saved
-    // mirror preference must not recreate a Docker Hub command by convention.
-    var currentRegistry = 'ghcr';
     var currentSearch = '';
     var currentStatus = 'all';
 
@@ -13,48 +10,6 @@
       var liveRegion = document.getElementById('status-live');
       if (liveRegion) {
         liveRegion.textContent = message;
-      }
-    }
-
-    // Set global registry for all containers
-    function setGlobalRegistry(registry, save) {
-      if (save === undefined) save = true;
-      if (registry !== 'ghcr') registry = 'ghcr';
-      currentRegistry = registry;
-      if (save) {
-        localStorage.setItem('preferredRegistry', registry);
-      }
-
-      // Update toggle buttons and ARIA state
-      document.querySelectorAll('.registry-btn').forEach(function(btn) {
-        var isActive = btn.dataset.registry === registry;
-        btn.classList.toggle('active', isActive);
-        btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
-      });
-
-      // Update all container cards
-      document.querySelectorAll('.container-card').forEach(function(card) {
-        var pullSection = card.querySelector('.pull-section');
-        if (pullSection) {
-          var ghcrBase = pullSection.dataset.ghcrBase;
-          var dockerhubBase = pullSection.dataset.dockerhubBase;
-          var defaultTag = pullSection.dataset.defaultTag;
-          var selectedVariant = card.querySelector('.variant-tag.selected');
-          var tag = selectedVariant ? selectedVariant.dataset.tag : defaultTag;
-          // Docker Hub is selectable only where the generator emitted an
-          // observed mirror reference. Never synthesize one from the name.
-          var baseUrl = registry === 'dockerhub' && dockerhubBase ? dockerhubBase : ghcrBase;
-          var imageUrl = baseUrl + ':' + tag;
-          var containerName = card.dataset.container;
-          var input = document.getElementById('pull-' + containerName);
-          if (input) {
-            input.value = 'docker pull ' + imageUrl;
-          }
-        }
-      });
-
-      if (save) {
-        announceStatus('Registry switched to ' + (registry === 'ghcr' ? 'GitHub Container Registry' : 'Docker Hub'));
       }
     }
 
@@ -217,9 +172,7 @@
 
       var pullSection = card.querySelector('.pull-section');
       var ghcrBase = pullSection ? pullSection.dataset.ghcrBase : '';
-      var dockerhubBase = pullSection ? pullSection.dataset.dockerhubBase : '';
-      var baseUrl = currentRegistry === 'dockerhub' && dockerhubBase ? dockerhubBase : ghcrBase;
-      var imageUrl = baseUrl + ':' + tag;
+      var imageUrl = ghcrBase + ':' + tag;
 
       var containerName = card.dataset.container;
       var input = document.getElementById('pull-' + containerName);
@@ -302,9 +255,6 @@
 
     // Event delegation — no inline onclick handlers
     document.addEventListener('DOMContentLoaded', function() {
-      // Restore registry preference
-      setGlobalRegistry(currentRegistry, false);
-
       // Auto-select text on click
       document.querySelectorAll('input[id^="pull-"]').forEach(function(input) {
         input.addEventListener('click', function() { this.select(); });
@@ -318,13 +268,6 @@
       if (themeBtn) themeBtn.addEventListener('click', function() {
         ThemeManager.toggleTheme();
         announceStatus('Theme switched to ' + ThemeManager.currentTheme + ' mode');
-      });
-
-      // Registry buttons
-      document.querySelectorAll('.registry-btn').forEach(function(btn) {
-        btn.addEventListener('click', function() {
-          setGlobalRegistry(this.dataset.registry);
-        });
       });
 
       // Search input

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -23,6 +23,7 @@ description: Real-time status monitoring for Docker containers with automated up
      name=container.name
      current_version=container.current_version
      current_version_confirmed=container.current_version_confirmed
+     update_available=container.update_available
      latest_version=container.latest_version
      status_color=container.status_color
      status_text=container.status_text

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -9,6 +9,7 @@ description: Real-time status monitoring for Docker containers with automated up
    total_containers=site.data.stats.total_containers
    up_to_date=site.data.stats.up_to_date
    updates_available=site.data.stats.updates_available
+   unpublished_releases=site.data.stats.unpublished_releases
    build_success_rate=site.data.stats.build_success_rate
 %}
 
@@ -96,6 +97,10 @@ description: Real-time status monitoring for Docker containers with automated up
     <div class="health-item">
       <span class="health-label">Updates Available</span>
       <span class="health-value">{{ site.data.stats.updates_available }}</span>
+    </div>
+    <div class="health-item">
+      <span class="health-label">Unpublished Releases</span>
+      <span class="health-value">{{ site.data.stats.unpublished_releases | default: 0 }}</span>
     </div>
     <div class="health-item">
       <span class="health-label">Last Check</span>

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -308,38 +308,82 @@ get_container_versions() {
     local container=$1
 
     pushd "$container" >/dev/null 2>&1 || {
-        echo "unknown|unknown|secondary|Unknown Status"
+        jq -nc '{
+            current_version: "", latest_version: "", status_color: "secondary",
+            status_text: "Unknown Status", current_version_confirmed: false,
+            upstream_lookup: "failed", comparison_concluded: false,
+            update_available: false, unpublished_release: false
+        }'
         return 1
     }
 
     local current_version latest_version status_color status_text current_version_confirmed="false"
+    local upstream_lookup="failed" upstream_output comparison_concluded="false"
+    local update_available="false" unpublished_release="false"
 
     local _t0_skopeo=${EPOCHREALTIME:-}
-    current_version=$(get_current_published_version "oorabona/$container")
+    if ! current_version=$(get_current_published_version "oorabona/$container"); then
+        # A registry failure is not an empty-but-concluded publication lookup.
+        # Either way there is no version to compare in this dashboard run.
+        current_version=""
+    fi
     log_latency "skopeo-list-tags oorabona/$container" "$_t0_skopeo" 60
-    if [[ -n "$current_version" ]]; then
+    if [[ -n "$current_version" && "$current_version" != "unknown" ]]; then
         current_version_confirmed="true"
     fi
 
-    latest_version=$(timeout 30 ./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
+    # Capture version.sh before selecting its display line.  A resolver that
+    # writes a version and then fails has not established a usable candidate.
+    if upstream_output=$(timeout 30 ./version.sh 2>/dev/null); then
+        latest_version=$(printf '%s' "$upstream_output" | head -1 | tr -d '\n')
+        [[ -n "$latest_version" ]] && upstream_lookup="matched" || upstream_lookup="no-match"
+    else
+        latest_version=""
+    fi
 
     popd >/dev/null 2>&1
 
     if [[ "$current_version_confirmed" != "true" ]]; then
         status_color="warning"
         status_text="Publication information unavailable"
-    elif [[ "$current_version" == "unknown" || "$latest_version" == "unknown" ]]; then
+        if [[ "$upstream_lookup" == "matched" ]]; then
+            unpublished_release="true"
+        fi
+    elif [[ "$upstream_lookup" != "matched" ]]; then
         status_color="secondary"
-        status_text="Unknown Status"
+        status_text="Upstream version unavailable"
     elif [[ "$current_version" == "$latest_version" ]]; then
         status_color="green"
         status_text="Up to Date"
+        comparison_concluded="true"
     else
         status_color="warning"
         status_text="Update Available"
+        comparison_concluded="true"
+        update_available="true"
     fi
 
-    echo "${current_version}|${latest_version}|${status_color}|${status_text}|${current_version_confirmed}"
+    jq -nc \
+        --arg current_version "$current_version" \
+        --arg latest_version "$latest_version" \
+        --arg status_color "$status_color" \
+        --arg status_text "$status_text" \
+        --arg upstream_lookup "$upstream_lookup" \
+        --argjson current_version_confirmed "$current_version_confirmed" \
+        --argjson comparison_concluded "$comparison_concluded" \
+        --argjson update_available "$update_available" \
+        --argjson unpublished_release "$unpublished_release" \
+        '{
+            current_version: $current_version,
+            latest_version: $latest_version,
+            status_color: $status_color,
+            status_text: $status_text,
+            current_version_confirmed: $current_version_confirmed,
+            upstream_lookup: $upstream_lookup,
+            comparison_concluded: $comparison_concluded,
+            update_available: $update_available,
+            unpublished_release: $unpublished_release
+        }'
 }
 
 # Get container description from README
@@ -883,6 +927,7 @@ collect_variant_json() {
         {
             name: $name, tag: $tag, description: $desc,
             is_default: $is_default,
+            reference_confirmed: (($lineage.multi_arch_index_digest // "") | length > 0),
             size_amd64: $size_amd64, size_arm64: $size_arm64,
             build_digest: $lineage.build_digest,
             base_image: $lineage.base_image,
@@ -1451,11 +1496,11 @@ fetch_recent_activity() {
 }
 
 # Write dashboard stats YAML file
-# Args: total up_to_date updates_available build_success build_total build_success_rate activity_yaml
+# Args: total up_to_date updates_available unpublished_releases build_success build_total build_success_rate activity_yaml
 write_stats_file() {
-    local total="$1" up_to_date="$2" updates_available="$3"
-    local build_success="$4" build_total="$5" build_success_rate="$6"
-    local activity_yaml="$7"
+    local total="$1" up_to_date="$2" updates_available="$3" unpublished_releases="$4"
+    local build_success="$5" build_total="$6" build_success_rate="$7"
+    local activity_yaml="$8"
 
     cat > "$STATS_FILE" << EOF
 # Auto-generated dashboard statistics
@@ -1464,6 +1509,7 @@ write_stats_file() {
 total_containers: $total
 up_to_date: $up_to_date
 updates_available: $updates_available
+unpublished_releases: $unpublished_releases
 build_success_rate: $build_success_rate
 build_success_count: $build_success
 build_total_count: $build_total
@@ -1567,7 +1613,7 @@ generate_data() {
     populate_container_build_status_cache
     load_dockerhub_pull_trends >/dev/null
 
-    local total=0 up_to_date=0 updates_available=0
+    local total=0 up_to_date=0 updates_available=0 unpublished_releases=0
     local all_containers_json="[]"
 
     # Prepare containers collection directory
@@ -1591,9 +1637,17 @@ generate_data() {
         local version_info
         version_info=$(get_container_versions "$container")
 
-        local current_version_confirmed
-        IFS='|' read -r current_version latest_version status_color status_text current_version_confirmed <<< "$version_info"
-        [[ "$current_version_confirmed" == "true" ]] || current_version_confirmed="false"
+        local current_version latest_version status_color status_text current_version_confirmed
+        local upstream_lookup comparison_concluded update_available unpublished_release
+        current_version=$(jq -r '.current_version // ""' <<< "$version_info")
+        latest_version=$(jq -r '.latest_version // ""' <<< "$version_info")
+        status_color=$(jq -r '.status_color // "secondary"' <<< "$version_info")
+        status_text=$(jq -r '.status_text // "Unknown Status"' <<< "$version_info")
+        current_version_confirmed=$(jq -r '.current_version_confirmed == true' <<< "$version_info")
+        upstream_lookup=$(jq -r '.upstream_lookup // "failed"' <<< "$version_info")
+        comparison_concluded=$(jq -r '.comparison_concluded == true' <<< "$version_info")
+        update_available=$(jq -r '.update_available == true' <<< "$version_info")
+        unpublished_release=$(jq -r '.unpublished_release == true' <<< "$version_info")
 
         local description
         description=$(get_container_description "$container")
@@ -1612,10 +1666,9 @@ generate_data() {
         fi
 
         total=$((total + 1))
-        case "$status_color" in
-            "green") up_to_date=$((up_to_date + 1)) ;;
-            "warning") updates_available=$((updates_available + 1)) ;;
-        esac
+        [[ "$comparison_concluded" == "true" && "$status_color" == "green" ]] && up_to_date=$((up_to_date + 1))
+        [[ "$update_available" == "true" ]] && updates_available=$((updates_available + 1))
+        [[ "$unpublished_release" == "true" ]] && unpublished_releases=$((unpublished_releases + 1))
 
         # Get Docker Hub stats (pulls and stars)
         local dockerhub_stats pull_count pull_count_formatted star_count pull_trend_json
@@ -1641,15 +1694,19 @@ generate_data() {
         build_digest=$(get_build_lineage_field "$container" "build_digest")
         base_image=$(get_build_lineage_field "$container" "base_image_ref")
 
+        # The GHCR lookup above confirms this exact default reference. No
+        # equivalent per-reference Docker Hub evidence is collected here, so
+        # do not manufacture a mirror command from a naming convention.
         local container_json
         container_json=$(
             NAME="$container" \
             CV="$current_version" LV="$latest_version" \
             CVC="$current_version_confirmed" \
+            UL="$upstream_lookup" CC="$comparison_concluded" UA="$update_available" UR="$unpublished_release" \
             SC="$status_color" ST="$status_text" BS="$build_status" \
             DESC="$description" \
             GHCR="$([[ "$current_version_confirmed" == "true" ]] && printf 'ghcr.io/oorabona/%s:%s' "$container" "$current_version")" \
-            DH="$([[ "$current_version_confirmed" == "true" ]] && printf 'docker.io/oorabona/%s:%s' "$container" "$current_version")" \
+            DH="" \
             BD="$build_digest" BI="$base_image" \
             PC="$pull_count" PCF="$pull_count_formatted" SC2="$star_count" \
             SA="$sizes_amd64" SR="$sizes_arm64" \
@@ -1657,6 +1714,8 @@ generate_data() {
                 .name = strenv(NAME) |
                 .current_version = strenv(CV) | .latest_version = strenv(LV) |
                 .current_version_confirmed = (strenv(CVC) == "true") |
+                .upstream_lookup = strenv(UL) | .comparison_concluded = (strenv(CC) == "true") |
+                .update_available = (strenv(UA) == "true") | .unpublished_release = (strenv(UR) == "true") |
                 .status_color = strenv(SC) | .status_text = strenv(ST) | .build_status = strenv(BS) |
                 .description = strenv(DESC) |
                 .ghcr_image = strenv(GHCR) | .dockerhub_image = strenv(DH) |
@@ -1905,7 +1964,7 @@ generate_data() {
     activity_yaml=$(fetch_recent_activity)
 
     # Write stats file
-    write_stats_file "$total" "$up_to_date" "$updates_available" \
+    write_stats_file "$total" "$up_to_date" "$updates_available" "$unpublished_releases" \
         "$build_success" "$build_total" "$build_success_rate" "$activity_yaml"
 
     log_info "Generated $DATA_FILE with $total containers"

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -314,7 +314,10 @@ get_container_versions() {
             upstream_lookup: "failed", comparison_concluded: false,
             update_available: false, unpublished_release: false
         }'
-        return 1
+        # The caller runs under set -e. The structured failed-lookup record is
+        # the handling for this error, so do not discard it by returning a
+        # failing status from the command substitution.
+        return 0
     }
 
     local current_version latest_version status_color status_text current_version_confirmed="false"
@@ -344,8 +347,12 @@ get_container_versions() {
         if latest_version=$(version_lookup_candidate "$upstream_output"); then
             upstream_lookup="matched"
         else
+            local upstream_rc=$?
             latest_version=""
-            upstream_lookup="no-match"
+            case "$upstream_rc" in
+                1) upstream_lookup="no-match" ;;
+                *) upstream_lookup="failed" ;;
+            esac
         fi
     else
         latest_version=""

--- a/generate-dashboard.sh
+++ b/generate-dashboard.sh
@@ -318,14 +318,20 @@ get_container_versions() {
     }
 
     local current_version latest_version status_color status_text current_version_confirmed="false"
+    local publication_lookup publication_rc
     local upstream_lookup="failed" upstream_output comparison_concluded="false"
     local update_available="false" unpublished_release="false"
 
     local _t0_skopeo=${EPOCHREALTIME:-}
-    if ! current_version=$(get_current_published_version "oorabona/$container"); then
-        # A registry failure is not an empty-but-concluded publication lookup.
-        # Either way there is no version to compare in this dashboard run.
+    if current_version=$(get_current_published_version "oorabona/$container"); then
+        publication_lookup="matched"
+    else
+        publication_rc=$?
         current_version=""
+        case "$publication_rc" in
+            1) publication_lookup="no-match" ;;
+            *) publication_lookup="failed" ;;
+        esac
     fi
     log_latency "skopeo-list-tags oorabona/$container" "$_t0_skopeo" 60
     if [[ -n "$current_version" && "$current_version" != "unknown" ]]; then
@@ -335,8 +341,12 @@ get_container_versions() {
     # Capture version.sh before selecting its display line.  A resolver that
     # writes a version and then fails has not established a usable candidate.
     if upstream_output=$(timeout 30 ./version.sh 2>/dev/null); then
-        latest_version=$(printf '%s' "$upstream_output" | head -1 | tr -d '\n')
-        [[ -n "$latest_version" ]] && upstream_lookup="matched" || upstream_lookup="no-match"
+        if latest_version=$(version_lookup_candidate "$upstream_output"); then
+            upstream_lookup="matched"
+        else
+            latest_version=""
+            upstream_lookup="no-match"
+        fi
     else
         latest_version=""
     fi
@@ -346,7 +356,7 @@ get_container_versions() {
     if [[ "$current_version_confirmed" != "true" ]]; then
         status_color="warning"
         status_text="Publication information unavailable"
-        if [[ "$upstream_lookup" == "matched" ]]; then
+        if [[ "$publication_lookup" == "no-match" && "$upstream_lookup" == "matched" ]]; then
             unpublished_release="true"
         fi
     elif [[ "$upstream_lookup" != "matched" ]]; then
@@ -927,7 +937,7 @@ collect_variant_json() {
         {
             name: $name, tag: $tag, description: $desc,
             is_default: $is_default,
-            reference_confirmed: (($lineage.multi_arch_index_digest // "") | length > 0),
+            reference_confirmed: (($multi_arch_digests.index_digest // "") | length > 0),
             size_amd64: $size_amd64, size_arm64: $size_arm64,
             build_digest: $lineage.build_digest,
             base_image: $lineage.base_image,

--- a/helpers/version-utils.sh
+++ b/helpers/version-utils.sh
@@ -14,16 +14,20 @@ version_first_line() {
     printf '%s\n' "$line"
 }
 
-# A successful resolver with no usable version is a concluded no-match, not a
-# candidate. Keep this normalization shared by dashboard and monitor callers.
+# A successful resolver with an explicit sentinel is a concluded no-match, not
+# a candidate. Corrupted or unreadable output is a failed lookup instead. Keep
+# this normalization shared by dashboard and monitor callers.
 version_lookup_candidate() {
     local candidate raw_first_line=${1%%$'\n'*}
     # A CR is not part of a tag. Reject it rather than silently offering a
-    # transport-corrupted value as an update target.
-    [[ "$raw_first_line" != *$'\r'* ]] || return 1
+    # transport-corrupted value as an update target. This is not evidence that
+    # the tag is absent, so it must not use the no-match status.
+    [[ "$raw_first_line" != *$'\r'* ]] || return 3
+    # `unknown` is the resolver's explicit no-candidate sentinel.
+    [[ "$raw_first_line" != "unknown" ]] || return 1
     candidate=$(version_first_line "$1")
-    [[ "$candidate" =~ [^[:space:]] ]] || return 1
-    [[ "$candidate" != "unknown" ]] || return 1
+    # A successful resolver that produced no usable bytes did not conclude.
+    [[ "$candidate" =~ [^[:space:]] ]] || return 3
     printf '%s\n' "$candidate"
 }
 
@@ -105,7 +109,7 @@ get_registry_pattern() {
 # Note: defaults to GHCR (primary registry) when no registry prefix is provided
 get_current_published_version() {
     local image="$1"
-    local pattern output rc
+    local pattern output rc candidate candidate_rc
     pattern=$(get_registry_pattern)
 
     # Default to GHCR (primary registry) unless a specific registry is provided
@@ -120,9 +124,16 @@ get_current_published_version() {
     fi
 
     # Preserve latest-docker-tag's three states: 0 matched, 1 no-match, and
-    # 3 failed enumeration. A successful sentinel is no-match.
+    # 3 failed enumeration. Only its exit 1 or the explicit `unknown` sentinel
+    # below conclude that there was no candidate.
     if [[ "$rc" -eq 0 ]]; then
-        version_lookup_candidate "$output" || return 1
+        if candidate=$(version_lookup_candidate "$output"); then
+            printf '%s\n' "$candidate"
+            return 0
+        else
+            candidate_rc=$?
+            return "$candidate_rc"
+        fi
     fi
     return "$rc"
 }

--- a/helpers/version-utils.sh
+++ b/helpers/version-utils.sh
@@ -5,6 +5,28 @@
 # Default semver pattern when container has no custom --registry-pattern
 DEFAULT_VERSION_PATTERN='^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'
 
+# Extract a first line from already-captured output without `printf | head`.
+# Under pipefail that pipeline can report SIGPIPE when the output is large even
+# though the resolver itself succeeded.
+version_first_line() {
+    local line=${1%%$'\n'*}
+    line=${line%$'\r'}
+    printf '%s\n' "$line"
+}
+
+# A successful resolver with no usable version is a concluded no-match, not a
+# candidate. Keep this normalization shared by dashboard and monitor callers.
+version_lookup_candidate() {
+    local candidate raw_first_line=${1%%$'\n'*}
+    # A CR is not part of a tag. Reject it rather than silently offering a
+    # transport-corrupted value as an update target.
+    [[ "$raw_first_line" != *$'\r'* ]] || return 1
+    candidate=$(version_first_line "$1")
+    [[ "$candidate" =~ [^[:space:]] ]] || return 1
+    [[ "$candidate" != "unknown" ]] || return 1
+    printf '%s\n' "$candidate"
+}
+
 _version_numeric_tuple() {
     local version="$1"
     if [[ "$version" =~ ^[vV]?([0-9]+([.][0-9]+)*) ]]; then
@@ -83,7 +105,7 @@ get_registry_pattern() {
 # Note: defaults to GHCR (primary registry) when no registry prefix is provided
 get_current_published_version() {
     local image="$1"
-    local pattern
+    local pattern output rc
     pattern=$(get_registry_pattern)
 
     # Default to GHCR (primary registry) unless a specific registry is provided
@@ -91,5 +113,16 @@ get_current_published_version() {
         image="ghcr.io/$image"
     fi
 
-    ../helpers/latest-docker-tag "$image" "$pattern" 2>/dev/null | head -1 | tr -d '\n'
+    if output=$(../helpers/latest-docker-tag "$image" "$pattern" 2>/dev/null); then
+        rc=0
+    else
+        rc=$?
+    fi
+
+    # Preserve latest-docker-tag's three states: 0 matched, 1 no-match, and
+    # 3 failed enumeration. A successful sentinel is no-match.
+    if [[ "$rc" -eq 0 ]]; then
+        version_lookup_candidate "$output" || return 1
+    fi
+    return "$rc"
 }

--- a/make
+++ b/make
@@ -319,10 +319,13 @@ show_sizes() {
     # Show registry sizes
     echo "   └── Registries:"
 
-    # Get latest tag from version.sh if available, fallback to "latest"
-    local latest_tag
+    # Get latest tag from version.sh if available, fallback to "latest".
+    # A failed lookup may have produced partial stdout; it is not a tag.
+    local latest_tag upstream_lookup upstream_info
     if [[ -f "$container/version.sh" ]]; then
-      latest_tag=$("$container/version.sh" 2>/dev/null | head -1)
+      upstream_info=$(check_updates_upstream_version "$container/version.sh")
+      IFS=$'\t' read -r upstream_lookup latest_tag <<< "$upstream_info"
+      [[ "$upstream_lookup" == "matched" ]] || latest_tag=""
     fi
     [[ -z "$latest_tag" ]] && latest_tag="latest"
 
@@ -563,6 +566,28 @@ check_updates_current_version() {
   esac
 }
 
+# Emit a tab-separated upstream lookup outcome and confirmed candidate version.
+# Do not pipe version.sh into head: a script can emit a plausible first line and
+# then fail, in which case there is no established upstream candidate.
+check_updates_upstream_version() {
+  local output rc
+
+  if output=$("$@" 2>/dev/null); then
+    rc=0
+  else
+    rc=$?
+  fi
+  output=$(printf '%s' "$output" | head -1 | tr -d '\n')
+
+  if [[ "$rc" -ne 0 ]]; then
+    printf 'failed\t\n'
+  elif [[ -n "$output" ]]; then
+    printf 'matched\t%s\n' "$output"
+  else
+    printf 'no-match\t\n'
+  fi
+}
+
 # An absent declaration preserves the historical behaviour (actionable when
 # there is a confirmed update). Do not use yq's `// true` here: false is a
 # valid declaration and must not be coalesced with an absent value.
@@ -649,8 +674,9 @@ check_updates() {
         IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
 
         # Latest upstream version for this major line
-        local latest_version
-        latest_version=$(./version.sh --major "$major" 2>/dev/null | head -1 | tr -d '\n' || echo "")
+        local latest_version upstream_lookup upstream_info
+        upstream_info=$(check_updates_upstream_version ./version.sh --major "$major")
+        IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_info"
 
         # Determine update status
         local update_available="false"
@@ -659,6 +685,8 @@ check_updates() {
 
         if [[ "$registry_lookup" == "failed" ]]; then
           status="registry-lookup-failed"
+        elif [[ "$upstream_lookup" == "failed" ]]; then
+          status="upstream-lookup-failed"
         elif [[ "$registry_lookup" == "no-match" ]]; then
           if [ -n "$latest_version" ]; then
             update_available="true"
@@ -678,7 +706,7 @@ check_updates() {
           fi
         fi
 
-        if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+        if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" == "matched" && "$declared_actionable" == "true" ]]; then
           actionable="true"
         fi
 
@@ -694,6 +722,7 @@ check_updates() {
           --argjson update_available "$update_available" \
           --argjson actionable "$actionable" \
           --arg registry_lookup "$registry_lookup" \
+          --arg upstream_lookup "$upstream_lookup" \
           --arg status "$status" \
           '{
             container: $container,
@@ -703,6 +732,7 @@ check_updates() {
             update_available: $update_available,
             actionable: $actionable,
             registry_lookup: $registry_lookup,
+            upstream_lookup: $upstream_lookup,
             status: $status
           }')
 
@@ -725,7 +755,9 @@ check_updates() {
       fi
     fi
     IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
-    latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
+    local upstream_lookup upstream_info
+    upstream_info=$(check_updates_upstream_version ./version.sh)
+    IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_info"
 
     # Determine update status
     local update_available="false"
@@ -734,6 +766,8 @@ check_updates() {
 
     if [[ "$registry_lookup" == "failed" ]]; then
       status="registry-lookup-failed"
+    elif [[ "$upstream_lookup" == "failed" ]]; then
+      status="upstream-lookup-failed"
     elif [[ "$registry_lookup" == "no-match" ]]; then
       if [ -n "$latest_version" ]; then
         update_available="true"
@@ -753,7 +787,7 @@ check_updates() {
       fi
     fi
 
-    if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+    if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" == "matched" && "$declared_actionable" == "true" ]]; then
       actionable="true"
     fi
 
@@ -765,6 +799,7 @@ check_updates() {
       --argjson update_available "$update_available" \
       --argjson actionable "$actionable" \
       --arg registry_lookup "$registry_lookup" \
+      --arg upstream_lookup "$upstream_lookup" \
       --arg status "$status" \
       '{
         container: $container,
@@ -773,6 +808,7 @@ check_updates() {
         update_available: $update_available,
         actionable: $actionable,
         registry_lookup: $registry_lookup,
+        upstream_lookup: $upstream_lookup,
         status: $status
       }')
 

--- a/make
+++ b/make
@@ -551,7 +551,7 @@ make() {
 check_updates_current_version() {
   local image=$1
   local pattern=$2
-  local current_version rc
+  local current_version rc candidate_rc
 
   if current_version=$(../helpers/latest-docker-tag "$image" "$pattern" 2>/dev/null); then
     rc=0
@@ -561,10 +561,18 @@ check_updates_current_version() {
   case "$rc" in
     0)
       # no-published-version is a legacy caller sentinel, never a confirmed tag.
-      if current_version=$(version_lookup_candidate "$current_version") && [[ "$current_version" != "no-published-version" ]]; then
-        printf 'matched\t%s\n' "$current_version"
+      if current_version=$(version_lookup_candidate "$current_version"); then
+        if [[ "$current_version" != "no-published-version" ]]; then
+          printf 'matched\t%s\n' "$current_version"
+        else
+          printf 'no-match\t\n'
+        fi
       else
-        printf 'no-match\t\n'
+        candidate_rc=$?
+        case "$candidate_rc" in
+          1) printf 'no-match\t\n' ;;
+          *) printf 'failed\t\n' ;;
+        esac
       fi
       ;;
     1) printf 'no-match\t\n' ;;
@@ -578,7 +586,7 @@ check_updates_current_version() {
 check_updates_upstream_version() {
   # A lookup that exceeds either documented bound has not established a
   # candidate. The values are overridable only to keep refusal tests fast.
-  local output candidate output_file rc
+  local output candidate output_file rc candidate_rc
   local timeout_seconds="${CHECK_UPDATES_UPSTREAM_TIMEOUT_SECONDS:-30}"
   local max_output_blocks="${CHECK_UPDATES_UPSTREAM_MAX_OUTPUT_BLOCKS:-1024}"
 
@@ -599,7 +607,11 @@ check_updates_upstream_version() {
   elif candidate=$(version_lookup_candidate "$output"); then
     printf 'matched\t%s\n' "$candidate"
   else
-    printf 'no-match\t\n'
+    candidate_rc=$?
+    case "$candidate_rc" in
+      1) printf 'no-match\t\n' ;;
+      *) printf 'failed\t\n' ;;
+    esac
   fi
 }
 

--- a/make
+++ b/make
@@ -125,8 +125,16 @@ check_updates_current_blocks_latest() {
   fi
 
   local numeric_alias_image numeric_alias_pattern
-  numeric_alias_image=$(./version.sh --numeric-alias-image 2>/dev/null | head -1 | tr -d '\n' || true)
-  numeric_alias_pattern=$(./version.sh --numeric-alias-pattern 2>/dev/null | head -1 | tr -d '\n' || true)
+  if numeric_alias_image=$(./version.sh --numeric-alias-image 2>/dev/null); then
+    numeric_alias_image=$(version_first_line "$numeric_alias_image")
+  else
+    numeric_alias_image=""
+  fi
+  if numeric_alias_pattern=$(./version.sh --numeric-alias-pattern 2>/dev/null); then
+    numeric_alias_pattern=$(version_first_line "$numeric_alias_pattern")
+  else
+    numeric_alias_pattern=""
+  fi
 
   # Unknown flags in some older version.sh files fall through to the normal
   # latest-version lookup. Require an explicit image-like source to opt in.
@@ -550,12 +558,10 @@ check_updates_current_version() {
   else
     rc=$?
   fi
-  current_version=$(printf '%s' "$current_version" | head -1 | tr -d '\n')
-
   case "$rc" in
     0)
       # no-published-version is a legacy caller sentinel, never a confirmed tag.
-      if [[ -n "$current_version" && "$current_version" != "no-published-version" ]]; then
+      if current_version=$(version_lookup_candidate "$current_version") && [[ "$current_version" != "no-published-version" ]]; then
         printf 'matched\t%s\n' "$current_version"
       else
         printf 'no-match\t\n'
@@ -570,19 +576,28 @@ check_updates_current_version() {
 # Do not pipe version.sh into head: a script can emit a plausible first line and
 # then fail, in which case there is no established upstream candidate.
 check_updates_upstream_version() {
-  local output rc
+  # A lookup that exceeds either documented bound has not established a
+  # candidate. The values are overridable only to keep refusal tests fast.
+  local output candidate output_file rc
+  local timeout_seconds="${CHECK_UPDATES_UPSTREAM_TIMEOUT_SECONDS:-30}"
+  local max_output_blocks="${CHECK_UPDATES_UPSTREAM_MAX_OUTPUT_BLOCKS:-1024}"
 
-  if output=$("$@" 2>/dev/null); then
+  output_file=$(mktemp "${TMPDIR:-/tmp}/check-updates-upstream.XXXXXX") || {
+    printf 'failed\t\n'
+    return
+  }
+  if (ulimit -f "$max_output_blocks"; timeout "$timeout_seconds" "$@" >"$output_file" 2>/dev/null); then
     rc=0
   else
     rc=$?
   fi
-  output=$(printf '%s' "$output" | head -1 | tr -d '\n')
+  output=$(<"$output_file")
+  rm -f "$output_file" || true
 
   if [[ "$rc" -ne 0 ]]; then
     printf 'failed\t\n'
-  elif [[ -n "$output" ]]; then
-    printf 'matched\t%s\n' "$output"
+  elif candidate=$(version_lookup_candidate "$output"); then
+    printf 'matched\t%s\n' "$candidate"
   else
     printf 'no-match\t\n'
   fi
@@ -681,12 +696,14 @@ check_updates() {
         # Determine update status
         local update_available="false"
         local actionable="false"
-        local status="up_to_date"
+        local status="upstream-no-match"
 
         if [[ "$registry_lookup" == "failed" ]]; then
           status="registry-lookup-failed"
         elif [[ "$upstream_lookup" == "failed" ]]; then
           status="upstream-lookup-failed"
+        elif [[ "$upstream_lookup" == "no-match" ]]; then
+          status="upstream-no-match"
         elif [[ "$registry_lookup" == "no-match" ]]; then
           if [ -n "$latest_version" ]; then
             update_available="true"
@@ -694,7 +711,7 @@ check_updates() {
           fi
         elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
           if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
-            :
+            status="up_to_date"
           else
             local downgrade_guard_rc=$?
             if [ "$downgrade_guard_rc" -eq 1 ]; then
@@ -704,6 +721,8 @@ check_updates() {
               status="downgrade-guard-failed"
             fi
           fi
+        else
+          status="up_to_date"
         fi
 
         if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" == "matched" && "$declared_actionable" == "true" ]]; then
@@ -749,7 +768,7 @@ check_updates() {
     local pattern current_version registry_lookup lookup_info
     lookup_info=$'failed\t'
     if pattern=$(./version.sh --registry-pattern 2>/dev/null); then
-      pattern=$(printf '%s' "$pattern" | head -1 | tr -d '\n')
+      pattern=$(version_first_line "$pattern")
       if [[ -n "$pattern" ]]; then
         lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$pattern")
       fi
@@ -762,12 +781,14 @@ check_updates() {
     # Determine update status
     local update_available="false"
     local actionable="false"
-    local status="up_to_date"
+    local status="upstream-no-match"
 
     if [[ "$registry_lookup" == "failed" ]]; then
       status="registry-lookup-failed"
     elif [[ "$upstream_lookup" == "failed" ]]; then
       status="upstream-lookup-failed"
+    elif [[ "$upstream_lookup" == "no-match" ]]; then
+      status="upstream-no-match"
     elif [[ "$registry_lookup" == "no-match" ]]; then
       if [ -n "$latest_version" ]; then
         update_available="true"
@@ -775,7 +796,7 @@ check_updates() {
       fi
     elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
       if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
-        :
+        status="up_to_date"
       else
         local downgrade_guard_rc=$?
         if [ "$downgrade_guard_rc" -eq 1 ]; then
@@ -785,6 +806,8 @@ check_updates() {
           status="downgrade-guard-failed"
         fi
       fi
+    else
+      status="up_to_date"
     fi
 
     if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" == "matched" && "$declared_actionable" == "true" ]]; then

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -10,6 +10,7 @@ setup() {
     source "$ORIG_DIR/helpers/logging.sh" 2>/dev/null || true
     source "$ORIG_DIR/helpers/variant-utils.sh" 2>/dev/null || true
     source "$ORIG_DIR/generate-dashboard.sh" 2>/dev/null || true
+    source "$ORIG_DIR/helpers/version-utils.sh"
     eval "$(declare -f get_container_versions | sed '1s/get_container_versions/_real_get_container_versions/')"
     _SOURCED_TRIVY_CACHE="${TRIVY_CACHE_FILE:-}"
     if [[ -n "$_saved_exit_trap" ]]; then
@@ -125,10 +126,10 @@ capture_container_page() {
     }
 }
 
-@test "dashboard: unconfirmed current version carries explicit absence and no image references" {
+@test "dashboard: a concluded no-match current version marks an unpublished release" {
     make_fixture_container "unconfirmed"
 
-    get_current_published_version() { echo ""; }
+    get_current_published_version() { return 1; }
     run _real_get_container_versions "unconfirmed"
     [ "$status" -eq 0 ]
     # get_container_versions records an optional latency line before its JSON
@@ -169,6 +170,77 @@ capture_container_page() {
         "$ORIG_DIR/docs/site/_includes/container-card.html"
     grep -q 'page.current_version_confirmed == true' \
         "$ORIG_DIR/docs/site/_layouts/container-detail.html"
+}
+
+@test "dashboard: failed publication lookups never mark an unpublished release" {
+    make_fixture_container "registry-failed"
+
+    get_current_published_version() { return 3; }
+    run _real_get_container_versions "registry-failed"
+    [ "$status" -eq 0 ]
+    echo "$output" | sed -n '/^{/,$p' | jq -e '
+        .current_version == "" and .current_version_confirmed == false and
+        .unpublished_release == false and .comparison_concluded == false
+    ' >/dev/null
+}
+
+@test "dashboard: failed publication lookup with a successful upstream candidate is not an unpublished release" {
+    make_fixture_container "registry-failed-upstream"
+
+    get_current_published_version() { return 3; }
+    run _real_get_container_versions "registry-failed-upstream"
+    [ "$status" -eq 0 ]
+    echo "$output" | sed -n '/^{/,$p' | jq -e '
+        .upstream_lookup == "matched" and .unpublished_release == false
+    ' >/dev/null
+}
+
+@test "dashboard: live multi-arch digest confirms a lineage record that lacks digests" {
+    make_fixture_container "live-digest"
+    mkdir -p "$TEST_DIR/.build-lineage"
+    cat > "$TEST_DIR/.build-lineage/live-digest-1.0.0.json" <<'EOF'
+{"container":"live-digest","tag":"1.0.0","version":"1.0.0","build_digest":"sha256:build","base_image_ref":"alpine:3.21"}
+EOF
+    resolve_variant_lineage_file() {
+        printf '%s/.build-lineage/live-digest-%s.json\n' "$TEST_DIR" "$2"
+    }
+    ghcr_get_multi_arch_digests() {
+        printf '%s\n' '{"index_digest":"sha256:live","manifest_digest_amd64":"sha256:amd","manifest_digest_arm64":null}'
+    }
+
+    record=$(collect_variant_json "live-digest" "$TEST_DIR/live-digest" "default" \
+        "1.0.0" "1.0.0" "alpine:3.21" "true" "true")
+    echo "$record" | jq -e '
+        .reference_confirmed == true and
+        .multi_arch_index_digest == "sha256:live" and
+        .manifest_digest_amd64 == "sha256:amd"
+    ' >/dev/null
+}
+
+@test "container detail: a confirmed non-variant reference exposes its attestation command" {
+    local no_variant_provenance
+    no_variant_provenance=$(sed -n '535,655p' "$ORIG_DIR/docs/site/_layouts/container-detail.html")
+    [[ "$no_variant_provenance" == *'if page.current_version_confirmed == true'* ]]
+    [[ "$no_variant_provenance" != *'if prov_variant.reference_confirmed == true'* ]]
+}
+
+@test "dashboard: resolver sentinels and whitespace never become an upstream candidate" {
+    local resolver_output container index=0
+    for resolver_output in "unknown" "   " $'1.2.3\r'; do
+        container="candidate-${index}"
+        index=$((index + 1))
+        make_fixture_container "$container"
+        printf '#!/usr/bin/env bash\nprintf %q\n' "$resolver_output" > "$TEST_DIR/$container/version.sh"
+        chmod +x "$TEST_DIR/$container/version.sh"
+        get_current_published_version() { printf '1.0.0\n'; }
+
+        run _real_get_container_versions "$container"
+        [ "$status" -eq 0 ]
+        echo "$output" | sed -n '/^{/,$p' | jq -e '
+            .upstream_lookup == "no-match" and .latest_version == "" and
+            .comparison_concluded == false
+        ' >/dev/null
+    done
 }
 
 @test "dashboard: a failed lookup is not counted as an available update" {

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -28,7 +28,7 @@ setup() {
     TRIVY_CACHE_FILE=$(mktemp)
     export DATA_FILE CONTAINERS_DIR STATS_FILE TRIVY_CACHE_FILE
 
-    get_container_versions()             { echo "1.0.0|1.0.0|green|Up to date|true"; }
+    get_container_versions()             { jq -nc '{current_version:"1.0.0", latest_version:"1.0.0", status_color:"green", status_text:"Up to date", current_version_confirmed:true, upstream_lookup:"matched", comparison_concluded:true, update_available:false, unpublished_release:false}'; }
     get_container_description()          { echo "Alpha test container"; }
     get_container_build_status()         { echo "success"; }
     populate_container_build_status_cache() { :; }
@@ -131,10 +131,19 @@ capture_container_page() {
     get_current_published_version() { echo ""; }
     run _real_get_container_versions "unconfirmed"
     [ "$status" -eq 0 ]
-    [[ "$(tail -n1 <<< "$output")" == "|1.0.0|warning|Publication information unavailable|false" ]]
+    # get_container_versions records an optional latency line before its JSON
+    # payload; parse the structured record, not the presentation telemetry.
+    echo "$output" | sed -n '/^{/,$p' | jq -e '
+        .current_version == "" and .latest_version == "1.0.0" and
+        .status_color == "warning" and
+        .status_text == "Publication information unavailable" and
+        .current_version_confirmed == false and
+        .comparison_concluded == false and .update_available == false and
+        .unpublished_release == true
+    ' >/dev/null
 
     capture_container_page
-    get_container_versions() { echo "|9.9.9|warning|Publication information unavailable|false"; }
+    get_container_versions() { jq -nc '{current_version:"", latest_version:"9.9.9", status_color:"warning", status_text:"Publication information unavailable", current_version_confirmed:false, upstream_lookup:"matched", comparison_concluded:false, update_available:false, unpublished_release:true}'; }
 
     run generate_data
     [ "$status" -eq 0 ]
@@ -160,6 +169,80 @@ capture_container_page() {
         "$ORIG_DIR/docs/site/_includes/container-card.html"
     grep -q 'page.current_version_confirmed == true' \
         "$ORIG_DIR/docs/site/_layouts/container-detail.html"
+}
+
+@test "dashboard: a failed lookup is not counted as an available update" {
+    make_fixture_container "indeterminate"
+    capture_container_page
+    # A failed lookup used to land in the warning presentation state.  Keep
+    # that defect state here so the retired colour-based counter would count it.
+    get_container_versions() { jq -nc '{current_version:"1.0.0", latest_version:"", status_color:"warning", status_text:"Upstream version unavailable", current_version_confirmed:true, upstream_lookup:"failed", comparison_concluded:false, update_available:false, unpublished_release:false}'; }
+
+    run generate_data
+    [ "$status" -eq 0 ]
+
+    yq -e '.updates_available == 0 and .unpublished_releases == 0' "$STATS_FILE" >/dev/null
+    jq -e '.comparison_concluded == false and .update_available == false' \
+        "$TEST_DIR/captured-indeterminate.json" >/dev/null
+}
+
+@test "dashboard: JSON version records preserve a pipe in every field" {
+    make_fixture_container "pipe-version"
+    capture_container_page
+    get_container_versions() { jq -nc '{current_version:"1|0", latest_version:"2|0", status_color:"warning", status_text:"Update | Available", current_version_confirmed:true, upstream_lookup:"matched", comparison_concluded:true, update_available:true, unpublished_release:false}'; }
+
+    run generate_data
+    [ "$status" -eq 0 ]
+
+    local record
+    record=$(cat "$TEST_DIR/captured-pipe-version.json")
+    [[ "$(jq -r '.current_version' <<< "$record")" == "1|0" ]]
+    [[ "$(jq -r '.latest_version' <<< "$record")" == "2|0" ]]
+    [[ "$(jq -r '.status_color' <<< "$record")" == "warning" ]]
+    [[ "$(jq -r '.status_text' <<< "$record")" == "Update | Available" ]]
+    [[ "$(jq -r '.current_version_confirmed' <<< "$record")" == "true" ]]
+    [[ "$(jq -r '.comparison_concluded' <<< "$record")" == "true" ]]
+    [[ "$(jq -r '.update_available' <<< "$record")" == "true" ]]
+}
+
+@test "dashboard: an unevidenced variant is excluded from pull-command inputs" {
+    make_fixture_container "cell-aware"
+    cat > "$TEST_DIR/cell-aware/variants.yaml" <<'EOF'
+versions:
+  - tag: 1.0.0
+    variants:
+      - name: default
+        suffix: ""
+        default: true
+      - name: unpublished
+        suffix: "-unpublished"
+EOF
+    mkdir -p "$TEST_DIR/.build-lineage"
+    cat > "$TEST_DIR/.build-lineage/cell-aware-1.0.0.json" <<'EOF'
+{"container":"cell-aware","tag":"1.0.0","version":"1.0.0","build_digest":"sha256:default","base_image_ref":"alpine:3.21","multi_arch_index_digest":"sha256:observed"}
+EOF
+    cat > "$TEST_DIR/.build-lineage/cell-aware-1.0.0-unpublished.json" <<'EOF'
+{"container":"cell-aware","tag":"1.0.0-unpublished","version":"1.0.0","build_digest":"sha256:built-not-mirrored","base_image_ref":"alpine:3.21"}
+EOF
+    resolve_variant_lineage_file() {
+        printf '%s/.build-lineage/cell-aware-%s.json\n' "$TEST_DIR" "$2"
+    }
+
+    # A manifest digest is recorded only after the generator has observed the
+    # exact GHCR tag. A build digest alone is not mirror evidence.
+    observed=$(collect_variant_json "cell-aware" "$TEST_DIR/cell-aware" "default" \
+        "1.0.0" "1.0.0" "alpine:3.21" "true" "true")
+    unpublished=$(collect_variant_json "cell-aware" "$TEST_DIR/cell-aware" "unpublished" \
+        "1.0.0" "1.0.0" "alpine:3.21" "true" "true")
+    [[ "$(jq -r '.reference_confirmed' <<< "$observed")" == "true" ]]
+    [[ "$(jq -r '.reference_confirmed' <<< "$unpublished")" == "false" ]]
+
+    # This is the rendering boundary: the versions path has one guard for the
+    # command JSON and one for the no-JS command table. Count both exact
+    # guards; a presence-only grep would leave either output path unprotected.
+    local template="$ORIG_DIR/docs/site/_includes/variant-action-bar.html"
+    [[ "$(grep -c 'if _vab_v.reference_confirmed == true' "$template")" -eq 3 ]]
+    [[ "$(grep -c 'if _ns_v.reference_confirmed == true' "$template")" -eq 2 ]]
 }
 
 # Creates a minimal container directory that satisfies generate_data()'s

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -160,16 +160,6 @@ capture_container_page() {
         .dockerhub_image == ""
     ' >/dev/null
 
-    # Lexical, and deliberately so: no Ruby or Jekyll runs in this environment,
-    # so nothing here renders Liquid. These two greps assert only that the
-    # templates branch on the explicit field rather than on a string sentinel.
-    # They cannot show what the built page emits — that check is fetching the
-    # deployed site, which is where a Liquid quirk that survives a source grep
-    # has bitten this repository before.
-    grep -q 'include.current_version_confirmed == true' \
-        "$ORIG_DIR/docs/site/_includes/container-card.html"
-    grep -q 'page.current_version_confirmed == true' \
-        "$ORIG_DIR/docs/site/_layouts/container-detail.html"
 }
 
 @test "dashboard: failed publication lookups never mark an unpublished release" {
@@ -248,10 +238,97 @@ EOF
     ' >/dev/null
 }
 
-@test "container detail: attestation commands require the selected reference's evidence" {
-    local no_variant_provenance
-    no_variant_provenance=$(sed -n '535,655p' "$ORIG_DIR/docs/site/_layouts/container-detail.html")
-    [[ "$no_variant_provenance" == *'if prov_variant.reference_confirmed == true'* ]]
+@test "container detail: a non-variant shows its verify command only when its reference is confirmed" {
+    run node - "$ORIG_DIR/docs/site/_layouts/container-detail.html" <<'NODE'
+const fs = require('fs');
+const source = fs.readFileSync(process.argv[2], 'utf8');
+const marker = 'No-variant container: single Provenance block';
+const start = source.indexOf(marker);
+const end = source.indexOf('<!-- Security Scan Summary', start);
+if (start < 0 || end < 0) throw new Error('non-variant provenance block was not found');
+
+const block = source.slice(start, end);
+const guard = block.match(/\{%\-?\s*if\s+(prov_variant\.[a-z_]+)\s*==\s*true\s*\-?%\}([\s\S]*?<dt>Verify<\/dt>[\s\S]*?)\{%\-?\s*endif\s*\-?%\}/);
+if (!guard) throw new Error('non-variant verify branch was not found');
+
+function renderNonVariant(page) {
+  const field = guard[1].slice('prov_variant.'.length);
+  return page[field] === true ? guard[2] : '';
+}
+
+const confirmed = renderNonVariant({ current_version_confirmed: true, current_version: '1.2.3' });
+if (!confirmed.includes('<dt>Verify</dt>') || !confirmed.includes('gh attestation verify oci://ghcr.io/')) {
+  throw new Error('confirmed non-variant did not render its verification command');
+}
+const unconfirmed = renderNonVariant({ current_version_confirmed: false, current_version: '1.2.3' });
+if (unconfirmed.includes('<dt>Verify</dt>') || unconfirmed.includes('gh attestation verify oci://ghcr.io/')) {
+  throw new Error('unconfirmed non-variant rendered a verification command');
+}
+NODE
+    [ "$status" -eq 0 ]
+}
+
+@test "dashboard: Updates filter and count use update_available rather than warning presentation" {
+    run node - "$ORIG_DIR/docs/site/assets/js/dashboard.js" <<'NODE'
+const source = process.argv[2];
+const cards = [
+  makeCard('actual-update', ['status-warning'], 'true'),
+  makeCard('lookup-failed', ['status-warning'], 'false'),
+  makeCard('up-to-date', ['status-green'], 'false')
+];
+const counts = Object.fromEntries(['all', 'up-to-date', 'update-available', 'not-published']
+  .map(function (status) { return [status, { textContent: '' }]; }));
+const buttons = ['all', 'up-to-date', 'update-available', 'not-published'].map(makeButton);
+const grid = { querySelector: function () { return null; }, appendChild: function () {} };
+let ready;
+
+global.document = {
+  addEventListener: function (event, callback) { if (event === 'DOMContentLoaded') ready = callback; },
+  querySelectorAll: function (selector) {
+    if (selector === '.container-card') return cards;
+    if (selector === '.filter-btn') return buttons;
+    if (selector === 'input[id^="pull-"]') return [];
+    return [];
+  },
+  querySelector: function (selector) { return selector === '.cards-grid' ? grid : null; },
+  getElementById: function (id) {
+    if (id.indexOf('count-') === 0) return counts[id.slice('count-'.length)];
+    if (id === 'status-live') return { textContent: '' };
+    return null;
+  }
+};
+global.ThemeManager = { toggleTheme: function () {}, currentTheme: 'light' };
+require(source);
+if (!ready) throw new Error('dashboard did not register its initializer');
+ready();
+
+if (String(counts['update-available'].textContent) !== '1') {
+  throw new Error('Updates count included a warning card without an available update');
+}
+buttons.find(function (button) { return button.dataset.status === 'update-available'; }).click();
+if (cards[0].style.display !== '' || cards[1].style.display !== 'none' || cards[2].style.display !== 'none') {
+  throw new Error('Updates filter included a lookup that did not conclude');
+}
+
+function makeCard(name, classes, updateAvailable) {
+  return {
+    dataset: { container: name, updateAvailable: updateAvailable },
+    style: {},
+    classList: { contains: function (name) { return classes.includes(name); } },
+    querySelector: function () { return null; },
+    querySelectorAll: function () { return []; }
+  };
+}
+function makeButton(status) {
+  return {
+    dataset: { status: status },
+    classList: { toggle: function () {} },
+    setAttribute: function () {},
+    addEventListener: function (event, callback) { if (event === 'click') this.click = callback; }
+  };
+}
+NODE
+    [ "$status" -eq 0 ]
 }
 
 @test "dashboard: only an explicit resolver sentinel is a concluded upstream no-match" {
@@ -353,13 +430,97 @@ EOF
     [[ "$(jq -r '.reference_confirmed' <<< "$observed")" == "true" ]]
     [[ "$(jq -r '.reference_confirmed' <<< "$unpublished")" == "false" ]]
 
-    # Selectors and JS inputs retain every declared variant. Command rendering
-    # alone branches on the exact reference evidence.
-    local template="$ORIG_DIR/docs/site/_includes/variant-action-bar.html"
-    grep -q '"reference_confirmed":{{ _vab_v.reference_confirmed' "$template"
-    grep -q 'No published image was observed for this reference.' "$template"
-    [[ "$(grep -c 'if _vab_v.reference_confirmed == true' "$template")" -eq 0 ]]
-    [[ "$(grep -c 'if _ns_v.reference_confirmed == true' "$template")" -eq 2 ]]
+    # The card keeps both YAML declarations. Selecting the unevidenced one
+    # hides the actionable pull control instead of inventing a command.
+    run node - "$ORIG_DIR/docs/site/_includes/container-card.html" "$ORIG_DIR/docs/site/assets/js/dashboard.js" <<'NODE'
+const fs = require('fs');
+const cardTemplate = fs.readFileSync(process.argv[2], 'utf8');
+const dashboard = process.argv[3];
+const singleVersion = cardTemplate.slice(cardTemplate.indexOf('<!-- Single-version structure -->'));
+const loop = singleVersion.match(/\{%\s*for variant in include\.variants\s*%\}([\s\S]*?)\{%\s*endfor\s*%\}/);
+if (!loop) throw new Error('single-version card variant loop was not found');
+
+function renderVariant(variant) {
+  return loop[1]
+    .replace(/\{%\-?\s*if\s+variant\.reference_confirmed\s*==\s*true\s*\-?%\}([\s\S]*?)\{%\-?\s*endif\s*\-?%\}/g,
+      function (_, content) { return variant.reference_confirmed ? content : ''; })
+    .replace(/\{\{\s*variant\.tag[^}]*\}\}/g, variant.tag)
+    .replace(/\{\{\s*variant\.reference_confirmed[^}]*\}\}/g, String(variant.reference_confirmed))
+    .replace(/\{%[\s\S]*?%\}/g, '');
+}
+
+const declared = [
+  { tag: '1.0.0', reference_confirmed: true },
+  { tag: '1.0.0-unpublished', reference_confirmed: false }
+].map(renderVariant).join('');
+if (!declared.includes('data-tag="1.0.0"') || !declared.includes('data-tag="1.0.0-unpublished"')) {
+  throw new Error('an unevidenced declared variant was omitted from its card');
+}
+if (!declared.includes('data-reference-confirmed="false"')) {
+  throw new Error('card did not carry the selected variant evidence state');
+}
+
+const command = { hidden: false };
+const unavailable = { hidden: true };
+const input = { value: 'docker pull ghcr.io/example/demo:1.0.0' };
+const tag = {
+  dataset: { tag: '1.0.0-unpublished', referenceConfirmed: 'false' },
+  classList: { add: function () {}, remove: function () {} },
+  querySelector: function () { return null; },
+  setAttribute: function () {},
+  closest: function (selector) {
+    if (selector === '.variant-tag') return this;
+    if (selector === '.container-card') return card;
+    return null;
+  }
+};
+const card = {
+  dataset: { container: 'demo', updateAvailable: 'false' },
+  style: {},
+  classList: { contains: function (name) { return name === 'status-green'; } },
+  querySelectorAll: function (selector) { return selector === '.variant-tag' ? [tag] : []; },
+  querySelector: function (selector) {
+    if (selector === '.pull-section') return { dataset: { ghcrBase: 'ghcr.io/example/demo' } };
+    if (selector === '[data-pull-command]') return command;
+    if (selector === '[data-pull-unavailable]') return unavailable;
+    return null;
+  },
+  dispatchEvent: function () {}
+};
+const counts = Object.fromEntries(['all', 'up-to-date', 'update-available', 'not-published']
+  .map(function (status) { return [status, { textContent: '' }]; }));
+let ready;
+let click;
+global.CustomEvent = function (name, init) { this.type = name; this.detail = init.detail; };
+global.document = {
+  addEventListener: function (event, callback) {
+    if (event === 'DOMContentLoaded') ready = callback;
+    if (event === 'click') click = callback;
+  },
+  querySelectorAll: function (selector) {
+    if (selector === '.container-card') return [card];
+    if (selector === '.filter-btn' || selector === 'input[id^="pull-"]') return [];
+    return [];
+  },
+  querySelector: function (selector) {
+    return selector === '.cards-grid' ? { querySelector: function () { return null; } } : null;
+  },
+  getElementById: function (id) {
+    if (id === 'pull-demo') return input;
+    if (id === 'status-live') return { textContent: '' };
+    if (id.indexOf('count-') === 0) return counts[id.slice('count-'.length)];
+    return null;
+  }
+};
+global.ThemeManager = { toggleTheme: function () {}, currentTheme: 'light' };
+require(dashboard);
+ready();
+click({ target: tag });
+if (command.hidden !== true || unavailable.hidden !== false || input.value !== 'docker pull ghcr.io/example/demo:1.0.0') {
+  throw new Error('unevidenced declared variant rendered an actionable pull command');
+}
+NODE
+    [ "$status" -eq 0 ]
 }
 
 # Creates a minimal container directory that satisfies generate_data()'s

--- a/tests/unit/dashboard-trends.bats
+++ b/tests/unit/dashboard-trends.bats
@@ -195,6 +195,37 @@ capture_container_page() {
     ' >/dev/null
 }
 
+@test "dashboard: a carriage-return registry answer is failed, not an unpublished release" {
+    make_fixture_container "registry-cr"
+    mkdir -p "$TEST_DIR/helpers"
+    cat > "$TEST_DIR/helpers/latest-docker-tag" <<'EOF'
+#!/usr/bin/env bash
+printf '1.2.3\r\n'
+EOF
+    chmod +x "$TEST_DIR/helpers/latest-docker-tag"
+
+    run _real_get_container_versions "registry-cr"
+    [ "$status" -eq 0 ]
+    local record
+    record=$(echo "$output" | sed -n '/^{/,$p')
+    [[ "$(jq -r '.current_version_confirmed' <<< "$record")" == "false" ]]
+    [[ "$(jq -r '.upstream_lookup' <<< "$record")" == "matched" ]]
+    [[ "$(jq -r '.unpublished_release' <<< "$record")" == "false" ]] || {
+        echo "carriage-return registry answer was treated as a concluded no-match" >&3
+        return 1
+    }
+    [[ "$(jq -r '.comparison_concluded' <<< "$record")" == "false" ]]
+}
+
+@test "dashboard: an inaccessible container emits its structured failed-lookup record" {
+    run _real_get_container_versions "does-not-exist"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '
+        .upstream_lookup == "failed" and .comparison_concluded == false and
+        .update_available == false and .unpublished_release == false
+    ' >/dev/null
+}
+
 @test "dashboard: live multi-arch digest confirms a lineage record that lacks digests" {
     make_fixture_container "live-digest"
     mkdir -p "$TEST_DIR/.build-lineage"
@@ -217,16 +248,29 @@ EOF
     ' >/dev/null
 }
 
-@test "container detail: a confirmed non-variant reference exposes its attestation command" {
+@test "container detail: attestation commands require the selected reference's evidence" {
     local no_variant_provenance
     no_variant_provenance=$(sed -n '535,655p' "$ORIG_DIR/docs/site/_layouts/container-detail.html")
-    [[ "$no_variant_provenance" == *'if page.current_version_confirmed == true'* ]]
-    [[ "$no_variant_provenance" != *'if prov_variant.reference_confirmed == true'* ]]
+    [[ "$no_variant_provenance" == *'if prov_variant.reference_confirmed == true'* ]]
 }
 
-@test "dashboard: resolver sentinels and whitespace never become an upstream candidate" {
+@test "dashboard: only an explicit resolver sentinel is a concluded upstream no-match" {
+    make_fixture_container "candidate-sentinel"
+    printf '#!/usr/bin/env bash\nprintf "unknown"\n' > "$TEST_DIR/candidate-sentinel/version.sh"
+    chmod +x "$TEST_DIR/candidate-sentinel/version.sh"
+    get_current_published_version() { printf '1.0.0\n'; }
+
+    run _real_get_container_versions "candidate-sentinel"
+    [ "$status" -eq 0 ]
+    echo "$output" | sed -n '/^{/,$p' | jq -e '
+        .upstream_lookup == "no-match" and .latest_version == "" and
+        .comparison_concluded == false
+    ' >/dev/null
+}
+
+@test "dashboard: malformed successful resolver output is a failed lookup" {
     local resolver_output container index=0
-    for resolver_output in "unknown" "   " $'1.2.3\r'; do
+    for resolver_output in "   " $'1.2.3\r'; do
         container="candidate-${index}"
         index=$((index + 1))
         make_fixture_container "$container"
@@ -237,7 +281,7 @@ EOF
         run _real_get_container_versions "$container"
         [ "$status" -eq 0 ]
         echo "$output" | sed -n '/^{/,$p' | jq -e '
-            .upstream_lookup == "no-match" and .latest_version == "" and
+            .upstream_lookup == "failed" and .latest_version == "" and
             .comparison_concluded == false
         ' >/dev/null
     done
@@ -277,7 +321,7 @@ EOF
     [[ "$(jq -r '.update_available' <<< "$record")" == "true" ]]
 }
 
-@test "dashboard: an unevidenced variant is excluded from pull-command inputs" {
+@test "dashboard: an unevidenced variant remains declared but carries no command evidence" {
     make_fixture_container "cell-aware"
     cat > "$TEST_DIR/cell-aware/variants.yaml" <<'EOF'
 versions:
@@ -309,11 +353,12 @@ EOF
     [[ "$(jq -r '.reference_confirmed' <<< "$observed")" == "true" ]]
     [[ "$(jq -r '.reference_confirmed' <<< "$unpublished")" == "false" ]]
 
-    # This is the rendering boundary: the versions path has one guard for the
-    # command JSON and one for the no-JS command table. Count both exact
-    # guards; a presence-only grep would leave either output path unprotected.
+    # Selectors and JS inputs retain every declared variant. Command rendering
+    # alone branches on the exact reference evidence.
     local template="$ORIG_DIR/docs/site/_includes/variant-action-bar.html"
-    [[ "$(grep -c 'if _vab_v.reference_confirmed == true' "$template")" -eq 3 ]]
+    grep -q '"reference_confirmed":{{ _vab_v.reference_confirmed' "$template"
+    grep -q 'No published image was observed for this reference.' "$template"
+    [[ "$(grep -c 'if _vab_v.reference_confirmed == true' "$template")" -eq 0 ]]
     [[ "$(grep -c 'if _ns_v.reference_confirmed == true' "$template")" -eq 2 ]]
 }
 

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -252,14 +252,11 @@ EOF
     mkdir -p helpers
     cat > helpers/latest-docker-tag <<'MOCK'
 #!/bin/bash
-# Args: library/wordpress "^7\.[0-9]+\.[0-9]+$"
-# Return a fixed version matching the major
-pattern="$2"
-if echo "7.0.0" | grep -qE "${pattern}"; then
-    echo "7.0.0"
-    exit 0
-fi
-exit 1
+# This stub is the entire upstream boundary: it both controls the result and
+# refuses an unexpected image/pattern so this unit test cannot reach GHCR.
+[[ "${1:-}" == "library/wordpress" ]] || exit 41
+[[ "${2:-}" == '^7\.[0-9]+\.[0-9]+$' ]] || exit 42
+printf '7.0.0\n'
 MOCK
     chmod +x helpers/latest-docker-tag
 
@@ -274,6 +271,60 @@ MOCK
     run wordpress/version.sh --major 7
     [ "$status" -eq 0 ]
     [[ "$output" == "7.0.0-alpine" ]]
+}
+
+@test "check_updates: a resolver that hangs after a version is a bounded failed lookup" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' 'printf "1.1.0-ubuntu\\n"' 'sleep 60' > ansible/version.sh
+    chmod +x ansible/version.sh
+    run timeout 4 env CHECK_UPDATES_UPSTREAM_TIMEOUT_SECONDS=1 ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates: sentinels, whitespace, and CR-terminated candidates conclude no-match" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local resolver_output
+    for resolver_output in "unknown" "   " $'1.1.0-ubuntu\r'; do
+        create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+        printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' "printf '%s\\n' $(printf '%q' "$resolver_output")" > ansible/version.sh
+        chmod +x ansible/version.sh
+        run run_check_updates ansible
+        [ "$status" -eq 0 ]
+        [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "no-match" ]]
+        [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+        [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-no-match" ]]
+    done
+}
+
+@test "check_updates: large successful resolver output keeps the first candidate without SIGPIPE" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' 'printf "1.1.0-ubuntu\\n"' 'yes x | head -c 131072' > ansible/version.sh
+    chmod +x ansible/version.sh
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "matched" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "1.1.0-ubuntu" ]]
+}
+
+@test "check_updates: resolver output beyond the 1 MiB bound is a failed lookup" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' 'printf "1.1.0-ubuntu\\n"' 'yes x | head -c 1100000' > ansible/version.sh
+    chmod +x ansible/version.sh
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
 }
 
 @test "version.sh --major: fails fast with non-numeric argument" {

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -915,6 +915,77 @@ EOF
     [[ "$status_value" == "update-available" ]]
 }
 
+@test "check_updates default path: partial output from a failed upstream lookup supplies no candidate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "--registry-pattern" ]]; then
+    echo '^[0-9]+\.[0-9]+(\.[0-9]+)?-ubuntu$'
+    exit 0
+fi
+echo '2.0.0-ubuntu'
+exit 28
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates multi-entry path: partial output from a failed major lookup supplies no candidate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.1-alpine" "6.9.5-alpine"
+    cat > wordpress/version.sh <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "--major" ]]; then
+    echo "${2}.99.99-alpine"
+    exit 28
+fi
+echo '7.99.99-alpine'
+exit 28
+EOF
+    chmod +x wordpress/version.sh
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r 'all(.[]; .latest_version == "")')" == "true" ]]
+    [[ "$(echo "$output" | jq -r 'all(.[]; .upstream_lookup == "failed")')" == "true" ]]
+    [[ "$(echo "$output" | jq -r 'all(.[]; .update_available == false and .actionable == false and .status == "upstream-lookup-failed")')" == "true" ]]
+}
+
+@test "show_sizes: partial output from a failed upstream lookup falls back without using that tag" {
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "--registry-pattern" ]]; then
+    echo '^[0-9]+\.[0-9]+(\.[0-9]+)?-ubuntu$'
+    exit 0
+fi
+echo '2.0.0-ubuntu'
+exit 28
+EOF
+    chmod +x ansible/version.sh
+    cat > sizes-config.sh <<'EOF'
+get_dockerhub_sizes() { echo 'amd64: 1MB'; }
+get_ghcr_sizes() { echo 'amd64: 1MB'; }
+EOF
+
+    run env CONFIG_MK="$TEST_DIR/sizes-config.sh" ./make sizes ansible
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GHCR (latest):"* ]]
+    [[ "$output" != *"2.0.0-ubuntu"* ]]
+}
+
 # Positive control for registry-pattern refusal cases below: a version.sh that
 # supplies a usable pattern still reaches the registry helper and can report an
 # actionable update.

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -286,19 +286,33 @@ MOCK
     [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
 }
 
-@test "check_updates: sentinels, whitespace, and CR-terminated candidates conclude no-match" {
+@test "check_updates: only an explicit resolver sentinel concludes no-match" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' 'printf "unknown"' > ansible/version.sh
+    chmod +x ansible/version.sh
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "no-match" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-no-match" ]]
+}
+
+@test "check_updates: malformed successful resolver output is failed and non-actionable" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
     local resolver_output
-    for resolver_output in "unknown" "   " $'1.1.0-ubuntu\r'; do
+    for resolver_output in "   " $'1.1.0-ubuntu\r'; do
         create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
         printf '%s\n' '#!/usr/bin/env bash' 'if [[ "${1:-}" == "--registry-pattern" ]]; then printf "%s\\n" "^[0-9]+\\.[0-9]+(\\.[0-9]+)?-ubuntu$"; exit 0; fi' "printf '%s\\n' $(printf '%q' "$resolver_output")" > ansible/version.sh
         chmod +x ansible/version.sh
         run run_check_updates ansible
         [ "$status" -eq 0 ]
-        [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "no-match" ]]
+        [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
         [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
-        [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-no-match" ]]
+        [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+        [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
     done
 }
 
@@ -592,6 +606,9 @@ EOF
         printf 'exit 3\n' >> helpers/latest-docker-tag
     elif [[ "$mock_current" == "__NO_MATCH__" ]]; then
         printf 'exit 1\n' >> helpers/latest-docker-tag
+    elif [[ "$mock_current" == "__CR__" ]]; then
+        printf "printf '1.2.3\\r\\n'\n" >> helpers/latest-docker-tag
+        printf 'exit 0\n' >> helpers/latest-docker-tag
     else
         printf 'echo "%s"\n' "$mock_current" >> helpers/latest-docker-tag
         printf 'exit 0\n' >> helpers/latest-docker-tag
@@ -639,6 +656,20 @@ EOF
 
     cp "$ORIG_DIR/make" ./make
     chmod +x ./make
+}
+
+@test "check_updates: a malformed successful registry answer is failed and non-actionable" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "__CR__" "1.1.0-ubuntu"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].registry_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "registry-lookup-failed" ]]
 }
 
 create_debian_check_updates_fixture() {

--- a/tests/unit/variant-action-bar.bats
+++ b/tests/unit/variant-action-bar.bats
@@ -4,7 +4,7 @@ setup() {
     ORIG_DIR="$PWD"
 }
 
-@test "variant action bar only selects versions that have confirmed records" {
+@test "variant action bar keeps unconfirmed selectors selectable but renders no command for them" {
     run node - "$ORIG_DIR/docs/site/assets/js/components/variant-action-bar.js" <<'NODE'
 const source = process.argv[2];
 global.HTMLElement = class {};
@@ -30,11 +30,31 @@ bar.dataset = {
   ])
 };
 bar._parseData();
-if (bar._versions.length !== 1 || bar._versions[0].tag !== '2.0') {
-  throw new Error('unconfirmed-only version stayed selectable');
+if (bar._versions.length !== 2 || bar._versions[0].tag !== '1.0') {
+  throw new Error('unconfirmed version was filtered from selectors');
 }
-if (!bar._currentVariant || bar._currentVariant.tag !== '2.0-confirmed') {
-  throw new Error('selector fell through to a different record');
+if (!bar._currentVariant || bar._currentVariant.tag !== '1.0-unconfirmed') {
+  throw new Error('selector did not retain its declared default');
+}
+const pull = { textContent: '' };
+const verify = { textContent: '' };
+bar.querySelector = function (selector) {
+  if (selector === '[data-vab-cmd="pull"]') return pull;
+  if (selector === '[data-vab-cmd="verify"]') return verify;
+  return null;
+};
+bar.querySelectorAll = function () { return []; };
+bar._updateCollapsedActionsState = function () {};
+bar._updateStickyCommand = function () {};
+bar._updateCommands();
+if (pull.textContent !== 'No published image was observed for this reference.' ||
+    verify.textContent !== 'No published image was observed for this reference.') {
+  throw new Error('unconfirmed reference rendered a command');
+}
+bar._currentVariant = bar._variants[1];
+bar._updateCommands();
+if (pull.textContent !== 'docker pull ghcr.io/example/demo:2.0-confirmed') {
+  throw new Error('confirmed reference did not render its command');
 }
 NODE
     [ "$status" -eq 0 ]

--- a/tests/unit/variant-action-bar.bats
+++ b/tests/unit/variant-action-bar.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+    ORIG_DIR="$PWD"
+}
+
+@test "variant action bar only selects versions that have confirmed records" {
+    run node - "$ORIG_DIR/docs/site/assets/js/components/variant-action-bar.js" <<'NODE'
+const source = process.argv[2];
+global.HTMLElement = class {};
+global.customElements = {
+  get: function () { return undefined; },
+  define: function (_, value) { global.VariantActionBar = value; }
+};
+require(source);
+const bar = new global.VariantActionBar();
+bar.dataset = {
+  imageBase: 'ghcr.io/example/demo',
+  defaultTag: '1.0-unconfirmed',
+  defaultVersion: '1.0',
+  defaultFlavor: 'base',
+  versions: JSON.stringify([
+    { tag: '1.0', label: '1.0' },
+    { tag: '2.0', label: '2.0' }
+  ]),
+  flavors: JSON.stringify([{ name: 'base', label: 'base' }]),
+  variants: JSON.stringify([
+    { tag: '1.0-unconfirmed', version: '1.0', flavor: 'base', reference_confirmed: false },
+    { tag: '2.0-confirmed', version: '2.0', flavor: 'base', reference_confirmed: true }
+  ])
+};
+bar._parseData();
+if (bar._versions.length !== 1 || bar._versions[0].tag !== '2.0') {
+  throw new Error('unconfirmed-only version stayed selectable');
+}
+if (!bar._currentVariant || bar._currentVariant.tag !== '2.0-confirmed') {
+  throw new Error('selector fell through to a different record');
+}
+NODE
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
**Draft: not ready to merge.** The review did not converge and the split described below is the
suggested next step.

A `version.sh` that printed a value and then exited nonzero supplied that value as a candidate: the
guard appended to the pipeline's output rather than replacing it, and one of the three capture sites
had no guard at all. The dashboard counted an indeterminate lookup as an available update, deriving
that statistic from a presentation colour two unrelated conditions share.

Refs #1514, #1515.

## Why this is a draft

Four review rounds returned 14, 14, 12 and 24 findings. The count rose rather than fell, and each
round's fixes produced the next round's findings — filtering the selectors produced six defects on
its own and was removed; the bounded capture added for a hanging resolver can be switched off by the
values it reads and was not applied to its siblings.

The `make` side and the dashboard side are two different problems sharing one sentence, and only the
first has converged. The three `version.sh` capture sites are small, verified by mutation, and appear
in none of the 24 findings. Splitting them out as their own change, and taking the dashboard work
back as a separate one, is the way to get either of them landed.

## What is here and verified

- 3018 tests, 0 failures, rebased onto `30f4d7a6`.
- A failed lookup produces no candidate and an entry automation may not act on.
- A malformed registry answer is a failed lookup rather than a concluded absence, so corrupted output
  cannot count toward the unpublished figure.
- Taking a resolver's first line no longer runs a pipeline, so a producer writing past the pipe
  buffer cannot abort the caller.
- Mutation proofs observed red for the sentinel rejection, for collapsing a malformed answer into a
  concluded no-match, and for the verification command under a third deliberately wrong field name.

## Filed

#1556 — the lookup bound can be switched off and does not cover its siblings. #1557 — twelve places
where a card claims more than its evidence supports. #1551 — any text a `version.sh` prints before
exiting 0 becomes a version. #1552 — seven dashboard values never established but shown as though
they were. #1533 — ten places where the registry-reading path uses a failure as evidence.

## One decision for a maintainer

The Docker Hub registry selector, its navigation and the stored preference are removed here, because
there is no per-reference evidence for Docker Hub and a selector leading to an empty registry is
worse than none. #1515 sanctions omitting unevidenced commands; it does not explicitly sanction
removing the selector. Reverting that part is isolated to two files.
