### PR TITLE
fix(monitor): a lookup that did not conclude no longer proposes an update

### DIFF
--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -77,7 +77,8 @@ runs:
             (.actionable | type == "boolean") and
             (if .actionable then
               .update_available and
-              (.registry_lookup | type == "string" and (. == "matched" or . == "no-match"))
+              (.registry_lookup | type == "string" and (. == "matched" or . == "no-match")) and
+              (.upstream_lookup | type == "string" and . == "matched")
             else
               true
             end)
@@ -113,12 +114,12 @@ runs:
             echo "   ⚠️ Upstream lookup returned no version — no PR from this entry"
           elif [ "$status" = "downgrade-guard-failed" ]; then
             echo "   ⚠️ Version comparison did not conclude — no PR from this entry"
-          elif [ "$status" = "upstream-version-rejected" ]; then
-            echo "   ⚠️ Upstream value does not match the declared version pattern — no PR from this entry"
-          elif [ "$update_available" = "true" ]; then
+          elif { [ "$status" = "new-container" ] || [ "$status" = "update-available" ]; } && [ "$update_available" = "true" ]; then
             echo "   ⏸️ Update available but this container declines monitor PRs"
-          else
+          elif [ "$status" = "up_to_date" ]; then
             echo "   ✅ Up to date"
+          else
+            echo "   ⚠️ Unrecognised status '$status' — no PR from this entry"
           fi
           
         done < <(echo "$version_info" | jq -c '.[]')

--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -107,6 +107,10 @@ runs:
             containers_with_updates+=("$container")
           elif [ "$status" = "registry-lookup-failed" ]; then
             echo "   ⚠️ Registry lookup did not conclude — no PR from this entry"
+          elif [ "$status" = "upstream-lookup-failed" ]; then
+            echo "   ⚠️ Upstream lookup did not conclude — no PR from this entry"
+          elif [ "$status" = "upstream-no-match" ]; then
+            echo "   ⚠️ Upstream lookup returned no version — no PR from this entry"
           elif [ "$status" = "downgrade-guard-failed" ]; then
             echo "   ⚠️ Version comparison did not conclude — no PR from this entry"
           elif [ "$status" = "upstream-version-rejected" ]; then

--- a/.github/actions/check-upstream-versions/action.yaml
+++ b/.github/actions/check-upstream-versions/action.yaml
@@ -107,6 +107,10 @@ runs:
             containers_with_updates+=("$container")
           elif [ "$status" = "registry-lookup-failed" ]; then
             echo "   ⚠️ Registry lookup did not conclude — no PR from this entry"
+          elif [ "$status" = "downgrade-guard-failed" ]; then
+            echo "   ⚠️ Version comparison did not conclude — no PR from this entry"
+          elif [ "$status" = "upstream-version-rejected" ]; then
+            echo "   ⚠️ Upstream value does not match the declared version pattern — no PR from this entry"
           elif [ "$update_available" = "true" ]; then
             echo "   ⏸️ Update available but this container declines monitor PRs"
           else

--- a/make
+++ b/make
@@ -171,7 +171,10 @@ check_updates_current_blocks_latest() {
     return 3
   fi
 
-  return 1
+  # A non-numeric pair without declared numeric aliases was not compared.
+  # Return the same indeterminate outcome used for failed alias resolution;
+  # only return 1 after a completed comparison concludes current does not block.
+  return 3
 }
 
 # Show project-internal dependency graph for a container
@@ -320,9 +323,10 @@ show_sizes() {
     echo "   └── Registries:"
 
     # Get latest tag from version.sh if available, fallback to "latest"
-    local latest_tag
+    local latest_tag upstream_lookup lookup_info
     if [[ -f "$container/version.sh" ]]; then
-      latest_tag=$("$container/version.sh" 2>/dev/null | head -1)
+      lookup_info=$(check_updates_upstream_version "$container/version.sh")
+      IFS=$'\t' read -r upstream_lookup latest_tag <<< "$lookup_info"
     fi
     [[ -z "$latest_tag" ]] && latest_tag="latest"
 
@@ -563,6 +567,31 @@ check_updates_current_version() {
   esac
 }
 
+# Emit a tab-separated upstream lookup outcome and confirmed candidate version.
+# Successful empty output is a concluded no-match; any nonzero resolver exit
+# discards its output so a partial response cannot become a candidate.
+check_updates_upstream_version() {
+  local latest_version rc
+
+  if latest_version=$("$@" 2>/dev/null); then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  if [[ "$rc" -ne 0 ]]; then
+    printf 'failed\t\n'
+    return
+  fi
+
+  latest_version=$(printf '%s' "$latest_version" | head -1 | tr -d '\n')
+  if [[ -n "$latest_version" ]]; then
+    printf 'matched\t%s\n' "$latest_version"
+  else
+    printf 'no-match\t\n'
+  fi
+}
+
 # An absent declaration preserves the historical behaviour (actionable when
 # there is a confirmed update). Do not use yq's `// true` here: false is a
 # valid declaration and must not be coalesced with an absent value.
@@ -649,8 +678,9 @@ check_updates() {
         IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
 
         # Latest upstream version for this major line
-        local latest_version
-        latest_version=$(./version.sh --major "$major" 2>/dev/null | head -1 | tr -d '\n' || echo "")
+        local latest_version upstream_lookup upstream_lookup_info
+        upstream_lookup_info=$(check_updates_upstream_version ./version.sh --major "$major")
+        IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_lookup_info"
 
         # Determine update status
         local update_available="false"
@@ -659,10 +689,17 @@ check_updates() {
 
         if [[ "$registry_lookup" == "failed" ]]; then
           status="registry-lookup-failed"
+        elif [[ "$upstream_lookup" == "failed" ]]; then
+          status="upstream-lookup-failed"
         elif [[ "$registry_lookup" == "no-match" ]]; then
-          if [ -n "$latest_version" ]; then
+          # A first publication has no current tag to compare. Admit the
+          # upstream value only when it matches the retained major's declared
+          # tag shape; resolver diagnostics must not become a new-container PR.
+          if [[ -n "$latest_version" && "$latest_version" =~ $major_pattern ]]; then
             update_available="true"
             status="new-container"
+          elif [ -n "$latest_version" ]; then
+            status="upstream-version-rejected"
           fi
         elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
           if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
@@ -678,7 +715,7 @@ check_updates() {
           fi
         fi
 
-        if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+        if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
           actionable="true"
         fi
 
@@ -694,6 +731,7 @@ check_updates() {
           --argjson update_available "$update_available" \
           --argjson actionable "$actionable" \
           --arg registry_lookup "$registry_lookup" \
+          --arg upstream_lookup "$upstream_lookup" \
           --arg status "$status" \
           '{
             container: $container,
@@ -703,6 +741,7 @@ check_updates() {
             update_available: $update_available,
             actionable: $actionable,
             registry_lookup: $registry_lookup,
+            upstream_lookup: $upstream_lookup,
             status: $status
           }')
 
@@ -725,7 +764,9 @@ check_updates() {
       fi
     fi
     IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
-    latest_version=$(./version.sh 2>/dev/null | head -1 | tr -d '\n' || echo "")
+    local upstream_lookup upstream_lookup_info
+    upstream_lookup_info=$(check_updates_upstream_version ./version.sh)
+    IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_lookup_info"
 
     # Determine update status
     local update_available="false"
@@ -734,10 +775,17 @@ check_updates() {
 
     if [[ "$registry_lookup" == "failed" ]]; then
       status="registry-lookup-failed"
+    elif [[ "$upstream_lookup" == "failed" ]]; then
+      status="upstream-lookup-failed"
     elif [[ "$registry_lookup" == "no-match" ]]; then
-      if [ -n "$latest_version" ]; then
+      # A first publication has no current tag to compare. The registry
+      # pattern declared by version.sh is the admission rule for an upstream
+      # candidate, so successful resolver diagnostics cannot open a PR.
+      if [[ -n "$latest_version" && "$latest_version" =~ $pattern ]]; then
         update_available="true"
         status="new-container"
+      elif [ -n "$latest_version" ]; then
+        status="upstream-version-rejected"
       fi
     elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
       if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
@@ -753,7 +801,7 @@ check_updates() {
       fi
     fi
 
-    if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
+    if [[ "$update_available" == "true" && "$registry_lookup" != "failed" && "$upstream_lookup" != "failed" && "$declared_actionable" == "true" ]]; then
       actionable="true"
     fi
 
@@ -765,6 +813,7 @@ check_updates() {
       --argjson update_available "$update_available" \
       --argjson actionable "$actionable" \
       --arg registry_lookup "$registry_lookup" \
+      --arg upstream_lookup "$upstream_lookup" \
       --arg status "$status" \
       '{
         container: $container,
@@ -773,6 +822,7 @@ check_updates() {
         update_available: $update_available,
         actionable: $actionable,
         registry_lookup: $registry_lookup,
+        upstream_lookup: $upstream_lookup,
         status: $status
       }')
 

--- a/make
+++ b/make
@@ -323,10 +323,11 @@ show_sizes() {
     echo "   └── Registries:"
 
     # Get latest tag from version.sh if available, fallback to "latest"
-    local latest_tag upstream_lookup lookup_info
+    local latest_tag="" upstream_lookup="" lookup_info=""
     if [[ -f "$container/version.sh" ]]; then
       lookup_info=$(check_updates_upstream_version "$container/version.sh")
-      IFS=$'\t' read -r upstream_lookup latest_tag <<< "$lookup_info"
+      upstream_lookup=${lookup_info%%$'\t'*}
+      latest_tag=${lookup_info#*$'\t'}
     fi
     [[ -z "$latest_tag" ]] && latest_tag="latest"
 
@@ -568,27 +569,83 @@ check_updates_current_version() {
 }
 
 # Emit a tab-separated upstream lookup outcome and confirmed candidate version.
-# Successful empty output is a concluded no-match; any nonzero resolver exit
-# discards its output so a partial response cannot become a candidate.
+# Read only a fixed-size first line, while draining the remainder so a resolver
+# cannot block behind a full pipe.  A fixed timeout bounds the resolver wait;
+# the drainer is stopped once that wait concludes so a descendant keeping stdout
+# open cannot hold the caller.  Neither bound is configurable.  A successful
+# empty first line is a concluded no-match; a timeout, oversized first line, or
+# nonzero resolver exit discards the candidate.
 check_updates_upstream_version() {
-  local latest_version rc
+  # All 14 repository version.sh resolvers were timed: the longest observed
+  # lookup was 18.34s (vector/web-shell fallback chains); 60s is over 3x that
+  # duration and still ends a hang during the daily scheduled monitor.
+  local readonly_timeout_seconds=60
+  local readonly_max_line_bytes=4096
+  local resolver_dir resolver_fifo resolver_result resolver_state resolver_pid reader_pid
+  local latest_version="" rc=0 outcome=""
 
-  if latest_version=$("$@" 2>/dev/null); then
-    rc=0
-  else
-    rc=$?
+  if ! resolver_dir=$(mktemp -d "${TMPDIR:-/tmp}/check-updates-resolver.XXXXXX"); then
+    printf 'failed\t\n'
+    return
   fi
-
-  if [[ "$rc" -ne 0 ]]; then
+  resolver_fifo="$resolver_dir/stdout"
+  resolver_result="$resolver_dir/first-line"
+  resolver_state="$resolver_dir/outcome"
+  if ! mkfifo "$resolver_fifo"; then
+    rmdir "$resolver_dir" || true
     printf 'failed\t\n'
     return
   fi
 
-  latest_version=$(printf '%s' "$latest_version" | head -1 | tr -d '\n')
-  if [[ -n "$latest_version" ]]; then
-    printf 'matched\t%s\n' "$latest_version"
+  # The reader retains only the first line plus one probe byte and continues
+  # draining.  Its outcome is written before the unbounded drain begins.
+  (
+    local first_line="" overflow_probe="" line_too_long="false"
+    IFS= read -r -n "$readonly_max_line_bytes" first_line || true
+    if [[ ${#first_line} -eq "$readonly_max_line_bytes" ]]; then
+      IFS= read -r -n 1 overflow_probe || true
+      if [[ -n "$overflow_probe" ]]; then
+        line_too_long="true"
+      fi
+    fi
+    printf '%s' "$first_line" > "$resolver_result"
+    if [[ "$line_too_long" == "true" ]]; then
+      printf 'too-long\n' > "$resolver_state"
+    elif [[ -n "$first_line" ]]; then
+      printf 'matched\n' > "$resolver_state"
+    else
+      printf 'no-match\n' > "$resolver_state"
+    fi
+    cat > /dev/null
+  ) < "$resolver_fifo" &
+  reader_pid=$!
+  # `command -p` uses Bash's system command path, so a caller-provided PATH
+  # cannot replace the timeout and remove this bound.
+  command -p timeout "$readonly_timeout_seconds" "$@" 2>/dev/null > "$resolver_fifo" &
+  resolver_pid=$!
+  if wait "$resolver_pid"; then
+    rc=0
   else
+    rc=$?
+  fi
+  # Normal resolvers have already produced a reader outcome when they exit.
+  # If a descendant still owns stdout, do not let it extend the fixed wait.
+  for _ in $(seq 1 100); do
+    [[ -s "$resolver_state" ]] && break
+    sleep 0.01
+  done
+  kill "$reader_pid" 2>/dev/null || true
+  wait "$reader_pid" 2>/dev/null || true
+  [[ -s "$resolver_state" ]] && outcome=$(<"$resolver_state")
+  [[ -f "$resolver_result" ]] && latest_version=$(<"$resolver_result")
+  rm -rf "$resolver_dir"
+
+  if [[ "$rc" -eq 0 && "$outcome" == "matched" ]]; then
+    printf 'matched\t%s\n' "$latest_version"
+  elif [[ "$rc" -eq 0 && "$outcome" == "no-match" ]]; then
     printf 'no-match\t\n'
+  else
+    printf 'failed\t\n'
   fi
 }
 
@@ -675,12 +732,20 @@ check_updates() {
         major_pattern="^${major}\\.[0-9]+\\.[0-9]+-alpine\$"
         local current_version registry_lookup lookup_info
         lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$major_pattern")
-        IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
+        registry_lookup=${lookup_info%%$'\t'*}
+        current_version=${lookup_info#*$'\t'}
 
         # Latest upstream version for this major line
         local latest_version upstream_lookup upstream_lookup_info
         upstream_lookup_info=$(check_updates_upstream_version ./version.sh --major "$major")
-        IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_lookup_info"
+        upstream_lookup=${upstream_lookup_info%%$'\t'*}
+        latest_version=${upstream_lookup_info#*$'\t'}
+        # Admission happens at the state-machine boundary, before this value
+        # reaches either comparison or first-publication branch (or JSON).
+        if [[ "$upstream_lookup" == "matched" && ! "$latest_version" =~ $major_pattern ]]; then
+          upstream_lookup="failed"
+          latest_version=""
+        fi
 
         # Determine update status
         local update_available="false"
@@ -691,16 +756,12 @@ check_updates() {
           status="registry-lookup-failed"
         elif [[ "$upstream_lookup" == "failed" ]]; then
           status="upstream-lookup-failed"
+        elif [[ "$upstream_lookup" == "no-match" ]]; then
+          status="upstream-no-match"
         elif [[ "$registry_lookup" == "no-match" ]]; then
-          # A first publication has no current tag to compare. Admit the
-          # upstream value only when it matches the retained major's declared
-          # tag shape; resolver diagnostics must not become a new-container PR.
-          if [[ -n "$latest_version" && "$latest_version" =~ $major_pattern ]]; then
-            update_available="true"
-            status="new-container"
-          elif [ -n "$latest_version" ]; then
-            status="upstream-version-rejected"
-          fi
+          # The candidate was admitted before entering this branch.
+          update_available="true"
+          status="new-container"
         elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
           if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
             :
@@ -763,10 +824,18 @@ check_updates() {
         lookup_info=$(check_updates_current_version "ghcr.io/oorabona/$container" "$pattern")
       fi
     fi
-    IFS=$'\t' read -r registry_lookup current_version <<< "$lookup_info"
+    registry_lookup=${lookup_info%%$'\t'*}
+    current_version=${lookup_info#*$'\t'}
     local upstream_lookup upstream_lookup_info
     upstream_lookup_info=$(check_updates_upstream_version ./version.sh)
-    IFS=$'\t' read -r upstream_lookup latest_version <<< "$upstream_lookup_info"
+    upstream_lookup=${upstream_lookup_info%%$'\t'*}
+    latest_version=${upstream_lookup_info#*$'\t'}
+    # Admission happens at the state-machine boundary, before this value
+    # reaches either comparison or first-publication branch (or JSON).
+    if [[ "$upstream_lookup" == "matched" && ! "$latest_version" =~ $pattern ]]; then
+      upstream_lookup="failed"
+      latest_version=""
+    fi
 
     # Determine update status
     local update_available="false"
@@ -777,16 +846,12 @@ check_updates() {
       status="registry-lookup-failed"
     elif [[ "$upstream_lookup" == "failed" ]]; then
       status="upstream-lookup-failed"
+    elif [[ "$upstream_lookup" == "no-match" ]]; then
+      status="upstream-no-match"
     elif [[ "$registry_lookup" == "no-match" ]]; then
-      # A first publication has no current tag to compare. The registry
-      # pattern declared by version.sh is the admission rule for an upstream
-      # candidate, so successful resolver diagnostics cannot open a PR.
-      if [[ -n "$latest_version" && "$latest_version" =~ $pattern ]]; then
-        update_available="true"
-        status="new-container"
-      elif [ -n "$latest_version" ]; then
-        status="upstream-version-rejected"
-      fi
+      # The candidate was admitted before entering this branch.
+      update_available="true"
+      status="new-container"
     elif [ -n "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
       if check_updates_current_blocks_latest "$current_version" "$latest_version"; then
         :

--- a/make
+++ b/make
@@ -323,11 +323,16 @@ show_sizes() {
     echo "   └── Registries:"
 
     # Get latest tag from version.sh if available, fallback to "latest"
-    local latest_tag="" upstream_lookup="" lookup_info=""
+    local latest_tag=""
     if [[ -f "$container/version.sh" ]]; then
-      lookup_info=$(check_updates_upstream_version "$container/version.sh")
-      upstream_lookup=${lookup_info%%$'\t'*}
-      latest_tag=${lookup_info#*$'\t'}
+      # Preserve the resolver's status: only a successful resolver supplies a
+      # tag. This deliberately does not bound time; a resolver that writes one
+      # line and then hangs is tracked separately in #1556.
+      if latest_tag=$("$container/version.sh" 2>/dev/null | head -1; exit "${PIPESTATUS[0]}"); then
+        :
+      else
+        latest_tag=""
+      fi
     fi
     [[ -z "$latest_tag" ]] && latest_tag="latest"
 
@@ -568,87 +573,6 @@ check_updates_current_version() {
   esac
 }
 
-# Emit a tab-separated upstream lookup outcome and confirmed candidate version.
-# Read only a fixed-size first line, while draining the remainder so a resolver
-# cannot block behind a full pipe.  A fixed timeout bounds the resolver wait;
-# the drainer is stopped once that wait concludes so a descendant keeping stdout
-# open cannot hold the caller.  Neither bound is configurable.  A successful
-# empty first line is a concluded no-match; a timeout, oversized first line, or
-# nonzero resolver exit discards the candidate.
-check_updates_upstream_version() {
-  # All 14 repository version.sh resolvers were timed: the longest observed
-  # lookup was 18.34s (vector/web-shell fallback chains); 60s is over 3x that
-  # duration and still ends a hang during the daily scheduled monitor.
-  local readonly_timeout_seconds=60
-  local readonly_max_line_bytes=4096
-  local resolver_dir resolver_fifo resolver_result resolver_state resolver_pid reader_pid
-  local latest_version="" rc=0 outcome=""
-
-  if ! resolver_dir=$(mktemp -d "${TMPDIR:-/tmp}/check-updates-resolver.XXXXXX"); then
-    printf 'failed\t\n'
-    return
-  fi
-  resolver_fifo="$resolver_dir/stdout"
-  resolver_result="$resolver_dir/first-line"
-  resolver_state="$resolver_dir/outcome"
-  if ! mkfifo "$resolver_fifo"; then
-    rmdir "$resolver_dir" || true
-    printf 'failed\t\n'
-    return
-  fi
-
-  # The reader retains only the first line plus one probe byte and continues
-  # draining.  Its outcome is written before the unbounded drain begins.
-  (
-    local first_line="" overflow_probe="" line_too_long="false"
-    IFS= read -r -n "$readonly_max_line_bytes" first_line || true
-    if [[ ${#first_line} -eq "$readonly_max_line_bytes" ]]; then
-      IFS= read -r -n 1 overflow_probe || true
-      if [[ -n "$overflow_probe" ]]; then
-        line_too_long="true"
-      fi
-    fi
-    printf '%s' "$first_line" > "$resolver_result"
-    if [[ "$line_too_long" == "true" ]]; then
-      printf 'too-long\n' > "$resolver_state"
-    elif [[ -n "$first_line" ]]; then
-      printf 'matched\n' > "$resolver_state"
-    else
-      printf 'no-match\n' > "$resolver_state"
-    fi
-    cat > /dev/null
-  ) < "$resolver_fifo" &
-  reader_pid=$!
-  # `command -p` uses Bash's system command path, so a caller-provided PATH
-  # cannot replace the timeout and remove this bound.
-  command -p timeout "$readonly_timeout_seconds" "$@" 2>/dev/null > "$resolver_fifo" &
-  resolver_pid=$!
-  if wait "$resolver_pid"; then
-    rc=0
-  else
-    rc=$?
-  fi
-  # Normal resolvers have already produced a reader outcome when they exit.
-  # If a descendant still owns stdout, do not let it extend the fixed wait.
-  for _ in $(seq 1 100); do
-    [[ -s "$resolver_state" ]] && break
-    sleep 0.01
-  done
-  kill "$reader_pid" 2>/dev/null || true
-  wait "$reader_pid" 2>/dev/null || true
-  [[ -s "$resolver_state" ]] && outcome=$(<"$resolver_state")
-  [[ -f "$resolver_result" ]] && latest_version=$(<"$resolver_result")
-  rm -rf "$resolver_dir"
-
-  if [[ "$rc" -eq 0 && "$outcome" == "matched" ]]; then
-    printf 'matched\t%s\n' "$latest_version"
-  elif [[ "$rc" -eq 0 && "$outcome" == "no-match" ]]; then
-    printf 'no-match\t\n'
-  else
-    printf 'failed\t\n'
-  fi
-}
-
 # An absent declaration preserves the historical behaviour (actionable when
 # there is a confirmed update). Do not use yq's `// true` here: false is a
 # valid declaration and must not be coalesced with an absent value.
@@ -736,10 +660,23 @@ check_updates() {
         current_version=${lookup_info#*$'\t'}
 
         # Latest upstream version for this major line
-        local latest_version upstream_lookup upstream_lookup_info
-        upstream_lookup_info=$(check_updates_upstream_version ./version.sh --major "$major")
-        upstream_lookup=${upstream_lookup_info%%$'\t'*}
-        latest_version=${upstream_lookup_info#*$'\t'}
+        local latest_version="" upstream_lookup upstream_rc
+        # Keep only the first line while recovering the resolver's status.
+        # Time is intentionally unbounded here: the one-line-then-hang case is
+        # #1556, not a reason to reintroduce a timeout harness.
+        if latest_version=$(./version.sh --major "$major" 2>/dev/null | head -1; exit "${PIPESTATUS[0]}"); then
+          upstream_rc=0
+        else
+          upstream_rc=$?
+          latest_version=""
+        fi
+        if [[ "$upstream_rc" -eq 0 && -n "$latest_version" ]]; then
+          upstream_lookup="matched"
+        elif [[ "$upstream_rc" -eq 0 ]]; then
+          upstream_lookup="no-match"
+        else
+          upstream_lookup="failed"
+        fi
         # Admission happens at the state-machine boundary, before this value
         # reaches either comparison or first-publication branch (or JSON).
         if [[ "$upstream_lookup" == "matched" && ! "$latest_version" =~ $major_pattern ]]; then
@@ -826,10 +763,22 @@ check_updates() {
     fi
     registry_lookup=${lookup_info%%$'\t'*}
     current_version=${lookup_info#*$'\t'}
-    local upstream_lookup upstream_lookup_info
-    upstream_lookup_info=$(check_updates_upstream_version ./version.sh)
-    upstream_lookup=${upstream_lookup_info%%$'\t'*}
-    latest_version=${upstream_lookup_info#*$'\t'}
+    local upstream_lookup upstream_rc
+    # Keep only the first line while recovering the resolver's status. Time is
+    # intentionally unbounded: the one-line-then-hang case is tracked in #1556.
+    if latest_version=$(./version.sh 2>/dev/null | head -1; exit "${PIPESTATUS[0]}"); then
+      upstream_rc=0
+    else
+      upstream_rc=$?
+      latest_version=""
+    fi
+    if [[ "$upstream_rc" -eq 0 && -n "$latest_version" ]]; then
+      upstream_lookup="matched"
+    elif [[ "$upstream_rc" -eq 0 ]]; then
+      upstream_lookup="no-match"
+    else
+      upstream_lookup="failed"
+    fi
     # Admission happens at the state-machine boundary, before this value
     # reaches either comparison or first-publication branch (or JSON).
     if [[ "$upstream_lookup" == "matched" && ! "$latest_version" =~ $pattern ]]; then

--- a/tests/unit/check-upstream-versions-action.bats
+++ b/tests/unit/check-upstream-versions-action.bats
@@ -145,6 +145,24 @@ assert_byte_for_byte() {
     [[ "$output" == *"Registry lookup did not conclude"* ]]
 }
 
+@test "composite action reports an upstream lookup failure without claiming it is up to date" {
+    write_make_result '[{"container":"ansible","current_version":"1.0.0-ubuntu","latest_version":"","update_available":false,"actionable":false,"registry_lookup":"matched","upstream_lookup":"failed","status":"upstream-lookup-failed"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Upstream lookup did not conclude"* ]]
+    [[ "$output" != *"✅ Up to date"* ]]
+}
+
+@test "composite action reports an upstream no-match without claiming it is up to date" {
+    write_make_result '[{"container":"ansible","current_version":"1.0.0-ubuntu","latest_version":"","update_available":false,"actionable":false,"registry_lookup":"matched","upstream_lookup":"no-match","status":"upstream-no-match"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Upstream lookup returned no version"* ]]
+    [[ "$output" != *"✅ Up to date"* ]]
+}
+
 @test "composite action reports an indeterminate version comparison without claiming it is up to date" {
     write_make_result '[{"container":"debian","current_version":"trixie","latest_version":"bookworm","update_available":false,"actionable":false,"registry_lookup":"matched","status":"downgrade-guard-failed"}]'
 

--- a/tests/unit/check-upstream-versions-action.bats
+++ b/tests/unit/check-upstream-versions-action.bats
@@ -145,6 +145,24 @@ assert_byte_for_byte() {
     [[ "$output" == *"Registry lookup did not conclude"* ]]
 }
 
+@test "composite action reports an indeterminate version comparison without claiming it is up to date" {
+    write_make_result '[{"container":"debian","current_version":"trixie","latest_version":"bookworm","update_available":false,"actionable":false,"registry_lookup":"matched","status":"downgrade-guard-failed"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Version comparison did not conclude"* ]]
+    [[ "$output" != *"✅ Up to date"* ]]
+}
+
+@test "composite action reports a rejected upstream value without claiming it is up to date" {
+    write_make_result '[{"container":"ansible","current_version":"","latest_version":"error: rate limited","update_available":false,"actionable":false,"registry_lookup":"no-match","status":"upstream-version-rejected"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"does not match the declared version pattern"* ]]
+    [[ "$output" != *"✅ Up to date"* ]]
+}
+
 @test "composite action rejects an entry without a container" {
     write_make_result '[{"actionable":true,"update_available":true,"registry_lookup":"matched"}]'
 

--- a/tests/unit/check-upstream-versions-action.bats
+++ b/tests/unit/check-upstream-versions-action.bats
@@ -108,7 +108,7 @@ assert_byte_for_byte() {
 # Positive control for the two exclusion tests above. Without it a mutation that
 # emptied containers_with_updates unconditionally would satisfy both of them.
 @test "composite action selects an actionable update" {
-    write_make_result '[{"container":"terraform","current_version":"1.15.9-alpine","latest_version":"1.16.0-alpine","update_available":true,"actionable":true,"registry_lookup":"matched","status":"update-available"}]'
+    write_make_result '[{"container":"terraform","current_version":"1.15.9-alpine","latest_version":"1.16.0-alpine","update_available":true,"actionable":true,"registry_lookup":"matched","upstream_lookup":"matched","status":"update-available"}]'
 
     run run_action
     [ "$status" -eq 0 ]
@@ -123,7 +123,7 @@ assert_byte_for_byte() {
     result=$(jq -cn \
         --arg container "$hostile_container" \
         --arg version "$hostile_version" \
-        '[{container: $container, current_version: "1.0.0", latest_version: $version, update_available: true, actionable: true, registry_lookup: "matched", status: "update-available"}]')
+        '[{container: $container, current_version: "1.0.0", latest_version: $version, update_available: true, actionable: true, registry_lookup: "matched", upstream_lookup: "matched", status: "update-available"}]')
     write_make_result "$result"
 
     run run_action "$hostile_container"
@@ -172,15 +172,6 @@ assert_byte_for_byte() {
     [[ "$output" != *"✅ Up to date"* ]]
 }
 
-@test "composite action reports a rejected upstream value without claiming it is up to date" {
-    write_make_result '[{"container":"ansible","current_version":"","latest_version":"error: rate limited","update_available":false,"actionable":false,"registry_lookup":"no-match","status":"upstream-version-rejected"}]'
-
-    run run_action
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"does not match the declared version pattern"* ]]
-    [[ "$output" != *"✅ Up to date"* ]]
-}
-
 @test "composite action rejects an entry without a container" {
     write_make_result '[{"actionable":true,"update_available":true,"registry_lookup":"matched"}]'
 
@@ -208,6 +199,15 @@ assert_byte_for_byte() {
     [[ "$output" != *"update_count="* ]]
 }
 
+@test "composite action rejects actionable entries whose upstream lookup failed" {
+    write_make_result '[{"container":"failed-upstream","update_available":true,"actionable":true,"registry_lookup":"matched","upstream_lookup":"failed","status":"update-available"}]'
+
+    run run_action
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
+    [[ "$output" != *"update_count="* ]]
+}
+
 @test "composite action rejects actionable entries without a concluded lookup" {
     write_make_result '[{"container":"missing-lookup","update_available":true,"actionable":true}]'
 
@@ -215,6 +215,15 @@ assert_byte_for_byte() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"invalid or unauthorized version_info entry"* ]]
     [[ "$output" != *"update_count="* ]]
+}
+
+@test "composite action reports an unrecognised status without claiming it is up to date" {
+    write_make_result '[{"container":"unknown-state","current_version":"1.0.0","latest_version":"1.1.0","update_available":true,"actionable":false,"registry_lookup":"matched","upstream_lookup":"matched","status":"future-failure-status"}]'
+
+    run run_action
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Unrecognised status 'future-failure-status'"* ]]
+    [[ "$output" != *"✅ Up to date"* ]]
 }
 
 @test "composite action reports zero updates for a well-formed empty array" {

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -564,6 +564,8 @@ list_containers() {
         2>/dev/null | xargs -I{} basename {} 2>/dev/null
 }
 has_dockerfile()  { return 0; }
+dockerhub_get_tag_sizes() { printf '%s\n' "$3" >> "$SIZE_TAG_LOG"; }
+ghcr_get_manifest_sizes() { printf '%s\n' "$2" >> "$SIZE_TAG_LOG"; }
 EOF
 
     cat > helpers/sbom-utils.sh <<'EOF'
@@ -900,6 +902,61 @@ EOF
     [[ "$status_6" == "new-container" ]]
 }
 
+@test "check_updates multi-entry: a non-version upstream value cannot create a retained-major container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "__NO_MATCH__" "7.0.0-alpine" "error: rate limited"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-version-rejected" ]]
+}
+
+@test "check_updates multi-entry: failed upstream lookup discards partial candidate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "6.9.5-alpine"
+    cat > wordpress/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--major" && "$2" == "7" ]]; then echo "7.0.0-alpine"; exit 0; fi
+if [[ "$1" == "--major" && "$2" == "6" ]]; then echo "6.9.5-alpine"; exit 23; fi
+exit 1
+EOF
+    chmod +x wordpress/version.sh
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates multi-entry: empty successful upstream lookup is a no-match" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "6.9.5-alpine"
+    cat > wordpress/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--major" && "$2" == "7" ]]; then echo "7.0.0-alpine"; exit 0; fi
+if [[ "$1" == "--major" && "$2" == "6" ]]; then exit 0; fi
+exit 1
+EOF
+    chmod +x wordpress/version.sh
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .upstream_lookup')" == "no-match" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "up_to_date" ]]
+}
+
 @test "check_updates default path: genuine newer latest is an update" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
@@ -913,6 +970,76 @@ EOF
     status_value=$(echo "$output" | jq -r '.[0].status')
     [[ "$update_available" == "true" ]]
     [[ "$status_value" == "update-available" ]]
+}
+
+@test "check_updates default path: an uncomparable upstream value cannot become an update" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "error: rate limited"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+}
+
+@test "check_updates default path: a non-version upstream value cannot create a container" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "__NO_PUBLISHED__" "error: rate limited"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-version-rejected" ]]
+}
+
+@test "check_updates default path: failed upstream lookup discards partial candidate" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\\.[0-9]+\\.[0-9]+-ubuntu$'; exit 0; fi
+echo "1.1.0-ubuntu"
+exit 23
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "sizes: failed upstream lookup discards partial tag and falls back to latest" {
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+echo "1.1.0-ubuntu"
+exit 23
+EOF
+    chmod +x ansible/version.sh
+    mkdir -p bin
+    cat > bin/docker <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+    chmod +x bin/docker
+    export PATH="$TEST_DIR/bin:$PATH"
+    export SIZE_TAG_LOG="$TEST_DIR/size-tags"
+
+    run ./make sizes ansible
+    [ "$status" -eq 0 ]
+    [[ "$(sort -u "$SIZE_TAG_LOG")" == "latest" ]]
 }
 
 # Positive control for registry-pattern refusal cases below: a version.sh that
@@ -1434,7 +1561,7 @@ EOF
     [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
 }
 
-@test "check_updates default path: testing and stable labels without numeric alias remain permissive" {
+@test "check_updates default path: uncomparable labels without numeric aliases fail closed" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
@@ -1445,8 +1572,8 @@ EOF
 
     update_available=$(echo "$output" | jq -r '.[0].update_available')
     status_value=$(echo "$output" | jq -r '.[0].status')
-    [[ "$update_available" == "true" ]]
-    [[ "$status_value" == "update-available" ]]
+    [[ "$update_available" == "false" ]]
+    [[ "$status_value" == "downgrade-guard-failed" ]]
 }
 
 @test "check_updates default path: equal versions are not an update" {

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -912,7 +912,9 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')" == "false" ]]
     [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .actionable')" == "false" ]]
-    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-version-rejected" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-lookup-failed" ]]
 }
 
 @test "check_updates multi-entry: failed upstream lookup discards partial candidate" {
@@ -954,7 +956,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .latest_version')" == "" ]]
     [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .upstream_lookup')" == "no-match" ]]
-    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "up_to_date" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-no-match" ]]
 }
 
 @test "check_updates default path: genuine newer latest is an update" {
@@ -982,7 +984,112 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
     [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
-    [[ "$(echo "$output" | jq -r '.[0].status')" == "downgrade-guard-failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates default path: digit-leading resolver junk is rejected before comparison" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    # This would pass dpkg's digit gate and compare newer without admission.
+    create_default_check_updates_fixture "1.0.0-ubuntu" "2;error"
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates multi-entry: digit-leading resolver junk is rejected before comparison" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_check_updates_fixture "7.0.0-alpine" "6.9.4-alpine" "7.0.0-alpine" "2;error"
+
+    run run_check_updates wordpress
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[] | select(.major_line == "6") | .status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates default path: leading tab is rejected rather than stripped before admission" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" $'\t1.1.0-ubuntu'
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+}
+
+@test "check_updates default path: an oversized resolver line fails without retaining it" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
+head -c 1048576 /dev/zero | tr '\0' x
+printf '\n'
+EOF
+    chmod +x ansible/version.sh
+
+    run run_check_updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+}
+
+@test "check_updates default path: a resolver that writes then hangs fails within the fixed bound" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
+printf '1.1.0-ubuntu\n'
+sleep 90
+EOF
+    chmod +x ansible/version.sh
+
+    # The implementation exposes no timeout knob: hostile environment values
+    # must not raise the fixed wait or make this resolver an update.
+    run timeout 65 env CHECK_UPDATES_RESOLVER_TIMEOUT=99999 CHECK_UPDATES_RESOLVER_MAX_LINE_BYTES=9999999 ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
+}
+
+@test "check_updates default path: a resolver that succeeds after six seconds remains matched" {
+    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    cat > ansible/version.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
+sleep 6
+printf '1.1.0-ubuntu\n'
+EOF
+    chmod +x ansible/version.sh
+
+    run ./make check-updates ansible
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "matched" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "1.1.0-ubuntu" ]]
+    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
 }
 
 @test "check_updates default path: a non-version upstream value cannot create a container" {
@@ -995,7 +1102,9 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.[0].update_available')" == "false" ]]
     [[ "$(echo "$output" | jq -r '.[0].actionable')" == "false" ]]
-    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-version-rejected" ]]
+    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
+    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
+    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
 }
 
 @test "check_updates default path: failed upstream lookup discards partial candidate" {
@@ -1040,6 +1149,33 @@ EOF
     run ./make sizes ansible
     [ "$status" -eq 0 ]
     [[ "$(sort -u "$SIZE_TAG_LOG")" == "latest" ]]
+}
+
+@test "sizes: a failed lookup does not reuse the preceding container tag" {
+    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
+    mkdir -p beta
+    cat > beta/version.sh <<'EOF'
+#!/bin/bash
+printf '2.0.0-ubuntu\n'
+exit 23
+EOF
+    chmod +x beta/version.sh
+    # Make the successful lookup immediately precede the failed one.
+    cat >> helpers/registry-utils.sh <<'EOF'
+list_containers() { printf '%s\n' ansible beta; }
+EOF
+    mkdir -p bin
+    cat > bin/docker <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+    chmod +x bin/docker
+    export PATH="$TEST_DIR/bin:$PATH"
+    export SIZE_TAG_LOG="$TEST_DIR/size-tags"
+
+    run ./make sizes
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$SIZE_TAG_LOG")" == $'1.1.0-ubuntu\n1.1.0-ubuntu\nlatest\nlatest' ]]
 }
 
 # Positive control for registry-pattern refusal cases below: a version.sh that

--- a/tests/unit/latest-per-major.bats
+++ b/tests/unit/latest-per-major.bats
@@ -1031,7 +1031,7 @@ EOF
     [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
 }
 
-@test "check_updates default path: an oversized resolver line fails without retaining it" {
+@test "check_updates default path: a streaming resolver is discarded without retaining its output" {
     if ! command -v yq &>/dev/null; then skip "yq not available"; fi
     if ! command -v jq &>/dev/null; then skip "jq not available"; fi
 
@@ -1039,8 +1039,7 @@ EOF
     cat > ansible/version.sh <<'EOF'
 #!/bin/bash
 if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
-head -c 1048576 /dev/zero | tr '\0' x
-printf '\n'
+exec yes '1.1.0-ubuntu'
 EOF
     chmod +x ansible/version.sh
 
@@ -1048,48 +1047,6 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
     [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
-}
-
-@test "check_updates default path: a resolver that writes then hangs fails within the fixed bound" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
-
-    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
-    cat > ansible/version.sh <<'EOF'
-#!/bin/bash
-if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
-printf '1.1.0-ubuntu\n'
-sleep 90
-EOF
-    chmod +x ansible/version.sh
-
-    # The implementation exposes no timeout knob: hostile environment values
-    # must not raise the fixed wait or make this resolver an update.
-    run timeout 65 env CHECK_UPDATES_RESOLVER_TIMEOUT=99999 CHECK_UPDATES_RESOLVER_MAX_LINE_BYTES=9999999 ./make check-updates ansible
-    [ "$status" -eq 0 ]
-    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "failed" ]]
-    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "" ]]
-    [[ "$(echo "$output" | jq -r '.[0].status')" == "upstream-lookup-failed" ]]
-}
-
-@test "check_updates default path: a resolver that succeeds after six seconds remains matched" {
-    if ! command -v yq &>/dev/null; then skip "yq not available"; fi
-    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
-
-    create_default_check_updates_fixture "1.0.0-ubuntu" "1.1.0-ubuntu"
-    cat > ansible/version.sh <<'EOF'
-#!/bin/bash
-if [[ "$1" == "--registry-pattern" ]]; then echo '^[0-9]+\.[0-9]+\.[0-9]+-ubuntu$'; exit 0; fi
-sleep 6
-printf '1.1.0-ubuntu\n'
-EOF
-    chmod +x ansible/version.sh
-
-    run ./make check-updates ansible
-    [ "$status" -eq 0 ]
-    [[ "$(echo "$output" | jq -r '.[0].upstream_lookup')" == "matched" ]]
-    [[ "$(echo "$output" | jq -r '.[0].latest_version')" == "1.1.0-ubuntu" ]]
-    [[ "$(echo "$output" | jq -r '.[0].update_available')" == "true" ]]
 }
 
 @test "check_updates default path: a non-version upstream value cannot create a container" {


### PR DESCRIPTION
Several routes let a `version.sh` that never established a version produce an available update.

A resolver that printed a plausible value and then exited nonzero supplied that value: the guard
appended to the pipeline's output instead of replacing it, and one of the three capture sites had no
guard. A resolver that exited zero printing an error message reached two further routes — the
downgrade guard said "does not block" when it could not compare at all, and an unpublished container
needed no comparison, so `error: rate limited` became either an update or an initial release.

The resolver's own exit status now decides whether its output is a candidate, an upstream value is
admitted only if it matches the tag pattern that container declares, and admission happens before
both the comparison and the first-publication branch. A status meaning "could not conclude" no longer
reports as up to date, and the action refuses a record whose upstream lookup failed.

Refs #1514.

## Verified

- 3013 tests, 0 failures, 114 suites.
- Mutations seen red for restoring the appending fallback, for restoring the fall-through to "does
  not block", for disabling admission on both paths, for moving admission back to the
  first-publication branch alone, and for removing the action's new validation clause.
- Every `version.sh` in the repository was timed and its output measured: eleven produce a value, all
  matching their own registry pattern; none of the fourteen patterns accepts `error: rate limited` or
  `2;error`.

## Two things worth knowing

A bounding harness for a hanging resolver was built here and removed after it produced eight defects
across two rounds — its 60-second bound did not bind on a process ignoring `SIGTERM`, its `timeout`
lookup broke the documented macOS path, and its polling loop discarded successful results. The read
is back to the pipeline it replaced, which bounds output as before. Time is unbounded exactly as it
was before this branch; #1556 tracks the hang and the code says so.

Admission makes each container's declared pattern authoritative. `debian` declares
`^(trixie|bookworm|bullseye)$`, so a future codename is refused until that is expanded. The failure is
closed and visible rather than silent, but it turns a permissive path into one needing maintenance.

## Filed, not fixed here

#1563 — an absent numeric alias is read as proof an update is safe, and a test locks that in
(pre-existing). #1564 — a rejected value reports as a failed lookup and loses its evidence, and
admission uses a pattern documented as describing published tags rather than resolver output. #1562 —
a resolver printing more than one line would take `SIGPIPE` from our own `head` and read as failed;
latent, none does today. #1556, #1551, #1533, #1541.

## Where this came from

Split out of draft PR #1558, which tried to fix this together with the dashboard's own copy of the
same decision and returned 14, 14, 12 and 24 findings over four rounds. That PR stays open; none of
its dashboard work is here.
